### PR TITLE
fix: use npx to find node_module binaries

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -15,7 +15,7 @@
     "passport-google-oauth20": "^2.0.0"
   },
   "scripts": {
-    "dev": "node-dev server.js",
+    "dev": "npx node-dev server.js",
     "start": "node server.js"
   },
   "devDependencies": {

--- a/sharedb.planx.uk/package.json
+++ b/sharedb.planx.uk/package.json
@@ -9,7 +9,7 @@
     "ws": "^7.3.1"
   },
   "scripts": {
-    "dev": "node-dev server.js",
+    "dev": "npx node-dev server.js",
     "start": "node server.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Previously `docker-compose up --build` was giving error the error

> /bish/sh: node-dev: not found

because node binaries are located under node_modules/.bin/