### PR TITLE
feat: database auditing system

### DIFF
--- a/hasura.planx.uk/migrations/1595862109212_audit/down.sql
+++ b/hasura.planx.uk/migrations/1595862109212_audit/down.sql
@@ -1,0 +1,22 @@
+DROP TABLE events CASCADE;
+DROP FUNCTION process_event;
+DROP FUNCTION track_events;
+
+DO
+$do$
+DECLARE
+   _sql text;
+   table_name text;
+   table_names varchar[] := array[
+  'flows',
+  'team_members',
+  'teams',
+  'users'
+  ];
+BEGIN
+  FOREACH table_name IN ARRAY table_names
+  LOOP
+    EXECUTE 'DROP TRIGGER IF EXISTS tg_event ON ' || table_name;
+  END LOOP;
+END
+$do$;

--- a/hasura.planx.uk/migrations/1595862109212_audit/up.sql
+++ b/hasura.planx.uk/migrations/1595862109212_audit/up.sql
@@ -1,0 +1,96 @@
+-- Audit (Activity log) table and triggers
+-- Based on https://github.com/hasura/audit-trigger
+
+CREATE TABLE events (
+  id bigserial PRIMARY KEY,
+  table_name text NOT NULL,
+  author_id integer REFERENCES users ON DELETE CASCADE,
+  action char(1) NOT NULL CHECK (action IN ('I','D','U', 'T')),
+  row_data jsonb,
+  changed_fields jsonb,
+  created_at timestamptz DEFAULT NOW() NOT NULL
+);
+COMMENT ON COLUMN events.row_data IS 'Record value. For INSERT this is the new record. For DELETE and UPDATE it is the old record.';
+COMMENT ON COLUMN events.changed_fields IS 'New values of fields changed by UPDATE. Null except for row-level UPDATE events.';
+
+CREATE OR REPLACE FUNCTION process_event()
+RETURNS TRIGGER
+LANGUAGE plpgsql AS $$
+DECLARE
+  _sql text;
+  event_row events%ROWTYPE;
+  _user_id users.id%TYPE;
+  excluded_cols text[] = ARRAY[]::text[];
+  new_r jsonb;
+  old_r jsonb;
+BEGIN
+  _user_id := current_setting('hasura.user', 't')::jsonb->>'x-hasura-user-id';
+  event_row = ROW(
+    nextval('events_id_seq'),  -- id
+    TG_TABLE_NAME::text,       -- table_name
+    _user_id,                  -- author_id
+    substring(TG_OP,1,1),      -- action
+    NULL,                      -- row_data
+    NULL,                      -- changed_fields
+    NOW()                      -- created_at
+  );
+
+  IF (TG_OP = 'UPDATE' AND TG_LEVEL = 'ROW') THEN
+    old_r = to_jsonb(OLD);
+    new_r = to_jsonb(NEW);
+    event_row.row_data = old_r - excluded_cols;
+    SELECT
+      jsonb_object_agg(new_t.key, new_t.value) - excluded_cols
+    INTO
+      event_row.changed_fields
+    FROM jsonb_each(old_r) as old_t
+    JOIN jsonb_each(new_r) as new_t
+    ON (old_t.key = new_t.key AND old_t.value <> new_t.value);
+  ELSIF (TG_OP = 'DELETE' AND TG_LEVEL = 'ROW') THEN
+    event_row.row_data = to_jsonb(OLD) - excluded_cols;
+  ELSIF (TG_OP = 'INSERT' AND TG_LEVEL = 'ROW') THEN
+    event_row.row_data = to_jsonb(NEW) - excluded_cols;
+  ELSIF (TG_LEVEL = 'STATEMENT' AND TG_OP IN ('INSERT','UPDATE','DELETE','TRUNCATE')) THEN
+    RAISE EXCEPTION '[process_event] - Trigger func added as trigger for unhandled case: %, %',TG_OP, TG_LEVEL;
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO events VALUES (event_row.*);
+
+  RETURN NULL;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION track_events(target_table regclass) RETURNS void AS $body$
+DECLARE
+_sql text;
+BEGIN
+  EXECUTE 'DROP TRIGGER IF EXISTS tg_event ON ' || target_table;
+
+  EXECUTE '
+  CREATE TRIGGER tg_event
+  AFTER INSERT OR UPDATE OR DELETE
+  ON ' || target_table || '
+  FOR EACH ROW EXECUTE PROCEDURE process_event();
+    ';
+END;
+$body$
+language 'plpgsql';
+
+DO
+  $do$
+  DECLARE
+  table_name text;
+  table_names varchar[] := array[
+  'flows',
+  'team_members',
+  'teams',
+  'users'
+  ];
+  BEGIN
+    FOREACH table_name IN ARRAY table_names
+    LOOP
+      EXECUTE 'SELECT track_events(' || quote_literal(table_name) || ')';
+END LOOP;
+END
+$do$;

--- a/hasura.planx.uk/run-tests.sh
+++ b/hasura.planx.uk/run-tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# These DB tests require you to have Postgres up and the database created
+# `docker-compose up --build` should do all of that for you
+
+# When writing new tests, I suggest using `nodemon` to get a nice feedback-loop
+# $ npx nodemon -e sql --exec "./run-tests.sh"
+
+psql "postgres://${PG_USERNAME}:${PG_PASSWORD}@0.0.0.0:${PG_PORT}/${PG_DATABASE}" <tests/audit.test.sql

--- a/hasura.planx.uk/tests/audit.test.sql
+++ b/hasura.planx.uk/tests/audit.test.sql
@@ -1,0 +1,60 @@
+CREATE PROCEDURE _test_audit()
+LANGUAGE plpgsql AS $$
+DECLARE
+  event events%ROWTYPE;
+BEGIN
+
+  ASSERT (SELECT COUNT(*) FROM events) = 0, 'database not empty! skipping tests';
+  ASSERT (SELECT COUNT(*) FROM users) = 0, 'database not empty! skipping tests';
+
+  CREATE TABLE _tmp_table_for_tests (
+    id integer PRIMARY KEY,
+    name text NOT NULL,
+    created_at timestamptz DEFAULT NOW() NOT NULL,
+    updated_at timestamptz
+  );
+
+  CREATE TRIGGER set__tmp_table_for_tests_updated_at
+  BEFORE UPDATE ON _tmp_table_for_tests
+  FOR EACH ROW EXECUTE PROCEDURE set_current_timestamp_updated_at();
+
+  PERFORM track_events('_tmp_table_for_tests');
+
+  -- Inserting a row generates an event
+  INSERT INTO _tmp_table_for_tests VALUES (1, 'john', NOW());
+  ASSERT (SELECT COUNT(*) FROM _tmp_table_for_tests) = 1;
+  ASSERT (SELECT COUNT(*) FROM events) = 1;
+  SELECT * FROM events ORDER BY id DESC LIMIT 1 INTO event;
+  RAISE INFO 'Insert event = %', event;
+  ASSERT event.table_name = '_tmp_table_for_tests';
+  ASSERT event.action = 'I';
+  ASSERT event.row_data @> ('{"id":1, "name": "john", "updated_at": null}')::jsonb;
+  ASSERT event.changed_fields::text IS NULL;
+
+  -- Updating a row generates an event
+  UPDATE _tmp_table_for_tests SET name = 'rees';
+  ASSERT (SELECT COUNT(*) FROM _tmp_table_for_tests) = 1;
+  ASSERT (SELECT COUNT(*) FROM events) = 2;
+  SELECT * FROM events ORDER BY id DESC LIMIT 1 INTO event;
+  RAISE INFO 'Update event = %', event;
+  ASSERT event.table_name = '_tmp_table_for_tests';
+  ASSERT event.action = 'U';
+  ASSERT event.row_data @> ('{"id":1, "name": "john"}')::jsonb;
+  ASSERT event.changed_fields @> ('{"name": "rees"}')::jsonb;
+
+  -- Deleting a row generates an event
+  DELETE FROM _tmp_table_for_tests;
+  ASSERT (SELECT COUNT(*) FROM _tmp_table_for_tests) = 0;
+  ASSERT (SELECT COUNT(*) FROM events) = 3;
+  SELECT * FROM events ORDER BY id DESC LIMIT 1 INTO event;
+  RAISE INFO 'Delete event = %', event;
+  ASSERT event.table_name = '_tmp_table_for_tests';
+  ASSERT event.action = 'D';
+  ASSERT event.row_data @> ('{"id":1, "name": "rees"}')::jsonb;
+  ASSERT event.changed_fields IS NULL;
+
+ROLLBACK; END $$;
+
+CALL _test_audit();
+
+DROP PROCEDURE _test_audit;


### PR DESCRIPTION
Closes #1

Creates a trigger-based auditing system (i.e. activity log).
To track a table, use `PERFORM track_events(<name-of-the-table>);`