### PR TITLE
feat: create new session

### DIFF
--- a/editor.planx.uk/src/pages/Preview/Context.tsx
+++ b/editor.planx.uk/src/pages/Preview/Context.tsx
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const PreviewContext = React.createContext(null);

--- a/editor.planx.uk/src/pages/Preview/components/PropertyInformation/index.tsx
+++ b/editor.planx.uk/src/pages/Preview/components/PropertyInformation/index.tsx
@@ -1,14 +1,17 @@
+import { useMutation } from "@apollo/client";
+import gql from "graphql-tag";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import useAxios from "axios-hooks";
 import capitalize from "lodash/capitalize";
-import React from "react";
+import React, { useEffect, useContext } from "react";
 import InnerQuestion from "../Question/InnerQuestion";
 import Card from "../shared/Card";
 import BasicMap from "./BasicMap";
 import "./map.css";
 import { convertOrdnanceSurveyToStandard } from "./maputils";
 import PropertyConstraints from "./PropertyConstraints";
+import { PreviewContext } from "../../Context";
 import PropertyDetail from "./PropertyDetail";
 import { propertyInformationStyles } from "./styles";
 
@@ -62,6 +65,44 @@ const PropertyInformation = ({
 const PropWithConstraints = ({ info, handleSubmit }) => {
   const url = `https://local-authority-api.planx.uk/${info.team}?x=${info.x}&y=${info.y}&cacheBuster=10`;
   const [{ data }] = useAxios(url);
+
+  const flow = useContext(PreviewContext);
+  const MUTATION = gql`
+    mutation CreateSession(
+      $flow_data: jsonb
+      $flow_id: uuid
+      $flow_version: Int
+      $passport: jsonb
+    ) {
+      insert_sessions_one(
+        object: {
+          flow_data: $flow_data
+          flow_id: $flow_id
+          flow_version: $flow_version
+          passport: $passport
+        }
+      ) {
+        id
+      }
+    }
+  `;
+  const [createSessionMutation] = useMutation(MUTATION);
+  useEffect(() => {
+    if (flow && data && info) {
+      // TODO: Store the returned session id into the context provider
+      //       so that we can reference it in subsequent calls
+      //       that will register session events (i.e. insert_session_event)
+      createSessionMutation({
+        variables: {
+          flow_data: flow.data,
+          flow_id: flow.id,
+          flow_version: flow.version,
+          passport: { info, data },
+        },
+      });
+    }
+  }, [createSessionMutation, flow, data, info]);
+
   if (!data) return null;
 
   const { lng, lat } = convertOrdnanceSurveyToStandard(info.x, info.y);
@@ -115,6 +156,8 @@ const PropWithConstraints = ({ info, handleSubmit }) => {
 const PropertyInformationWithData: React.FC<any> = ({
   UPRN = 10009795450,
   handleSubmit = console.log,
+  flowId,
+  flowData,
 }) => {
   const [{ data }] = useAxios(
     `https://llpg.planx.uk/addresses?limit=1&UPRN=eq.${UPRN}&nocache`

--- a/editor.planx.uk/src/routes/preview.tsx
+++ b/editor.planx.uk/src/routes/preview.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { client } from "../lib/graphql";
 import { api } from "../pages/FlowEditor/lib/store";
 import Preview from "../pages/Preview";
+import { PreviewContext } from "../pages/Preview/Context";
 
 const routes = route(async (req) => {
   const { data } = await client.query({
@@ -17,6 +18,7 @@ const routes = route(async (req) => {
           }
         ) {
           id
+          version
           data
           team {
             theme
@@ -38,7 +40,13 @@ const routes = route(async (req) => {
 
   api.getState().setFlow(flow.id, flow.data);
 
-  return { view: <Preview theme={flow.team.theme} /> };
+  return {
+    view: (
+      <PreviewContext.Provider value={flow}>
+        <Preview theme={flow.team.theme} />
+      </PreviewContext.Provider>
+    ),
+  };
 });
 
 export default routes;


### PR DESCRIPTION
Closes #36

I was in two minds about where to store and retrieve the flow id, data, and version. On the one hand, we already have a store in place, that we could query for the id and data, and that we could easily extend to add the version field. On the other hand, that store really belongs to the editor, not to the preview. I've decided to go with the latter. I hope this will further decouple the preview pane from the editor, and will make things simpler in the public interface.
