### PR TITLE
Add 'why it matters' section to notices

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/Checklist.tsx
@@ -11,12 +11,11 @@ import {
   ListManager,
   ModalSection,
   ModalSectionContent,
-  MoreInformation,
   OptionButton,
   RichTextInput,
 } from "../../../../ui";
 import { Checklist, Option, TYPES } from "../../data/types";
-import { PermissionSelect } from "./shared";
+import { MoreInformation, PermissionSelect } from "./shared";
 import { nodeIcon } from "../shared";
 
 interface ChecklistProps extends Checklist {
@@ -230,7 +229,6 @@ export const ChecklistComponent: React.FC<ChecklistProps> = ({
         definitionImg={formik.values.definitionImg}
         definitionName="howMeasured"
         definitionValue={formik.values.howMeasured}
-        formik={formik}
         policyName="policyRef"
         policyValue={formik.values.policyRef}
         whyName="info"

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -14,6 +14,12 @@ import { useStore } from "../../lib/store";
 import { parseFormValues } from "./shared";
 
 const useStyles = makeStyles((theme) => ({
+  dialog: {
+    // Target all modal sections (the direct child is the backdrop, hence the double child selector)
+    "& > * > *": {
+      backgroundColor: theme.palette.grey[100],
+    },
+  },
   closeButton: {
     float: "right",
     margin: 0,
@@ -98,6 +104,7 @@ const FormModal: React.FC<{
       maxWidth="md"
       disableScrollLock
       onClose={handleClose}
+      className={classes.dialog}
     >
       <DialogTitle>
         {!handleDelete && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/Notice.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/Notice.tsx
@@ -12,6 +12,7 @@ import {
 import { useFormik } from "formik";
 import { Notice, TYPES } from "../../data/types";
 import { nodeIcon } from "../shared";
+import { MoreInformation } from "./shared";
 
 export interface Props {
   id?: string;
@@ -77,6 +78,21 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
           </OptionButton>
         </ModalSectionContent>
       </ModalSection>
+      <MoreInformation
+        changeField={(ev: any) => {
+          props.onChange({
+            ...props.value,
+            [ev.target.name]: ev.target.value,
+          });
+        }}
+        definitionImg={props.value.definitionImg}
+        definitionName="howMeasured"
+        definitionValue={props.value.howMeasured}
+        policyName="policyRef"
+        policyValue={props.value.policyRef}
+        whyName="info"
+        whyValue={props.value.info}
+      />
       <InternalNotes
         name="notes"
         onChange={(ev) => {
@@ -92,7 +108,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
 };
 
 const NoticeComponent: React.FC<Props> = (props) => {
-  const formik = useFormik({
+  const formik = useFormik<{ notice: Notice }>({
     initialValues: {
       notice: {
         // TODO: improve runtime validation here (joi, io-ts)
@@ -101,6 +117,10 @@ const NoticeComponent: React.FC<Props> = (props) => {
         color: props.node?.color || "#EFEFEF",
         notes: props.node?.notes || "",
         resetButton: props.node?.resetButton || false,
+        definitionImg: props.node?.definitionImg,
+        howMeasured: props.node?.howMeasured,
+        policyRef: props.node?.policyRef,
+        info: props.node?.info,
       },
     },
     onSubmit: (newValues) => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/Question.tsx
@@ -11,11 +11,10 @@ import {
   ListManager,
   ModalSection,
   ModalSectionContent,
-  MoreInformation,
   RichTextInput,
 } from "../../../../ui";
 import { TYPES } from "../../data/types";
-import { PermissionSelect } from "./shared";
+import { MoreInformation, PermissionSelect } from "./shared";
 import { nodeIcon } from "../shared";
 
 interface Option {
@@ -239,7 +238,6 @@ export const Question: React.FC<Props> = ({
         definitionImg={formik.values.definitionImg}
         definitionName="howMeasured"
         definitionValue={formik.values.howMeasured}
-        formik={formik}
         policyName="policyRef"
         policyValue={formik.values.policyRef}
         whyName="info"

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/shared.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/shared.tsx
@@ -1,8 +1,18 @@
 import React from "react";
 import { MenuItem } from "@material-ui/core";
+import { InfoOutlined } from "@material-ui/icons";
 import trim from "lodash/trim";
 import flags from "../../data/flags";
-import { SelectInput, SelectInputProps } from "../../../../ui";
+import {
+  ModalSection,
+  ModalSectionContent,
+  InputGroup,
+  InputRow,
+  SelectInput,
+  SelectInputProps,
+  RichTextInput,
+  ImgInput,
+} from "../../../../ui";
 
 export interface IEditor {
   headerTextField?: string;
@@ -20,6 +30,65 @@ const renderMenuItem = (category: string) => {
         {flag.text}
       </MenuItem>
     ));
+};
+
+export const MoreInformation = ({
+  changeField,
+  definitionImg,
+  definitionName,
+  definitionValue,
+  policyName,
+  policyValue,
+  whyName,
+  whyValue,
+}) => {
+  return (
+    <ModalSection>
+      <ModalSectionContent title="More Information" Icon={InfoOutlined}>
+        <InputGroup label="Why it matters">
+          <InputRow>
+            <RichTextInput
+              multiline
+              name={whyName}
+              value={whyValue}
+              onChange={changeField}
+              placeholder="Why it matters"
+            />
+          </InputRow>
+        </InputGroup>
+        <InputGroup label="Policy source">
+          <InputRow>
+            <RichTextInput
+              multiline
+              name={policyName}
+              value={policyValue}
+              onChange={changeField}
+              placeholder="Policy source"
+            />
+          </InputRow>
+        </InputGroup>
+        <InputGroup label="How it is defined?">
+          <InputRow>
+            <RichTextInput
+              multiline
+              name={definitionName}
+              value={definitionValue}
+              onChange={changeField}
+              placeholder="How it is defined?"
+            />
+            <ImgInput
+              img={definitionImg}
+              onChange={(newUrl) => {
+                changeField({
+                  target: { name: "definitionImg", value: newUrl },
+                });
+              }}
+            />
+          </InputRow>
+        </InputGroup>
+      </ModalSectionContent>
+    </ModalSection>
+  );
 };
 
 export const PermissionSelect: React.FC<SelectInputProps> = (props) => (

--- a/editor.planx.uk/src/pages/FlowEditor/data/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/data/types.ts
@@ -33,7 +33,7 @@ export interface Task {
 
 // Notice
 
-export interface Notice {
+export interface Notice extends MoreInformation {
   title: string;
   description: string;
   color: string;
@@ -45,15 +45,11 @@ export interface Notice {
 
 export interface Checklist extends MoreInformation {
   fn?: string;
-  howMeasured?: string;
   description?: string;
   text?: string;
   notes?: string;
-  policyRef?: string;
-  info?: string;
   options?: Array<Option>;
   img?: string;
-  definitionImg?: string;
   allRequired?: boolean;
 }
 
@@ -68,6 +64,7 @@ export interface Content extends MoreInformation {
 export interface MoreInformation {
   howMeasured?: string;
   policyRef?: string;
+  info?: string;
   notes?: string;
   definitionImg?: string;
 }

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -81,6 +81,9 @@ const theme = createMuiTheme({
     },
     ...({
       MUIRichTextEditor: {
+        root: {
+          padding: 0,
+        },
         container: {
           // Disable margins to allow a container <Box/>
           margin: 0,
@@ -89,7 +92,7 @@ const theme = createMuiTheme({
           },
         },
         editor: {
-          backgroundColor: "#fafafa",
+          backgroundColor: "#fff",
           padding: "4px 10px",
           minHeight: 48,
           fontSize: 15,

--- a/editor.planx.uk/src/ui/README.md
+++ b/editor.planx.uk/src/ui/README.md
@@ -1,0 +1,1 @@
+This folder holds domain-independent, 'dumb' components like input fields and layout helpers.

--- a/editor.planx.uk/src/ui/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.tsx
@@ -21,6 +21,8 @@ const rteContainerStyles = makeStyles((theme) => ({
   regular: {
     position: "relative",
     boxSizing: "border-box",
+    // This is necessary for the focus styles to be visible. Breaks the layout a bit
+    // unfortunately. TODO: find a better solution.
     padding: 2,
     outline: "none",
     width: "100%",
@@ -28,10 +30,15 @@ const rteContainerStyles = makeStyles((theme) => ({
   focused: {
     position: "relative",
     boxSizing: "border-box",
+    // This is necessary for the focus styles to be visible. Breaks the layout a bit
+    // unfortunately. TODO: find a better solution.
     padding: 2,
     outline: "none",
     boxShadow: `inset 0 0 0 2px ${theme.palette.primary.light}`,
     width: "100%",
+  },
+  editorFocus: {
+    boxShadow: `inset 0 0 0 2px ${theme.palette.primary.light}`,
   },
 }));
 
@@ -42,7 +49,7 @@ const RichTextInput: React.FC<
   Props & { editorStateRef: MutableRefObject<EditorState | null> }
 > = (props) => {
   // Set the initial `value` prop and ignore updated values to avoid infinite loops
-  const [initialValue] = useState(mdToEditorRawContent(props.value));
+  const [initialValue] = useState(mdToEditorRawContent(props.value || ""));
 
   const [focused, setFocused] = useState(false);
 


### PR DESCRIPTION
Add section + styling updates, focusing on making form elements clearly distinguishable inside forms.

![Screen Shot 2020-10-04 at 10 28 04](https://user-images.githubusercontent.com/6738398/95010772-4f147300-062c-11eb-847b-8e95241db9ad.png)
