### PR TITLE
Update .eslintrc

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -2,6 +2,6 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["simple-import-sort"],
   "rules": {
-    "simple-import-sort/sort": "error"
+    "simple-import-sort/sort": "warn"
   }
 }


### PR DESCRIPTION
Show warning instead of throwing an error when imports aren't sorted so that it doesn't(?) stop `pnpm start` from running