### PR TITLE
Move choice options between groups

### DIFF
--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -8,13 +8,10 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  IconButton,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
-  Menu,
-  MenuItem,
   Typography,
 } from "@material-ui/core";
 import makeStyles from "@material-ui/core/styles/makeStyles";
@@ -23,13 +20,13 @@ import {
   CallSplitOutlined,
   DeleteOutline,
   FolderOutlined,
-  MoreVert,
 } from "@material-ui/icons";
 import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import React from "react";
 import { Link } from "react-navi";
 
 import { client } from "../lib/graphql";
+import SimpleMenu from "../ui/SimpleMenu";
 import { api } from "./FlowEditor/lib/store";
 
 const useStyles = makeStyles((theme) => ({
@@ -194,7 +191,6 @@ const FooterLinks = () => (
 
 const FlowItem = ({ flow, teamId }) => {
   const classes = useStyles();
-  const [anchorEl, setAnchorEl] = React.useState(null);
   const [deleting, setDeleting] = React.useState(false);
   const handleDelete = () => {
     api
@@ -202,7 +198,6 @@ const FlowItem = ({ flow, teamId }) => {
       .deleteFlow(teamId, flow.slug)
       .then(() => {
         setDeleting(false);
-        setAnchorEl(null);
 
         // TODO: remove flow from list rather than this hard refresh
         window.location.reload();
@@ -233,28 +228,11 @@ const FlowItem = ({ flow, teamId }) => {
         <Box className={classes.linkSubText}>
           {flowInfoHelper(flow.updated_at, flow.operations)}
         </Box>
-        <div>
-          <IconButton
-            color="inherit"
-            className={classes.menu}
-            size="small"
-            onClick={(ev) => {
-              setAnchorEl(ev.currentTarget);
-            }}
-          >
-            <MoreVert />
-          </IconButton>
-          <Menu
-            id="long-menu"
-            anchorEl={anchorEl}
-            keepMounted
-            open={Boolean(anchorEl)}
-            onClose={() => {
-              setAnchorEl(null);
-            }}
-          >
-            <MenuItem
-              onClick={async () => {
+        <SimpleMenu
+          className={classes.menu}
+          items={[
+            {
+              onClick: async () => {
                 const newSlug = prompt("New name", flow.slug);
                 if (newSlug && newSlug !== flow.slug) {
                   await client.mutate({
@@ -284,21 +262,18 @@ const FlowItem = ({ flow, teamId }) => {
 
                   window.location.reload();
                 }
-              }}
-            >
-              Rename
-            </MenuItem>
-
-            <MenuItem
-              style={{ color: "red" }}
-              onClick={() => {
+              },
+              label: "Rename",
+            },
+            {
+              label: "Delete",
+              onClick: () => {
                 setDeleting(true);
-              }}
-            >
-              Delete
-            </MenuItem>
-          </Menu>
-        </div>
+              },
+              error: true,
+            },
+          ]}
+        />
       </li>
     </>
   );

--- a/editor.planx.uk/src/ui/ListManager.tsx
+++ b/editor.planx.uk/src/ui/ListManager.tsx
@@ -14,6 +14,7 @@ import {
 import { removeAt, setAt } from "../utils";
 
 export interface EditorProps<T> {
+  index?: number;
   value: T;
   onChange: (newValue: T) => void;
 }
@@ -55,6 +56,7 @@ function ListManager<T, EditorExtraProps>(props: Props<T, EditorExtraProps>) {
                 </IconButton>
               </Box>
               <Editor
+                index={index}
                 value={item}
                 onChange={(newItem) => {
                   props.onChange(setAt(index, newItem, props.values));
@@ -129,6 +131,7 @@ function ListManager<T, EditorExtraProps>(props: Props<T, EditorExtraProps>) {
                         </IconButton>
                       </Box>
                       <Editor
+                        index={index}
                         value={item}
                         onChange={(newItem) => {
                           props.onChange(setAt(index, newItem, props.values));

--- a/editor.planx.uk/src/ui/SimpleMenu.tsx
+++ b/editor.planx.uk/src/ui/SimpleMenu.tsx
@@ -1,0 +1,54 @@
+import { IconButton, Menu, MenuItem } from "@material-ui/core";
+import { MoreVert } from "@material-ui/icons";
+import React, { useState } from "react";
+
+interface Props {
+  className?: string;
+  items: Array<{
+    label: string;
+    disabled?: boolean;
+    error?: boolean;
+    onClick: () => void;
+  }>;
+}
+
+const SimpleMenu: React.FC<Props> = ({ items, ...restProps }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  return (
+    <div {...restProps}>
+      <IconButton
+        color="inherit"
+        onClick={(ev) => {
+          setAnchorEl(ev.currentTarget);
+        }}
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        id="long-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={() => {
+          setAnchorEl(null);
+        }}
+      >
+        {items.map((item, index) => (
+          <MenuItem
+            key={index}
+            style={item.error ? { color: "red" } : {}}
+            disabled={item.disabled}
+            onClick={() => {
+              item.onClick();
+              setAnchorEl(null);
+            }}
+          >
+            {item.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  );
+};
+
+export default SimpleMenu;

--- a/editor.planx.uk/src/ui/index.ts
+++ b/editor.planx.uk/src/ui/index.ts
@@ -16,6 +16,7 @@ export { default as ModalSectionContent } from "./ModalSectionContent";
 export { default as OptionButton } from "./OptionButton";
 export { default as RichTextInput } from "./RichTextInput";
 export { default as SelectInput } from "./SelectInput";
+export { default as SimpleMenu } from "./SimpleMenu";
 export { ExpandableList, ExpandableListItem } from "./ExpandableList";
 export type { Props as SelectInputProps } from "./SelectInput";
 export { default as VisibilityToggle } from "./VisibilityToggle";


### PR DESCRIPTION
Partially fixes #110.

Also extracted a `SimpleMenu` component to be re-used between the team page (where flows are renamed and deleted) and wherever else they're needed.

![rearrange-groups](https://user-images.githubusercontent.com/6738398/98095484-f5050880-1e8a-11eb-8022-e20a53fd2ec4.gif)
