### PR TITLE
Avoid page loads when managing flows

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store.ts
@@ -165,6 +165,7 @@ export const [useStore, api] = create((set, get) => ({
   },
 
   getFlows: async (teamId: number) => {
+    client.cache.reset();
     const { data } = await client.query({
       query: gql`
         query GetFlow($teamId: Int!) {

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -321,14 +321,10 @@ const Team: React.FC<{ id: number; slug: string }> = ({ id, slug }) => {
                 key={flow.slug}
                 teamId={id}
                 onDeleteSuccess={() => {
-                  // TODO: fetching flows here doesn't update the list, even with a generous timeout
-                  window.location.reload();
-                  // setTimeout(fetchFlows, 1500);
+                  fetchFlows();
                 }}
                 onRenameSuccess={() => {
-                  // TODO: fetching flows here doesn't update the list, even with a generous timeout
-                  window.location.reload();
-                  // setTimeout(fetchFlows, 1500);
+                  fetchFlows();
                 }}
               />
             ))}


### PR DESCRIPTION
Avoid having to reload the page when flows are managed.

![flow-ux](https://user-images.githubusercontent.com/6738398/98672117-9392dd00-2355-11eb-85e9-f6d2a9544b35.gif)
