### PR TITLE
Fix some cosmos bugs

### DIFF
--- a/editor.planx.uk/src/cosmos.decorator.tsx
+++ b/editor.planx.uk/src/cosmos.decorator.tsx
@@ -7,7 +7,7 @@ import theme from "./theme";
 
 const Decorator = ({ children }) => (
   <div style={{ padding: 80 }}>
-    <DndProvider backend={HTML5Backend}>
+    <DndProvider backend={HTML5Backend} key={Date.now()}>
       <ThemeProvider theme={theme}>{children}</ThemeProvider>
     </DndProvider>
   </div>


### PR DESCRIPTION
Add a unique key to the DndProvider when rendering the cosmos decorator which hopefully solves an error related to creating multiple HTML5Backends