### PR TITLE
fix: long words breaking out of content area

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -32,6 +32,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   flex: 1;
   display: flex;
   overflow: hidden;
+  word-break: break-all;
 }
 
 #fake-browser {


### PR DESCRIPTION
Fixes #148 

Before:
<img width="623" alt="Screen Shot 2020-11-17 at 4 10 15 PM" src="https://user-images.githubusercontent.com/2712962/99465709-d1f94080-28ef-11eb-85d0-1d7327b9bf13.png">

After:
<img width="390" alt="Screen Shot 2020-11-17 at 4 10 24 PM" src="https://user-images.githubusercontent.com/2712962/99465727-d58cc780-28ef-11eb-87f1-3364ab26a9a5.png">
