### PR TITLE
fix: use overflow-wrap: break-word in graph editor nodes

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -32,7 +32,6 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   flex: 1;
   display: flex;
   overflow: hidden;
-  word-break: break-all;
 }
 
 #fake-browser {
@@ -150,6 +149,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
 
     > span {
       max-width: 170px;
+      overflow-wrap: break-word;
     }
 
     > svg {


### PR DESCRIPTION
### original css with no word-breaking (issue #148)
![Screenshot 2020-11-18 at 11 52 24 AM](https://user-images.githubusercontent.com/601961/99527486-c744b700-2994-11eb-9418-2b8a2ef71716.png)

### PR #168 added `break-word`, fixed individual node ✅  but caused vertical text display issue with flexbox
![Screenshot 2020-11-18 at 11 52 36 AM](https://user-images.githubusercontent.com/601961/99527495-cad83e00-2994-11eb-9e5f-a782e4a17227.png)

### this PR, using `overflow-wrap`, seems to be ok with flexbox
![Screenshot 2020-11-18 at 11 52 45 AM](https://user-images.githubusercontent.com/601961/99527498-cca20180-2994-11eb-8268-017cb3ac041a.png)
