### PR TITLE
Move Content component to @planx/components

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Editor.tsx
@@ -1,31 +1,19 @@
-import { Content } from "@planx/components/Content/types";
-import { parseMoreInformation } from "@planx/components/shared";
+import { Content, parseContent } from "@planx/components/Content/types";
 import { TYPES } from "@planx/components/types";
-import { ICONS } from "@planx/components/ui";
+import { EditorProps, ICONS } from "@planx/components/ui";
 import { InternalNotes, MoreInformation } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import InputRow from "ui/InputRow";
+import ModalSection from "ui/ModalSection";
+import ModalSectionContent from "ui/ModalSectionContent";
+import RichTextInput from "ui/RichTextInput";
 
-import {
-  InputRow,
-  ModalSection,
-  ModalSectionContent,
-  RichTextInput,
-} from "../../../../ui";
-
-export interface Props {
-  id?: string;
-  handleSubmit?: (d: any) => void;
-  node?: any;
-}
+export type Props = EditorProps<TYPES.Content, Content>;
 
 const ContentComponent: React.FC<Props> = (props) => {
   const formik = useFormik<Content>({
-    initialValues: {
-      // TODO: improve runtime validation here (joi, io-ts)
-      content: props.node?.data?.content || "",
-      ...parseMoreInformation(props.node?.data),
-    },
+    initialValues: parseContent(props.node?.data),
     onSubmit: (newValues) => {
       if (props.handleSubmit) {
         props.handleSubmit({ type: TYPES.Content, data: newValues });

--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -2,11 +2,10 @@ import Button from "@material-ui/core/Button";
 import { Content } from "@planx/components/Content/types";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
+import { PublicProps } from "@planx/components/ui";
 import React from "react";
 
-interface Props extends Content {
-  handleSubmit?: any;
-}
+export type Props = PublicProps<Content>;
 
 const ContentComponent: React.FC<Props> = (props) => {
   return (

--- a/editor.planx.uk/src/@planx/components/Content/types.ts
+++ b/editor.planx.uk/src/@planx/components/Content/types.ts
@@ -1,5 +1,11 @@
-import { MoreInformation } from "../shared";
+import { MoreInformation, parseMoreInformation } from "../shared";
 
 export interface Content extends MoreInformation {
   content: string;
 }
+
+export const parseContent = (data: Record<string, any> | undefined) => ({
+  // TODO: improve runtime validation here (joi, io-ts)
+  content: data?.content || "",
+  ...parseMoreInformation(data),
+});

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -5,13 +5,11 @@ import ErrorOutline from "@material-ui/icons/ErrorOutline";
 import { Notice } from "@planx/components/Notice/types";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
+import { PublicProps } from "@planx/components/ui";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
-interface Props extends Notice {
-  handleSubmit?: () => void;
-  resetPreview: () => void;
-}
+export type Props = PublicProps<Notice>;
 
 interface StyleProps {
   color: string;

--- a/editor.planx.uk/src/@planx/components/fixtures/Content.fixture.tsx
+++ b/editor.planx.uk/src/@planx/components/fixtures/Content.fixture.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+import Editor from "../Content/Editor";
+import Public from "../Content/Public";
+import Wrapper from "./Wrapper";
+
+export default () => {
+  return <Wrapper Editor={Editor} Public={Public} />;
+};

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -29,8 +29,10 @@ export interface EditorProps<Type, Data> {
   node?: any;
 }
 
-export type PublicProps<Data, UserData> = Data & {
+export type PublicProps<Data, UserData = {}> = Data & {
   handleSubmit?: (value?: UserData) => void;
+  resetButton?: boolean;
+  resetPreview?: () => void;
 };
 
 // XXX: We define the Icon type in terms of one of the Icons so as not to have to repeat ourselves

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/index.ts
@@ -1,3 +1,4 @@
+import Content from "@planx/components/Content/Editor";
 import Notice from "@planx/components/Notice/Editor";
 import TextInput from "@planx/components/TextInput/Editor";
 import { TYPES } from "@planx/components/types";
@@ -5,7 +6,6 @@ import React from "react";
 
 import { SLUGS } from "../../data/types";
 import Checklist from "./Checklist";
-import Content from "./Content";
 import ExternalPortal from "./ExternalPortal";
 import FileUpload from "./FileUpload";
 import Filter from "./Filter";

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -1,3 +1,4 @@
+import Content from "@planx/components/Content/Public";
 import Notice from "@planx/components/Notice/Public";
 import TextInput from "@planx/components/TextInput/Public";
 import { TYPES } from "@planx/components/types";
@@ -6,7 +7,6 @@ import React from "react";
 
 import { useStore } from "../FlowEditor/lib/store";
 import Checklist from "./components/Checklist";
-import Content from "./components/Content";
 import FileUpload from "./components/FileUpload";
 import FindProperty from "./components/FindProperty";
 import Pay from "./components/Pay";


### PR DESCRIPTION
This is one of a laborious list of PR's to move components into `@planx/components`. They involve moving files and defining different components based on shared standard interfaces like `EditorProps<Data, UserData>` and `PublicProps<Data, UserData>`.