### PR TITLE
Fix cosmos decorator

### DIFF
--- a/editor.planx.uk/src/@planx/components/fixtures/Wrapper.tsx
+++ b/editor.planx.uk/src/@planx/components/fixtures/Wrapper.tsx
@@ -13,10 +13,9 @@ function Wrapper<Type, Data, UserData>(props: Props<Type, Data, UserData>) {
 
   return (
     <div style={{ display: "flex" }}>
-      <div>
+      <div style={{ minWidth: 380 }}>
         <props.Editor
           handleSubmit={(newNode) => {
-            console.log(newNode);
             setData(newNode.data);
           }}
         />

--- a/editor.planx.uk/src/cosmos.decorator.tsx
+++ b/editor.planx.uk/src/cosmos.decorator.tsx
@@ -1,3 +1,4 @@
+import CssBaseline from "@material-ui/core/CssBaseline";
 import { ThemeProvider } from "@material-ui/core/styles";
 import React from "react";
 import { DndProvider } from "react-dnd";
@@ -5,12 +6,17 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 
 import theme from "./theme";
 
-const Decorator = ({ children }) => (
-  <div style={{ padding: 80 }}>
-    <DndProvider backend={HTML5Backend} key={Date.now()}>
-      <ThemeProvider theme={theme}>{children}</ThemeProvider>
-    </DndProvider>
-  </div>
-);
+const Decorator = ({ children }) => {
+  return (
+    <div style={{ padding: 80 }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <DndProvider backend={HTML5Backend} key={Date.now()}>
+          {children}
+        </DndProvider>
+      </ThemeProvider>
+    </div>
+  );
+};
 
 export default Decorator;


### PR DESCRIPTION
Fixes #193. Looks like Material UI wants the global CSS to be included explicitly.

![Screen Shot 2020-11-21 at 15 05 41](https://user-images.githubusercontent.com/6738398/99879201-7be80e00-2c0b-11eb-855a-653bd3b63cc7.png)
