### PR TITLE
fix(checklist): TypeError: Cannot read property 'categories' of undefined

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -23,7 +23,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
 
   const groupedOptions = useMemo(
     () =>
-      !props.data.categories
+      !props.data?.categories
         ? undefined
         : mapAccum(
             (index: number, category: { title: string; count: number }) => [


### PR DESCRIPTION
This is a runtime error that happens if you haven't added any checkitems to the checklist
