### PR TITLE
break(int-portal): more descriptive labels

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/InternalPortal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/InternalPortal.tsx
@@ -46,6 +46,7 @@ const InternalPortalForm: React.FC<{
   return (
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">
       <div>
+        Create new internal portal:{" "}
         <InputField
           autoFocus
           name="text"
@@ -60,7 +61,12 @@ const InternalPortalForm: React.FC<{
       </div>
       {flows?.length > 0 && (
         <>
-          <span> OR </span>
+          <span>
+            <br /> OR
+            <br />
+            <br />
+            Point to an existing portal: <br />
+          </span>
           <select
             data-testid="flowId"
             name="flowId"


### PR DESCRIPTION
I know we want to refrain from using \<br/>s,
so if you don't think this PR is a net positive I'm happy to kill it.
Personally, I think it's an improvement worth merging.

You be the judge ;)


![image](https://user-images.githubusercontent.com/7684574/100093407-6400cc00-2e4f-11eb-9b82-7db3ed932f53.png)
![image](https://user-images.githubusercontent.com/7684574/100093461-7549d880-2e4f-11eb-931d-01de09877228.png)
