### PR TITLE
Date input editor copy fix

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -29,7 +29,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Text Input" Icon={ICONS[TYPES.DateInput]}>
+        <ModalSectionContent title="Date Input" Icon={ICONS[TYPES.DateInput]}>
           <InputRow>
             <Input
               format="large"


### PR DESCRIPTION
Fixes this little mistake here with the `Text Input` copy:

![Screen Shot 2020-11-26 at 11 47 30](https://user-images.githubusercontent.com/6738398/100341746-43ff1300-2fdd-11eb-82c6-d07a711099ba.png)
