### PR TITLE
update hasura permissions to allow public to use preview urls

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -30,6 +30,16 @@
         schema: public
         name: compile_flow_portals
     comment: Flow data with portals merged in
+  select_permissions:
+  - role: public
+    permission:
+      columns:
+      - data
+      - id
+      - name
+      - slug
+      - team_id
+      filter: {}
 - table:
     schema: public
     name: operations
@@ -140,6 +150,15 @@
         table:
           schema: public
           name: team_members
+  select_permissions:
+  - role: public
+    permission:
+      columns:
+      - id
+      - name
+      - slug
+      - theme
+      filter: {}
 - table:
     schema: public
     name: users


### PR DESCRIPTION
This is a temporary update as there is no sensitive info held in flows yet. It will allow us to share /preview urls to unauthenticated users during demos.