### PR TITLE
fix header margin

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/DecisionButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/DecisionButton.tsx
@@ -8,6 +8,7 @@ import ButtonBase, { Props as ButtonProps } from "./ButtonBase";
 export const useStyles = makeStyles((theme) => ({
   key: {
     opacity: 0.5,
+    backgroundColor: "inherit",
   },
 }));
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
   },
   description: {
     "& p": {
-      margin: `${theme.spacing(1)} 0`,
+      margin: `${theme.spacing(1)}px 0`,
     },
   },
 }));
@@ -39,7 +39,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
   const classes = useStyles();
 
   return (
-    <>
+    <Box mb={2}>
       <Grid container justify="space-between" wrap="nowrap">
         <Grid item>
           {title && (
@@ -87,7 +87,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           </MoreInfoSection>
         )}
       </MoreInfo>
-    </>
+    </Box>
   );
 };
 export default QuestionHeader;


### PR DESCRIPTION
Fix margin issue on questions without descriptions:

Before:
<img width="714" alt="Screen Shot 2020-12-15 at 2 32 30 PM" src="https://user-images.githubusercontent.com/2712962/102280627-5f758380-3ee2-11eb-8f4b-70e4c0c790f1.png">


After:
<img width="498" alt="Screen Shot 2020-12-15 at 2 30 07 PM" src="https://user-images.githubusercontent.com/2712962/102280562-3ead2e00-3ee2-11eb-9d17-8bb0e425ca95.png">
<img width="499" alt="Screen Shot 2020-12-15 at 2 30 22 PM" src="https://user-images.githubusercontent.com/2712962/102280566-410f8800-3ee2-11eb-96c1-44ffd2b10ab3.png">
