### PR TITLE
Validate AddressInput

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/Combined.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Combined.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta } from "@storybook/react/types-6-0";
+import React from "react";
+
+import Wrapper from "../fixtures/Wrapper";
+import Editor from "./Editor";
+import Public from "./Public";
+
+const metadata: Meta = {
+  title: "PlanX Components/AddressInput",
+};
+
+export const Combined = () => {
+  return <Wrapper Editor={Editor} Public={Public} />;
+};
+
+export default metadata;

--- a/editor.planx.uk/src/@planx/components/AddressInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Public.tsx
@@ -1,43 +1,37 @@
-import Button from "@material-ui/core/Button";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { PublicProps } from "@planx/components/ui";
-import React, { ChangeEvent, useMemo, useState } from "react";
+import { useFormik } from "formik";
+import React from "react";
 import Input from "ui/Input";
 import InputLabel from "ui/InputLabel";
 import InputRow from "ui/InputRow";
 import InputRowItem from "ui/InputRowItem";
 
-import { AddressInput, UserData } from "./model";
+import type { AddressInput, UserData } from "./model";
+import { userDataSchema } from "./model";
 
 export type Props = PublicProps<AddressInput, UserData>;
 
 export default function AddressInputComponent(props: Props): FCReturn {
-  const [value, setValue] = useState<UserData>({
-    line1: "",
-    line2: "",
-    town: "",
-    county: "",
-    postcode: "",
+  const formik = useFormik({
+    initialValues: {
+      line1: "",
+      line2: "",
+      town: "",
+      county: "",
+      postcode: "",
+    },
+    onSubmit: (values) => {
+      props.handleSubmit && props.handleSubmit(values);
+    },
+    validateOnBlur: false,
+    validateOnChange: false,
+    validationSchema: userDataSchema,
   });
 
-  type AddressLine = keyof UserData;
-
-  const isValid = useMemo(() => {
-    return true;
-  }, [value]);
-
-  const update = (line: AddressLine) => ({
-    target: { value },
-  }: ChangeEvent<HTMLInputElement>) => {
-    setValue((prev) => ({
-      ...prev,
-      [line]: value,
-    }));
-  };
-
   return (
-    <Card>
+    <Card handleSubmit={formik.handleSubmit}>
       <QuestionHeader
         title={props.title}
         description={props.description}
@@ -47,58 +41,56 @@ export default function AddressInputComponent(props: Props): FCReturn {
       />
       <InputLabel label="building and street">
         <Input
-          value={value.line1}
+          name="line1"
+          value={formik.values.line1}
           placeholder="Line 1"
           bordered
-          onChange={update("line1")}
+          errorMessage={formik.errors.line1}
+          onChange={formik.handleChange}
         />
       </InputLabel>
       <InputRow>
         <Input
-          value={value.line2}
+          name="line2"
+          value={formik.values.line2}
           placeholder="Line 2"
           bordered
-          onChange={update("line2")}
+          errorMessage={formik.errors.line2}
+          onChange={formik.handleChange}
         />
       </InputRow>
       <InputLabel label="town">
         <Input
-          value={value.town}
+          name="town"
+          value={formik.values.town}
           placeholder="Town"
           bordered
-          onChange={update("town")}
+          errorMessage={formik.errors.town}
+          onChange={formik.handleChange}
         />
       </InputLabel>
       <InputLabel label="county">
         <Input
-          value={value.county}
+          name="county"
+          value={formik.values.county}
           placeholder="County"
           bordered
-          onChange={update("county")}
+          errorMessage={formik.errors.county}
+          onChange={formik.handleChange}
         />
       </InputLabel>
       <InputLabel label="postal code">
         <InputRowItem width="40%">
           <Input
-            value={value.postcode}
+            name="postcode"
+            value={formik.values.postcode}
             placeholder="Postal code"
             bordered
-            onChange={update("postcode")}
+            errorMessage={formik.errors.postcode}
+            onChange={formik.handleChange}
           />
         </InputRowItem>
       </InputLabel>
-      <Button
-        variant="contained"
-        color="primary"
-        size="large"
-        type="submit"
-        disabled={!isValid}
-        onClick={() => {
-          props.handleSubmit && props.handleSubmit(value);
-        }}
-      >
-        Continue
-      </Button>
     </Card>
   );
 }

--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -1,3 +1,6 @@
+import type { SchemaOf } from "yup";
+import { object, string } from "yup";
+
 import { MoreInformation, parseMoreInformation } from "../shared";
 
 export type UserData = {
@@ -7,6 +10,14 @@ export type UserData = {
   county: string;
   postcode: string;
 };
+
+export const userDataSchema: SchemaOf<UserData> = object({
+  line1: string().required(),
+  line2: string().required(),
+  town: string().required(),
+  county: string().required(),
+  postcode: string().required(),
+});
 
 export interface AddressInput extends MoreInformation {
   title: string;

--- a/editor.planx.uk/src/@planx/components/fixtures/AddressInput.fixture.tsx
+++ b/editor.planx.uk/src/@planx/components/fixtures/AddressInput.fixture.tsx
@@ -1,9 +1,0 @@
-import React from "react";
-
-import Editor from "../AddressInput/Editor";
-import Public from "../AddressInput/Public";
-import Wrapper from "./Wrapper";
-
-export default () => {
-  return <Wrapper Editor={Editor} Public={Public} />;
-};

--- a/editor.planx.uk/src/ui/ErrorWrapper.tsx
+++ b/editor.planx.uk/src/ui/ErrorWrapper.tsx
@@ -8,6 +8,7 @@ export interface Props {
 
 const useClasses = makeStyles((theme) => ({
   rootError: {
+    width: "100%",
     paddingLeft: theme.spacing(2),
     borderLeft: `3px solid ${theme.palette.error.main}`,
   },

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -3,6 +3,8 @@ import { makeStyles } from "@material-ui/core/styles";
 import classNames from "classnames";
 import React, { ChangeEvent } from "react";
 
+import ErrorWrapper from "./ErrorWrapper";
+
 interface Props extends InputBaseProps {
   format?: "large" | "bold" | "data";
   classes?: any;
@@ -10,6 +12,7 @@ interface Props extends InputBaseProps {
   grow?: boolean;
   large?: boolean;
   bordered?: boolean;
+  errorMessage?: string;
   onChange?: (ev: ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -60,20 +63,22 @@ export default function Input(props: Props): FCReturn {
   const { format, bordered, ...restProps } = props;
 
   return (
-    <InputBase
-      className={classNames(
-        classes.input,
-        format === "large" && classes.questionInput,
-        format === "bold" && classes.bold,
-        format === "data" && classes.data,
-        bordered && classes.bordered
-      )}
-      classes={{
-        multiline: classes.inputMultiline,
-        adornedEnd: classes.adornedEnd,
-        focused: classes.focused,
-      }}
-      {...restProps}
-    />
+    <ErrorWrapper error={props.errorMessage}>
+      <InputBase
+        className={classNames(
+          classes.input,
+          format === "large" && classes.questionInput,
+          format === "bold" && classes.bold,
+          format === "data" && classes.data,
+          bordered && classes.bordered
+        )}
+        classes={{
+          multiline: classes.inputMultiline,
+          adornedEnd: classes.adornedEnd,
+          focused: classes.focused,
+        }}
+        {...restProps}
+      />
+    </ErrorWrapper>
   );
 }


### PR DESCRIPTION
Address validation in the public interface:

![Screen Shot 2021-01-20 at 11 03 01](https://user-images.githubusercontent.com/6738398/105159230-20ed6d00-5b0f-11eb-89f6-ff365ec598e2.png)

@johnrees any specific rules we'd like to implement at this time? Currently address line 2 is mandatory, and I'm not doing anything with the postal code apart from checking it's non-empty. Also county is free text.