### PR TITLE
Fix preview layout on safari

### DIFF
--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -7,9 +7,10 @@ import { Link } from "react-navi";
 
 const useClasses = makeStyles((theme) => ({
   root: {
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: "#fff",
     padding: `${theme.spacing(1.5)}px 0`,
     display: "flex",
+    flex: "0 0 auto",
     justifyContent: "space-between",
   },
   link: {

--- a/editor.planx.uk/src/pages/Preview/index.tsx
+++ b/editor.planx.uk/src/pages/Preview/index.tsx
@@ -62,7 +62,7 @@ const Preview: React.FC<{ theme?: any; embedded?: boolean }> = ({
         style={{
           paddingTop: 40,
           display: "flex",
-          flex: 1,
+          flex: "1 0 auto",
           flexDirection: "column",
           alignItems: "center",
           background: "#fff",


### PR DESCRIPTION
A bit of flexbox property juggling but I finally get it to work and do the proper sticky footer thing:

![safari-footer](https://user-images.githubusercontent.com/6738398/105733937-5ab8dc00-5f32-11eb-80f1-b2d4e9994a4d.gif)
