### PR TITLE
feat: custom council primary colour in Preview

### DIFF
--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -46,12 +46,13 @@ export default function PhaseBanner(): FCReturn {
       >
         <Box
           bgcolor="primary.main"
+          color="white"
           display="flex"
           alignItems="center"
           px={2}
           className={classes.betaIcon}
         >
-          <Typography color="textSecondary" variant="h6" align="center">
+          <Typography color="inherit" variant="h6" align="center">
             BETA
           </Typography>
         </Box>

--- a/editor.planx.uk/src/pages/Preview/index.tsx
+++ b/editor.planx.uk/src/pages/Preview/index.tsx
@@ -1,3 +1,4 @@
+import { createMuiTheme, Theme, ThemeProvider } from "@material-ui/core/styles";
 import React from "react";
 
 import Footer from "../../components/Footer";
@@ -36,8 +37,6 @@ const Preview: React.FC<{ theme?: any; embedded?: boolean }> = ({
     state.previousCard(),
   ]);
 
-  // TODO: are these configurable in settings?
-
   const leftFooterItems = [
     {
       title: "Privacy",
@@ -53,8 +52,19 @@ const Preview: React.FC<{ theme?: any; embedded?: boolean }> = ({
     },
   ];
 
+  const generatePreviewTheme = (baseTheme: Theme) =>
+    createMuiTheme({
+      ...baseTheme,
+      palette: {
+        ...baseTheme.palette,
+        primary: {
+          main: theme.primary,
+        },
+      },
+    });
+
   return (
-    <>
+    <ThemeProvider theme={generatePreviewTheme}>
       {!embedded && (
         <Header bgcolor={theme.primary} logo={theme.logo} phaseBanner />
       )}
@@ -88,7 +98,7 @@ const Preview: React.FC<{ theme?: any; embedded?: boolean }> = ({
       {!embedded && (
         <Footer leftItems={leftFooterItems} rightItems={rightFooterItems} />
       )}
-    </>
+    </ThemeProvider>
   );
 };
 


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-01-28 at 2 26 51 PM" src="https://user-images.githubusercontent.com/2712962/106206411-df933800-6174-11eb-863e-b2b8b94d10ba.png">



###  Known issue: this is a quick solution for the non-embedded `Preview`; the Editor browser will use the default colour `#2c2c2c` for now:
<img width="1440" alt="Screen Shot 2021-01-28 at 2 30 22 PM" src="https://user-images.githubusercontent.com/2712962/106206693-5d574380-6175-11eb-8394-41d6e9b8e44a.png">
