### PR TITLE
fix: Phase Banner looks better on mobile

### DIFF
--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -41,7 +41,7 @@ export default function PhaseBanner(): FCReturn {
         display="flex"
         alignItems="center"
         borderBottom={`1px solid ${theme.palette.grey[300]}`}
-        px={1}
+        px={2}
         py={1}
       >
         <Box
@@ -49,13 +49,12 @@ export default function PhaseBanner(): FCReturn {
           color="white"
           display="flex"
           alignItems="center"
-          flexShrink={3}
-          flexGrow={0}
+          flexBasis={0}
           px={2}
           mr={2}
           className={classes.betaIcon}
         >
-          <Typography color="inherit" variant="h6">
+          <Typography color="inherit" variant="h6" align="center">
             BETA
           </Typography>
         </Box>


### PR DESCRIPTION
<img width="356" alt="Screen Shot 2021-02-02 at 5 33 14 PM" src="https://user-images.githubusercontent.com/2712962/106685463-4baedb00-657d-11eb-9406-ac683e4a9489.png">
