### PR TITLE
fix: add wait-for-expect to handle transitions

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -104,7 +104,8 @@
     "sass-loader": "^10.1.1",
     "storybook-addon-material-ui": "^0.9.0-alpha.21",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.0.5",
+    "wait-for-expect": "^3.0.2"
   },
   "scripts": {
     "start": "craco start",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -100,6 +100,7 @@ devDependencies:
   storybook-addon-material-ui: 0.9.0-alpha.21_60294784e9b0e2a5de011e6f55e7076d
   tsconfig-paths-webpack-plugin: 3.3.0
   typescript: 4.0.5
+  wait-for-expect: 3.0.2
 lockfileVersion: 5.2
 packages:
   /@apollo/client/3.2.5_c933677bd974310a9e498a3507664588:
@@ -8141,12 +8142,12 @@ packages:
     resolution:
       integrity: sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
   /core-js/1.2.7:
-    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: true
     resolution:
       integrity: sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
   /core-js/2.6.11:
-    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     requiresBuild: true
     resolution:
       integrity: sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -17410,7 +17411,7 @@ packages:
       request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
-    deprecated: 'request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142'
+    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     dev: false
     engines:
       node: '>=0.12.0'
@@ -17440,7 +17441,7 @@ packages:
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    deprecated: 'request has been deprecated, see https://github.com/request/request/issues/3142'
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     engines:
       node: '>= 6'
     resolution:
@@ -17525,7 +17526,7 @@ packages:
     resolution:
       integrity: sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==
   /resolve-url/0.2.1:
-    deprecated: 'https://github.com/lydell/resolve-url#deprecated'
+    deprecated: https://github.com/lydell/resolve-url#deprecated
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
   /resolve/1.18.1:
@@ -19632,7 +19633,7 @@ packages:
     resolution:
       integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   /urix/0.1.0:
-    deprecated: 'Please see https://github.com/lydell/urix#deprecated'
+    deprecated: Please see https://github.com/lydell/urix#deprecated
     resolution:
       integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
   /url-loader/4.1.1_file-loader@6.1.1+webpack@4.44.2:
@@ -19906,6 +19907,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+  /wait-for-expect/3.0.2:
+    dev: true
+    resolution:
+      integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
   /walker/1.0.7:
     dependencies:
       makeerror: 1.0.11
@@ -20734,5 +20739,6 @@ specifiers:
   swr: ^0.4.0
   tsconfig-paths-webpack-plugin: ^3.3.0
   typescript: ^4.0.5
+  wait-for-expect: ^3.0.2
   yup: ^0.32.8
   zustand: ^3.1.4

--- a/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import waitForExpect from "wait-for-expect";
 
 import Question from "./Public";
 
@@ -28,7 +29,11 @@ test("renders correctly", async () => {
 
   expect(screen.getByRole("heading")).toHaveTextContent("Best food");
 
-  userEvent.click(screen.getByText("Pizza"));
+  await act(async () => {
+    await userEvent.click(screen.getByText("Pizza"));
 
-  expect(handleSubmit).toHaveBeenCalledWith("pizza_id");
+    await waitForExpect(() => {
+      expect(handleSubmit).toHaveBeenCalledWith("pizza_id");
+    });
+  });
 });


### PR DESCRIPTION
These async tests are starting to look silly now but this fixes the failing test in #307

Let's focus on which tests to remove/edit in the next dev call