### PR TITLE
fix: make ReactMarkdownOrHtml.source optional to fix editor crash

### DIFF
--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -12,11 +12,11 @@ const useClasses = makeStyles({
 });
 
 export default function ReactMarkdownOrHtml(props: {
-  source: string;
+  source?: string;
   className?: string;
 }): FCReturn {
   const classes = useClasses();
-  if (props.source.includes("<p>")) {
+  if (props.source?.includes("<p>")) {
     return (
       <div
         className={classNames(props.className, classes.htmlRoot)}


### PR DESCRIPTION
https://opensystemslab.slack.com/archives/C5Q59R3HB/p1612863266022500