### PR TITLE
Allow space after postcode

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -312,6 +312,8 @@ function GetAddress({
               placeholder="Enter the postcode of the property"
               value={postcode || ""}
               onChange={(e: any) => {
+                // XXX: If you press a key on the keyboard, you expect something to show up on the screen,
+                //      so this code attempts to validate postcodes without blocking any characters.
                 const input = e.target.value;
                 if (parse(input.trim()).valid) {
                   setSanitizedPostcode(toNormalised(input.trim()));


### PR DESCRIPTION
> One of the little bits of feedback we got from testing is that users found if they enter a space after the postcode, it wont let them proceed. Is it possible to doing anything about this? e.g it disregards any spaces?
