### PR TITLE
feat: nicer loading font

### DIFF
--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -1,5 +1,6 @@
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 import React, { useEffect, useState } from "react";
 
 const useClasses = makeStyles({
@@ -9,15 +10,15 @@ const useClasses = makeStyles({
     alignItems: "center",
     justifyContent: "center",
   },
-  children: {
+  text: {
     marginLeft: "1rem",
   },
 });
 
 const DelayedLoadingIndicator: React.FC<{
   msDelayBeforeVisible?: number;
-  children?: React.ReactNode;
-}> = ({ msDelayBeforeVisible = 50, children }) => {
+  text?: string;
+}> = ({ msDelayBeforeVisible = 50, text }) => {
   const [visible, setVisible] = useState(false);
 
   const classes = useClasses();
@@ -32,7 +33,9 @@ const DelayedLoadingIndicator: React.FC<{
   return visible ? (
     <div className={classes.container}>
       <CircularProgress />
-      <div className={classes.children}>{children ?? "Loading…"}</div>
+      <Typography variant="body2" className={classes.text}>
+        {text ?? "Loading…"}
+      </Typography>
     </div>
   ) : null;
 };


### PR DESCRIPTION
Before:

![after](https://user-images.githubusercontent.com/2712962/107837578-6e4bab80-6d56-11eb-89d7-b19ae8d04d9b.gif)

After:
![before](https://user-images.githubusercontent.com/2712962/107837579-70156f00-6d56-11eb-8748-2496492e9b5b.gif)


Not an earth-shattering improvement, but I made a [trello ticket](https://trello.com/c/B9MYmTQk/867-nicer-loading-state) for that 😉 
