### PR TITLE
fix: remove test warnings related to wrapping with act()

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -9,7 +9,9 @@ test("renders correctly and blocks submit if there are no files added", async ()
 
   render(<FileUpload handleSubmit={handleSubmit} />);
 
-  userEvent.click(screen.getByText("Continue"));
+  await act(async () => {
+    await userEvent.click(screen.getByText("Continue"));
+  });
 
   expect(handleSubmit).toHaveBeenCalledTimes(0);
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -13,10 +13,12 @@ test("apple pay", async () => {
 
   render(<Pay handleSubmit={handleSubmit} />);
 
-  await waitForThenClick("Apple Pay");
-  await waitForThenClick("Continue");
-  await waitForThenClick("Pay & submit");
-  await waitForThenClick("Continue");
+  await act(async () => {
+    await waitForThenClick("Apple Pay");
+    await waitForThenClick("Continue");
+    await waitForThenClick("Pay & submit");
+    await waitForThenClick("Continue");
+  });
 
   expect(handleSubmit).toHaveBeenCalled();
 });
@@ -26,8 +28,10 @@ test("do not call credit card form that was not filled out", async () => {
 
   render(<Pay handleSubmit={handleSubmit} />);
 
-  await waitForThenClick("Credit or debit card");
-  await waitForThenClick("Continue");
+  await act(async () => {
+    await waitForThenClick("Credit or debit card");
+    await waitForThenClick("Continue");
+  });
 
   expect(handleSubmit).toHaveBeenCalledTimes(0);
 });


### PR DESCRIPTION
![Screenshot 2021-02-15 at 12 21 30 PM](https://user-images.githubusercontent.com/601961/107948480-c8818200-6f8b-11eb-8557-dd444cc7fdb7.png)

Wrapped some public component tests in act to remove the warnings about changing state