### PR TITLE
fix: add default type to Pay button

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Button.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Button.tsx
@@ -14,5 +14,9 @@ import React from "react";
 
 function Component(props: any) {
   const { children, ...rest } = props;
-  return <button {...rest}>{children}</button>;
+  return (
+    <button type="submit" {...rest}>
+      {children}
+    </button>
+  );
 }


### PR DESCRIPTION
![Screenshot 2021-02-15 at 12 25 00 PM](https://user-images.githubusercontent.com/601961/107948617-01215b80-6f8c-11eb-9ea3-4331ed5b7b2e.png)

adds a default type="submit" state to the button used in Pay component(s) to remove warning from logs