### PR TITLE
fix: preview vs editor inconsistency

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -168,7 +168,7 @@ function Component(props: Props) {
           },
           {
             heading: "District",
-            detail: capitalize(route.data.team),
+            detail: capitalize(team),
           },
           {
             heading: "Building type",


### PR DESCRIPTION
Sidebar preview doesn't go past FindProperty right now. This fixes it.

This is a HOTFIX so I'll probably merge without review.
