### PR TITLE
draw boundary PR suggestions

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -32,6 +32,8 @@ function Component(props: Props) {
   const [boundary, setBoundary] = useState<Boundary>();
   const area = boundary !== undefined ? round(turfArea(boundary)) : 0;
 
+  if (!passport?.info?.latitude || !passport?.info?.longitude) return null;
+
   return (
     <Card handleSubmit={handleSubmit} isValid={Boolean(boundary)}>
       <QuestionHeader title={props.title} description={props.description} />


### PR DESCRIPTION
I noticed there's an issue with the editor, if someone was to accidentally add the `draw boundary` component before the `find property` component, or move it somewhere else in the flow, or delete the preceding `find property` component it can cause the editor to crash because I think mapbox always expects lat/lng values?

I added a quick and dirty fix here but could you take a look and add this or something similar to the original PR please?

https://user-images.githubusercontent.com/601961/109141021-24e75d00-7755-11eb-895b-9d7af5f17152.mp4

Thanks!