### PR TITLE
feat: remember values to answers that are not selected (not null logic)

### DIFF
--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -434,3 +434,24 @@ export const makeUnique = (
     };
     _makeUnique(id, parent, { idFn }, true);
   });
+
+const dfs = (graph: Graph) => (startId: string) => {
+  const visited = new Set([startId]);
+  const crawlFrom = (id: string) => {
+    visited.add(id);
+    graph[id].edges?.forEach((childId) => {
+      crawlFrom(childId);
+    });
+  };
+  crawlFrom(startId);
+  return [...visited];
+};
+
+export const sortIdsDepthFirst = (graph: Graph) => (
+  nodeIds: Set<string>
+): Array<string> => {
+  const allNodeIdsSorted = dfs(graph)(ROOT_NODE_KEY);
+  return Array.from(nodeIds).sort(
+    (a, b) => allNodeIdsSorted.indexOf(a) - allNodeIdsSorted.indexOf(b)
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/useNotValues.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/useNotValues.test.ts
@@ -1,0 +1,133 @@
+import { vanillaStore } from "../store";
+
+// flow preview: https://i.imgur.com/nCov5CE.png
+
+const flow = {
+  _root: {
+    edges: ["NS7QFc7Cjc", "3cNtq1pLmt", "eTBHJsbJKc"],
+  },
+  "3cNtq1pLmt": {
+    data: {
+      fn: "animal",
+      text: "is it a lion?",
+    },
+    type: 100,
+    edges: ["TDIbLrdTdd", "TnvmCtle0s"],
+  },
+  BecasKrIhI: {
+    data: {
+      text: "neither",
+    },
+    type: 200,
+  },
+  NS7QFc7Cjc: {
+    data: {
+      fn: "animal",
+      text: "which wild cat is it?",
+    },
+    type: 100,
+    edges: ["sv0hklWPX1", "UqZo0rGwcY", "BecasKrIhI"],
+  },
+  Nrf7BHDJvO: {
+    data: {
+      text: "neither",
+    },
+    type: 200,
+    edges: ["UOefNWg6uf"],
+  },
+  Sd38UCC8Cg: {
+    data: {
+      content: "<p>it's a lion</p>\n",
+    },
+    type: 250,
+  },
+  TDIbLrdTdd: {
+    data: {
+      val: "lion",
+      text: "yes",
+    },
+    type: 200,
+  },
+  TnvmCtle0s: {
+    data: {
+      text: "no",
+    },
+    type: 200,
+  },
+  UOefNWg6uf: {
+    data: {
+      content: "<p>it's a tiger or something else</p>\n",
+    },
+    type: 250,
+  },
+  UqZo0rGwcY: {
+    data: {
+      val: "tiger",
+      text: "tiger",
+    },
+    type: 200,
+  },
+  eOoDvdKjWf: {
+    data: {
+      val: "lion",
+      text: "lion",
+    },
+    type: 200,
+    edges: ["Sd38UCC8Cg"],
+  },
+  eTBHJsbJKc: {
+    data: {
+      fn: "animal",
+      text: "ok, so which animal is it?",
+    },
+    type: 100,
+    edges: ["eOoDvdKjWf", "nR15Tl0lhC", "Nrf7BHDJvO"],
+  },
+  nR15Tl0lhC: {
+    data: {
+      val: "gazelle",
+      text: "gazelle",
+    },
+    type: 200,
+    edges: ["pqZK1mpn23"],
+  },
+  pqZK1mpn23: {
+    data: {
+      content: "<p>it's a gazelle</p>\n",
+    },
+    type: 250,
+  },
+  sv0hklWPX1: {
+    data: {
+      val: "lion",
+      text: "lion",
+    },
+    type: 200,
+  },
+};
+
+const { getState, setState } = vanillaStore;
+
+describe("if I initially pick", () => {
+  beforeEach(() => {
+    getState().resetPreview();
+    setState({ flow });
+  });
+
+  test("lion, it should display 'lion'", () => {
+    getState().record("NS7QFc7Cjc", ["TDIbLrdTdd"]);
+    expect(getState().upcomingCardIds()).toEqual(["Sd38UCC8Cg"]);
+  });
+
+  test("tiger, it should display 'tiger or something else'", () => {
+    getState().record("NS7QFc7Cjc", ["UqZo0rGwcY"]);
+    expect(getState().upcomingCardIds()).toEqual(["UOefNWg6uf"]);
+  });
+
+  test("gazelle, it should ask which animal it is", () => {
+    getState().record("NS7QFc7Cjc", ["BecasKrIhI"]);
+    expect(getState().upcomingCardIds()).toEqual(["eTBHJsbJKc"]);
+    getState().record("eTBHJsbJKc", ["nR15Tl0lhC"]);
+    expect(getState().upcomingCardIds()).toEqual(["pqZK1mpn23"]);
+  });
+});


### PR DESCRIPTION
first step towards getting not null logic to work, test flow below -

https://605dcbd5aa318cf334a8147e--planx-new.netlify.app/testing/not-null-test

Unfortunately the logic code is still really nasty but it does what it needs to right now. I'd like to merge this PR and then open some new ones related to

- back button logic fixes (#399)
- fixing issues with different granularities of data e.g. `lion.simba` and `lion`
- fixing an issue with lists of data
- more refactoring to help with the readability and maintainability of store.upcomingCardIds
- possibly hiding or disabling options that should not be selectable e.g. if you pick gazelle in the example below then _Lion_ should not be a choice

https://user-images.githubusercontent.com/601961/112628577-fbd8eb80-8e2a-11eb-8bd1-73776604df64.mp4

I'm also aware of the issues that might arise with the different terms used in the codebase e.g. flow/graph, node/card etc. I'd like to raise it as a point of discussion in the next dev chat.