### PR TITLE
break: only type check staged files

### DIFF
--- a/editor.planx.uk/.gitignore
+++ b/editor.planx.uk/.gitignore
@@ -24,3 +24,4 @@ yarn-debug.log*
 yarn-error.log*
 
 *.validator.ts
+.tsconfig-lint.json

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -159,7 +159,7 @@
       "prettier --write"
     ],
     "src/**/*.{ts,tsx}": [
-      "sh -c tsc --noEmit"
+      "scripts/tsc-lint.sh"
     ]
   }
 }

--- a/editor.planx.uk/scripts/tsc-lint.sh
+++ b/editor.planx.uk/scripts/tsc-lint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+TMP=.tsconfig-lint.json
+cat >$TMP <<EOF
+{
+  "extends": "./tsconfig.json",
+  "include": [
+EOF
+for file in "$@"; do
+  echo "    \"$file\"," >> $TMP
+done
+cat >>$TMP <<EOF
+    "**/*.d.ts"
+  ]
+}
+EOF
+
+FILES_WITH_ERRORS=$(tsc --project $TMP --noEmit --skipLibCheck | cut -d '(' -f 1)
+
+for file in "$@"; do
+  grep -v "$file"<<<"$FILES_WITH_ERRORS" >/dev/null
+done


### PR DESCRIPTION
Previous command was type-checking all files in the repo, which was an incentive for larger commits.

This is based on and improved upon:

https://stackoverflow.com/a/60950355/1456173
