### PR TITLE
fix: ensure flow[id] exists before crawling it

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store.ts
@@ -655,6 +655,7 @@ export const vanillaStore = vanillaCreate<Store>((set, get) => ({
       const visited = new Set([start]);
 
       const crawlFrom = (id: string) => {
+        if (!flow[id]) return;
         visited.add(id);
         flow[id].edges?.forEach((childId) => {
           crawlFrom(childId);


### PR DESCRIPTION
prevents this error when adding a node to an empty flow -

![Screenshot 2021-03-23 at 2 11 55 PM](https://user-images.githubusercontent.com/601961/112165281-82e95200-8be6-11eb-8582-91c7c3b4fc2a.png)