### PR TITLE
fix: add optional chaining for node?.data to fix deleting bug

### DIFF
--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -102,7 +102,7 @@ const editNode = route(async (req) => {
 
   if (type === "checklist" || type === "question") {
     const childNodes = useStore.getState().childNodesOf(id);
-    if (node.data.categories) {
+    if (node.data?.categories) {
       extraProps.groupedOptions = mapAccum(
         (index: number, category: { title: string; count: number }) => [
           index + category.count,


### PR DESCRIPTION
should prevent this from happening -

user tries to delete empty question:
<img width="713" alt="screenshot_2021-03-24_at_16 41 16" src="https://user-images.githubusercontent.com/601961/112352580-ca451080-8cc2-11eb-9e7a-36b64ed5f1f6.png">

gets:
<img width="761" alt="screenshot_2021-03-24_at_16 42 53" src="https://user-images.githubusercontent.com/601961/112352575-c9ac7a00-8cc2-11eb-8dbe-5c3cff67eabe.png">
