### PR TITLE
fix: remove ids from seeds to avoid not-unique sequence error

### DIFF
--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -1,5 +1,5 @@
-INSERT INTO public.teams (id, name, slug, theme) VALUES (1, 'Open Systems Lab', 'opensystemslab', '{}');
-INSERT INTO public.teams (id, name, slug, theme) VALUES (2, 'Canterbury', 'canterbury', '{"logo": "https://editor.planx.uk/logos/canterbury.svg", "primary": "#331035"}');
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (1, 'John', 'Rees', 'john@opensystemslab.io', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (3, 'Gunar', 'Gessner', 'gunargessner@gmail.com', true);
+INSERT INTO public.teams (name, slug, theme) VALUES ('Open Systems Lab', 'opensystemslab', '{}');
+INSERT INTO public.teams (name, slug, theme) VALUES ('Canterbury', 'canterbury', '{"logo": "https://editor.planx.uk/logos/canterbury.svg", "primary": "#331035"}');
+INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('John', 'Rees', 'john@opensystemslab.io', true);
+INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Alastair', 'Parvin', 'alastair@opensystemslab.io', true);
+INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Gunar', 'Gessner', 'gunargessner@gmail.com', true);


### PR DESCRIPTION
we ran into an issue earlier when trying to add a new user in hasura console 

![Screenshot from 2021-03-30 16-37-28](https://user-images.githubusercontent.com/601961/113025783-3ec6f600-9180-11eb-9dd3-9e6addcc5894.png)

fixed it by running this SQL and then trying again

![Screenshot 2021-03-30 at 3 41 07 PM](https://user-images.githubusercontent.com/601961/113025850-51412f80-9180-11eb-9e0a-9cc3d12ed6e9.png)

but it also works if we don't specify ids as proposed in this PR