### PR TITLE
fix: ensure graph node[id] exists before trying to crawl from it

### DIFF
--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -438,6 +438,7 @@ export const makeUnique = (
 const dfs = (graph: Graph) => (startId: string) => {
   const visited = new Set([startId]);
   const crawlFrom = (id: string) => {
+    if (!graph[id]) return;
     visited.add(id);
     graph[id].edges?.forEach((childId) => {
       crawlFrom(childId);


### PR DESCRIPTION
prevents this from happening

here I try to delete the only node in a flow -

https://user-images.githubusercontent.com/601961/113909955-30a45580-97d0-11eb-99cf-f450b55c5209.mp4

it's trying to crawl a deleted id because of the order of state updates or something.

I'll add tests to fix it more thoroughly when there's a bit of time to do so