### PR TITLE
fix: spread allProps to get wasVisited outline on Date + DrawBoundary

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -36,10 +36,10 @@ const Node: React.FC<any> = (props) => {
         />
       );
     case TYPES.DateInput:
-      return <Question {...props} text={node?.data?.title ?? "Date"} />;
+      return <Question {...allProps} text={node?.data?.title ?? "Date"} />;
     case TYPES.DrawBoundary:
       return (
-        <Question {...props} text={node?.data?.title ?? "Draw boundary"} />
+        <Question {...allProps} text={node?.data?.title ?? "Draw boundary"} />
       );
     case TYPES.ExternalPortal:
       return <Portal {...allProps} />;


### PR DESCRIPTION
before = `{...props}`
after = `{...allProps}`

https://user-images.githubusercontent.com/601961/114053260-b1be2400-9886-11eb-9114-c63f5dd666f5.mp4
