### PR TITLE
fix: optional chaining in calculate toScope

### DIFF
--- a/editor.planx.uk/src/@planx/components/Calculate/model.ts
+++ b/editor.planx.uk/src/@planx/components/Calculate/model.ts
@@ -104,6 +104,3 @@ export function evaluatePassport(
 function serialize(x: string) {
   return x.replace(/\./g, "_");
 }
-function parse(x: string) {
-  return x.replace(/_/g, ".");
-}


### PR DESCRIPTION
@gunar I just ran into this because `passport.data` isn't always `value: []` right now.

As all of this passport data stuff is changing imminently anyway so I propose we merge this fix now so that it doesn't crash on the live site. Not sure why an error boundary didn't catch it but hopefully this'll be ok for now?

![Screenshot 2021-04-08 at 4 35 35 PM](https://user-images.githubusercontent.com/601961/114056721-de276f80-9889-11eb-9409-510d569a4e34.png)

![Screenshot 2021-04-08 at 4 39 32 PM](https://user-images.githubusercontent.com/601961/114056744-e1baf680-9889-11eb-8391-53ec88cadfb9.png)
