### PR TITLE
fix: check if node exists to prevent bug when refreshing

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -503,6 +503,8 @@ export const previewStore = (
 
     const knownNotVals = Object.entries(breadcrumbs).reduce(
       (acc, [id, { answers = [] }]) => {
+        if (!flow[id]) return acc;
+
         const _knownNotVals = difference(
           flow[id].edges,
           answers as Array<Store.nodeId>


### PR DESCRIPTION
replaces #419

quick fix to ensure flow node exists when checking for `not` ids

prevents an error that occurred after refreshing the page
<img width="1666" alt="Screenshot 2021-04-09 at 10 26 53" src="https://user-images.githubusercontent.com/601961/114168727-8db31f00-9928-11eb-89e9-c4da86b67bc7.png">
