### PR TITLE
fix: force remove cookie for logout

### DIFF
--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -30,9 +30,19 @@ const editorRoutes = mount({
   ),
 
   "/logout": map((): any => {
-    client.resetStore();
-    Cookies.remove("jwt");
-    window.location.href = "/";
+    try {
+      client.resetStore();
+      Cookies.remove("jwt");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      // hack to force-remove cookie on editor.planx.uk
+      const cookieString = `jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      document.cookie = cookieString;
+      document.cookie = cookieString.concat(" domain=.planx.uk;");
+
+      window.location.href = "/";
+    }
   }),
 
   "*": map(async (req, context: RoutingContext) =>


### PR DESCRIPTION
Something weird is happening with /logout

The current `main` branch /logout works as expected on http://planx-new.netlify.app (1st attempt in video) but it doesn't on https://editor.planx.uk (2nd attempt in video)

https://user-images.githubusercontent.com/601961/115282571-43a91500-a142-11eb-9920-01ded5184677.mp4

It also works correctly locally.

---

I suspected it might be due to some cloudflare settings so I disabled RocketLoader and eventually put CF into development mode so it was effectively disabled, but nothing fixed it.

I'm proposing this temporary hack-fix, which should make sure the `jwt` cookie is deleted. It deletes cookies on the current domain and `.planx.uk` domain because they're set slightly differently for github PR previews.

The annoying part is, because this issue is only affecting production, I'll only know if it actually works once it's deployed. The PR preview is going to be helpful here.
