### PR TITLE
wip: improve editor navigation node outlines

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -14,6 +14,7 @@ import Node from "./Node";
 type Props = {
   type: TYPES;
   [key: string]: any;
+  isCurrent?: boolean;
   wasVisited?: boolean;
 };
 
@@ -77,6 +78,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           isDragging,
           isClone: isClone(props.id),
           isNote: childNodes.length === 0,
+          isCurrent: props.isCurrent,
           wasVisited: props.wasVisited,
         })}
       >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -13,13 +13,15 @@ import Portal from "./Portal";
 import Question from "./Question";
 
 const Node: React.FC<any> = (props) => {
-  const [node, wasVisited] = useStore((state) => [
+  const [node, wasVisited, isCurrent] = useStore((state) => [
     state.flow[props.id],
+    state.isCurrent(props.id),
     state.wasVisited(props.id),
   ]);
 
   const allProps = {
     ...props,
+    isCurrent,
     wasVisited,
   };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -24,7 +24,10 @@ const Option: React.FC<any> = (props) => {
 
   return (
     <li
-      className={classNames("card", "option", { wasVisited: props.wasVisited })}
+      className={classNames("card", "option", {
+        isCurrent: props.isCurrent,
+        wasVisited: props.wasVisited,
+      })}
     >
       <Link
         href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -14,6 +14,7 @@ import Node from "./Node";
 type Props = {
   type: TYPES | "Error";
   [key: string]: any;
+  isCurrent?: boolean;
   wasVisited?: boolean;
 };
 
@@ -59,6 +60,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           isDragging,
           isClone: isClone(props.id),
           isNote: childNodes.length === 0,
+          isCurrent: props.isCurrent,
           wasVisited: props.wasVisited,
           hasFailed: props.hasFailed,
         })}

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -127,11 +127,23 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     }
   }
 
-  &.wasVisited > a {
-    span {
-      opacity: 1;
+  &.isCurrent,
+  &.wasVisited {
+    & > a {
+      span {
+        opacity: 1;
+      }
+      border-width: 2px;
+      border-style: solid;
     }
-    border: 2px solid limegreen;
+  }
+
+  &.isCurrent > a {
+    border-color: hotpink;
+  }
+
+  &.wasVisited > a {
+    border-color: limegreen;
   }
 
   &.isClone > a {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -53,6 +53,8 @@ export interface PreviewStore extends Store.Store {
   // temporary measure for storing payment fee & id between gov uk redirect
   govUkPayment?: GovUKPayment;
   setGovUkPayment: (govUkPayment: GovUKPayment) => void;
+  // should really be in shared store
+  isCurrent: (id: Store.nodeId) => boolean;
 }
 
 // export const previewStore = vanillaCreate<PreviewStore>((set, get) => ({
@@ -641,5 +643,9 @@ export const previewStore = (
 
     // then return an array of the upcoming node ids, in depth-first order
     return sortIdsDepthFirst(flow)(ids);
+  },
+
+  isCurrent(id) {
+    return id === get().upcomingCardIds()?.[0];
   },
 });


### PR DESCRIPTION
# TODO

- [ ] highlight current active node
- [ ] different shade of green for nodes that were auto answered vs human answered
- [ ] highlight visited nodes that aren't recorded in breadcrumbs, i.e. < 1 answers