### PR TITLE
fix: hide continue button for final card in flow

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -3,6 +3,7 @@ import Button from "@material-ui/core/Button";
 import Container from "@material-ui/core/Container";
 import Fade from "@material-ui/core/Fade";
 import { makeStyles, Theme, useTheme } from "@material-ui/core/styles";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 interface Props {
@@ -34,6 +35,9 @@ const Card: React.FC<Props> = ({
   const classes = useStyles();
   const theme = useTheme();
 
+  const showContinue =
+    handleSubmit && useStore((state) => state.upcomingCardIds().length > 1);
+
   return (
     <Fade in={true} timeout={theme.transitions.duration.enteringScreen}>
       <Container maxWidth="md">
@@ -47,14 +51,14 @@ const Card: React.FC<Props> = ({
         >
           {children}
 
-          {handleSubmit && (
+          {showContinue && (
             <Button
               variant="contained"
               color="primary"
               size="large"
               type="submit"
               disabled={!isValid}
-              onClick={async () => await handleSubmit()}
+              onClick={async () => await handleSubmit!()}
             >
               Continue
             </Button>


### PR DESCRIPTION
Ideally this wouldn't recompute `state.upcomingCardIds()` as it is a relatively expensive operation, but it works for now. Zustand doesn't provide any support for memoized calls but maybe we could hack something together. I've really been missing [mobx's @computed](https://mobx.js.org/computeds.html) recently

before
![Screenshot 2021-05-07 at 1 29 23 PM](https://user-images.githubusercontent.com/601961/117449791-47a5a700-af38-11eb-98d3-4f6013e4130f.png)

after
![Screenshot 2021-05-07 at 1 29 27 PM](https://user-images.githubusercontent.com/601961/117449802-4bd1c480-af38-11eb-8d40-d5e8c2d9c07d.png)

It would also possibly be better if this was passed to Card as a prop, but the control flow is a bit messy now. This could be something to look at addressing in future.

## TODO

- [x] hide continue from final card
- [ ] amend the hasura session stuff so that it knows a flow is complete at this point
- [ ] ensure there is always a final card with no answer buttons or checkboxes?