### PR TITLE
fix: swap planning permission flags order so "immune" is most important

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/data/flags.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/data/flags.ts
@@ -6,8 +6,8 @@ import type { Flag } from "../../../types";
 // https://www.figma.com/file/bnUUrsVRG6qPwDkTmVKACI/Design?node-id=1971%3A0
 const categoriesAndFlags = {
   "Planning permission": {
-    MISSING_INFO: ["Missing information", "#EAEAEA"],
     IMMUNE: ["Immune", "#BEE6E7"],
+    MISSING_INFO: ["Missing information", "#EAEAEA"],
     PLANNING_PERMISSION_REQUIRED: ["Permission needed", "#A8A8A8"],
     PRIOR_APPROVAL: ["Prior approval", "#FCFF58"],
     "PP-NOTICE": ["Notice", "#CAFB8B"],


### PR DESCRIPTION
A small logic fix so that in a flow that picks up multiple flags, "Immune" will be considered the most important planning permission flag and shown in the Result component. Previously, "Missing information" was most important.

Deploy previews are broken still for a bit I guess, but I tested locally using a small flow like this: https://editor.planx.dev/testing/immunity

![Screenshot from 2021-05-27 15-14-10](https://user-images.githubusercontent.com/5132349/119832222-485da780-befe-11eb-906e-0b991c17b36b.png)
