### PR TITLE
fix: review page data parsing

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -116,7 +116,7 @@ function Component(props: Props) {
                       <a
                         onClick={() => {
                           const confirmed = window.confirm(
-                            `Are you sure you want to go back to change your answer? You may lose your answers to questions answered after this one.`
+                            `Are you sure you want to go back to change your answer? You will lose your answers to questions answered after this one.`
                           );
                           if (confirmed) {
                             props.changeAnswer(nodeId);
@@ -232,12 +232,14 @@ function DateInput(props: ComponentProps) {
 }
 
 function DrawBoundary(props: ComponentProps) {
+  const NOT_FOUND:string = "No drawing found";
+
   const { latitude, longitude } = props.passport.data?._address;
 
   // If a drawing, then encode GeoJSON for Mapbox API, else show a simple message
   const geojson:string = props.userData?.data && props.userData?.data["property.boundary.site"]
     ? encodeURIComponent(JSON.stringify(props.userData?.data["property.boundary.site"]))
-    : "No drawing found";
+    : NOT_FOUND;
 
   // Ordnance survey stylesheet (will also need `&addlayer={}` param to accurately display in future, I think)
   const stylesheet:string = "opensystemslab/ckbuw2xmi0mum1il33qucl4dv";
@@ -249,7 +251,7 @@ function DrawBoundary(props: ComponentProps) {
     <>
       <div>Site boundary</div>
       <div>
-        {geojson !== "No drawing found"
+        {geojson !== NOT_FOUND
           ? <img alt="Site boundary drawing" src={mapImg} />
           : geojson
         }


### PR DESCRIPTION
- [x] add draw boundary display component that renders static map image or "No drawing found" msg
- [x] add date input display component
- [x] add number input display component
- [x] fix file upload display component (was pointed to wrong props, now accounts for list items)
- [x] adjust alert message on "change" click per Trello suggestion
- [x] change button behavior (ensure can't skip pay)

Will make a new/separate card for Trello card for points about eventually editing in place, as that feels a lot bigger than display issues! 

Before:
![Screenshot from 2021-06-03 16-22-42](https://user-images.githubusercontent.com/5132349/120680434-95abbd00-c49a-11eb-974d-c615edd48341.png)
After:
![Screenshot from 2021-06-08 13-04-39](https://user-images.githubusercontent.com/5132349/121175554-77a7d900-c85b-11eb-98f8-8a7d2eaccef0.png)


