### PR TITLE
break: always return false from store.isFinalCard to fix sluggish UI

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -631,8 +631,11 @@ export const previewStore = (
   },
 
   isFinalCard: () => {
-    const { upcomingCardIds } = get();
+    // Temporarily always returns false until upcomingCardIds is optimised
+    // OSL Slack explanation: https://bit.ly/3x38IRY
+    return false;
 
+    const { upcomingCardIds } = get();
     return upcomingCardIds().length === 1;
   },
 });


### PR DESCRIPTION
more info https://opensystemslab.slack.com/archives/C01E3AC0C03/p1623254202110800?thread_ts=1623253726.109400&cid=C01E3AC0C03

tldr: upcomingCardIds() ideally needs to be in a webworker, or optimised and/or memoized to avoid sluggish UI