### PR TITLE
fix: settings correspond to flow name + team name

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -4,6 +4,7 @@ import Switch, { SwitchProps } from "@material-ui/core/Switch";
 import Typography from "@material-ui/core/Typography";
 import { useFormik } from "formik";
 import React from "react";
+import { useCurrentRoute } from "react-navi";
 import Input, { Props as InputProps } from "ui/Input";
 import InputGroup from "ui/InputGroup";
 import InputRow from "ui/InputRow";
@@ -50,10 +51,11 @@ const TextInput: React.FC<{
 
 interface Props {
   settings?: FlowSettings;
-  flowId: string;
 }
 
 const ServiceSettings: React.FC<Props> = (props) => {
+  const { data } = useCurrentRoute();
+
   const formik = useFormik<FlowSettings>({
     initialValues: {
       elements: {
@@ -75,7 +77,7 @@ const ServiceSettings: React.FC<Props> = (props) => {
       },
     },
     onSubmit: (values) => {
-      useStore.getState().updateFlowSettings(props.flowId, values);
+      useStore.getState().updateFlowSettings(data.team, data.flow, values);
     },
     validate: () => {},
   });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -172,7 +172,7 @@ const NavTabs: React.FC<{ tab?: string; settings?: FlowSettings }> = (
         <TeamSettings />
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <ServiceSettings settings={props.settings} flowId={data.flow} />
+        <ServiceSettings settings={props.settings} />
       </TabPanel>
       <TabPanel value={value} index={2}>
         <ServiceFlags

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -66,7 +66,8 @@ export interface EditorStore extends Store.Store {
   pasteNode: (toParent: Store.nodeId, toBefore: Store.nodeId) => void;
   removeNode: (id: Store.nodeId, parent: Store.nodeId) => void;
   updateFlowSettings: (
-    flowId: string,
+    teamSlug: string,
+    flowSlug: string,
     newSettings: FlowSettings
   ) => Promise<number>;
   updateNode: (node: any, relationships?: any) => void;
@@ -292,12 +293,19 @@ export const editorStore = (
     send(ops);
   },
 
-  updateFlowSettings: async (flowSlug, newSettings) => {
+  updateFlowSettings: async (teamSlug, flowSlug, newSettings) => {
     let response = await client.mutate({
       mutation: gql`
-        mutation UpdateFlowSettings($slug: String, $settings: jsonb) {
+        mutation UpdateFlowSettings(
+          $team_slug: String
+          $flow_slug: String
+          $settings: jsonb
+        ) {
           update_flows(
-            where: { slug: { _eq: $slug } }
+            where: {
+              team: { slug: { _eq: $team_slug } }
+              slug: { _eq: $flow_slug }
+            }
             _set: { settings: $settings }
           ) {
             affected_rows
@@ -309,7 +317,8 @@ export const editorStore = (
         }
       `,
       variables: {
-        slug: flowSlug,
+        team_slug: teamSlug,
+        flow_slug: flowSlug,
         settings: newSettings,
       },
     });

--- a/editor.planx.uk/src/routes/settings.tsx
+++ b/editor.planx.uk/src/routes/settings.tsx
@@ -17,11 +17,14 @@ const flowSettingsRoutes = compose(
     "/:tab": route(async (req) => {
       const { data } = await client.query({
         query: gql`
-          query GetFlow($slug: String!) {
+          query GetFlow($slug: String!, $team_slug: String!) {
             flows(
               order_by: { name: asc }
               limit: 1
-              where: { slug: { _eq: $slug } }
+              where: {
+                slug: { _eq: $slug }
+                team: { slug: { _eq: $team_slug } }
+              }
             ) {
               id
               settings
@@ -30,6 +33,7 @@ const flowSettingsRoutes = compose(
         `,
         variables: {
           slug: req.params.flow,
+          team_slug: req.params.team,
         },
       });
 


### PR DESCRIPTION
Because settings corresponded to a flow `slug` instead of a flow `slug` + a team `slug`, flow settings for different teams that had flows of the same name were getting mixed up.  This fix makes sure we're only updating or reading from the one particular flow of the current team. 