### PR TITLE
fix: bops api uses app.post instead of app.use

### DIFF
--- a/api.planx.uk/server.js
+++ b/api.planx.uk/server.js
@@ -198,7 +198,7 @@ if (!process.env.BOPS_API_TOKEN) {
   process.exit(1);
 }
 
-app.use("/bops/:localAuthority", (req, res) => {
+app.post("/bops/:localAuthority", (req, res) => {
   const target = `https://${req.params.localAuthority}.bops.services/api/v1/planning_applications`;
 
   createProxyMiddleware({


### PR DESCRIPTION
This disables /GET requests in the browser that exposed sensitive data like names & emails

Eg https://api.editor.planx.uk/bops/bucks

We should test once more when merged to main, before production, so we can run through a whole proper lawfulness flow that creates the schema BOPS expects - I tested locally with a small test flow and really just confirmed that Hasura mutations and API http response codes didn't change, but consistently got error message `{ "message": "Unable to create application" }` because of schema mismatch