### PR TITLE
fix: ensure TextInput responses are sent to BOPS

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops.test.ts
@@ -126,7 +126,9 @@ test("makes a more advanced payload", () => {
       auto: false,
     },
     "8kKGIvNzEN": {
-      answers: ["extension demolition followed by a rebuild"],
+      data: {
+        "8kKGIvNzEN": "extension demolition followed by a rebuild",
+      },
       auto: false,
     },
   };

--- a/editor.planx.uk/src/@planx/components/Send/bops.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops.ts
@@ -125,7 +125,15 @@ export const makePayload = (flow: Store.flow, breadcrumbs: Store.breadcrumbs) =>
     .map(([id, bc]) => {
       const { edges = [], ...question } = flow[id];
 
-      const answers: Array<string> = bc.answers ?? [];
+      const answers: Array<string> = (() => {
+        if (flow[id].type === TYPES.TextInput) {
+          return Object.values(bc.data ?? {}).filter(
+            (x) => typeof x === "string"
+          );
+        } else {
+          return bc.answers ?? [];
+        }
+      })();
 
       const responses = answers.map((id) => {
         let value = id;


### PR DESCRIPTION
TextInput values were previously not being sent to BOPS.

This code extracts string `values` from the `data: {}` object on a `TextField` node and puts them inside the `responses: [{value}]` of the BOPS payload