### PR TITLE
remove configurable url from Pay component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -1,4 +1,4 @@
-import type { Pay } from "@planx/components/Pay/model";
+import { GOV_UK_PAY_URL, Pay } from "@planx/components/Pay/model";
 import { parseMoreInformation } from "@planx/components/shared";
 import { TYPES } from "@planx/components/types";
 import { ICONS, InternalNotes, MoreInformation } from "@planx/components/ui";
@@ -21,7 +21,6 @@ function Component(props: any) {
          <a href="https://www.gov.uk/guidance/fees-for-planning-applications" target="_self">here</a>.</p>`,
       color: props.node?.data?.color || "#EFEFEF",
       fn: props.node?.data?.fn,
-      url: props.node?.data?.url,
       ...parseMoreInformation(props.node?.data),
     },
     onSubmit: (newValues) => {
@@ -64,12 +63,8 @@ function Component(props: any) {
             />
           </InputRow>
           <InputRow>
-            <Input
-              name="url"
-              value={formik.values.url}
-              placeholder={`${process.env.REACT_APP_API_URL}/pay`}
-              onChange={formik.handleChange}
-            />
+            {/* Keep the url in the form temporarily while debugging */}
+            <Input disabled name="url" value={GOV_UK_PAY_URL} />
           </InputRow>
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -4,13 +4,7 @@ import React from "react";
 import Pay from "./Pay";
 
 it("renders correctly", () => {
-  render(
-    <Pay
-      handleSubmit={jest.fn()}
-      url={"test-url"}
-      title="Pay for your application"
-    />
-  );
+  render(<Pay handleSubmit={jest.fn()} title="Pay for your application" />);
 
   const title = screen.getByText("Pay for your application");
   expect(title).toBeTruthy();

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -6,14 +6,13 @@ import { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useReducer } from "react";
 import type { GovUKPayment } from "types";
 
-import { createPayload, Pay, toDecimal } from "../model";
+import { createPayload, GOV_UK_PAY_URL, Pay, toDecimal } from "../model";
 import Confirm from "./Confirm";
 
 export default Component;
 
 interface Props extends Pay {
   handleSubmit: handleSubmit;
-  url?: string;
   fn?: string;
 }
 
@@ -48,8 +47,6 @@ function Component(props: Props) {
     state.computePassport(),
     state.previewEnvironment,
   ]);
-
-  if (!props.url) throw new Error("Missing Gov.UK Pay URL");
 
   const fee = props.fn ? Number(passport.data?.[props.fn]) : 0;
 
@@ -123,7 +120,7 @@ function Component(props: Props) {
 
   const refetchPayment = async (id: string) => {
     await axios
-      .get(props.url + `/${id}`)
+      .get(GOV_UK_PAY_URL + `/${id}`)
       .then((res) => {
         const payment = updatePayment(res.data);
 
@@ -180,10 +177,8 @@ function Component(props: Props) {
       return;
     }
 
-    if (!props.url) throw new Error("Missing GovUK Pay URL");
-
     await axios
-      .post(props.url, createPayload(fee, id))
+      .post(GOV_UK_PAY_URL, createPayload(fee, id))
       .then((res) => {
         const payment = updatePayment(res.data);
 

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -12,7 +12,6 @@ export interface Pay extends MoreInformation {
   description?: string;
   color?: string;
   fn?: string;
-  url?: string;
 }
 
 // https://docs.payments.service.gov.uk/making_payments/#creating-a-payment
@@ -48,3 +47,5 @@ export const createPayload = (
   description: "New application",
   return_url: window.location.href,
 });
+
+export const GOV_UK_PAY_URL = `${process.env.REACT_APP_API_URL}/pay`;


### PR DESCRIPTION
This will make running the same content in different environments easier if we need to go down that route.

At the moment we need to remember to check and manually set the URL in each environment

- http://localhost:7002/pay
- https://api.editor.planx.dev/pay
- https://api.editor.planx.uk/pay

![Screenshot 2021-06-10 at 8 49 54 PM](https://user-images.githubusercontent.com/601961/121588091-6a424880-ca2d-11eb-9b09-588f38deb88d.png)

For now this PR disables the `url` field in the Pay component and the component always uses a preconfigured url that's stored in the Pay model instead

```typescript
export const GOV_UK_PAY_URL = `${process.env.REACT_APP_API_URL}/pay`;
```

![Screenshot 2021-06-10 at 8 52 28 PM](https://user-images.githubusercontent.com/601961/121588654-14ba6b80-ca2e-11eb-8642-576b68b0eb26.png)


In a follow-up PR I will remove the URL field altogether, it's just useful to have as a disabled field for now to confirm that everything looks properly configured.
