### PR TITLE
feat: private beta phase banner + legal disclaimer open by default

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -98,7 +98,7 @@ const Result: React.FC<Props> = ({
   const visibleResponses = responses.filter((r) => !r.hidden);
   const hiddenResponses = responses.filter((r) => r.hidden);
 
-  const [showDisclaimer, setShowDisclaimer] = useState(false);
+  const [showDisclaimer, setShowDisclaimer] = useState(true);
   const [showSubmitButton, setShowSubmitButton] = useState<boolean>(
     Boolean(handleSubmit)
   );

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -54,8 +54,8 @@ export default function PhaseBanner(): FCReturn {
           mr={2}
           className={classes.betaIcon}
         >
-          <Typography color="inherit" variant="h6" align="center">
-            BETA
+          <Typography color="inherit" variant="h6" align="center" noWrap>
+            PRIVATE BETA
           </Typography>
         </Box>
         <Typography variant="body2" color="textPrimary">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -155,7 +155,7 @@ const ServiceSettings: React.FC<Props> = (props) => {
 
         <Box py={2} justifyContent="flex-end" mb={4}>
           <Button type="submit" variant="contained" color="primary">
-            Submit
+            Save
           </Button>
         </Box>
       </Box>


### PR DESCRIPTION
really hacking the matrix with this one:

<img width="1276" alt="Screen Shot 2021-06-10 at 2 12 46 PM" src="https://user-images.githubusercontent.com/2712962/121598203-6e06a880-c9f6-11eb-9574-7a08dd9c42e0.png">
