### PR TITLE
fix: airbrake should only log production errors

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -26,6 +26,7 @@ if (
   new Notifier({
     projectId: Number(process.env.REACT_APP_AIRBRAKE_PROJECT_ID),
     projectKey: process.env.REACT_APP_AIRBRAKE_PROJECT_KEY,
+    environment: 'production',
   });
 }
 


### PR DESCRIPTION
not sure why the existing `NODE_ENV !== "test"` check isn't already working, but I think this should eliminate emails & logs about localhost errors!