### PR TITLE
fix: use pnpm install in pulumi actions to respect lockfile

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -105,7 +105,9 @@ jobs:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install
+      - run: npm install -g pnpm
+        working-directory: infrastructure/application
+      - run: pnpm install
         working-directory: infrastructure/application
       - name: Download Build Artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -76,7 +76,9 @@ jobs:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install
+      - run: npm install -g pnpm
+        working-directory: infrastructure/application
+      - run: pnpm install
         working-directory: infrastructure/application
       - name: Download Build Artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -76,7 +76,9 @@ jobs:
           aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install
+      - run: npm install -g pnpm
+        working-directory: infrastructure/application
+      - run: pnpm install
         working-directory: infrastructure/application
       - name: Download Build Artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
`npm install` is throwing warnings which stop deployments

https://github.com/theopensystemslab/planx-new/runs/2802338094

<img width="856" alt="Screenshot 2021-06-11 at 12 51 10 PM" src="https://user-images.githubusercontent.com/601961/121682244-bf28a200-cab3-11eb-923d-4ffb1f06c68a.png">

These fixes aren't optimal but will hopefully solve the problem for now.

Using `pnpm install` should use the package versions defined in `pnpm-lock.yaml` and, in theory, will pass without halting the workflows.