### PR TITLE
fix: review page parsing & hide auto-answers

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -102,7 +102,8 @@ function Component(props: Props) {
             Object.entries(props.breadcrumbs).map(([nodeId, value], i) => {
               const node = props.flow[nodeId];
               const Component = node.type && components[node.type];
-              if (Component === undefined) {
+              // Hide questions if they lack a presentation component or are auto-answered
+              if (Component === undefined || value.auto) {
                 return null;
               }
               return (


### PR DESCRIPTION
Updates:
- Renamed helper function & added comment for clarity - now accounting for answers stored by planx variable name, else retrieving answers by default node id
- Add AddressInput presentation component
- Remove review page fallback messages like "No date" to avoid confusion since those questions can't actually be left blank
- Small alignment tweaks: right-align change button & add a bit of right padding to second column
- Hide auto-answered questions

![Screenshot from 2021-06-14 16-43-32](https://user-images.githubusercontent.com/5132349/121911101-ba702200-cd2f-11eb-93d1-6da4eb2dc02f.png)
