### PR TITLE
use pnpm install --frozen-lockfile in CI

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -119,5 +119,6 @@ jobs:
           command: preview
           stack-name: staging
           work-dir: infrastructure/application
+          edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -90,5 +90,6 @@ jobs:
           command: up
           stack-name: staging
           work-dir: infrastructure/application
+          edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -90,5 +90,6 @@ jobs:
           command: up
           stack-name: production
           work-dir: infrastructure/application
+          edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}


### PR DESCRIPTION
in an effort to reduce unnecessary compiled JS file changes in pulumi, this explicitly forces pnpm to use the package versions specified  in the pnpm-lock.yaml file, because of the --frozen-lockfile flag.

Theoretically this should be enforced anyway because env should have CI=true, but perhaps something is cancelling that? idk?

I built `main` both locally and on a remote server and they both produced the exact same files, which makes me think Pulumi should do the same.

![Screenshot 2021-06-15 at 7 57 29 PM](https://user-images.githubusercontent.com/601961/122109736-9be45680-ce15-11eb-90df-2288f6c75ce8.png)

The comment that pulumi leaves in this PR will still be be noisy, but hopefully after this is merged, a follow up PR that only updates the README will result in Pulumi saying that only the README file needs to change, and not any JS files.