### PR TITLE
fix: order planning constraints true -> false

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -364,6 +364,12 @@ export function PropertyInformation(props: any) {
 
 function PropertyConstraints({ constraintsData }: any) {
   const { title, constraints } = constraintsData;
+
+  // Order constraints so that { value: true } ones come first
+  constraints.sort(function (a: any, b: any) {
+    return b.value - a.value;
+  });
+
   const visibleConstraints = constraints
     .filter((x: any, i: number) => i < 3)
     .map((con: any) => (


### PR DESCRIPTION
Planning constraints previously displayed in any order, now those that are "active" (aka `{ value: true }`) will appear at the top of the list