### PR TITLE
break: don't show continue button on confirmation card & remove custom feedback input

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -41,8 +41,7 @@ Basic.args = {
   - if any additional information is required
   - to arrange a site visit, if required
   - to inform you whether a certificate has been granted or not`,
-  contactInfo: `You can contact us at **planning@lambeth.gov.uk**`,
-  feedbackCTA: "What did you think of this service? (takes 30 seconds)",
+  contactInfo: `You can contact us at **planning@lambeth.gov.uk**<br/>What did you think of this service? Please give us your feedback using the link in the footer below.`,
 };
 
 export const WithEditor = () => (

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -71,10 +71,7 @@ export default function ConfirmationEditor(props: Props) {
         </ul>`,
       contactInfo:
         props.node?.data?.contactInfo ||
-        "You can contact us at **planning@lambeth.gov.uk**",
-      feedbackCTA:
-        props.node?.data?.feedbackCTA ||
-        "What did you think of this service? (takes 30 seconds)",
+        "You can contact us at **planning@lambeth.gov.uk**<br/>What did you think of this service? Please give us your feedback using the link in the footer below.",
       ...parseNextSteps(props.node?.data),
     },
     onSubmit: (values) => {
@@ -138,19 +135,6 @@ export default function ConfirmationEditor(props: Props) {
           <RichTextInput
             value={formik.values.contactInfo}
             name="contactInfo"
-            onChange={formik.handleChange}
-          />
-        </ModalSectionContent>
-      </ModalSection>
-
-      <ModalSection>
-        <ModalSectionContent
-          title="Feedback Call-To-Action"
-          Icon={ICONS[TYPES.Notice]}
-        >
-          <Input
-            value={formik.values.feedbackCTA}
-            name="feedbackCTA"
             onChange={formik.handleChange}
           />
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -1,15 +1,11 @@
 import Box from "@material-ui/core/Box";
-import Button from "@material-ui/core/Button";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Check from "@material-ui/icons/CheckCircleOutlineOutlined";
 import Card from "@planx/components/shared/Preview/Card";
 import { PublicProps } from "@planx/components/ui";
-import { useFormik } from "formik";
-import { submitFeedback } from "lib/feedback";
-import React, { useEffect } from "react";
+import React from "react";
 import Banner from "ui/Banner";
-import CollapsibleInput from "ui/CollapsibleInput";
 import NumberedList from "ui/NumberedList";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
@@ -31,43 +27,12 @@ const useClasses = makeStyles((theme) => ({
   listHeading: {
     marginBottom: theme.spacing(2),
   },
-  feedback: {
-    cursor: "pointer",
-    "&:hover": {
-      textDecoration: "underline",
-    },
-  },
 }));
 
 export type Props = PublicProps<Confirmation>;
 
 export default function ConfirmationComponent(props: Props) {
-  const formik = useFormik({
-    initialValues: {
-      feedback: "",
-    },
-    onSubmit: (values, { resetForm }) => {
-      if (values.feedback) {
-        submitFeedback(values.feedback, {
-          reason: "Confirmation",
-        });
-        resetForm();
-      }
-      props.handleSubmit?.();
-    },
-  });
-
   const classes = useClasses();
-
-  const [showButton, setShowButton] = React.useState<boolean>(
-    !!props.handleSubmit
-  );
-
-  useEffect(() => {
-    if (props.handleSubmit) return;
-
-    setShowButton(formik.values.feedback.length > 0);
-  }, [formik.values.feedback]);
 
   return (
     <Box width="100%">
@@ -118,41 +83,7 @@ export default function ConfirmationComponent(props: Props) {
               <Typography variant="h3">Contact us</Typography>
               <ReactMarkdownOrHtml source={props.contactInfo} />
             </Box>
-            <hr />
           </>
-        )}
-
-        {props.feedbackCTA && (
-          <CollapsibleInput
-            handleChange={formik.handleChange}
-            name="feedback"
-            value={formik.values.feedback}
-          >
-            <Typography
-              variant="body2"
-              color="primary"
-              className={classes.feedback}
-            >
-              {props.feedbackCTA}
-            </Typography>
-          </CollapsibleInput>
-        )}
-
-        {formik.values.feedback.length > 0 && (
-          <Button
-            variant="contained"
-            color="primary"
-            size="large"
-            type="submit"
-            onClick={() => {
-              submitFeedback(formik.values.feedback, {
-                reason: "Confirmation",
-              });
-              formik.resetForm();
-            }}
-          >
-            Submit feedback
-          </Button>
         )}
       </Card>
     </Box>

--- a/editor.planx.uk/src/@planx/components/Confirmation/model.ts
+++ b/editor.planx.uk/src/@planx/components/Confirmation/model.ts
@@ -11,7 +11,6 @@ export interface Confirmation {
   nextSteps?: Step[];
   moreInfo?: string;
   contactInfo?: string;
-  feedbackCTA?: string;
 }
 
 export const parseNextSteps = (


### PR DESCRIPTION
A short-term hack to hide continue on the Confirmation component, since we can assume that's always (and exclusively) used as the final node in an "apply for a certificate of lawfulness" flow for now. 

"findoutifyouneedplanningpermission" services end with a Notice, so you'll still see "continue" button there for now - but I hope this is less crucial/confusing since you haven't gone through payment or send in these flows. 

Removes custom feedback input from Confirmation preview & editor, and instead adds a simple static second line of default text to the Contact section (per [Slack thread](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1625066065176800))
![Screenshot from 2021-07-01 11-39-56](https://user-images.githubusercontent.com/5132349/124102962-1ee5ed80-da61-11eb-8a1e-1004a12bdc64.png)