### PR TITLE
fix: drawboundary shows more info in question header

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -58,6 +58,10 @@ export default function Component(props: Props) {
           <QuestionHeader
             title={props.title ?? DEFAULT_TITLE}
             description={props.description}
+            info={props.info}
+            policyRef={props.policyRef}
+            howMeasured={props.howMeasured}
+            definitionImg={props.definitionImg}
           />
           <Box className={classes.map}>
             <Map
@@ -82,6 +86,10 @@ export default function Component(props: Props) {
           <QuestionHeader
             title={props.titleForUploading ?? DEFAULT_TITLE_FOR_UPLOADING}
             description={props.descriptionForUploading}
+            info={props.info}
+            policyRef={props.policyRef}
+            howMeasured={props.howMeasured}
+            definitionImg={props.definitionImg}
           />
           <Upload setUrl={setUrl} />
           <p className={classes.uploadInstead}>

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -7,6 +7,10 @@ export interface DrawBoundary extends MoreInformation {
   descriptionForUploading: string;
   dataFieldBoundary: string;
   dataFieldArea: string;
+  info?: string;
+  policyRef?: string;
+  howMeasured?: string;
+  definitionImg?: string;
 }
 
 export const parseDrawBoundary = (


### PR DESCRIPTION
If more info text exists, render the "?" more info button in the question header for both drawing & uploading a boundary file. 

![Screenshot from 2021-06-21 12-03-23](https://user-images.githubusercontent.com/5132349/122745053-e556fa80-d288-11eb-9f01-7ecb42bf2270.png)
