### PR TITLE
hotfix: save SetValue passport value as [string] not string

### DIFF
--- a/editor.planx.uk/src/@planx/components/SetValue/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Public.tsx
@@ -9,7 +9,7 @@ export type Props = PublicProps<SetValue>;
 export default function Component(props: Props) {
   useEffect(() => {
     props.handleSubmit?.({
-      ...makeData(props, props.val, props.fn),
+      ...makeData(props, [props.val], props.fn),
       auto: true,
     });
   }, []);


### PR DESCRIPTION
should fix https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3038070877074855639?tab=overview