### PR TITLE
fix: ignore undefined and null values when saving breadcrumb.data

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -200,7 +200,14 @@ export const previewStore = (
 
       const breadcrumb: Store.userData = { auto: Boolean(auto) };
       if (answers?.length > 0) breadcrumb.answers = answers;
-      if (Object.keys(data).length > 0) breadcrumb.data = data;
+
+      const filteredData = Object.entries(data).reduce((acc, [k, v]) => {
+        if (k && v !== null && v !== undefined) acc[k] = v;
+        return acc;
+      }, {} as typeof data);
+
+      if (Object.keys(filteredData).length > 0) breadcrumb.data = filteredData;
+
       set({
         breadcrumbs: {
           ...breadcrumbs,


### PR DESCRIPTION
things like this might cause problems so this will prevent anything with `null` or `undefined` values being saved to the passport

![Screenshot 2021-06-27 at 3 12 17 PM](https://user-images.githubusercontent.com/601961/123554542-65dd9580-d778-11eb-89ef-899f72f8d671.png)

in future this might need to be changed so that we filter the `computedPassport()` output instead. This would mean if we need to remove existing passport values we could set their key's value to `undefined` or `null`, but I'll leave that as a separate thing to think about.

### related

* filter computedPassport branch https://github.com/theopensystemslab/planx-new/tree/jr/filter-computedpassport
* https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1624802906000100