### PR TITLE
fix: update how Confirmation renders data if Payment is skipped

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops.ts
@@ -110,7 +110,7 @@ export function getParams(
 ) {
   const data = {} as BOPSFullPayload;
 
-  // Hardcode application type for now
+  // XXX: Hardcode application type for now
   data.application_type = "lawfulness_certificate";
 
   if (sessionId) data.session_id = sessionId;
@@ -194,16 +194,8 @@ export function getParams(
   }
 
   // 4. work status
-  // XXX: this is currently probably a [string], but will be string soon
-  //      howver, String(string) === string and String([string]) === string
-  switch (String(passport?.data?.["application.type"])) {
-    case "ldc.existing":
-      data.work_status = "existing";
-      break;
-    case "ldc.proposed":
-      data.work_status = "proposed";
-      break;
-  }
+  const workStatus = getWorkStatus(passport);
+  if (workStatus) data.work_status = workStatus;
 
   // 5. keys
 
@@ -263,3 +255,14 @@ export function getParams(
     ...bopsData,
   };
 }
+
+export const getWorkStatus = (passport: Store.passport) => {
+  // XXX: this is currently probably a [string], but will be string soon
+  //      howver, String(string) === string and String([string]) === string
+  switch (String(passport?.data?.["application.type"])) {
+    case "ldc.existing":
+      return "existing";
+    case "ldc.proposed":
+      return "proposed";
+  }
+};

--- a/editor.planx.uk/src/lib/objectHelpers.ts
+++ b/editor.planx.uk/src/lib/objectHelpers.ts
@@ -1,0 +1,11 @@
+/**
+ * returns a cloned object excluding any shallow values such as undefined, null or ""
+ * @example
+ * // returns { a: 1, e: { foo: null } }
+ * objectWithoutNullishValues({ a: 1, b: undefined, c: null, d: "", e: { foo: null } })
+ */
+export const objectWithoutNullishValues = (ob: Record<string, unknown>) =>
+  Object.entries(ob).reduce((acc, [key, value]) => {
+    if (value !== null && value !== undefined && value !== "") acc[key] = value;
+    return acc;
+  }, {} as typeof ob);

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -3,6 +3,7 @@ import tinycolor from "@ctrl/tinycolor";
 import { TYPES } from "@planx/components/types";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { client } from "lib/graphql";
+import { objectWithoutNullishValues } from "lib/objectHelpers";
 import difference from "lodash/difference";
 import flatten from "lodash/flatten";
 import isNil from "lodash/isNil";
@@ -201,10 +202,7 @@ export const previewStore = (
       const breadcrumb: Store.userData = { auto: Boolean(auto) };
       if (answers?.length > 0) breadcrumb.answers = answers;
 
-      const filteredData = Object.entries(data).reduce((acc, [k, v]) => {
-        if (k && v !== null && v !== undefined) acc[k] = v;
-        return acc;
-      }, {} as typeof data);
+      const filteredData = objectWithoutNullishValues(data);
 
       if (Object.keys(filteredData).length > 0) breadcrumb.data = filteredData;
 


### PR DESCRIPTION
The `Confirmation` component currently anticipates that the user has made a payment. However, in some cases, such as when the application is a resubmission, the user does not make a payment and the component lacks data which might make the user think that something has gone wrong.

### Current
<img width="789" alt="Screenshot_2021-06-27_at_11 07 10_PM" src="https://user-images.githubusercontent.com/601961/123629922-c9b19e00-d80c-11eb-889f-f5694af63458.png">

These changes -
- Remove N/A fields from the UI
- Update the logic to handle "existing" application types

### New
![Screenshot 2021-06-28 at 12 36 56 PM](https://user-images.githubusercontent.com/601961/123630557-958aad00-d80d-11eb-8d8d-b8f47b17fc55.png)

There is still a point of confusion where the component says "A payment receipt has been emailed to you", when there might not have been a payment. However, this can be fixed by a content editor for now.

related: https://trello.com/c/ZqNlvvln/1338-fix-application-sent-page-for-resubmission