### PR TITLE
fix: disable continue until files are successfully uploaded

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -135,7 +135,7 @@ const slotsSchema = array()
   });
 
 const FileUpload: React.FC<Props> = (props) => {
-  const [slots, setSlots] = useState([]);
+  const [slots, setSlots] = useState<any[]>([]);
   const [validationError, setValidationError] = useState<string>();
 
   const handleSubmit = () => {
@@ -174,7 +174,13 @@ const FileUpload: React.FC<Props> = (props) => {
   }, [slots]);
 
   return (
-    <Card isValid handleSubmit={handleSubmit}>
+    <Card
+      isValid={
+        slots.length > 0 &&
+        slots.every((slot) => slot.url && slot.status === "success")
+      }
+      handleSubmit={handleSubmit}
+    >
       <QuestionHeader
         title={props.title}
         description={props.description}


### PR DESCRIPTION
Reported here: https://ripahq.slack.com/archives/C0241GWFG4B/p1624977113005400

DrawBoundary file upload was already validating that the URL exists before showing "continue", so only updating FileUpload here.