### PR TITLE
feat: add planx_debug_data to bops payload

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops.ts
@@ -113,8 +113,6 @@ export function getParams(
   // XXX: Hardcode application type for now
   data.application_type = "lawfulness_certificate";
 
-  if (sessionId) data.session_id = sessionId;
-
   // 1a. address
 
   const address = passport.data?._address;
@@ -253,6 +251,11 @@ export function getParams(
   return {
     ...data,
     ...bopsData,
+    planx_debug_data: {
+      session_id: sessionId,
+      breadcrumbs,
+      passport,
+    },
   };
 }
 

--- a/editor.planx.uk/src/@planx/components/Send/bops_flags.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops_flags.test.ts
@@ -36,7 +36,11 @@ test("prior", () => {
       flag: "Planning permission / Prior approval",
       heading: "Custom prior heading",
     },
-    session_id: "123",
+    planx_debug_data: {
+      breadcrumbs,
+      passport,
+      session_id: sessionId,
+    },
   };
 
   expect(actual).toStrictEqual(expected);
@@ -89,7 +93,11 @@ test("permission", () => {
       heading: "Permission needed",
       override: "i don't agree",
     },
-    session_id: "123",
+    planx_debug_data: {
+      breadcrumbs,
+      passport,
+      session_id: sessionId,
+    },
   };
 
   expect(actual).toStrictEqual(expected);
@@ -113,7 +121,11 @@ test("other", () => {
     proposal_details: [
       { question: "which answer?", responses: [{ value: "other" }] },
     ],
-    session_id: "123",
+    planx_debug_data: {
+      breadcrumbs,
+      passport,
+      session_id: sessionId,
+    },
   };
 
   expect(actual).toStrictEqual(expected);

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -23,7 +23,6 @@ export interface BOPSFullPayload extends BOPSMinimumPayload {
   description?: string;
   payment_reference?: string;
   payment_amount?: number;
-  session_id?: string;
   ward?: string;
   work_status?: "proposed" | "existing";
   applicant_first_name?: string;
@@ -44,6 +43,7 @@ export interface BOPSFullPayload extends BOPSMinimumPayload {
     description?: string;
     override?: string;
   };
+  planx_debug_data?: Record<string, unknown>;
 }
 
 export interface QuestionMetaData {


### PR DESCRIPTION
This sends some extra info to BOPS that will not get shown to anyone, but will be helpful for debugging and testing new features in future.

Ideally we'd send the whole flow object too but I think that's too big.

We could potentially send the flow version, or in future the published flow id and maybe the gitSha of the code that generated the payload. Or we include some sort of version identifier in it.

@sarahscott I notice you added session_id to the bops payload. Would it break anything if I move it inside the planx_debug_data object?