### PR TITLE
chore: replace Loading text

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -137,9 +137,10 @@ function Component(props: Props) {
     );
   } else {
     return (
-      <DelayedLoadingIndicator msDelayBeforeVisible={0}>
-        Waiting for property data…
-      </DelayedLoadingIndicator>
+      <DelayedLoadingIndicator
+        msDelayBeforeVisible={0}
+        text="Fetching property information..."
+      />
     );
   }
 }


### PR DESCRIPTION
"Waiting for property data…" wasn't being rendered when searching GIS data as it's a prop. So it was showing the default Loading instead.

I've confirmed the wording of "Fetching property information..." with Alastair.

Admittedly it'd make more sense for the loader use children instead so there's more customisability. I'll add a card.