### PR TITLE
fix: ensure local (JWT|SESSION)_SECRET are strings

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,13 @@
+# Avoid using long numbers as values if possible, because Node tries to parse them
+# More info: https://github.com/theopensystemslab/planx-new/pull/566
+
+
+
 HASURA_GRAPHQL_ADMIN_SECRET=TODO
 HASURA_GRAPHQL_PORT=7000
 HASURA_GRAPHQL_URL=http://localhost:7000/v1/graphql
 
-JWT_SECRET=0987654321234567890987654321234567890
+JWT_SECRET=secret4321234567890987654321234567890
 
 PG_DATABASE=db
 PG_PASSWORD=dbpass
@@ -17,7 +22,7 @@ EDITOR_URL_EXT=http://localhost:3000
 GOOGLE_CLIENT_ID=987324067365-anl1o207sphdeu28i6nk2e6brec8fh4b.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=9VPLg_Zc7YmfFHp3lQqbDMIX
 
-SESSION_SECRET=12345678909876543210
+SESSION_SECRET=secret78909876543210
 
 SHAREDB_PORT=7003
 


### PR DESCRIPTION
When `JWT_SECRET=0987654321234567890987654321234567890`

I was getting invalid JWT token errors trying to log in locally.

I inspected env and saw that `process.env.JWT_SECRET` was actually `"9.876543212345678e+35"`

![Screenshot 2021-07-13 at 2 32 43 PM](https://user-images.githubusercontent.com/601961/125463997-e1587782-b43e-41e6-9896-23d8068cac73.png)

I think either docker-compose yaml or node is trying to be clever and do something like  `Number("0987654321234567890987654321234567890")`

...but that number would be bigger than `Number.MAX_SAFE_INTEGER`, so it becomes `~9e+35`

I tried explicitly setting it to a string in .env with double quotes

`JWT_SECRET="0987654321234567890987654321234567890"`

but that didn't fix the issue.

Perhaps changing `docker-compose.yaml` to use

`JWT_SECRET: "${JWT_SECRET}"`

instead of

`JWT_SECRET: ${JWT_SECRET}`

might help, but I'm not sure as I thought ENV vars would always be passed between processes as strings?

To fix the problem without needing to remember to put these quotes in different places I changed the local ENV vars to start with strings so that they can't be considered numbers. Now I can log in to development again
