### PR TITLE
fix: ensure all nodes exist in Review component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -101,41 +101,45 @@ function Component(props: Props) {
         <div className={grid}>
           {
             // XXX: This works because since ES2015 key order is guaranteed to be the insertion order
-            Object.entries(props.breadcrumbs).map(([nodeId, value], i) => {
-              const node = props.flow[nodeId];
-              const Component = node.type && components[node.type];
-              // Hide questions if they lack a presentation component or are auto-answered
-              if (Component === undefined || value.auto) {
-                return null;
-              }
-              return (
-                <React.Fragment key={i}>
-                  <Component
-                    nodeId={nodeId}
-                    node={node}
-                    userData={value}
-                    flow={props.flow}
-                    passport={props.passport}
-                  />
-                  {props.showChangeButton && (
-                    <div>
-                      <a
-                        onClick={() => {
-                          const confirmed = window.confirm(
-                            `Are you sure you want to go back to change your answer? You will lose your answers to questions answered after this one.`
-                          );
-                          if (confirmed) {
-                            props.changeAnswer(nodeId);
-                          }
-                        }}
-                      >
-                        Change
-                      </a>
-                    </div>
-                  )}
-                </React.Fragment>
-              );
-            })
+            Object.entries(props.breadcrumbs)
+              // ensure node exists, need to find the root cause but for now this should fix
+              // https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3049111363214482333
+              .filter(([nodeId]) => Boolean(props.flow[nodeId]))
+              .map(([nodeId, value], i) => {
+                const node = props.flow[nodeId];
+                const Component = node.type && components[node.type];
+                // Hide questions if they lack a presentation component or are auto-answered
+                if (Component === undefined || value.auto) {
+                  return null;
+                }
+                return (
+                  <React.Fragment key={i}>
+                    <Component
+                      nodeId={nodeId}
+                      node={node}
+                      userData={value}
+                      flow={props.flow}
+                      passport={props.passport}
+                    />
+                    {props.showChangeButton && (
+                      <div>
+                        <a
+                          onClick={() => {
+                            const confirmed = window.confirm(
+                              `Are you sure you want to go back to change your answer? You will lose your answers to questions answered after this one.`
+                            );
+                            if (confirmed) {
+                              props.changeAnswer(nodeId);
+                            }
+                          }}
+                        >
+                          Change
+                        </a>
+                      </div>
+                    )}
+                  </React.Fragment>
+                );
+              })
           }
         </div>
       </div>


### PR DESCRIPTION
fixes https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3049111363214482333?tab=notice-detail

although there shouldn't really be nodes in breadcrumbs that no longer exist. I assume this is related to refreshes or something. I'm trying to find whoever is creating the error to understand exactly what's happening

<img width="835" alt="Screenshot 2021-07-15 at 10 03 00 AM" src="https://user-images.githubusercontent.com/601961/125760984-58ebb76b-4ce6-466c-9b6d-43b3d17e4bc9.png">
