### PR TITLE
chore: notify of PRs with changes to hasura schema

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -236,9 +236,6 @@
       filter: {}
 - table:
     schema: public
-    name: test_table
-- table:
-    schema: public
     name: users
   array_relationships:
   - name: created_flows


### PR DESCRIPTION
Adds a GitHub comment whenever the PR proposes a change to Hasura metadata files.

---
e.g.
![image](https://user-images.githubusercontent.com/7684574/127034512-f695bb65-807a-46f6-8509-3cd1edb822b0.png)
