### PR TITLE
chore: make 2nd line and county optional

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -5,17 +5,17 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 
 export type UserData = {
   line1: string;
-  line2: string;
+  line2?: string;
   town: string;
-  county: string;
+  county?: string;
   postcode: string;
 };
 
 export const userDataSchema: SchemaOf<UserData> = object({
   line1: string().required(),
-  line2: string().required(),
+  line2: string(),
   town: string().required(),
-  county: string().required(),
+  county: string(),
   postcode: string().required(),
 });
 


### PR DESCRIPTION
https://trello.com/c/OVf3RqxG/1409-in-address-component-make-second-line-of-address-and-county-optional-ie-users-can-leave-them-blank
