### PR TITLE
fix: tweak language for planning constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -133,9 +133,8 @@ function Component(props: Props) {
           },
         ]}
         propertyConstraints={{
-          title: "Constraints",
-          description:
-            "These are the planning policies that apply to this property. We will use this information to ask you relevant questions.",
+          title: "Planning constraints",
+          description: "Things that might affect your project",
           constraints: (Object.values(constraints) || []).filter(
             ({ text }: any) => text
           ),


### PR DESCRIPTION
a very small request from Alastair.

long term we'll aim to make these fields available for Editors, but saving that for a larger refactor of FindProperty/DrawBoundary in the nearish future. 