### PR TITLE
fix: use address_base.single_line_address

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -178,7 +178,7 @@ function GetAddress(props: {
           blpu_code
           latitude
           longitude
-          full_address
+          single_line_address
         }
       }
     `,
@@ -250,7 +250,11 @@ function GetAddress(props: {
                   .map(
                     (address: Address): Option => ({
                       ...address,
-                      title: address.full_address,
+                      // we already know the postcode so remove it from full address
+                      title: address.single_line_address.replace(
+                        `, ${address.postcode}`,
+                        ""
+                      ),
                     })
                   )
                   .sort((a: Option, b: Option) => sorter(a.title, b.title))}

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -28,7 +28,7 @@ export interface Address {
   y: number;
   planx_description: string;
   planx_value: string;
-  full_address: string;
+  single_line_address: string;
 }
 
 export const DEFAULT_TITLE = "Find the property" as const;

--- a/hasura.planx.uk/migrations/1628509235238_update-addresses/up.sql
+++ b/hasura.planx.uk/migrations/1628509235238_update-addresses/up.sql
@@ -1,0 +1,21 @@
+-- appends single_line_address to existing addresses view
+CREATE OR REPLACE VIEW addresses AS
+  SELECT
+    uprn
+  , classification_code as blpu_code
+  , latitude
+  , longitude
+  , organisation
+  , sub_building as sao
+  , building_number as pao
+  , street_name as street
+  , town_name as town
+  , postcode
+  , ST_X(ST_Transform(ST_SetSRID(ST_Point(longitude::float, latitude::float), 4326), 27700)) as x
+  , ST_Y(ST_Transform(ST_SetSRID(ST_Point(longitude::float, latitude::float), 4326), 27700)) as y
+  , blpu_codes.description as planx_description
+  , blpu_codes.value as planx_value
+  , single_line_address
+  FROM address_base
+  JOIN blpu_codes ON classification_code = blpu_codes.code
+  ;


### PR DESCRIPTION
fixes https://trello.com/c/ZShMlTGq/1269-investigate-whether-addressbase-premium-provides-these-missing-building-names-property-details

We already have a dynamic field in hasura `addresses` called `full_address` which concatenates address parts to try and make a full address, but it doesn't always have enough information to make a unique address. So we end up with situations like

![Screenshot 2021-08-09 at 1 07 37 PM](https://user-images.githubusercontent.com/601961/128703672-387fb1e7-a1a3-4247-a694-fb8a11863960.png)

![Screenshot 2021-08-09 at 1 03 59 PM](https://user-images.githubusercontent.com/601961/128703277-d1aa28d7-7676-491b-995f-a1ff6dcda562.png)


AddressBase Core already contains a field called `address_base.single_line_address` which gives us what we need. We can use this instead for now.

![Screenshot 2021-08-09 at 12 55 55 PM](https://user-images.githubusercontent.com/601961/128702477-e2ebe63b-10ee-45a8-8b5b-27efe4c2ee98.png)

### Notes

This doesn't do anything destructive i.e. remove existing `full_address` field, once this has been tested and verified as working in staging I might do that in a future PR.

The migration isn't very DRY and it's a shame to put `single_line_address` at the end of the columns, but it was too much hassle to put it in a different position for now as altering views is weird and it wasn't trivial to drop and replace the view in the migration due to other things depending on it.

### Future goals

- Use OS Places API instead so that we don't host address data https://osdatahub.os.uk/docs/places/technicalSpecification (or better, https://labs.os.uk/public/os-data-hub-examples/os-places-api/geosearch-example-bbox if we get PSGA license)
- If we can't use that for some reason, use a [full-text](https://www.compose.com/articles/mastering-postgresql-tools-full-text-search-and-phrase-search/) index on the single_line_address so that we can autocomplete addresses and not need to use the postcode > select address flow
