### PR TITLE
break: make 'long' text input longer

### DIFF
--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -45,6 +45,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
             return "text";
           })(props.type)}
           multiline={props.type === "long"}
+          rows={props.type === "long" ? 5 : undefined}
           name="text"
           value={formik.values.text}
           placeholder={props.placeholder || "Type your answer"}


### PR DESCRIPTION
https://trello.com/c/JSYkgcM5/994-make-long-text-field-larger-on-text-component
