### PR TITLE
feat: highlight feature in FindProperty map

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -305,7 +305,7 @@ export function PropertyInformation(props: any) {
           hideResetControl
           showFeaturesAtPoint
           osFeaturesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY}
-          featureColor="Orchid"
+          featureColor="#9a9a9a"
         />
       </Box>
       <Box mb={6}>


### PR DESCRIPTION
Showing a subtle border around the Ordnance Survey Feature that intersects with the address point, which is often the building on the property. Talked through design with Alastair on this one: it can't be a formal "blue border" unless we're outlining the parcel (made a followup card to investigate access to land registry inspire polygons for this), but this feature outline should still help resolve immediate user feedback points around difficulty reading the map. 

before:
![Screenshot from 2021-08-24 12-41-16](https://user-images.githubusercontent.com/5132349/130603079-172b2711-2fb9-4e40-a672-2f2ae86080c3.png)

after: 
![Screenshot from 2021-08-24 12-29-20](https://user-images.githubusercontent.com/5132349/130602892-8b09d706-04ee-4b5d-9b15-f29b3c048a4e.png)