### PR TITLE
Retain data user has entered so it is still visible when you click 'back' button

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Public.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { uniqueId } from "lodash";
 import React from "react";
 
 import { fillInFieldsUsingPlaceholder } from "../shared/testHelpers";
@@ -29,6 +30,96 @@ test("submits an address", async () => {
         line2: "221b Baker St",
         town: "London",
         county: "County",
+        postcode: "SW1A 2AA",
+      },
+    },
+  });
+});
+
+test("recovers previously submitted text when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+
+  render(
+    <AddressInput
+      handleSubmit={handleSubmit}
+      title=""
+      id={componentId}
+      previouslySubmittedData={{
+        data: {
+          [componentId]: {
+            line1: "Flat 1",
+            line2: "",
+            town: "London",
+            county: "",
+            postcode: "SW1A 2AA",
+          },
+        },
+      }}
+    />
+  );
+
+  await waitFor(async () => {
+    await fillInFieldsUsingPlaceholder({
+      "Line 2": "221b Baker St",
+    });
+
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      [componentId]: {
+        line1: "Flat 1",
+        line2: "221b Baker St",
+        town: "London",
+        county: "",
+        postcode: "SW1A 2AA",
+      },
+    },
+  });
+});
+
+test("recovers previously submitted text when clicking the back button even if a data field is set", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+  const dataField = "data-field";
+
+  render(
+    <AddressInput
+      handleSubmit={handleSubmit}
+      title=""
+      fn={dataField}
+      id={componentId}
+      previouslySubmittedData={{
+        data: {
+          [dataField]: {
+            line1: "Flat 1",
+            line2: "",
+            town: "London",
+            county: "",
+            postcode: "SW1A 2AA",
+          },
+        },
+      }}
+    />
+  );
+
+  await waitFor(async () => {
+    await fillInFieldsUsingPlaceholder({
+      "Line 2": "221b Baker St",
+    });
+
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      [dataField]: {
+        line1: "Flat 1",
+        line2: "221b Baker St",
+        town: "London",
+        county: "",
         postcode: "SW1A 2AA",
       },
     },

--- a/editor.planx.uk/src/@planx/components/AddressInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Public.tsx
@@ -8,15 +8,23 @@ import InputLabel from "ui/InputLabel";
 import InputRow from "ui/InputRow";
 import InputRowItem from "ui/InputRowItem";
 
-import { makeData } from "../shared/utils";
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { AddressInput, UserData } from "./model";
 import { userDataSchema } from "./model";
 
 export type Props = PublicProps<AddressInput, UserData>;
 
+interface FormProps {
+  line1: string;
+  line2: string;
+  town: string;
+  county: string;
+  postcode: string;
+}
+
 export default function AddressInputComponent(props: Props): FCReturn {
-  const formik = useFormik({
-    initialValues: {
+  const formik = useFormik<FormProps>({
+    initialValues: getPreviouslySubmittedData(props) ?? {
       line1: "",
       line2: "",
       town: "",

--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -23,7 +23,7 @@ export interface AddressInput extends MoreInformation {
   title: string;
   description?: string;
   placeholder?: string;
-  fn: string;
+  fn?: string;
 }
 
 export const parseAddressInput = (

--- a/editor.planx.uk/src/@planx/components/Checklist/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -58,4 +58,215 @@ test("answers are submitted in order they were supplied", async () => {
   });
 });
 
-test.todo("expandable checklist");
+test("submits answers with grouped options", async () => {
+  const handleSubmit = jest.fn();
+
+  render(
+    <Checklist
+      allRequired={false}
+      description=""
+      text="home type?"
+      handleSubmit={handleSubmit}
+      groupedOptions={[
+        {
+          title: "Section 1",
+          children: [
+            {
+              id: "S1_Option1",
+              data: {
+                text: "S1 Option1",
+              },
+            },
+            {
+              id: "S1_Option2",
+              data: {
+                text: "S1 Option2",
+              },
+            },
+          ],
+        },
+        {
+          title: "Section 2",
+          children: [
+            {
+              id: "S2_Option1",
+              data: {
+                text: "S2 Option1",
+              },
+            },
+            {
+              id: "S2_Option2",
+              data: {
+                text: "S2 Option2",
+              },
+            },
+          ],
+        },
+        {
+          title: "Section 3",
+          children: [
+            {
+              id: "S3_Option1",
+              data: {
+                text: "S3 Option1",
+              },
+            },
+            {
+              id: "S3_Option2",
+              data: {
+                text: "S3 Option2",
+              },
+            },
+          ],
+        },
+      ]}
+    />
+  );
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Section 1"));
+  });
+
+  userEvent.click(screen.getByText("S1 Option1"));
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Section 2"));
+  });
+
+  userEvent.click(screen.getByText("S2 Option2"));
+
+  await waitFor(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    answers: ["S1_Option1", "S2_Option2"],
+  });
+});
+
+test("recovers checkboxes state when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+
+  render(
+    <Checklist
+      allRequired={false}
+      description=""
+      text="home type?"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{ answers: ["flat_id", "house_id"] }}
+      options={[
+        {
+          id: "flat_id",
+          data: {
+            text: "Flat",
+          },
+        },
+        {
+          id: "caravan_id",
+          data: {
+            text: "Caravan",
+          },
+        },
+        {
+          id: "house_id",
+          data: {
+            text: "House",
+          },
+        },
+        {
+          id: "spaceship_id",
+          data: {
+            text: "Spaceship",
+          },
+        },
+      ]}
+    />
+  );
+
+  await waitFor(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    answers: ["flat_id", "house_id"],
+  });
+});
+
+test("recovers grouped options state when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+
+  render(
+    <Checklist
+      allRequired={false}
+      description=""
+      text="home type?"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{ answers: ["S1_Option1", "S3_Option1"] }}
+      groupedOptions={[
+        {
+          title: "Section 1",
+          children: [
+            {
+              id: "S1_Option1",
+              data: {
+                text: "S1 Option1",
+              },
+            },
+            {
+              id: "S1_Option2",
+              data: {
+                text: "S1 Option2",
+              },
+            },
+          ],
+        },
+        {
+          title: "Section 2",
+          children: [
+            {
+              id: "S2_Option1",
+              data: {
+                text: "S2 Option1",
+              },
+            },
+            {
+              id: "S2_Option2",
+              data: {
+                text: "S2 Option2",
+              },
+            },
+          ],
+        },
+        {
+          title: "Section 3",
+          children: [
+            {
+              id: "S3_Option1",
+              data: {
+                text: "S3 Option1",
+              },
+            },
+            {
+              id: "S3_Option2",
+              data: {
+                text: "S3 Option2",
+              },
+            },
+          ],
+        },
+      ]}
+    />
+  );
+
+  expect(screen.getByTestId("group-0-expanded")).toBeTruthy();
+  expect(screen.queryAllByTestId("group-1-expanded")).toHaveLength(0);
+  expect(screen.getByTestId("group-2-expanded")).toBeTruthy();
+
+  await waitFor(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    answers: ["S1_Option1", "S3_Option1"],
+  });
+});

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
@@ -1,10 +1,97 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { uniqueId } from "lodash";
 import React from "react";
 import { act } from "react-dom/test-utils";
 
+import { fillInFieldsUsingPlaceholder } from "../shared/testHelpers";
 import { dateRangeSchema, dateSchema, paddedDate } from "./model";
 import DateInput from "./Public";
+
+test("submits a date", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+
+  render(
+    <DateInput id={componentId} title="Pizza Day" handleSubmit={handleSubmit} />
+  );
+
+  expect(screen.getByRole("heading")).toHaveTextContent("Pizza Day");
+
+  await waitFor(async () => {
+    await fillInFieldsUsingPlaceholder({
+      DD: "22",
+      MM: "05",
+      YYYY: "2010",
+    });
+
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      [componentId]: "2010-05-22",
+    },
+  });
+});
+
+test("recovers previously submitted date when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+
+  render(
+    <DateInput
+      id={componentId}
+      title="Pizza Day"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: {
+          [componentId]: "2010-05-22",
+        },
+      }}
+    />
+  );
+
+  await waitFor(() => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      [componentId]: "2010-05-22",
+    },
+  });
+});
+
+test("recovers previously submitted date when clicking the back button even if a data field is set", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+  const dataField = "data-field";
+
+  render(
+    <DateInput
+      fn={dataField}
+      id={componentId}
+      title="Pizza Day"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: {
+          [dataField]: "2010-05-22",
+        },
+      }}
+    />
+  );
+
+  await waitFor(() => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      [dataField]: "2010-05-22",
+    },
+  });
+});
 
 test("renders", async () => {
   render(<DateInput title="Enter a date" />);

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -13,14 +13,14 @@ import DateInputComponent from "ui/DateInput";
 import InputRow from "ui/InputRow";
 import { object } from "yup";
 
-import { makeData } from "../shared/utils";
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 
 export type Props = PublicProps<DateInput, UserData>;
 
 const DateInputPublic: React.FC<Props> = (props) => {
   const formik = useFormik({
     initialValues: {
-      date: "",
+      date: getPreviouslySubmittedData(props) ?? "",
     },
     onSubmit: (values) => {
       props.handleSubmit?.(makeData(props, values.date));
@@ -49,7 +49,7 @@ const DateInputPublic: React.FC<Props> = (props) => {
             // Pad it here if necessary; keep DateInputComponent simple
             formik.setFieldValue("date", paddedDate(newDate));
           }}
-          error={formik.errors.date}
+          error={formik.errors.date as string}
         />
       </InputRow>
     </Card>

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import DrawBoundary from "./";
+
+test("recovers previously submitted files when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const previouslySubmittedData = {
+    "proposal.drawing.locationPlan":
+      "http://127.0.0.1:9000/planx-temp/tdgg8gvf/file.pdf",
+    "property.uploadedFile": {
+      file: {
+        path: "file.pdf",
+        type: "application.pdf",
+      },
+      status: "success",
+      progress: 1,
+      id: "g5Xy36kAGY2k9xoTxtk_i",
+      url: "http://127.0.0.1:9000/planx-temp/tdgg8gvf/file.pdf",
+    },
+  };
+
+  render(
+    <DrawBoundary
+      dataFieldBoundary="property.boundary.site"
+      dataFieldArea="property.area.site"
+      description=""
+      descriptionForUploading=""
+      title="Draw a boundary"
+      titleForUploading="Upload a file"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: previouslySubmittedData,
+      }}
+    />
+  );
+
+  userEvent.click(screen.getByText("Continue"));
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: previouslySubmittedData,
+  });
+});
+
+test("recovers previously submitted drawing when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const previouslySubmittedData = {
+    "property.boundary.site": {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-0.07643975531307334, 51.485847769536015],
+            [-0.0764006164494183, 51.4855918619739],
+            [-0.07587615567891393, 51.48561867140494],
+            [-0.0759899845402056, 51.48584045791162],
+            [-0.07643975531307334, 51.485847769536015],
+          ],
+        ],
+      },
+    },
+  };
+
+  render(
+    <DrawBoundary
+      dataFieldBoundary="property.boundary.site"
+      dataFieldArea="property.area.site"
+      description=""
+      descriptionForUploading=""
+      title="Draw a boundary"
+      titleForUploading="Upload a file"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: previouslySubmittedData,
+      }}
+    />
+  );
+
+  userEvent.click(screen.getByText("Continue"));
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: expect.objectContaining(previouslySubmittedData),
+  });
+});

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -109,17 +109,25 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function FileUpload(props: any) {
-  const [slot, setSlot] = useState<any>();
+export interface FileUpload<T extends File = any> {
+  file: T;
+  status: "success" | "error" | "uploading";
+  progress: number;
+  id: string;
+  url?: string;
+}
+interface Props {
+  setFile: (file?: FileUpload) => void;
+  initialFile?: FileUpload;
+}
+
+export default function FileUpload(props: Props) {
+  const [slot, setSlot] = useState<FileUpload | undefined>(props.initialFile);
   const MAX_UPLOAD_SIZE_MB = 30;
 
-  const handleSubmit = () => {
-    // url: slot.url,
-    // filename: slot.file.path,
-  };
   useEffect(() => {
-    props.setUrl(slot?.url);
-  }, [props.setUrl, slot]);
+    props.setFile(slot);
+  }, [props.setFile, slot]);
   const classes = useStyles();
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: ["image/jpeg", "image/png", "application/pdf"],

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -7,17 +7,19 @@ import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import type { PublicProps } from "@planx/components/ui";
 import type { Geometry } from "@turf/helpers";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
-import type { DrawBoundary } from "../model";
+import { DEFAULT_PASSPORT_AREA_KEY, DrawBoundary } from "../model";
 import {
   DEFAULT_TITLE,
   DEFAULT_TITLE_FOR_UPLOADING,
   PASSPORT_UPLOAD_KEY,
+  PASSPORT_UPLOADED_FILE_KEY,
 } from "../model";
-import Upload from "./Upload";
+import Upload, { FileUpload } from "./Upload";
 
 export type Props = PublicProps<DrawBoundary>;
+export type SelectedFile = FileUpload;
 
 const useClasses = makeStyles((theme) => ({
   map: {
@@ -36,15 +38,28 @@ const useClasses = makeStyles((theme) => ({
 }));
 
 export default function Component(props: Props) {
-  const [page, setPage] = useState<"draw" | "upload">("draw");
+  const isMounted = useRef(false);
+  const previousBoundary =
+    props.previouslySubmittedData?.data?.[props.dataFieldBoundary];
+  const previousArea =
+    props.previouslySubmittedData?.data?.[
+      props.dataFieldArea || DEFAULT_PASSPORT_AREA_KEY
+    ];
+  const previousFile =
+    props.previouslySubmittedData?.data?.[PASSPORT_UPLOADED_FILE_KEY];
+  const startPage = previousFile ? "upload" : "draw";
+  const [page, setPage] = useState<"draw" | "upload">(startPage);
   const passport = useStore((state) => state.computePassport());
   const classes = useClasses();
-  const [boundary, setBoundary] = useState<Boundary>();
-  const [url, setUrl] = useState<string | undefined>();
-  const [area, setArea] = useState<number | undefined>();
+  const [boundary, setBoundary] = useState<Boundary>(previousBoundary);
+  const [selectedFile, setSelectedFile] = useState<SelectedFile | undefined>(
+    previousFile
+  );
+  const [area, setArea] = useState<number | undefined>(previousArea);
 
   useEffect(() => {
-    setUrl(undefined);
+    if (isMounted.current) setSelectedFile(undefined);
+    isMounted.current = true;
 
     const areaChangeHandler = ({ detail }: { detail: string }) => {
       const numberString = detail.split(" ")[0];
@@ -57,7 +72,7 @@ export default function Component(props: Props) {
       setBoundary(geojson.features[0]);
     };
 
-    const map = document.querySelector("my-map");
+    const map: any = document.querySelector("my-map");
     map?.addEventListener("areaChange", areaChangeHandler);
     map?.addEventListener("geojsonChange", geojsonChangeHandler);
 
@@ -65,10 +80,13 @@ export default function Component(props: Props) {
       map?.removeEventListener("areaChange", areaChangeHandler);
       map?.removeEventListener("geojsonChange", geojsonChangeHandler);
     };
-  }, [page, setArea, setBoundary, setUrl]);
+  }, [page, setArea, setBoundary, setSelectedFile]);
 
   return (
-    <Card handleSubmit={handleSubmit} isValid={Boolean(boundary || url)}>
+    <Card
+      handleSubmit={handleSubmit}
+      isValid={Boolean(boundary || selectedFile?.url)}
+    >
       {getBody()}
     </Card>
   );
@@ -115,7 +133,7 @@ export default function Component(props: Props) {
             howMeasured={props.howMeasured}
             definitionImg={props.definitionImg}
           />
-          <Upload setUrl={setUrl} />
+          <Upload setFile={setSelectedFile} initialFile={selectedFile} />
           <p className={classes.uploadInstead}>
             <a onClick={() => setPage("draw")}>
               Draw the boundary on a map instead
@@ -139,7 +157,12 @@ export default function Component(props: Props) {
           boundary && props.dataFieldBoundary && props.dataFieldArea
             ? area
             : undefined,
-        [propsDataFieldUrl]: url && propsDataFieldUrl ? url : undefined,
+        [propsDataFieldUrl]:
+          selectedFile?.url && propsDataFieldUrl
+            ? selectedFile?.url
+            : undefined,
+        [PASSPORT_UPLOADED_FILE_KEY]:
+          selectedFile && propsDataFieldUrl ? selectedFile : undefined,
       };
     })();
 

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -25,7 +25,9 @@ export const parseDrawBoundary = (
   dataFieldArea: data?.dataFieldArea || "",
 });
 
-const DEFAULT_PASSPORT_BOUNDARY_KEY = "property.boundary.site" as const;
+export const DEFAULT_PASSPORT_BOUNDARY_KEY = "property.boundary.site" as const;
+export const DEFAULT_PASSPORT_AREA_KEY = "property.boundary.area" as const;
 export const DEFAULT_TITLE = "Draw the boundary of the property" as const;
 export const DEFAULT_TITLE_FOR_UPLOADING = "Upload the PDF location plan" as const;
 export const PASSPORT_UPLOAD_KEY = "proposal.drawing.locationPlan" as const; // not added to editor yet
+export const PASSPORT_UPLOADED_FILE_KEY = "property.uploadedFile";

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { uniqueId } from "lodash";
 import React from "react";
 
 import FileUpload from "./Public";
@@ -16,4 +17,69 @@ test("renders correctly and blocks submit if there are no files added", async ()
   expect(handleSubmit).toHaveBeenCalledTimes(0);
 });
 
+test("recovers previously submitted files when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+  const uploadedFile = {
+    data: {
+      [componentId]: [dummyFile],
+    },
+  };
+
+  render(
+    <FileUpload
+      id={componentId}
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={uploadedFile}
+    />
+  );
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith(uploadedFile);
+});
+
+test("recovers previously submitted files when clicking the back button even if a data field is set", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+  const dataField = "data-field";
+  const uploadedFile = {
+    data: {
+      [dataField]: [dummyFile],
+    },
+  };
+
+  render(
+    <FileUpload
+      fn={dataField}
+      id={componentId}
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={uploadedFile}
+    />
+  );
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith(uploadedFile);
+});
+
 test.todo("cannot continue until uploads have finished");
+
+const dummyFile = {
+  url: "http://127.0.0.1:9000/planx-temp/4oh73out/PXL_20210327_122515714.pdf",
+  filename: "PXL_20210327_122515714.pdf",
+  cachedSlot: {
+    file: {
+      path: "PXL_20210327_122515714.pdf",
+      type: "application/pdf",
+    },
+    status: "success",
+    progress: 1,
+    id: "2vBmuynz-3D_EN-H2gF2E",
+    url: "http://127.0.0.1:9000/planx-temp/4oh73out/PXL_20210327_122515714.pdf",
+  },
+};

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -10,6 +10,7 @@ import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { uploadFile } from "api/upload";
 import classNames from "classnames";
 import { nanoid } from "nanoid";
+import { Store } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
@@ -17,7 +18,7 @@ import ErrorWrapper from "ui/ErrorWrapper";
 import { array } from "yup";
 
 import handleRejectedUpload from "../shared/handleRejectedUpload";
-import { makeData } from "../shared/utils";
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 
 interface Props extends MoreInformation {
   id?: string;
@@ -25,6 +26,7 @@ interface Props extends MoreInformation {
   fn?: string;
   description?: string;
   handleSubmit: handleSubmit;
+  previouslySubmittedData?: Store.userData;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -139,7 +141,10 @@ const slotsSchema = array()
   });
 
 const FileUpload: React.FC<Props> = (props) => {
-  const [slots, setSlots] = useState<any[]>([]);
+  const recoveredSlots = getPreviouslySubmittedData(props)?.map(
+    (slot: any) => slot.cachedSlot
+  );
+  const [slots, setSlots] = useState<any[]>(recoveredSlots ?? []);
   const [validationError, setValidationError] = useState<string>();
 
   const handleSubmit = () => {
@@ -152,6 +157,7 @@ const FileUpload: React.FC<Props> = (props) => {
             slots.map((slot: any) => ({
               url: slot.url,
               filename: slot.file.path,
+              cachedSlot: slot,
             }))
           )
         );

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -1,0 +1,140 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { uniqueId } from "lodash";
+import React from "react";
+import * as ReactNavi from "react-navi";
+import * as SWR from "swr";
+
+import FindProperty from "./";
+import addressMock from "./mocks/addressMock";
+import findAddressReturnMock from "./mocks/findAddressReturnMock";
+
+jest.spyOn(SWR, "default").mockImplementation(
+  () =>
+    ({
+      data: addressMock,
+    } as any)
+);
+
+jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+  () =>
+    ({
+      data: {
+        team: "canterbury",
+      },
+    } as any)
+);
+
+const originalFetch = global.fetch;
+global.fetch = jest.fn(async () => ({
+  json: async () => ({ rates: { CAD: 1.42 } }),
+})) as any;
+
+afterAll(() => {
+  jest.restoreAllMocks();
+  global.fetch = originalFetch;
+});
+
+test("renders correctly", async () => {
+  const handleSubmit = jest.fn();
+  const id = uniqueId();
+
+  render(
+    <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <FindProperty
+        description="Find your property"
+        title="Type your postal code"
+        handleSubmit={handleSubmit}
+      />
+    </MockedProvider>
+  );
+
+  await act(async () => {
+    await userEvent.type(
+      screen.getByPlaceholderText("Enter the postcode of the property"),
+      "SE5 0HU",
+      {
+        delay: 1,
+      }
+    );
+  });
+  await act(async () => {
+    await userEvent.type(screen.getByTestId("autocomplete-input"), "75", {
+      delay: 1,
+    });
+  });
+  await act(async () => {
+    userEvent.click(screen.getByText("75 COBOURG ROAD, LONDON"));
+  });
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalled();
+});
+
+test("recovers previously submitted address when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const previousData = {
+    _address: {
+      __typename: "addresses",
+      uprn: "200003497830",
+      town: "LONDON",
+      y: 177898.62376470293,
+      x: 533662.1449918789,
+      street: "COBOURG ROAD",
+      sao: "",
+      postcode: "SE5 0HU",
+      pao: "103",
+      organisation: "",
+      blpu_code: "PP",
+      latitude: "51.4842536",
+      longitude: "-0.0764165",
+      single_line_address: "103 COBOURG ROAD, LONDON, SE5 0HU",
+      title: "103 COBOURG ROAD, LONDON",
+    },
+    _nots: {
+      "property.constraints.planning": [
+        "designated.nationalPark",
+        "designated.broads",
+        "article4",
+        "article4.canterbury.hmo",
+        "listed",
+        "designated.conservationArea",
+        "designated.AONB",
+        "designated.WHS",
+        "designated.monument",
+        "nature.SSSI",
+        "designated",
+      ],
+    },
+  };
+
+  render(
+    <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <FindProperty
+        description="Find your property"
+        title="Type your postal code"
+        handleSubmit={handleSubmit}
+        previouslySubmittedData={{
+          data: previousData,
+        }}
+      />
+    </MockedProvider>
+  );
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: previousData,
+  });
+});

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/addressMock.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/addressMock.ts
@@ -1,0 +1,58 @@
+export default {
+  "designated.nationalPark": {
+    text: "is not in a National Park",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "designated.broads": {
+    text: "is not in a Broad",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  article4: {
+    text: "is not subject to any Article 4 Restrictions",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "article4.canterbury.hmo": { value: false },
+  listed: {
+    text: "is not in, or within, a Listed Building",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "designated.conservationArea": {
+    text: "is not in a Conservation Area",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "designated.AONB": {
+    text: "is not an Area of Outstanding Natural Beauty",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "designated.WHS": {
+    text: "is not an UNESCO World Heritage Site",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "designated.monument": {
+    text: "is not the site of an Ancient Monument",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  "nature.SSSI": {
+    text: "is not a Site of Special Scientific Interest",
+    value: false,
+    type: "check",
+    data: {},
+  },
+  designated: { value: false },
+};

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/findAddressReturnMock.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/findAddressReturnMock.ts
@@ -1,0 +1,50 @@
+import { FIND_ADDRESS } from "..";
+
+export default [
+  {
+    request: {
+      query: FIND_ADDRESS,
+      variables: {
+        postcode: "SE5 0HU",
+      },
+    },
+    result: {
+      data: {
+        addresses: [
+          {
+            __typename: "addresses",
+            uprn: "10009794876",
+            town: "LONDON",
+            y: 177993.1576962067,
+            x: 533675.7866412636,
+            street: "COBOURG ROAD",
+            sao: "",
+            postcode: "SE5 0HU",
+            pao: "75",
+            organisation: "",
+            blpu_code: "RD",
+            latitude: "51.4850999",
+            longitude: "-0.0761844",
+            single_line_address: "75 COBOURG ROAD, LONDON, SE5 0HU",
+          },
+          {
+            __typename: "addresses",
+            uprn: "200003497830",
+            town: "LONDON",
+            y: 177898.62376470293,
+            x: 533662.1449918789,
+            street: "COBOURG ROAD",
+            sao: "",
+            postcode: "SE5 0HU",
+            pao: "103",
+            organisation: "",
+            blpu_code: "PP",
+            latitude: "51.4842536",
+            longitude: "-0.0764165",
+            single_line_address: "103 COBOURG ROAD, LONDON, SE5 0HU",
+          },
+        ],
+      },
+    },
+  },
+];

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { uniqueId } from "lodash";
 import React from "react";
 import { act } from "react-dom/test-utils";
 
@@ -26,4 +27,54 @@ test("renders correctly", async () => {
   });
 
   expect(handleSubmit).toHaveBeenCalledWith({ data: { num: 3 } });
+});
+
+test("recovers previously submitted number when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+
+  render(
+    <NumberInput
+      title="Cached Number"
+      handleSubmit={handleSubmit}
+      id={componentId}
+      previouslySubmittedData={{
+        data: {
+          [componentId]: 43,
+        },
+      }}
+    />
+  );
+
+  await waitFor(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({ data: { [componentId]: 43 } });
+});
+
+test("recovers previously submitted number when clicking the back button even if a data field is set", async () => {
+  const handleSubmit = jest.fn();
+  const componentId = uniqueId();
+  const dataField = "data-field";
+
+  render(
+    <NumberInput
+      fn={dataField}
+      title="Cached Number"
+      handleSubmit={handleSubmit}
+      id={componentId}
+      previouslySubmittedData={{
+        data: {
+          [dataField]: 43,
+        },
+      }}
+    />
+  );
+
+  await waitFor(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({ data: { [dataField]: 43 } });
 });

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
@@ -9,7 +9,7 @@ import InputRow from "ui/InputRow";
 import InputRowLabel from "ui/InputRowLabel";
 import { object, string } from "yup";
 
-import { makeData } from "../shared/utils";
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { NumberInput, UserData } from "./model";
 import { parseNumber } from "./model";
 
@@ -18,7 +18,7 @@ export type Props = PublicProps<NumberInput, UserData>;
 export default function NumberInputComponent(props: Props): FCReturn {
   const formik = useFormik({
     initialValues: {
-      value: "",
+      value: getPreviouslySubmittedData(props) ?? "",
     },
     onSubmit: (values) => {
       if (values.value && props.handleSubmit) {
@@ -70,7 +70,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
           placeholder="enter value"
           value={formik.values.value}
           onChange={formik.handleChange}
-          errorMessage={formik.errors.value}
+          errorMessage={formik.errors.value as string}
         />
         {props.units && <InputRowLabel>{props.units}</InputRowLabel>}
       </InputRow>

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -4,7 +4,7 @@ export interface NumberInput extends MoreInformation {
   title: string;
   description?: string;
   placeholder?: string;
-  fn: string;
+  fn?: string;
   units?: string;
 }
 

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -1,10 +1,10 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { uniqueId } from "lodash";
 import React from "react";
 
 import { TextInputType } from "./model";
 import TextInput from "./Public";
-
 test("requires a value before being able to continue", async () => {
   const handleSubmit = jest.fn();
 
@@ -67,6 +67,63 @@ test("requires a valid phone number before being able to continue", async () => 
   });
 
   expect(handleSubmit).toHaveBeenCalledTimes(0);
+});
+
+test("recovers previously submitted text when clicking the back button", async () => {
+  const handleSubmit = jest.fn();
+  const nodeId = uniqueId();
+
+  render(
+    <TextInput
+      id={nodeId}
+      title="Submit text"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: {
+          [nodeId]: "Previously submitted text",
+        },
+      }}
+    />
+  );
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      [nodeId]: "Previously submitted text",
+    },
+  });
+});
+
+test("recovers previously submitted text when clicking the back button even if a data field is set", async () => {
+  const handleSubmit = jest.fn();
+  const nodeId = uniqueId();
+
+  render(
+    <TextInput
+      fn="text-input-key"
+      id={nodeId}
+      title="Submit text"
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: {
+          "text-input-key": "Previously submitted text",
+        },
+      }}
+    />
+  );
+
+  await act(async () => {
+    userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledWith({
+    data: {
+      "text-input-key": "Previously submitted text",
+    },
+  });
 });
 
 const examplePhoneNumbers = [

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -7,16 +7,17 @@ import Input from "ui/Input";
 import InputRow from "ui/InputRow";
 import { object } from "yup";
 
-import { makeData } from "../shared/utils";
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { TextInput, UserData } from "./model";
 import { userDataSchema } from "./model";
 
 export type Props = PublicProps<TextInput, UserData>;
 
+// TODO: fix this data field bug for all components
 const TextInputComponent: React.FC<Props> = (props) => {
   const formik = useFormik({
     initialValues: {
-      text: "",
+      text: getPreviouslySubmittedData(props) ?? "",
     },
     onSubmit: (values) => {
       props.handleSubmit?.(makeData(props, values.text));
@@ -51,7 +52,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
           placeholder={props.placeholder || "Type your answer"}
           bordered
           onChange={formik.handleChange}
-          errorMessage={formik.errors.text}
+          errorMessage={formik.errors.text as string}
         />
       </InputRow>
     </Card>

--- a/editor.planx.uk/src/@planx/components/shared/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/shared/utils.test.ts
@@ -1,4 +1,7 @@
-import { useStagingUrlIfTestApplication } from "./utils";
+import {
+  getPreviouslySubmittedData,
+  useStagingUrlIfTestApplication,
+} from "./utils";
 
 describe("useStagingUrlIfTestApplication()", () => {
   test("replaces URL if test user", () => {
@@ -21,5 +24,34 @@ describe("useStagingUrlIfTestApplication()", () => {
     })("https://api.editor.planx.uk/pay");
 
     expect(url).toStrictEqual("https://api.editor.planx.uk/pay");
+  });
+
+  test("returns correct result providing an id", () => {
+    const data = {
+      id: "some-id",
+      previouslySubmittedData: {
+        data: {
+          "some-id": 1234,
+          randomAttribute: "abcd",
+        },
+      },
+    };
+
+    expect(getPreviouslySubmittedData(data)).toEqual(1234);
+  });
+
+  test("returns correct result providing an fn value", () => {
+    const data = {
+      id: "some-id",
+      fn: "data-field",
+      previouslySubmittedData: {
+        data: {
+          "data-field": 1234,
+          randomAttribute: "abcd",
+        },
+      },
+    };
+
+    expect(getPreviouslySubmittedData(data)).toEqual(1234);
   });
 });

--- a/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -78,3 +78,18 @@ export const useStagingUrlIfTestApplication = (passport: Store.passport) => (
 
   return urlThatMightBeReplaced;
 };
+
+export const getPreviouslySubmittedData = ({
+  id,
+  fn,
+  previouslySubmittedData,
+}: {
+  id?: string;
+  fn?: string;
+  previouslySubmittedData?: any;
+}) => {
+  const key = fn || id;
+  const data = key && previouslySubmittedData?.data?.[key];
+
+  return data;
+};

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -21,6 +21,7 @@ import Send from "@material-ui/icons/Send";
 import SquareFoot from "@material-ui/icons/SquareFoot";
 import TextFields from "@material-ui/icons/TextFields";
 import { TYPES } from "@planx/components/types";
+import { Store } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React, { ChangeEvent } from "react";
 import ImgInput from "ui/ImgInput";
@@ -38,10 +39,12 @@ export interface EditorProps<Type, Data> {
 }
 
 export type PublicProps<Data, UserData = {}> = Data & {
+  id?: string;
   handleSubmit?: handleSubmit;
   resetButton?: boolean;
   resetPreview?: () => void;
   autoFocus?: boolean;
+  previouslySubmittedData?: Store.userData;
 };
 
 // XXX: We define the Icon type in terms of one of the Icons so as not to have to repeat ourselves

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -36,10 +36,16 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const DebugConsole = () => {
-  const [passport, breadcrumbs, flowId] = useStore((state) => [
+  const [
+    passport,
+    breadcrumbs,
+    flowId,
+    cachedBreadcrumbs,
+  ] = useStore((state) => [
     state.computePassport(),
     state.breadcrumbs,
     state.id,
+    state.cachedBreadcrumbs,
   ]);
   const classes = useStyles();
   return (
@@ -53,7 +59,9 @@ const DebugConsole = () => {
           Download the flow schema
         </a>
       </Typography>
-      <pre>{JSON.stringify({ passport, breadcrumbs }, null, 2)}</pre>
+      <pre>
+        {JSON.stringify({ passport, breadcrumbs, cachedBreadcrumbs }, null, 2)}
+      </pre>
     </div>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -18,6 +18,7 @@ export declare namespace Store {
     auto?: boolean;
   };
   export type breadcrumbs = Record<nodeId, userData>;
+  export type cachedBreadcrumbs = Record<nodeId, userData> | undefined;
   export type node = {
     id?: nodeId;
     type?: TYPES;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -53,6 +53,7 @@ export interface PreviewStore extends Store.Store {
   // temporary measure for storing payment fee & id between gov uk redirect
   govUkPayment?: GovUKPayment;
   setGovUkPayment: (govUkPayment: GovUKPayment) => void;
+  cachedBreadcrumbs?: Store.cachedBreadcrumbs;
 }
 
 // export const previewStore = vanillaCreate<PreviewStore>((set, get) => ({
@@ -248,6 +249,7 @@ export const previewStore = (
       if (idx >= 0) {
         set({
           breadcrumbs: pick(breadcrumbs, breadcrumbIds.slice(0, idx)),
+          cachedBreadcrumbs: pick(breadcrumbs, [id]),
         });
       }
     }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -45,7 +45,7 @@ export const sharedStore = (
   },
 
   resetPreview() {
-    set({ breadcrumbs: {}, sessionId: "" });
+    set({ cachedBreadcrumbs: {}, breadcrumbs: {}, sessionId: "" });
   },
 
   setFlow(id, flow) {

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -48,6 +48,7 @@ const Node: React.FC<any> = (props: Props) => {
     isFinalCard,
     resetPreview,
     sessionId,
+    cachedBreadcrumbs,
   ] = useStore((state) => [
     state.childNodesOf,
     state.resultData,
@@ -56,13 +57,18 @@ const Node: React.FC<any> = (props: Props) => {
     state.isFinalCard(),
     state.resetPreview,
     state.sessionId,
+    state.cachedBreadcrumbs,
   ]);
 
   const handleSubmit = isFinalCard ? undefined : props.handleSubmit;
 
+  const nodeId = props.node.id;
+  const previouslySubmittedData =
+    nodeId && cachedBreadcrumbs ? cachedBreadcrumbs[nodeId] : undefined;
   const allProps = {
-    id: props.node.id,
+    id: nodeId,
     ...props.node.data,
+    previouslySubmittedData,
     resetPreview,
     handleSubmit,
   };


### PR DESCRIPTION
At present the back button removes text field values, checkbox values, etc. This PR fixes that.

https://trello.com/c/YXCE5Kpi/1118-retain-data-user-has-entered-so-it-is-still-visible-when-you-click-back-button
