### PR TITLE
fix: cascade flow deletions to published flows

### DIFF
--- a/hasura.planx.uk/migrations/1629873996426_set_fk_public_published_flows_flow_id/down.sql
+++ b/hasura.planx.uk/migrations/1629873996426_set_fk_public_published_flows_flow_id/down.sql
@@ -1,0 +1,7 @@
+alter table "public"."published_flows" drop constraint "published_flows_flow_id_fkey",
+          add constraint "published_flows_flow_id_fkey"
+          foreign key ("flow_id")
+          references "public"."flows"
+          ("id")
+          on update restrict
+          on delete restrict;

--- a/hasura.planx.uk/migrations/1629873996426_set_fk_public_published_flows_flow_id/up.sql
+++ b/hasura.planx.uk/migrations/1629873996426_set_fk_public_published_flows_flow_id/up.sql
@@ -1,0 +1,7 @@
+alter table "public"."published_flows" drop constraint "published_flows_flow_id_fkey",
+          add constraint "published_flows_flow_id_fkey"
+          foreign key ("flow_id")
+          references "public"."flows"
+          ("id")
+          on update cascade
+          on delete cascade;


### PR DESCRIPTION
the hasura foreign key is set to "restrict" by default, changing to "cascade" autogenerates this migration and fixes [this Airbrake error](https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1629466590004000)! 

![Screenshot from 2021-08-25 09-22-17](https://user-images.githubusercontent.com/5132349/130745015-274e3887-d831-4271-8987-56aaaee2f731.png)
