### PR TITLE
fix: adjust global_settings permissions and add introspection tests

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -103,6 +103,13 @@
 - table:
     schema: public
     name: global_settings
+  select_permissions:
+  - role: public
+    permission:
+      columns:
+      - id
+      - footer_content
+      filter: {}
 - table:
     schema: public
     name: operations

--- a/hasura.planx.uk/tests/global_settings.test.js
+++ b/hasura.planx.uk/tests/global_settings.test.js
@@ -1,0 +1,47 @@
+const { gqlPublic, gqlAdmin } = require("./utils");
+
+describe("global_settings", () => {
+  const INTROSPECTION_QUERY = `
+    query IntrospectionQuery {
+      __schema {
+        types {
+          name
+          description
+          fields {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  test("public can query global settings", async () => {
+    const response = await gqlPublic(INTROSPECTION_QUERY);
+    const { types } = response.data.__schema;
+    const queries = types.find(x => x.name === 'query_root').fields.map(x => x.name);
+
+    expect(queries).toContain('global_settings');
+  });
+
+  test("public cannot create, update, or delete global settings", async () => {
+    const response = await gqlPublic(INTROSPECTION_QUERY);
+    const { types } = response.data.__schema;
+    const mutations = types.find(x => x.name === 'mutation_root').fields.map(x => x.name);
+
+    expect(mutations).not.toContain('insert_global_settings');
+    expect(mutations).not.toContain('update_global_settings_by_pk');
+    expect(mutations).not.toContain('delete_global_settings');
+  });
+
+  test("admin has full access to query and mutate global settings", async () => {
+    const response = await gqlAdmin(INTROSPECTION_QUERY);
+    const { types } = response.data.__schema;
+    const queries = types.find(x => x.name === 'query_root').fields.map(x => x.name);
+    const mutations = types.find(x => x.name === 'mutation_root').fields.map(x => x.name);
+
+    expect(queries).toContain('global_settings');
+    expect(mutations).toContain('insert_global_settings');
+    expect(mutations).toContain('update_global_settings_by_pk');
+    expect(mutations).toContain('delete_global_settings');
+  });
+});


### PR DESCRIPTION
Airbrake caught this bug on staging a couple of times this week! public role is now allowed to "select", but nothing else

![Screenshot from 2021-08-26 08-40-30](https://user-images.githubusercontent.com/5132349/130915024-6c3aa11e-26be-445f-8ce4-d0caac62540e.png)
