### PR TITLE
fix: ensure storybook can load new maps & use newest map release throughout

### DIFF
--- a/editor.planx.uk/.storybook/preview-head.html
+++ b/editor.planx.uk/.storybook/preview-head.html
@@ -3,3 +3,14 @@
   href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap"
   rel="stylesheet"
 />
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3.1"
+></script>
+<!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap"
+  rel="stylesheet"
+/>

--- a/editor.planx.uk/README.md
+++ b/editor.planx.uk/README.md
@@ -22,3 +22,11 @@ and start the development server
 If your IDE does type checking for you and you want to save some CPU resources,
 you can opt-out of type checking by setting the environment variable
 `DISABLE_TYPE_CHECKING=true`.
+
+### Running Storybook
+
+We use [Storybook](https://storybook.js.org/) for our UI component library.
+
+Start the development server
+
+`pnpm start-storybook`

--- a/editor.planx.uk/public/index.html
+++ b/editor.planx.uk/public/index.html
@@ -27,7 +27,7 @@
     <title>PlanX Editor</title>
     <script
       type="module"
-      src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3"
+      src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3.1"
     ></script>
     <!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
- add map package CDN to storybook's preview-head.html too until we're importing via shared package.json
- bump map package version overall: new release introduces a small fix to make sure that when you go 'back' you can't draw a second new boundary while the first is still visible on the map (a rare edge case, but was strangely possible I think!)
