### PR TITLE
save storybook build output in build/storybook

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -120,8 +120,8 @@
     "classic:start": "react-app-rewired start",
     "classic:build": "react-scripts build",
     "classic:test": "react-scripts test",
-    "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public",
+    "storybook": "start-storybook -p 6006 --static-dir public",
+    "build-storybook": "mkdir -p build && build-storybook --static-dir public --quiet --output-dir ./build/storybook",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}' --fix"
   },
   "eslintConfig": {


### PR DESCRIPTION
Part of the individual PR builds work. Just a little change here.

This will break the netlify storybook builds for the time being, but it will enable us to preview storybook at /storybook URLs

e.g. https://625.planx.pizza/storybook

netlify could be fixed so that it looks for editor.planx.uk/build/storybook instead of editor.planx.uk/storybook-static but then it would be broken for every other PR, so I think it's ok if the netlify storybook builds fail in this PR for now

I will remove the netlify preview builds once the PR staging builds are complete


