### PR TITLE
fix: prevent Review from displaying 'undefined'

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -22,3 +22,62 @@ test("renders correctly", async () => {
 
   expect(handleSubmit).toHaveBeenCalled();
 });
+
+test("REGRESSION: doesn't return undefined when multiple nodes are filled", async () => {
+  const handleSubmit = jest.fn();
+
+  render(
+    <Review
+      flow={mockedFlow}
+      breadcrumbs={mockedBreadcrumbs}
+      passport={mockedPassport}
+      changeAnswer={() => {}}
+      handleSubmit={handleSubmit}
+      showChangeButton={true}
+    />
+  );
+
+  expect(screen.getByText("This is a text")).toBeTruthy();
+  expect(screen.getByText("356")).toBeTruthy();
+  expect(screen.getByText("Option 2")).toBeTruthy();
+  expect(screen.queryAllByText("undefined")).toHaveLength(0);
+});
+
+const mockedBreadcrumbs = {
+  ZM31xEWH2c: {
+    auto: false,
+    data: {
+      ZM31xEWH2c: 356,
+    },
+  },
+  "1A14DTRw0d": {
+    auto: false,
+    data: {
+      "1A14DTRw0d": "This is a text",
+    },
+  },
+  duzkfXlWGn: {
+    auto: false,
+    answers: ["iWvI9QkgIT"],
+  },
+};
+const mockedPassport = {
+  data: {
+    ZM31xEWH2c: 356,
+    "1A14DTRw0d": "This is a text",
+  },
+};
+const mockedFlow = {
+  _root: { edges: ["ZM31xEWH2c", "1A14DTRw0d", "duzkfXlWGn", "EJBY2zSbmL"] },
+  "1A14DTRw0d": { data: { title: "Input a text" }, type: 110 },
+  EJBY2zSbmL: { type: 600 },
+  ZM31xEWH2c: { data: { title: "Input a number" }, type: 150 },
+  duzkfXlWGn: {
+    data: { text: "Select the desired options", allRequired: false },
+    type: 105,
+    edges: ["ky2QQWHgi5", "iWvI9QkgIT", "nyYCBQs24s"],
+  },
+  iWvI9QkgIT: { data: { text: "Option 2" }, type: 200 },
+  ky2QQWHgi5: { data: { text: "Option 1" }, type: 200 },
+  nyYCBQs24s: { data: { text: "Option 3" }, type: 200 },
+};

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -339,7 +339,7 @@ function getAnswers(props: ComponentProps): string[] {
 function getAnswersByNode(props: ComponentProps): any {
   try {
     const variableName: string = props.node!.data!.fn!;
-    return props.userData?.data![variableName ?? props.nodeId];
+    return props.userData?.data![variableName || props.nodeId];
   } catch (err) {}
   return "";
 }


### PR DESCRIPTION
https://trello.com/c/s00Pijid/1497-fix-review-component-where-it-shows-wrong-value-for-number-inputs


![](https://trello.com/1/cards/61310e3401d930402d741ec7/attachments/61310e3d8dca3d7ca0e174dc/previews/61310e3d8dca3d7ca0e17524/download/image.png)
