### PR TITLE
fix: minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     image: minio/minio:RELEASE.2021-08-31T05-46-54Z
     ports:
       - "9000:9000"
+      - "9001:9001"
     volumes:
       - ./minio-data:/data
     environment:
@@ -101,7 +102,7 @@ services:
       MINIO_ROOT_USER: ${AWS_ACCESS_KEY}
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_KEY}
     entrypoint: sh
-    command: -c "mkdir -p /data/${AWS_S3_BUCKET} && minio server /data"
+    command: -c "mkdir -p /data/${AWS_S3_BUCKET} && minio server --console-address ':9001' /data"
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
minio stopped working on my machine after I cleared my docker images cache.

because we're using `minio:latest` something must've have changed since my last `docker pull`

- 1st commit: fixes the problem
- 2nd commit: hard-codes a minio version so that this doesn't happen again
- 3rd commit: re-enables minio's console at port 9001


happy to have @johnrees incorporate these changes into one of his open PRs (instead of merging this one)
