### PR TITLE
fix: use single_line_address in Send, FindProperty, and Review

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -108,14 +108,10 @@ function Component(props: Props) {
         propertyDetails={[
           {
             heading: "Address",
-            detail: [
-              address.organisation,
-              address.sao,
-              [address.pao, address.street].filter(Boolean).join(" "),
-              address.town,
-            ]
-              .filter(Boolean)
-              .join(", "),
+            detail: address.single_line_address.replace(
+              `, ${address.postcode}`,
+              ""
+            ),
           },
           {
             heading: "Postcode",

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -171,12 +171,12 @@ function Question(props: ComponentProps) {
 }
 
 function FindProperty(props: ComponentProps) {
-  const { postcode, street, pao, town } = props.passport.data?._address;
+  const { postcode, single_line_address, town } = props.passport.data?._address;
   return (
     <>
       <div>Property</div>
       <div>
-        {`${pao} ${street}`}
+        {`${single_line_address.split(`, ${town}`)[0]}`}
         <br />
         {town}
         <br />

--- a/editor.planx.uk/src/@planx/components/Send/bops.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops.ts
@@ -174,9 +174,7 @@ export function getParams(
 
     site.uprn = String(address.uprn);
 
-    site.address_1 = [address.sao, address.pao, address.street]
-      .filter(Boolean)
-      .join(" ");
+    site.address_1 = address.single_line_address.split(`, ${address.town}`)[0];
 
     site.town = address.town;
     site.postcode = address.postcode;


### PR DESCRIPTION
We were using `single_line_address` in search, but still relying on sao, pao & street to make `site.address1` when sending to BOPS , which lacked the house names in some cases (eg Buckinghamshire postcode HP10 0EG)

Similarly updating FindProperty & Review address displays for consistency