### PR TITLE
fix: don't set "designated" GIS key if subvariables are missing

### DIFF
--- a/api.planx.uk/gis/helpers.js
+++ b/api.planx.uk/gis/helpers.js
@@ -124,8 +124,8 @@ const addDesignatedVariable = (responseObject) => {
   // Ensure that our response includes all the expected subVariables before returning "designated"
   //   so we don't incorrectly auto-answer any questions for individual layer queries that may have failed
   let subVariablesFound = 0;
-  Object.keys(responseObject).forEach((s) => {
-    if (s.startsWith(`designated.`)) {
+  Object.keys(responseObject).forEach((key) => {
+    if (key.startsWith(`designated.`)) {
       subVariablesFound++;
     }
   });


### PR DESCRIPTION
another tedious GIS edge case! explained in [this Slack thread](https://ripahq.slack.com/archives/C0241GWFG4B/p1631195336022100) and in linked Trello cards

this fix makes sure that we don't set the parent-level variable is a subvariable query fails or is unavailable - ensuring that a user would then get asked questions related to that subvariable because it is the most granular (whereas "designated" would prematurely auto-answer the question for a missing designated subvariable if it is set)

note: intentionally not updating [this expect statement in our GIS tests](https://github.com/theopensystemslab/planx-new/blob/main/api.planx.uk/server.test.js#L238), because all subvariables _should_ be defined if all mapservers are operational/queries are valid & therefore "designated" is still expected to be set as we originally test for here! 