### PR TITLE
break: move validation warning message to above the input

### DIFF
--- a/editor.planx.uk/src/ui/ErrorWrapper.tsx
+++ b/editor.planx.uk/src/ui/ErrorWrapper.tsx
@@ -15,8 +15,8 @@ const useClasses = makeStyles((theme) => ({
   errorText: {
     color: theme.palette.error.main,
     margin: 0,
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(0.5),
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(1),
     fontWeight: "bold",
   },
 }));
@@ -25,8 +25,8 @@ export default function ErrorWrapper(props: Props): FCReturn {
   const classes = useClasses();
   return (
     <div className={props.error ? classes.rootError : undefined}>
-      {props.children || null}
       {props.error && <p className={classes.errorText}>{props.error}</p>}
+      {props.children || null}
     </div>
   );
 }


### PR DESCRIPTION
According to GOV UK guidelines, validation warning messages should appear above the respective input, not below, so that screen readers can read it.


Example:

![](https://trello.com/1/cards/6103e0b47928355dc3d84178/attachments/6103e0ee1b81a488dd676c7c/previews/6103e0ef1b81a488dd676c84/download/Screenshot_2021-07-30_at_12.22.16.png)


Card:

https://trello.com/c/VQO6PgY5/1437-move-validation-warning-messages-to-above-component-as-per-govuk
