### PR TITLE
fix: account for empty gss_code in address_base data

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -179,7 +179,14 @@ function GetAddress(props: {
     gql`
       query FindAddress($postcode: String = "", $gss_code: String) {
         addresses(
-          where: { postcode: { _eq: $postcode }, gss_code: { _eq: $gss_code } }
+          where: {
+            postcode: { _eq: $postcode }
+            _or: [
+              { gss_code: { _eq: $gss_code } }
+              { gss_code: { _eq: "" } }
+              { gss_code: { _is_null: true } }
+            ]
+          }
         ) {
           uprn
           town

--- a/hasura.planx.uk/migrations/1632478783948_create_gss_code_index/down.sql
+++ b/hasura.planx.uk/migrations/1632478783948_create_gss_code_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX "gss_code_hash_idx";

--- a/hasura.planx.uk/migrations/1632478783948_create_gss_code_index/up.sql
+++ b/hasura.planx.uk/migrations/1632478783948_create_gss_code_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "gss_code_hash_idx" ON address_base USING hash(gss_code);


### PR DESCRIPTION
when testing in staging against full address base data, postcode validation warnings were incorrectly showing for some values (eg "HP20 1UY" in Bucks) because of missing/empty string gss_code values, which then resulted in a list of 0 valid addresses. 

changes:
- adjust query to use `_or`
- add an index to `gss_code` column in underlying address_base table (same as existing index on `postcode`)