### PR TITLE
feat: make FindProperty accessible

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -389,7 +389,7 @@ function PropertyConstraints({ constraintsData }: any) {
   return (
     <Box mb={3}>
       <Box pb={2}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h3" component="h2" gutterBottom>
           {title}
         </Typography>
         <Typography variant="body2" gutterBottom>


### PR DESCRIPTION
This PR makes the tests in the accessibility extension pass—there was very little to do. Making the map itself accessible is already happening in another PR.