### PR TITLE
fix: make DrawBoundary links more visible

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -25,12 +25,15 @@ const useClasses = makeStyles((theme) => ({
   },
   uploadInstead: {
     textAlign: "right",
-    fontSize: "small",
+    fontSize: "medium",
     marginTop: theme.spacing(1),
     "& a": {
-      color: theme.palette.text.secondary,
+      color: theme.palette.text.primary,
       cursor: "pointer",
       padding: theme.spacing(2),
+    },
+    "& a:hover": {
+      backgroundColor: theme.palette.background.paper,
     },
   },
 }));


### PR DESCRIPTION
Links are now the primary text colour & size per suggestion in Trello card! 

![Screenshot from 2021-10-14 09-26-03](https://user-images.githubusercontent.com/5132349/137272524-c070281d-e6b3-464d-bfbb-aee1426d173b.png
)
![Screenshot from 2021-10-14 09-26-19](https://user-images.githubusercontent.com/5132349/137272551-2f42fe51-5045-41e5-be87-a7d906866c15.png)
)
