### PR TITLE
fix: better fit review page map to bounds

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -290,6 +290,7 @@ function DrawBoundary(props: ComponentProps) {
               geojsonData={JSON.stringify(data)}
               geojsonColor="#ff0000"
               geojsonFill
+              geojsonBuffer="20"
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
               hideResetControl
               staticMode


### PR DESCRIPTION
bump up the `geojsonBuffer` value (was previously using default = 15) so that map attribution doesn't cover the shape

![Screenshot from 2021-10-15 16-16-42](https://user-images.githubusercontent.com/5132349/137502869-0ed73404-3664-4209-99f9-df5fca9eecd2.png)

