### PR TITLE
fix: display How Measured image on FileUpload component

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -193,6 +193,7 @@ const FileUpload: React.FC<Props> = (props) => {
         description={props.description}
         info={props.info}
         howMeasured={props.howMeasured}
+        definitionImg={props.definitionImg}
         policyRef={props.policyRef}
       />
       <ErrorWrapper error={validationError}>


### PR DESCRIPTION
Makes the "How is it defined" image show up on the File Upload, as it should.

Bug report: https://opensystemslab.slack.com/messages/C01E3AC0C03/p1634830534014600
