### PR TITLE
fix: use correct cookie domain when testing localhost frontend

### DIFF
--- a/editor.planx.uk/src/lib/cookie.ts
+++ b/editor.planx.uk/src/lib/cookie.ts
@@ -1,11 +1,13 @@
 import Cookies from "js-cookie";
 
-// XXX: leading . is important here, it allows us to set cookie
-//      that can be used across other subdomains. For example,
-//      .planx.uk cookie will work with planx.uk AND editor.planx.uk
+// XXX: leading . is important for non-localhost domains here,
+//      it allows us to set cookie that can be used across
+//      other subdomains. For example, .planx.uk cookie will work
+//      with both planx.uk AND editor.planx.uk.
+const { hostname } = window.location;
 const defaultCookieSettings = {
   path: "/",
-  domain: `.${window.location.hostname}`,
+  domain: hostname === "localhost" ? hostname : `.${hostname}`,
 };
 
 export const getCookie = (key: string): string | null =>


### PR DESCRIPTION
I wasn't able to log in to the editor.planx.uk frontend from http://localhost:3000 because the cookie domain was being set to `.localhost`, which I think might be an invalid domain. This fixes that.