### PR TITLE
chore: update Review page DateInput to Gov.UK style guideline

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -3,6 +3,7 @@ import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { ENTER, SPACE_BAR } from "@planx/components/shared/constants";
 import Card from "@planx/components/shared/Preview/Card";
 import { TYPES } from "@planx/components/types";
+import format from "date-fns/format";
 import type { Store } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React from "react";
@@ -253,7 +254,7 @@ function DateInput(props: ComponentProps) {
   return (
     <>
       <div>{props.node.data.title ?? "Date"}</div>
-      <div>{getAnswersByNode(props)}</div>
+      <div>{format(new Date(getAnswersByNode(props)), "d MMMM yyyy")}</div>
     </>
   );
 }


### PR DESCRIPTION
Now displays per [Gov.UK guidelines](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates): 
![Screenshot from 2021-11-05 08-53-56](https://user-images.githubusercontent.com/5132349/140477654-b81c65f2-21fd-4663-afdd-34d504e3dad0.png)
 
Trello card also mentions Result component, but the DateInput component can't actually be attached to flag sets currently, so I'm a little confused about when you'd see a date answer under Result "Reasons"? Will ask for a more specific example or screenshot, but this can be reviewed in meantime! (Guessing this case might actually fall under content/editor formatting  rather than codebase formatting)