### PR TITLE
fix: ensure UPRNs are length 12 with leading 0s

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -216,7 +216,7 @@ function GetAddress(props: {
   ) {
     addressesInPostcode.results.map((a: any) => {
       addresses.push({
-        uprn: a.DPA.UPRN,
+        uprn: a.DPA.UPRN.padStart(12, "0"),
         blpu_code: a.DPA.BLPU_STATE_CODE,
         latitude: a.DPA.LAT,
         longitude: a.DPA.LNG,


### PR DESCRIPTION
OS annoyingly drops the leading 0s, leading to confusion when BOPs officers are validating applications with an 11-digit UPRN