### PR TITLE
fix: Southwark conservation area columns were re-named

### DIFF
--- a/api.planx.uk/gis/local_authorities/metadata/southwark.js
+++ b/api.planx.uk/gis/local_authorities/metadata/southwark.js
@@ -62,16 +62,13 @@ const planningConstraints = {
     source: "Southwark Maps",
     tables: ["Conservation areas"],
     columns: [
-      "Conservation_area",
-      "Conservation_area_number",
-      "More_information",
+      "Name",
+      "Schedule_ID"
     ],
     neg: "is not in a Conservation Area",
     pos: (data) => ({
       text: "is in a Conservation Area",
-      description: data.More_information
-        ? data.More_information
-        : data.Conservation_area,
+      description: data.Name,
     }),
   },
   "designated.AONB": {

--- a/api.planx.uk/gis/local_authorities/southwark.js
+++ b/api.planx.uk/gis/local_authorities/southwark.js
@@ -122,7 +122,7 @@ async function locationSearch(x, y, extras) {
 
   ob["article4.southwark.sunray"] = {
     value:
-      ob["designated.conservationArea"]?.data?.Conservation_area_number === 39
+      ob["designated.conservationArea"]?.data?.Schedule_ID === 39
         ? true
         : false,
   };


### PR DESCRIPTION
Sample /gis endpoint in linked Trello card