### PR TITLE
fix: only expand filter flags when it's the active node

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -325,7 +325,7 @@ export const previewStore = (
           // XXX: temp fix to prevent expanding filter nodes that are not currently
           //      being visited, they should be excluded from the previous .filter
           //      method above instead.
-          if (node.type === TYPES.Filter && ids.size > 0) return ids.add(id);
+          if (node.type === TYPES.Filter && i > 0) return ids.add(id);
 
           const passport = computePassport();
 


### PR DESCRIPTION
hopefully fixes the problems created by #665

related issue https://ripahq.slack.com/archives/C0241GWFG4B/p1637146928004900

associated hotfix (in production, not staging): 49e631b661dc4443b04bf567078f7919237579aa