### PR TITLE
feat: snap to OS Vector Tile points when drawing boundary

### DIFF
--- a/editor.planx.uk/.storybook/preview-head.html
+++ b/editor.planx.uk/.storybook/preview-head.html
@@ -5,7 +5,7 @@
 />
 <script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3.4"
+  src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3.6"
 ></script>
 <!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/editor.planx.uk/public/index.html
+++ b/editor.planx.uk/public/index.html
@@ -27,7 +27,7 @@
     <title>PlanX Editor</title>
     <script
       type="module"
-      src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3.5"
+      src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.3.6"
     ></script>
     <!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -133,7 +133,7 @@ export default function Component(props: Props) {
               drawMode
               drawGeojsonData={JSON.stringify(boundary)}
               zoom={19}
-              maxZoom={20}
+              maxZoom={23}
               latitude={Number(passport?.data?._address?.latitude)}
               longitude={Number(passport?.data?._address?.longitude)}
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}


### PR DESCRIPTION
released in v0.3.6 of map lib, along with other minor things like crosshair cursor for drawing & darker control buttons for accessibility/contrast