### PR TITLE
fix(Result): remove 'change' for autoanswered Qs + hide autoanswered Qs with no flag

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public.test.tsx
@@ -3,7 +3,14 @@ import userEvent from "@testing-library/user-event";
 import axe from "axe-helper";
 import React from "react";
 
+import { vanillaStore } from "../../../pages/FlowEditor/lib/store";
 import Result from "./Public";
+
+const { getState, setState } = vanillaStore;
+
+beforeEach(() => {
+  getState().resetPreview();
+});
 
 test("renders correctly", async () => {
   const handleSubmit = jest.fn();
@@ -69,23 +76,104 @@ describe("showing and hiding change capabilities", () => {
     expect(screen.queryByText("Change")).toBeFalsy();
   });
 
-  it("shows the change button when allowChanges is true", () => {
-    render(
-      <Result
-        responses={[
-          {
-            question: { data: { text: "How's the weather?" }, id: "a" },
-            hidden: false,
-            selections: [],
-          },
-        ]}
-        handleSubmit={() => {}}
-        headingColor={{ text: "pink", background: "white" }}
-        allowChanges={true}
-      />
-    );
+  describe("change button scenarios", () => {
+    // `responses` need to be available outside the `beforeEach` block
+    let responses: Array<any>;
 
-    expect(screen.queryByText("Change")).toBeTruthy();
+    beforeEach(() => {
+      // a basic flow state where the second question has been
+      // auto-answered based on the first question's responses.
+      // see: https://imgur.com/a/llkklXB
+      // state code below was copy/pasted from an example flow
+      // for now, but could be simplified in future.
+
+      setState({
+        breadcrumbs: {
+          "1mOeERQtaC": {
+            auto: false,
+            answers: ["DaDuvkVptX"],
+          },
+          oMb32KxEsJ: {
+            answers: ["WrC0G1zSud"],
+            auto: true,
+          },
+        },
+      });
+
+      responses = [
+        {
+          question: {
+            id: "1mOeERQtaC",
+            data: {
+              fn: "test",
+              text: "test",
+            },
+            type: 100,
+            edges: ["DaDuvkVptX", "dNJPqsXIR9"],
+          },
+          selections: [
+            {
+              id: "DaDuvkVptX",
+              data: {
+                val: "1",
+                text: "1",
+              },
+              type: 200,
+            },
+          ],
+          hidden: false,
+        },
+        {
+          question: {
+            id: "oMb32KxEsJ",
+            data: {
+              fn: "test",
+              text: "test",
+            },
+            type: 100,
+            edges: ["WrC0G1zSud", "2E5gpk8Fpu"],
+          },
+          selections: [
+            {
+              id: "WrC0G1zSud",
+              data: {
+                val: "1",
+                text: "1",
+              },
+              type: 200,
+            },
+          ],
+          hidden: false,
+        },
+      ];
+    });
+
+    const scenarios = [
+      { allowChanges: true, autoAnswered: true, shouldBeChangeable: true },
+      { allowChanges: false, autoAnswered: false, shouldBeChangeable: false },
+      { allowChanges: true, autoAnswered: false, shouldBeChangeable: true },
+      { allowChanges: false, autoAnswered: true, shouldBeChangeable: false },
+    ];
+
+    scenarios.forEach(({ allowChanges, autoAnswered, shouldBeChangeable }) => {
+      it(`${
+        shouldBeChangeable ? "shows" : "hides"
+      } the change button when allowChanges is ${allowChanges} and question ${
+        autoAnswered ? "was" : "wasn't"
+      } auto-answered`, () => {
+        render(
+          <Result
+            {...{ allowChanges, responses }}
+            handleSubmit={() => {}}
+            headingColor={{ text: "pink", background: "white" }}
+          />
+        );
+
+        expect(Boolean(screen.queryByText("Change"))).toEqual(
+          shouldBeChangeable
+        );
+      });
+    });
   });
 });
 

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -8,6 +8,7 @@ import Card from "@planx/components/shared/Preview/Card";
 import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
 import { useFormik } from "formik";
 import { submitFeedback } from "lib/feedback";
+import { useStore } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useState } from "react";
 import type { Node, TextContent } from "types";
@@ -62,19 +63,30 @@ const Responses = ({
 }: {
   responses: Response[];
   allowChanges: boolean;
-}) => (
-  <>
-    {responses.map(({ question, selections }: Response) => (
-      <ResultReason
-        key={question.id}
-        id={question.id}
-        question={question}
-        showChangeButton={allowChanges}
-        response={selections.map((s: any) => s.data.text).join(", ")}
-      />
-    ))}
-  </>
-);
+}) => {
+  const breadcrumbs = useStore((state) => state.breadcrumbs);
+  return (
+    <>
+      {responses
+        .filter((response) =>
+          breadcrumbs[response.question.id]
+            ? breadcrumbs[response.question.id].auto
+              ? response.selections.some((s) => s.data?.flag)
+              : true
+            : false
+        )
+        .map(({ question, selections }: Response) => (
+          <ResultReason
+            key={question.id}
+            id={question.id}
+            question={question}
+            showChangeButton={allowChanges && !breadcrumbs[question.id].auto}
+            response={selections.map((s: any) => s.data.text).join(",")}
+          />
+        ))}
+    </>
+  );
+};
 
 const Result: React.FC<Props> = ({
   allowChanges = false,


### PR DESCRIPTION
https://trello.com/c/quWJXfcG/1623-remove-any-answer-that-do-not-contain-a-flag-from-the-result-component

## Before
![Screenshot 2021-11-22 at 5 47 19 PM](https://user-images.githubusercontent.com/601961/142910219-efe500a6-48f7-4a94-b214-7157a3b9515a.png)

## After

- hide `autoanswered question` because it has no flag
- remove change button from `autoanswered with flag`
![Screenshot 2021-11-22 at 5 47 01 PM](https://user-images.githubusercontent.com/601961/142910352-68478356-3253-4473-9655-939dfd98d5df.png)


## Before

![Screenshot 2021-11-22 at 5 48 58 PM](https://user-images.githubusercontent.com/601961/142910463-3c4babaf-8fef-4f6d-b7a6-285398c1e2a7.png)

## After

- hide both autoanswered questions because the chosen responses have no flags

![Screenshot 2021-11-22 at 5 48 45 PM](https://user-images.githubusercontent.com/601961/142910477-cc4260a9-76f8-42eb-af8c-a27e481e022c.png)


## Example flow

https://713.planx.pizza/testing/results-test

```
showing and hiding change capabilities
    ✓ hides the change button by default
    change button scenarios
      ✓ shows the change button when allowChanges is true and question was auto-answered
      ✓ hides the change button when allowChanges is false and question wasn't auto-answered
      ✓ shows the change button when allowChanges is true and question wasn't auto-answered
      ✓ hides the change button when allowChanges is false and question was auto-answered
```