### PR TITLE
hotfix: update OS API keys

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -63,7 +63,6 @@ jobs:
           REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY: ${{ secrets.ORDNANCE_SURVEY_FEATURES_KEY }}
           REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           # needed because there's no API to change google's allowed OAuth URLs
@@ -77,7 +76,6 @@ jobs:
           REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY: ${{ secrets.ORDNANCE_SURVEY_FEATURES_KEY }}
           REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -55,7 +55,6 @@ jobs:
         working-directory: editor.planx.uk
         env:
           REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
-          REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY: ${{ secrets.ORDNANCE_SURVEY_FEATURES_KEY }}
           REACT_APP_API_URL: https://api.editor.planx.dev
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.editor.planx.dev/v1/graphql

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -55,7 +55,6 @@ jobs:
         working-directory: editor.planx.uk
         env:
           REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
-          REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY: ${{ secrets.ORDNANCE_SURVEY_FEATURES_KEY }}
           REACT_APP_API_URL: https://api.editor.planx.uk
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.editor.planx.uk/v1/graphql

--- a/editor.planx.uk/.env
+++ b/editor.planx.uk/.env
@@ -1,7 +1,6 @@
 # used in dev/test/prod
 
-REACT_APP_ORDNANCE_SURVEY_KEY=se00yjrqJx8ypuQZ84GGdvYrzOEXJzOU
-REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY=qZghZEbd91m1gxJqYE9N5Cfj0LAB9s1F
+REACT_APP_ORDNANCE_SURVEY_KEY=a69TM3Yjy4YUiAXFAyI6KyadBPrwYqex
 
 # used in dev/test, overwritten in .env.production
 

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -329,7 +329,7 @@ export function PropertyInformation(props: any) {
           osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
           hideResetControl
           showFeaturesAtPoint
-          osFeaturesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY}
+          osFeaturesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
           featureColor={teamColor}
           featureFill
           ariaLabel="A static map centered on your address input, showing the Ordnance Survey basemap features."


### PR DESCRIPTION
new central API key courtesy of Michael & DHLUC's PGSA means we don't need to maintain two separate env vars & can access all OS API products :tada: 

:alarm_clock: **the OS Places API trial under our current key used in FindProperty expires in 4 days, so this needs to be fully deployed before then!!**

already updated value of primary key in Github Secrets & will remove `REACT_APP_ORDNANCE_SURVEY_FEATURES_KEY` after this is merged

https://722.planx.pizza/southwark/maps-test/preview (still waiting on new map attribution text from michael, that will be updated later direct in map repo)