### PR TITLE
break: remove TYPES.Page entirely

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -77,7 +77,6 @@ const components: {
   [TYPES.Notice]: undefined,
   [TYPES.Notify]: undefined,
   [TYPES.NumberInput]: NumberInput,
-  [TYPES.Page]: undefined,
   [TYPES.Pay]: undefined,
   [TYPES.PlanningConstraints]: undefined,
   [TYPES.Response]: Debug,

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -53,7 +53,6 @@ function isTypeForBopsPayload(type?: TYPES) {
     case TYPES.InternalPortal:
     case TYPES.Notice:
     case TYPES.Notify:
-    case TYPES.Page:
     case TYPES.Pay:
     case TYPES.PlanningConstraints:
     case TYPES.Response:

--- a/editor.planx.uk/src/@planx/components/types.ts
+++ b/editor.planx.uk/src/@planx/components/types.ts
@@ -17,7 +17,7 @@ export enum TYPES {
   Content = 250,
   InternalPortal = 300,
   ExternalPortal = 310,
-  Page = 350,
+  // Page = 350,
   SetValue = 380,
   Pay = 400,
   Filter = 500,

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -3,7 +3,6 @@ import CallSplit from "@material-ui/icons/CallSplit";
 import CheckBoxOutlined from "@material-ui/icons/CheckBoxOutlined";
 import CloudUpload from "@material-ui/icons/CloudUpload";
 import Create from "@material-ui/icons/Create";
-import Description from "@material-ui/icons/Description";
 import Event from "@material-ui/icons/Event";
 import ExposureZero from "@material-ui/icons/ExposureZero";
 import FunctionsIcon from "@material-ui/icons/Functions";
@@ -70,7 +69,6 @@ export const ICONS: {
   [TYPES.Notice]: ReportProblemOutlined,
   [TYPES.Notify]: MailOutlined,
   [TYPES.NumberInput]: ExposureZero,
-  [TYPES.Page]: Description,
   [TYPES.Pay]: PaymentOutlined,
   [TYPES.PlanningConstraints]: Map,
   [TYPES.Response]: undefined,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -8,7 +8,6 @@ import Breadcrumb from "./Breadcrumb";
 import Checklist from "./Checklist";
 import Filter from "./Filter";
 import Option from "./Option";
-import Page from "./Page";
 import Portal from "./Portal";
 import Question from "./Question";
 
@@ -64,8 +63,6 @@ const Node: React.FC<any> = (props) => {
       return <Question {...allProps} text="Notify" />;
     case TYPES.NumberInput:
       return <Question {...allProps} text={node?.data?.title ?? "Number"} />;
-    case TYPES.Page:
-      return <Page {...allProps} text={node?.data?.title ?? "Page"} />;
     case TYPES.Pay:
       return <Question {...allProps} text={node?.data?.title ?? "Pay"} />;
     case TYPES.PlanningConstraints:

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -75,7 +75,6 @@ const NodeTypeSelect: React.FC<{
         <option value={TYPES.Filter}>Filter</option>
         <option value={TYPES.InternalPortal}>Internal Portal</option>
         <option value={TYPES.ExternalPortal}>External Portal</option>
-        <option value={TYPES.Page}>Page</option>
         <option value={TYPES.SetValue}>Set Value</option>
       </optgroup>
       <optgroup label="Payment">

--- a/editor.planx.uk/src/pages/FlowEditor/data/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/data/types.ts
@@ -19,7 +19,6 @@ export const SLUGS: {
   [TYPES.Notice]: "notice",
   [TYPES.Notify]: "notify",
   [TYPES.NumberInput]: "number-input",
-  [TYPES.Page]: "page",
   [TYPES.Pay]: "pay",
   [TYPES.PlanningConstraints]: "planning-constraints",
   [TYPES.Response]: "question",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -330,10 +330,7 @@ export const previewStore = (
 
           const passport = computePassport();
 
-          if (
-            node.type &&
-            [TYPES.InternalPortal, TYPES.Page].includes(node.type)
-          ) {
+          if (node.type === TYPES.InternalPortal) {
             return nodeIdsConnectedFrom(id);
           }
 

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -236,7 +236,6 @@ const Node: React.FC<any> = (props: Props) => {
     case TYPES.Filter:
     case TYPES.Flow:
     case TYPES.InternalPortal:
-    case TYPES.Page:
     case TYPES.Response:
     case undefined:
       return null;


### PR DESCRIPTION
Removing unused code.

Long term I think we will need to keep `TYPES` enums around, but as this will be reimplemented at some point and I can manually check all the flows I think it's ok to remove properly.