### PR TITLE
feat: create pizza if it doesn't exist

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -10,11 +10,11 @@ env:
   PULLREQUEST_ID: ${{ github.event.number }}
 
 jobs:
-  teardown_vultr:
+  teardown_pizza:
     runs-on: ubuntu-latest
     steps:
       - name: Remove vultr resources
-        uses: theopensystemslab/vultr-action@v1.6
+        uses: theopensystemslab/vultr-action@v1.15
         with:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -148,16 +148,15 @@ jobs:
           delete: true
 
   create_or_update_vultr_instance:
+    # XXX: Does nothing if the pizza instance or DNS entries exist,
+    #      see https://github.com/theopensystemslab/planx-new/pull/725
     name: Create or Update Vultr Instance
     needs: [integration_tests, test_and_build]
     runs-on: ubuntu-latest
     steps:
-      # CREATE STEPS
-
-      - if: github.event_name == 'pull_request' && github.event.action == 'opened'
-        name: Create Server
+      - name: Create Pizza (if it doesn't exist)
         id: create
-        uses: theopensystemslab/vultr-action@v1.6
+        uses: theopensystemslab/vultr-action@v1.15
         with:
           action: create
           api_key: ${{ secrets.VULTR_API_KEY }}
@@ -168,7 +167,9 @@ jobs:
           region: lhr
           tag: pullrequest
 
-      - if: github.event_name == 'pull_request' && github.event.action == 'opened'
+      # CREATE STEPS
+
+      - if: steps.create.outputs.ip_address != null
         name: Create commands
         uses: appleboy/ssh-action@master
         with:
@@ -196,7 +197,7 @@ jobs:
 
       # UPDATE STEPS
 
-      - if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+      - if: steps.create.outputs.ip_address == null
         name: Update commands
         uses: appleboy/ssh-action@master
         with:


### PR DESCRIPTION
## before

|             | no pizza exists                    | pizza exists |
| ----------- | ---------------------------------- | ------------ |
| create PR     | create pizza                       | 🥴 ??        |
| update PR | complain and make PR author sad :( | update pizza |

## after

|             | no pizza exists    | pizza exists |
| ----------- | ------------------ | ------------ |
| create PR      | create pizza       | update pizza |
| update PR | ✨ 🍕 create pizza 🍕✨ | update pizza |


it doesn't matter if the PR is opened or updated, if the pizza doesn't exist it will create it

this should mean we won't have to create new pull requests if the first commit fails

### bonus!

This also ensures pizza DNS records are removed during teardown, it was silently failing before.

---

## testing

I've been testing this quite extensively over the past few hours with various PRs and am reasonably confident that it will work as expected once merged into main.

### caveat

This [checks if pizza DNS records, or if an instance with the label PRNUMBER.planx.pizza exists](https://github.com/theopensystemslab/vultr-action/blob/9ef37bcccfc1730c2a0ced9e2ee03f96ccdeede6/src/index.ts#L22-L46), it will attempt to UPDATE the pizza if either of those things are true.

If we're in a situation where the pizza server instance doesn't exist but DNS entries do, we should manually remove them in vultr. And vice-versa. This is an 80/20 solution for now. I hope this won't happen very often, if at all.