### PR TITLE
Revert "fix: Southwark conservation area columns were re-named"

### DIFF
--- a/api.planx.uk/gis/local_authorities/metadata/southwark.js
+++ b/api.planx.uk/gis/local_authorities/metadata/southwark.js
@@ -62,13 +62,16 @@ const planningConstraints = {
     source: "Southwark Maps",
     tables: ["Conservation areas"],
     columns: [
-      "Name",
-      "Schedule_ID"
+      "Conservation_area",
+      "Conservation_area_number",
+      "More_information",
     ],
     neg: "is not in a Conservation Area",
     pos: (data) => ({
       text: "is in a Conservation Area",
-      description: data.Name,
+      description: data.More_information
+        ? data.More_information
+        : data.Conservation_area,
     }),
   },
   "designated.AONB": {

--- a/api.planx.uk/gis/local_authorities/southwark.js
+++ b/api.planx.uk/gis/local_authorities/southwark.js
@@ -135,7 +135,7 @@ async function locationSearch(x, y, siteBoundary, extras) {
 
   ob["article4.southwark.sunray"] = {
     value:
-      ob["designated.conservationArea"]?.data?.Schedule_ID === 39
+      ob["designated.conservationArea"]?.data?.Conservation_area_number === 39
         ? true
         : false,
   };


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#702

Turns out Southwark didn't know about this change either! Freya read the Trello card and told someone at Southwark, and then they changed it immediately back so it's been down again lol dizzy

Sample endpoint: https://api.708.planx.pizza/gis/southwark?x=533684.7876189677&y=178083.16308626917&siteBoundary=%5B%5B%5B-0.07629064162104782,51.48596223952467%5D,%5B-0.07630554274586188,51.48590470936898%5D,%5B-0.07555452422169195,51.485845323371706%5D,%5B-0.07554856357531546,51.485906565237485%5D,%5B-0.07629064162104782,51.48596223952467%5D%5D%5D&version=1 (heavy_check_mark has designated.conservationArea key again!)