### PR TITLE
fix: Missing focus indicator

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -22,8 +22,8 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1.5),
     position: "relative",
     zIndex: 10,
-    "&:focus": {
-      outline: "none",
+    "&:focus-visible": {
+      outline: `2px solid ${theme.palette.secondary.dark}`,
     },
     "&::before": {
       content: "''",

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -29,15 +29,20 @@ const useClasses = makeStyles((theme) => ({
   hidden: { display: "none" },
   uploadInstead: {
     textAlign: "right",
-    fontSize: "medium",
     marginTop: theme.spacing(1),
-    "& a": {
+    "& button": {
+      background: "none",
+      "border-style": "none",
       color: theme.palette.text.primary,
       cursor: "pointer",
+      fontSize: "medium",
       padding: theme.spacing(2),
     },
-    "& a:hover": {
+    "& button:hover": {
       backgroundColor: theme.palette.background.paper,
+    },
+    "& button:focus-visible": {
+      outline: `2px solid ${theme.palette.secondary.dark}`,
     },
   },
 }));
@@ -148,11 +153,11 @@ export default function Component(props: Props) {
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
           </Box>
-          <p className={classes.uploadInstead}>
-            <a onClick={() => setPage("upload")}>
+          <div className={classes.uploadInstead}>
+            <button onClick={() => setPage("upload")}>
               Upload a location plan instead
-            </a>
-          </p>
+            </button>
+          </div>
           <p>
             The boundary you have drawn has an area of{" "}
             <strong>{area ?? 0} m²</strong>
@@ -171,11 +176,11 @@ export default function Component(props: Props) {
             definitionImg={props.definitionImg}
           />
           <Upload setFile={setSelectedFile} initialFile={selectedFile} />
-          <p className={classes.uploadInstead}>
-            <a onClick={() => setPage("draw")}>
+          <div className={classes.uploadInstead}>
+            <button onClick={() => setPage("draw")}>
               Draw the boundary on a map instead
-            </a>
-          </p>
+            </button>
+          </div>
         </div>
       );
     }

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -39,9 +39,6 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1.5),
     position: "relative",
     zIndex: 10,
-    "&:focus": {
-      outline: "none",
-    },
     "&::before": {
       content: "''",
       position: "absolute",


### PR DESCRIPTION
From the A11y audit - 

> What?
> Components were found to be missing focus indicators.
> 
> Page: Upload a location plan drawing
> 
> The ‘Drag files here or choose a file’ section does not display a visible focus indicator when receiving focus. This is because the outline of the element has been set to none in the CSS. Users who rely on keyboard alone to navigate a page, rely on clear and distinguishable focus indicators to identify their location on a page and confidently action components.

**Solution**
-  Ensure `:focus-visible` displays on file upload component
- Change anchor elements to buttons, which allows focus to be set for setPage elements

From [a11y project](https://www.a11yproject.com/posts/2019-02-15-creating-valid-and-accessible-links/) - 

> **When should you use a button instead?**
> If you have an <a> element that has:
> - An empty or no href attribute
> - Scripting attached via the onClick attribute or listeners.
>
> This will probably be triggering an action on the same page, such as opening a menu or toggling content and as such is a much better candidate for the <button> element.

![chrome-capture](https://user-images.githubusercontent.com/20502206/144271879-552f12c8-f0e1-488d-ba60-eb4f0e64614b.gif) 