### PR TITLE
fix: metabase healthchecks

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -79,10 +79,10 @@ new pulumi.Config("cloudflare").require("apiToken");
     healthCheck: {
       path: "/api/health",
       // XXX: Attempt to fix "504 Gateway Time-out"
-      healthyThreshold: 1,
+      healthyThreshold: 2,
       interval: 300,
       timeout: 120,
-      unhealthyThreshold: 100,
+      unhealthyThreshold: 10,
     },
   });
   // Forward HTTP to HTTPS


### PR DESCRIPTION
If this works then we can consider reducing the interval later.

The Health check grace period should've fixed this but... didn't?
