### PR TITLE
fix: update scheduled monument gis connections

### DIFF
--- a/api.planx.uk/gis/local_authorities/metadata/lambeth.js
+++ b/api.planx.uk/gis/local_authorities/metadata/lambeth.js
@@ -108,7 +108,17 @@ const planningConstraints = {
       description: data.name,
     }),
   },
-  "designated.monument": { value: false },
+  "designated.monument": { 
+    key: "designated.monument",
+    source: environmentDomain,
+    id: "HE/ScheduledMonuments",
+    fields: ["objectid", "name", "scheddate", "amenddate"],
+    neg: "is not the site of a Scheduled Monument",
+    pos: (data) => ({
+      text: "is the site of a Scheduled Monument",
+      description: data.name,
+    }),
+  },
   tpo: {
     key: "tpo",
     source: lambethDomain,


### PR DESCRIPTION
- Lambeth now queries environment.data.gov.uk layer (previously didn't support "query" operations)
  - Sample endpoint to confirm that `designated.monument` now has `type: "check"` http://api.746.planx.pizza/gis/lambeth?x=530834.7757826984&y=176523.14525194484&siteBoundary=[] 
 
- Southwark is built around spectrum spatial query formats, making hard to mix-n-match server domains and have "fallback" national data sources like we do with ESRI partners, because we'd also need to support multiple systems/underlying query formats. Choosing to hold off on this hookup since we know Digital Land is actively working on this anyways. Therefore, Southwark applicants will still be uniquely asked questions about Scheduled Monuments
  - If I remember correctly, Southwark may have also had a local Scheduled Monument table in Spectrum Spatial that similarly didn't support query operations, but I can't confirm that or see if it's been updated while their GIS is down. That may be a possible interim solution once GIS is back up, but otherwise Digital Land work is underway & we'll wait for that!