### PR TITLE
feat: track data for analytics

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -3,6 +3,7 @@ import Grid from "@material-ui/core/Grid";
 import IconButton from "@material-ui/core/IconButton";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
+import useAnalyticsTracking from "pages/FlowEditor/lib/useAnalyticsTracking";
 import React from "react";
 import MoreInfoIcon from "ui/icons/MoreInfo";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
@@ -53,6 +54,12 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
   const classes = useStyles();
+  const { trackHelpClick } = useAnalyticsTracking();
+
+  const handleHelpClick = () => {
+    setOpen(true);
+    trackHelpClick(); // This returns a promise but we don't need to await for it
+  };
 
   return (
     <Box mb={2}>
@@ -76,7 +83,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
             <IconButton
               className={classes.iconButton}
               aria-label="See more information about this question"
-              onClick={() => setOpen(true)}
+              onClick={handleHelpClick}
             >
               <MoreInfoIcon viewBox="0 0 30 30" />
             </IconButton>

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -102,7 +102,6 @@ const PreviewBrowser: React.FC<{ url: string }> = React.memo((props) => {
   const [
     flowId,
     resetPreview,
-    setPreviewEnvironment,
     publishFlow,
     lastPublished,
     lastPublisher,
@@ -110,7 +109,6 @@ const PreviewBrowser: React.FC<{ url: string }> = React.memo((props) => {
   ] = useStore((state) => [
     state.id,
     state.resetPreview,
-    state.setPreviewEnvironment,
     state.publishFlow,
     state.lastPublished,
     state.lastPublisher,
@@ -124,8 +122,6 @@ const PreviewBrowser: React.FC<{ url: string }> = React.memo((props) => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
   const classes = useStyles();
-
-  useEffect(() => setPreviewEnvironment("editor"), []);
 
   const formatLastPublish = (date: string, user: string) =>
     `Last published ${formatDistanceToNow(new Date(date))} ago by ${user}`;
@@ -279,7 +275,7 @@ const PreviewBrowser: React.FC<{ url: string }> = React.memo((props) => {
         </Box>
       </header>
       <div className={classes.previewContainer}>
-        <Questions key={String(key)} />
+        <Questions previewEnvironment="editor" key={String(key)} />
       </div>
       {showDebugConsole && <DebugConsole />}
     </div>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -54,12 +54,18 @@ export interface PreviewStore extends Store.Store {
   govUkPayment?: GovUKPayment;
   setGovUkPayment: (govUkPayment: GovUKPayment) => void;
   cachedBreadcrumbs?: Store.cachedBreadcrumbs;
+  analyticsId?: number;
+  setAnalyticsId: (analyticsId: number) => void;
 }
 
 export const previewStore = (
   set: SetState<PreviewStore>,
   get: GetState<SharedStore & PreviewStore>
 ): PreviewStore => ({
+  setAnalyticsId(analyticsId) {
+    set({ analyticsId });
+  },
+
   setGovUkPayment(govUkPayment) {
     set({ govUkPayment });
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -4,7 +4,7 @@ import type { GetState, SetState } from "zustand/vanilla";
 
 import type { Store } from ".";
 
-type PreviewEnvironment = "editor" | "standalone";
+export type PreviewEnvironment = "editor" | "standalone";
 export interface SharedStore extends Store.Store {
   breadcrumbs: Store.breadcrumbs;
   childNodesOf: (id?: Store.nodeId) => Store.node[];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/useAnalyticsTracking.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/useAnalyticsTracking.ts
@@ -1,0 +1,183 @@
+import { gql } from "@apollo/client";
+import { TYPES } from "@planx/components/types";
+import { client } from "lib/graphql";
+import { useEffect, useState } from "react";
+
+import { DEFAULT_FLAG_CATEGORY } from "../data/flags";
+import { useStore } from "./store";
+
+export type AnalyticsType = "init" | "resume";
+type AnalyticsLogDirection = AnalyticsType | "forwards" | "backwards";
+
+let lastAnalyticsLogId: number | undefined = undefined;
+
+const useAnalyticsTracking = () => {
+  const [
+    currentCard,
+    breadcrumbs,
+    analyticsId,
+    setAnalyticsId,
+    resultData,
+    previewEnvironment,
+    flowId,
+  ] = useStore((state) => [
+    state.currentCard,
+    state.breadcrumbs,
+    state.analyticsId,
+    state.setAnalyticsId,
+    state.resultData,
+    state.previewEnvironment,
+    state.id,
+  ]);
+  const node = currentCard();
+  const isStandalone = previewEnvironment === "standalone";
+
+  const [lastBreadcrumbs, setLastBreadcrumb] = useState(breadcrumbs);
+
+  const onPageExit = () => {
+    document.addEventListener("visibilitychange", () => {
+      if (lastAnalyticsLogId && isStandalone) {
+        if (document.visibilityState === "hidden") trackPageExit();
+        if (document.visibilityState === "visible") trackPageResume();
+      }
+    });
+  };
+
+  useEffect(() => {
+    onPageExit();
+  }, []);
+
+  useEffect(() => {
+    if (isStandalone && analyticsId) {
+      const currentBreadcrumbsLength = Object.keys(breadcrumbs).length;
+      const storedBreadcrumbsLength = Object.keys(lastBreadcrumbs).length;
+
+      if (currentBreadcrumbsLength > storedBreadcrumbsLength) {
+        track("forwards", analyticsId);
+      }
+      if (currentBreadcrumbsLength < storedBreadcrumbsLength) {
+        track("backwards", analyticsId);
+      }
+      setLastBreadcrumb(breadcrumbs);
+    }
+  }, [breadcrumbs]);
+
+  return {
+    createAnalytics,
+    trackHelpClick,
+  };
+
+  function trackPageExit() {
+    if (lastAnalyticsLogId !== undefined) {
+      navigator.sendBeacon(
+        `${
+          process.env.REACT_APP_API_URL
+        }/analytics/log-user-exit?analyticsLogId=${lastAnalyticsLogId.toString()}`
+      );
+    }
+  }
+
+  function trackPageResume() {
+    navigator.sendBeacon(
+      `${
+        process.env.REACT_APP_API_URL
+      }/analytics/log-user-resume?analyticsLogId=${lastAnalyticsLogId?.toString()}`
+    );
+  }
+
+  async function track(direction: AnalyticsLogDirection, analyticsId: number) {
+    const metadata = getNodeMetadata();
+    const result = await client.mutate({
+      mutation: gql`
+        mutation InsertNewAnalyticsLog(
+          $flow_direction: String
+          $analytics_id: Int
+          $metadata: jsonb
+          $node_type: Int
+          $node_title: String!
+        ) {
+          insert_analytics_logs_one(
+            object: {
+              flow_direction: $flow_direction
+              analytics_id: $analytics_id
+              user_exit: false
+              metadata: $metadata
+              node_type: $node_type
+              node_title: $node_title
+            }
+          ) {
+            id
+          }
+        }
+      `,
+      variables: {
+        flow_direction: direction,
+        analytics_id: analyticsId,
+        metadata: metadata,
+        node_type: node?.type,
+        node_title:
+          node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet,
+      },
+    });
+    const id = result?.data.insert_analytics_logs_one?.id;
+    lastAnalyticsLogId = id;
+  }
+
+  async function trackHelpClick() {
+    if (isStandalone && lastAnalyticsLogId) {
+      await client.mutate({
+        mutation: gql`
+          mutation UpdateHasClickedHelp($id: bigint!) {
+            update_analytics_logs_by_pk(
+              pk_columns: { id: $id }
+              _set: { has_clicked_help: true }
+            ) {
+              id
+            }
+          }
+        `,
+        variables: {
+          id: lastAnalyticsLogId,
+        },
+      });
+    }
+  }
+
+  async function createAnalytics(type: AnalyticsType) {
+    const response = await client.mutate({
+      mutation: gql`
+        mutation InsertNewAnalytics($type: String, $flow_id: uuid) {
+          insert_analytics_one(object: { type: $type, flow_id: $flow_id }) {
+            id
+          }
+        }
+      `,
+      variables: {
+        type,
+        flow_id: flowId,
+      },
+    });
+    const id = response.data.insert_analytics_one.id;
+    setAnalyticsId(id);
+    track(type, id);
+  }
+
+  function getNodeMetadata() {
+    switch (node?.type) {
+      case TYPES.Result:
+        const flagSet = node?.data?.flagSet || DEFAULT_FLAG_CATEGORY;
+        const data = resultData(flagSet, node?.data?.overrides);
+        const { displayText, flag, responses } = data[flagSet];
+        return {
+          flagSet,
+          displayText,
+          flag,
+        };
+
+      default:
+        return {};
+    }
+  }
+};
+
+export default useAnalyticsTracking;

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -2,6 +2,10 @@ import Box from "@material-ui/core/Box";
 import { makeStyles } from "@material-ui/core/styles";
 import classnames from "classnames";
 import { getLocalFlow, setLocalFlow } from "lib/local";
+import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
+import useAnalyticsTracking, {
+  AnalyticsType,
+} from "pages/FlowEditor/lib/useAnalyticsTracking";
 import React, { useContext, useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -33,7 +37,11 @@ const useClasses = makeStyles((theme) => ({
   },
 }));
 
-const Questions = () => {
+interface QuestionsProps {
+  previewEnvironment: PreviewEnvironment;
+}
+
+const Questions = ({ previewEnvironment }: QuestionsProps) => {
   const [
     currentCard,
     previousCard,
@@ -44,8 +52,8 @@ const Questions = () => {
     id,
     resumeSession,
     govUkPayment,
-    previewEnvironment,
     canGoBack,
+    setPreviewEnvironment,
   ] = useStore((state) => [
     state.currentCard,
     state.previousCard(),
@@ -56,24 +64,25 @@ const Questions = () => {
     state.id,
     state.resumeSession,
     state.govUkPayment,
-    state.previewEnvironment,
     state.canGoBack,
+    state.setPreviewEnvironment,
   ]);
-
+  const isStandalone = previewEnvironment === "standalone";
   const node = currentCard();
   const flow = useContext(PreviewContext)?.flow;
-
+  const { createAnalytics } = useAnalyticsTracking();
   const classes = useClasses();
 
   const showBackButton = node?.id ? canGoBack(node.id) : false;
-  const isStandalone = previewEnvironment === "standalone";
 
   useEffect(() => {
+    setPreviewEnvironment(previewEnvironment);
     if (isStandalone) {
       const state = getLocalFlow(id);
       if (state) {
         resumeSession(state);
       }
+      createAnalytics(state ? "resume" : "init");
     }
   }, []);
 

--- a/editor.planx.uk/src/routes/preview.tsx
+++ b/editor.planx.uk/src/routes/preview.tsx
@@ -92,7 +92,7 @@ const routes = compose(
 
   mount({
     "/": route({
-      view: <Questions />,
+      view: <Questions previewEnvironment="standalone" />,
     }),
     "/pages/:page": map((req) => {
       return route({

--- a/editor.planx.uk/src/routes/unpublished.tsx
+++ b/editor.planx.uk/src/routes/unpublished.tsx
@@ -80,7 +80,7 @@ const routes = compose(
 
   mount({
     "/": route({
-      view: <Questions />,
+      view: <Questions previewEnvironment="editor" />,
     }),
     "/pages/:page": map((req) => {
       return route({

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -42,6 +42,57 @@
       filter: {}
 - table:
     schema: public
+    name: analytics
+  insert_permissions:
+  - role: public
+    permission:
+      check: {}
+      columns:
+      - created_at
+      - flow_id
+      - id
+      - type
+      backend_only: false
+  select_permissions:
+  - role: public
+    permission:
+      columns:
+      - id
+      filter: {}
+- table:
+    schema: public
+    name: analytics_logs
+  insert_permissions:
+  - role: public
+    permission:
+      check: {}
+      columns:
+      - analytics_id
+      - created_at
+      - flow_direction
+      - has_clicked_help
+      - id
+      - metadata
+      - node_title
+      - node_type
+      - user_exit
+      backend_only: false
+  select_permissions:
+  - role: public
+    permission:
+      columns:
+      - analytics_id
+      - id
+      filter: {}
+  update_permissions:
+  - role: public
+    permission:
+      columns:
+      - has_clicked_help
+      filter: {}
+      check: null
+- table:
+    schema: public
     name: blpu_codes
   select_permissions:
   - role: public

--- a/hasura.planx.uk/migrations/1638310061599_create_tables_analytics_and_analytics_logs/down.sql
+++ b/hasura.planx.uk/migrations/1638310061599_create_tables_analytics_and_analytics_logs/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE "public"."analytics_logs";
+
+DROP TABLE "public"."analytics";

--- a/hasura.planx.uk/migrations/1638310061599_create_tables_analytics_and_analytics_logs/up.sql
+++ b/hasura.planx.uk/migrations/1638310061599_create_tables_analytics_and_analytics_logs/up.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "public"."analytics"(
+  "id" bigserial NOT NULL, 
+  "type" text NOT NULL, 
+  "created_at" timestamptz NOT NULL DEFAULT now(), 
+  "ended_at" timestamptz NULL,
+  "flow_id" uuid NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "analytics_flow_id_fkey"
+    FOREIGN KEY ("flow_id") 
+    REFERENCES "public"."flows"("id") 
+    ON UPDATE restrict 
+    ON DELETE restrict
+);
+
+CREATE TABLE "public"."analytics_logs"(
+  "id" bigserial NOT NULL,
+  "flow_direction" text NOT NULL DEFAULT 'forwards', 
+  "metadata" jsonb NOT NULL DEFAULT jsonb_build_object(), 
+  "created_at" timestamptz NOT NULL DEFAULT now(), 
+  "analytics_id" integer NOT NULL, 
+  "user_exit" boolean NOT NULL DEFAULT false,
+  "node_type" integer NOT NULL,
+  "node_title" text,
+  "has_clicked_help" boolean NOT NULL DEFAULT false,
+  PRIMARY KEY ("id"), 
+  CONSTRAINT "analytics_log_analytics_id_fkey"
+    FOREIGN KEY ("analytics_id") 
+    REFERENCES "public"."analytics"("id") 
+    ON UPDATE cascade 
+    ON DELETE set null
+);

--- a/hasura.planx.uk/tests/analytics.test.js
+++ b/hasura.planx.uk/tests/analytics.test.js
@@ -1,0 +1,42 @@
+const { introspectAs } = require("./utils");
+
+describe("analytics and analytics_logs", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("can query analytics and their associated analytics_logs", () => {
+      expect(i.queries).toContain("analytics");
+      expect(i.queries).toContain("analytics_logs");
+    });
+
+    test("can create analytics but not update or delete them", () => {
+      expect(i.mutations).toContain("insert_analytics_one");
+      expect(i.mutations).not.toContain("update_analytics_by_pk");
+      expect(i.mutations).not.toContain("update_analytics");
+      expect(i.mutations).not.toContain("delete_analytics");
+      expect(i.mutations).not.toContain("delete_analytics_by_pk");
+    });
+
+    test("can create and update analytics_log but not delete them", () => {
+      expect(i.mutations).toContain("insert_analytics_logs_one");
+      expect(i.mutations).toContain("update_analytics_logs_by_pk");
+      expect(i.mutations).not.toContain("delete_analytics_logs");
+      expect(i.mutations).not.toContain("delete_analytics_logs_by_pk");
+    })
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("can delete analytics and session events", () => {
+      expect(i.mutations).toContain("delete_analytics");
+      expect(i.mutations).toContain("delete_analytics_logs");
+    });
+  });
+});


### PR DESCRIPTION
This PR adds instrumentation to PlanX. It tracks certain user events to generate service analytics. There's a [list of desired analytics](https://docs.google.com/document/d/1YMaCP_XcDa04FK5sLIaYyz-hgt2J0i6wOGKbz601AfQ/edit) I've worked off of. The SQL queries to fullfil those requests are almost ready too and will be added to [Metabase](https://metabase.editor.planx.dev/) as dashboards. One dashboard per service. You'll notice we're using the [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API) to send requests in the background. The [Beacon API is compatible with all modern browsers (not IE)](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API#browser_compatibility). I appreciate this is a big PR, thanks in advance for the review!
