### PR TITLE
fix: Assign button role to DrawBoundary FileUpload

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -161,6 +161,7 @@ export default function FileUpload(props: Props) {
     return (
       <div
         className={classNames(classes.root, isDragActive && classes.dragActive)}
+        role="button"
         {...getRootProps()}
       >
         <input {...getInputProps()} />


### PR DESCRIPTION
**Problem**
- Addresses https://trello.com/c/2jt0S2FV/1672-element-type
> The element does not have a role which reflects its purpose or behaviour. The file upload
section has not been given an appropriate role. This can cause misidentification by screen
reader users and an inability to access for Voice Activation users.

**Solution**
 - Assign role of button to the element - this was already done on the standalone file upload component