### PR TITLE
fix: set maxLength on postcode input, validate onBlur

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -257,6 +257,10 @@ function GetAddress(props: {
   }));
   const classes = useStyles();
 
+  const handleCheckPostcode = () => {
+    if (!sanitizedPostcode) setShowPostcodeError(true);
+  };
+
   return (
     <Card
       handleSubmit={() => props.setAddress(selectedOption ?? undefined)}
@@ -278,7 +282,7 @@ function GetAddress(props: {
                 ? "Enter a valid UK postcode"
                 : ""
             }
-            onChange={(e: any) => {
+            onChange={(e) => {
               // XXX: If you press a key on the keyboard, you expect something to show up on the screen,
               //      so this code attempts to validate postcodes without blocking any characters.
               const input = e.target.value;
@@ -290,9 +294,10 @@ function GetAddress(props: {
                 setPostcode(input.toUpperCase());
               }
             }}
-            onBlur={() => {
-              if (!sanitizedPostcode) setShowPostcodeError(true);
+            onKeyUp={({ key }) => {
+              if (key === "Enter") handleCheckPostcode();
             }}
+            onBlur={handleCheckPostcode}
             aria-label="Enter the postcode of the property"
             style={{ marginBottom: "20px" }}
             inputProps={{


### PR DESCRIPTION
briefly revisiting this topic that was part of other recent FindProperty updates (#738) - this now shows an error whenever the user tabs away from the input without entering a valid postcode - it's still a bit different from the specific audit feedback, but closer! I can't quite figure out how to listen for enter rather than tab, but hoping that's not a wcag deal breaker.

> When a user tries to press the ‘Enter’ key when entering an invalid postcode, there is no error identification for the fields that do not meet the required format. Users would expect different types of error identification depending on the error that they have committed.