### PR TITLE
fix: add granular values for all known Canterbury Article 4s

### DIFF
--- a/api.planx.uk/gis/local_authorities/canterbury.js
+++ b/api.planx.uk/gis/local_authorities/canterbury.js
@@ -7,6 +7,8 @@ const {
   setEsriGeometryType,
   setEsriGeometry,
   addDesignatedVariable,
+  rollupResultLayers,
+  squashResultLayers,
 } = require("../helpers.js");
 const { planningConstraints } = require("./metadata/canterbury.js");
 
@@ -99,14 +101,6 @@ async function go(x, y, siteBoundary, extras) {
         }
       );
 
-    // Since we have multiple article 4 layers, account for granularity & ensure root variable is synced with the subvariable
-    if (ob["article4.canterbury.hmo"].value) {
-      // Remove "text" and other keys from subvariable so it doesn't render as separate entry in planning constraints list
-      ob["article4.canterbury.hmo"] = { value: true };
-    } else if (!ob["article4.canterbury.hmo"].value) {
-      ob["article4.canterbury.hmo"] = { value: false };
-    }
-
     // Set granular article 4 values
     (Object.keys(articleFours)).forEach((key) => {
       if (ob["article4"]?.data?.REF === articleFours[key]) {
@@ -117,15 +111,13 @@ async function go(x, y, siteBoundary, extras) {
     });
 
     // Merge Listed Buildings & "Locally Listed Buildings" responses under single "listed" variable
-    if (ob["listed.local"].value && !ob["listed"].value) {
-      ob["listed"] = ob["listed.local"];
-      delete ob["listed.local"];
-    } else if (!ob["listed.local"].value) {
-      delete ob["listed.local"];
-    } // If both are true, show each in planning constraints list for MVP debugging; flow schemas only care if passport has "listed"
+    const obSquashed = squashResultLayers(ob, ["listed.local"], "listed");
+
+    // Roll up multiple article 4 layers, while preserving granularity for HMO type
+    const obRolledUp = rollupResultLayers(obSquashed, ["article4.canterbury.hmo"], "article4");
 
     // Add summary "designated" key to response
-    const obWithDesignated = addDesignatedVariable(ob);
+    const obWithDesignated = addDesignatedVariable(obRolledUp);
 
     return obWithDesignated;
   } catch (e) {

--- a/api.planx.uk/gis/local_authorities/metadata/canterbury.js
+++ b/api.planx.uk/gis/local_authorities/metadata/canterbury.js
@@ -124,7 +124,7 @@ const planningConstraints = {
     id: "External/Planning_Constraints_New",
     serverIndex: 8,
     fields: ["OBJECTID", "LOCATION", "DESCRIPTIO", "POLICY", "info1"],
-    neg: "is not in, or within, a Locally Listed Building",
+    neg: "is not in, or within, a Listed Building",
     pos: (data) => ({
       text: `is, or is within, a Locally Listed Building`,
     }),


### PR DESCRIPTION
https://764.planx.pizza/canterbury/test/preview <-- synced with production `article4check` flow/portal for Canterbury

Find example addresses, project types & expected results in [this Trello card](https://trello.com/c/qdQSbvPi/1705-investigate-canterbury-article-4-cases).

After staring at [this spreadsheet](https://docs.google.com/spreadsheets/d/1VWmVk1tuiXWY-iEZlBHSZXqaEqitPgN6dIwVzoVTM1U/edit#gid=601893004) for awhile, I finally realized that Cleo & Andy had long-ago mapped the planx data field values to a "CODE" field from the GIS data (see "Project Code" tab). The static GIS data tab is outdated, and the "CODE" field is no longer published in the layer we query, but they do still publish a "REF" which seems to be unique per "CODE". So, I made a new mapping from planx data field value to "REF" which we can loop through to assign all 60+ granular article4 values. There's a few odd mappings that I'll double check with Andy, but most make sense & seem to fix the example scenarios!

There may still be lingering out-of-sync variable names in the flow itself requiring further content updates. Let's just make a note of any we find & we can pass them onto George/Alastair to be updated direct in production.