### PR TITLE
fix: Make file upload components more accessible

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -108,6 +108,9 @@ const useStyles = makeStyles((theme) => ({
     textDecoration: "underline",
     color: theme.palette.primary.main,
   },
+  fileSize: {
+    whiteSpace: "nowrap",
+  },
 }));
 
 export interface FileUpload<T extends File = any> {
@@ -201,7 +204,11 @@ export default function FileUpload(props: Props) {
             </Box>
             {slot?.file.path}
           </Box>
-          <Box color="text.secondary" alignSelf="flex-end">
+          <Box
+            color="text.secondary"
+            alignSelf="flex-end"
+            className={classes.fileSize}
+          >
             {formatBytes(slot?.file.size)}
           </Box>
         </Box>

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -125,6 +125,9 @@ const useStyles = makeStyles((theme) => ({
     textDecoration: "underline",
     color: theme.palette.primary.main,
   },
+  fileSize: {
+    whiteSpace: "nowrap",
+  },
 }));
 
 const slotsSchema = array()
@@ -326,7 +329,11 @@ function Dropzone(props: any) {
               </Box>
               {file.path}
             </Box>
-            <Box color="text.secondary" alignSelf="flex-end">
+            <Box
+              color="text.secondary"
+              alignSelf="flex-end"
+              className={classes.fileSize}
+            >
               {formatBytes(file.size)}
             </Box>
           </Box>


### PR DESCRIPTION
**Problem**
 - Addresses https://trello.com/c/wieuTx7f/1677-update-on-input
 > Ensure that all changes to a page’s content is provided to screen reader users via status messages. The users should be made aware when a file has been successfully uploaded/removed.


**Solution**
 - Make delete button clearer
 - Add aria labels to progress bar
- Create visually hidden `fileUploadStatus` element
- Small refactor on `DrawBoundary` component to make it structurally more similar to `FileUpload` - will hopefully make like a little easier if/when we combine the upload elements.