### PR TITLE
hotfix: disable analytics in frontend

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -3,7 +3,7 @@ import Grid from "@material-ui/core/Grid";
 import IconButton from "@material-ui/core/IconButton";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import useAnalyticsTracking from "pages/FlowEditor/lib/useAnalyticsTracking";
+// import useAnalyticsTracking from "pages/FlowEditor/lib/useAnalyticsTracking";
 import React from "react";
 import MoreInfoIcon from "ui/icons/MoreInfo";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
@@ -51,11 +51,11 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
   const classes = useStyles();
-  const { trackHelpClick } = useAnalyticsTracking();
+  // const { trackHelpClick } = useAnalyticsTracking();
 
   const handleHelpClick = () => {
     setOpen(true);
-    trackHelpClick(); // This returns a promise but we don't need to await for it
+    // trackHelpClick(); // This returns a promise but we don't need to await for it
   };
 
   return (

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -3,9 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import classnames from "classnames";
 import { getLocalFlow, setLocalFlow } from "lib/local";
 import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
-import useAnalyticsTracking, {
-  AnalyticsType,
-} from "pages/FlowEditor/lib/useAnalyticsTracking";
+// import useAnalyticsTracking from "pages/FlowEditor/lib/useAnalyticsTracking";
 import React, { useContext, useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -70,7 +68,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   const isStandalone = previewEnvironment === "standalone";
   const node = currentCard();
   const flow = useContext(PreviewContext)?.flow;
-  const { createAnalytics } = useAnalyticsTracking();
+  // const { createAnalytics } = useAnalyticsTracking();
   const classes = useClasses();
 
   const showBackButton = node?.id ? canGoBack(node.id) : false;
@@ -82,7 +80,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
       if (state) {
         resumeSession(state);
       }
-      createAnalytics(state ? "resume" : "init");
+      // createAnalytics(state ? "resume" : "init");
     }
   }, []);
 


### PR DESCRIPTION
This is in production already. There are a couple of issues coming up, I think we might need to kick this back to UAT if poss.

- node_type fails with not NULL value, when reaching the end of a flow I think(?) the `_root` node is posted and that doesn't have a type field atm
- 404s on some queries (see below)
- I think analytics queries might be getting being posted on each render? including keyUp etc

![Screenshot 2021-12-15 at 3 29 10 PM](https://user-images.githubusercontent.com/601961/146215262-9833b082-9c47-4e99-8c94-14119790716e.png)

