### PR TITLE
fix: Make Planning Application Reference table in Confirmation component full width

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -13,6 +13,7 @@ import type { Confirmation } from "./model";
 
 const useClasses = makeStyles((theme) => ({
   table: {
+    width: "100%",
     borderCollapse: "collapse",
     "& tr": {
       borderBottom: `1px solid ${theme.palette.grey[400]}`,


### PR DESCRIPTION
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/20502206/146390376-b9bdb7cb-c817-493d-b048-5275a5457b16.png)|![image](https://user-images.githubusercontent.com/20502206/146390499-b626fc06-b9e2-4c7c-8980-f3bd9b18bca5.png)|