### PR TITLE
fix: postcode input maxLength should include spaces

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -301,7 +301,7 @@ function GetAddress(props: {
             aria-label="Enter the postcode of the property"
             style={{ marginBottom: "20px" }}
             inputProps={{
-              maxLength: 7,
+              maxLength: 8,
             }}
           />
         </InputLabel>


### PR DESCRIPTION
UK postcodes are 6-8 characters _including spaces_, so maxLength of 7 was my bad! 

spotted during UAT here: https://trello.com/c/AcbTd4Nq/1708-findproperty-accessibility-updates