### PR TITLE
feat: Wire up Article 4s for Braintree

### DIFF
--- a/api.planx.uk/gis/helpers.js
+++ b/api.planx.uk/gis/helpers.js
@@ -183,6 +183,18 @@ const rollupResultLayers = (originalOb, layers, layerName) => {
   return ob;
 }
 
+// Handle Article 4 subvariables
+// Return an object with a simple result for each A4 subvariable
+const getA4Subvariables = (features, articleFours, a4Key) => {
+  const result = {};
+  const a4Keys = features.map(feature => feature.attributes[a4Key]);
+  Object.entries(articleFours).forEach(([key, value]) => {
+    const isMatch = a4Keys.includes(value);
+    result[key] = { "value": isMatch };
+  });
+  return result;
+}
+
 module.exports = {
   setEsriGeometryType,
   setEsriGeometry,
@@ -195,4 +207,5 @@ module.exports = {
   addDesignatedVariable,
   squashResultLayers,
   rollupResultLayers,
+  getA4Subvariables,
 };

--- a/api.planx.uk/gis/helpers.test.js
+++ b/api.planx.uk/gis/helpers.test.js
@@ -1,4 +1,4 @@
-const { squashResultLayers, rollupResultLayers } = require("./helpers");
+const { squashResultLayers, rollupResultLayers, getA4Subvariables } = require("./helpers");
 
 describe("squashResultLayer helper function", () => {
   test("It should squash the list of layers passed in", () => {
@@ -234,3 +234,49 @@ describe("rollupResultLayer helper function", () => {
   });
 
 });
+
+describe("getA4Subvariables helper function", () => {
+  const A4_KEY = "OBJECTID"
+  const articleFours = {
+    "article4.test.a": 1,
+    "article4.test.b": 5,
+    "article4.test.c": 13,
+  }
+  it("returns a property for each Article 4 passed in", () => {
+    // Arrange
+    const features = [
+      { attributes: { OBJECTID: 1, name: "Hackney Road"},},
+      { attributes: { OBJECTID: 5, name: "Peckham Way"},},
+      { attributes: { OBJECTID: 13, name: "Chelsea Park"},},
+    ]
+    // Act
+    const result = getA4Subvariables(features, articleFours, A4_KEY);
+    // Assert
+    Object.keys(articleFours).forEach(key => expect(result).toHaveProperty([key]));
+  });
+
+  it("correctly matches features which have a hit on an Article 4", () => {
+    // Arrange
+    const features = [
+      { attributes: { OBJECTID: 1, name: "Hackney Road"},},
+      { attributes: { OBJECTID: 13, name: "Chelsea Park"},},
+    ]
+    // Act
+    const result = getA4Subvariables(features, articleFours, A4_KEY);
+    // Assert
+    expect(result).toMatchObject({
+      ["article4.test.a"]: { value: true },
+      ["article4.test.b"]: { value: false },
+      ["article4.test.c"]: { value: true },
+    })
+  });
+
+  it("handles no matching Article 4 results", () => {
+    const result = getA4Subvariables([], articleFours, A4_KEY);
+    expect(result).toMatchObject({
+      ["article4.test.a"]: { value: false },
+      ["article4.test.b"]: { value: false },
+      ["article4.test.c"]: { value: false },
+    });
+  })
+})

--- a/api.planx.uk/gis/local_authorities/braintree.js
+++ b/api.planx.uk/gis/local_authorities/braintree.js
@@ -9,13 +9,14 @@ const {
   addDesignatedVariable,
   squashResultLayers,
   rollupResultLayers,
+  getA4Subvariables,
 } = require("../helpers.js");
-const { planningConstraints } = require("./metadata/braintree.js");
+const { planningConstraints, A4_KEY } = require("./metadata/braintree.js");
 
 // Process local authority metadata
 const gisLayers = getQueryableConstraints(planningConstraints);
 const preCheckedLayers = getManualConstraints(planningConstraints);
-const articleFours = {}; // "planningConstraints.article4.records" in future
+const articleFours = planningConstraints.article4.records;
 
 // Fetch a data layer
 async function search(
@@ -80,6 +81,11 @@ async function go(x, y, siteBoundary, extras) {
                 type: "warning",
                 data: properties,
               };
+              if (k === "article4") {
+                // In addition to the Article 4 variable, also map A4 subvariables onto the accumulator
+                const a4Subvariables = getA4Subvariables(data.features, articleFours, A4_KEY);
+                acc = { ...acc, ...a4Subvariables };
+              }
             } else {
               if (!acc[k]) {
                 acc[k] = {
@@ -97,10 +103,6 @@ async function go(x, y, siteBoundary, extras) {
           return acc;
         },
         {
-          ...Object.values(articleFours).reduce((acc, curr) => {
-            acc[curr] = { value: false };
-            return acc;
-          }, {}),
           ...preCheckedLayers,
           ...extras,
         }
@@ -121,8 +123,8 @@ async function go(x, y, siteBoundary, extras) {
       "listed.grade1",
       "listed.grade2",
       "listed.grade2star",
-    ]
-    const obWithSingleListed = rollupResultLayers(obWithSingleTPO, listedLayers, "listed")
+    ];
+    const obWithSingleListed = rollupResultLayers(obWithSingleTPO, listedLayers, "listed");
 
     // Add summary "designated" key to response
     const obWithDesignated = addDesignatedVariable(obWithSingleListed);

--- a/api.planx.uk/gis/local_authorities/metadata/braintree.js
+++ b/api.planx.uk/gis/local_authorities/metadata/braintree.js
@@ -10,6 +10,7 @@ https://environment.data.gov.uk/arcgis/rest/services
 
 const braintreeDomain = "https://mapping.braintree.gov.uk/";
 const environmentDomain = "https://environment.data.gov.uk";
+const A4_KEY = "OBJECTID";
 
 const planningConstraints = {
   "listed.grade1": {
@@ -144,19 +145,19 @@ const planningConstraints = {
       description: data.INFORMATIO,
     }),
     records: {
-      0: "article4.braintree.braintree",
-      1: "article4.braintree.silverend",
-      2: "article4.braintree.gosfield",
-      3: "article4.braintree.middleton",
-      4: "article4.braintree.shalford.a",
-      5: "article4.braintree.shalford.b",
-      6: "article4.braintree.greensteadgreen",
-      7: "article4.braintree.stisted.a",
-      8: "article4.braintree.stisted.b",
-      9: "article4.braintree.stisted.c",
-      10: "article4.braintree.stisted.d",
-      11: "article4.braintree.coggeshall",
-      12: "article4.braintree.ashen",
+      "article4.braintree.braintree": 1,
+      "article4.braintree.silverEnd": 2,
+      "article4.braintree.gosfield": 3,
+      "article4.braintree.middleton": 4,
+      "article4.braintree.shalford.a": 5,
+      "article4.braintree.shalford.b": 6,
+      "article4.braintree.greensteadGreen": 7,
+      "article4.braintree.stisted.a": 9,
+      "article4.braintree.stisted.b": 10,
+      "article4.braintree.stisted.c": 17,
+      "article4.braintree.stisted.d": 18,
+      "article4.braintree.coggeshall": 19,
+      "article4.braintree.ashen": 35,
     },
   },
   "designated.AONB": {
@@ -186,4 +187,5 @@ const planningConstraints = {
 
 module.exports = {
   planningConstraints,
+  A4_KEY
 };


### PR DESCRIPTION
**Objective**
 - Expose Article 4 variables for Braintree, to a granular level
 - This is done using the `OBJECTID` field which is really the only available field for this on the provided data

**Comments**
 - This feels very much like a workaround, as we're only catching the first returned feature which intersects as opposed to all matches currently. Another approach would be to restructure the way the `data` object is returned but I'm not quite sure of the implications of that.