### PR TITLE
fix: Improve visual presentation a11y

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => {
       top: 0,
       left: 0,
       objectFit: "contain",
+      backgroundColor: "white",
     },
     key: {
       opacity: 0.3,


### PR DESCRIPTION
**Problem**
- Addresses https://trello.com/c/TVvCc8Rj/1681-visual-presentation
> When users view the service in an inverted colour scheme, the images of the different types of houses are not displayed.

**Solution**
 - Set white background for images, meaning that if "smart inversion" choses to ignore images, high contrast is maintained between diagram and background
 - Tested on Chrome, Safari, and Firefox using MacOS Accessibility tool (Settings > Accessibility > Display > Invert colours / Classic Invert)
 - No funky screenshots as I've not worked out how to do that with an inverted screen...!