### PR TITLE
fix: Update Metabase for log4j vulnerability CVE-2021-45046

### DIFF
--- a/hasura.planx.uk/Dockerfile
+++ b/hasura.planx.uk/Dockerfile
@@ -1,4 +1,6 @@
-FROM hasura/graphql-engine:v1.3.0.cli-migrations-v2
+# FROM hasura/graphql-engine:v2.0.10.cli-migrations-v2
+# FROM fedormelexin/graphql-engine-arm64:v1.3.3.cli-migrations-v2
+FROM hasura/graphql-engine:v2.1.0-beta.3.cli-migrations-v2
 WORKDIR /
 COPY metadata hasura-metadata
 COPY migrations hasura-migrations


### PR DESCRIPTION
- Fixes another log4j vulnerability [CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046)
- https://github.com/metabase/metabase/releases/tag/v0.41.5