### PR TITLE
fix: add aria-describedby to inputs to associate hint text

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -299,6 +299,7 @@ function GetAddress(props: {
             }}
             onBlur={handleCheckPostcode}
             aria-label="Enter the postcode of the property"
+            aria-describedby="question-header-description"
             style={{ marginBottom: "20px" }}
             inputProps={{
               maxLength: 8,

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
@@ -71,6 +71,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
           value={formik.values.value}
           onChange={formik.handleChange}
           errorMessage={formik.errors.value as string}
+          aria-describedby="question-header-description"
         />
         {props.units && <InputRowLabel>{props.units}</InputRowLabel>}
       </InputRow>

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -59,6 +59,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
             bordered
             onChange={formik.handleChange}
             errorMessage={formik.errors.text as string}
+            aria-describedby="question-header-description"
           />
         </InputLabel>
       </InputRow>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -70,7 +70,10 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
             </Box>
           )}
           {description && (
-            <Box className={classes.description}>
+            <Box
+              className={classes.description}
+              id="question-header-description"
+            >
               <ReactMarkdownOrHtml source={description} />
             </Box>
           )}


### PR DESCRIPTION
See [accessibilty report](https://drive.google.com/file/d/198yQ_tjM9mCGeiJqS9PID_rG2EhYNWe1/view) page 130

QuestionHeader descriptions are used to write hint text for various input components (& will be even more so when we remove placeholders), but aren't actually associated to the input as far as screenreaders can tell. Adding `aria-describedby` on the input tells screenreaders to first read the input label, then the hint text.

![Screenshot from 2021-12-20 15-28-20](https://user-images.githubusercontent.com/5132349/146782731-8e9a0f74-9afc-4014-a33a-9a2a39b51d58.png)

