### PR TITLE
fix: Canterbury "article4" parent variable should always have data fields for debugging

### DIFF
--- a/api.planx.uk/gis/local_authorities/canterbury.js
+++ b/api.planx.uk/gis/local_authorities/canterbury.js
@@ -110,14 +110,21 @@ async function go(x, y, siteBoundary, extras) {
       }
     });
 
+    // Roll up multiple article 4 layers, while preserving data debug details & granular HMO value
+    if (ob["article4"].value && ob["article4.canterbury.hmo"].value) {
+      ob["article4.canterbury.hmo"] = { value: true };
+    } else if (!ob["article4"].value && ob["article4.canterbury.hmo"].value) {
+      ob["article4"] = ob["article4.canterbury.hmo"];
+      ob["article4.canterbury.hmo"] = { value: true };
+    } else if (!ob["article4.canterbury.hmo"].value) {
+      ob["article4.canterbury.hmo"] = { value: false };
+    }
+
     // Merge Listed Buildings & "Locally Listed Buildings" responses under single "listed" variable
     const obSquashed = squashResultLayers(ob, ["listed.local"], "listed");
 
-    // Roll up multiple article 4 layers, while preserving granularity for HMO type
-    const obRolledUp = rollupResultLayers(obSquashed, ["article4.canterbury.hmo"], "article4");
-
     // Add summary "designated" key to response
-    const obWithDesignated = addDesignatedVariable(obRolledUp);
+    const obWithDesignated = addDesignatedVariable(obSquashed);
 
     return obWithDesignated;
   } catch (e) {

--- a/api.planx.uk/gis/local_authorities/metadata/canterbury.js
+++ b/api.planx.uk/gis/local_authorities/metadata/canterbury.js
@@ -63,7 +63,7 @@ const planningConstraints = {
       "article4.canterbury.lowerHardres": "Article 4 Direction No 29 2003",
       "article4.canterbury.mountsWoods": "Article 4 Direction 1995",
       "article4.canterbury.nackington": "Article 4 Direction No 30 2003",
-      "article4.canterbury.nelsonroad": "Article 4 Direction, 1985",
+      "article4.canterbury.nelsonRoad": "Article 4 Direction, 1985",
       "article4.canterbury.patrixbourne": "Article 4 Direction No 2 2004",
       "article4.canterbury.pennyPot": "Article 4 Direction No 1 1976",
       "article4.canterbury.petham.a": "Article 4 Direction No 20 2003",


### PR DESCRIPTION
"data" object was getting dropped by the rollup helper method for the parent-level "article4" variable, and there's value to keeping that around & explicit right now while there's still a lot of back & forth testing with the council. we only want to return the simple object for "article4.canterbury.hmo". also fixing one misspelled granular variable name.

example: 98 Sydenham Street, Whitstable, CT5 1HL
- before: https://api.editor.planx.uk/gis/canterbury?x=610925&y=166735&siteBoundary=[]&version=1
- after: https://api.787.planx.pizza/gis/canterbury?x=610925&y=166735&siteBoundary=[]&version=1