### PR TITLE
fix: configure granular article 4s in Southwark

### DIFF
--- a/api.planx.uk/gis/local_authorities/metadata/southwark.js
+++ b/api.planx.uk/gis/local_authorities/metadata/southwark.js
@@ -13,16 +13,100 @@ const planningConstraints = {
     key: "article4",
     source: "Southwark Maps",
     tables: [
-      "Article 4 - Sunray Estate",
+      "Article 4 - Demolition of the Stables and the Forge on Catlin Street",
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.sunray": {
+    key: "article4.southwark.sunray",
+    source: "Southwark Maps",
+    tables: [
+      "Article 4 - Sunray Estate"
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.caz": {
+    key: "article4.southwark.caz",
+    source: "Southwark Maps",
+    tables: [
       "Article 4 - offices in the Central Activities Zone",
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.publichouse": {
+    key: "article4.southwark.publichouse",
+    source: "Southwark Maps",
+    tables: [
       "Article 4 - Public Houses",
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.hmo": {
+    key: "article4.southwark.hmo",
+    source: "Southwark Maps",
+    tables: [
       "Article 4 - HMO Henshaw Street",
       "Article 4 - HMO Bywater Place",
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.lightindustrial": {
+    key: "article4.southwark.lightindustrial",
+    source: "Southwark Maps",
+    tables: [
       "Article 4 - Light Industrial",
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.towncentre": {
+    key: "article4.southwark.towncentre",
+    source: "Southwark Maps",
+    tables: [
       "Article 4 - Town Centres A3 - A5 to A2 and from A1 – A5 B1 D1 and D2 to flexible uses",
       "Article 4 - Town Centres A1 to A2",
+    ],
+    columns: ["Article_4_Direction", "More_information"],
+    neg: "is not subject to any Article 4 restrictions",
+    pos: (data) => ({
+      text: "is subject to Article 4 restriction(s)",
+      description: data.Article_4_Direction,
+    }),
+  },
+  "article4.southwark.southernrail": {
+    key: "article4.southwark.southernrail",
+    source: "Southwark Maps",
+    tables: [
       "Article 4 - Railway Arches",
-      "Article 4 - Demolition of the Stables and the Forge on Catlin Street",
     ],
     columns: ["Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",

--- a/api.planx.uk/gis/local_authorities/southwark.js
+++ b/api.planx.uk/gis/local_authorities/southwark.js
@@ -6,6 +6,7 @@ const {
   getQueryableConstraints,
   getManualConstraints,
   addDesignatedVariable,
+  rollupResultLayers,
 } = require("../helpers.js");
 const { planningConstraints } = require("./metadata/southwark.js");
 
@@ -133,13 +134,6 @@ async function locationSearch(x, y, siteBoundary, extras) {
       }
     );
 
-  ob["article4.southwark.sunray"] = {
-    value:
-      ob["designated.conservationArea"]?.data?.Conservation_area_number === 39
-        ? true
-        : false,
-  };
-
   responses
     .filter(([_key, result]) => result instanceof Error)
     .forEach(([key, _result]) => {
@@ -148,8 +142,12 @@ async function locationSearch(x, y, siteBoundary, extras) {
       } catch (e) {}
     });
 
+  // Rollup multiple Article4 layers
+  const a4Layers = Object.keys(planningConstraints).filter(constraint => constraint.startsWith("article4"));
+  const obRolledUp = rollupResultLayers(ob, a4Layers, "article4");
+
   // Add summary "designated" key to response
-  const obWithDesignated = addDesignatedVariable(ob);
+  const obWithDesignated = addDesignatedVariable(obRolledUp);
 
   return obWithDesignated;
 }


### PR DESCRIPTION
Based on https://docs.google.com/spreadsheets/d/1qPbDgcfs7Mutfa-2gkbyLGJZ_z4MK01Iu5ZGHDqa1Jc/edit#gid=0

Example:
- before https://api.editor.planx.uk/gis/southwark?x=532616&y=174821&siteBoundary=[]&version=1
- after https://api.789.planx.pizza/gis/southwark?x=532616&y=174821&siteBoundary=[]&version=1