### PR TITLE
feat: add "latitude" & "longitude" properties to "site" object sent to BOPS

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
@@ -129,8 +129,6 @@ const breadcrumbs: Store.breadcrumbs = {
         town: "town",
         county: "county",
         postcode: "postcode",
-        latitude: "51.4842536",
-        longitude: "-0.0764165",
       },
     },
   },
@@ -170,11 +168,7 @@ test("valid node types are serialized correctly for BOPS", () => {
   const expected = [
     {
       question: "address question",
-      responses: [
-        {
-          value: "line1, line, town, county, postcode, 51.4842536, -0.0764165",
-        },
-      ],
+      responses: [{ value: "line1, line, town, county, postcode" }],
     },
     { question: "checklist", responses: [{ value: "1" }, { value: "2" }] },
     {

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -10,6 +10,8 @@ export const BOPS_URL = `${process.env.REACT_APP_API_URL}/bops`;
 
 export const USER_ROLES = ["applicant", "agent", "proxy"] as const;
 
+// See minimum POST schema for /api/v1/planning_applications
+// https://ripa.bops.services/api-docs/index.html
 interface BOPSMinimumPayload {
   application_type: "lawfulness_certificate";
   site: {
@@ -21,6 +23,7 @@ interface BOPSMinimumPayload {
     latitude: string;
     longitude: string;
   };
+  applicant_email: string;
 }
 
 export interface BOPSFullPayload extends BOPSMinimumPayload {
@@ -32,7 +35,6 @@ export interface BOPSFullPayload extends BOPSMinimumPayload {
   applicant_first_name?: string;
   applicant_last_name?: string;
   applicant_phone?: string;
-  applicant_email?: string;
   agent_first_name?: string;
   agent_last_name?: string;
   agent_phone?: string;


### PR DESCRIPTION
In cases where no site outline has been drawn, BOPs still wants to display a map that is centered on & zoomed into the site address of the application for the officer. This extends the `site` object to include the `latitude` & `longitude` returned by OS Places. 

See https://ripahq.slack.com/archives/C02DE0PFA1L/p1641387077002700

In the future, we may want to send these as numbers, but I kept as strings for now for consistency. There's a ticket somewhere in the backlog to review all BOPs data types, and we could rework then.

Bonus change: 
- Moved `applicant_email` from full to minimum payload interface to match current BOPs schema docs https://ripa.bops.services/api-docs/index.html