### PR TITLE
fix: focused input should set border instead of boxshadow

### DIFF
--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -54,7 +54,7 @@ export const useClasses = makeStyles((theme) => ({
     paddingRight: 2,
   },
   focused: {
-    boxShadow: `inset 0 0 0 2px ${theme.palette.primary.light}`,
+    border: `2px solid ${theme.palette.primary.light}`,
   },
 }));
 


### PR DESCRIPTION
See [accessibility report](https://drive.google.com/file/d/198yQ_tjM9mCGeiJqS9PID_rG2EhYNWe1/view) pages 123-125

Focused input is styled using a border rather than a box-shadow now. This should fix two usability issues mentioned:
- When inverting screen color, inputs with only box shadows & no border were difficult to distinguish
- Borders weren't displaying properly for Safari users

Adjusting public-facing input only here, some editor inputs & global MUI "Paper" themes still set a box-shadow - which we can address in the future or move away from entirely with gov-uk components. 