### PR TITLE
fix: Ensure change of postcode clears previously selected address

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -265,6 +265,24 @@ function GetAddress(props: {
     if (!sanitizedPostcode) setShowPostcodeError(true);
   };
 
+  // XXX: If you press a key on the keyboard, you expect something to show up on the screen,
+  //      so this code attempts to validate postcodes without blocking any characters.
+  const handlePostcodeInputChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    // Reset the address on change of postcode - ensures no visual mismatch between address and postcode
+    if (selectedOption) setSelectedOption(null);
+    // Validate and set Postcode
+    const input = e.target.value;
+    if (parse(input.trim()).valid) {
+      setSanitizedPostcode(toNormalised(input.trim()));
+      setPostcode(toNormalised(input.trim()));
+    } else {
+      setSanitizedPostcode(null);
+      setPostcode(input.toUpperCase());
+    }
+  };
+
   return (
     <Card
       handleSubmit={() => props.setAddress(selectedOption ?? undefined)}
@@ -287,18 +305,7 @@ function GetAddress(props: {
                 ? "Enter a valid UK postcode"
                 : ""
             }
-            onChange={(e) => {
-              // XXX: If you press a key on the keyboard, you expect something to show up on the screen,
-              //      so this code attempts to validate postcodes without blocking any characters.
-              const input = e.target.value;
-              if (parse(input.trim()).valid) {
-                setSanitizedPostcode(toNormalised(input.trim()));
-                setPostcode(toNormalised(input.trim()));
-              } else {
-                setSanitizedPostcode(null);
-                setPostcode(input.toUpperCase());
-              }
-            }}
+            onChange={(e) => handlePostcodeInputChange(e)}
             onKeyUp={({ key }) => {
               if (key === "Enter") handleCheckPostcode();
             }}


### PR DESCRIPTION
Addresses https://trello.com/c/kQOPKP9T/1706-changing-a-postcode-retains-the-prior-address-even-though-its-not-a-valid-option-within-the-new-postcode 

Old address is now cleared when there's a change to the postcode.

![chrome-capture (2)](https://user-images.githubusercontent.com/20502206/148803494-5822ace2-72cf-4a30-bea7-4f5d1f9c8186.gif)

