### PR TITLE
fix: adjust retry options for fetching planning constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -46,8 +46,8 @@ function Component(props: Props) {
         : null,
     {
       shouldRetryOnError: true,
-      errorRetryInterval: 1000,
-      errorRetryCount: 3,
+      errorRetryInterval: 500,
+      errorRetryCount: 5,
     }
   );
 


### PR DESCRIPTION
Buckinghamshire specifically is still reporting occassional timeout issues when fetching planning constraints. Making a very minor tweak here to refetch sooner & more times, but personally don't think this is worth investing a lot of effort/refactor work into right now knowing that Digital Land's new GIS API is in progress - but open to other opinions here! 