### PR TITLE
fix: Fetch flow settings and pass into preview browser

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -8,9 +8,10 @@ import { makeStyles } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import formatDistanceToNow from "date-fns/formatDistanceToNow";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ExternalLink, Globe, RefreshCw, Terminal } from "react-feather";
 import { useAsync } from "react-use";
+import { FlowSettings } from "types";
 import Input from "ui/Input";
 
 import { TYPES } from "../../../@planx/components/types";
@@ -97,7 +98,10 @@ function PublishChangeItem(props: any) {
   );
 }
 
-const PreviewBrowser: React.FC<{ url: string }> = React.memo((props) => {
+const PreviewBrowser: React.FC<{
+  url: string;
+  settings: FlowSettings;
+}> = React.memo((props) => {
   const [showDebugConsole, setDebugConsoleVisibility] = useState(false);
   const [
     flowId,
@@ -274,7 +278,11 @@ const PreviewBrowser: React.FC<{ url: string }> = React.memo((props) => {
         </Box>
       </header>
       <div className={classes.previewContainer}>
-        <Questions previewEnvironment="editor" key={String(key)} />
+        <Questions
+          previewEnvironment="editor"
+          key={String(key)}
+          settings={props.settings}
+        />
       </div>
       {showDebugConsole && <DebugConsole />}
     </div>

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const FlowEditor: React.FC<any> = ({ flow, breadcrumbs }) => {
+const FlowEditor: React.FC<any> = ({ flow, breadcrumbs, settings }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   useScrollControlsAndRememberPosition(scrollContainerRef);
 
@@ -37,6 +37,7 @@ const FlowEditor: React.FC<any> = ({ flow, breadcrumbs }) => {
       {showPreview && (
         <PreviewBrowser
           url={`${window.location.origin}${rootFlowPath(false)}/preview`}
+          settings={settings}
         />
       )}
     </div>

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -6,6 +6,7 @@ import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
 // import useAnalyticsTracking from "pages/FlowEditor/lib/useAnalyticsTracking";
 import React, { useContext, useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { FlowSettings } from "types";
 
 import ErrorFallback from "../../components/ErrorFallback";
 import { useStore } from "../FlowEditor/lib/store";
@@ -37,9 +38,10 @@ const useClasses = makeStyles((theme) => ({
 
 interface QuestionsProps {
   previewEnvironment: PreviewEnvironment;
+  settings?: FlowSettings;
 }
 
-const Questions = ({ previewEnvironment }: QuestionsProps) => {
+const Questions = ({ previewEnvironment, settings }: QuestionsProps) => {
   const [
     currentCard,
     previousCard,
@@ -128,7 +130,9 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
             node={node}
             key={node.id}
             handleSubmit={handleSubmit(node.id!)}
-            settings={flow?.settings}
+            settings={
+              previewEnvironment === "editor" ? settings : flow?.settings
+            }
           />
         </ErrorBoundary>
       )}


### PR DESCRIPTION
Addresses https://trello.com/c/HoX2CumQ/1701-flow-editor-does-not-correctly-fetch-flow-settings

**Problem**
Originally discovered that the legal disclaimer does not show when in Editor mode, but does in preview & unpublished.

The difference appears to be that the flow is being fetched using GraphQL/Hasura in Preview/Unpublished, but websockets/ShareDB in the Editor mode.

The display of the legal disclaimer in edit mode is not a showstopper, but this should be resolved in order to avoid further issues which may require data from Flow Settings.

**Solution** 
 - Added a query to Hasura to fetch the flow settings, and passed this into the preview browser
 - Happy discuss if this approach is most appropriate - I did consider modifying what gets returned by ShareDB but it seemed to make sense to keep this as lean as possible