### PR TITLE
fix: Get flow without breadcrumbs to make query for settings

### DIFF
--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -181,8 +181,8 @@ const routes = compose(
   })),
 
   withView(async (req) => {
-    const settings = await getFlowSettings(req.params.flow, req.params.team);
     const [flow, ...breadcrumbs] = req.params.flow.split(",");
+    const settings = await getFlowSettings(flow, req.params.team);
     return (
       <>
         <ErrorBoundary FallbackComponent={ErrorFallback}>


### PR DESCRIPTION
This PR resolves the following Airflow error - https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3186657101728553027

Previous PR https://github.com/theopensystemslab/planx-new/pull/809 was a hotfix which hid the error, but did not resolve the underlying issue.

As routes can have a `:flow` param in the url with is constructed of a flow name and breadcrumbs when viewing a portal (e.g. https://editor.planx.uk/opensystemslab/permitteddevelopment,AB6019Wu3e), it is important we just pass in the flow name when making a request for settings.