### PR TITLE
break: remove custom placeholder inputs from TextInput and NumberInput components

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
@@ -56,14 +56,6 @@ export default function AddressInputComponent(props: Props): FCReturn {
           </InputRow>
           <InputRow>
             <Input
-              placeholder="Placeholder"
-              name="placeholder"
-              value={formik.values.placeholder}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <Input
               required
               format="data"
               name="fn"

--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -24,7 +24,6 @@ export const userDataSchema: SchemaOf<UserData> = object({
 export interface AddressInput extends MoreInformation {
   title: string;
   description?: string;
-  placeholder?: string;
   fn?: string;
 }
 
@@ -33,7 +32,6 @@ export const parseAddressInput = (
 ): AddressInput => ({
   title: data?.title || "",
   description: data?.description,
-  placeholder: data?.placeholder,
   fn: data?.fn || "",
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -54,14 +54,6 @@ export default function NumberInputComponent(props: Props): FCReturn {
             />
           </InputRow>
           <InputRow>
-            <RichTextInput
-              placeholder="Placeholder"
-              name="placeholder"
-              value={formik.values.placeholder}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
             <Input
               // required
               format="data"

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -17,17 +17,25 @@ test("renders correctly", async () => {
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
 
   await act(async () => {
-    await userEvent.click(screen.getByText("Continue"));
-  });
-
-  expect(handleSubmit).toHaveBeenCalledTimes(0);
-
-  await act(async () => {
-    await userEvent.type(screen.getByPlaceholderText("enter value"), "3");
+    await userEvent.type(screen.getByLabelText("Numberwang!"), "3");
     await userEvent.click(screen.getByText("Continue"));
   });
 
   expect(handleSubmit).toHaveBeenCalledWith({ data: { num: 3 } });
+});
+
+test("requires a value before being able to continue", async () => {
+  const handleSubmit = jest.fn();
+
+  render(
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
+  );
+
+  await act(async () => {
+    await userEvent.click(screen.getByText("Continue"));
+  });
+
+  expect(handleSubmit).toHaveBeenCalledTimes(0);
 });
 
 test("recovers previously submitted number when clicking the back button", async () => {

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
@@ -70,7 +70,6 @@ export default function NumberInputComponent(props: Props): FCReturn {
             bordered
             name="value"
             type="number"
-            placeholder="enter value"
             value={formik.values.value}
             onChange={formik.handleChange}
             errorMessage={formik.errors.value as string}

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -3,7 +3,6 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 export interface NumberInput extends MoreInformation {
   title: string;
   description?: string;
-  placeholder?: string;
   fn?: string;
   units?: string;
 }
@@ -23,7 +22,6 @@ export const parseNumberInput = (
 ): NumberInput => ({
   title: data?.title || "",
   description: data?.description,
-  placeholder: data?.placeholder,
   fn: data?.fn || "",
   units: data?.units,
   ...parseMoreInformation(data),

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -78,14 +78,6 @@ const TextInputComponent: React.FC<Props> = (props) => {
           </InputRow>
           <InputRow>
             <Input
-              placeholder="Placeholder"
-              name="placeholder"
-              value={formik.values.placeholder}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <Input
               // required
               format="data"
               name="fn"

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -9,17 +9,12 @@ import TextInput from "./Public";
 test("requires a value before being able to continue", async () => {
   const handleSubmit = jest.fn();
 
-  render(
-    <TextInput title="hello" placeholder="what?" handleSubmit={handleSubmit} />
-  );
+  render(<TextInput title="hello" handleSubmit={handleSubmit} />);
 
   expect(screen.getByRole("heading")).toHaveTextContent("hello");
 
   await act(async () => {
-    await userEvent.type(
-      await screen.getByPlaceholderText("what?"),
-      "something"
-    );
+    await userEvent.type(await screen.getByLabelText("hello"), "something");
     await userEvent.click(screen.getByText("Continue"));
   });
 
@@ -32,7 +27,6 @@ test("requires a valid email before being able to continue", async () => {
   render(
     <TextInput
       title="hello"
-      placeholder="what?"
       type={TextInputType.Email}
       handleSubmit={handleSubmit}
     />
@@ -41,7 +35,7 @@ test("requires a valid email before being able to continue", async () => {
   expect(screen.getByRole("heading")).toHaveTextContent("hello");
 
   await act(async () => {
-    await userEvent.type(screen.getByPlaceholderText("what?"), "not-an-email");
+    await userEvent.type(screen.getByLabelText("hello"), "not-an-email");
     await userEvent.click(screen.getByText("Continue"));
   });
 
@@ -121,13 +115,12 @@ examplePhoneNumbers.forEach((number) => {
     render(
       <TextInput
         title="phone"
-        placeholder={number}
         type={TextInputType.Phone}
         handleSubmit={handleSubmit}
       />
     );
 
-    fireEvent.change(screen.getByPlaceholderText(number), {
+    fireEvent.change(screen.getByLabelText("phone"), {
       target: { value: number },
     });
 
@@ -141,11 +134,7 @@ examplePhoneNumbers.forEach((number) => {
 
 it("should not have any accessibility violations", async () => {
   const { container } = render(
-    <TextInput
-      title="phone"
-      placeholder="(01234) 123456"
-      type={TextInputType.Phone}
-    />
+    <TextInput title="phone" type={TextInputType.Phone} />
   );
   const results = await axe(container);
   expect(results).toHaveNoViolations();

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -52,7 +52,6 @@ const TextInputComponent: React.FC<Props> = (props) => {
             rows={props.type === "long" ? 5 : undefined}
             name="text"
             value={formik.values.text}
-            placeholder={props.placeholder}
             bordered
             onChange={formik.handleChange}
             errorMessage={formik.errors.text as string}

--- a/editor.planx.uk/src/@planx/components/TextInput/TextInput.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/TextInput.stories.tsx
@@ -20,7 +20,6 @@ export const Frontend: Story<Props> = Template.bind({});
 Frontend.args = {
   title: "How was your day?",
   description: "Be as descriptive as you can.",
-  placeholder: "I started with a long stroll...",
   type: TextInputType.Short,
 };
 
@@ -28,7 +27,6 @@ export const FrontendEmail: Story<Props> = Template.bind({});
 FrontendEmail.args = {
   title: "What's your email?",
   type: TextInputType.Email,
-  placeholder: "",
   description: "",
 };
 

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -60,7 +60,6 @@ export const userDataSchema = (type?: TextInputType): SchemaOf<UserData> =>
 export interface TextInput extends MoreInformation {
   title: string;
   description?: string;
-  placeholder?: string;
   fn?: string;
   type?: TextInputType;
 }
@@ -70,7 +69,6 @@ export const parseTextInput = (
 ): TextInput => ({
   title: data?.title || "",
   description: data?.description,
-  placeholder: data?.placeholder,
   fn: data?.fn,
   type: data?.type,
   ...parseMoreInformation(data),


### PR DESCRIPTION
Removes ability to add custom placeholder text from the Editor for TextInput and NumberInput components per accessbility audit recommendation to entirely move away from placeholders, instead using "hint text" or what we call "description" in the QuestionHeader.

We still keep minimal placeholder text in DateInput and AddressInput components, but content editors cannot access this.

Content editors moved custom placeholders into the description field already :heavy_check_mark: 