### PR TITLE
fix: RichTextInput bug #372

### DIFF
--- a/editor.planx.uk/src/ui/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.tsx
@@ -112,8 +112,11 @@ const RichTextInput: React.FC<Props> = (props) => {
     const currentHtml = draftToHtml(
       convertToRaw(editorState.getCurrentContent())
     );
-    // Do not sync state if value has been forcefully changed to "" as newHtmlContentNonEmpty
-    if (currentHtml !== props.value && props.value !== "") {
+    if (
+      currentHtml !== props.value &&
+      // Do not sync state if value has been forcefully changed to "" as newHtmlContentNonEmpty
+      props.value !== ""
+    ) {
       setEditorState(
         EditorState.createWithContent(
           valueToContentState((props.value as string) || ""),


### PR DESCRIPTION
 - Addresses #372 which has been bugging me for a while!
 - In order to save `""` to the db instead of `<p></p>` for an empty RichText string, the value was being manually changed using the variable `newHtmlContentNonEmpty`
 - This then caused a situation where the editor state would be out of sync with the value of the input, triggering a second onChange event
 - This second calling of the onChange event did not detect change (as there was none second time round), leading to the input cursor not moving to the end of the field
 
(That's my understanding anyway! 😅 )

**Before**
![chrome-capture (3)](https://user-images.githubusercontent.com/20502206/150186792-598dd246-e9c2-4c1b-8505-45dc315e8f07.gif)

**After**
![chrome-capture (4)](https://user-images.githubusercontent.com/20502206/150186906-de3439d8-215b-45b8-b300-abb4e2899a7f.gif)

