### PR TITLE
fix: Remove redundant alt text for image buttons

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -99,7 +99,13 @@ function ImageResponse(props: Props) {
               <ImageIcon />
             </Box>
           ) : (
-            <img className={classes.img} src={img} onError={onError} alt="" />
+            <img
+              className={classes.img}
+              src={img}
+              onError={onError}
+              // Use a null alt to indicate that this image can be ignored by screen readers
+              alt=""
+            />
           )}
         </Box>
         {/*


### PR DESCRIPTION
**Problem**
> When users encountered the diagrams throughout the service, they all have the same alternative attribute of 'An illustration of this option'. This is not an accessible method of informing users of the purpose of the image, and what the information it is meant to be conveying. When a screen reader user views the service out of context, they will not be able to assign the relationship between the image and the button that it corresponds to.

**Suggested Solution**
> We suggest providing a null alt (alt="") attribute on the images in this instance, as the information will be provided to them from the buttons associated. To make this section accessible for users, we suggest marking up the “What type of house is it” as a heading within a fieldset to group the buttons together, as there is already text within the button. It would be even more beneficial is these buttons could be implemented as radio buttons.


**What I've done** 
 - Removed alt text as suggested
 - Removed redundant `aria-labelledby` and `htmlFor` props - as this is a button, it is already picking up the label correctly. Tested with MacOS voice over (see screenshot), and also [confirmed in MDN docs here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby#description).
 
 > Some elements get their accessible name from their inner content. For example, the accessible name for a `<button>`, `<a>`, or `<td>` comes from the text between the opening and closing tags. 
 
 
![image](https://user-images.githubusercontent.com/20502206/150333366-b25d6848-c1a9-48d9-800e-6b753ee3e7bd.png)

