### PR TITLE
fix: Save actor_id when an operation is saved

### DIFF
--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -22,7 +22,9 @@ const sharedb = new ShareDB({
 sharedb.use("connect", (context, next) => {
   try {
     context.agent.connectSession = { userId: context.req.uId.sub };
-  } catch (e) {};
+  } catch (e) {
+    console.error("Error connecting to ShareDB: ", e);
+  };
   next();
 });
 
@@ -32,7 +34,9 @@ sharedb.use("commit", (context, done) => {
   try {
     const { op, agent } = context;
     op.m.uId = agent.connectSession.userId;
-  } catch (e) {};
+  } catch (e) {
+    console.error("Error committing to ShareDB: ", e);
+  };
   done();
 });
 


### PR DESCRIPTION
**Problem**
 - Addresses the following ticket - https://trello.com/c/VCj2cyEi/1746-name-of-last-editor-that-made-changes-missing-from-recent-flows
  - Since approx September 2021, `actor_id` has not been saved to the `operations` table then a change has been made to a flow (I checked the last updated operation with an `actor_id`).
   - Possibly linked to the following PR which made a number of changes - https://github.com/theopensystemslab/planx-new/pull/628

**Solution**
- Use commit hook to assign user id to op metadata, which can then be picked up on the db layer
- Still unsure as to how this was broke - very open to ideas!
- Variable name changed from `request` to `context` to match sharedb docs
- Docs here for sharedb middleware and hooks - https://share.github.io/sharedb/middleware/