### PR TITLE
fix: Re-enable MUI ripple on text links

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -146,11 +146,7 @@ function SuggestionDrawer() {
 
   return (
     <>
-      <ButtonBase
-        disableRipple
-        className={classes.link}
-        onClick={handleLinkClick}
-      >
+      <ButtonBase className={classes.link} onClick={handleLinkClick}>
         Tell us other ways you'd like to pay in the future
       </ButtonBase>
       <Drawer

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -174,7 +174,6 @@ const Result: React.FC<Props> = ({
                   onClick={() =>
                     setShowDisclaimer((showDisclaimer) => !showDisclaimer)
                   }
-                  disableRipple
                 >
                   <Typography variant="body2" className={classes.readMore}>
                     Read {showDisclaimer ? "less" : "more"}

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -139,7 +139,6 @@ function Component(props: Props) {
                       <dd>
                         <ButtonBase
                           className={button}
-                          disableRipple
                           onClick={() => handleClick(nodeId)}
                         >
                           Change
@@ -314,9 +313,8 @@ function NumberInput(props: ComponentProps) {
 }
 
 function AddressInput(props: ComponentProps) {
-  const { line1, line2, town, county, postcode, country } = getAnswersByNode(
-    props
-  );
+  const { line1, line2, town, county, postcode, country } =
+    getAnswersByNode(props);
 
   return (
     <>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -81,7 +81,6 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
         {!!(info || policyRef || howMeasured) && (
           <Grid item>
             <IconButton
-              disableRipple
               className={classes.iconButton}
               title={`More information`}
               aria-label={`See more information about "${title}"`}

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -59,7 +59,7 @@ export default function Footer(props: Props) {
             <FooterItem {...item} key={item.title} />
           ))}
         {feedbackFishId && (
-          <ButtonBase disableRipple>
+          <ButtonBase>
             <FeedbackFish projectId={feedbackFishId}>
               <Typography variant="body2" className={classes.link}>
                 Feedback
@@ -95,7 +95,7 @@ function FooterItem(props: {
       {title}
     </Link>
   ) : (
-    <ButtonBase onClick={props.onClick} className={classes.link} disableRipple>
+    <ButtonBase onClick={props.onClick} className={classes.link}>
       {title}
     </ButtonBase>
   );


### PR DESCRIPTION
 - Raised in a previous review that this wasn't applied in a consistent manner to text links
 - Re-enabled the ripple in the handful of places I'd disabled it
 - We can later decide if this is something we want on all interactive elements or not, and control it at theme level