### PR TITLE
fix: display publish button errors in editor

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -43,17 +43,14 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const DebugConsole = () => {
-  const [
-    passport,
-    breadcrumbs,
-    flowId,
-    cachedBreadcrumbs,
-  ] = useStore((state) => [
-    state.computePassport(),
-    state.breadcrumbs,
-    state.id,
-    state.cachedBreadcrumbs,
-  ]);
+  const [passport, breadcrumbs, flowId, cachedBreadcrumbs] = useStore(
+    (state) => [
+      state.computePassport(),
+      state.breadcrumbs,
+      state.id,
+      state.cachedBreadcrumbs,
+    ]
+  );
   const classes = useStyles();
   return (
     <div className={classes.console}>
@@ -262,6 +259,8 @@ const PreviewBrowser: React.FC<{
                           : "No new changes to publish"
                       );
                     } catch (error) {
+                      setLastPublishedTitle("Error trying to publish");
+                      alert(error);
                       console.log(error);
                     }
                   }}


### PR DESCRIPTION
Quickly fixes #822 

![Screenshot from 2022-01-25 13-15-48](https://user-images.githubusercontent.com/5132349/150976114-0ba496d9-6863-48ca-b2b1-518ded73a92b.png)

![Screenshot from 2022-01-25 13-15-59](https://user-images.githubusercontent.com/5132349/150976121-67dddf6f-8497-4ce4-b3fe-cf094848ca01.png)

Currently, since user ids are out of sync btwn pizza seed data & production, re-create this by trying to publish any flow on a pizza (errors on foreign key violation that publisher_id isn't a valid user_id).