### PR TITLE
fix: send "_nots" planning constraints to BOPs in addition to applicable ones

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -264,7 +264,7 @@ export function getParams(
     return acc;
   }, {});
   if (Object.keys(nots).map(Boolean).length > 0) {
-    data.constraints_not_applicable = nots;
+    data.constraints = { ...data.constraints, ...nots };
   }
 
   // 4. work status

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -41,7 +41,6 @@ export interface BOPSFullPayload extends BOPSMinimumPayload {
   agent_email?: string;
   proposal_details?: Array<QuestionAndResponses>;
   constraints?: Record<string, boolean>;
-  constraints_not_applicable?: Record<string, boolean>;
   files?: Array<File>;
   boundary_geojson?: Object;
   result?: {


### PR DESCRIPTION
extending the `constraints` dictionary in the BOPs response to additionally include "negative" planning constraint variables.

variables with value `false` represent successful gis queries, but no intersection with the property. 

this should help BOPs distinguish cases were a property is not subject to any planning constraints (will now still have `constraints` key) from a property where GIS data was not successfully fetched or asked about at all (will not have `constraints` key).

example request payload snippet: 
![Screenshot from 2022-02-02 12-20-28](https://user-images.githubusercontent.com/5132349/152145848-d2f85ae2-d447-49e4-aed2-5cd5ed76b929.png)