### PR TITLE
fix: review component shouldn't hardcode title

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -7,28 +7,20 @@ import ModalSectionContent from "ui/ModalSectionContent";
 import RichTextInput from "ui/RichTextInput";
 
 import { TYPES } from "../types";
-import { ICONS, InternalNotes } from "../ui";
-import type { Review } from "./model";
+import { EditorProps, ICONS, InternalNotes } from "../ui";
+import { parseContent, Review } from "./model";
 
-interface Props {
-  id?: string;
-  handleSubmit?: (data: { type: TYPES.Review; data: Review }) => void;
-  node?: any;
-}
+type Props = EditorProps<TYPES.Review, Review>;
 
 function Component(props: Props) {
   const formik = useFormik<Review>({
-    initialValues: {
-      title: props.node?.data?.title ?? "",
-      description: props.node?.data?.description ?? "",
-      notes: props.node?.data?.notes ?? "",
-    },
+    initialValues: parseContent(props.node?.data),
     onSubmit: (newValues) => {
-      if (props.handleSubmit) {
-        props.handleSubmit({ type: TYPES.Review, data: newValues });
-      }
+      props.handleSubmit?.({
+        type: TYPES.Review,
+        data: newValues,
+      });
     },
-    validate: () => {},
   });
 
   return (
@@ -38,16 +30,16 @@ function Component(props: Props) {
           <InputRow>
             <Input
               format="large"
-              placeholder="Review"
               name="title"
+              placeholder={formik.values.title}
               value={formik.values.title}
               onChange={formik.handleChange}
             />
           </InputRow>
           <InputRow>
             <RichTextInput
-              placeholder="Description"
               name="description"
+              placeholder="Description"
               value={formik.values.description}
               onChange={formik.handleChange}
             />

--- a/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
@@ -10,6 +10,8 @@ test("renders correctly", async () => {
 
   render(
     <Review
+      title="Review"
+      description="Check your answers before submitting"
       flow={{}}
       breadcrumbs={{}}
       passport={{}}
@@ -18,6 +20,8 @@ test("renders correctly", async () => {
       showChangeButton={true}
     />
   );
+
+  expect(screen.getByRole("heading")).toHaveTextContent("Review");
 
   userEvent.click(screen.getByText("Continue"));
 
@@ -29,6 +33,8 @@ test("REGRESSION: doesn't return undefined when multiple nodes are filled", asyn
 
   render(
     <Review
+      title="Review"
+      description="Check your answers before submitting"
       flow={mockedFlow}
       breadcrumbs={mockedBreadcrumbs}
       passport={mockedPassport}
@@ -86,6 +92,8 @@ const mockedFlow = {
 it("should not have any accessibility violations", async () => {
   const { container } = render(
     <Review
+      title="Review"
+      description="Check your answers before submitting"
       flow={mockedFlow}
       breadcrumbs={mockedBreadcrumbs}
       passport={mockedPassport}

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { visuallyHidden } from "@material-ui/utils";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import Card from "@planx/components/shared/Preview/Card";
+import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { TYPES } from "@planx/components/types";
 import format from "date-fns/format";
 import type { Store } from "pages/FlowEditor/lib/store";
@@ -21,7 +22,8 @@ const useStyles = makeStyles((theme) => ({
     display: "grid",
     gridTemplateColumns: "1fr 2fr 100px",
     gridRowGap: "10px",
-    marginBottom: theme.spacing(8),
+    marginTop: theme.spacing(4),
+    marginBottom: theme.spacing(4),
     "& > *": {
       borderBottom: "1px solid grey",
       paddingBottom: theme.spacing(2),
@@ -88,6 +90,8 @@ const components: {
 };
 
 interface Props {
+  title: string;
+  description: string;
   breadcrumbs: Store.breadcrumbs;
   flow: Store.flow;
   passport: Store.passport;
@@ -111,7 +115,7 @@ function Component(props: Props) {
   return (
     <Card isValid handleSubmit={props.handleSubmit}>
       <div className={root}>
-        <h1>Check your answers before sending your application</h1>
+        <QuestionHeader title={props.title} description={props.description} />
         <dl className={grid}>
           {
             // XXX: This works because since ES2015 key order is guaranteed to be the insertion order

--- a/editor.planx.uk/src/@planx/components/Review/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/index.tsx
@@ -1,14 +1,14 @@
-import { MoreInformation } from "@planx/components/shared";
 import { PublicProps } from "@planx/components/ui";
 import type { Store } from "pages/FlowEditor/lib/store";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
+import type { Review } from "../model";
 import Presentational from "./Presentational";
 
 export default Component;
 
-function Component(props: PublicProps<MoreInformation>) {
+function Component(props: PublicProps<Review>) {
   const [breadcrumbs, flow, passport, record, hasPaid] = useStore((state) => [
     state.breadcrumbs,
     state.flow,
@@ -18,6 +18,8 @@ function Component(props: PublicProps<MoreInformation>) {
   ]);
   return (
     <Presentational
+      title={props.title}
+      description={props.description || ""}
       breadcrumbs={breadcrumbs}
       flow={flow}
       passport={passport}

--- a/editor.planx.uk/src/@planx/components/Review/Review.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Review.stories.tsx
@@ -63,8 +63,7 @@ const breadcrumbs = {
       // temporary measure to ensure that the answers are an array of strings, not objects
       JSON.stringify({
         filename: "planx.png",
-        url:
-          "https://planx-temp.s3.eu-west-2.amazonaws.com/development/11q1npcp/planx.png",
+        url: "https://planx-temp.s3.eu-west-2.amazonaws.com/development/11q1npcp/planx.png",
       }),
     ],
     auto: true,
@@ -267,6 +266,8 @@ const flow = {
 export const Frontend: Story<{}> = () => {
   return (
     <Presentational
+      title="Review"
+      description="Check your answers before submitting"
       breadcrumbs={breadcrumbs}
       flow={flow}
       passport={passport}

--- a/editor.planx.uk/src/@planx/components/Review/model.ts
+++ b/editor.planx.uk/src/@planx/components/Review/model.ts
@@ -3,3 +3,11 @@ export interface Review {
   description: string;
   notes: string;
 }
+
+export const parseContent = (
+  data: Record<string, any> | undefined
+): Review => ({
+  title: data?.title || "Check your answers before sending your application",
+  description: data?.description || "",
+  notes: data?.notes || "",
+});


### PR DESCRIPTION
Review component was using a hard-coded title, even though users could enter a custom title & description in the editor. This updates the component to read the title & description from the user data props. I set the default title text to what is currently used in flows, so I don't think this should introduce any breaking changes to existing components.

Notably, this'll make it possible to place multiple copies of this component anywhere in a flow with unique headers & descriptions - like we saw in the Save & Return workflow yesterday for 'review your answers so far' when returning to an applicatoin before continuing on. 

https://834.planx.pizza/opensystemslab/test/preview