### PR TITLE
wip: ShareDB op version mismatch

### DIFF
--- a/sharedb.planx.uk/sharedb-postgresql.js
+++ b/sharedb.planx.uk/sharedb-postgresql.js
@@ -228,7 +228,7 @@ PostgresDB.prototype.getOps = function (
     }
     client.query(
       // "SELECT version, operation FROM operations WHERE collection = $1 AND doc_id = $2 AND version >= $3 AND version < $4",
-      "SELECT version, data FROM operations WHERE flow_id = $1 AND version >= $2 AND version < $3",
+      "SELECT version, data FROM operations WHERE flow_id = $1 AND version > $2 AND version <= $3",
       [id, from, to],
       (err, res) => {
         done();


### PR DESCRIPTION
Addresses error raised on Airbrake multiple times here - https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3195960999563861513?tab=notice-detail

Description matched the following open issue on the sharedb-postgres repo - https://github.com/share/sharedb-postgres/issues/8

According to the above issue, this seems to be caused by "[ops] submitted in a high frequency ( 3 ~ 4 ops a second from different sources )"

Worth testing out (maybe simultaneously on tomorrow's dev call?) to see if we can now reproduce the issue on the Pizza.