### PR TITLE
fix: Sync user ids on pizza and staging

### DIFF
--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -1,9 +1,10 @@
 INSERT INTO public.teams (name, slug, theme) VALUES ('Open Systems Lab', 'opensystemslab', '{}');
 INSERT INTO public.teams (name, slug, theme, settings) VALUES ('Canterbury', 'canterbury', '{"logo": "https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/canterbury.svg", "primary": "#331035"}', '{"homepage": "https://www.canterbury.gov.uk/"}');
 INSERT INTO public.teams (name, slug, theme) VALUES ('Southwark', 'southwark', '{}');
-INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('John', 'Rees', 'john@opensystemslab.io', true);
-INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Alastair', 'Parvin', 'alastair@opensystemslab.io', true);
-INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Gunar', 'Gessner', 'gunargessner@gmail.com', true);
-INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Jessica', 'McInchak', 'jessica@opensystemslab.io', true);
-INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Sarah', 'Scott', 'sarah@opensystemslab.io', true);
-INSERT INTO public.users (first_name, last_name, email, is_admin) VALUES ('Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (1, 'John', 'Rees', 'john@opensystemslab.io', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (6, 'Gunar', 'Gessner', 'gunargessner@gmail.com', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (13, 'Sarah', 'Scott', 'sarah@opensystemslab.io', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true);
+SELECT setval('users_id_seq', max(id)) FROM users;


### PR DESCRIPTION
Addresses https://trello.com/c/bQ6OTTfB/1752-sync-user-ids-across-pizza-staging-production-environments

My understanding of the issue is as follows -

- We auth on pizzas using the staging API (through the REACT_APP_GOOGLE_OAUTH_OVERRIDE variable)
- The JWT is build using the userId from the staging DB
- This can then lead to issues interacting with the Pizza db (seen in the errors with foreign keys on PRs).
- There’s no real issues with prod and staging not being in sync as there shouldn’t be any crossover as described above

**Solution**
 - Manually set userIds on the Pizza db which match staging
 - Increment the sequence to allow the next inserts to work

**Issues**
I think this could still lead to issues with non-dev users who do UAT, e.g. UAT users can log onto Pizzas as they're on the staging DB, but could hit foreign key issues when writing to the Pizza db right?

Adding UAT users to the seed file strikes me as a solution which won't work if the repo is going public.

Can we accept that some actions for UAT users may fail (and need to be tested on staging), or manually insert data into the Pizza user table when needed?