### PR TITLE
fix: add prop to opt out of auto-incrementing headers in Content components

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -37,7 +37,11 @@ const ContentComponent: React.FC<Props> = (props) => {
         howMeasured={props.howMeasured}
       />
       <div className={classes.content} data-testid="content">
-        <ReactMarkdownOrHtml source={props.content} openLinksOnNewTab />
+        <ReactMarkdownOrHtml
+          source={props.content}
+          openLinksOnNewTab
+          manuallyIncrementHeaders
+        />
       </div>
     </Card>
   );

--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -29,6 +29,7 @@ export default function ReactMarkdownOrHtml(props: {
   className?: string;
   openLinksOnNewTab?: boolean;
   id?: string;
+  manuallyIncrementHeaders?: boolean;
 }): FCReturn {
   const classes = useClasses();
   if (typeof props.source !== "string") {
@@ -38,7 +39,9 @@ export default function ReactMarkdownOrHtml(props: {
     const replaceTarget = props.openLinksOnNewTab
       ? props.source.replaceAll(`target="_self"`, `target="_blank" external`)
       : props.source;
-    const incrementHeaders = incrementHeaderElements(replaceTarget);
+    const incrementHeaders = props.manuallyIncrementHeaders
+      ? replaceTarget
+      : incrementHeaderElements(replaceTarget);
 
     return (
       <div


### PR DESCRIPTION
addresses [accessibility report](https://drive.google.com/file/d/1tAn2cmZwGimJWAksOTfJJozgUlUkCWK3/view) page 13-14

the Content component is an edge-case implementation of the `<ReactMarkdownOrHtml />` component in that it is the only content rendered on the card (its' `<QuestionHeader />` is exclusively used for help menu, never title text), therefore we do not want to automatically change any user-entered `h1` elements to `h2`. 

this adds an optional prop so we can specify when headers should be "manually" incremented, meaning fully controlled by the content editors and not programmatically overwritten. on a quick scan, all other implementations of `<ReactMarkdownOrHtml />` seem to occur alongside other text-rendering components - so defaulting to automatically adjusting the heirarchy of user-entered content is still very useful! 