### PR TITLE
fix: Resolve checkbox a11y issues

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -153,6 +153,7 @@ const ChecklistComponent: React.FC<Props> = ({
                 <Grid item xs={12} sm={6} key={option.data.text}>
                   <ImageButton
                     title={option.data.text}
+                    id={option.id}
                     img={option.data.img}
                     selected={formik.values.checked.includes(option.id)}
                     onClick={changeCheckbox(option.id)}

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -5,14 +5,14 @@ import ImageIcon from "@material-ui/icons/Image";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import Checkbox from "ui/Checkbox";
 
-import ButtonBase, { Props as ButtonProps } from "./ButtonBase";
-
-export interface Props extends ButtonProps {
+export interface Props {
   id?: string;
   title: string;
   responseKey?: string | number;
   img?: string;
   checkbox?: boolean;
+  selected: boolean;
+  onClick: (checked: boolean) => void;
 }
 
 const useStyles = makeStyles((theme) => {
@@ -42,7 +42,7 @@ const useStyles = makeStyles((theme) => {
 });
 
 function ImageResponse(props: Props) {
-  const { selected, title, img, checkbox, id } = props;
+  const { selected, title, img, checkbox, id, onClick } = props;
   const [imgError, setImgError] = useState(!(img && img.length));
   const [multiline, setMultiline] = useState(false);
 
@@ -76,7 +76,7 @@ function ImageResponse(props: Props) {
   };
 
   return (
-    <ButtonBase {...props}>
+    <label htmlFor={id} className={classes.label}>
       <Box display="flex" flexDirection="column" width="100%" height="100%">
         <Box
           width="100%"
@@ -135,18 +135,19 @@ function ImageResponse(props: Props) {
                 id={id}
                 checked={selected}
                 color={selected ? "primary.contrastText" : "text.primary"}
+                onChange={onClick}
               />
             )}
             <Typography
               variant="body2"
               className={checkbox ? classes.title : undefined}
             >
-              <label className={classes.label}>{title}</label>
+              {title}
             </Typography>
           </Box>
         </Box>
       </Box>
-    </ButtonBase>
+    </label>
   );
 }
 

--- a/editor.planx.uk/src/ui/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/Checkbox.tsx
@@ -1,6 +1,6 @@
 import Box from "@material-ui/core/Box";
 import { makeStyles, Theme } from "@material-ui/core/styles";
-import * as React from "react";
+import React from "react";
 import { borderedFocusStyle } from "theme";
 
 export const useClasses = makeStyles<Theme, Props>((theme) => ({
@@ -39,6 +39,7 @@ export interface Props {
   id?: string;
   checked: boolean;
   color?: string;
+  onChange: (checked: boolean) => void;
 }
 
 export default function Checkbox(props: Props): FCReturn {
@@ -51,6 +52,9 @@ export default function Checkbox(props: Props): FCReturn {
         className={classes.input}
         type="checkbox"
         id={props.id}
+        onChange={(ev) => {
+          props.onChange(ev?.target?.checked);
+        }}
       />
       <span className={classes.icon}></span>
     </Box>

--- a/editor.planx.uk/src/ui/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/ChecklistItem.tsx
@@ -37,15 +37,9 @@ export default function ChecklistItem({
 }: Props): FCReturn {
   const classes = useClasses();
 
-  const handleChange = (ev: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    // Prevent bubbling of event from label associated with checkbox
-    ev.preventDefault();
-    onChange(!checked);
-  };
-
   return (
-    <Box className={classes.root} onClick={(ev) => handleChange(ev)}>
-      <Checkbox checked={checked} id={id} />
+    <Box className={classes.root}>
+      <Checkbox checked={checked} id={id} onChange={onChange} />
       <Typography variant="body2" className={classes.label}>
         <label htmlFor={id}>{label}</label>
       </Typography>


### PR DESCRIPTION
Addresses issues identified here - https://trello.com/c/7bDr7jLZ/1773-custom-checkboxes

This PR does this following - 
 - Correctly associated labels with checkboxes, which ensures that the label is correctly announced by screenreaders
   - This also ensures that screenreaders announce the "ticked" and "unticked" status of the checkbox when clicking on the label
 - ImageButton - this is no longer a checkbox wrapped in a button which caused issues with event bubbling as well as keyboard navigation
   - I believe is the cause of the issue described in the report as _"I had to use Dragon commands ‘Click Button’ whereas I would have expected to use command ‘Click Box’"_ (though I'm unable to really test this).

**Ticked/Unticked being read when clicking on label**

https://user-images.githubusercontent.com/20502206/155306126-3cccea08-8c38-483b-a71f-55e98f59aec0.mov



**Ticked/Unticked being read when clicking on image**

https://user-images.githubusercontent.com/20502206/155306061-04b4f9bb-8d27-4813-81a3-ff0556a5ade9.mov



**Keyboard navigation only goes between checkboxes**

https://user-images.githubusercontent.com/20502206/155306167-9f09d271-7514-42cc-a562-408daeacfe7b.mov


