### PR TITLE
fix: A11y for Result component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public.test.tsx
@@ -29,7 +29,19 @@ it("should not have any accessibility violations", async () => {
   const { container } = render(
     <Result
       headingColor={{ text: "#000", background: "#fff" }}
-      responses={[]}
+      responses={[
+        {
+          question: { data: { text: "Is this hidden?" }, id: "a" },
+          hidden: false,
+          selections: [],
+        },
+        {
+          question: { data: { text: "Is this shown?" }, id: "b" },
+          hidden: true,
+          selections: [],
+        },
+      ]}
+      allowChanges
       headingTitle="title"
       reasonsTitle="reasons"
     />

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -22,7 +22,12 @@ interface IResultReason {
 
 const useClasses = makeStyles((theme: Theme) => ({
   root: {
+    display: "flex",
+    alignItems: "baseline",
+  },
+  accordion: {
     cursor: "pointer",
+    width: "100%",
     marginBottom: theme.spacing(0.5),
     backgroundColor: theme.palette.background.paper,
     "&:hover": {
@@ -37,6 +42,8 @@ const useClasses = makeStyles((theme: Theme) => ({
     whiteSpace: "nowrap",
   },
   changeButton: {
+    marginLeft: theme.spacing(2),
+    marginBottom: theme.spacing(0.5),
     textDecoration: "underline",
   },
   removeTopBorder: {
@@ -60,87 +67,96 @@ const ResultReason: React.FC<IResultReason> = ({
   const hasMoreInfo = question.data.info ?? question.data.policyRef;
   const toggleAdditionalInfo = () => setExpanded(!expanded);
 
+  const ariaLabel = `${question.data.text}: Your answer was: ${response}. ${
+    hasMoreInfo
+      ? "Click to expand for more information about this question."
+      : ""
+  }`;
+
   return (
-    <Accordion
-      className={classes.root}
-      classes={{ root: classes.removeTopBorder }}
-      onChange={() => hasMoreInfo && toggleAdditionalInfo()}
-      expanded={expanded}
-      elevation={0}
-      square
-    >
-      <AccordionSummary
-        expandIcon={hasMoreInfo ? <Caret /> : null}
-        aria-label={`${question.data.text}: Your answer was: ${response}. Click to expand for more information about this question.`}
-        aria-controls={`group-${id}-content`}
-        id={`group-${id}-header`}
+    <Box className={classes.root}>
+      <Accordion
+        className={classes.accordion}
+        classes={{ root: classes.removeTopBorder }}
+        onChange={() => hasMoreInfo && toggleAdditionalInfo()}
+        expanded={expanded}
+        elevation={0}
+        square
       >
-        <Box
-          display="flex"
-          alignItems="flex-start"
-          flexDirection="column"
-          width="100%"
-          px={1.5}
+        <AccordionSummary
+          expandIcon={hasMoreInfo ? <Caret /> : null}
+          aria-label={ariaLabel}
+          aria-controls={`group-${id}-content`}
+          id={`group-${id}-header`}
         >
           <Box
             display="flex"
-            justifyContent="space-between"
-            alignItems="center"
+            alignItems="flex-start"
+            flexDirection="column"
             width="100%"
+            px={1.5}
           >
             <Box
-              flexGrow={1}
               display="flex"
+              justifyContent="space-between"
               alignItems="center"
-              color="text.primary"
+              width="100%"
             >
-              <Typography
-                variant="body2"
-                color="textPrimary"
-                id={`questionText-${id}`}
+              <Box
+                flexGrow={1}
+                display="flex"
+                alignItems="center"
+                color="text.primary"
               >
-                {question.data.text}{" "}
-                <strong className={classes.responseText}>{response}</strong>
-              </Typography>
-            </Box>
-            <Box>
-              {showChangeButton && (
-                <ButtonBase
-                  className={classes.changeButton}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    record(id);
-                  }}
+                <Typography
+                  variant="body2"
+                  color="textPrimary"
+                  id={`questionText-${id}`}
                 >
-                  Change
-                  <span style={visuallyHidden}>
-                    {question.data.text || "this answer"}
-                  </span>
-                </ButtonBase>
+                  {question.data.text}{" "}
+                  <strong className={classes.responseText}>{response}</strong>
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+        </AccordionSummary>
+        {hasMoreInfo && (
+          <AccordionDetails>
+            <Box className={classes.moreInfo}>
+              {question.data.info && (
+                <ReactMarkdownOrHtml
+                  source={question.data.info}
+                  openLinksOnNewTab
+                />
+              )}
+              {question.data.policyRef && (
+                <ReactMarkdownOrHtml
+                  source={question.data.policyRef}
+                  openLinksOnNewTab
+                />
               )}
             </Box>
-          </Box>
-        </Box>
-      </AccordionSummary>
-      {hasMoreInfo && (
-        <AccordionDetails>
-          <Box className={classes.moreInfo}>
-            {question.data.info && (
-              <ReactMarkdownOrHtml
-                source={question.data.info}
-                openLinksOnNewTab
-              />
-            )}
-            {question.data.policyRef && (
-              <ReactMarkdownOrHtml
-                source={question.data.policyRef}
-                openLinksOnNewTab
-              />
-            )}
-          </Box>
-        </AccordionDetails>
-      )}
-    </Accordion>
+          </AccordionDetails>
+        )}
+      </Accordion>
+      <Box>
+        {showChangeButton && (
+          <ButtonBase
+            className={classes.changeButton}
+            onClick={(event) => {
+              event.stopPropagation();
+              record(id);
+            }}
+          >
+            Change
+            <span style={visuallyHidden}>
+              your response to {question.data.text || "this question"}
+            </span>
+          </ButtonBase>
+        )}
+      </Box>
+    </Box>
   );
 };
+
 export default ResultReason;

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SimpleExpand.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SimpleExpand.tsx
@@ -1,16 +1,21 @@
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Collapse from "@material-ui/core/Collapse";
+import { makeStyles, Theme } from "@material-ui/core/styles";
 import React from "react";
+
+const useClasses = makeStyles((theme: Theme) => ({
+  root: {
+    paddingBottom: theme.spacing(0.5),
+  },
+}));
 
 const SimpleExpand = ({ children, buttonText }: any) => {
   const [show, setShow] = React.useState(false);
+  const classes = useClasses();
   return (
     <>
-      <Collapse in={show}>
-        <div>{children}</div>
-      </Collapse>
-      <Box color="background.dark">
+      <Box className={classes.root}>
         <Button
           size="large"
           fullWidth
@@ -20,6 +25,7 @@ const SimpleExpand = ({ children, buttonText }: any) => {
           {show ? buttonText.closed : buttonText.open}
         </Button>
       </Box>
+      <Collapse in={show}>{children}</Collapse>
     </>
   );
 };


### PR DESCRIPTION
Addresses this ticket - https://trello.com/c/idIXgqgL/1774-focus-order-nested-elements

This PR does the following - 
 - Removes the "Change" button button from the `AccordianSummary` element (as this is an interactive element with `role="button"`)
 - Changes the order of the `SimpleExpand` to maintain focus order
 - Slight changes to labels to make things a little more explicit. The report notes that the labels are the not unique, though this is not actually the case.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/20502206/155368877-68ad660a-1cee-4a1a-8a54-02fcfb816879.png)|![image](https://user-images.githubusercontent.com/20502206/155368973-d029edce-e2b5-4536-a347-741eba7eca1b.png)| 