### PR TITLE
fix: account for possibly undefined data when displaying address errors in FindProperty

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -425,7 +425,7 @@ function GetAddress(props: {
         {(data?.error || totalAddresses === 0) && Boolean(sanitizedPostcode) && (
           <Box pt={2} role="status">
             <Typography variant="body1" color="error">
-              {data.error?.message || "No addresses found in this postcode."}
+              {data?.error?.message || "No addresses found in this postcode."}
             </Typography>
           </Box>
         )}


### PR DESCRIPTION
Should fix this TypeError: https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3220066893591319446 (staging) & https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3220600187298880087 (prod)

Postcodes to test:
- HP11 1BC: request fails with statuscode 400, so show OS-generated error mesage 
- HP11 1BR: request succeeds with `data.header.totalresults === 0`, so show message "No addresses in this postcode"
- HP11 1BB: request succeeds and loads addresses
