### PR TITLE
fix: set `role="status"` on autocomplete because it is dynamically rendered

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -398,13 +398,8 @@ function GetAddress(props: {
                 <TextField
                   {...params}
                   variant="outlined"
+                  aria-label="Select an address in this postcode by typing or using your arrow keys"
                   id="address-textfield"
-                  helperText={
-                    <span style={visuallyHidden}>
-                      Start typing or use your arrow keys to select an address
-                      in this postcode
-                    </span>
-                  }
                 />
               </InputLabel>
             )}


### PR DESCRIPTION
we got an email from the DAC folks with updated test notes: 
![Screenshot from 2022-03-03 10-51-27](https://user-images.githubusercontent.com/5132349/156540372-c3f66ef2-fbe9-46ba-b321-3ecd5fee77a6.png)

i'm quite sure this confirms that the underlying issue is how our autocomplete component is conditionally rendered without the proper markup to announce it's now available on the page - which i'm fairly confident we can solve without moving away from material ui altogether.

changes: 
- autocomplete get's `role="status"` (announce on render), `aria-atomic={true}` (present in context of whole region) & `aria-live="polite"` (announce changes only if user is idle) which is consistent with [alphagov source code here](https://github.com/alphagov/accessible-autocomplete/blob/main/src/status.js#L103-L105) & [this usds form systems thread](https://github.com/usds/us-forms-system/issues/279)
  - our first report suggested removing the autofocus prop, which means the label will be repeated when you actually focus the component. this doesn't sound totally ideal, but i also don't think it should be a fail-able offense on it's own
- textfield sets `id` so that it's `label` can be properly associated using `htmlFor`
- textfield uses `aria-label` for visually hidden, instructional text on focus - this hopefully helps clear up some of the confusion around how to use an autocomplete expressed in qualitative comments in the report !
- `handleHomeEndKeys` is a minor addition that let's you navigate directly to the beginning or end of the list of options

things to watch for in review:
- "select an address" label is read out, followed by instructional aria-label text
- number of items in list is read out when it's expanded 
  - my ubuntu screenreader & a chrome screen reader extension don't read the total number upfront when the dropdown opens, but do read each item as "4, WOODLAND RD, LONDON 1 of 87" etc - so I think that's OK? would be curious if a mac user can confirm how VoiceOver handles this
  - if this doesn't seem sufficient, i think we could also try `ListBox` with explicit `role` [like this](https://mui.com/components/autocomplete/#listboxcomponent)

plan b:
- we could still move to the GDS `accessible-autocomplete` component which is at feature-parity [over here](https://github.com/usds/us-forms-system/issues/279), but just blocked by a few vite build quirks i'm still figuring out
- a helpful exercise is to locally run the branch linked above & test screenreader on `address-autocomplete` as baseline comparison for how we want our material ui component to behave/be read out - i think we're pretty close! 

if going with plan b:
- possible challenges/cons: overriding govuk styles to blend with material ui themes when integrated with planx
- pros: 
  - no more Ordnance Survey logic or dependencies in planx - all address & map data fetching would be handled in web components repo, planx would simply pass OS api keys
  - maybe useful/reusable by BOPs if they're building applicant-facing microservices for resubmissions (we'd both have the same FindProperty search interfaces)