### PR TITLE
fix: Questions shouldn't render ExternalPlanningDialog any longer

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -9,12 +9,9 @@ import { DESCRIPTION_TEXT } from "@planx/components/shared/constants";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { useFormik } from "formik";
-import { Store, useStore } from "pages/FlowEditor/lib/store";
+import { Store } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
 import React from "react";
-import ExternalPlanningSiteDialog, {
-  DialogPurpose,
-} from "ui/ExternalPlanningSiteDialog";
 
 export interface IQuestion {
   text?: string;
@@ -57,9 +54,6 @@ const useClasses = makeStyles(() => ({
 const Question: React.FC<IQuestion> = (props) => {
   const theme = useTheme();
   const classes = useClasses();
-  const currentCard = useStore((state) => state.currentCard());
-  const isProjectTypeQuestion =
-    currentCard?.data?.fn === "proposal.projectType";
 
   const previousResponseId = props?.previouslySubmittedData?.answers?.[0];
   const previousResponseKey = props.responses.find(
@@ -154,11 +148,6 @@ const Question: React.FC<IQuestion> = (props) => {
           </Grid>
         </fieldset>
       </form>
-      {isProjectTypeQuestion && (
-        <ExternalPlanningSiteDialog
-          purpose={DialogPurpose.MissingProjectType}
-        ></ExternalPlanningSiteDialog>
-      )}
     </Card>
   );
 };


### PR DESCRIPTION
Continuation of #858, partially reverts #842

Specifically, removing the `currentCard` variable check on Questions that may help with continued reports of lagginess. 

Didn't remove the associated content for `MissingProjectType` purpose in the `ExternalPlanningDialog` component file, but that shouldn't cause any issues and may be useful to reference later.