### PR TITLE
fix: Date Input style tweak

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -23,6 +23,7 @@ export type Props = PublicProps<DateInput, UserData>;
 const useClasses = makeStyles(() => ({
   fieldset: {
     border: 0,
+    padding: 0,
   },
 }));
 

--- a/editor.planx.uk/src/ui/DateInput.tsx
+++ b/editor.planx.uk/src/ui/DateInput.tsx
@@ -25,10 +25,13 @@ const useClasses = makeStyles((theme) => ({
       marginLeft: theme.spacing(2),
     },
   },
-  label: {
+  editorLabel: {
     minWidth: 60,
     alignSelf: "end",
     marginBottom: theme.spacing(1.5),
+  },
+  label: {
+    paddingBottom: theme.spacing(0.5),
   },
 }));
 
@@ -41,12 +44,12 @@ export default function DateInput(props: Props): FCReturn {
       <div className={classes.root}>
         <div className={classes.editor}>
           {props.label && (
-            <Typography className={classes.label} variant="body1">
+            <Typography className={classes.editorLabel} variant="body1">
               {props.label}:
             </Typography>
           )}
           <Box>
-            <Typography variant="body1">
+            <Typography variant="body1" className={classes.label}>
               <label htmlFor="day">Day</label>
             </Typography>
             <Input
@@ -71,7 +74,7 @@ export default function DateInput(props: Props): FCReturn {
             />
           </Box>
           <Box>
-            <Typography variant="body1">
+            <Typography variant="body1" className={classes.label}>
               <label htmlFor="month">Month</label>
             </Typography>
             <Input
@@ -96,7 +99,7 @@ export default function DateInput(props: Props): FCReturn {
             />
           </Box>
           <Box>
-            <Typography variant="body1">
+            <Typography variant="body1" className={classes.label}>
               <label htmlFor="year">Year</label>
             </Typography>
             <Input


### PR DESCRIPTION
Something that's been bugging me for a while...!

 - Align date input correctly with continue button
 - Add a little more padding underneath day/month/year labels (focus was almost touching)
 
 |Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/20502206/156770476-c61ccf5d-7d97-45fc-9688-13827631c0d4.png)|![image](https://user-images.githubusercontent.com/20502206/156770626-2c45eb3f-cbfe-4518-acbd-f700ad3f8832.png)|