### PR TITLE
fix: disable firefox feedback warning as postMessage not working

### DIFF
--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -51,6 +51,7 @@ export default function Footer(props: Props) {
     useState(false);
 
   useEffect(() => {
+    let feedbackFishPostMessageWorkingCorrectly: boolean;
     const handleMessage = (event: MessageEvent) => {
       try {
         // the feedback fish widget posts a message that's either
@@ -58,7 +59,16 @@ export default function Footer(props: Props) {
         // or {"width":320,"height":200} if the iframe is visible
         if (event.origin.endsWith("feedback.fish")) {
           const { width, height } = JSON.parse(event.data);
-          setFeedbackPrivacyNoteVisible(width > 0 && height > 0);
+          // XXX: postMessage not working in firefox as expected
+          //      https://trello.com/c/MX1cpAM8 this disables it in FF
+          //      by checking if the initial {"width":0,"height":0} message
+          //      was received. If not then never show feedback warning msg
+          if (width === 0 && height === 0) {
+            feedbackFishPostMessageWorkingCorrectly = true;
+          }
+          setFeedbackPrivacyNoteVisible(
+            width > 0 && height > 0 && feedbackFishPostMessageWorkingCorrectly
+          );
         }
       } catch (err) {}
     };
@@ -66,7 +76,7 @@ export default function Footer(props: Props) {
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  });
+  }, []);
 
   const feedbackFishId = process.env.REACT_APP_FEEDBACK_FISH_ID;
 


### PR DESCRIPTION
disables feedback personal message in firefox for now, because postmessage does not behave as expected

https://ripahq.slack.com/archives/C0241GWFG4B/p1646416010261389

https://trello.com/c/MX1cpAM8