### PR TITLE
fix: update bux article 4 variables to reflect content updates

### DIFF
--- a/api.planx.uk/gis/local_authorities/metadata/buckinghamshire.js
+++ b/api.planx.uk/gis/local_authorities/metadata/buckinghamshire.js
@@ -70,7 +70,7 @@ const planningConstraints = {
       "article4.buckinghamshire.coppicesouthheathcaravan": "Land at The Coppice, South Heath - Caravan Sites",
       "article4.buckinghamshire.cryershillroad": "Valley Road/Cryers Hill Road, Hughenden - Caravan Sites",
       "article4.buckinghamshire.deanfield": "Part Fields SW of Deanfield, Saunderton (b) - Caravan sites",
-      "article4.buckinghamshire.DO10fulmer": "DO.10 Fulmer - Agricultural", // no clear gis match
+      "article4.buckinghamshire.DO10fulmer": "Fulmer - Agricultural",
       "article4.buckinghamshire.dorneywoodroad": "Dorney Wood Road, Burnham - Agricultural",
       "article4.buckinghamshire.eastamershamroadOS0006": "Land East of Amersham Road including OS parcel 0006. Agricultural Buildings.",
       "article4.buckinghamshire.eastamershamroadOS9269": "Land East of Amersham Road including OS Parcel 9269 Agricultural buildings.",


### PR DESCRIPTION
emily's been refactoring content for buckinghamshire article4s, which led to updates in the airtable (adding/renaming variables, etc) - this PR brings our API variables back into sync

https://airtable.com/appEOFA94X5saiZBl/tblEbeOisfgg20VM5/viwxsIjVhcbSvPtkD?blocks=hide

https://871.planx.pizza/buckinghamshire/a4-test

sample address: 
- Fulmer House Farm, Slough SL3 6JB should now set `article4.buckinghamshire.DO10fulmer` 