### PR TITLE
fix: Ensure caret displays when inverted

### DIFF
--- a/editor.planx.uk/src/ui/icons/Caret.tsx
+++ b/editor.planx.uk/src/ui/icons/Caret.tsx
@@ -27,7 +27,7 @@ export default function Caret({
       })}
       viewBox="0 0 14 8"
     >
-      <path d="M1 1L7 7L13 1" stroke="black" fill="none" />
+      <path d="M1 1L7 7L13 1" stroke="currentColor" fill="none" />
     </SvgIcon>
   );
 }


### PR DESCRIPTION
Quick proof of concept to see if this works...

Page 33 of the accessibility audit (under "Usability Feedback") showed that the carets ("V" icons) in the expandable checklist do not display using "System inverted colours" on Windows.

https://drive.google.com/file/d/1tAn2cmZwGimJWAksOTfJJozgUlUkCWK3/view

![image](https://user-images.githubusercontent.com/20502206/157070405-5f93d3ab-7f57-4aa0-a735-353558cf58bc.png)

The document suggests that the screenshot (above) was generated using the "System inverted colours" on Windows, using Edge as a browser.

I'm not able to recreate this on Mac, setting up a pizza so that somebody with a Windows device can test this.