### PR TITLE
fix: address gis error message type error

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -210,7 +210,9 @@ function ConstraintsList({ data, refreshConstraints }: any) {
           <Typography variant="h5" component="h2" gutterBottom>
             Failed to fetch data
           </Typography>
-          {error && error.endsWith("local authority") ? (
+          {error &&
+          typeof error === "string" &&
+          error.endsWith("local authority") ? (
             <Typography variant="body2">{capitalize(error)}</Typography>
           ) : (
             <>


### PR DESCRIPTION
immediately fixes this type error reported by Freya in #mvp-issues: https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3225678979826552950 

still need to diagnose what changed with southwark GIS to cause `error: {}` (will do in separate PR)

to test:
- Southwark constraints should show "Failed to fetch... try again" message (but try again will never load)
- Opensystemlab team constraints should show "... is not a supported local authority error"
- Buckinghamshire/Lambeth/Canterbury/Braintree should successfully fetch constraints