### PR TITLE
fix: try/catch in api gis endpoint

### DIFF
--- a/api.planx.uk/gis/helpers.js
+++ b/api.planx.uk/gis/helpers.js
@@ -173,20 +173,26 @@ const squashResultLayers = (originalOb, layers, layerName) => {
 // Rollup multiple layers into a single result, whilst preserving granularity
 const rollupResultLayers = (originalOb, layers, layerName) => {
   const ob = {...originalOb}
-  const granularLayers = layers.filter(layer => layer != layerName);
 
-  if (ob[layerName]?.value) {
-    // If the parent layer is in the original object & intersects, preserve all properties for rendering PlanningConstraints and debugging
-    ob[layerName] = ob[layerName];
-  } else {
-    // Check to see if any granular layers intersect
-    const match = granularLayers.find(layer => ob[layer].value);
-    // If there is a granular match, set it as the parent result. Otherwise take the first (negative) value
-    ob[layerName] = match ? ob[match] : ob[layers[0]];
+  try {
+    const granularLayers = layers.filter(layer => layer !== layerName);
+
+    if (ob[layerName]?.value) {
+      // If the parent layer is in the original object & intersects, preserve all properties for rendering PlanningConstraints and debugging
+      ob[layerName] = ob[layerName];
+    } else {
+      // Check to see if any granular layers intersect
+      const match = granularLayers.find(layer => ob[layer].value);
+      // If there is a granular match, set it as the parent result. Otherwise take the first (negative) value
+      ob[layerName] = match ? ob[match] : ob[layers[0]];
+    }
+
+    // Return a simple view of the granular layers to avoid duplicate PlanningConstraint entries
+    granularLayers.forEach(layer => ob[layer] = { value: ob[layer].value });
+
+  } catch(err) {
+    console.error({ err })
   }
-
-  // Return a simple view of the granular layers to avoid duplicate PlanningConstraint entries
-  granularLayers.forEach(layer => ob[layer] = { value: ob[layer].value });
 
   return ob;
 }


### PR DESCRIPTION
## southwark's planning constraints are currently broken in production

fixes

```
TypeError: Cannot read properties of undefined (reading 'value')
      at /Users/john/Code/theopensystemslab/planx-new/api.planx.uk/gis/helpers.js:185:60
```

example broken endpoint

http://localhost:8001/gis/southwark?x=533676&y=178075&siteBoundary=[[[-0.07632628083229737,51.48582760417486],[-0.07633835077286438,51.48577081619891],[-0.07560744881630672,51.485710687676686],[-0.0756007432937695,51.48576747572753],[-0.07632628083229737,51.48582760417486]]]&version=1

<img width="425" alt="Screenshot 2022-03-12 at 00 14 58" src="https://user-images.githubusercontent.com/601961/158004870-6885764b-a888-4841-a981-b6468248cc9d.png">

