### PR TITLE
chore: Refactor header into Editor and Public components

### DIFF
--- a/editor.planx.uk/src/components/AuthenticatedLayout.tsx
+++ b/editor.planx.uk/src/components/AuthenticatedLayout.tsx
@@ -3,11 +3,11 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { View } from "react-navi";
 
-import Header from "./Header";
+import Header, { HeaderVariant } from "./Header";
 
 const Layout: React.FC = () => (
   <>
-    <Header />
+    <Header variant={HeaderVariant.Editor} />
     <DndProvider backend={HTML5Backend}>
       <View />
     </DndProvider>

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -1,15 +1,10 @@
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import axe from "axe-helper";
 import React from "react";
 import * as ReactNavi from "react-navi";
 import { Team } from "types";
 
-import Header from "./Header";
+import Header, { HeaderVariant } from "./Header";
 
 const mockTeam1: Team = {
   name: "Open Systems Lab",
@@ -49,21 +44,21 @@ jest.spyOn(ReactNavi, "useNavigation").mockImplementation(
 
 describe("Header Component - Editor Route", () => {
   it("displays breadcrumbs", () => {
-    render(<Header isPublicRoute={false} team={mockTeam1}></Header>);
+    render(<Header variant={HeaderVariant.Editor} team={mockTeam1}></Header>);
     expect(screen.getByText("Plan✕")).toBeInTheDocument();
     expect(screen.getByText(mockTeam1.slug)).toBeInTheDocument();
     expect(screen.getByText("test-flow")).toBeInTheDocument();
   });
 
   it("displays avatar and settings", () => {
-    render(<Header isPublicRoute={false} team={mockTeam1}></Header>);
+    render(<Header variant={HeaderVariant.Editor} team={mockTeam1}></Header>);
     expect(screen.getByText("T")).toBeInTheDocument();
     expect(screen.getByLabelText("Toggle Menu")).toBeInTheDocument();
   });
 
   it("should not have any accessibility violations", async () => {
     const { container } = render(
-      <Header isPublicRoute={false} team={mockTeam1}></Header>
+      <Header variant={HeaderVariant.Editor} team={mockTeam1}></Header>
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -72,7 +67,7 @@ describe("Header Component - Editor Route", () => {
 
 describe("Header Component - Public Routes", () => {
   it("displays a logo when available", () => {
-    render(<Header isPublicRoute={true} team={mockTeam1}></Header>);
+    render(<Header variant={HeaderVariant.Preview} team={mockTeam1}></Header>);
     expect(screen.queryByText("Plan✕")).not.toBeInTheDocument();
     expect(screen.getByAltText(`${mockTeam1.name} Logo`)).toHaveAttribute(
       "src",
@@ -81,7 +76,7 @@ describe("Header Component - Public Routes", () => {
   });
 
   it("falls back to the PlanX link when a logo is not present", () => {
-    render(<Header isPublicRoute={true} team={mockTeam2}></Header>);
+    render(<Header variant={HeaderVariant.Preview} team={mockTeam2}></Header>);
     expect(
       screen.queryByAltText(`${mockTeam2.name} Logo`)
     ).not.toBeInTheDocument();
@@ -90,7 +85,7 @@ describe("Header Component - Public Routes", () => {
 
   it("should not have any accessibility violations", async () => {
     const { container } = render(
-      <Header isPublicRoute={true} team={mockTeam1}></Header>
+      <Header variant={HeaderVariant.Preview} team={mockTeam1}></Header>
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -92,6 +92,15 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+/**
+ * Describes the differing headers, based on the primary routes through which a flow can be interacted with
+ */
+export enum HeaderVariant {
+  Preview,
+  Unpublished,
+  Editor,
+}
+
 const TeamLogo: React.FC<{ team?: Team }> = ({ team }) => {
   const classes = useStyles();
   const altText = team?.settings?.homepage
@@ -156,7 +165,7 @@ const Breadcrumbs: React.FC<{
   );
 };
 
-const PreviewToolbar: React.FC<{
+const PublicToolbar: React.FC<{
   team?: Team;
   handleRestart?: () => void;
   route: Route;
@@ -292,8 +301,8 @@ const Header: React.FC<{
   bgcolor?: string;
   team?: Team;
   handleRestart?: () => void;
-  isPublicRoute?: boolean;
-}> = ({ bgcolor = "#2c2c2c", team, handleRestart, isPublicRoute = false }) => {
+  variant: HeaderVariant;
+}> = ({ bgcolor = "#2c2c2c", team, handleRestart, variant }) => {
   const classes = useStyles();
   const headerRef = useRef<HTMLElement>(null);
   const route = useCurrentRoute();
@@ -309,14 +318,14 @@ const Header: React.FC<{
         backgroundColor: team?.theme?.primary || bgcolor,
       }}
     >
-      {isPublicRoute ? (
-        <PreviewToolbar
+      {variant === HeaderVariant.Editor ? (
+        <EditorToolbar headerRef={headerRef} route={route}></EditorToolbar>
+      ) : (
+        <PublicToolbar
           team={team}
           handleRestart={handleRestart}
           route={route}
-        ></PreviewToolbar>
-      ) : (
-        <EditorToolbar headerRef={headerRef} route={route}></EditorToolbar>
+        ></PublicToolbar>
       )}
     </AppBar>
   );

--- a/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
+++ b/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
@@ -18,7 +18,7 @@ import { getGlobalThemeOptions, getTeamThemeOptions } from "theme";
 import Logo from "ui/images/OGLLogo.svg";
 
 import Footer from "../../components/Footer";
-import Header from "../../components/Header";
+import Header, { HeaderVariant } from "../../components/Header";
 import { FlowSettings, FOOTER_ITEMS, Team, TextContent } from "../../types";
 
 const useClasses = makeStyles((theme) => ({
@@ -39,7 +39,8 @@ const PreviewLayout: React.FC<{
   children?: any;
   settings?: FlowSettings;
   footerContent?: { [key: string]: TextContent };
-}> = ({ team, children, settings, footerContent }) => {
+  headerVariant: HeaderVariant;
+}> = ({ team, children, settings, footerContent, headerVariant }) => {
   const { data } = useCurrentRoute();
 
   const classes = useClasses();
@@ -96,7 +97,11 @@ const PreviewLayout: React.FC<{
 
   return (
     <ThemeProvider theme={generatePreviewTheme}>
-      <Header team={team} isPublicRoute={true} handleRestart={handleRestart} />
+      <Header
+        team={team}
+        variant={headerVariant}
+        handleRestart={handleRestart}
+      />
       <Box id="main-content" className={classes.mainContainer}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           {children}

--- a/editor.planx.uk/src/routes/preview.tsx
+++ b/editor.planx.uk/src/routes/preview.tsx
@@ -1,4 +1,5 @@
 import camelcaseKeys from "camelcase-keys";
+import { HeaderVariant } from "components/Header";
 import gql from "graphql-tag";
 import { dataMerged } from "lib/dataMergedHotfix";
 import { client } from "lib/graphql";
@@ -18,7 +19,7 @@ import Layout from "pages/Preview/PreviewLayout";
 import Questions from "pages/Preview/Questions";
 import React from "react";
 import { View } from "react-navi";
-import type { Flow, GlobalSettings, Maybe } from "types";
+import { Flow, GlobalSettings, Maybe } from "types";
 
 const routes = compose(
   withData((req) => ({
@@ -84,6 +85,7 @@ const routes = compose(
           team={flow.team}
           settings={flow.settings}
           footerContent={globalSettings?.footerContent}
+          headerVariant={HeaderVariant.Preview}
         >
           <View />
         </Layout>

--- a/editor.planx.uk/src/routes/unpublished.tsx
+++ b/editor.planx.uk/src/routes/unpublished.tsx
@@ -1,4 +1,5 @@
 import camelcaseKeys from "camelcase-keys";
+import { HeaderVariant } from "components/Header";
 import gql from "graphql-tag";
 import { dataMerged } from "lib/dataMergedHotfix";
 import { client } from "lib/graphql";
@@ -71,6 +72,7 @@ const routes = compose(
           team={flow.team}
           settings={flow.settings}
           footerContent={globalSettings?.footerContent}
+          headerVariant={HeaderVariant.Unpublished}
         >
           <View />
         </Layout>


### PR DESCRIPTION
There should be no visual or behavioural changes here, just a refactor to separate out some of the logic in the shared `Header` component. There's a fair amount going on there at the moment, and there's more to be added as part of save & return.

Took the opportunity to split up Editor only, and `/preview` & `/unpublished` functionality by creating an `EditorToolbar` and `PreviewToolbar`, and added a few very simple tests.