### PR TITLE
break: disable analytics with route param

### DIFF
--- a/e2e/tests/first.js
+++ b/e2e/tests/first.js
@@ -152,7 +152,7 @@ test
 
   await t.click(Selector("button").withText("Back"));
 
-  await t.click(Selector("p").withText("No"));
+  await t.click(Selector("button>div>p").withText("No"));
   await t.click(Selector("button").withText("Continue"));
   await t.expect(Selector("h3").withText(noNoticeResult).exists).ok();
 });

--- a/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
@@ -153,19 +153,18 @@ it("should not have any accessibility violations", async () => {
   expect(results).toHaveNoViolations();
 });
 
-
 it("renders correctly with responses containing comments", async () => {
   const handleSubmit = jest.fn();
 
   render(
-    <Question 
-      handleSubmit={handleSubmit} 
-      responses={responsesWithComment} 
+    <Question
+      handleSubmit={handleSubmit}
+      responses={responsesWithComment}
       text="Question"
     />
   );
 
-  expect(screen.getAllByTestId('description-button')).toHaveLength(3);
+  expect(screen.getAllByTestId("description-button")).toHaveLength(3);
   expect(screen.getByText("Some description")).toBeInTheDocument();
 
   await act(async () => {
@@ -185,14 +184,14 @@ it("renders correctly with responses containing images", async () => {
   const handleSubmit = jest.fn();
 
   render(
-    <Question 
-      handleSubmit={handleSubmit} 
-      responses={responsesWithImages} 
+    <Question
+      handleSubmit={handleSubmit}
+      responses={responsesWithImages}
       text="Question"
     />
   );
 
-  expect(screen.getAllByTestId('image-button')).toHaveLength(3);
+  expect(screen.getAllByTestId("image-button")).toHaveLength(3);
   expect(screen.getByText("Some description")).toBeInTheDocument();
 
   await act(async () => {
@@ -210,49 +209,52 @@ it("renders correctly with responses containing images", async () => {
 
 const responsesWithComment = [
   {
-      "id": "option1",
-      "responseKey": 1,
-      "title": "Commented",
-      "text": "Commented",
-      "description": "Lorem Ipsum is simply dummy text of the printing and typesetting industry."
+    id: "option1",
+    responseKey: 1,
+    title: "Commented",
+    text: "Commented",
+    description:
+      "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
   },
   {
-      "id": "option2",
-      "responseKey": 2,
-      "title": "No comment",
-      "description": "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s",
-      "text": "No comment"
+    id: "option2",
+    responseKey: 2,
+    title: "No comment",
+    description:
+      "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s",
+    text: "No comment",
   },
   {
-      "id": "option3",
-      "responseKey": 3,
-      "title": "No Comment 2",
-      "text": "No Comment 2",
-      "description": "Some description",
-  }
+    id: "option3",
+    responseKey: 3,
+    title: "No Comment 2",
+    text: "No Comment 2",
+    description: "Some description",
+  },
 ];
 
 const responsesWithImages = [
   {
-      "id": "image1",
-      "responseKey": 1,
-      "title": "Image",
-      "img": "https://planx-temp.s3.eu-west-2.amazonaws.com/2qp7swtk/fut.email.png",
-      "text": "Image",
-      "description": "Description"
+    id: "image1",
+    responseKey: 1,
+    title: "Image",
+    img: "https://planx-temp.s3.eu-west-2.amazonaws.com/2qp7swtk/fut.email.png",
+    text: "Image",
+    description: "Description",
   },
   {
-      "id": "image2",
-      "responseKey": 2,
-      "title": "Without image",
-      "text": "Without image",
-      "description": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout."
+    id: "image2",
+    responseKey: 2,
+    title: "Without image",
+    text: "Without image",
+    description:
+      "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.",
   },
   {
-      "id": "image3",
-      "responseKey": 3,
-      "title": "Without image 2",
-      "text": "Without image 2",
-      "description": "Some description",
-  }
+    id: "image3",
+    responseKey: 3,
+    title: "Without image 2",
+    text: "Without image 2",
+    description: "Some description",
+  },
 ];

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -127,12 +127,22 @@ const Question: React.FC<IQuestion> = (props) => {
                   case QuestionLayout.Basic:
                     return (
                       <Grid item xs={12} key={response.id}>
-                        <DecisionButton {...buttonProps} {...response} data-testid="decision-button" />
+                        <DecisionButton
+                          {...buttonProps}
+                          {...response}
+                          data-testid="decision-button"
+                        />
                       </Grid>
                     );
                   case QuestionLayout.Descriptions:
                     return (
-                      <Grid item xs={6} sm={4} key={response.id} data-testid="description-button">
+                      <Grid
+                        item
+                        xs={6}
+                        sm={4}
+                        key={response.id}
+                        data-testid="description-button"
+                      >
                         <DescriptionButton {...buttonProps} {...response} />
                       </Grid>
                     );

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -54,8 +54,8 @@ const useStyles = makeStyles<Theme, Partial<TextLabelProps>>((theme) => {
       flexGrow: 1,
     },
     imageButton: {
-      alignItems: 'flex-start'
-    }
+      alignItems: "flex-start",
+    },
   };
 });
 
@@ -107,17 +107,29 @@ const TextLabel = (props: TextLabelProps): FCReturn => {
   } else {
     const descriptionId = description ? `${id}-description` : undefined;
     return (
-      <ButtonBase selected={props.selected} onClick={props.onClick} id={id} className={classes.imageButton}>
+      <ButtonBase
+        selected={props.selected}
+        onClick={props.onClick}
+        id={id}
+        className={classes.imageButton}
+      >
         <Box {...({ ref: textContentEl } as any)} px={2.25} py={1.75}>
-          <Typography variant="body1" className={classes.bold} aria-describedby={descriptionId}>
+          <Typography
+            variant="body1"
+            className={classes.bold}
+            aria-describedby={descriptionId}
+          >
             {title}
           </Typography>
-          {
-            Boolean(description) &&
-            <Typography variant="body2" className={classes.subtitle} id={descriptionId}>
+          {Boolean(description) && (
+            <Typography
+              variant="body2"
+              className={classes.subtitle}
+              id={descriptionId}
+            >
               {description}
             </Typography>
-          }
+          )}
         </Box>
       </ButtonBase>
     );
@@ -182,15 +194,19 @@ function ImageResponse(props: Props): FCReturn {
   const bgColor = selected
     ? theme?.palette?.primary?.main
     : theme?.palette?.secondary?.main;
-  
-  const altText = description ?
-    `${title} - ${description}`
-    : title;
-  
+
+  const altText = description ? `${title} - ${description}` : title;
+
   return (
     <label htmlFor={checkbox ? id : undefined} className={classes.label}>
-      <Box display="flex" flexDirection="column" width="100%" height="100%" data-testid="image-button">
-        <ImageLabel bgColor={bgColor} img={img} alt={altText}/>
+      <Box
+        display="flex"
+        flexDirection="column"
+        width="100%"
+        height="100%"
+        data-testid="image-button"
+      >
+        <ImageLabel bgColor={bgColor} img={img} alt={altText} />
         <TextLabel bgColor={bgColor} {...props}></TextLabel>
       </Box>
     </label>

--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -1,0 +1,52 @@
+import Box from "@material-ui/core/Box";
+import Button from "@material-ui/core/Button";
+import Link from "@material-ui/core/Link";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import React, { useState } from "react";
+import AnalyticsChart from "ui/icons/AnalyticsChart";
+
+const useStyles = makeStyles((theme) => ({
+  analyticsWarning: {
+    display: "flex",
+    backgroundColor: "#FFFB00",
+    padding: "0 24px",
+    color: "#070707",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+}));
+
+const AnalyticsDisabledBanner: React.FC = () => {
+  const classes = useStyles();
+  const [showAnalyticsWarning, setShowAnalyticsWarning] = useState(true);
+
+  const isAnalyticsDisabled = () =>
+    new URL(window.location.href).searchParams.get("analytics") === "false";
+
+  const enableAnalytics = () => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("analytics");
+    return url.toString();
+  };
+
+  return (
+    <>
+      {isAnalyticsDisabled() && showAnalyticsWarning && (
+        <Box className={classes.analyticsWarning}>
+          <Box display="flex" alignItems="center">
+            <AnalyticsChart />
+            <Typography variant="body2">
+              <b>Analytics off</b> This is a preview link for testing. No usage
+              data is being recorded.{"  "}
+              <Link href={enableAnalytics()}>Go to normal link</Link>
+            </Typography>
+          </Box>
+          <Button onClick={() => setShowAnalyticsWarning(false)}>Hide</Button>
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default AnalyticsDisabledBanner;

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -19,6 +19,7 @@ import Reset from "ui/icons/Reset";
 
 import { useStore } from "../pages/FlowEditor/lib/store";
 import { rootFlowPath } from "../routes/utils";
+import AnalyticsDisabledBanner from "./AnalyticsDisabledBanner";
 import PhaseBanner from "./PhaseBanner";
 
 export const HEADER_HEIGHT = 75;
@@ -89,6 +90,14 @@ const useStyles = makeStyles((theme) => ({
       position: "relative",
       ...focusStyle(theme.palette.action.focus),
     },
+  },
+  analyticsWarning: {
+    display: "flex",
+    backgroundColor: "#FFFB00",
+    padding: "0 24px",
+    color: "#070707",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
 }));
 
@@ -191,6 +200,7 @@ const PublicToolbar: React.FC<{
           <Reset color="secondary" />
         </IconButton>
       </Toolbar>
+      <AnalyticsDisabledBanner />
       <PhaseBanner />
     </>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -171,7 +171,7 @@ const PreviewBrowser: React.FC<{
 
           <Tooltip arrow title="Open published service">
             <a
-              href={props.url}
+              href={props.url + "?analytics=false"}
               target="_blank"
               rel="noopener noreferrer"
               className={classes.refreshButton}

--- a/editor.planx.uk/src/ui/icons/AnalyticsChart.tsx
+++ b/editor.planx.uk/src/ui/icons/AnalyticsChart.tsx
@@ -1,0 +1,19 @@
+import SvgIcon, { SvgIconProps } from "@material-ui/core/SvgIcon";
+import React from "react";
+
+export default function AnalyticsChart(props: SvgIconProps) {
+  return (
+    <SvgIcon
+      {...props}
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect x="9" y="17" width="5" height="14" fill="black" />
+      <rect x="17" y="9" width="5" height="20" fill="black" />
+      <rect x="25" y="13" width="5" height="12" fill="black" />
+    </SvgIcon>
+  );
+}


### PR DESCRIPTION
Prevents analytrics from tracking our test users.

- Updates the link to the preview and live services and adds a query argument to disable analytics
- Also adds a top bar to indicate that analytics is disabled


Links:
- Trello: https://trello.com/c/4ThUL1QR/1724-prevent-analytics-clutter-by-not-tracking-partner-sessions
- Mock: https://planx.webflow.io/no-analytics
