### PR TITLE
fix: set new granular Article 4 variables for Southwark

### DIFF
--- a/api.planx.uk/gis/local_authorities/metadata/southwark.js
+++ b/api.planx.uk/gis/local_authorities/metadata/southwark.js
@@ -15,7 +15,7 @@ const planningConstraints = {
     tables: [
       "Article 4 - Class ZA - Demolition of commercial",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -28,7 +28,7 @@ const planningConstraints = {
     tables: [
       "Article 4 - Sunray Estate"
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -41,7 +41,7 @@ const planningConstraints = {
     tables: [
       "Article 4 - offices in the Central Activities Zone",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -54,7 +54,7 @@ const planningConstraints = {
     tables: [
       "Article 4 - Public Houses",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -68,7 +68,7 @@ const planningConstraints = {
       "Article 4 - HMO Henshaw Street",
       "Article 4 - HMO Bywater Place",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -79,9 +79,9 @@ const planningConstraints = {
     key: "article4.southwark.MA",
     source: "Southwark Maps",
     tables: [
-      "Article 4 - CLass MA - Change of use from Class E to residential",
+      "Article 4 - Class MA - Change of use from Class E to residential",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -94,7 +94,7 @@ const planningConstraints = {
     tables: [
       "Article 4 - Demolition of the Stables and the Forge on Catlin Street",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",
@@ -107,7 +107,7 @@ const planningConstraints = {
     tables: [
       "Article 4 - Railway Arches",
     ],
-    columns: ["Article_4_Direction", "More_information"],
+    columns: ["Name", "Article_4_Direction", "More_information"],
     neg: "is not subject to any Article 4 restrictions",
     pos: (data) => ({
       text: "is subject to Article 4 restriction(s)",

--- a/api.planx.uk/gis/local_authorities/southwark.js
+++ b/api.planx.uk/gis/local_authorities/southwark.js
@@ -105,7 +105,7 @@ async function locationSearch(x, y, siteBoundary, extras) {
         const k = `${key}`;
 
         try {
-          if (data.features.length > 0) {
+          if (data?.features?.length > 0) {
             const { properties } = data.features[0];
             acc[k] = {
               ...planningConstraints[key].pos(properties),


### PR DESCRIPTION
now reflects newly added Article 4 tables & their associated schema variables, as mapped here: https://docs.google.com/spreadsheets/d/1qPbDgcfs7Mutfa-2gkbyLGJZ_z4MK01Iu5ZGHDqa1Jc/edit#gid=0

example location that should pickup `article4.southwark.caz` restrictions:
- before: https://api.editor.planx.uk/gis/southwark?x=532113&y=179701&siteBoundary=[]&version=1
- after: https://api.888.planx.pizza/gis/southwark?x=532113&y=179701&siteBoundary=[]&version=1