### PR TITLE
fix: Update autocomplete, improve styling

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/utils": "^5.0.0-beta.5",
-    "@opensystemslab/map": "^0.5.0",
+    "@opensystemslab/map": "^0.5.1",
     "array-move": "^3.0.1",
     "axios": "^0.19.2",
     "camelcase-keys": "^7.0.0",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   '@material-ui/icons': ^4.9.1
   '@material-ui/lab': ^4.0.0-alpha.56
   '@material-ui/utils': ^5.0.0-beta.5
-  '@opensystemslab/map': ^0.5.0
+  '@opensystemslab/map': ^0.5.1
   '@react-theming/storybook-addon': ^1.1.3
   '@storybook/addon-actions': ^6.4.10
   '@storybook/addon-essentials': ^6.4.10
@@ -128,7 +128,7 @@ dependencies:
   '@material-ui/icons': 4.9.1_aca2900b4bcc0ae456c0c6b700ff3f91
   '@material-ui/lab': 4.0.0-alpha.56_aca2900b4bcc0ae456c0c6b700ff3f91
   '@material-ui/utils': 5.0.0-beta.5_react@17.0.2
-  '@opensystemslab/map': 0.5.0
+  '@opensystemslab/map': 0.5.1
   array-move: 3.0.1
   axios: 0.19.2
   camelcase-keys: 7.0.0
@@ -2541,8 +2541,8 @@ packages:
       mkdirp: 1.0.4
     dev: true
 
-  /@opensystemslab/map/0.5.0:
-    resolution: {integrity: sha512-gvQ6MIhRJR5B+PWjd9PBazl5N9VSVSMVCSUihgDTji/f9NPUk1n0hxSZlOvOZXZt/cZp+UNIPEqW/2RtaoXSjw==}
+  /@opensystemslab/map/0.5.1:
+    resolution: {integrity: sha512-TBd4iGNSwVGs8fIeUjf/Ycr8RJRsOarMijBlrUnS/eS9UfVy4Xb2ekvDu3+pt5F9rEEv6m+5QjA8HQ46N4XHow==}
     dependencies:
       '@turf/union': 6.5.0
       accessible-autocomplete: 2.0.4

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -232,7 +232,7 @@ function GetAddress(props: {
   // Autocomplete overrides
   const useStyles = makeStyles((theme) => ({
     autocomplete: {
-      "--autocomplete__input__padding": "6px 12px 7px 12px",
+      "--autocomplete__input__padding": "6px 40px 7px 12px",
       "--autocomplete__input__font-size": "15px",
       "--autocomplete__input__height": "50px",
       "--autocomplete__dropdown-arrow-down__top": "16px",
@@ -323,6 +323,7 @@ function GetAddress(props: {
             postcode={sanitizedPostcode}
             initialAddress={selectedOption?.title || ""}
             osPlacesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
+            arrowStyle="light"
           />
         )}
       </Box>


### PR DESCRIPTION
Bump map up to v0.5.1 and make the following changes - 

 - Down arrow is clickable (and visible)
 - Down arrow uses new "light" option
 - Increase padding on right to handle long addresses interfering with down arrow
 - Improved styling for when focus and hover interact

<img width="504" alt="image" src="https://user-images.githubusercontent.com/20502206/160082355-f4304883-6ae6-446b-bf0c-251074245c2c.png">
