### PR TITLE
fix: role=status should not be conditional

### DIFF
--- a/editor.planx.uk/src/ui/ErrorWrapper.tsx
+++ b/editor.planx.uk/src/ui/ErrorWrapper.tsx
@@ -34,7 +34,7 @@ export default function ErrorWrapper(props: Props): FCReturn {
     // role="status" immediately announces the error to screenreaders without interrupting focus
     <div
       className={props.error ? classes.rootError : undefined}
-      role={props.error ? "status" : undefined}
+      role="status"
       data-testid="error-wrapper"
     >
       <p id={id} className={classes.errorText}>


### PR DESCRIPTION
The fix in this PR makes `role="status"` always apply to the error wrapper, regardless of error state.

For the screenreader on MacOS this makes no difference - the error is read immediately with or without this change for me, making this is a little tricky to test.

Please see message below for context (Email from DAC, 28/03/22) - 

> I have a call booked with our screen reader analyst to explore this and we will record our findings for you if we encounter any issues.
>
> In relation to the status message this has not been implemented as demonstrated and the messages are still not reading out.
>
>The issue is that although a role of status is being added to the div containing the error message after the error is triggered, the div needs to have the role of status applied in the first place so that when the error message text is added it gets read out.
>
>Prior to submission:
>
>```
><div data-testid="error-wrapper" role="status" >
>  <p id="error-message-postcode-input" class="jss756"></p>
>  <div class="MuiInputBase-root-757 jss746 jss747" required="" style="margin-bottom: 20px;">
>    <input aria-describedby="description-text" id="postcode-input" name="postcode" required="" type="text" maxlength="8" class="MuiInputBase-input-765" value="">
>  </div>
></div>
>```
>
> After submission:
>
>```
><div data-testid="error-wrapper" role="status" class="jss755">
>  <p id="error-message-postcode-input" class="jss756">Enter a valid UK postcode</p>
>  <div class="MuiInputBase-root-757 jss746 jss747" required="" style="margin-bottom: 20px;">
>    <input aria-describedby="description-text error-message-GzQpqiOMyb" id="postcode-input" name="postcode" required="" type="text" maxlength="8" class="MuiInputBase-input-765" value="">
>  </div>
></div>
>```
> 
>This is also the case with the ‘No addresses found in postcode TE45 4FG’ message.
>
> We would also recommend adding the error message outside of the label.