### PR TITLE
fix: Update map repo to v0.5.3

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/utils": "^5.0.0-beta.5",
-    "@opensystemslab/map": "^0.5.1",
+    "@opensystemslab/map": "^0.5.3",
     "array-move": "^3.0.1",
     "axios": "^0.19.2",
     "camelcase-keys": "^7.0.0",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   '@material-ui/icons': ^4.9.1
   '@material-ui/lab': ^4.0.0-alpha.56
   '@material-ui/utils': ^5.0.0-beta.5
-  '@opensystemslab/map': ^0.5.1
+  '@opensystemslab/map': ^0.5.3
   '@react-theming/storybook-addon': ^1.1.3
   '@storybook/addon-actions': ^6.4.10
   '@storybook/addon-essentials': ^6.4.10
@@ -128,7 +128,7 @@ dependencies:
   '@material-ui/icons': 4.9.1_aca2900b4bcc0ae456c0c6b700ff3f91
   '@material-ui/lab': 4.0.0-alpha.56_aca2900b4bcc0ae456c0c6b700ff3f91
   '@material-ui/utils': 5.0.0-beta.5_react@17.0.2
-  '@opensystemslab/map': 0.5.1
+  '@opensystemslab/map': 0.5.3
   array-move: 3.0.1
   axios: 0.19.2
   camelcase-keys: 7.0.0
@@ -2541,8 +2541,8 @@ packages:
       mkdirp: 1.0.4
     dev: true
 
-  /@opensystemslab/map/0.5.1:
-    resolution: {integrity: sha512-TBd4iGNSwVGs8fIeUjf/Ycr8RJRsOarMijBlrUnS/eS9UfVy4Xb2ekvDu3+pt5F9rEEv6m+5QjA8HQ46N4XHow==}
+  /@opensystemslab/map/0.5.3:
+    resolution: {integrity: sha512-20MiRu3EufR90vqFsr6FELVVvlkvVzrjfdyazU9xy4RutR85W9Ynhx/YCfS1WCu+HCWFYwS/pvwcAT5UB4RZ+g==}
     dependencies:
       '@turf/union': 6.5.0
       accessible-autocomplete: 2.0.4

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -232,6 +232,7 @@ function GetAddress(props: {
   // Autocomplete overrides
   const useStyles = makeStyles((theme) => ({
     autocomplete: {
+      "--autocomplete__label__font-size": "18px",
       "--autocomplete__input__padding": "6px 40px 7px 12px",
       "--autocomplete__input__font-size": "15px",
       "--autocomplete__input__height": "50px",
@@ -324,6 +325,7 @@ function GetAddress(props: {
             initialAddress={selectedOption?.title || ""}
             osPlacesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             arrowStyle="light"
+            labelStyle="static"
           />
         )}
       </Box>


### PR DESCRIPTION
 - Addresses recent a11y feedback (https://github.com/theopensystemslab/map/pull/131)
 - Ensures postcode and address labels are a consistent style

**To test**
 - `role="status"` removed from wrapper in `address-autocomplete`
 - Label associated correctly using `for` not `htmlFor`
 - Postcode and address labels both 18px