### PR TITLE
feat: Add min/max error handling to editor date input

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { act, Simulate } from "react-dom/test-utils";
+
+import DateInputComponent from "./Editor";
+
+const minError = "Min must be less than max";
+const maxError = "Max must be greater than min";
+
+describe("DateInputComponent - Editor Modal", () => {
+  it("renders", () => {
+    render(
+      <DndProvider backend={HTML5Backend}>
+        <DateInputComponent id="test" />
+      </DndProvider>
+    );
+    expect(screen.getByText("Date Input")).toBeInTheDocument();
+  });
+
+  it("throws an error for incompatible date values", () => {
+    const handleSubmit = jest.fn();
+    render(
+      <DndProvider backend={HTML5Backend}>
+        <DateInputComponent id="test" handleSubmit={handleSubmit} />
+      </DndProvider>
+    );
+
+    const [minDay, maxDay] = screen.getAllByPlaceholderText("DD");
+    const [minMonth, maxMonth] = screen.getAllByPlaceholderText("MM");
+    const [minYear, maxYear] = screen.getAllByPlaceholderText("YYYY");
+
+    expect(screen.queryByText(minError)).toBeNull();
+    expect(screen.queryByText(maxError)).toBeNull();
+
+    userEvent.type(minDay, "01");
+    userEvent.type(minMonth, "01");
+    userEvent.type(minYear, "2000");
+
+    userEvent.type(maxDay, "01");
+    userEvent.type(maxMonth, "01");
+    userEvent.type(maxYear, "1900");
+
+    act(() => Simulate.submit(screen.getByRole("form")));
+
+    waitFor(() => {
+      expect(screen.getByText(minError)).toBeVisible();
+      expect(screen.getByText(maxError)).toBeVisible();
+    });
+  });
+
+  it("does not show errors if min is less than max", () => {
+    const handleSubmit = jest.fn();
+    render(
+      <DndProvider backend={HTML5Backend}>
+        <DateInputComponent id="test" handleSubmit={handleSubmit} />
+      </DndProvider>
+    );
+
+    const [minDay, maxDay] = screen.getAllByPlaceholderText("DD");
+    const [minMonth, maxMonth] = screen.getAllByPlaceholderText("MM");
+    const [minYear, maxYear] = screen.getAllByPlaceholderText("YYYY");
+
+    expect(screen.queryByText(minError)).toBeNull();
+    expect(screen.queryByText(maxError)).toBeNull();
+
+    userEvent.type(minDay, "01");
+    userEvent.type(minMonth, "01");
+    userEvent.type(minYear, "1900");
+
+    userEvent.type(maxDay, "01");
+    userEvent.type(maxMonth, "01");
+    userEvent.type(maxYear, "2000");
+
+    act(() => Simulate.submit(screen.getByRole("form")));
+
+    waitFor(() => {
+      expect(screen.queryByText(minError)).toBeNull();
+      expect(screen.queryByText(maxError)).toBeNull();
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -4,7 +4,7 @@ import {
   editorValidationSchema,
   paddedDate,
 } from "@planx/components/DateInput/model";
-import { dateSchema, parseDateInput } from "@planx/components/DateInput/model";
+import { parseDateInput } from "@planx/components/DateInput/model";
 import { TYPES } from "@planx/components/types";
 import {
   EditorProps,
@@ -20,7 +20,6 @@ import InputRow from "ui/InputRow";
 import ModalSection from "ui/ModalSection";
 import ModalSectionContent from "ui/ModalSectionContent";
 import RichTextInput from "ui/RichTextInput";
-import { object } from "yup";
 
 export type Props = EditorProps<TYPES.DateInput, DateInput>;
 
@@ -40,7 +39,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
   });
 
   return (
-    <form onSubmit={formik.handleSubmit} id="modal">
+    <form onSubmit={formik.handleSubmit} id="modal" name="modal">
       <ModalSection>
         <ModalSectionContent title="Date Input" Icon={ICONS[TYPES.DateInput]}>
           <InputRow>

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -110,14 +110,14 @@ export const editorValidationSchema = () =>
     min: dateSchema().test({
       name: "Min less than max",
       message: "Min must be less than max",
-      test: function (date: string | undefined) {
+      test(date: string | undefined) {
         return Boolean(date && date < this.parent.max);
       },
     }),
     max: dateSchema().test({
       name: "Max greater than min",
       message: "Max must be greater than min",
-      test: function (date: string | undefined) {
+      test(date: string | undefined) {
         return Boolean(date && date > this.parent.min);
       },
     }),


### PR DESCRIPTION
Addresses #201 

This PR adds validation that min date < max date (and vice versa) in the Editor.

![image](https://user-images.githubusercontent.com/20502206/160821369-06531e5a-8008-4412-8b68-32ae24c85604.png)

Also changed `validateOnChange` following GDS advice here, see section **"When to tell the user about validation errors"** 

https://design-system.service.gov.uk/patterns/validation/

