### PR TITLE
fix: account for undefined blpu code lookup in FindProperty

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -239,11 +239,11 @@ function GetAddress(props: {
           x: selectedAddress.X_COORDINATE,
           y: selectedAddress.Y_COORDINATE,
           planx_description:
-            find(blpuCodes.blpu_codes, {
+            find(blpuCodes?.blpu_codes, {
               code: selectedAddress.CLASSIFICATION_CODE,
             })?.description || null,
           planx_value:
-            find(blpuCodes.blpu_codes, {
+            find(blpuCodes?.blpu_codes, {
               code: selectedAddress.CLASSIFICATION_CODE,
             })?.value || null,
           single_line_address: selectedAddress.ADDRESS,


### PR DESCRIPTION
fixes https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3249554071622882418?tab=overview

trace context shows that hasura query against blpu codes table succeeded, which is a bit strange since this was a "can't read properties of undefined" type error. i can't recreate on production or locally (original postcode entered was SE1 6EY), but this should protect against any future occurances!