### PR TITLE
fix: don't auto-set "property.type" passport variable in FindProperty

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -111,7 +111,7 @@ test("recovers previously submitted address when clicking the back button", asyn
       os_local_custodian_code: "SOUTHWARK",
       planx_team_name: "CANTERBURY",
     },
-    "property.type": ["residential.HMO.parent"],
+    // "property.type": ["residential.HMO.parent"],
     "property.localAuthorityDistrict": ["Southwark"],
   };
 

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -127,9 +127,13 @@ function Component(props: Props) {
           if (flow && address) {
             const newPassportData: any = {};
 
-            if (address?.planx_value) {
-              newPassportData["property.type"] = [address.planx_value];
-            }
+            // XXX: do NOT set/auto-answer "property.type" right now because of content bugs around behavior of various 'parent shells', always ask user
+            //   https://trello.com/c/biqspUXF/1858-issue-with-overriding-value
+            //   https://trello.com/c/QqILomoQ/1686-add-hmo-hmo-parent-to-property-types-so-this-doesnt-go-down-other-property-unless-we-want-it-to
+            //   https://trello.com/c/vlXuDgwF/1684-do-not-send-a-property-type-to-the-passport-if-blpu-returns-property-shell
+            // if (address?.planx_value) {
+            //   newPassportData["property.type"] = [address.planx_value];
+            // }
 
             if (localAuthorityDistricts) {
               newPassportData["property.localAuthorityDistrict"] =


### PR DESCRIPTION
a temporary fix to some larger content questions that have been popping up around property shells - this "turns off" auto-completing "property.type" based on BLPU code lookup, so that instead the user will always be asked what type of property they're in. 

gist of Alastair's longer term question is: if we auto-complete property.type during FindProperty & auto-answer the question "What type of property", in the case that the answer was a "parent shell", can we ask the user _again_ to confirm what kind of property type they're in (is it really the parent shell building or is the work actually intended for a single flat or multiple flats for example?) - all while using the same passport value (overwriting, not appending new answer I think). But our current logic will never prompt that second question because it already has a matching passport entry, and any other quesitons at the root of the service outside of the answer path would have already been auto-answered when property.type was initially set by FindProperty. visualized here https://editor.planx.uk/opensystemslab/parent-shell-filter-v2