### PR TITLE
fix: set `article4.braintree.stisted` value

### DIFF
--- a/api.planx.uk/gis/local_authorities/braintree.js
+++ b/api.planx.uk/gis/local_authorities/braintree.js
@@ -81,11 +81,6 @@ async function go(x, y, siteBoundary, extras) {
                 type: "warning",
                 data: properties,
               };
-              if (k === "article4") {
-                // In addition to the Article 4 variable, also map A4 subvariables onto the accumulator
-                const a4Subvariables = getA4Subvariables(data.features, articleFours, A4_KEY);
-                acc = { ...acc, ...a4Subvariables };
-              }
             } else {
               if (!acc[k]) {
                 acc[k] = {
@@ -107,6 +102,17 @@ async function go(x, y, siteBoundary, extras) {
           ...extras,
         }
       );
+
+    // Set granular A4s, accounting for one variable matching to many possible shapes
+    if (ob["article4"].value) {
+      Object.keys(articleFours).forEach((key) => {
+        if (articleFours[key].includes(ob["article4"].data[A4_KEY]) || ob[key]?.value) {
+          ob[key] = { value: true }
+        } else {
+          ob[key] = { value: false }
+        }
+      });
+    }
 
     // Braintree host multiple TPO layers, but we only want to return a single result
     const tpoLayers = [

--- a/api.planx.uk/gis/local_authorities/metadata/braintree.js
+++ b/api.planx.uk/gis/local_authorities/metadata/braintree.js
@@ -145,15 +145,8 @@ const planningConstraints = {
       description: data.INFORMATIO,
     }),
     records: { // planx value to "PARISH" lookup
-      "article4.braintree.silverEnd": "Silver End",
-      "article4.braintree.stisted": "Stisted",
-      "article4.braintree.stisted": "Braintree",
-      "article4.braintree.stisted": "Gosfield",
-      "article4.braintree.stisted": "Middleton",
-      "article4.braintree.stisted": "Shalford",
-      "article4.braintree.stisted": "Greenstead Green",
-      "article4.braintree.stisted": "Coggeshall",
-      "article4.braintree.stisted": "Ashen",
+      "article4.braintree.silverEnd": ["Silver End"],
+      "article4.braintree.stisted": ["Stisted", "Braintree", "Gosfield", "Middleton", "Shalford", "Greenstead Green", "Coggeshall", "Ashen"],
     },
   },
   "designated.AONB": {


### PR DESCRIPTION
API response updated to align with George's changes here https://docs.google.com/spreadsheets/d/10u5z7PMj0nswD1fcJcPCilhhhk6uxYLViNorhOkYNZk/edit#gid=0

Example address:
- 1, LITTLE CODHAM FARM COTTAGE, BEAZLEY END, WETHERSFIELD, CM7 5JE
- Before: https://api.editor.planx.uk/gis/braintree?x=574775.49&y=228305.67&siteBoundary=%5B%5B%5B0.5402857084121789%2C51.926077851671806%5D%2C%5B0.540217163107067%2C51.925807688031625%5D%2C%5B0.5405330675424778%2C51.92576909302102%5D%2C%5B0.5405837315632963%2C51.92605212189059%5D%2C%5B0.5402857084121789%2C51.926077851671806%5D%5D%5D&version=1
- After: https://api.911.planx.pizza/gis/braintree?x=574775.49&y=228305.67&siteBoundary=%5B%5B%5B0.5402857084121789%2C51.926077851671806%5D%2C%5B0.540217163107067%2C51.925807688031625%5D%2C%5B0.5405330675424778%2C51.92576909302102%5D%2C%5B0.5405837315632963%2C51.92605212189059%5D%2C%5B0.5402857084121789%2C51.926077851671806%5D%5D%5D&version=1