### PR TITLE
fix: remove address-not-in-council warning in FindProperty, now checked via content

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -105,12 +105,6 @@ test("recovers previously submitted address when clicking the back button", asyn
       administrative_area: "SOUTHWARK",
       local_custodian_code: "SOUTHWARK",
     },
-    _addressWarning: {
-      show: true,
-      os_administrative_area: "SOUTHWARK",
-      os_local_custodian_code: "SOUTHWARK",
-      planx_team_name: "CANTERBURY",
-    },
     // "property.type": ["residential.HMO.parent"],
     "property.localAuthorityDistrict": ["Southwark"],
   };

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -101,26 +101,6 @@ function Component(props: Props) {
       />
     );
   } else if (address) {
-    let warning: {
-      show: boolean;
-      os_administrative_area: string;
-      os_local_custodian_code: string;
-      planx_team_name?: string;
-    } = {
-      show: false,
-      os_administrative_area: address.administrative_area,
-      os_local_custodian_code: address.local_custodian_code,
-    };
-
-    if (team?.name) {
-      // if neither admin area nor LCC match team, then show warning error msg
-      warning.show = ![
-        address.administrative_area,
-        address.local_custodian_code,
-      ].includes(team.name.toUpperCase());
-      warning.planx_team_name = team.name.toUpperCase();
-    }
-
     return (
       <PropertyInformation
         handleSubmit={(feedback?: string) => {
@@ -142,7 +122,6 @@ function Component(props: Props) {
 
             const passportData = {
               _address: address,
-              _addressWarning: warning,
               ...newPassportData,
             };
 
@@ -175,9 +154,7 @@ function Component(props: Props) {
             detail: address.planx_description,
           },
         ]}
-        team={team}
         teamColor={team?.theme?.primary || "#2c2c2c"}
-        error={warning.show}
       />
     );
   } else {
@@ -251,9 +228,6 @@ function GetAddress(props: {
               code: selectedAddress.CLASSIFICATION_CODE,
             })?.value || null,
           single_line_address: selectedAddress.ADDRESS,
-          administrative_area: selectedAddress.ADMINISTRATIVE_AREA, // local highway authority name (proxy for local authority?)
-          local_custodian_code:
-            selectedAddress.LOCAL_CUSTODIAN_CODE_DESCRIPTION, // similar to GSS_CODE, but may not reflect merged councils
           title: selectedAddress.ADDRESS.split(
             `, ${selectedAddress.ADMINISTRATIVE_AREA}`
           )[0], // display value used in autocomplete dropdown & FindProperty
@@ -408,9 +382,7 @@ export function PropertyInformation(props: any) {
     lat,
     lng,
     handleSubmit,
-    team,
     teamColor,
-    error,
   } = props;
   const styles = useClasses();
   const formik = useFormik({
@@ -462,14 +434,6 @@ export function PropertyInformation(props: any) {
           </Box>
         ))}
       </Box>
-      {error && team?.name && (
-        <Box role="status">
-          <Typography variant="body1" color="error">
-            This address may not be in {team.name}, are you sure you want to
-            continue using this service?
-          </Typography>
-        </Box>
-      )}
       <Box color="text.secondary" textAlign="right">
         <CollapsibleInput
           handleChange={formik.handleChange}

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -29,8 +29,6 @@ export interface Address {
   planx_description: string;
   planx_value: string;
   single_line_address: string;
-  administrative_area: string;
-  local_custodian_code: string;
   title: string;
 }
 

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -170,7 +170,6 @@ export function getParams(
   // 1a. address
 
   const address = passport.data?._address;
-  const warning = passport.data?._addressWarning;
 
   if (address) {
     const site = {} as BOPSFullPayload["site"];
@@ -184,12 +183,6 @@ export function getParams(
 
     site.latitude = address.latitude;
     site.longitude = address.longitude;
-
-    // if the applicant was shown a warning message that their selected address
-    //   may not be in this council, send the error context to BOPS
-    if (warning && warning.show) {
-      site.warning = warning;
-    }
 
     data.site = site;
   }

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -22,12 +22,6 @@ interface BOPSMinimumPayload {
     postcode: string;
     latitude: string;
     longitude: string;
-    warning?: {
-      show: boolean;
-      os_administrative_area: string;
-      os_local_custodian_code: string;
-      planx_team_name?: string;
-    };
   };
   applicant_email: string;
 }


### PR DESCRIPTION
user-testing showed that the warning message in FindProperty wasn't strong enough to actually prevent applicants from continuing, so now we'll handle this via an auto-answered Question referencing passport variable `property.localAuthorityDistrict` & the Notice component with "reset" toggled on to prevent proceeding

this PR removes the old error logic, updates to flows will be fully handled by content team

https://918.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate (try postcode SE5 0HU to trigger Notice)

![Screenshot from 2022-04-28 17-29-42](https://user-images.githubusercontent.com/5132349/165788988-276e3b59-89d3-4d99-a371-905a3a566dbe.png)