### PR TITLE
chore: Tie pnpm to v6.24.1 as v7 now released

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - run: npm install -g pnpm
+      - run: npm install -g pnpm@6.24.1
         working-directory: editor.planx.uk
       - run: pnpm install --frozen-lockfile
         working-directory: editor.planx.uk
@@ -86,7 +86,7 @@ jobs:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install -g pnpm
+      - run: npm install -g pnpm@6.24.1
         working-directory: infrastructure/application
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - run: npm install -g pnpm
+      - run: npm install -g pnpm@6.24.1
         working-directory: editor.planx.uk
       - run: pnpm install --frozen-lockfile
         working-directory: editor.planx.uk
@@ -86,7 +86,7 @@ jobs:
           aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install -g pnpm
+      - run: npm install -g pnpm@6.24.1
         working-directory: infrastructure/application
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application

--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:16.13.1-alpine as base
 
 WORKDIR /api
-RUN npm install -g pnpm
+RUN npm install -g pnpm@6.24.1
 COPY pnpm-lock.yaml .
 EXPOSE 4000
 

--- a/api.planx.uk/README.md
+++ b/api.planx.uk/README.md
@@ -4,7 +4,7 @@ This currently handles the login process for PlanX. Most of the functionality of
 
 ## Running locally
 
-Install [pnpm](https://pnpm.io) if you don't have it `npm install -g pnpm`
+Install [pnpm](https://pnpm.io) if you don't have it `npm install -g pnpm@6.24.1`
 
 Then install the project's dependencies
 

--- a/scripts/seed-database/Dockerfile
+++ b/scripts/seed-database/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.13.1-alpine
 RUN npm install -g hasura-cli
 
 WORKDIR /scripts/
-RUN npm install -g pnpm
+RUN npm install -g pnpm@6.24.1
 COPY pnpm-lock.yaml .
 
 RUN pnpm fetch --prod

--- a/sharedb.planx.uk/Dockerfile
+++ b/sharedb.planx.uk/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:16.13.1-alpine as base
 
 WORKDIR /sharedb
-RUN npm install -g pnpm
+RUN npm install -g pnpm@6.24.1
 COPY pnpm-lock.yaml .
 EXPOSE 4000
 


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases/tag/v7.0.0

pnpm v7 was released on 30/04/22 which has breaking changes where peer dependencies are concerned, which caused pipeline failures on a few PRs.

This PR ties the pnpm version to v6.24.1 which was the specified version on the current GitHub action - longer terms we could look at upgrading or going for ^6.