### PR TITLE
fix: Send component "destination" can be null

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -9,7 +9,7 @@ import Card from "../shared/Preview/Card";
 import { makeData, useStagingUrlIfTestApplication } from "../shared/utils";
 import { PublicProps } from "../ui";
 import { getParams } from "./bops";
-import { Destination,Send } from "./model";
+import { Destination, Send } from "./model";
 import { getUniformParams } from "./uniform";
 
 export type Props = PublicProps<Send>;
@@ -63,7 +63,7 @@ const SendComponent: React.FC<Props> = (props) => {
     return (
       <Card>
         <DelayedLoadingIndicator
-          text={`Sending data to ${props.destination.toUpperCase()} - ${teamSlug?.toUpperCase()}`}
+          text={`Sending data to ${props.destination?.toUpperCase()} ${teamSlug?.toUpperCase()}`}
           msDelayBeforeVisible={0}
         />
       </Card>


### PR DESCRIPTION
https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3276290168130212017?tab=overview

This can be null for existing Send components as long as Uniform is behind a feature flag still, oops!