### PR TITLE
fix: Change notifyPersonalisation column name to notify_personalisation

### DIFF
--- a/api.planx.uk/saveAndReturn/resumeApplication.js
+++ b/api.planx.uk/saveAndReturn/resumeApplication.js
@@ -49,7 +49,7 @@ const validateRequest = async (teamSlug, email, res) => {
         teams(where: { slug: { _eq: $teamSlug } }) {
           slug
           name
-          notifyPersonalisation
+          notify_personalisation
         }
       }
     `
@@ -63,7 +63,7 @@ const validateRequest = async (teamSlug, email, res) => {
     return {
       teamSlug: teams[0].slug,
       teamName: teams[0].name,
-      teamPersonalisation: teams[0].notifyPersonalisation,
+      teamPersonalisation: teams[0].notify_personalisation,
       sessions: lowcal_sessions,
     };
   } catch (error) {

--- a/api.planx.uk/saveAndReturn/utils.js
+++ b/api.planx.uk/saveAndReturn/utils.js
@@ -148,7 +148,7 @@ const validateSingleSessionRequest = async (email, sessionId) => {
           team {
             name
             slug
-            notifyPersonalisation
+            notify_personalisation
           }
         }
       }
@@ -162,7 +162,7 @@ const validateSingleSessionRequest = async (email, sessionId) => {
     return {
       flowSlug: session.flow.slug,
       teamSlug: session.flow.team.slug,
-      teamPersonalisation: session.flow.team.notifyPersonalisation,
+      teamPersonalisation: session.flow.team.notify_personalisation,
       session: getSessionDetails(session),
       teamName: session.flow.team.name,
     };

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.js
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.js
@@ -1,7 +1,7 @@
 const mockTeam = {
   slug: "test-team",
   name: "Test Team",
-  notifyPersonalisation: {
+  notify_personalisation: {
     helpEmail: "example@council.gov.uk",
     helpPhone: "(01234) 567890",
     emailReplyToId: "testID",

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -413,7 +413,7 @@
           - created_at
           - id
           - name
-          - notifyPersonalisation
+          - notify_personalisation
           - settings
           - slug
           - theme

--- a/hasura.planx.uk/migrations/1649248200787_alter_table_public_teams_add_column_notifyPersonalisation/down.sql
+++ b/hasura.planx.uk/migrations/1649248200787_alter_table_public_teams_add_column_notifyPersonalisation/down.sql
@@ -1,6 +1,6 @@
 -- Could not auto-generate a down migration.
 -- Please write an appropriate down migration for the SQL below:
--- alter table "public"."teams" add column "notifyPersonalisation" jsonb
+-- alter table "public"."teams" add column "notify_personalisation" jsonb
 --  null;
 
-alter table "public"."teams" drop column "notifyPersonalisation";
+alter table "public"."teams" drop column "notify_personalisation";

--- a/hasura.planx.uk/migrations/1649248200787_alter_table_public_teams_add_column_notifyPersonalisation/up.sql
+++ b/hasura.planx.uk/migrations/1649248200787_alter_table_public_teams_add_column_notifyPersonalisation/up.sql
@@ -1,2 +1,2 @@
-alter table "public"."teams" add column "notifyPersonalisation" jsonb
+alter table "public"."teams" add column "notify_personalisation" jsonb
  null;


### PR DESCRIPTION
Quick fix - realised my mistake!

Editing the migration files should be fine as this will all be going into the `feat/save-and-return` branch before hitting the staging or prod databases. 

Marked as draft in order to favour other waiting Save & Return branches.