### PR TITLE
chore: update hasura to update warp (recc. from security audit)

### DIFF
--- a/hasura.planx.uk/Dockerfile
+++ b/hasura.planx.uk/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.2.1.cli-migrations-v2
+FROM hasura/graphql-engine:v2.7.0.cli-migrations-v2
 WORKDIR /
 COPY metadata hasura-metadata
 COPY migrations hasura-migrations


### PR DESCRIPTION
https://trello.com/c/9d2XHwvN/1910-jumpsec-audit-see-if-latest-hasura-version-uses-warp-3320


Security audit recommended 3.3.20. The latest Hasura version (this PR) implements 3.3.19, which is already better/newer. We shuold come up with a system to be notified on new Hasura releases. 
