### PR TITLE
chore: Shorten Save & Return event timers for UAT

### DIFF
--- a/api.planx.uk/webhooks/lowcalSessionEvents.js
+++ b/api.planx.uk/webhooks/lowcalSessionEvents.js
@@ -1,4 +1,4 @@
-const { addDays } = require("date-fns");
+const { addDays, addMinutes } = require("date-fns");
 const { createScheduledEvent } = require("../hasura/metadata");
 const { DAYS_UNTIL_EXPIRY } = require("../saveAndReturn/utils");
 
@@ -18,7 +18,8 @@ const createReminderEvent = async (req, res, next) => {
       });
     const response = await createScheduledEvent({
       webhook: "{{HASURA_PLANX_API_URL}}/send-email/reminder",
-      schedule_at: addDays(Date.parse(createdAt), (DAYS_UNTIL_EXPIRY - 7)),
+      // schedule_at: addDays(Date.parse(createdAt), (DAYS_UNTIL_EXPIRY - 7)),
+      schedule_at: addMinutes(Date.parse(createdAt), 10),
       payload: payload,
       comment: `reminder_${payload.sessionId}`,
     });
@@ -46,7 +47,8 @@ const createExpiryEvent = async (req, res, next) => {
       });
     const response = await createScheduledEvent({
       webhook: "{{HASURA_PLANX_API_URL}}/send-email/expiry",
-      schedule_at: addDays(Date.parse(createdAt), DAYS_UNTIL_EXPIRY),
+      // schedule_at: addDays(Date.parse(createdAt), DAYS_UNTIL_EXPIRY),
+      schedule_at: addMinutes(Date.parse(createdAt), 15),
       payload: payload,
       comment: `expiry_${payload.sessionId}`,
     }, next);


### PR DESCRIPTION
Temporarily change reminder and expiry events to trigger after 10 and 15 minutes respectively for upcoming UAT.