### PR TITLE
feat: basic audit log of raw Digital Land responses

### DIFF
--- a/api.planx.uk/gis/index.js
+++ b/api.planx.uk/gis/index.js
@@ -4,10 +4,10 @@ const localAuthorities = {
 };
 
 // Digital Land is a single request with standardized geometry, so remove timeout & simplify query params
-function locationSearchWithoutTimeout(localAuthority, { geom }) {
+function locationSearchWithoutTimeout(localAuthority, queryParams) {
   return new Promise(async (resolve, reject) => {
     try {
-      const resp = await localAuthorities["digitalLand"].locationSearch(localAuthority, geom);
+      const resp = await localAuthorities["digitalLand"].locationSearch(localAuthority, queryParams.geom, queryParams);
       resolve(resp);
     } catch (err) {
       reject(err);

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -35,6 +35,11 @@ function Component(props: Props) {
   ]);
   const route = useCurrentRoute();
   const team = route?.data?.team ?? route.data.mountpath.split("/")[1];
+
+  // Get current query parameters (eg ?analytics=false&sessionId=XXX) to determine if we should audit this response
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const params = Object.fromEntries(urlSearchParams.entries());
+
   const classes = useClasses();
 
   // Get the coordinates of the site boundary drawing if they exist, fallback on x & y if file was uploaded
@@ -58,6 +63,7 @@ function Component(props: Props) {
 
   const digitalLandParams: Record<string, string> = {
     geom: wktPolygon || wktPoint,
+    ...params,
   };
   const customGisParams: Record<string, any> = {
     x: x,

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -188,6 +188,9 @@
         foreign_key_constraint_on: flow_id
 - table:
     schema: public
+    name: planning_constraints_requests
+- table:
+    schema: public
     name: published_flows
   object_relationships:
     - name: flow

--- a/hasura.planx.uk/migrations/1655300598099_create_table_planning_constraints_requests/down.sql
+++ b/hasura.planx.uk/migrations/1655300598099_create_table_planning_constraints_requests/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "public"."planning_constraints_requests" CASCADE;

--- a/hasura.planx.uk/migrations/1655300598099_create_table_planning_constraints_requests/up.sql
+++ b/hasura.planx.uk/migrations/1655300598099_create_table_planning_constraints_requests/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "public"."planning_constraints_requests" (
+    "id" serial NOT NULL,
+    "destination_url" text,
+    "response" jsonb,
+    "session_id" text,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY ("id")
+);
+COMMENT ON TABLE "public"."planning_constraints_requests" IS E'Audit log of raw planning constraints responses from Digital Land API';

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -1,0 +1,32 @@
+const { introspectAs } = require("./utils");
+
+describe("planning_constraints_requests", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query planning constraints requests", () => {
+      expect(i.queries).not.toContain("planning_constraints_requests");
+    });
+
+    test("cannot create, update, or delete planning constraints requests", () => {
+      expect(i).toHaveNoMutationsFor("planning_constraints_requests");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate planning constraints requests", () => {
+      expect(i.queries).toContain("planning_constraints_requests");
+      expect(i.mutations).toContain("insert_planning_constraints_requests");
+      expect(i.mutations).toContain("update_planning_constraints_requests_by_pk");
+      expect(i.mutations).toContain("delete_planning_constraints_requests");
+    });
+  });
+});


### PR DESCRIPTION
Our passport, session data, and application payloads sent to BOPS & Uniform only contain processed planning constraints data, meaning the Digital Land response has been translated into a list of true/false planx variable names.

We want to keep an audit record of the raw response from the Digital Land API at the point of fetch because, for example, planning constraints may have changed by the time an officer is assessing an application. Our audit is purely of Digital Land's response though, which doesn't account for how they might statically host or cache data provided directly by councils.

This updates our `/gis/:localAuthority` endpoint to additionally create a database record anytime we're querying Digital Land. We are _not_ auditing lingering custom GIS integrations like Braintree that are routed through the same endpoint because that would be ~8x individual ESRI responses to record. It won't create a record if the request comes from an environment where `?analytics=false`.

Open questions:
- Should the conditions for creating an audit record be stricter than `analytics !== false` ? Eg the editor knows if we're in a preview environment or not, should that be additonally passed to the API?
- I don't anticipate we'll have to actually use this table often, but if we do, it won't be particularly easy to match an audit record to its' application if the `session_id` is null. Based on what we know about save & return and subdomains so far, is referencing the URL query params okay here or should I use passport variables instead?
- How long should we retain records? Worth setting up an automatic trigger to delete?