### PR TITLE
fix: add uniform secrets to pulumi so github deploy actions can succeed

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -26,6 +26,10 @@ config:
     secure: AAABAN1bRAyO0jk0n4rfVAntYPWNat+naRsld87v3I18Bn9Iu5HGHmdKyF8Z0qpKoa7Sm88hmxlYsOb9wxQi0Yxtl7sdGZvodD6iLg==
   application:session-secret:
     secure: AAABACeZpncVIdwarlb/J9qtaPqUob0YwbaOVDNEgfhSJ71aq0pkZml1EP+JqMKvyhkG483LcIiGzEh/ZDJehMu2
+  application:uniform-api-token:
+    secure: AAABAG3JJ43EfMXi85e6QT46Wk9xLB4jlXTHoNRgSlIbmzeuELq6IDANkoHk6LfU6vLDKvt9fA==
+  application:uniform-api-username:
+    secure: AAABAOCeei4Uz5zF4LTLIYIMeUkNW9U0s4g7K/R3lMinZo9IDrz5G7M=
   aws:region: eu-west-2
   cloudflare:apiToken:
     secure: AAABAMbIBX9N21ModHyDYCQCGZXkRUP62NIUMhsxkK+/YUPRQr6PEqgZX9LRP2UuVwvVHd2RxvKGT8lpq8oAgyeDYP1eZSUl

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -27,6 +27,10 @@ config:
     secure: AAABAI1jwOCiVQ7FdyxRXyZQh0VeN/z1R9t3Y2QXSdAgBq5cu7lT7UKRpDmtSS857F8GqOIAAedPXng11w0dmqWe1783BRtczE7tOQ==
   application:session-secret:
     secure: AAABABAEQraYY1NSIufhqZ1XYWTEqYgQl1M1CJmouRiD1mMx7LqKbyoYzAS4H3nfksuavw==
+  application:uniform-api-token:
+    secure: AAABAHGjA/gkaror7iagv50+ey99M+YhNQkK7rgs7DJNP4eOONIEeoYbLRLWScgS+dBAhRTeHA==
+  application:uniform-api-username:
+    secure: AAABAAoTJS/8qMxFzVzxeiYTh2FLYxIZJxt8yG7dlQqWJ7xIbiqZMXs=
   aws:region: eu-west-2
   certificates:cloudflare-zone-id: dc27ac531ff8862559ed9ab5016c4953
   cloudflare:apiToken:


### PR DESCRIPTION
see https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1655449664847639 & https://github.com/theopensystemslab/planx-new/actions/runs/2513888606

going to directly merge this to main so I can re-rerun action & complete the deploy for #957, sorry for bypassing approval process in this case! 

Uniform work all safely still behind a feature flag though, not sending applications yet.