### PR TITLE
test: Add healthcheck to Github actions

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -265,3 +265,21 @@ jobs:
           header: vultr
           message: |
             Deployed ${{ github.sha }} to https://${{ env.FULL_DOMAIN }}
+
+  healthcheck:
+    name: Healthcheck Pizza Services
+    needs: [create_or_update_vultr_instance]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Startup grace period
+        run: sleep 60s
+        shell: bash
+      - name: API healthcheck
+        run: |
+          curl --fail -sv --retry 3 --retry-delay 30 --retry-connrefused https://api.${{ env.FULL_DOMAIN }}
+      - name: Hasura healthcheck
+        run: |
+          curl --fail -sv --retry 3 --retry-delay 30 --retry-connrefused https://hasura.${{ env.FULL_DOMAIN }}/healthz
+      - name: Editor healthcheck
+        run: |
+          curl --fail -sv --retry 3 --retry-delay 30 --retry-connrefused https://${{ env.FULL_DOMAIN }}


### PR DESCRIPTION
 - Adds a new job to the Pull Request action, which runs a health check against Hasura, API and Editor on the Pizza
 - Came up as an issue earlier in the week where the Pizza was successfully deployed, but the API was unhealthy due to a missing dependency
 - Tested by trying to call https://httpstat.us/500 as an additional step in the job, which resulted in a failure

**Question**
 - The call to Hasura may be redundant as other services in the `docker-compose.yml` are linked to this via `depends_on` - this is not true for the API and Editor
 - Pulumi has a healthcheck set up for these services, but I'm not exactly sure how the deployment is handled if a health check were to fail. I'd like to think that catching errors at the Pizza stage should negate this issue either way.