### PR TITLE
infra: hard-code ubuntu version

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   teardown_pizza:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Remove vultr resources
         uses: theopensystemslab/vultr-action@v1.15

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   integration_tests:
     name: Integration and E2E tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.0.1
@@ -41,7 +41,7 @@ jobs:
 
   api_tests:
     name: API Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.0.1
@@ -58,7 +58,7 @@ jobs:
 
   test_and_build:
     name: Test and Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.0.1
@@ -107,7 +107,7 @@ jobs:
   preview:
     name: Pulumi Preview
     needs: [integration_tests, test_and_build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS Credentials
@@ -143,7 +143,7 @@ jobs:
   hasura-change-summary:
     name: Hasura Change Summary
     needs: [integration_tests, test_and_build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: Fieldguide/action-hasura-change-summary@v2
@@ -170,7 +170,7 @@ jobs:
     #      see https://github.com/theopensystemslab/planx-new/pull/725
     name: Create or Update Vultr Instance
     needs: [integration_tests, api_tests, test_and_build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Create Pizza (if it doesn't exist)
         id: create
@@ -269,7 +269,7 @@ jobs:
   healthcheck:
     name: Healthcheck Pizza Services
     needs: [create_or_update_vultr_instance]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Startup grace period
         run: sleep 60s

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   test_and_build:
     name: Test and Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -72,7 +72,7 @@ jobs:
   preview:
     name: Pulumi Up
     needs: test_and_build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -108,7 +108,7 @@ jobs:
   notifications:
     name: Notifications
     needs: preview
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       # Airbrake notification - https://airbrake.io/docs/features/deploy-tracking

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   test_and_build:
     name: Test and Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -72,7 +72,7 @@ jobs:
   preview:
     name: Pulumi Up
     needs: test_and_build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -108,7 +108,7 @@ jobs:
   notifications:
     name: Notifications
     needs: preview
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       # Airbrake notification - https://airbrake.io/docs/features/deploy-tracking


### PR DESCRIPTION
Hard-coding the GitHub Actions Ubuntu version just as a precaution against future possible incompatibility.

[The `ubuntu-latest` tag was lastly updated to `20.04`](https://github.blog/changelog/2020-10-29-github-actions-ubuntu-latest-workflows-will-use-ubuntu-20-04/).