### PR TITLE
fix: Do not filter Pizza Teardown by branch

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -2,9 +2,6 @@ name: Pizza Teardown
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
-      - feat/save-and-return # TODO: Delete when feature branch merged
 
 env:
   DOMAIN: planx.pizza


### PR DESCRIPTION
Found two Vultr instances which have not been destroyed this morning - those for #978 and #980, which were both going into the `feat/save-and-return` branch.

I've now manually removed both instances and associated DNS records on Vultr.

This fix matches the corresponding change to `pull-request-main.yml` on `feat/save-and-return` here - https://github.com/theopensystemslab/planx-new/blob/866e37568bc817c2c5fdc76bbf91b3c5c4ee2a3c/.github/workflows/pull-request-main.yml#L7

Once the feature branch is merged, both these can be tidied up - they've been added as a TODO on the Save and Return PR #899 

**Question**
 - Do we actually want to be filtering down Pizzas to only be created / destroyed when pointing at `main`? Are we likely to just forget about this issue in the future and repeat the mistake?