### PR TITLE
fix: navigator.sendBeacon() illegal innvocation

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -22,6 +22,9 @@ const analyticsContext = createContext<{
 });
 const { Provider } = analyticsContext;
 
+// Navigator has to be bound to ensure it does not error in some browsers
+const send = navigator?.sendBeacon?.bind(navigator);
+
 export const AnalyticsProvider: React.FC = ({ children }) => {
   const [
     currentCard,
@@ -49,7 +52,6 @@ export const AnalyticsProvider: React.FC = ({ children }) => {
 
   const onPageExit = () => {
     if (lastAnalyticsLogId && shouldTrackAnalytics) {
-      const send = navigator.sendBeacon && navigator.sendBeacon.bind(navigator);
       if (document.visibilityState === "hidden") {
         send(
           `${


### PR DESCRIPTION
**Problem**
Addresses Airbrake error here - https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3302348445993507549?tab=overview

**Solution**
Navigator has to be bound to ensure it does not error in some browsers
https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch