### PR TITLE
fix: Restrict "Resume" sessions to the chosen team

### DIFF
--- a/api.planx.uk/saveAndReturn/resumeApplication.js
+++ b/api.planx.uk/saveAndReturn/resumeApplication.js
@@ -59,6 +59,7 @@ const validateRequest = async (teamSlug, email) => {
             email: { _eq: $email }
             deleted_at: { _is_null: true }
             submitted_at: { _is_null: true }
+            flow: { team: { slug: { _eq: $teamSlug } } }
           }
           order_by: { flow: { slug: asc }, created_at: asc }
         ) {


### PR DESCRIPTION
🍒 (cherry picked from commit fd678bebc6f56f2ac928dd566feb3e92217f1981) - https://github.com/theopensystemslab/planx-new/pull/978

---

![image](https://user-images.githubusercontent.com/20502206/175333844-4e6c8b91-3f6a-4f26-84db-37795ee24d0b.png)

See comments from Emily here - https://trello.com/c/87xr9JFv/1942-save-return-uat-save-return

> Received email but all applications use the braintree email (see screenshot 2), meaning that the magic links did not open on the Bucks addresses (see screenshot 3)

**What this PR does**
 - Adds `where` clause to ensure a "Resume" email only lists sessions linked to a single team