### PR TITLE
fix: Revert padding change to Content component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -16,8 +16,7 @@ interface StyleProps {
 
 const useClasses = makeStyles<Theme, StyleProps>((theme) => ({
   content: {
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
+    padding: theme.spacing(2),
     backgroundColor: (props) => props.color,
     color: (props) =>
       mostReadable(props.color || "#fff", ["#fff", "#000"])?.toHexString() ||


### PR DESCRIPTION
Reverts recent changes made here - https://github.com/theopensystemslab/planx-new/pull/965

The reason for this is that the Content component can have a background colour, which requires padding (see image).

![image](https://user-images.githubusercontent.com/20502206/178020994-7e0a63a7-37be-4626-acaa-606023133418.png)
