### PR TITLE
fix: remove duplicate "proposal.description" mappings in Uniform XML schema

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -71,7 +71,7 @@ export function makeXmlString(
         <portaloneapp:ApplicationTo>00QA</portaloneapp:ApplicationTo>
         <portaloneapp:DateSubmitted>${proposalCompletionDate}</portaloneapp:DateSubmitted>
         <portaloneapp:RefNum>${sessionId}</portaloneapp:RefNum>
-        <portaloneapp:FormattedRefNum>${sessionId}</portaloneapp:FormattedRefNum>
+        <portaloneapp:FormattedRefNum>RIPA-${sessionId}</portaloneapp:FormattedRefNum>
         <portaloneapp:ApplicationVersion>1</portaloneapp:ApplicationVersion>
         <portaloneapp:AttachmentsChanged>false</portaloneapp:AttachmentsChanged>
         <portaloneapp:Payment>


### PR DESCRIPTION
Addresses two minor pieces of feedback from Kev about the XML schema: 

1. >The application proposal descriptions are coming through twice into Uniform. Everything else looks ok.
![image (2)](https://user-images.githubusercontent.com/5132349/178478414-d00f9766-02e0-46b1-a1bb-da61ade76a3c.png)

2. > Catherine at Lambeth has asked if the PlanX reference which falls into the Altref field in uniform can have RIPA as a prefix?
