### PR TITLE
fix: Correctly startNewApplication() on SaveSuccess page

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -123,27 +123,16 @@ const ValidationSuccess: React.FC<{
 
 const InvalidSession: React.FC<{
   retry: () => void;
-}> = ({ retry }) => {
-  const startNewApplication = () => {
-    // Drop sessionId from URL to route to ApplicationPath.SaveAndReturn, not ApplicationPath.Resume
-    const currentURL = new URL(window.location.href);
-    currentURL.searchParams.delete("sessionId");
-    window.history.pushState({}, document.title, currentURL);
-    window.location.reload();
-  };
-
-  return (
-    <StatusPage
-      bannerHeading="We can't find your application"
-      bannerText='Click "Try Again" enter your email address again, or start a new application'
-      cardText=""
-      buttonText="Try again"
-      onButtonClick={retry}
-      altButtonText="Start a new application"
-      onAltButtonClick={() => startNewApplication()}
-    ></StatusPage>
-  );
-};
+}> = ({ retry }) => (
+  <StatusPage
+    bannerHeading="We can't find your application"
+    bannerText='Click "Try Again" enter your email address again, or start a new application'
+    cardText=""
+    buttonText="Try again"
+    onButtonClick={retry}
+    additionalOption="startNewApplication"
+  ></StatusPage>
+);
 
 /**
  * If an email is passed in as a query param, do not prompt a user for this

--- a/editor.planx.uk/src/pages/Preview/SavePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/SavePage.tsx
@@ -16,30 +16,17 @@ enum Status {
 const SaveSuccess: React.FC<{ saveToEmail?: string; expiryDate?: string }> = ({
   saveToEmail,
   expiryDate,
-}) => {
-  const startNewApplication = () => {
-    // Drop sessionId from URL to route to ApplicationPath.SaveAndReturn, not ApplicationPath.Resume
-    const currentURL = new URL(window.location.href);
-    currentURL.searchParams.delete("sessionId");
-    window.history.pushState({}, document.title, currentURL);
-    window.location.reload();
-  };
-
-  return (
-    <>
-      <StatusPage
-        bannerHeading="Application saved"
-        bannerText={`We have sent a link to ${saveToEmail}. Use that link to continue your application.`}
-        cardText={`You have until ${expiryDate} to complete and send this application.`}
-        showDownloadLink
-        buttonText="Close tab"
-        onButtonClick={() => window.close()}
-        altButtonText="Start a new application"
-        onAltButtonClick={() => startNewApplication()}
-      ></StatusPage>
-    </>
-  );
-};
+}) => (
+  <StatusPage
+    bannerHeading="Application saved"
+    bannerText={`We have sent a link to ${saveToEmail}. Use that link to continue your application.`}
+    cardText={`You have until ${expiryDate} to complete and send this application.`}
+    showDownloadLink
+    buttonText="Close tab"
+    onButtonClick={() => window.close()}
+    additionalOption="startNewApplication"
+  ></StatusPage>
+);
 
 const SaveError: React.FC = () => {
   return (

--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -19,9 +19,8 @@ interface Props {
   cardText: string;
   buttonText?: string;
   onButtonClick?: () => void;
-  altButtonText?: string;
-  onAltButtonClick?: () => void;
   showDownloadLink?: boolean;
+  additionalOption?: "startNewApplication";
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -37,9 +36,8 @@ const StatusPage: React.FC<Props> = ({
   cardText,
   buttonText,
   onButtonClick,
-  altButtonText,
-  onAltButtonClick,
   showDownloadLink,
+  additionalOption,
 }) => {
   const [breadcrumbs, flow, passport, sessionId] = useStore((state) => [
     state.breadcrumbs,
@@ -53,6 +51,14 @@ const StatusPage: React.FC<Props> = ({
 
   const theme = useTheme();
   const classes = useStyles();
+
+  // Drop sessionId from URL to route to ApplicationPath.SaveAndReturn, not ApplicationPath.Resume
+  const startNewApplication = () => {
+    const currentURL = new URL(window.location.href);
+    currentURL.searchParams.delete("sessionId");
+    window.history.pushState({}, document.title, currentURL);
+    window.location.reload();
+  };
 
   return (
     <>
@@ -84,14 +90,14 @@ const StatusPage: React.FC<Props> = ({
             {buttonText}
           </Button>
         )}
-        {altButtonText && (
+        {additionalOption === "startNewApplication" && (
           <>
             <Typography variant="body2">or</Typography>
             <ButtonBase
               className={classes.linkButton}
-              onClick={onAltButtonClick}
+              onClick={startNewApplication}
             >
-              <Typography variant="body2">{altButtonText}</Typography>
+              <Typography variant="body2">Start new application</Typography>
             </ButtonBase>
           </>
         )}


### PR DESCRIPTION
**Context**
Picked up by Lam here (slide 17) https://docs.google.com/presentation/d/1YuoFPJJ_-iFX95Ovn0kJ1wZXA_MaaYF_zN1_6vlAFs0/edit#slide=id.g13a4ea32fa0_0_9 and easily replicable.

Introduced as part of changes in this PR - https://github.com/theopensystemslab/planx-new/pull/987

The logic for starting a new application was only implemented on the `ResumePage` but not the `SavePage`.

**Fix**
 - Strip sessionId, then reload page

