### PR TITLE
fix: "FormattedRefNum" must match "RefNum" in Uniform XML schema

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -71,7 +71,7 @@ export function makeXmlString(
         <portaloneapp:ApplicationTo>00QA</portaloneapp:ApplicationTo>
         <portaloneapp:DateSubmitted>${proposalCompletionDate}</portaloneapp:DateSubmitted>
         <portaloneapp:RefNum>${sessionId}</portaloneapp:RefNum>
-        <portaloneapp:FormattedRefNum>RIPA-${sessionId}</portaloneapp:FormattedRefNum>
+        <portaloneapp:FormattedRefNum>${sessionId}</portaloneapp:FormattedRefNum>
         <portaloneapp:ApplicationVersion>1</portaloneapp:ApplicationVersion>
         <portaloneapp:AttachmentsChanged>false</portaloneapp:AttachmentsChanged>
         <portaloneapp:Payment>


### PR DESCRIPTION
Reverts change from yesterday that Kev initially thought was fine, but actually prevents a record from being created :cyclone: 

Once merged, Kev can send test submissions from staging again.

(I'm deeply sorry this is PR 1000 :clown_face:)