### PR TITLE
fix: X & Y coords need to be rounded to whole numbers in Uniform XML schema

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -212,8 +212,8 @@ export function makeXmlString(
           }</bs7666:UniquePropertyReferenceNumber>
         </bs7666:BS7666Address>
         <common:SiteGridRefence>
-          <bs7666:X>${passport.data?.["_address"]?.["x"]}</bs7666:X>
-          <bs7666:Y>${passport.data?.["_address"]?.["y"]}</bs7666:Y>
+          <bs7666:X>${Math.round(passport.data?.["_address"]?.["x"])}</bs7666:X>
+          <bs7666:Y>${Math.round(passport.data?.["_address"]?.["y"])}</bs7666:Y>
         </common:SiteGridRefence>
       </portaloneapp:SiteLocation>
       ${getApplicationType()}


### PR DESCRIPTION
Southwark was failing on this address because there was a decimal in the `<bs7666:X>` & `<bs7666:Y>` coords: 160 Tooley St, London SE1 2QH. Applications for addresses with whole number coordinates can be successfully downloaded.

Turns out Uniform only wants to know _approximately_ where the project site is located :triangular_ruler:

`<portaloneapp:SchemaVersion>`, `<common:AmountDue>` and `<common:AmountPaid>` can still accept decimals as far as we know so far. Kev says "To check the fee I have to now email Southwark IT guy then get him to check the test environment there then wait for his email back then can let you know" :see_no_evil: 