### PR TITLE
feat: Encrypt user-data S3 bucket at rest

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -43,6 +43,7 @@ const apiBucket = new aws.s3.Bucket("user-data", {
       maxAgeSeconds: 3000,
     },
   ],
+  // Encrypt objects at rest using SSE-S3 encryption
   serverSideEncryptionConfiguration: {
     rule: {
       applyServerSideEncryptionByDefault: {


### PR DESCRIPTION
## What does this PR do?
 - Ensures that any  _new_ files uploaded by users to the `user-data` bucket will be encrypted at rest

**Docs**
 - Pulumi docs - https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucket/#enable-default-server-side-encryption
 - AWS S3 Server side encryption - https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html

**Context**
From reading the Pulumi and S3 docs I initially thought that we needed to use SSE-KMS to manage this, and spent a bit of time reading up on that. We can use the default SSE-S3 method, and I don't think that SE-KMS is necessary for or use case for PlanX currently. A decent summary of the differences is given here - https://stackoverflow.com/a/63478717

Fundamentally what I expect to happen is that...
 - An uploaded file is encrypted at rest using the SSE-S3 method
 - AWS will automatically decrypt the file for anybody with permission to access it

The Pulumi docs are a little sparse on what the `applyServerSideEncryptionByDefault` rule is doing under the hood, but once on staging I'll try to test this to see how it's applied (e.g. can it be bypassed by uploading via CLI, or console etc). If so, we can specify a bucket policy to restrict this. Example here - https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html

This will need to be merged to staging to actually test. 

Obviously this functionality overlaps with https://github.com/theopensystemslab/planx-new/pull/940 - I'd be in favour of merging that PR first in order to properly test this.

**To test on staging**
 - [ ] Is a user uploaded file encrypted at rest?
 - [ ] Can I still access it in the expected way?
 - [ ] Can I bypass the Pulumi rules and upload a file which is not encrypted (e.g. through CLI, console, REST API).