### PR TITLE
fix: Set default destination for Send component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -36,12 +36,15 @@ const SendComponent: React.FC<Props> = ({ destination = DEFAULT_DESTINATION, ...
 
   const destinationUrl = `${process.env.REACT_APP_API_URL}/${destination}/${teamSlug}`;
 
+  const params = {
+    [Destination.BOPS]: getParams(breadcrumbs, flow, passport, sessionId),
+    [Destination.Uniform]: getUniformParams(breadcrumbs, flow, passport, sessionId)
+  }[destination];
+
   const request = useAsync(async () =>
     axios.post(
       useStagingUrlIfTestApplication(passport)(destinationUrl),
-      destination === Destination.BOPS
-        ? getParams(breadcrumbs, flow, passport, sessionId)
-        : getUniformParams(breadcrumbs, flow, passport, sessionId)
+      params
     )
   );
 


### PR DESCRIPTION
Raised by Emily here - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1658142961773389

In this example, which I can recreate, sending a submission via [this flow](https://editor.planx.dev/buckinghamshire/apply-for-a-certificate-of-lawfulness/unpublished) flow results in `props.destination` being `undefined`.

The reason for this is that `destination` has not been saved as part of the flow data.

This ultimately results in a Uniform submission being sent to `${process.env.REACT_APP_API_URL}/undefined/${teamSlug}` which results in a 404.

I think manually saving each send component could also fix this as the default will also be populated that way, but this felt more explicit and allows us to better understand the flow of logic in the component (for example, if `props.destination = undefined`, it's a Uniform submission which gets generated).