### PR TITLE
fix: Send all uploaded files to Uniform

### DIFF
--- a/api.planx.uk/send.js
+++ b/api.planx.uk/send.js
@@ -131,6 +131,7 @@ async function createZip(stringXml, csv, files, sessionId) {
       for (let file of files) {
         // Ensure unique filename by combining original filename and S3 folder name, which is a nanoid
         // Uniform requires all uploaded files to be present in the zip, even if they are duplicates
+        // Must match unique filename in editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
         const uniqueFilename = file.split("/").slice(-2).join("-");
         const filePath = path.join(tmpDir, uniqueFilename);
         await downloadFile(file, filePath, zip);

--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -40,7 +40,7 @@ export function makeXmlString(
 
   const userUploadedFiles: string[] = [];
   files?.forEach((file) => {
-    // Must match the uniqueFilename generated in send.js
+    // Must match the unique filename in api.planx.uk/send.js
     const uniqueFilename = file.split("/").slice(-2).join("-");
     userUploadedFiles.push(`
       <common:FileAttachment>


### PR DESCRIPTION
**Context**
Currently, if files with the same name are uploaded as part of an application (e.g. `plans.pdf`), only a single one is zipped and sent to Uniform. Presumably this is as each one is overwritten as we iterate over the files. 

I've tested with Kev, and Uniform requires all files to be present and sent as part of the zip (so we couldn't compare something like a checksum to see if a file is _actually_ unique).

**Solution**
Format the filename by combining the S3 folder name (which is a `nanoid()`) and the original filename to ensure uniqueness.

Example generated zip file attached - [ripa-test-40574641-ac4e-43f6-ae6f-a3f4efe4090d.zip](https://github.com/theopensystemslab/planx-new/files/9135364/ripa-test-40574641-ac4e-43f6-ae6f-a3f4efe4090d.zip)