### PR TITLE
docs: point to URL where devops user can create CloudFlare tokens

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -20,6 +20,7 @@ const networking = new pulumi.StackReference(`planx/networking/${env}`);
 const data = new pulumi.StackReference(`planx/data/${env}`);
 
 // The @pulumi/cloudflare package doesn't generate errors so this is here just to create a warning in case the CloudFlare API token is missing.
+// You can generate tokens here: https://dash.cloudflare.com/profile/api-tokens
 new pulumi.Config("cloudflare").require("apiToken");
 
 export = async () => {


### PR DESCRIPTION
Small documentation improvement.
