### PR TITLE
fix: Drop defaultValue prop from CollapsibleInput

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/FeedbackInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FeedbackInput.tsx
@@ -7,7 +7,6 @@ interface Props {
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   value: string;
   text: string;
-  defaultValue?: string;
 }
 
 const FeedbackInput: React.FC<Props> = ({ text, ...componentProps }: Props) => (

--- a/editor.planx.uk/src/ui/CollapsibleInput.tsx
+++ b/editor.planx.uk/src/ui/CollapsibleInput.tsx
@@ -9,7 +9,6 @@ export interface Props {
   children: JSX.Element[] | JSX.Element;
   handleChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   value: string;
-  defaultValue?: string;
   name: string;
 }
 
@@ -41,7 +40,6 @@ const CollapsibleInput: React.FC<Props> = (props: Props) => {
           <Input
             multiline
             bordered
-            defaultValue={props.defaultValue || ""}
             value={props.value}
             name={props.name}
             onChange={props.handleChange}


### PR DESCRIPTION
**Context**
Currently, the `FindProperty` component raises the following console error - 

```
Warning: ForwardRef(TextareaAutosize) contains a textarea with both value and defaultValue props. 
Textarea elements must be either controlled or uncontrolled (specify either the value prop, or the 
defaultValue prop, but not both). Decide between using a controlled or uncontrolled textarea and 
remove one of these props. More info: https://reactjs.org/link/controlled-components
    at textarea
    at TextareaAutosize (http://localhost:3000/static/js/bundle.js:27677:24)
```

![image](https://user-images.githubusercontent.com/20502206/179734651-e1885d41-7617-4656-a478-ac39e18f6532.png)

This was likely introduced in the following PR where this component was created - https://github.com/theopensystemslab/planx-new/pull/946/files


**Solution**
I've simply removed the `defaultValue` prop for now - it wasn't being used anywhere.

If we wanted to set a "default value" for this component we could do this by initially setting the `value` property and controlling this via state as described here - https://reactjs.org/link/controlled-components