### PR TITLE
chore: Update Wycombe Uniform credentials (Production)

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -43,7 +43,7 @@ config:
   application:uniform-client-southwark:
     secure: AAABAPU5mofUcMemIN579HhHs8LVwH/ikqLTUinpj1qNmmesfZUBKRrPUUtTuqJ7B0YDnxNB8uZb8UkGy5y8
   application:uniform-client-wycombe:
-    secure: AAABAOekVYcOih6KmOn6s2PYUGydT6i8FRSLw2jfFj5qt2uPs9QbZrmqbvvH8OVLuKKpfGcKnN1W9YXsHQ==
+    secure: AAABABSDO6aSlHFLy4RclrYJDIKNQdlgDo12EeGDzuMD325xo//ABR0yGFl4DzuyU+33TtrAwqgvtxZe1Q==
   application:uniform-submission-url: https://identity.idoxgroup.com/agw/submission-api
   application:uniform-token-url: https://identity.idoxgroup.com/uaa/oauth/token
   aws:region: eu-west-2


### PR DESCRIPTION
Credentials supplied by Uniform via Kev.

Credentials for both stacks have been checked using `pulumi config get uniform-client-wycombe -s <STACK>`

This reintroduced this change originally made here - https://github.com/theopensystemslab/planx-new/pull/1012

This was incorrectly overwritten whilst merging conflicts between `main` and `production` in this commit - https://github.com/theopensystemslab/planx-new/commit/065bbcd597cb7d71c0842de1c6ffc00f82c906bf