### PR TITLE
docs: add links to status pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## https://editor.planx.uk
 
+### Status pages
+
+- Staging: https://status.planx.dev
+- Production: https://status.planx.uk
+- GIS: https://gis-status.planx.uk (pass: `geography!`)
+
 ### Running Locally
 
 1. [Download and install Docker](https://docs.docker.com/get-docker/) if you don't have it already


### PR DESCRIPTION
I've thought this would be a better place to store this info, as opposed to pinned slack messages.

I'm wondering if we can remove the password from the GIS status page.
