### PR TITLE
chore: remove Uniform feature flag

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -1,5 +1,4 @@
 import { useFormik } from "formik";
-import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import Input from "ui/Input";
 import InputRow from "ui/InputRow";
@@ -24,20 +23,16 @@ const SendComponent: React.FC<Props> = (props) => {
     },
   });
 
-  // only show radio buttons if we have support > 1 destination
-  let options: { value: string; label: string }[] = [];
-  if (hasFeatureFlag("SEND_TO_UNIFORM")) {
-    options = [
-      {
-        value: "bops",
-        label: "BOPS",
-      },
-      {
-        value: "uniform",
-        label: "Uniform",
-      },
-    ];
-  }
+  let options: { value: string; label: string }[] = [
+    {
+      value: "bops",
+      label: "BOPS",
+    },
+    {
+      value: "uniform",
+      label: "Uniform",
+    },
+  ];
 
   return (
     <form onSubmit={formik.handleSubmit} id="modal">

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["SAVE_AND_RETURN", "SEND_TO_UNIFORM"] as const;
+const AVAILABLE_FEATURE_FLAGS = ["SAVE_AND_RETURN"] as const;
 
 type featureFlag = typeof AVAILABLE_FEATURE_FLAGS[number];
 


### PR DESCRIPTION
Uniform submissions work & all secrets are configured for prod & staging :rocket: 

Existing "Send" components will still default to "BOPS" destination when this is merged, but will now have an extra option to select "Uniform" as a destination when adding/updating. 