### PR TITLE
chore: Drop Save and Return feature flag

### DIFF
--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["SAVE_AND_RETURN"] as const;
+const AVAILABLE_FEATURE_FLAGS = [] as const;
 
 type featureFlag = typeof AVAILABLE_FEATURE_FLAGS[number];
 

--- a/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
+++ b/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
@@ -118,16 +118,11 @@ const PreviewLayout: React.FC<{
         "Are you sure you want to restart? This will delete your previous answers"
       )
     ) {
-      if (hasFeatureFlag("SAVE_AND_RETURN")) {
-        // don't delete old flow for now
-        // await NEW_LOCAL.clearLocalFlow(sessionId)
-        const url = new URL(window.location.href);
-        url.searchParams.delete("sessionId");
-        window.location.href = url.href;
-      } else {
-        clearLocalFlow(id);
-        window.location.reload();
-      }
+      // don't delete old flow for now
+      // await NEW_LOCAL.clearLocalFlow(sessionId)
+      const url = new URL(window.location.href);
+      url.searchParams.delete("sessionId");
+      window.location.href = url.href;
     }
   };
 

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -3,8 +3,6 @@ import ButtonBase from "@material-ui/core/ButtonBase";
 import { makeStyles } from "@material-ui/core/styles";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import classnames from "classnames";
-import { hasFeatureFlag } from "lib/featureFlags";
-import { getLocalFlow, setLocalFlow } from "lib/local";
 import * as NEW from "lib/local.new";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
@@ -82,57 +80,31 @@ const Questions = ({ previewEnvironment, settings }: QuestionsProps) => {
   const classes = useClasses();
   const [gotFlow, setGotFlow] = useState(false);
 
-  if (hasFeatureFlag("SAVE_AND_RETURN")) {
-    useEffect(() => {
-      setPreviewEnvironment(previewEnvironment);
-      if (isStandalone) {
-        NEW.getLocalFlow(sessionId).then((state) => {
-          if (state) {
-            resumeSession(state);
-          }
-          createAnalytics(state ? "resume" : "init");
-          setGotFlow(true);
-        });
-      }
-    }, []);
-
-    useEffect(() => {
-      if (gotFlow && isStandalone && sessionId) {
-        NEW.setLocalFlow(sessionId, {
-          breadcrumbs,
-          // todo: replace `id` with `flow: { id, published_flow_id }`
-          id,
-          passport,
-          sessionId,
-          govUkPayment,
-        });
-      }
-    }, [gotFlow, breadcrumbs, passport, sessionId, id, govUkPayment]);
-  } else {
-    useEffect(() => {
-      setPreviewEnvironment(previewEnvironment);
-      if (isStandalone) {
-        const state = getLocalFlow(id);
+  useEffect(() => {
+    setPreviewEnvironment(previewEnvironment);
+    if (isStandalone) {
+      NEW.getLocalFlow(sessionId).then((state) => {
         if (state) {
           resumeSession(state);
         }
         createAnalytics(state ? "resume" : "init");
         setGotFlow(true);
-      }
-    }, []);
+      });
+    }
+  }, []);
 
-    useEffect(() => {
-      if (gotFlow && isStandalone && id) {
-        setLocalFlow(id, {
-          breadcrumbs,
-          id,
-          passport,
-          sessionId,
-          govUkPayment,
-        });
-      }
-    }, [gotFlow, breadcrumbs, passport, sessionId, id, govUkPayment]);
-  }
+  useEffect(() => {
+    if (gotFlow && isStandalone && sessionId) {
+      NEW.setLocalFlow(sessionId, {
+        breadcrumbs,
+        // todo: replace `id` with `flow: { id, published_flow_id }`
+        id,
+        passport,
+        sessionId,
+        govUkPayment,
+      });
+    }
+  }, [gotFlow, breadcrumbs, passport, sessionId, id, govUkPayment]);
 
   const handleSubmit =
     (id: string): handleSubmit =>

--- a/editor.planx.uk/src/routes/utils.test.tsx
+++ b/editor.planx.uk/src/routes/utils.test.tsx
@@ -84,9 +84,6 @@ const mockSendFlow = {
 };
 
 describe("isSaveReturnFlow helper function", () => {
-  beforeAll(() => (window as any).featureFlags.toggle("SAVE_AND_RETURN"));
-  afterAll(() => (window as any).featureFlags.toggle("SAVE_AND_RETURN"));
-
   it("correctly identifies flows with a 'Send' node", () => {
     expect(isSaveReturnFlow(mockSendFlow)).toEqual(true);
   });
@@ -97,14 +94,9 @@ describe("isSaveReturnFlow helper function", () => {
 });
 
 describe("setPath helper function", () => {
-  beforeAll(() => {
-    initialState = getState();
-    (window as any).featureFlags.toggle("SAVE_AND_RETURN");
-  });
+  beforeAll(() => initialState = getState());
 
   afterEach(() => waitFor(() => setState(initialState)));
-
-  afterAll(() => (window as any).featureFlags.toggle("SAVE_AND_RETURN"));
 
   it("correctly sets the path for a 'Save/Return' user journey", () => {
     const mockNaviRequest = { params: {} } as unknown as NaviRequest;

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -1,5 +1,4 @@
 import { TYPES as NodeTypes } from "@planx/components/types";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { NaviRequest } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { ApplicationPath } from "types";
@@ -13,7 +12,6 @@ export const rootFlowPath = (includePortals = false) => {
 };
 
 export const isSaveReturnFlow = (flowData: Record<string, any>): Boolean =>
-  hasFeatureFlag("SAVE_AND_RETURN") &&
   Boolean(
     Object.values(flowData).find(
       (node: Record<string, any>) => node.type === NodeTypes.Send


### PR DESCRIPTION
**What does this PR do?**
 - Removes the `SAVE_AND_RETURN` feature flag, and associated logic

**Question**
 - Is this actually what we want to do?
 - Would be benefit from just toggling the feature flag logic so that we can turn off Save & Return as devs - what would be the risk here?