### PR TITLE
chore: Remove feat/save-and-return branch from GitHub actions

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -4,7 +4,6 @@ on:
     types: [opened, synchronize]
     branches:
       - main
-      - feat/save-and-return # TODO: Delete when feature branch merged
 
 env:
   DOMAIN: planx.pizza


### PR DESCRIPTION
**What does this PR do?**
 - Updates our GitHub action which runs when pull requests are opened
 - This change means that Pizzas only get created if a PR is pointing to `main`