### PR TITLE
fix: adjust CSV rows to include sessionId & payment/send references

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/index.ts
@@ -89,8 +89,32 @@ export function makeCsvData(
     });
   });
 
-  // concat into single list, each object will be row in CSV
-  return formattedSummary
+  // gather key reference fields, these will be first rows of CSV
+  const references: { question: string; responses: any }[] = [
+    {
+      question: "Planning Application Reference", // match language used on Confirmation page
+      responses: sessionId,
+    },
+  ];
+
+  // check if the passport has payment or submission ids, add them as reference rows if exist
+  const conditionalKeys = [
+    "application.fee.reference.govPay",
+    "bopsId",
+    "idoxSubmissionId",
+  ];
+  conditionalKeys.forEach((key) => {
+    if (passport.data?.[key]) {
+      references.push({
+        question: key,
+        responses: passport.data?.[key],
+      });
+    }
+  });
+
+  // concat data sections into single list, each object will be row in CSV
+  return references
+    .concat(formattedSummary)
     .concat(bopsData["proposal_details"] || [])
     .concat(formattedFiles);
 }


### PR DESCRIPTION
This helps make the CSV a bit more usable by Uniform officers by adding a couple extra rows to the top of the CSV to capture key reference fields. This will always include the RIPA sessionId and will also include payment & send references if those exist in our passport (eg we expect them to if downloading CSV from final Confirmation page, but not if downloading in-progress CSV during save+return). 

Kev additonally asked for fields to be removed from the CSV - including all site address info, geojson, and the result - but I'm not doing that yet (hoping to avoid altogether?)