### PR TITLE
fix: Downgrade passport back to 0.5.3

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -26,7 +26,7 @@
     "mime": "^3.0.0",
     "nanoid": "^3.3.4",
     "notifications-node-client": "^5.1.1",
-    "passport": "^0.6.0",
+    "passport": "^0.5.3",
     "passport-google-oauth20": "^2.0.0",
     "pino-noir": "^2.2.1",
     "string-to-stream": "^3.0.1"

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -37,7 +37,7 @@ specifiers:
   nock: ^13.2.9
   node-dev: ^7.4.3
   notifications-node-client: ^5.1.1
-  passport: ^0.6.0
+  passport: ^0.5.3
   passport-google-oauth20: ^2.0.0
   pino-noir: ^2.2.1
   prettier: ~2.7.1
@@ -68,7 +68,7 @@ dependencies:
   mime: 3.0.0
   nanoid: 3.3.4
   notifications-node-client: 5.1.1
-  passport: 0.6.0
+  passport: 0.5.3
   passport-google-oauth20: 2.0.0
   pino-noir: 2.2.1
   string-to-stream: 3.0.1
@@ -4231,13 +4231,12 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /passport/0.6.0:
-    resolution: {integrity: sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==}
+  /passport/0.5.3:
+    resolution: {integrity: sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       passport-strategy: 1.0.0
       pause: 0.0.1
-      utils-merge: 1.0.1
     dev: false
 
   /path-exists/4.0.0:


### PR DESCRIPTION
Undoes changes made in this commit - https://github.com/theopensystemslab/planx-new/pull/1033/commits/22dad6cc82a5776a314da407c5dbb363505519e6

Issue described here - https://github.com/jaredhanson/passport/issues/904

Initially I thought this was a conflict caused by cookie-session v2, which is maybe not the cause of the issue. I'll separately try to update that and test. Discussion here that triggered this belief...! https://github.com/jaredhanson/passport/issues/907

We'll have to keep an eye on this one as there is a CVE associated with this package/version (I'll maybe add to Slack for now like Hasura until we sort out dependabot?). There is an override in the `package.json` which should keep up on the safe side here however so no immediate worries 👍 

 - CVE - https://github.com/advisories/GHSA-f794-r6xc-hf3v

**To test...**
 - I can log in to pizza
 - I can log out of pizza
 - I can repeat the above many times