### PR TITLE
fix: restrict a user from drawing a site boundary and uploading a location plan

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -40,6 +40,9 @@ const useClasses = makeStyles((theme) => ({
     "& button:hover": {
       backgroundColor: theme.palette.background.paper,
     },
+    "& button:disabled": {
+      color: theme.palette.text.disabled,
+    },
   },
 }));
 
@@ -141,11 +144,12 @@ export default function Component(props: Props) {
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
           </Box>
-          {!props.hideFileUpload && !Boolean(boundary) && (
+          {!props.hideFileUpload && (
             <div className={classes.uploadInstead}>
               <button
                 data-testid="upload-file-button"
                 onClick={() => setPage("upload")}
+                disabled={Boolean(boundary)}
               >
                 Upload a location plan instead
               </button>
@@ -169,13 +173,14 @@ export default function Component(props: Props) {
             definitionImg={props.definitionImg}
           />
           <Upload setFile={setSelectedFile} initialFile={selectedFile} />
-          {!Boolean(selectedFile?.url) && (
-            <div className={classes.uploadInstead}>
-              <Button onClick={() => setPage("draw")}>
-                Draw the boundary on a map instead
-              </Button>
-            </div>
-          )}
+          <div className={classes.uploadInstead}>
+            <Button
+              onClick={() => setPage("draw")}
+              disabled={Boolean(selectedFile?.url)}
+            >
+              Draw the boundary on a map instead
+            </Button>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
Based on recent reply from BOPS here (they talked internally after yesterday's dev call and actually _do_ want it restricted :cyclone:): https://ripahq.slack.com/archives/C0182MVK4AW/p1658827590556379

**What this does:**
Once the drawing is complete, we disable the "Upload a file instead" button so the user can only click "Continue". If you erase the drawing, the button is re-enabled. 

And vice versa: once a file is uploaded, disable the "Draw on a map instead" button, forcing the user to "Continue". If you remove your uploaded file, the button is re-enabled.

Conditionally disabling buttons probably isn't the most ideal for accessibility (albeit better than hiding/re-rendering them altogether?), but I think it's the simplest way to restrict two inputs in the short term.