### PR TITLE
fix: adjust HASURA_GRAPHQL_CORS_DOMAIN in pulumi

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -200,7 +200,7 @@ export = async () => {
     },
   });
   // Configure white-listed domains; Pulumi doesn't need to support "localhost" or introspection but root .env should
-  const HASURA_DOMAINS = `http://api:${DOMAIN}, https://*.planx.uk, https://*.planx.dev, https://*.planx.pizza, https://*.gov.uk`;
+  const HASURA_DOMAINS = `http://*.${DOMAIN}, https://*.${DOMAIN}, https://${DOMAIN}`;
   const hasuraListenerHttps = targetHasura.createListener("hasura-https", {
     protocol: "HTTPS",
     certificateArn: certificates.requireOutput("certificateArn"),


### PR DESCRIPTION
Now, this will whitelist: 
- `http://*.${DOMAIN}` - covers Hasura to API requests within Docker (eg `http://api.planx.dev`, which is `http://api:7002` locally)
- `https://*.${DOMAIN}` - covers public domains (eg `https://api.planx.dev`)
- `https://${DOMAIN}` - covers custom subdomains (eg `https://planningservices.southwark.gov.uk`, but not `https://api.planningservices.southwark.gov.uk`)

Continues #1039 