### PR TITLE
fix: add single line address as separate CSV row

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/index.ts
@@ -98,10 +98,10 @@ export function makeCsvData(
     {
       question: "Property Address",
       responses: [
-        bopsData.site.address_1,
-        bopsData.site.address_2,
-        bopsData.site.town,
-        bopsData.site.postcode,
+        bopsData.site?.address_1,
+        bopsData.site?.address_2,
+        bopsData.site?.town,
+        bopsData.site?.postcode,
       ]
         .filter(Boolean)
         .join(" ")


### PR DESCRIPTION
New CSV request from Kev this morning - to show the single line address directly under Planning Application Reference as its own row because the "site" data currently comes through in the CSV as a dictionary. 

