### PR TITLE
chore(infra): Update HTTP/HTTPS listener SSL policy

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -111,6 +111,7 @@ export = async () => {
   // Forward HTTP to HTTPS
   const metabaseListenerHttp = targetMetabase.createListener("metabase-http", {
     protocol: "HTTP",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -124,6 +125,7 @@ export = async () => {
     "metabase-https",
     {
       protocol: "HTTPS",
+      sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
       certificateArn: certificates.requireOutput("certificateArn"),
     }
   );
@@ -190,6 +192,7 @@ export = async () => {
   // Forward HTTP to HTTPS
   const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
     protocol: "HTTP",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -203,6 +206,7 @@ export = async () => {
   const HASURA_DOMAINS = `http://*.${DOMAIN}, https://*.${DOMAIN}, https://${DOMAIN}`;
   const hasuraListenerHttps = targetHasura.createListener("hasura-https", {
     protocol: "HTTPS",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     certificateArn: certificates.requireOutput("certificateArn"),
   });
   const hasuraService = new awsx.ecs.FargateService("hasura", {
@@ -318,6 +322,7 @@ export = async () => {
   // Forward HTTP to HTTPS
   const apiListenerHttp = targetApi.createListener("api-http", {
     protocol: "HTTP",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -329,6 +334,7 @@ export = async () => {
   });
   const apiListenerHttps = targetApi.createListener("api-https", {
     protocol: "HTTPS",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     certificateArn: certificates.requireOutput("certificateArn"),
   });
   const apiService = new awsx.ecs.FargateService("api", {
@@ -459,6 +465,7 @@ export = async () => {
   // Forward HTTP to HTTPS
   const sharedbListenerHttp = targetSharedb.createListener("sharedb-http", {
     protocol: "HTTP",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -470,6 +477,7 @@ export = async () => {
   });
   const sharedbListenerHttps = targetSharedb.createListener("sharedb-https", {
     protocol: "HTTPS",
+    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     certificateArn: certificates.requireOutput("certificateArn"),
   });
   const sharedbService = new awsx.ecs.FargateService("sharedb", {


### PR DESCRIPTION
- New policy should exclude TLS1.0 and TLS1.1
- Addresses Jumpsec feedback here - https://trello.com/c/hpoWjXK9/2003-fix-ssl-tls-vulnerabilities
- Default policy is "ELBSecurityPolicy-2016-08" which supports TLS1.0 & TLS1.1
- AWS docs here - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
- It's possible this isn't needed on HTTP which just redirects to HTTPS

**To test**
Currently staging and production environments for API/Hasura/Metabase/ShareDB allow a handshake using TLS1.0 & TLS1.2.

This can be done with `openssl s_client -connect {DOMAIN}:443 -tls{VERSION}`, e.g. `openssl s_client -connect hasura.editor.planx.dev:443 -tls1_1` and `openssl s_client -connect hasura.editor.planx.dev:443 -tls1`

Once merged to staging, I'd expect the two above commands to return an error - handshake failed.