### PR TITLE
chore(infra): Remove sslPolicy from HTTP listeners

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -111,7 +111,6 @@ export = async () => {
   // Forward HTTP to HTTPS
   const metabaseListenerHttp = targetMetabase.createListener("metabase-http", {
     protocol: "HTTP",
-    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -192,7 +191,6 @@ export = async () => {
   // Forward HTTP to HTTPS
   const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
     protocol: "HTTP",
-    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -322,7 +320,6 @@ export = async () => {
   // Forward HTTP to HTTPS
   const apiListenerHttp = targetApi.createListener("api-http", {
     protocol: "HTTP",
-    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {
@@ -465,7 +462,6 @@ export = async () => {
   // Forward HTTP to HTTPS
   const sharedbListenerHttp = targetSharedb.createListener("sharedb-http", {
     protocol: "HTTP",
-    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
     defaultAction: {
       type: "redirect",
       redirect: {


### PR DESCRIPTION
Previous PR (#1049) failing at Pulumi Up step, despite succeeding at pulumi preview.

sslPolicy cannot be specified for HTTP listeners, only HTTP.

```
api-http (aws:lb:ApplicationLoadBalancer$awsx:lb:ApplicationTargetGroup$awsx:lb:ApplicationListener$aws:lb/listener:Listener)
error: 1 error occurred:
	* updating urn:pulumi:staging::application::aws:lb:ApplicationLoadBalancer$awsx:lb:ApplicationTargetGroup$awsx:lb:ApplicationListener$aws:lb/listener:Listener::api-http: 1 error occurred:
	* error modifying ELBv2 Listener (arn:aws:elasticloadbalancing:eu-west-2:781751952389:listener/app/api-e0cca30/05545e752c374e34/9b738aebdbc589f0): ValidationError: An SSL policy cannot be specifed for HTTP listeners
	status code: 400, request id: d29842a2-fd14-48ff-9554-d8aba174bdbf
```