### PR TITLE
fix: adjust passport <> XML mapping for Uniform

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -61,8 +61,10 @@ export function makeXmlString(
   });
 
   const getApplicationType = (): string => {
-    const planXAppType: PlanXAppTypes =
-      passport.data?.["application.type"] || "ldc.existing";
+    const passportValue = passport.data?.["application.type"][0];
+    const planXAppType: PlanXAppTypes = passportValue.startsWith("ldc.existing")
+      ? "ldc.existing"
+      : "ldc.proposed";
     const uniformAppType: UniformAppTypes = appTypeLookup[planXAppType];
 
     return `
@@ -76,7 +78,7 @@ export function makeXmlString(
   };
 
   const getCertificateOfLawfulness = () => {
-    const planXAppType: PlanXAppTypes = passport.data?.["application.type"];
+    const planXAppType: PlanXAppTypes = passport.data?.["application.type"][0];
     if (planXAppType === "ldc.proposed") {
       return `
         <portaloneapp:CertificateLawfulness>
@@ -217,9 +219,6 @@ export function makeXmlString(
           </common:Telephone>
         </common:ContactDetails>
       </portaloneapp:Applicant>
-      ${
-        /* TODO: Check for "application.agent.." || "applicant.proxy.." variables in this section??  */ ""
-      }
       <portaloneapp:Agent>
         <common:PersonName>
         <pdt:PersonNameTitle>${


### PR DESCRIPTION
See #mvp-issues thread https://ripahq.slack.com/archives/C0241GWFG4B/p1659025295627379

- [x] Applicant/agent address are dictionaries in the passport, not period-seperated passport variable names
- [x] Application type is a one-item array in the passport, not a string, therefore `getCertificateOfLawfulness()` was only returning the default template which would be missing descriptions in "proposed" cases
- [x] Adjust `planXAppType` to account for third granular passport type (not flagged in Em & Kev's testing, but did throw an error that it couldn't be mapped to an existing scenario number)
