### PR TITLE
feat(api): Add helmet middleware to Express

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -20,6 +20,7 @@
     "form-data": "^4.0.0",
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
+    "helmet": "^5.1.1",
     "http-proxy-middleware": "^2.0.6",
     "isomorphic-fetch": "^3.0.0",
     "jsondiffpatch": "^0.4.1",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -27,6 +27,7 @@ specifiers:
   graphql: ^16.5.0
   graphql-query-test-mock: ^0.12.1
   graphql-request: ^4.3.0
+  helmet: ^5.1.1
   http-proxy-middleware: ^2.0.6
   isomorphic-fetch: ^3.0.0
   jest: ^28.1.3
@@ -63,6 +64,7 @@ dependencies:
   form-data: 4.0.0
   graphql: 16.5.0
   graphql-request: 4.3.0_graphql@16.5.0
+  helmet: 5.1.1
   http-proxy-middleware: 2.0.6
   isomorphic-fetch: 3.0.0
   jsondiffpatch: 0.4.1
@@ -2653,6 +2655,11 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+
+  /helmet/5.1.1:
+    resolution: {integrity: sha512-/yX0oVZBggA9cLJh8aw3PPCfedBnbd7J2aowjzsaWwZh7/UFY0nccn/aHAggIgWUFfnykX8GKd3a1pSbrmlcVQ==}
+    engines: {node: '>=12.0.0'}
+    dev: false
 
   /hexoid/1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}

--- a/api.planx.uk/server.js
+++ b/api.planx.uk/server.js
@@ -18,6 +18,7 @@ const {
   responseInterceptor,
   fixRequestBody,
 } = require("http-proxy-middleware");
+const helmet = require('helmet')
 
 const { signS3Upload } = require("./s3");
 const { locationSearch } = require("./gis/index");
@@ -254,6 +255,9 @@ if (process.env.NODE_ENV !== "test") {
 
 // Rate limit requests per IP address
 app.use(apiLimiter);
+
+// Secure Express by setting various HTTP headers
+app.use(helmet());
 
 assert(process.env.BOPS_API_ROOT_DOMAIN);
 assert(process.env.BOPS_API_TOKEN);


### PR DESCRIPTION
## Context
 - The Jumpsec pen test report requires that HTTP Strict Transport Security (HSTS) is enabled on the API
 - Express recommends using Helmet to achieve this - https://expressjs.com/en/advanced/best-practice-security.html
 - Helmet adds the required `Strict-Transport-Security` header

**To test**
 - API response headers on staging/prod **do not** have the `Strict-Transport-Security` header ❌ 
 - API response headers on staging/prod **do** have the `Strict-Transport-Security` header ✅ 

<img width="563" alt="image" src="https://user-images.githubusercontent.com/20502206/181623622-8d242c21-b9fb-4795-8885-10cdf1feda6d.png">

N.B. There are probably other useful recommendations on the Express "Security Best Practices" page 🤔 
