### PR TITLE
fix: Proxy Hasura through Cloudflare to enable HSTS

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -260,7 +260,7 @@ export = async () => {
     zoneId: config.require("cloudflare-zone-id"),
     value: hasuraListenerHttps.endpoint.hostname,
     ttl: 1,
-    proxied: false,
+    proxied: true,
   });
 
   // ----------------------- API


### PR DESCRIPTION
See discussion on #planx-dev here - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1659094963776539

In order for Cloudflare to control HSTS, Hasura must be proxied through it.

Very much a test!