### PR TITLE
fix: add Keep Alive Timeout to API server

### DIFF
--- a/api.planx.uk/server.js
+++ b/api.planx.uk/server.js
@@ -635,6 +635,9 @@ app.use(
 
 const server = new Server(app);
 
+server.keepAliveTimeout = 30000; // 30s
+server.headersTimeout = 35000; // 35s
+
 function useProxy(options = {}) {
   return createProxyMiddleware({
     changeOrigin: true,


### PR DESCRIPTION
Folks are reporting very laggy service while sending to two destinations, let's see if these headers make it feel any better https://ripahq.slack.com/archives/C0241GWFG4B/p1659109398235649

Should be test-able on pizza without merging.

Notes:
- Should confirm that AWS doesn't have defaults that are lower than what I've set here https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html (60s default here)
- Message queue still feels like ultimate direction here, but this could help ease UX in the interim