### PR TITLE
fix: Airbrake should label custom subdomains as "production" errors, not "pullrequest"

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -8,10 +8,12 @@ export const airbrake =
     ? new Notifier({
         projectId: Number(process.env.REACT_APP_AIRBRAKE_PROJECT_ID),
         projectKey: process.env.REACT_APP_AIRBRAKE_PROJECT_KEY,
-        environment: window.location.host.endsWith("planx.uk")
-          ? "production"
-          : window.location.host.endsWith("planx.dev")
-          ? "staging"
-          : "pullrequest",
+        environment:
+          window.location.host.endsWith("planx.uk") ||
+          window.location.host.endsWith("gov.uk")
+            ? "production"
+            : window.location.host.endsWith("planx.dev")
+            ? "staging"
+            : "pullrequest",
       })
     : undefined;


### PR DESCRIPTION
Showed up here https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1659354779979809
![Screenshot from 2022-08-01 14-08-15](https://user-images.githubusercontent.com/5132349/182144486-73af1ec7-8fdc-441f-a1e1-8c4aaee27708.png)

