### PR TITLE
fix: Call useTeamSlug() hook in component body

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -182,13 +182,14 @@ const ResumePage: React.FC = () => {
     if (email) handleSubmit();
   }, [email]);
 
+  const teamSlug = useTeamSlug();
+
   /**
    * Send magic link to user, based on submitted email
    * Sets page status based on validation of request by API
    */
   const sendResumeEmail = async () => {
     const url = `${process.env.REACT_APP_API_URL}/resume-application`;
-    const teamSlug = useTeamSlug();
     const data = {
       payload: { email, teamSlug },
     };


### PR DESCRIPTION
Addresses https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3330627207956635393

Fix - change scope of `useTeamSlug()` hook to ensure it's called in component body, and not inside helper function `sendResumeEmail()`. 

Error can occur since PR #1036.