### PR TITLE
fix: ensure `insert_session_backups_one` mutation is available to public user

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -159,7 +159,6 @@
           - email
           - flow_id
           - id
-        backend_only: false
   select_permissions:
     - role: public
       permission:
@@ -310,6 +309,13 @@
           - flow_id
           - session_id
           - user_data
+  select_permissions:
+    - role: public
+      permission:
+        columns:
+          - id
+        filter: {}
+        limit: 1
 - table:
     schema: public
     name: team_members

--- a/hasura.planx.uk/tests/session_backups.test.js
+++ b/hasura.planx.uk/tests/session_backups.test.js
@@ -1,0 +1,43 @@
+const { introspectAs } = require("./utils");
+
+describe("session_backups", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("can INSERT records", () => {
+      expect(i.mutations).toContain("insert_session_backups");
+      expect(i.mutations).toContain("insert_session_backups_one"); // this is the mutation we use
+    });
+
+    test("can QUERY records", () => {
+      expect(i.queries).toContain("session_backups"); // "permissions" limit to 1 row only and only "id" column
+    });
+
+    test("cannot DELETE records", () => {
+      expect(i.mutations).not.toContain("delete_session_backups");
+      expect(i.mutations).not.toContain("delete_session_backups_by_pk");
+    });
+
+    test("cannot UPDATE records", () => {
+      expect(i.mutations).not.toContain("update_session_backups");
+      expect(i.mutations).not.toContain("update_session_backups_by_pk");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate session_backups", async () => {
+      expect(i.queries).toContain("session_backups");
+      expect(i.mutations).toContain("insert_session_backups");
+      expect(i.mutations).toContain("update_session_backups_by_pk");
+      expect(i.mutations).toContain("delete_session_backups");
+    });
+  });
+});


### PR DESCRIPTION
In any flow with a Pay component, we insert a `session_backups` record right before they Pay as an audit trail in case anything goes wrong. 

The `insert_session_backups_one` mutation had been removed from the Public user's mutation root because there were no public "select" permissions on the table enabled.

![Screenshot from 2022-08-03 13-19-06](https://user-images.githubusercontent.com/5132349/182597123-748cc4a0-b354-4e19-9748-5dcd5142171d.png)

This was logged by Airbrake here: https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1659439832385099

This PR enables a minimal public select permission (1 row & `id` column only) so the `_one` mutation succeeds again and adds introspection tests.
