### PR TITLE
fix: Resume link broken for custom domains

### DIFF
--- a/api.planx.uk/saveAndReturn/resumeApplication.js
+++ b/api.planx.uk/saveAndReturn/resumeApplication.js
@@ -97,7 +97,7 @@ const validateRequest = async (teamSlug, email) => {
 const getPersonalisation = async (sessions, team) => {
   return {
     teamName: team.name,
-    content: await buildContentFromSessions(sessions, team.slug),
+    content: await buildContentFromSessions(sessions, team),
     ...team.notifyPersonalisation,
   };
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20502206/182647860-ab9c6dea-8f15-4b31-a680-330b13ca0264.png)

Currently, the magic link is broken when requesting a resume email.

This fixes this by correctly passing the entire `team` object to the `buildContentFromSessions()` function.