### PR TITLE
fix: only South Bucks should submit to Chiltern's Uniform instance

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -50,7 +50,7 @@ const SendComponent: React.FC<Props> = ({
       ?.toLowerCase()
       ?.replace(/\W+/g, "-");
 
-    if ((teamSlug = "south-bucks")) {
+    if (teamSlug === "south-bucks") {
       // South Bucks & Chiltern share an Idox connector, route addresses in either to Chiltern
       teamSlug = "chiltern";
     }


### PR DESCRIPTION
didn't catch this typo in review monday or Uniform testing (because UAT happened before we learned about this!)

fixes #1066 

our first live application today went to Chiltern's Uniform instance even though the site was in Wycombe - Kev was able to manually correct this

session id `2536cc18-0fc7-4dd9-8f2e-a0065a804234`