### PR TITLE
fix(public): descriptions falling outside of box

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
@@ -1,6 +1,6 @@
 import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
-import React from "react";
+import React, { useRef } from "react";
 
 import ButtonBase, { Props as ButtonProps } from "./ButtonBase";
 
@@ -13,32 +13,34 @@ export interface Props extends ButtonProps {
 
 export default function DescriptionButton(props: Props) {
   const { title, description } = props;
+  const buttonRef = useRef<HTMLDivElement>();
 
   return (
     <ButtonBase {...props}>
       <Box
+        // @ts-ignore-next-line - material ui did not include `ref` to the types definition
+        ref={buttonRef}
         display="flex"
         flexDirection="column"
         alignItems="flex-start"
-        height={0}
+        height="100%"
+        minHeight={buttonRef.current?.offsetWidth}
         width="100%"
-        pt="100%"
         position="relative"
+        p={2}
       >
-        <Box position="absolute" top={0} left={0} width="100%" p={2}>
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            width="100%"
-            pb={1}
-          >
-            <Typography variant="h6">{title}</Typography>
-          </Box>
-          <Typography align="left" variant="body2">
-            {description}
-          </Typography>
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          width="100%"
+          pb={1}
+        >
+          <Typography variant="h6">{title}</Typography>
         </Box>
+        <Typography align="left" variant="body2">
+          {description}
+        </Typography>
       </Box>
     </ButtonBase>
   );


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/7684574/183683276-4e44519a-019b-49a2-92cd-36bd280e306a.png)


After:

![image](https://user-images.githubusercontent.com/7684574/183683426-385d65a0-d511-4fc4-8433-2fac6847eb72.png)

![image](https://user-images.githubusercontent.com/7684574/183683479-5bf481b0-a391-4623-a7ba-23cfa3dc25f9.png)
