### PR TITLE
fix: keep squares when resizing window

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
@@ -1,6 +1,7 @@
 import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
 import React, { useRef } from "react";
+import { useWindowSize } from "react-use";
 
 import ButtonBase, { Props as ButtonProps } from "./ButtonBase";
 
@@ -14,6 +15,8 @@ export interface Props extends ButtonProps {
 export default function DescriptionButton(props: Props) {
   const { title, description } = props;
   const buttonRef = useRef<HTMLDivElement>();
+  // rerender component on windowSize change
+  useWindowSize();
 
   return (
     <ButtonBase {...props}>


### PR DESCRIPTION
Re-merging this following a revert of sequential commits on `main`. Original PR here - https://github.com/theopensystemslab/planx-new/pull/1081

`minHeight` expects a string, so when we pass
`buttonRef.current?.offsetWidth` that's actually a value not a reference.
In order to update it whenever the window size is updated,
and keep the square a square,
we need to use a hook to watch window resizes.

(cherry picked from commit 4b4a9eccd2aa9cf6245cbf5fb368da8bdf246d54)