### PR TITLE
fix: Skip reconciliation after pay

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -211,7 +211,9 @@ const ResumePage: React.FC = () => {
    * XXX: Pay component is still responsible for validating payment status and updating passport
    */
   const isPaymentCreated = (data: Record<string, any>): boolean => {
-    return data.reconciledSessionData.govUkPayment.state.status === "created";
+    return (
+      data?.reconciledSessionData?.govUkPayment?.state?.status === "created"
+    );
   };
 
   /**


### PR DESCRIPTION
Test flow - https://1110.planx.pizza/buckinghamshire/pay-skip-reconciliation-test/preview

Related to https://github.com/theopensystemslab/planx-new/pull/1111 & https://github.com/theopensystemslab/planx-new/pull/1107

This PR adds a check to the `ResumePage` that checks if a user should skip the `ReconciliationPage` component and proceed directly back to `Pay` in order to complete the process.

Spent a bit of time trying to come up with some tests for this but it's pretty tricky as we need to mock `document`, `window`, API calls, and track changes across multiple components. I actually think this is a pretty good candidate for an E2E test - I've added this as a talking point for next week's dev call as I have a few questions about this I'd like to cover 👍 

https://user-images.githubusercontent.com/20502206/185442319-b2d5621e-4d65-43a5-84f0-17087a169085.mov


