### PR TITLE
fix: Catch routing error in Save and Return

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from "@material-ui/core/styles";
 import { MyMap } from "@opensystemslab/map";
 import jwtDecode from "jwt-decode";
 import { getCookie, setCookie } from "lib/cookie";
+import ErrorPage from "pages/ErrorPage";
 import { AnalyticsProvider } from "pages/FlowEditor/lib/analyticsProvider";
 import React, { Suspense, useEffect } from "react";
 import { render } from "react-dom";
@@ -84,7 +85,7 @@ const Layout: React.FC<{
 
   return (
     <ThemeProvider theme={globalTheme}>
-      <NotFoundBoundary render={() => <h1>Not found</h1>}>
+      <NotFoundBoundary render={() => <ErrorPage title="Not found" />}>
         {!!isLoading ? (
           <DelayedLoadingIndicator msDelayBeforeVisible={500} />
         ) : (

--- a/editor.planx.uk/src/pages/ErrorPage.tsx
+++ b/editor.planx.uk/src/pages/ErrorPage.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
-const NetworkError: React.FC = () => {
+const ErrorPage: React.FC<{ title: string }> = ({ title }) => {
   const classes = useStyles();
 
   return (
@@ -30,7 +30,7 @@ const NetworkError: React.FC = () => {
       <Box className={classes.dashboard}>
         <Box pl={2} pb={2}>
           <Typography variant="h1" gutterBottom>
-            Network error
+            {title}
           </Typography>
           <Typography variant="body1">
             This bug has been automatically logged and our team will see it
@@ -42,4 +42,4 @@ const NetworkError: React.FC = () => {
   );
 };
 
-export default NetworkError;
+export default ErrorPage;

--- a/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
+++ b/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
@@ -8,10 +8,9 @@ import {
 } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import ErrorFallback from "components/ErrorFallback";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { clearLocalFlow } from "lib/local";
-import * as NEW_LOCAL from "lib/local.new";
 import { merge } from "lodash";
+import { NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -109,8 +108,13 @@ const PreviewLayout: React.FC<{
 }> = ({ team, children, settings, footerContent, headerVariant }) => {
   const classes = useClasses();
   const path = useStore((state) => state.path);
+  const id = useStore((state) => state.id);
 
-  const [id, sessionId] = useStore((state) => [state.id, state.sessionId]);
+  // Manually check for route errors
+  // We're not yet within the NaviView which will automatically handle this
+  // Save & Return "wrapper" must be resolved first
+  const route = useCurrentRoute();
+  if (route.error) throw new NotFoundError();
 
   const handleRestart = async () => {
     if (
@@ -134,7 +138,6 @@ const PreviewLayout: React.FC<{
 
   /**
    * Generates a MuiTheme by deep merging global and team ThemeOptions
-   * @returns {Theme}
    */
   const generatePreviewTheme = (): Theme => {
     const globalOptions = getGlobalThemeOptions();

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -3,7 +3,6 @@ import ButtonBase from "@material-ui/core/ButtonBase";
 import { makeStyles } from "@material-ui/core/styles";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import classnames from "classnames";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { getLocalFlow, setLocalFlow } from "lib/local";
 import * as NEW from "lib/local.new";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";

--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -2,8 +2,8 @@ import { lazy, map, mount, redirect, route } from "navi";
 import * as React from "react";
 
 import { client } from "../lib/graphql";
+import ErrorPage from "../pages/ErrorPage";
 import Login from "../pages/Login";
-import NetworkError from "../pages/NetworkError";
 import { isPreviewOnlyDomain, makeTitle } from "./utils";
 
 type RoutingContext = {
@@ -13,7 +13,7 @@ type RoutingContext = {
 const editorRoutes = mount({
   "/network-error": route({
     title: makeTitle("Network Error"),
-    view: <NetworkError />,
+    view: <ErrorPage title="Network error" />,
   }),
 
   "/login": map(async (req, context: RoutingContext) =>


### PR DESCRIPTION
## What does this PR do?
 - Addresses this Tello card - https://trello.com/c/McuLbxbi/2024-improve-missing-route-error-handling-in-public-interface
 - Manually check for routing errors in `PreviewLayout`
 - This is required as we're "above" the scope of the ReactNavi `View`, so errors aren't getting picked up.
 - Alternatively, we we wrap the `Question` component in the Save&Return "wrapper" we can fix this being being within that `View` scope.
 - Ideally, I think we would handle this at the route level as that's basically what's happening. The issue here is that this is not dynamic and I've not found a way to statefully update when `state.path` is updated.
 - This is probably something to revisit if/when we move from ReactNavi

**Also...**
 - Small change to standardise the error page

**To test**
 - Save and Return routing works
   - Save and Return flows prompt you for an email x2
   - Resume page displays
   - Non-S&R flows take you right to the first question
 - Random incorrect URLs throw an error (e.g. https://1114.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/preview/something)