### PR TITLE
fix: broken click on checkbox icon

### DIFF
--- a/editor.planx.uk/src/ui/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/Checkbox.tsx
@@ -46,7 +46,7 @@ export default function Checkbox(props: Props): FCReturn {
   const classes = useClasses(props);
 
   return (
-    <Box className={classes.box}>
+    <Box className={classes.box} onClick={() => props.onChange()}>
       <input
         defaultChecked={props.checked}
         className={classes.input}


### PR DESCRIPTION
The issue was that clicking on the icon wouldn't trigger the onChange prop.

https://trello.com/c/r9NlL3TA/1989-checkbox-interaction-broken-when-using-back-button
