### PR TITLE
test: remove unnecessary environment variable

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -43,8 +43,6 @@ jobs:
     name: API Tests
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    env:
-      GOVUK_NOTIFY_API_KEY: ${{ secrets.GOVUK_NOTIFY_API_KEY }}
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.2.2


### PR DESCRIPTION
Since #1112 tests consume `GOVUK_NOTIFY_API_KEY` from `env.test`.
