### PR TITLE
fix: Date should not be required in Editor

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
@@ -1,14 +1,15 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { clear } from "@testing-library/user-event/dist/clear";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { act, Simulate } from "react-dom/test-utils";
 
 import DateInputComponent from "./Editor";
 
 const minError = "Min must be less than max";
 const maxError = "Max must be greater than min";
+const invalidError = "Enter a valid date in DD.MM.YYYY format";
 
 describe("DateInputComponent - Editor Modal", () => {
   it("renders", () => {
@@ -20,7 +21,7 @@ describe("DateInputComponent - Editor Modal", () => {
     expect(screen.getByText("Date Input")).toBeInTheDocument();
   });
 
-  it("throws an error for incompatible date values", () => {
+  it("throws an error for incompatible date values", async () => {
     const handleSubmit = jest.fn();
     render(
       <DndProvider backend={HTML5Backend}>
@@ -43,15 +44,15 @@ describe("DateInputComponent - Editor Modal", () => {
     userEvent.type(maxMonth, "01");
     userEvent.type(maxYear, "1900");
 
-    act(() => Simulate.submit(screen.getByRole("form")));
+    fireEvent.submit(screen.getByRole("form"));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByText(minError)).toBeVisible();
       expect(screen.getByText(maxError)).toBeVisible();
     });
   });
 
-  it("does not show errors if min is less than max", () => {
+  it("does not show errors if min is less than max", async () => {
     const handleSubmit = jest.fn();
     render(
       <DndProvider backend={HTML5Backend}>
@@ -74,11 +75,37 @@ describe("DateInputComponent - Editor Modal", () => {
     userEvent.type(maxMonth, "01");
     userEvent.type(maxYear, "2000");
 
-    act(() => Simulate.submit(screen.getByRole("form")));
+    fireEvent.submit(screen.getByRole("form"));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.queryByText(minError)).toBeNull();
       expect(screen.queryByText(maxError)).toBeNull();
+    });
+  });
+
+  it("does not show an error if user deletes a date", async () => {
+    const handleSubmit = jest.fn();
+    const node = { data: { min: "1900-02-13", max: "2000-12-14" } };
+    render(
+      <DndProvider backend={HTML5Backend}>
+        <DateInputComponent id="test" handleSubmit={handleSubmit} node={node} />
+      </DndProvider>
+    );
+
+    const [minDay, maxDay] = screen.getAllByPlaceholderText("DD");
+    const [minMonth, maxMonth] = screen.getAllByPlaceholderText("MM");
+    const [minYear, maxYear] = screen.getAllByPlaceholderText("YYYY");
+
+    expect(screen.queryAllByText(invalidError)).toHaveLength(0);
+
+    [minDay, maxDay, minMonth, maxMonth, minYear, maxYear].forEach((el) =>
+      clear(el)
+    );
+
+    fireEvent.submit(screen.getByRole("form"));
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(invalidError)).toHaveLength(0);
     });
   });
 });

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -21,8 +21,14 @@ export const isDateValid = (date: string) => {
   return isComplete && isValid(parseISO(date));
 };
 
-export const paddedDate = (date: string, eventType: string) => {
+export const paddedDate = (
+  date: string,
+  eventType: string
+): string | undefined => {
   const [year, month, day] = date.split("-");
+
+  // Do not parse if no values given (e.g. deleting a date)
+  if (!year && !month && !day) return;
 
   // If month and/or year is single-digit, pad it
   const [paddedMonth, paddedDay] = [month, day].map((value) => {
@@ -111,14 +117,16 @@ export const editorValidationSchema = () =>
       name: "Min less than max",
       message: "Min must be less than max",
       test(date: string | undefined) {
-        return Boolean(date && date < this.parent.max);
+        if (!date) return true;
+        return date < this.parent.max;
       },
     }),
     max: dateSchema().test({
       name: "Max greater than min",
       message: "Max must be greater than min",
       test(date: string | undefined) {
-        return Boolean(date && date > this.parent.min);
+        if (!date) return true;
+        return date > this.parent.min;
       },
     }),
   });


### PR DESCRIPTION
- Update `editorValidationSchema()` to address main issue
- Update tests to remove false positives
- Update `paddedDate()` to catch empty deleted dates which were formatted as "--"