### PR TITLE
build: bump sharedb to latest version

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -58,7 +58,7 @@
     "reconnecting-websocket": "^4.4.0",
     "rxjs": "^7.5.6",
     "scroll-into-view-if-needed": "^2.2.29",
-    "sharedb": "^3.0.0",
+    "sharedb": "^3.1.0",
     "swr": "^1.3.0",
     "uuid": "^8.3.2",
     "wkt": "^0.1.1",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -143,7 +143,7 @@ specifiers:
   sass: ^1.54.3
   sass-loader: ^13.0.2
   scroll-into-view-if-needed: ^2.2.29
-  sharedb: ^3.0.0
+  sharedb: ^3.1.0
   storybook-addon-material-ui: ^0.9.0-alpha.24
   stream-browserify: ^3.0.0
   swr: ^1.3.0
@@ -211,7 +211,7 @@ dependencies:
   reconnecting-websocket: 4.4.0
   rxjs: 7.5.6
   scroll-into-view-if-needed: 2.2.29
-  sharedb: 3.0.0
+  sharedb: 3.1.0
   swr: 1.3.0_react@17.0.2
   uuid: 8.3.2
   wkt: 0.1.1
@@ -16390,8 +16390,8 @@ packages:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
     dev: false
 
-  /sharedb/3.0.0:
-    resolution: {integrity: sha512-shr/OionHtGfVs11+lucSWY1R242GOisKDXmxWQFOdom0rqkG8I0A832HKMNRG9figZlLdNSgDWpsJhNJ8euog==}
+  /sharedb/3.1.0:
+    resolution: {integrity: sha512-+GxnH59/qfEsDAppLt7N0o/vFGSiI50EhtrhIuL6nk3jUj2jRwOro0jo9QZjKKB16jAB/oN9rIBLHohoQKepbQ==}
     dependencies:
       arraydiff: 0.1.3
       async: 2.6.3

--- a/sharedb.planx.uk/package.json
+++ b/sharedb.planx.uk/package.json
@@ -6,7 +6,7 @@
     "@teamwork/websocket-json-stream": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "pg": "^8.7.3",
-    "sharedb": "^3.0.0",
+    "sharedb": "^3.1.0",
     "ws": "^8.8.1"
   },
   "scripts": {

--- a/sharedb.planx.uk/pnpm-lock.yaml
+++ b/sharedb.planx.uk/pnpm-lock.yaml
@@ -8,14 +8,14 @@ specifiers:
   jsonwebtoken: ^8.5.1
   node-dev: ^7.4.3
   pg: ^8.7.3
-  sharedb: ^3.0.0
+  sharedb: ^3.1.0
   ws: ^8.8.1
 
 dependencies:
   '@teamwork/websocket-json-stream': 2.0.0
   jsonwebtoken: 8.5.1
   pg: 8.7.3
-  sharedb: 3.0.0
+  sharedb: 3.1.0
   ws: 8.8.1
 
 devDependencies:
@@ -356,8 +356,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /sharedb/3.0.0:
-    resolution: {integrity: sha512-shr/OionHtGfVs11+lucSWY1R242GOisKDXmxWQFOdom0rqkG8I0A832HKMNRG9figZlLdNSgDWpsJhNJ8euog==}
+  /sharedb/3.1.0:
+    resolution: {integrity: sha512-+GxnH59/qfEsDAppLt7N0o/vFGSiI50EhtrhIuL6nk3jUj2jRwOro0jo9QZjKKB16jAB/oN9rIBLHohoQKepbQ==}
     dependencies:
       arraydiff: 0.1.3
       async: 2.6.3


### PR DESCRIPTION
originally opened this thinking it was related to our Editor bug, which isn't the case - but no harm in bumping our version anyways! 

changelog is minor: https://github.com/share/sharedb/releases/tag/v3.1.0