### PR TITLE
infra: enable CloudWatch Insights

### DIFF
--- a/infrastructure/networking/index.ts
+++ b/infrastructure/networking/index.ts
@@ -6,13 +6,21 @@ import * as awsx from "@pulumi/awsx";
 const vpc = new awsx.ec2.Vpc("vpc", {
   numberOfNatGateways: 0,
 });
-const cluster = new awsx.ecs.Cluster("cluster", { vpc });
+const cluster = new awsx.ecs.Cluster("cluster", {
+  vpc,
+  settings: [
+    {
+      name: "containerInsights",
+      value: "enabled",
+    },
+  ],
+});
 const subnet = new aws.rds.SubnetGroup("subnet-group", {
   subnetIds: vpc.publicSubnetIds,
 });
 
 export const subnetId = subnet.id;
-export const vpcSecurityGroupIds = cluster.securityGroups.map(g => g.id);
+export const vpcSecurityGroupIds = cluster.securityGroups.map((g) => g.id);
 export const vpcId = vpc.id;
 export const clusterName = cluster.cluster.name;
 export const privateSubnetIds = vpc.privateSubnetIds;


### PR DESCRIPTION
- Enables CloudWatch Insights for our Fargate services.
- Give observability into CPU and RAM usage
- Nota bene, the `networking` stack hereby being edited doesn't get automatically deployed with a PR merge, so **I've already deployed these changes manually to both staging and production environments**—this here PR is _almost_ a formality.
- You can see the insights under AWS > CloudWatch > Insights > Container Insights.
