### PR TITLE
fix: Correctly setup retries for Hasura scheduled events

### DIFF
--- a/api.planx.uk/hasura/metadata/index.js
+++ b/api.planx.uk/hasura/metadata/index.js
@@ -36,10 +36,10 @@ const createScheduledEvent = async (args) => {
         headers: [{
           name: "authorization",
           value_from_env: "HASURA_PLANX_API_KEY"
-        }]
-      },
-      retry_conf: {
-        num_retries: 3,
+        }],
+        retry_conf: {
+          num_retries: 3,
+        },
       },
     });
     return response.data;


### PR DESCRIPTION
Context - https://github.com/theopensystemslab/planx-new/pull/1127#discussion_r955860939

Currently, retries aren't being set up correctly as the JSON being posted to the Hasura metadata API was incorrectly formatted.

Please see docs here - https://hasura.io/docs/latest/api-reference/metadata-api/scheduled-triggers/#metadata-create-scheduled-event