### PR TITLE
fix: Resolve failing reconciliation

### DIFF
--- a/api.planx.uk/saveAndReturn/validateSession.js
+++ b/api.planx.uk/saveAndReturn/validateSession.js
@@ -78,7 +78,7 @@ const validateSession = async (req, res, next) => {
           // update the lowcal_session.data to match our updated in-memory sessionData.data
           //   XX: apply sorting to match the original get/set methods used in editor.planx.uk/src/lib/lowcalStorage.ts
           const sortedSessionData = stringifyWithRootKeysSortedAlphabetically(sessionData.data);
-          const reconciledSessionData = await updateLowcalSessionData(sessionId, JSON.parse(sortedSessionData.data), email);
+          const reconciledSessionData = await updateLowcalSessionData(sessionId, JSON.parse(sortedSessionData), email);
 
           res.status(200).json({
             message: "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue.",


### PR DESCRIPTION
Addresses numerous Airbrake errors grouped here - https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3345989376818649845?tab=overview

**Problem**
 - `Cannot read properties of undefined (reading 'data')` is being caused by us trying to read the non-existent `sortedSessionData.data` instead of just `sortedSessionData`

A bit of an unusual fix - not exactly sure what the cause of the regression is here. It seems a little odd/unlikely that this has been not working as expected since `stringifyWithRootKeysSortedAlphabetically()` was introduced.

I've done some testing both locally with data from a failed prod request, and on the pizza, and can trigger successful and correct reconciliation with this which I can't currently do on staging / prod.

If somebody could please test and reproduce that would be fantastic 👍 