### PR TITLE
feat: sync production data to staging weekly

### DIFF
--- a/.github/workflows/weekly-staging-db-sync.yml
+++ b/.github/workflows/weekly-staging-db-sync.yml
@@ -1,0 +1,27 @@
+name: Weekly staging database sync
+
+on:
+  schedule:
+    # Runs Sunday at 00:00 (https://crontab.guru/#0_0_*_*_0)
+    - cron: '0 0 * * 0'
+jobs:
+  build:
+    name: Seed Database
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install pulumi
+        uses: pulumi/setup-pulumi@v2
+      - run: |
+          echo "HASURA_GRAPHQL_ADMIN_SECRET=$(pulumi config get hasura-admin-secret --stack staging)" >> $GITHUB_ENV
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm install -g pnpm
+        working-directory: scripts/seed-database
+      - run: pnpm i
+        working-directory: scripts/seed-database
+      - run: node ./upsert-production-flows.js --overwrite
+        working-directory: scripts/seed-database
+        env:
+          HASURA_GRAPHQL_URL: https://hasura.editor.planx.dev/v1/graphql

--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -1,8 +1,8 @@
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (1, 'John', 'Rees', 'john@opensystemslab.io', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (6, 'Gunar', 'Gessner', 'gunargessner@gmail.com', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (13, 'Sarah', 'Scott', 'sarah@opensystemslab.io', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true);
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true);
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (1, 'John', 'Rees', 'john@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (6, 'Gunar', 'Gessner', 'gunargessner@gmail.com', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (13, 'Sarah', 'Scott', 'sarah@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
 SELECT setval('users_id_seq', max(id)) FROM users;
 SELECT setval('teams_id_seq', max(id)) FROM teams;

--- a/scripts/seed-database/package.json
+++ b/scripts/seed-database/package.json
@@ -1,16 +1,22 @@
 {
-  "name": "scripts",
+  "name": "seed-database",
   "private": true,
   "license": "MPL-2.0",
-  "dependencies": {
-    "graphql": "^16.5.0",
-    "graphql-request": "^4.3.0"
-  },
+  "type": "module",
   "scripts": {
-    "upsert-flows": "node ./upsert-production-flows"
+    "upsert-flows": "node --experimental-specifier-resolution=node ./upsert-production-flows"
   },
   "engines": {
     "node": "^16",
     "pnpm": "^7.8.0"
+  },
+  "dependencies": {
+    "graphql": "^16.5.0",
+    "graphql-request": "^4.3.0",
+    "lodash": "^4.17.21",
+    "p-throttle": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.184"
   }
 }

--- a/scripts/seed-database/pnpm-lock.yaml
+++ b/scripts/seed-database/pnpm-lock.yaml
@@ -1,14 +1,26 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@types/lodash': ^4.14.184
   graphql: ^16.5.0
   graphql-request: ^4.3.0
+  lodash: ^4.17.21
+  p-throttle: ^5.0.0
 
 dependencies:
-  graphql: 16.5.0
-  graphql-request: 4.3.0_graphql@16.5.0
+  graphql: 16.6.0
+  graphql-request: 4.3.0_graphql@16.6.0
+  lodash: 4.17.21
+  p-throttle: 5.0.0
+
+devDependencies:
+  '@types/lodash': 4.14.184
 
 packages:
+
+  /@types/lodash/4.14.184:
+    resolution: {integrity: sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==}
+    dev: true
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -48,7 +60,7 @@ packages:
       mime-types: 2.1.35
     dev: false
 
-  /graphql-request/4.3.0_graphql@16.5.0:
+  /graphql-request/4.3.0_graphql@16.6.0:
     resolution: {integrity: sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==}
     peerDependencies:
       graphql: 14 - 16
@@ -56,14 +68,18 @@ packages:
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
-      graphql: 16.5.0
+      graphql: 16.6.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /graphql/16.5.0:
-    resolution: {integrity: sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==}
+  /graphql/16.6.0:
+    resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
   /mime-db/1.52.0:
@@ -88,6 +104,11 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: false
+
+  /p-throttle/5.0.0:
+    resolution: {integrity: sha512-iXBFjW4kP/5Ivw7uC9EDnj+/xo3pNn4Rws3zgMGPwXnWTv1M3P0LVdZxLrqRUI5JK0Fp3Du0bt6lCaVrI3WF7g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
   /tr46/0.0.3:

--- a/scripts/seed-database/seed-db.sh
+++ b/scripts/seed-database/seed-db.sh
@@ -1,5 +1,7 @@
-pnpm upsert-flows
-
 cd /hasura/
 
 hasura seeds apply
+
+cd /scripts/
+
+pnpm upsert-flows

--- a/scripts/seed-database/upsert-production-flows.js
+++ b/scripts/seed-database/upsert-production-flows.js
@@ -1,4 +1,9 @@
-const { GraphQLClient } = require("graphql-request");
+import groupBy from "lodash/groupBy";
+import cloneDeep from "lodash/cloneDeep";
+import { GraphQLClient } from "graphql-request";
+import pThrottle from 'p-throttle';
+const args = process.argv.slice(2);
+
 const PRODUCTION_GRAPHQL_URL = 'https://hasura.editor.planx.uk/v1/graphql';
 const LOCAL_GRAPHQL_URL = process.env.HASURA_GRAPHQL_URL;
 const LOCAL_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
@@ -12,25 +17,29 @@ const LOCAL_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
       },
     });
 
-    const { flows: localFlows } = await localClient.request(`
-      query GetAllFlows {
-        flows {
-          id
-        }
-      }
-    `);
+    const shouldOverwrite = args?.includes('-o') || args?.includes('--overwrite');
 
-    if (localFlows.length > 0) {
-      // If a flow belongs to an existing team we can not delete the teams because of existing constraints.
-      console.log('There are flows in the local database, refusing to continue.');
-      process.exit(0);
-      return;
+    if (!shouldOverwrite) {
+      const { flows: localFlows } = await localClient.request(`
+        query GetAllFlows {
+          flows {
+            id
+          }
+        }
+      `);
+
+      if (localFlows.length > 0) {
+        // If a flow belongs to an existing team we can not delete the teams because of existing constraints.
+        console.log('There are flows in the local database, refusing to continue.');
+        process.exit(0)
+      }
     }
 
-    // Teams have 2 unique fields: `id` and `slug`, but the upsert `on_conflict` query only allows us to check for one of them. 
-    // So if both fields exist in the current database, the query will fail. To prevent it, all teams that have duplicated slugs are deleted.
-
-    const { flows, teams } = await productionClient.request(`
+    console.log('Fetching teams and flows...');
+    const {
+      flows: productionFlows,
+      teams: productionTeams,
+    } = await productionClient.request(`
       query GetAllFlowsAndTeams {
         flows {
           id
@@ -38,6 +47,7 @@ const LOCAL_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
           slug
           team_id
           settings
+          version
         }
         teams {
           id
@@ -50,65 +60,195 @@ const LOCAL_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
       }
     `);
 
-    await localClient.request(`
-      mutation DeleteTeams(
-        $teams_slugs: [String!]!, 
-      ) {
-        delete_teams(where: {slug: {_in: $teams_slugs}}) {
-          affected_rows
+    const {
+      teams: localTeams,
+      flows: localFlows,
+    } = await localClient.request(`
+      query GetAllFlowsAndTeams {
+        flows {
+          id
+          slug
+          team_id
+        }
+        teams {
+          id
+          slug
         }
       }
-      `,
+    `);
+
+    // Teams and Flows have 2 unique fields: `id` and `slug`, but the upsert `on_conflict` query only allows us to check for one of them.
+    // So if both fields exist in the current database, the query will fail.
+    // To prevent errors, we upsert production data in two different queries, filtering them by `id` and `slug`.
+
+    const localTeamsSlugs = localTeams.map(team => team.slug);
+    const {
+      false: teamsToUpsertById,
+      true: teamsToUpsertBySlug
+    } = groupBy(productionTeams, (team) => localTeamsSlugs.includes(team.slug));
+
+    const {
+      false: flowsToUpsertById,
+      true: flowsToUpsertBySlug
+    } = groupBy(
+      // XXX: overwrite flow version to match operation version and prevent sharedb sync errors
+      productionFlows.map(flow => ({ ...flow, version: 1, })),
+      (flow) => localFlows.some(localFlow =>
+        localFlow.slug === flow.slug && localFlow.team_id === flow.team_id
+      )
+    );
+
+    console.log("Inserting flows and teams...")
+    await localClient.request(
+      getInsertMutation({
+        teamConstraint: 'teams_pkey',
+        flowConstraint: 'flows_pkey',
+      }),
       {
-        teams_slugs: teams.map(team => team.slug),
+        teams: teamsToUpsertById || [],
+        flows: flowsToUpsertById || [],
       }
     );
 
-    const { insert_flows: { returning } } = await localClient.request(`
-      mutation InsertFlowsAndTeams(
-        $teams: [teams_insert_input!]!, 
-        $flows: [flows_insert_input!]!
-      ) {
-        insert_teams(
-          objects: $teams,
-          on_conflict: {constraint: teams_pkey, update_columns: [name, slug]}
-        ) {
-          affected_rows
-        }
-        insert_flows(
-          objects: $flows,
-          on_conflict: {constraint: flows_pkey, update_columns: [data, slug, created_at]}
-        ) {
-          affected_rows
-          returning {
-            id
-          }
-        }
-      }
-      `,
+    await localClient.request(
+      getInsertMutation({
+        teamConstraint: 'teams_slug_key',
+        flowConstraint: 'flows_team_id_slug_key',
+      }),
       {
-        teams,
-        flows: flows.map(flow => ({ ...flow, version: 1 })),
+        teams: teamsToUpsertBySlug || [],
+        flows: flowsToUpsertBySlug || []
       }
     );
 
-    // XXX: We need to add a row to `operations` for each inserted flow, otherwise sharedb throws a silent error when opening the flow in the UI
-    const ops = returning.map(({ id }) => ({ version: 1, flow_id: id, data: {} }));
+    await insertOperations(localClient)(flowsToUpsertById);
 
-    await localClient.request(`
-      mutation InsertOperations($ops:[operations_insert_input!]!) {
-        insert_operations(objects: $ops) {
-          affected_rows
-        }
-      }
-      `,
-      {
-        ops
-      }
+    console.log('Fetching published flows...');
+    // throttling is needed to prevent errors when fetching a large amount of data
+    const throttledSync = pThrottle({ limit: 10, interval: 5000 })(
+      syncPublishedFlow(productionClient, localClient)
     );
+
+    await Promise.all(productionFlows.map(async flow => throttledSync(flow.id)));
 
     console.log("Production flows and teams inserted successfully.");
   } catch (err) {
+    console.log(err)
+    console.error('It was not possible to insert flows and teams.')
     process.exit(1)
   }
 })()
+
+const getInsertMutation = ({ teamConstraint, flowConstraint }) => `
+  mutation InsertFlowsAndTeams(
+    $teams: [teams_insert_input!]!,
+    $flows: [flows_insert_input!]!,
+  ) {
+    insert_teams(
+      objects: $teams,
+      on_conflict: {constraint: ${teamConstraint}, update_columns: [name, settings, theme]}
+    ) {
+      affected_rows
+    }
+    insert_flows(
+      objects: $flows,
+      on_conflict: {constraint: ${flowConstraint}, update_columns: [data, slug, team_id]}
+    ) {
+      affected_rows
+    }
+  }
+`;
+
+const syncPublishedFlow = (productionClient, localClient) => async (flowId) => {
+  const publishedFlows = await publishedFlowsByFlowIdQuery(flowId, productionClient);
+
+  await Promise.all(publishedFlows.map(
+    async publishedFlow => insertPublishedFlowMutation(
+      {
+        ...publishedFlow,
+        publisher_id: 1 // prevents errors with non-existing ID constraint
+      },
+      localClient
+    )
+  ));
+}
+
+const publishedFlowsByFlowIdQuery = async (flowId, graphQLClient) => {
+  try {
+    const data = await graphQLClient.request(
+      `query GetPublishedFlowByFlowId($id: uuid!) {
+        published_flows(
+          where: {flow_id: {_eq: $id}},
+          limit: 2,
+          order_by: {created_at: desc}
+        ) {
+          id
+          data
+          flow_id
+          summary
+        }
+      }`,
+      { id: flowId }
+    );
+
+    return data.published_flows;
+  } catch (err) {
+    console.log(`Error fetching publishedFlow id ${flowId}`);
+    throw err;
+  }
+}
+
+const insertPublishedFlowMutation = (publishedFlow, graphQLClient) => {
+  return graphQLClient.request(`
+    mutation InsertPublishedFlow(
+      $publishedFlow: published_flows_insert_input!
+    ) {
+      insert_published_flows_one(
+        object: $publishedFlow,
+        on_conflict: {
+          constraint: published_flows_pkey,
+          update_columns: [data, flow_id, summary, publisher_id, created_at]
+        }
+      ) {
+        id
+      }
+    }
+  `, {
+    publishedFlow,
+  }).catch((err) => {
+    console.log(`Error inserting published flow ${publishedFlow?.id}`);
+    throw err
+  });
+}
+
+const insertOperations = (localClient) => async (flows) => {
+  const operations = flows.map(flow => buildOperationPayload(flow));
+
+  await localClient.request(`
+    mutation InsertOperations($operations: [operations_insert_input!]!) {
+      insert_operations(objects: $operations, on_conflict: {constraint: operations_flow_id_version_key, update_columns: data}) {
+        affected_rows
+      }
+    }
+  `, {
+    operations,
+  })
+}
+
+const buildOperationPayload = (flow) => ({
+  flow_id: flow.id,
+  data: {
+    m: {
+      ts: Date.now(),
+      uId: "1"
+    },
+    v: 0,
+    seq: 1,
+    src: "1",
+    create: {
+      data: {},
+      type: "http://sharejs.org/types/JSONv0"
+    }
+  },
+  version: 1,
+})

--- a/scripts/start-containers-for-tests.sh
+++ b/scripts/start-containers-for-tests.sh
@@ -17,6 +17,6 @@ docker-compose down --volumes --remove-orphans
 trap 'echo "Cleaning up…" ; docker-compose down --volumes --remove-orphans' TERM INT
 
 echo "Starting docker…"
-DOCKER_BUILDKIT=1 docker-compose up --build -d
+DOCKER_BUILDKIT=1 docker-compose up --build -d api sharedb minio
 
 echo "All containers ready."


### PR DESCRIPTION
Continuation of #913 and #1123:

- Pulls published_flows from production (the last 2 published flows per flow)
- The fetching of flows is now spread across multiple requests as to avoid Hasura running out of memory
- Requests run in parallel but are throttled

### To test it:

```
$ docker compose down --volumes --remove-orphans
$ docker compose up --build
$ # Wait for the seeding script to finish
$ # check that your local database now containes published flows from production
```

