### PR TITLE
fix: set custom description when creating Uniform submissions

### DIFF
--- a/api.planx.uk/send/uniform.js
+++ b/api.planx.uk/send/uniform.js
@@ -234,7 +234,8 @@ async function authenticate(clientId, clientSecret) {
  * @returns {Promise} - idox-generated submissionId
  */
 async function createSubmission(token, organisation, organisationId, sessionId = "TEST") {
-  const createSubmissionEndpoint = process.env.UNIFORM_SUBMISSION_URL + "/secure/submission"
+  const createSubmissionEndpoint = process.env.UNIFORM_SUBMISSION_URL + "/secure/submission";
+  const isStaging = process.env.UNIFORM_SUBMISSION_URL.includes("staging");
 
   const createSubmissionOptions = {
     method: "POST",
@@ -248,7 +249,7 @@ async function createSubmission(token, organisation, organisationId, sessionId =
       "organisation": organisation,
       "organisationId": organisationId,
       "submissionReference": sessionId,
-      "description": "Test insert for DLUHC",
+      "description": isStaging ? "Staging submission from PlanX" : "Production submission from PlanX",
       "submissionProcessorType": "API"
     }),
     redirect: "follow",


### PR DESCRIPTION
Fixes a minor Uniform request from Kev recently.

I sent a staging app through this pizza and he confirmed it came through as expected :heavy_check_mark: 