### PR TITLE
Prevent API from going down when a request to Hasura fails

### DIFF
--- a/api.planx.uk/server.js
+++ b/api.planx.uk/server.js
@@ -508,8 +508,9 @@ app.post("/sign-s3-upload", async (req, res, next) => {
 });
 
 const trackAnalyticsLogExit = async (id, isUserExit) => {
-  const result = await client.request(
-    `
+  try {
+    const result = await client.request(
+      `
       mutation UpdateAnalyticsLogUserExit($id: bigint!, $user_exit: Boolean) {
         update_analytics_logs_by_pk(
           pk_columns: {id: $id},
@@ -521,29 +522,36 @@ const trackAnalyticsLogExit = async (id, isUserExit) => {
         }
       }
     `,
-    {
-      id,
-      user_exit: isUserExit,
-    }
-  );
+      {
+        id,
+        user_exit: isUserExit,
+      }
+    );
 
-  const analytics_id = result.update_analytics_logs_by_pk.analytics_id;
-  await client.request(
-    `
+    const analytics_id = result.update_analytics_logs_by_pk.analytics_id;
+    await client.request(
+      `
       mutation SetAnalyticsEndedDate($id: bigint!, $ended_at: timestamptz) {
         update_analytics_by_pk(pk_columns: {id: $id}, _set: {ended_at: $ended_at}) {
           id
         }
       }
     `,
-    {
-      id: analytics_id,
-      ended_at: isUserExit ? new Date().toISOString() : null,
-    }
-  );
+      {
+        id: analytics_id,
+        ended_at: isUserExit ? new Date().toISOString() : null,
+      }
+    );
+  } catch (e) {
+    // We need to catch this exception here otherwise the exception would become an unhandle rejection which brings down the whole node.js process
+    console.error(
+      "There's been an error while recording metrics for analytics but because this thread is non-blocking we didn't reject the request",
+      e.stack
+    );
+  }
 
   return;
-}
+};
 
 app.post("/analytics/log-user-exit", async (req, res, next) => {
   const analyticsLogId = Number(req.query.analyticsLogId);


### PR DESCRIPTION
A failed request to Hasura would bring down the whole API service. It's easy to forget these try/catch but once we upgrade our express.js dependency this problem should go away:

> Starting with Express 5, route handlers and middleware that return a Promise will call next(value) automatically when they reject or throw an error ([source](https://expressjs.com/en/guide/error-handling.html))

---

Error that brought down the API Node.js process:

![image](https://user-images.githubusercontent.com/7684574/189983832-582808f0-20c0-4627-9539-d2c84dc896e0.png)
