### PR TITLE
fix: Allow Editor to upload SVGs

### DIFF
--- a/editor.planx.uk/src/ui/FileUpload.tsx
+++ b/editor.planx.uk/src/ui/FileUpload.tsx
@@ -72,8 +72,7 @@ export default function FileUpload(props: Props): FCReturn {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: {
-      "image/jpeg": [".jpg", ".jpeg"],
-      "image/png": [".png"],
+      "image/*": [".jpg", ".jpeg", ".png", ".svg"],
     },
   });
   const classes = useClasses();


### PR DESCRIPTION
Raised by @Alastairparvin here on Slack - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1663688671960829

This regression was introduced here when upgrading `react-dropzone` - https://github.com/theopensystemslab/planx-new/pull/1079/files#diff-8db979ad46aae1317528f619b0b2fab44afa68563a924ca929211a7eb75b7bf5

Docs: https://react-dropzone.js.org/#section-accepting-specific-file-types