### PR TITLE
fix: Set session immediately after reconciliation

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -176,12 +176,7 @@ function Component(props: Props) {
       />
     );
   } else {
-    return (
-      <DelayedLoadingIndicator
-        msDelayBeforeVisible={0}
-        text="Fetching property information..."
-      />
-    );
+    return <DelayedLoadingIndicator text="Fetching property information..." />;
   }
 }
 

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -141,10 +141,7 @@ function Component(props: Props) {
             description={props.description || ""}
           />
           {x && y && longitude && latitude ? (
-            <DelayedLoadingIndicator
-              msDelayBeforeVisible={0}
-              text="Fetching data..."
-            />
+            <DelayedLoadingIndicator text="Fetching data..." />
           ) : (
             <div className={classes.errorSummary} role="status">
               <Typography variant="h5" component="h2" gutterBottom>

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -116,10 +116,7 @@ const SendComponent: React.FC<Props> = ({
   if (request.loading) {
     return (
       <Card>
-        <DelayedLoadingIndicator
-          text={`Submitting your application...`}
-          msDelayBeforeVisible={0}
-        />
+        <DelayedLoadingIndicator text={`Submitting your application...`} />
       </Card>
     );
   } else if (request.error) {
@@ -128,10 +125,7 @@ const SendComponent: React.FC<Props> = ({
   } else {
     return (
       <Card>
-        <DelayedLoadingIndicator
-          text="Finalising your submission..."
-          msDelayBeforeVisible={0}
-        />
+        <DelayedLoadingIndicator text="Finalising your submission..." />
       </Card>
     );
   }

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -18,7 +18,7 @@ const useClasses = makeStyles({
 const DelayedLoadingIndicator: React.FC<{
   msDelayBeforeVisible?: number;
   text?: string;
-}> = ({ msDelayBeforeVisible = 50, text }) => {
+}> = ({ msDelayBeforeVisible = 0, text }) => {
   const [visible, setVisible] = useState(false);
 
   const classes = useClasses();

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -261,7 +261,6 @@ const ResumePage: React.FC = () => {
     [Status.Validating]: (
       <DelayedLoadingIndicator
         text={sessionId ? "Validating..." : "Sending..."}
-        msDelayBeforeVisible={0}
       />
     ),
     [Status.Validated]: (

--- a/editor.planx.uk/src/pages/Preview/SavePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/SavePage.tsx
@@ -26,10 +26,13 @@ const SaveSuccess: React.FC<{ saveToEmail?: string; expiryDate?: string }> = ({
     additionalOption="startNewApplication"
   >
     <Typography variant="body2">
-      We have sent a link to {saveToEmail}. Use the link to continue your application.
-      <br/><br/>
+      We have sent a link to {saveToEmail}. Use the link to continue your
+      application.
+      <br />
+      <br />
       You have until {expiryDate} to complete this application.
-      <br/><br/>
+      <br />
+      <br />
       Your application will be deleted if you do not complete it by this date.
     </Typography>
   </StatusPage>
@@ -37,14 +40,13 @@ const SaveSuccess: React.FC<{ saveToEmail?: string; expiryDate?: string }> = ({
 
 const SaveError: React.FC = () => {
   return (
-    <StatusPage
-      bannerHeading="Email not sent"
-      showDownloadLink
-    >
+    <StatusPage bannerHeading="Email not sent" showDownloadLink>
       <Typography variant="body2">
         We are having trouble sending emails at the moment.
-        <br/><br/>
-        We have saved your application. We will try to send the email again later.
+        <br />
+        <br />
+        We have saved your application. We will try to send the email again
+        later.
       </Typography>
     </StatusPage>
   );
@@ -80,9 +82,7 @@ const SavePage: React.FC = () => {
   }, []);
 
   return {
-    [Status.Sending]: (
-      <DelayedLoadingIndicator text={"Sending..."} msDelayBeforeVisible={0} />
-    ),
+    [Status.Sending]: <DelayedLoadingIndicator text={"Sending..."} />,
     [Status.Success]: (
       <SaveSuccess saveToEmail={saveToEmail} expiryDate={expiryDate} />
     ),


### PR DESCRIPTION
## What's going on...
 - When Save & Return is enabled, and you navigate back from Gov Pay, the internal state has the current card as the first node of the graph
   - This means that the node loads, and a request is made to for address data
   - This can be seen by checking the networking tab, and is particularly noticeable if throttling internet speed
- We currently sit on the `ResumePage` when resuming a session (or skip it when redirecting from GovPay) and don't take any action to update state.
-  The `Question` component calculates the current card (`state.getCurrentCard()`) based on the breadcrumbs and then displays the correct component
  - This is what causes the first node to briefly flash up
  - Fix: Setting the breadcrumbs and other associated `Session` details prior to the `Question` component appearing resolves this
  - At the moment, I _think_ it's basically an unintended race condition between fetching the `lowcal_session` in the Question component vs calculating the graph position in `getCurrentCard()`

### Also...
 - Just to help with UX I've removed the delay from the `DelayedLoadingIndicator` component on Pay - this will hopefully better inform users on a slower connection of what's happening at any given moment. This was set at 0 on all but one instances of the component, so I've updated 0 to be the default here.


 - Looking into what's happening on a redirect back to the app - 
   - Fetching the flattened graph takes a long time (about 860kb to fetch)
   - Validate-Session is pretty quick - there are ways we could maybe optimise this (e.g. checking flow version numbers instead of the diff - I'm not sure how much of an improvement this would really be tbh)
   - Pay always sends a large package to session_backups, even on a redirect. The request is non-blocking though so doesn't hold up anything - we could look at removing this as it's unnecessary the second time around but it may not speed things up.