### PR TITLE
infra: increase budget alert threshold

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -736,7 +736,7 @@ export = async () => {
 
 new aws.budgets.Budget("general-budget", {
   budgetType: "COST",
-  limitAmount: "300",
+  limitAmount: "400",
   limitUnit: "USD",
   timePeriodStart: "2020-05-01_00:00",
   timeUnit: "MONTHLY",


### PR DESCRIPTION
This month we're expected to go 0.91 cents over the expected budget. This is most likely due to having enabled CloudWatch
which is expected to cost ~/mo which is not too much.

![image](https://user-images.githubusercontent.com/7684574/191759473-6c264ac7-c93c-42a3-9095-5f36b58e5c8b.png)

![image](https://user-images.githubusercontent.com/7684574/191759596-0fbc3cc8-d1fc-4acc-bd80-aa96bad4fd5b.png)

