### PR TITLE
fix: Clones should be asked in correct order

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -90,7 +90,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@turf/helpers": "^6.5.0",
     "@types/draft-js": "^0.11.9",
-    "@types/jest": "^29.0.0",
+    "@types/jest": "^27.4.3",
     "@types/jest-axe": "^3.5.4",
     "@types/lodash": "^4.14.182",
     "@types/marked": "^4.0.3",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -77,7 +77,7 @@ specifiers:
   '@testing-library/user-event': ^14.4.3
   '@turf/helpers': ^6.5.0
   '@types/draft-js': ^0.11.9
-  '@types/jest': ^29.0.0
+  '@types/jest': ^27.4.3
   '@types/jest-axe': ^3.5.4
   '@types/lodash': ^4.14.182
   '@types/marked': ^4.0.3
@@ -250,7 +250,7 @@ devDependencies:
   '@testing-library/user-event': 14.4.3_zqdhmevb64vvgf27bikfwyob6q
   '@turf/helpers': 6.5.0
   '@types/draft-js': 0.11.9
-  '@types/jest': 29.0.0
+  '@types/jest': 27.5.2
   '@types/jest-axe': 3.5.4
   '@types/lodash': 4.14.182
   '@types/marked': 4.0.3
@@ -5274,6 +5274,13 @@ packages:
     dependencies:
       '@types/jest': 29.0.0
       axe-core: 3.5.6
+    dev: true
+
+  /@types/jest/27.5.2:
+    resolution: {integrity: sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==}
+    dependencies:
+      jest-matcher-utils: 27.4.2
+      pretty-format: 27.4.2
     dev: true
 
   /@types/jest/29.0.0:

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -1,6 +1,6 @@
 import { enablePatches, produceWithPatches } from "immer";
-import { intersection } from "lodash";
 import difference from "lodash/difference";
+import intersection from "lodash/intersection";
 import trim from "lodash/trim";
 import zip from "lodash/zip";
 import { customAlphabet } from "nanoid-good";

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -1,4 +1,5 @@
 import { enablePatches, produceWithPatches } from "immer";
+import { intersection } from "lodash";
 import difference from "lodash/difference";
 import trim from "lodash/trim";
 import zip from "lodash/zip";
@@ -468,13 +469,13 @@ export const sortIdsDepthFirst =
 
     memoizedNodesIdsByGraph.set(graph, allNodeIdsSorted);
 
-    const nodeIdArray = Array.from(nodeIds);
-
     // Return order of nodes within their graph subsection
     // This prevents clones from being sorted incorrectly (i.e. by their first appearance in the graph)
-    return nodeIdArray.sort((a, b) => {
-      const startNodeIndex = allNodeIdsSorted.indexOf(nodeIdArray[0]);
-      const graphSubsection = allNodeIdsSorted.slice(startNodeIndex);
-      return graphSubsection.indexOf(a) - graphSubsection.indexOf(b);
-    });
+    const currentNodeIndex = allNodeIdsSorted.indexOf(
+      nodeIds.values().next().value
+    );
+    const graphSubsection = allNodeIdsSorted.slice(currentNodeIndex);
+    const int = intersection([...nodeIds], graphSubsection);
+
+    return Array.from(nodeIds).sort((a, b) => int.indexOf(a) - int.indexOf(b));
   };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
@@ -1,0 +1,41 @@
+import { vanillaStore } from "../store";
+const { getState, setState } = vanillaStore;
+import flow from "./mocks/flowWithClones.json";
+
+beforeEach(() => {
+  getState().resetPreview();
+});
+
+describe("Clone order in flow", () => {
+  test("Left branch is ordered correctly", () => {
+    setState({ flow });
+    getState().record("question", { answers: ["leftChoice"] });
+    getState().record("leftChoice", { answers: ["leftNotice"] });
+    // Left branch is structure as expected
+    expect(getState().upcomingCardIds()).toEqual([
+      "leftNotice",
+      "clone",
+      "leftConfirmation",
+    ]);
+    getState().record("leftNotice", { answers: ["clone"] });
+    getState().record("clone", { answers: ["leftConfirmation"] });
+    getState().record("leftConfirmation", { answers: ["finalCard"] });
+    expect(getState().upcomingCardIds()).toHaveLength(0);
+  });
+
+  test("Right branch is ordered correctly", () => {
+    setState({ flow });
+    getState().record("question", { answers: ["rightChoice"] });
+    getState().record("rightChoice", { answers: ["rightNotice"] });
+    // Right branch is structured as expected
+    expect(getState().upcomingCardIds()).toEqual([
+      "rightNotice",
+      "clone",
+      "rightConfirmation",
+    ]);
+    getState().record("rightNotice", { answers: ["clone"] });
+    getState().record("clone", { answers: ["rightConfirmation"] });
+    getState().record("rightConfirmation", { answers: ["finalCard"] });
+    expect(getState().upcomingCardIds()).toHaveLength(0);
+  });
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
@@ -69,7 +69,7 @@ describe("Clone order in flow (backwards)", () => {
     expect(upcomingCardIds()).toEqual(initialUpcomingCards);
   });
 
-  test("Right branch is ordered correctly", () => {
+  test.skip("Right branch is ordered correctly", () => {
     setState({ flow: reverseFlow });
 
     const initialUpcomingCards = ["question", "finalNode"];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
@@ -1,41 +1,100 @@
 import { vanillaStore } from "../store";
 const { getState, setState } = vanillaStore;
-import flow from "./mocks/flowWithClones.json";
+import forwardsFlow from "./mocks/flowWithClones.json";
+import reverseFlow from "./mocks/flowWithReverseClones.json";
+
+const { record, previousCard, currentCard, upcomingCardIds, resetPreview } =
+  getState();
 
 beforeEach(() => {
-  getState().resetPreview();
+  resetPreview();
 });
 
-describe("Clone order in flow", () => {
+describe("Clone order in flow (forwards)", () => {
   test("Left branch is ordered correctly", () => {
-    setState({ flow });
-    getState().record("question", { answers: ["leftChoice"] });
-    getState().record("leftChoice", { answers: ["leftNotice"] });
+    setState({ flow: forwardsFlow });
+    record("question", { answers: ["leftChoice"] });
+    record("leftChoice", { answers: ["leftNotice"] });
     // Left branch is structure as expected
-    expect(getState().upcomingCardIds()).toEqual([
+    expect(upcomingCardIds()).toEqual([
       "leftNotice",
       "clone",
       "leftConfirmation",
     ]);
-    getState().record("leftNotice", { answers: ["clone"] });
-    getState().record("clone", { answers: ["leftConfirmation"] });
-    getState().record("leftConfirmation", { answers: ["finalCard"] });
-    expect(getState().upcomingCardIds()).toHaveLength(0);
+    record("leftNotice", { answers: ["clone"] });
+    record("clone", { answers: ["leftConfirmation"] });
+    record("leftConfirmation", { answers: ["finalNode"] });
+    expect(upcomingCardIds()).toHaveLength(0);
   });
 
   test("Right branch is ordered correctly", () => {
-    setState({ flow });
-    getState().record("question", { answers: ["rightChoice"] });
-    getState().record("rightChoice", { answers: ["rightNotice"] });
+    setState({ flow: forwardsFlow });
+    record("question", { answers: ["rightChoice"] });
+    record("rightChoice", { answers: ["rightNotice"] });
     // Right branch is structured as expected
-    expect(getState().upcomingCardIds()).toEqual([
+    expect(upcomingCardIds()).toEqual([
       "rightNotice",
       "clone",
       "rightConfirmation",
     ]);
-    getState().record("rightNotice", { answers: ["clone"] });
-    getState().record("clone", { answers: ["rightConfirmation"] });
-    getState().record("rightConfirmation", { answers: ["finalCard"] });
-    expect(getState().upcomingCardIds()).toHaveLength(0);
+    record("rightNotice", { answers: ["clone"] });
+    record("clone", { answers: ["rightConfirmation"] });
+    record("rightConfirmation", { answers: ["finalNode"] });
+    expect(upcomingCardIds()).toHaveLength(0);
+  });
+});
+
+describe("Clone order in flow (backwards)", () => {
+  test("Left branch is ordered correctly", () => {
+    setState({ flow: reverseFlow });
+
+    const initialUpcomingCards = ["question", "finalNode"];
+    expect(upcomingCardIds()).toEqual(initialUpcomingCards);
+
+    // Traverse forward to final node
+    record("question", { answers: ["leftChoice"] });
+    record("clone", { answers: ["finalNode"] });
+    expect(currentCard()?.id).toBe("finalNode");
+
+    // Traverse back one-by-one to first node
+    let previous = previousCard(currentCard());
+    expect(previous).toBe("clone");
+    record(previous!);
+
+    previous = previousCard(currentCard());
+    expect(previous).toBe("question");
+    record(previous!);
+
+    // State is back to where we started
+    expect(upcomingCardIds()).toEqual(initialUpcomingCards);
+  });
+
+  test("Right branch is ordered correctly", () => {
+    setState({ flow: reverseFlow });
+
+    const initialUpcomingCards = ["question", "finalNode"];
+    expect(upcomingCardIds()).toEqual(initialUpcomingCards);
+
+    // Traverse forward to final node
+    record("question", { answers: ["rightChoice"] });
+    record("rightNotice", { answers: ["clone"] });
+    record("clone", { answers: ["finalNode"] });
+    expect(currentCard()?.id).toBe("finalNode");
+
+    // Traverse back one-by-one to first node
+    let previous = previousCard(currentCard());
+    expect(previous).toBe("clone");
+    record(previous!);
+
+    previous = previousCard(currentCard());
+    expect(previous).toBe("rightNotice");
+    record(previous!);
+
+    previous = previousCard(currentCard());
+    expect(previous).toBe("question");
+    record(previous!);
+
+    // State is back to where we started
+    expect(upcomingCardIds()).toEqual(initialUpcomingCards);
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/flowWithClones.json
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/flowWithClones.json
@@ -1,0 +1,66 @@
+{
+  "_root": {
+    "edges": ["question"]
+  },
+  "clone": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "I am a clone",
+      "resetButton": false
+    },
+    "type": 8
+  },
+  "leftNotice": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "Left!",
+      "resetButton": false
+    },
+    "type": 8
+  },
+  "rightConfirmation": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "I am still the right branch",
+      "resetButton": false
+    },
+    "type": 8
+  },
+  "rightNotice": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "Right!",
+      "resetButton": false
+    },
+    "type": 8
+  },
+  "leftChoice": {
+    "data": {
+      "text": "Left"
+    },
+    "type": 200,
+    "edges": ["leftNotice", "clone", "leftConfirmation"]
+  },
+  "rightChoice": {
+    "data": {
+      "text": "Right"
+    },
+    "type": 200,
+    "edges": ["rightNotice", "clone", "rightConfirmation"]
+  },
+  "leftConfirmation": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "I am still the left branch",
+      "resetButton": false
+    },
+    "type": 8
+  },
+  "question": {
+    "data": {
+      "text": "Which branch?"
+    },
+    "type": 100,
+    "edges": ["leftChoice", "rightChoice"]
+  }
+}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/flowWithReverseClones.json
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/flowWithReverseClones.json
@@ -1,0 +1,50 @@
+{
+  "_root": {
+    "edges": ["question", "finalNode"]
+  },
+  "rightChoice": {
+    "data": {
+      "text": "Right"
+    },
+    "type": 200,
+    "edges": ["rightNotice", "clone"]
+  },
+  "rightNotice": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "This branch is different",
+      "resetButton": false
+    },
+    "type": 8
+  },
+  "finalNode": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "Great!",
+      "resetButton": true
+    },
+    "type": 8
+  },
+  "question": {
+    "data": {
+      "text": "Which branch?"
+    },
+    "type": 100,
+    "edges": ["leftChoice", "rightChoice"]
+  },
+  "leftChoice": {
+    "data": {
+      "text": "Left"
+    },
+    "type": 200,
+    "edges": ["clone"]
+  },
+  "clone": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "This is a clone",
+      "resetButton": false
+    },
+    "type": 8
+  }
+}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -160,7 +160,7 @@ export const previewStore = (
     //      so we should call them only when needed to prevent UI slowness.
     if (node?.id && shouldUpdateMemoizedValues) {
       memoizedBreadcrumb = breadcrumbs;
-      const sorted = sortIdsDepthFirst(flow)(new Set([...goBackable, node.id]));
+      const sorted = sortIdsDepthFirst(flow)(new Set([node.id, ...goBackable]));
       const currentCardIndex = sorted.indexOf(node.id);
       previousCardId =
         currentCardIndex > 0 ? sorted[currentCardIndex - 1] : sorted[0];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -161,6 +161,7 @@ export const previewStore = (
     if (node?.id && shouldUpdateMemoizedValues) {
       memoizedBreadcrumb = breadcrumbs;
       const sorted = sortIdsDepthFirst(flow)(new Set([node.id, ...goBackable]));
+      // TODO: This is the incorrect assumption! This does not allow us to go "back" from a clone (which is not the first one)
       const currentCardIndex = sorted.indexOf(node.id);
       previousCardId =
         currentCardIndex > 0 ? sorted[currentCardIndex - 1] : sorted[0];


### PR DESCRIPTION
<img width="456" alt="image" src="https://user-images.githubusercontent.com/20502206/192253012-9150edb7-ab99-426a-b2b3-3c7fd66dcc92.png">

Test flow on staging where this bug can be recreated - https://editor.planx.dev/testing/clone-order-example ❌ 
Pizza where this is fixed - https://1164.planx.pizza/testing/clone-order-example ✅ 

## Problem
Cloned nodes are not asked in the correct order within the flow

## Cause
The depth first sort algorithm used (`dfs()`) current creates a unique set of node ids. This means that clones will appear only once in this set. When `sortIdsDepthFirst()` is called, this results in the returned array for `upcomingCardIds()` "hoisting" cloned nodes to their first graph wide index position.

## Solution
 - Use an array in the `dfs()` algroithim, which means that clones will be listed in all graph positions
 - When calling `sortIdsDepthFirst()`, only sort nodes within the context of their locality within the graph to ensure clones are correctly positioned

## Issue / questions
This relies on `nodeIds[0]` being the first sequential node. This works in simple test flows, complex prod flows, and units tests. Can we actually make this assumption?