### PR TITLE
fix: vultr create script needs valid hasura admin secret

### DIFF
--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -30,4 +30,4 @@ docker-compose --env-file .env.prod -f docker-compose.yml -f docker-compose.pizz
 # install hasura cli
 curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
 cd hasura.planx.uk || exit 1
-hasura seed apply
+hasura seed apply --envfile ./../.env


### PR DESCRIPTION
didn't catch this when refactoring hasura env vars because the _update_ vultr script works fine, it's just the initial create that fails on this error when running `hasura seed apply`: 
![Screenshot from 2022-09-28 08-35-24](https://user-images.githubusercontent.com/5132349/192705586-8b7cf51b-f904-4b40-b033-fe8537b93aed.png)
