### PR TITLE
infra: rotate AWS credentials for user uploaded files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,10 @@ SESSION_SECRET=👻
 GOOGLE_CLIENT_ID=👻
 GOOGLE_CLIENT_SECRET=👻
 
-# AWS infrastructure
+# AWS credentials for uploading user files from local and pull request environments to a staging S3 bucket
 AWS_S3_REGION=eu-west-2
+AWS_S3_ACL=public-read
 AWS_S3_BUCKET=👻
-AWS_S3_ACL=👻
 AWS_ACCESS_KEY=👻
 AWS_SECRET_KEY=👻
 


### PR DESCRIPTION
Actually creates a fully new bucket and user, since we couldn't find account holding `planx-temp` bucket