### PR TITLE
feat: GIS API returns granular Article 4 values for Doncaster

### DIFF
--- a/api.planx.uk/gis/digitalLand.js
+++ b/api.planx.uk/gis/digitalLand.js
@@ -1,21 +1,16 @@
 require("isomorphic-fetch");
-import { GraphQLClient } from "graphql-request";
 
 const { addDesignatedVariable, omitGeometry } = require("./helpers");
 import { baseSchema } from "./local_authorities/metadata/base.js";
+import { adminGraphQLClient as client } from "../hasura";
 
 const localAuthorityMetadata = {
   "buckinghamshire": require("./local_authorities/metadata/buckinghamshire.js"),
   "canterbury": require("./local_authorities/metadata/canterbury.js"),
+  "doncaster": require("./local_authorities/metadata/doncaster.js"),
   "lambeth": require("./local_authorities/metadata/lambeth.js"),
   "southwark": require("./local_authorities/metadata/southwark.js"),
 };
-
-const client = new GraphQLClient(process.env.HASURA_GRAPHQL_URL, {
-  headers: {
-    "x-hasura-admin-secret": process.env.HASURA_GRAPHQL_ADMIN_SECRET,
-  },
-});
 
 /**
  * 

--- a/api.planx.uk/gis/local_authorities/metadata/doncaster.js
+++ b/api.planx.uk/gis/local_authorities/metadata/doncaster.js
@@ -1,0 +1,22 @@
+/*
+LAD20CD: E08000017
+LAD20NM: Doncaster
+LAD20NMW:
+FID:
+
+https://maps.doncaster.gov.uk/portal/apps/webappviewer/index.html?id=2435bce5ee1a41ff8ddb9e06d30bf35a
+https://www.doncaster.gov.uk/services/planning/houses-in-multiple-occupation-article-4-direction
+*/
+
+const planningConstraints = {
+  article4: {
+    // Planx granular values link to Digital Land entity.reference
+    records: {
+      "article4.doncaster.hmo": "1001", // https://www.digital-land.info/entity/7010002217
+    },
+  },
+};
+
+export {
+  planningConstraints,
+};


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1W72w2oEii7OeAUBkP8ya9ipMxD3m-PNmmZPiusKAOfA/edit#gid=0

Example address that picks up `article4.doncaster.hmo` passport variable: 121 Thorne Rd, Doncaster DN2 5BQ