### PR TITLE
feat: Setup Save & Return email notifications on user prompt, not automatically

### DIFF
--- a/api.planx.uk/saveAndReturn/sendEmail.js
+++ b/api.planx.uk/saveAndReturn/sendEmail.js
@@ -10,7 +10,7 @@ const sendSaveAndReturnEmail = async (req, res, next) => {
         message: "Required value missing"
       });
     const response = await sendSingleApplicationEmail(template, email, sessionId);
-    response.hasUserSaved = setupEmailEventTriggers(sessionId);
+    response.hasUserSaved = await setupEmailEventTriggers(sessionId);
     return res.json(response);
   } catch (error) {
     return next({

--- a/api.planx.uk/saveAndReturn/sendEmail.js
+++ b/api.planx.uk/saveAndReturn/sendEmail.js
@@ -10,7 +10,7 @@ const sendSaveAndReturnEmail = async (req, res, next) => {
         message: "Required value missing"
       });
     const response = await sendSingleApplicationEmail(template, email, sessionId);
-    response.isEmailEventTriggersSetup = setupEmailEventTriggers(sessionId);
+    response.hasUserSaved = setupEmailEventTriggers(sessionId);
     return res.json(response);
   } catch (error) {
     return next({

--- a/api.planx.uk/saveAndReturn/sendEmail.js
+++ b/api.planx.uk/saveAndReturn/sendEmail.js
@@ -1,4 +1,4 @@
-import { sendSingleApplicationEmail } from "./utils";
+import { sendSingleApplicationEmail, setupEmailEventTriggers } from "./utils";
 
 const sendSaveAndReturnEmail = async (req, res, next) => {
   try {
@@ -10,6 +10,7 @@ const sendSaveAndReturnEmail = async (req, res, next) => {
         message: "Required value missing"
       });
     const response = await sendSingleApplicationEmail(template, email, sessionId);
+    response.isEmailEventTriggersSetup = setupEmailEventTriggers(sessionId);
     return res.json(response);
   } catch (error) {
     return next({

--- a/api.planx.uk/saveAndReturn/sendEmail.test.js
+++ b/api.planx.uk/saveAndReturn/sendEmail.test.js
@@ -38,6 +38,17 @@ describe("Send Email endpoint", () => {
         sessionId: 123,
       }
     });
+
+    queryMock.mockQuery({
+      name: "SetupEmailNotifications",
+      data: {
+        update_lowcal_sessions_by_pk: { id: 123, has_user_saved: true }
+      },
+      variables: {
+        sessionId: 123,
+      }
+    });
+
   });
 
   describe("'Save' template", () => {
@@ -68,6 +79,7 @@ describe("Send Email endpoint", () => {
         .expect(200)
         .then((response) => {
           expect(response.body).toHaveProperty("expiryDate");
+          expect(response.body).toHaveProperty("hasUserSaved", true);
         });
     });
 

--- a/api.planx.uk/saveAndReturn/utils.js
+++ b/api.planx.uk/saveAndReturn/utils.js
@@ -307,6 +307,30 @@ const stringifyWithRootKeysSortedAlphabetically = (ob = {}) =>
       )
   );
 
+// Update lowcal_sessions.email_event_triggers_setup column to kick-off the setup_lowcal_expiry_events & 
+// setup_lowcal_reminder_events event triggers in Hasura
+const setupEmailEventTriggers = async (sessionId) => {
+  try {
+    const client = adminGraphQLClient;
+    const mutation = gql`
+      mutation SetupEmailNotifications($sessionId: uuid!) {
+        update_lowcal_sessions_by_pk(pk_columns: {id: $sessionId}, _set: {has_user_saved: true}) {
+          id
+          has_user_saved
+        }
+      }
+    `
+    const { data: {
+      update_lowcal_sessions_by_pk: {
+        email_event_triggers_setup: isEmailEmailEventTriggersSetup
+      }
+    }} = await client.request(mutation, { sessionId });
+    return isEmailEmailEventTriggersSetup;
+  } catch (error) {
+    throw new Error(`Error setting up email notifications for session ${sessionId}`);
+  };
+};
+
 export {
   getSaveAndReturnPublicHeaders,
   sendEmail,
@@ -319,4 +343,5 @@ export {
   calculateExpiryDate,
   getHumanReadableProjectType,
   stringifyWithRootKeysSortedAlphabetically,
+  setupEmailEventTriggers,
 };

--- a/api.planx.uk/saveAndReturn/utils.js
+++ b/api.planx.uk/saveAndReturn/utils.js
@@ -307,7 +307,7 @@ const stringifyWithRootKeysSortedAlphabetically = (ob = {}) =>
       )
   );
 
-// Update lowcal_sessions.email_event_triggers_setup column to kick-off the setup_lowcal_expiry_events & 
+// Update lowcal_sessions.has_user_saved column to kick-off the setup_lowcal_expiry_events & 
 // setup_lowcal_reminder_events event triggers in Hasura
 const setupEmailEventTriggers = async (sessionId) => {
   try {
@@ -322,10 +322,10 @@ const setupEmailEventTriggers = async (sessionId) => {
     `
     const { data: {
       update_lowcal_sessions_by_pk: {
-        email_event_triggers_setup: isEmailEmailEventTriggersSetup
+        has_user_saved: hasUserSaved
       }
     }} = await client.request(mutation, { sessionId });
-    return isEmailEmailEventTriggersSetup;
+    return hasUserSaved;
   } catch (error) {
     throw new Error(`Error setting up email notifications for session ${sessionId}`);
   };

--- a/api.planx.uk/saveAndReturn/utils.js
+++ b/api.planx.uk/saveAndReturn/utils.js
@@ -320,11 +320,7 @@ const setupEmailEventTriggers = async (sessionId) => {
         }
       }
     `
-    const { data: {
-      update_lowcal_sessions_by_pk: {
-        has_user_saved: hasUserSaved
-      }
-    }} = await client.request(mutation, { sessionId });
+    const { update_lowcal_sessions_by_pk: { has_user_saved: hasUserSaved } } = await client.request(mutation, { sessionId });
     return hasUserSaved;
   } catch (error) {
     throw new Error(`Error setting up email notifications for session ${sessionId}`);

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -219,8 +219,9 @@
     - name: setup_lowcal_expiry_events
       definition:
         enable_manual: false
-        insert:
-          columns: '*'
+        update:
+          columns:
+            - email_event_triggers_setup
       retry_conf:
         num_retries: 3
         interval_sec: 10
@@ -230,24 +231,27 @@
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        body: |-
-          {
-            "createdAt": {{$body.event.data.new.created_at}},
-            "payload": {
-              "sessionId": {{$body.event.data.new.id}},
-              "email": {{$body.event.data.new.email}}
+        body:
+          action: transform
+          template: |-
+            {
+              "createdAt": {{$body.event.data.new.created_at}},
+              "payload": {
+                "sessionId": {{$body.event.data.new.id}},
+                "email": {{$body.event.data.new.email}}
+              }
             }
-          }
         url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
         method: POST
-        version: 1
+        version: 2
         query_params: {}
         template_engine: Kriti
     - name: setup_lowcal_reminder_events
       definition:
         enable_manual: false
-        insert:
-          columns: '*'
+        update:
+          columns:
+            - email_event_triggers_setup
       retry_conf:
         num_retries: 3
         interval_sec: 10
@@ -257,17 +261,19 @@
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        body: |-
-          {
-            "createdAt": {{$body.event.data.new.created_at}},
-            "payload": {
-              "sessionId": {{$body.event.data.new.id}},
-              "email": {{$body.event.data.new.email}}
+        body:
+          action: transform
+          template: |-
+            {
+              "createdAt": {{$body.event.data.new.created_at}},
+              "payload": {
+                "sessionId": {{$body.event.data.new.id}},
+                "email": {{$body.event.data.new.email}}
+              }
             }
-          }
         url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
         method: POST
-        version: 1
+        version: 2
         query_params: {}
         template_engine: Kriti
 - table:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -221,7 +221,7 @@
         enable_manual: false
         update:
           columns:
-            - email_event_triggers_setup
+            - has_user_saved
       retry_conf:
         num_retries: 3
         interval_sec: 10
@@ -251,7 +251,7 @@
         enable_manual: false
         update:
           columns:
-            - email_event_triggers_setup
+            - has_user_saved
       retry_conf:
         num_retries: 3
         interval_sec: 10

--- a/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/down.sql
+++ b/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/down.sql
@@ -1,0 +1,3 @@
+COMMENT ON COLUMN "public"."lowcal_sessions"."email_event_triggers_setup" IS NULL;
+
+ALTER TABLE "public"."lowcal_sessions" DROP COLUMN "email_event_triggers_setup";

--- a/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/down.sql
+++ b/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/down.sql
@@ -1,3 +1,3 @@
-COMMENT ON COLUMN "public"."lowcal_sessions"."email_event_triggers_setup" IS NULL;
+COMMENT ON COLUMN "public"."lowcal_sessions"."has_user_saved" IS NULL;
 
-ALTER TABLE "public"."lowcal_sessions" DROP COLUMN "email_event_triggers_setup";
+ALTER TABLE "public"."lowcal_sessions" DROP COLUMN "has_user_saved";

--- a/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/up.sql
+++ b/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."lowcal_sessions" add column "email_event_triggers_setup" boolean
+ not null default 'false';
+
+COMMENT ON COLUMN "public"."lowcal_sessions"."email_event_triggers_setup" IS E'Tracks if email reminder and expiry events have beeen setup for session';

--- a/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/up.sql
+++ b/hasura.planx.uk/migrations/1664529923804_alter_table_public_lowcal_sessions_add_column_has_user_saved/up.sql
@@ -1,4 +1,4 @@
-alter table "public"."lowcal_sessions" add column "email_event_triggers_setup" boolean
+alter table "public"."lowcal_sessions" add column "has_user_saved" boolean
  not null default 'false';
 
-COMMENT ON COLUMN "public"."lowcal_sessions"."email_event_triggers_setup" IS E'Tracks if email reminder and expiry events have beeen setup for session';
+COMMENT ON COLUMN "public"."lowcal_sessions"."has_user_saved" IS E'Tracks if email reminder and expiry events have been setup for session';


### PR DESCRIPTION
## What does this PR do?

Sets up email "Reminder" and "Expiry" event when a user explicitly hits the "Save and return to this application later" button. Previously this was done automatically once a session was started.

Event triggers used to be hit with an insert to `lowcal_sessions`, it will now be an update on `lowcal_sessions.has_user_saved`.

### To test
 - Start a new session on flow, e.g. XXXX
 - Once you have entered email x2, a `lowcal_session` record will be inserted
 - Event will **not** be set up in Hasura (Events > One-off Scheduled Events > Pending Events)
 - Back on the flow, hit "Save and return to this application later" 
 - A reminder and expiry event has now been set up in Hasura, with the timestamp matching when you hit "Save and return..." ✅ 