### PR TITLE
fix: add status to pay notifications

### DIFF
--- a/api.planx.uk/server.js
+++ b/api.planx.uk/server.js
@@ -326,7 +326,7 @@ app.get("/pay/:localAuthority/:paymentId", (req, res, next) => {
         if (govUkResponse?.payment_provider !== "sandbox") {
           try {
             const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL);
-            const payMessage = `:coin: New GOV Pay payment *${govUkResponse.payment_id}* [${req.params.localAuthority}]`;
+            const payMessage = `:coin: New GOV Pay payment *${govUkResponse.payment_id}* with status *${govUkResponse.state.status}* [${req.params.localAuthority}]`;
             await slack.send(payMessage);
             console.log("Payment notification posted to Slack");
           } catch (error) {


### PR DESCRIPTION
see thread https://opensystemslab.slack.com/archives/C0405SQDP8B/p1663263727756039

we are logging pay notifications regardless of payment status, and we pushed a manual submission for a failed payment.

https://docs.payments.service.gov.uk/api_reference/#payment-status-meanings