### PR TITLE
fix: prevent duplicate submissions per sessionId and destination

### DIFF
--- a/api.planx.uk/send/bops.js
+++ b/api.planx.uk/send/bops.js
@@ -121,6 +121,11 @@ const sendToBOPS = async (req, res, next) => {
   }
 };
 
+/**
+ * Query the BOPS audit table to see if we already have an application for this session
+ * @param {string} sessionId 
+ * @returns {object|undefined} bops_applications.response
+ */
 async function checkBOPSAuditTable(sessionId) {
   const application = await client.request(
     `

--- a/api.planx.uk/send/bops.test.js
+++ b/api.planx.uk/send/bops.test.js
@@ -18,6 +18,15 @@ import app from "../server";
 
     beforeEach(() => {
       queryMock.mockQuery({
+        name: "FindApplication",
+        matchOnVariables: false,
+        data: {
+          bops_applications: []
+        },
+        variables: { sessionId: 123 },
+      });
+
+      queryMock.mockQuery({
         name: "CreateApplication",
         matchOnVariables: false,
         data: {


### PR DESCRIPTION
Since fixing the "don't show first node in the graph" issue when resuming between Pay & Send last week, it seems that the Send component has become more prone to automatically rerendering/reloading/etc. We hit this issue twice with manaul submissions and yesterday with a live submission. There have also been successful single-submisssions in between though.

While we're fully investigating and diagnosing that, this should help add a layer of protection to avoid duplicate successful submissions (and by extension notifications in the Slack channel) per sessionId & destination. Because the Send component creates Hasura Events, and then those events run with some level of parallelization, I'm not certain this will catch every case - but it seems to work as intended in testing.

This PR won't make any difference to the duplicate Pay notifications we're also occassionally seeing, but I'd argue that those are actually perhaps useful right now as we continue to debug that redirect as long as they continue to reflect a **single** payment.