### PR TITLE
fix: Remove duplicate "Proposal" value in Uniform

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -87,37 +87,34 @@ export function makeXmlString(
         <portaloneapp:CertificateLawfulness>
           <portaloneapp:ProposedUseApplication>
             <portaloneapp:DescriptionCPU>
-              <common:OperationsDescription>OperationsDescription - ${
-                escape(passport.data?.["proposal.description"]
-              )}</common:OperationsDescription>
               ${/* Get answer from Alastair here*/ ""}
               <common:IsUseChange>true</common:IsUseChange>
-              <common:ProposedUseDescription>ProposedUseDescription - ${
-                escape(passport.data?.["proposal.description"]
+              <common:ProposedUseDescription>${escape(
+                passport.data?.["proposal.description"]
               )}</common:ProposedUseDescription>
-              <common:ExistingUseDescription>ExistingUseDescription - ${
-                escape(passport.data?.["proposal.description"]
+              <common:ExistingUseDescription>${escape(
+                passport.data?.["proposal.description"]
               )}</common:ExistingUseDescription>
               <common:IsUseStarted>${
                 passport.data?.["proposal.started"]
               }</common:IsUseStarted>
             </portaloneapp:DescriptionCPU>
             <portaloneapp:GroundsCPU>
-              <common:UseLawfulnessReason>UseLawfulnessReason - ${
-                escape(passport.data?.["proposal.description"]
+              <common:UseLawfulnessReason>${escape(
+                passport.data?.["proposal.description"]
               )}</common:UseLawfulnessReason>
               <common:SupportingInformation>
                 <common:AdditionalInformation>true</common:AdditionalInformation>
-                <common:Reference>Reference - ${
-                  escape(passport.data?.["proposal.description"]
+                <common:Reference>${escape(
+                  passport.data?.["proposal.description"]
                 )}</common:Reference>
               </common:SupportingInformation>
               ${
                 /* Currently hardcoded, will later be a variable controlled by SetValue component */ ""
               }
               <common:ProposedUseStatus>permanent</common:ProposedUseStatus>
-              <common:LawfulDevCertificateReason>LawfulDevCertificateReason - ${
-                escape(passport.data?.["proposal.description"]
+              <common:LawfulDevCertificateReason>${escape(
+                passport.data?.["proposal.description"]
               )}</common:LawfulDevCertificateReason>
             </portaloneapp:GroundsCPU>
           </portaloneapp:ProposedUseApplication>
@@ -129,10 +126,14 @@ export function makeXmlString(
       <portaloneapp:CertificateLawfulness>
         <portaloneapp:ExistingUseApplication>
           <portaloneapp:CategoryCEU/>
-          <portaloneapp:DescriptionCEU>DescriptionCEU - ${escape(passport.data?.["proposal.description"])}</portaloneapp:DescriptionCEU>
+          <portaloneapp:DescriptionCEU>${escape(
+            passport.data?.["proposal.description"]
+          )}</portaloneapp:DescriptionCEU>
           <portaloneapp:GroundsCEU>
             <common:GroundsCategory/>
-            <common:CertificateLawfulnessReason>CertificateLawfulnessReason - ${escape(passport.data?.["proposal.description"])}</common:CertificateLawfulnessReason>
+            <common:CertificateLawfulnessReason>${escape(
+              passport.data?.["proposal.description"]
+            )}</common:CertificateLawfulnessReason>
           </portaloneapp:GroundsCEU>
           <portaloneapp:InformationCEU>
             <common:UseBegunDate>${

--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -87,37 +87,37 @@ export function makeXmlString(
         <portaloneapp:CertificateLawfulness>
           <portaloneapp:ProposedUseApplication>
             <portaloneapp:DescriptionCPU>
-              <common:OperationsDescription>${escape(
-                passport.data?.["proposal.description"]
+              <common:OperationsDescription>OperationsDescription - ${
+                escape(passport.data?.["proposal.description"]
               )}</common:OperationsDescription>
               ${/* Get answer from Alastair here*/ ""}
               <common:IsUseChange>true</common:IsUseChange>
-              <common:ProposedUseDescription>${escape(
-                passport.data?.["proposal.description"]
+              <common:ProposedUseDescription>ProposedUseDescription - ${
+                escape(passport.data?.["proposal.description"]
               )}</common:ProposedUseDescription>
-              <common:ExistingUseDescription>${escape(
-                passport.data?.["proposal.description"]
+              <common:ExistingUseDescription>ExistingUseDescription - ${
+                escape(passport.data?.["proposal.description"]
               )}</common:ExistingUseDescription>
               <common:IsUseStarted>${
                 passport.data?.["proposal.started"]
               }</common:IsUseStarted>
             </portaloneapp:DescriptionCPU>
             <portaloneapp:GroundsCPU>
-              <common:UseLawfulnessReason>${escape(
-                passport.data?.["proposal.description"]
+              <common:UseLawfulnessReason>UseLawfulnessReason - ${
+                escape(passport.data?.["proposal.description"]
               )}</common:UseLawfulnessReason>
               <common:SupportingInformation>
                 <common:AdditionalInformation>true</common:AdditionalInformation>
-                <common:Reference>${escape(
-                  passport.data?.["proposal.description"]
+                <common:Reference>Reference - ${
+                  escape(passport.data?.["proposal.description"]
                 )}</common:Reference>
               </common:SupportingInformation>
               ${
                 /* Currently hardcoded, will later be a variable controlled by SetValue component */ ""
               }
               <common:ProposedUseStatus>permanent</common:ProposedUseStatus>
-              <common:LawfulDevCertificateReason>${escape(
-                passport.data?.["proposal.description"]
+              <common:LawfulDevCertificateReason>LawfulDevCertificateReason - ${
+                escape(passport.data?.["proposal.description"]
               )}</common:LawfulDevCertificateReason>
             </portaloneapp:GroundsCPU>
           </portaloneapp:ProposedUseApplication>
@@ -129,14 +129,10 @@ export function makeXmlString(
       <portaloneapp:CertificateLawfulness>
         <portaloneapp:ExistingUseApplication>
           <portaloneapp:CategoryCEU/>
-          <portaloneapp:DescriptionCEU>${escape(
-            passport.data?.["proposal.description"]
-          )}</portaloneapp:DescriptionCEU>
+          <portaloneapp:DescriptionCEU>DescriptionCEU - ${escape(passport.data?.["proposal.description"])}</portaloneapp:DescriptionCEU>
           <portaloneapp:GroundsCEU>
             <common:GroundsCategory/>
-            <common:CertificateLawfulnessReason>${escape(
-              passport.data?.["proposal.description"]
-            )}</common:CertificateLawfulnessReason>
+            <common:CertificateLawfulnessReason>CertificateLawfulnessReason - ${escape(passport.data?.["proposal.description"])}</common:CertificateLawfulnessReason>
           </portaloneapp:GroundsCEU>
           <portaloneapp:InformationCEU>
             <common:UseBegunDate>${


### PR DESCRIPTION
After testing with Kev, I've identified `common:OperationsDescription` as the problem node which was duplicating descriptions for Proposed applications. 

The descriptions where never duplicated for Existing LDC apps (see second screenshot).


![image (5)](https://user-images.githubusercontent.com/20502206/195072059-e5b96677-5fdf-4220-aa30-fa750cc6239c.png)
![image (4)](https://user-images.githubusercontent.com/20502206/195072062-b1000421-abbe-47d7-8cd7-3c381271492d.png)
