### PR TITLE
ci(pizza): teardown pizzas manually

### DIFF
--- a/.github/workflows/pizza-teardown-manual.yml
+++ b/.github/workflows/pizza-teardown-manual.yml
@@ -1,0 +1,24 @@
+name: Pizza Teardown
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_id:
+        required: true
+        type: integer
+        description: Pull Request number which should have its pizza destroyed
+
+env:
+  DOMAIN: planx.pizza
+  PULLREQUEST_ID: ${{ github.event.number }}
+
+jobs:
+  teardown_pizza:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Remove vultr resources
+        uses: theopensystemslab/vultr-action@v1.15
+        with:
+          action: destroy
+          api_key: ${{ secrets.VULTR_API_KEY }}
+          domain: ${{ env.DOMAIN }}
+          pullrequest_id: ${{  github.event.inputs.pull_request_id  }}


### PR DESCRIPTION
- Allows us to teardown pizzas by manually triggering the GitHub Actions teardown workflow
- I can only test it by merging it (and seeing if the button shows up on the Actions tab of this repo) so I might need a couple of PRs to get this right

Here's a picture of a workflow_dispatch action and its input fields:

![image](https://user-images.githubusercontent.com/7684574/193900981-e89a39b8-d1b8-433e-abf6-b58818b1b912.png)


(of course, our fields will be different. the image above is for illustration purposes only)