### PR TITLE
fix: explicitly return res.send() for Send endpoints

### DIFF
--- a/api.planx.uk/send/bops.js
+++ b/api.planx.uk/send/bops.js
@@ -7,7 +7,7 @@ const sendToBOPS = async (req, res, next) => {
   // `/bops/:localAuthority` is only called via Hasura's scheduled event webhook now, so body is wrapped in a "payload" key
   const { payload } = req.body;
   if (!payload) {
-    next({
+    return next({
       status: 400,
       message: `Missing application payload data to send to BOPS`,
     });
@@ -16,7 +16,7 @@ const sendToBOPS = async (req, res, next) => {
   // confirm that this session has not already been successfully submitted before proceeding
   const submittedApp = await checkBOPSAuditTable(payload?.planx_debug_data?.session_id);
   if (submittedApp?.message === "Application created") {
-    res.status(200).send({
+    return res.status(200).send({
       sessionId: payload?.planx_debug_data?.session_id,
       bopsId: submittedApp?.id,
       message: `Skipping send, already successfully submitted`,
@@ -114,7 +114,7 @@ const sendToBOPS = async (req, res, next) => {
       ),
     })(req, res);
   } else {
-    next({
+    return next({
       status: 400,
       message: `Back-office Planning System (BOPS) is not enabled for this local authority`,
     });

--- a/api.planx.uk/send/createSendEvents.js
+++ b/api.planx.uk/send/createSendEvents.js
@@ -26,7 +26,7 @@ const createSendEvents = async (req, res, next) => {
       combinedResponse["uniform"] = uniformEvent;
     }
 
-    res.json(combinedResponse);
+    return res.json(combinedResponse);
   } catch (error) {
     return next({
       error,


### PR DESCRIPTION
Addresses this Airbrake error and this duplication report

https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3378518417177942286?tab=overview
https://opensystemslab.slack.com/archives/C0405SQDP8B/p1665054764800339

Explanation: https://stackoverflow.com/questions/16180502/why-can-i-execute-code-after-res-send
![Screenshot from 2022-10-06 13-45-28](https://user-images.githubusercontent.com/5132349/194304546-35b53ddc-0807-42af-b3aa-20b69f4a290b.png)