### PR TITLE
bug: Send payload should build despite additional breadcrumbs

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
@@ -228,3 +228,62 @@ test("valid node types are serialized correctly for BOPS", () => {
 
   expect(actual).toStrictEqual(expected);
 });
+
+test("removed nodes are skipped", () => {
+  const breadcrumbsWithAdditionalNode = {
+    ...breadcrumbs,
+    AFoFsXSDog: {
+      auto: false,
+      data: {
+        text: "Breadcrumb which no longer exists in the flow",
+      },
+    },
+  };
+
+  const expected = {
+    feedback: {
+      find_property: "test",
+    },
+    proposal_details: [
+      {
+        question: "address question",
+        responses: [{ value: "line1, line, town, county, postcode" }],
+        metadata: { portal_name: "_root" },
+      },
+      {
+        question: "checklist",
+        responses: [{ value: "1" }, { value: "2" }],
+        metadata: { portal_name: "_root" },
+      },
+      {
+        question: "expandable checklist question",
+        responses: [{ value: "c1" }, { value: "c2" }, { value: "c3" }],
+        metadata: { portal_name: "_root" },
+      },
+      {
+        question: "date question",
+        responses: [{ value: "1999-01-01" }],
+        metadata: { portal_name: "_root" },
+      },
+      {
+        question: "number question",
+        responses: [{ value: "500" }],
+        metadata: { portal_name: "_root" },
+      },
+      {
+        question: "regular question",
+        responses: [{ value: "a1" }],
+        metadata: { portal_name: "_root" },
+      },
+      {
+        question: "text question",
+        responses: [{ value: "testanswer" }],
+        metadata: { portal_name: "_root" },
+      },
+    ],
+  };
+
+  const actual = makePayload(flow, breadcrumbsWithAdditionalNode);
+
+  expect(actual).toStrictEqual(expected);
+});

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -109,6 +109,8 @@ export const makePayload = (
 
   const proposal_details = Object.entries(breadcrumbs)
     .map(([id, bc]) => {
+      // Skip nodes that may be in the breadcrumbs which are no longer in flow
+      if (!flow[id]) return;
       const { edges = [], ...question } = flow[id];
 
       try {


### PR DESCRIPTION
Addresses the following error - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1665145845295839

The affected user here had an additional breadcrumb which was subsequently removed from the flow, leading to the following error.

We could / should catch this at the reconciliation stage but a frontend guard will always be required as sometimes reconciliation is skipped (e.g. returning from pay).