### PR TITLE
fix: Escape XML special characters

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^2.29.1",
     "draft-js": "^0.11.7",
     "draftjs-to-html": "^0.9.1",
+    "fast-xml-parser": "^4.0.11",
     "formik": "^2.2.9",
     "graphql": "^16.5.0",
     "graphql-tag": "^2.12.6",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -105,6 +105,7 @@ specifiers:
   eslint-plugin-jsx-a11y: ^6.6.1
   eslint-plugin-simple-import-sort: ^7.0.0
   eslint-plugin-testing-library: ^5.6.0
+  fast-xml-parser: ^4.0.11
   formik: ^2.2.9
   graphql: ^16.5.0
   graphql-tag: ^2.12.6
@@ -188,6 +189,7 @@ dependencies:
   date-fns: 2.29.1
   draft-js: 0.11.7_biqbaboplfbrettd7655fr4n2y
   draftjs-to-html: 0.9.1
+  fast-xml-parser: 4.0.11
   formik: 2.2.9_react@18.2.0
   graphql: 16.5.0
   graphql-tag: 2.12.6_graphql@16.5.0
@@ -9759,6 +9761,13 @@ packages:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
     dev: false
 
+  /fast-xml-parser/4.0.11:
+    resolution: {integrity: sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
+
   /fastest-stable-stringify/2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
     dev: false
@@ -17466,6 +17475,10 @@ packages:
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  /strnum/1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
 
   /style-loader/1.3.0_webpack@4.44.2:
     resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}

--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.test.ts
@@ -1,0 +1,24 @@
+import { XMLValidator } from "fast-xml-parser";
+
+import { Store } from "./../../../../pages/FlowEditor/lib/store/index";
+import { UniformInstance } from "./applicationType";
+import { makeXmlString } from "./xml";
+
+describe("makeXmlString constructor", () => {
+  const sessionId = "123";
+  const files: string[] = [];
+
+  it("safely escapes special XML characters", () => {
+    const passport: Store.passport = {
+      data: { "proposal.description": `< > & " '` },
+    };
+    const xmlString = makeXmlString(
+      passport,
+      sessionId,
+      files,
+      UniformInstance.Aylesbury
+    );
+    const isValid = XMLValidator.validate(xmlString);
+    expect(isValid).toBe(true);
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -1,3 +1,4 @@
+import { escape } from "lodash";
 import { GovUKPayment } from "types";
 
 import { Store } from "../../../../pages/FlowEditor/lib/store";
@@ -54,7 +55,7 @@ export function makeXmlString(
     const uniqueFilename = file.split("/").slice(-2).join("-");
     userUploadedFiles.push(`
       <common:FileAttachment>
-        <common:FileName>${uniqueFilename}</common:FileName>
+        <common:FileName>${escape(uniqueFilename)}</common:FileName>
         <common:Reference>Other</common:Reference>
       </common:FileAttachment>
     `);
@@ -86,38 +87,38 @@ export function makeXmlString(
         <portaloneapp:CertificateLawfulness>
           <portaloneapp:ProposedUseApplication>
             <portaloneapp:DescriptionCPU>
-              <common:OperationsDescription>${
+              <common:OperationsDescription>${escape(
                 passport.data?.["proposal.description"]
-              }</common:OperationsDescription>
+              )}</common:OperationsDescription>
               ${/* Get answer from Alastair here*/ ""}
               <common:IsUseChange>true</common:IsUseChange>
-              <common:ProposedUseDescription>${
+              <common:ProposedUseDescription>${escape(
                 passport.data?.["proposal.description"]
-              }</common:ProposedUseDescription>
-              <common:ExistingUseDescription>${
+              )}</common:ProposedUseDescription>
+              <common:ExistingUseDescription>${escape(
                 passport.data?.["proposal.description"]
-              }</common:ExistingUseDescription>
+              )}</common:ExistingUseDescription>
               <common:IsUseStarted>${
                 passport.data?.["proposal.started"]
               }</common:IsUseStarted>
             </portaloneapp:DescriptionCPU>
             <portaloneapp:GroundsCPU>
-              <common:UseLawfulnessReason>${
+              <common:UseLawfulnessReason>${escape(
                 passport.data?.["proposal.description"]
-              }</common:UseLawfulnessReason>
+              )}</common:UseLawfulnessReason>
               <common:SupportingInformation>
                 <common:AdditionalInformation>true</common:AdditionalInformation>
-                <common:Reference>${
+                <common:Reference>${escape(
                   passport.data?.["proposal.description"]
-                }</common:Reference>
+                )}</common:Reference>
               </common:SupportingInformation>
               ${
                 /* Currently hardcoded, will later be a variable controlled by SetValue component */ ""
               }
               <common:ProposedUseStatus>permanent</common:ProposedUseStatus>
-              <common:LawfulDevCertificateReason>${
+              <common:LawfulDevCertificateReason>${escape(
                 passport.data?.["proposal.description"]
-              }</common:LawfulDevCertificateReason>
+              )}</common:LawfulDevCertificateReason>
             </portaloneapp:GroundsCPU>
           </portaloneapp:ProposedUseApplication>
         </portaloneapp:CertificateLawfulness>
@@ -128,13 +129,19 @@ export function makeXmlString(
       <portaloneapp:CertificateLawfulness>
         <portaloneapp:ExistingUseApplication>
           <portaloneapp:CategoryCEU/>
-          <portaloneapp:DescriptionCEU>${passport.data?.["proposal.description"]}</portaloneapp:DescriptionCEU>
+          <portaloneapp:DescriptionCEU>${escape(
+            passport.data?.["proposal.description"]
+          )}</portaloneapp:DescriptionCEU>
           <portaloneapp:GroundsCEU>
             <common:GroundsCategory/>
-            <common:CertificateLawfulnessReason>${passport.data?.["proposal.description"]}</common:CertificateLawfulnessReason>
+            <common:CertificateLawfulnessReason>${escape(
+              passport.data?.["proposal.description"]
+            )}</common:CertificateLawfulnessReason>
           </portaloneapp:GroundsCEU>
           <portaloneapp:InformationCEU>
-            <common:UseBegunDate>${passport.data?.["proposal.started.date"]}</common:UseBegunDate>
+            <common:UseBegunDate>${
+              passport.data?.["proposal.started.date"]
+            }</common:UseBegunDate>
           </portaloneapp:InformationCEU>
         </portaloneapp:ExistingUseApplication>
       </portaloneapp:CertificateLawfulness>
@@ -173,39 +180,39 @@ export function makeXmlString(
       </portaloneapp:FileAttachments>
       <portaloneapp:Applicant>
         <common:PersonName>
-          <pdt:PersonNameTitle>${
+          <pdt:PersonNameTitle>${escape(
             passport.data?.["applicant.title"]
-          }</pdt:PersonNameTitle>
-          <pdt:PersonGivenName>${
+          )}</pdt:PersonNameTitle>
+          <pdt:PersonGivenName>${escape(
             passport.data?.["applicant.name.first"]
-          }</pdt:PersonGivenName>
-          <pdt:PersonFamilyName>${
+          )}</pdt:PersonGivenName>
+          <pdt:PersonFamilyName>${escape(
             passport.data?.["applicant.name.last"]
-          }</pdt:PersonFamilyName>
+          )}</pdt:PersonFamilyName>
         </common:PersonName>
-        <common:OrgName>${
+        <common:OrgName>${escape(
           passport.data?.["applicant.company.name"]
-        }</common:OrgName>
+        )}</common:OrgName>
         <common:ExternalAddress>
           <common:InternationalAddress>
-            <apd:IntAddressLine>${
+            <apd:IntAddressLine>${escape(
               passport.data?.["applicant.address"]?.["line1"]
-            }</apd:IntAddressLine>
-            <apd:IntAddressLine>${
+            )}</apd:IntAddressLine>
+            <apd:IntAddressLine>${escape(
               passport.data?.["applicant.address"]?.["line2"]
-            }</apd:IntAddressLine>
-            <apd:IntAddressLine>${
+            )}</apd:IntAddressLine>
+            <apd:IntAddressLine>${escape(
               passport.data?.["applicant.address"]?.["town"]
-            }</apd:IntAddressLine>
-            <apd:IntAddressLine>${
+            )}</apd:IntAddressLine>
+            <apd:IntAddressLine>${escape(
               passport.data?.["applicant.address"]?.["county"]
-            }</apd:IntAddressLine>
-            <apd:Country>${
+            )}</apd:IntAddressLine>
+            <apd:Country>${escape(
               passport.data?.["applicant.address"]?.["country"]
-            }</apd:Country>
-            <apd:InternationalPostCode>${
+            )}</apd:Country>
+            <apd:InternationalPostCode>${escape(
               passport.data?.["applicant.address"]?.["postcode"]
-            }</apd:InternationalPostCode>
+            )}</apd:InternationalPostCode>
           </common:InternationalAddress>
         </common:ExternalAddress>
         <common:ContactDetails PreferredContactMedium="E-Mail">
@@ -215,47 +222,47 @@ export function makeXmlString(
             }</apd:EmailAddress>
           </common:Email>
           <common:Telephone TelUse="work" TelPreferred="no" TelMobile="yes">
-            <apd:TelNationalNumber>${
+            <apd:TelNationalNumber>${escape(
               passport.data?.["applicant.phone.primary"]
-            }</apd:TelNationalNumber>
+            )}</apd:TelNationalNumber>
           </common:Telephone>
         </common:ContactDetails>
       </portaloneapp:Applicant>
       <portaloneapp:Agent>
         <common:PersonName>
-        <pdt:PersonNameTitle>${
+        <pdt:PersonNameTitle>${escape(
           passport.data?.["applicant.agent.title"]
-        }</pdt:PersonNameTitle>
-        <pdt:PersonGivenName>${
+        )}</pdt:PersonNameTitle>
+        <pdt:PersonGivenName>${escape(
           passport.data?.["applicant.agent.name.first"]
-        }</pdt:PersonGivenName>
-        <pdt:PersonFamilyName>${
+        )}</pdt:PersonGivenName>
+        <pdt:PersonFamilyName>${escape(
           passport.data?.["applicant.agent.name.last"]
-        }</pdt:PersonFamilyName>
+        )}</pdt:PersonFamilyName>
         </common:PersonName>
-        <common:OrgName>${
+        <common:OrgName>${escape(
           passport.data?.["applicant.agent.company.name"]
-        }</common:OrgName>
+        )}</common:OrgName>
         <common:ExternalAddress>
           <common:InternationalAddress>
-          <apd:IntAddressLine>${
+          <apd:IntAddressLine>${escape(
             passport.data?.["applicant.agent.address"]?.["line1"]
-          }</apd:IntAddressLine>
-          <apd:IntAddressLine>${
+          )}</apd:IntAddressLine>
+          <apd:IntAddressLine>${escape(
             passport.data?.["applicant.agent.address"]?.["line2"]
-          }</apd:IntAddressLine>
-          <apd:IntAddressLine>${
+          )}</apd:IntAddressLine>
+          <apd:IntAddressLine>${escape(
             passport.data?.["applicant.agent.address"]?.["town"]
-          }</apd:IntAddressLine>
-          <apd:IntAddressLine>${
+          )}</apd:IntAddressLine>
+          <apd:IntAddressLine>${escape(
             passport.data?.["applicant.agent.address"]?.["county"]
-          }</apd:IntAddressLine>
-          <apd:Country>${
+          )}</apd:IntAddressLine>
+          <apd:Country>${escape(
             passport.data?.["applicant.agent.address"]?.["country"]
-          }</apd:Country>
-          <apd:InternationalPostCode>${
+          )}</apd:Country>
+          <apd:InternationalPostCode>${escape(
             passport.data?.["applicant.agent.address"]?.["postcode"]
-          }</apd:InternationalPostCode>
+          )}</apd:InternationalPostCode>
           </common:InternationalAddress>
         </common:ExternalAddress>
         <common:ContactDetails PreferredContactMedium="E-Mail">
@@ -265,28 +272,30 @@ export function makeXmlString(
             }</apd:EmailAddress>
           </common:Email>
           <common:Telephone TelUse="work" TelPreferred="no" TelMobile="yes">
-            <apd:TelNationalNumber>${
+            <apd:TelNationalNumber>${escape(
               passport.data?.["applicant.agent.phone.primary"]
-            }</apd:TelNationalNumber>
+            )}</apd:TelNationalNumber>
           </common:Telephone>
         </common:ContactDetails>
       </portaloneapp:Agent>
       <portaloneapp:SiteLocation>
         <bs7666:BS7666Address>
           <bs7666:PAON>
-            <bs7666:Description>${
+            <bs7666:Description>${escape(
               passport.data?.["_address"]?.["pao"]
-            }</bs7666:Description>
+            )}</bs7666:Description>
           </bs7666:PAON>
-          <bs7666:StreetDescription>${
+          <bs7666:StreetDescription>${escape(
             passport.data?.["_address"]?.["street"]
-          }</bs7666:StreetDescription>
-          <bs7666:Town>${passport.data?.["_address"]?.["town"]}</bs7666:Town>
+          )}</bs7666:StreetDescription>
+          <bs7666:Town>${escape(
+            passport.data?.["_address"]?.["town"]
+          )}</bs7666:Town>
           <bs7666:AdministrativeArea/>
           <bs7666:PostTown/>
-          <bs7666:PostCode>${
+          <bs7666:PostCode>${escape(
             passport.data?.["_address"]?.["postcode"]
-          }</bs7666:PostCode>
+          )}</bs7666:PostCode>
           <bs7666:UniquePropertyReferenceNumber>${
             passport.data?.["_address"]?.["uprn"]
           }</bs7666:UniquePropertyReferenceNumber>


### PR DESCRIPTION
## Problem
 - Uniform submission failed where an end user had entered a "&" character in their project description
 - This resulted in invalid XML being sent to Uniform, which the connector could not parse

## Solution
- Very quick and dirty - just using `_.escape()` on text fields which are part of the XML string template

## Comments
 - I think this is another indication we might want to take another look at the work started by @jessicamcinchak here to implement an alternative method of constructing the Uniform XML - https://github.com/theopensystemslab/planx-new/pull/939#discussion_r891010320
 - I've added a card to the backlog to discuss prioritising this - https://trello.com/c/6PD2SuLw/2144-implement-uniformpayload-interface-to-improve-xml-construction