### PR TITLE
fix: Point ts-node-dev to type definitions

### DIFF
--- a/api.planx.uk/@types/index.d.ts
+++ b/api.planx.uk/@types/index.d.ts
@@ -1,0 +1,2 @@
+declare module "@camptocamp/inkmap";
+declare module "pino-noir";

--- a/api.planx.uk/@types/pino-noir.d.ts
+++ b/api.planx.uk/@types/pino-noir.d.ts
@@ -1,1 +1,0 @@
-declare module "pino-noir";

--- a/api.planx.uk/tsconfig.json
+++ b/api.planx.uk/tsconfig.json
@@ -1,4 +1,10 @@
 {
+  "ts-node": {
+    "files": true
+  },
+  "files": [
+    "@types/index.d.ts"
+  ],
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,
@@ -14,5 +20,5 @@
     "strict": true,
     "target": "es2021",
   },
-  "exclude": ["node_modules", "./dist/**/*"]
+  "exclude": ["node_modules", "./dist/**/*"],
 }

--- a/api.planx.uk/tsconfig.json
+++ b/api.planx.uk/tsconfig.json
@@ -3,7 +3,8 @@
     "files": true
   },
   "files": [
-    "@types/index.d.ts"
+    "@types/index.d.ts",
+    "./dist"
   ],
   "compilerOptions": {
     "allowJs": true,


### PR DESCRIPTION
## What does this fix?

Currently getting the following error when running `pnpm run dev` in the api directory - 

```
[ERROR] 17:12:28 ⨯ Unable to compile TypeScript:
server.ts(10,18): error TS7016: Could not find a declaration file for module 'pino-noir'. '/Users/dafyddllyr/Code/planx-new/api.planx.uk/node_modules/.pnpm/pino-noir@2.2.1/node_modules/pino-noir/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/pino-noir` if it exists or add a new declaration (.d.ts) file containing `declare module 'pino-noir';`
```