### PR TITLE
fix: `ts-node-dev` not finding types

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -35,7 +35,7 @@
     "string-to-stream": "^3.0.1"
   },
   "scripts": {
-    "dev": "ts-node-dev index.ts",
+    "dev": "ts-node-dev --files index.ts",
     "start": "node ./dist/index.js",
     "test": "TZ=Europe/London jest",
     "test:watch": "TZ=Europe/London jest --watch",

--- a/api.planx.uk/tsconfig.json
+++ b/api.planx.uk/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2021",
+    "typeRoots": ["./node_modules/@types", "./@types"]
   },
   "exclude": ["node_modules", "./dist/**/*"]
 }


### PR DESCRIPTION
`ts-node-dev` does not check eagerly for type files,
therefore we need to add the flag `--files`.

See: https://github.com/TypeStrong/ts-node#missing-types
