### PR TITLE
fix(ci): Rollback of #1194

### DIFF
--- a/scripts/seed-database/upsert-production-flows.js
+++ b/scripts/seed-database/upsert-production-flows.js
@@ -1,4 +1,4 @@
-import { groupBy, cloneDeep } from "lodash";
+import groupBy from "lodash/groupBy";
 import { GraphQLClient } from "graphql-request";
 import pThrottle from 'p-throttle';
 const args = process.argv.slice(2);


### PR DESCRIPTION
To test - 
 - Pizza has flows downloaded from prod

This PR reverts the change made in #1194 as this leads to the seed-db script failing locally and on Pizzas. Quick revert of the above PR so that Pizzas continue to build - will take a look at the underlying issue here also.

See docker logs for container `planx-new_seed-database` on `1199.planx.pizza`

```sh
docker logs c05fbbf7c38a
{"level":"info","msg":"Help us improve Hasura! The cli collects anonymized usage stats which\nallow us to keep improving Hasura at warp speed. To opt-out or read more,\nvisit https://hasura.io/docs/latest/graphql/core/guides/telemetry.html\n","time":"2022-10-12T11:51:28Z"}
{"level":"info","msg":"Applying seeds...","time":"2022-10-12T11:51:29Z"}
{"level":"info","msg":"Seeds planted","time":"2022-10-12T11:51:29Z"}

> seed-database@ upsert-flows /scripts
> node --experimental-specifier-resolution=node ./upsert-production-flows

file:///scripts/upsert-production-flows.js:1
import { groupBy, cloneDeep } from "lodash";
                  ^^^^^^^^^
SyntaxError: Named export 'cloneDeep' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'lodash';
const { groupBy, cloneDeep } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:181:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
 ELIFECYCLE  Command failed with exit code 1.
```

