### PR TITLE
fix: Return string as addressLines, not array

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/xml.ts
@@ -125,22 +125,27 @@ export function makeXmlString(
   /**
    * Generate an Address based on a SiteAddress
    */
-  const getAddressFromSiteAddress = (): string => `
-    <common:ExternalAddress>
+  const getAddressFromSiteAddress = (): string => {
+    const addressLines: string = siteAddress.title
+      ?.split(", ")
+      .map(
+        (addressLine) =>
+          `<apd:IntAddressLine>${escape(addressLine)}</apd:IntAddressLine>`
+      )
+      .join("\n");
+
+    return `
+      <common:ExternalAddress>
       <common:InternationalAddress>
-        ${siteAddress.title
-          ?.split(", ")
-          .map(
-            (addressLine) =>
-              `<apd:IntAddressLine>${escape(addressLine)}</apd:IntAddressLine>`
-          )}
+        ${addressLines}
         <apd:Country></apd:Country>
         <apd:InternationalPostCode>${escape(
           siteAddress?.postcode
         )}</apd:InternationalPostCode>
       </common:InternationalAddress>
     </common:ExternalAddress>
-  `;
+    `;
+  };
 
   /**
    * Return an InternationalAddress node representing a personal address


### PR DESCRIPTION
Noticed this whilst working on the `UniformPayload` type. Currently `getAddressFromSiteAddress()` returns the following fragment with commas after each `apd:IntAddressLine` node.

It's perfectly valid XML (surprisingly!) and Uniform reads it, but just tidying up here!


```xml
<common:ExternalAddress>
  <common:InternationalAddress>
    <apd:IntAddressLine>DRF CONSULTING ENGINEERS</apd:IntAddressLine>,
    <apd:IntAddressLine>ANNEX BUILDING</apd:IntAddressLine>,
    <apd:IntAddressLine>DISTRICT COUNCIL OFFICES</apd:IntAddressLine>,
    <apd:IntAddressLine>QUEEN VICTORIA ROAD</apd:IntAddressLine>,
    <apd:IntAddressLine>HIGH WYCOMBE</apd:IntAddressLine>
    <apd:Country></apd:Country>
    <apd:InternationalPostCode>HP11 1BB</apd:InternationalPostCode>
  </common:InternationalAddress>
</common:ExternalAddress>
```

Tested on Pizza, the following XML fragment is now generated here - 

```xml
<common:ExternalAddress>
  <common:InternationalAddress>
    <apd:IntAddressLine>1</apd:IntAddressLine>
    <apd:IntAddressLine>RHYD-Y-BONT</apd:IntAddressLine>
    <apd:IntAddressLine>PENPARCAU</apd:IntAddressLine>
    <apd:IntAddressLine>ABERYSTWYTH</apd:IntAddressLine>
    <apd:Country></apd:Country>
    <apd:InternationalPostCode>SY23 1SR</apd:InternationalPostCode>
  </common:InternationalAddress>
</common:ExternalAddress>
```