### PR TITLE
fix: Drop scheduled events on update of submitted_at or deleted_at

### DIFF
--- a/hasura.planx.uk/migrations/1665744811194_delete_lowcal_events_on_submit_or_soft_delete/down.sql
+++ b/hasura.planx.uk/migrations/1665744811194_delete_lowcal_events_on_submit_or_soft_delete/down.sql
@@ -1,0 +1,25 @@
+-- Drop current function and trigger
+DROP TRIGGER IF EXISTS delete_lowcal_session_scheduled_events_trigger ON lowcal_sessions;
+DROP FUNCTION IF EXISTS delete_lowcal_session_scheduled_events;
+
+-- Replace with previous itteration from hasura.planx.uk/migrations/1661380924586_run_sql_migration/up.sql
+CREATE OR REPLACE FUNCTION 
+	delete_lowcal_session_scheduled_events()
+RETURNS TRIGGER AS $$ 
+BEGIN
+	DELETE FROM hdb_catalog.hdb_scheduled_events 
+	WHERE comment IN (
+    'reminder_' || OLD.id, 
+		'expiry_' || OLD.id 
+	);
+	RETURN NULL;
+END
+$$ LANGUAGE plpgsql VOLATILE;
+
+DROP TRIGGER IF EXISTS delete_lowcal_session_scheduled_events_trigger ON lowcal_sessions;
+CREATE TRIGGER delete_lowcal_session_scheduled_events_trigger
+AFTER DELETE ON lowcal_sessions FOR EACH ROW
+EXECUTE PROCEDURE delete_lowcal_session_scheduled_events();
+
+COMMENT ON TRIGGER delete_lowcal_session_scheduled_events_trigger ON lowcal_sessions
+IS 'Delete linked scheduled events (reminder and expiry emails) when deleting a lowcal_session';

--- a/hasura.planx.uk/migrations/1665744811194_delete_lowcal_events_on_submit_or_soft_delete/up.sql
+++ b/hasura.planx.uk/migrations/1665744811194_delete_lowcal_events_on_submit_or_soft_delete/up.sql
@@ -1,0 +1,23 @@
+DROP TRIGGER IF EXISTS delete_lowcal_session_scheduled_events_trigger ON lowcal_sessions;
+DROP FUNCTION IF EXISTS delete_lowcal_session_scheduled_events;
+
+CREATE OR REPLACE FUNCTION 
+	delete_lowcal_session_scheduled_events()
+RETURNS TRIGGER AS $$ 
+BEGIN
+	DELETE FROM hdb_catalog.hdb_scheduled_events 
+	WHERE comment IN (
+    'reminder_' || OLD.id, 
+		'expiry_' || OLD.id 
+	);
+	RETURN NULL;
+END
+$$ LANGUAGE plpgsql VOLATILE;
+
+DROP TRIGGER IF EXISTS delete_lowcal_session_scheduled_events_trigger ON lowcal_sessions;
+CREATE TRIGGER delete_lowcal_session_scheduled_events_trigger
+AFTER UPDATE OF submitted_at, deleted_at ON lowcal_sessions FOR EACH ROW
+EXECUTE PROCEDURE delete_lowcal_session_scheduled_events();
+
+COMMENT ON TRIGGER delete_lowcal_session_scheduled_events_trigger ON lowcal_sessions
+IS 'Delete linked scheduled events (reminder and expiry emails) when submitting or deleting a lowcal_session';


### PR DESCRIPTION
Issue raised here - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1665739302290809

Scheduled events are deleted via trigger when a hard delete takes place, but actually we want to delete them when either a submission or a soft delete takes place. This follows a recent change in the following PR - 

There's no user impact, as these API calls fail anyway (see Airbrake error above) but it's best to align everything here.

I'm getting increasingly keen to tidy things up in a more robust way...!  🗑️  https://trello.com/c/FlGxMbps/2078-data-retention-create-single-scheduled-task-to-purge-application-data-at-set-time-interval

To test - 
 - Create a lowcal_session record (via Hasura or frontend)
 - Query Hasura - there should be no scheduled events set up yet 
 - Set `has_user_saved` = true (via Hasura or frontend)
 - Query Hasura - there should be both a reminder and expiry event set up
 - Set either `deleted_at` or `submitted_at` = now() via Hasura
 -  Query Hasura - both scheduled event records should have been deleted 🗑️ 

One (significant!) issue here is that dropping the events means we cannot easily access the payload which has proved helpful in debugging send events. I propose that we actually add a `payload` column on our Uniform audit table and more explicitly capture this same raw data - we already do it for BOPS.

**Query for scheduled events (can also viewed in console)**
```sql
SELECT * FROM hdb_catalog.hdb_scheduled_events where comment ilike '%_<lowcal_session.id>'
```