### PR TITLE
feat: Capture payload on Uniform application audit table

### DIFF
--- a/api.planx.uk/send/uniform.js
+++ b/api.planx.uk/send/uniform.js
@@ -8,6 +8,7 @@ import str from "string-to-stream";
 import { stringify } from "csv-stringify";
 import { adminGraphQLClient } from "../hasura";
 import { markSessionAsSubmitted } from "../saveAndReturn/utils";
+import { gql } from "graphql-request";
 
 const client = adminGraphQLClient;
 
@@ -69,34 +70,36 @@ const sendToUniform = async (req, res, next) => {
         }
 
         const submissionDetails = await retrieveSubmission(token, idoxSubmissionId);
-        const application = await client.request(
-          `
-            mutation CreateUniformApplication(
-              $idox_submission_id: String = "",
-              $submission_reference: String = "",
-              $destination: String = "",
-              $response: jsonb = "",
-            ) {
-              insert_uniform_applications_one(object: {
-                idox_submission_id: $idox_submission_id,
-                submission_reference: $submission_reference,
-                destination: $destination,
-                response: $response,
-              }) {
-                id
-                idox_submission_id
-                submission_reference
-                destination
-                response
-                created_at
-              }
+        const application = await client.request(gql`
+          mutation CreateUniformApplication(
+            $idox_submission_id: String = "",
+            $submission_reference: String = "",
+            $destination: String = "",
+            $response: jsonb = "",
+            $payload: jsonb = "",
+          ) {
+            insert_uniform_applications_one(object: {
+              idox_submission_id: $idox_submission_id,
+              submission_reference: $submission_reference,
+              destination: $destination,
+              response: $response,
+              payload: $payload
+            }) {
+              id
+              idox_submission_id
+              submission_reference
+              destination
+              response
+              created_at
             }
-          `,
+          }
+        `,
           {
             idox_submission_id: idoxSubmissionId,
             submission_reference: payload?.sessionId,
             destination: req.params.localAuthority,
             response: submissionDetails,
+            payload: req.body.payload,
           }
         );
 

--- a/hasura.planx.uk/migrations/1665755400143_alter_table_public_uniform_applications_add_column_payload/down.sql
+++ b/hasura.planx.uk/migrations/1665755400143_alter_table_public_uniform_applications_add_column_payload/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."uniform_applications" DROP COLUMN "payload";

--- a/hasura.planx.uk/migrations/1665755400143_alter_table_public_uniform_applications_add_column_payload/up.sql
+++ b/hasura.planx.uk/migrations/1665755400143_alter_table_public_uniform_applications_add_column_payload/up.sql
@@ -1,0 +1,3 @@
+alter table "public"."uniform_applications" add column "payload" jsonb null;
+
+comment on column "public"."uniform_applications"."payload" is E'Payload which generated this submission to Uniform';


### PR DESCRIPTION
## What does this PR do?
- Adds a `payload` column on the `uniform_application` audit table
- This will be helpful for debugging as we're now doing a better job of cleaning up the scheduled event tables (#1206)

### To test
 - An application submitted to Uniform will have the `payload` column populated