### PR TITLE
wip: reboot the Editor representation of a Page with new rules for grouping certain components

### DIFF
--- a/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -1,5 +1,10 @@
 import { TYPES } from "@planx/components/types";
-import { ICONS } from "@planx/components/ui";
+import {
+  EditorProps,
+  ICONS,
+  InternalNotes,
+  MoreInformation,
+} from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import Input from "ui/Input";
@@ -8,28 +13,16 @@ import ModalSection from "ui/ModalSection";
 import ModalSectionContent from "ui/ModalSectionContent";
 import RichTextInput from "ui/RichTextInput";
 
-interface Props {
-  id?: string;
-  handleSubmit?: any;
-  node?: {
-    data?: {
-      title?: string;
-      description?: string;
-    };
-  };
-}
+import { Page, parsePage } from "./model";
+
+export type Props = EditorProps<TYPES.Page, Page>;
 
 const PageForm: React.FC<Props> = (props) => {
   const formik = useFormik({
-    initialValues: {
-      title: props.node?.data?.title || "",
-      description: props.node?.data?.description || "",
-    },
-    onSubmit: (values) => {
+    initialValues: parsePage(props.node?.data),
+    onSubmit: (newValues) => {
       if (props.handleSubmit) {
-        props.handleSubmit({ type: TYPES.Page, data: values });
-      } else {
-        alert(JSON.stringify(values, null, 2));
+        props.handleSubmit({ type: TYPES.Page, data: newValues });
       }
     },
   });
@@ -47,7 +40,6 @@ const PageForm: React.FC<Props> = (props) => {
               value={formik.values.title}
             />
           </InputRow>
-
           <InputRow>
             <RichTextInput
               name="description"
@@ -58,6 +50,18 @@ const PageForm: React.FC<Props> = (props) => {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
+      <MoreInformation
+        changeField={formik.handleChange}
+        definitionImg={formik.values.definitionImg}
+        howMeasured={formik.values.howMeasured}
+        policyRef={formik.values.policyRef}
+        info={formik.values.info}
+      />
+      <InternalNotes
+        name="notes"
+        value={formik.values.notes}
+        onChange={formik.handleChange}
+      />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -1,0 +1,65 @@
+import { TYPES } from "@planx/components/types";
+import { ICONS } from "@planx/components/ui";
+import { useFormik } from "formik";
+import React from "react";
+import Input from "ui/Input";
+import InputRow from "ui/InputRow";
+import ModalSection from "ui/ModalSection";
+import ModalSectionContent from "ui/ModalSectionContent";
+import RichTextInput from "ui/RichTextInput";
+
+interface Props {
+  id?: string;
+  handleSubmit?: any;
+  node?: {
+    data?: {
+      title?: string;
+      description?: string;
+    };
+  };
+}
+
+const PageForm: React.FC<Props> = (props) => {
+  const formik = useFormik({
+    initialValues: {
+      title: props.node?.data?.title || "",
+      description: props.node?.data?.description || "",
+    },
+    onSubmit: (values) => {
+      if (props.handleSubmit) {
+        props.handleSubmit({ type: TYPES.Page, data: values });
+      } else {
+        alert(JSON.stringify(values, null, 2));
+      }
+    },
+  });
+
+  return (
+    <form onSubmit={formik.handleSubmit} id="modal">
+      <ModalSection>
+        <ModalSectionContent title="Page" Icon={ICONS[TYPES.Page]}>
+          <InputRow>
+            <Input
+              format="large"
+              name="title"
+              onChange={formik.handleChange}
+              placeholder="Title"
+              value={formik.values.title}
+            />
+          </InputRow>
+
+          <InputRow>
+            <RichTextInput
+              name="description"
+              onChange={formik.handleChange}
+              placeholder="Description"
+              value={formik.values.description}
+            />
+          </InputRow>
+        </ModalSectionContent>
+      </ModalSection>
+    </form>
+  );
+};
+
+export default PageForm;

--- a/editor.planx.uk/src/@planx/components/Page/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Public.tsx
@@ -9,7 +9,6 @@ import type { Page, UserData } from "./model";
 
 export type Props = PublicProps<Page, UserData>;
 
-// TODO: fix this data field bug for all components
 const PageComponent: React.FC<Props> = (props) => {
   const formik = useFormik({
     initialValues: {
@@ -29,6 +28,7 @@ const PageComponent: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
         howMeasured={props.howMeasured}
       />
+      {/* TODO: Render child nodes, rollup handleSubmits to this outer card */}
     </Card>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Page/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Public.tsx
@@ -1,0 +1,36 @@
+import Card from "@planx/components/shared/Preview/Card";
+import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
+import { PublicProps } from "@planx/components/ui";
+import { useFormik } from "formik";
+import React from "react";
+
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
+import type { Page, UserData } from "./model";
+
+export type Props = PublicProps<Page, UserData>;
+
+// TODO: fix this data field bug for all components
+const PageComponent: React.FC<Props> = (props) => {
+  const formik = useFormik({
+    initialValues: {
+      text: getPreviouslySubmittedData(props) ?? "",
+    },
+    onSubmit: (values) => {
+      props.handleSubmit?.(makeData(props, values.text));
+    },
+  });
+
+  return (
+    <Card handleSubmit={formik.handleSubmit} isValid>
+      <QuestionHeader
+        title={props.title}
+        description={props.description}
+        info={props.info}
+        policyRef={props.policyRef}
+        howMeasured={props.howMeasured}
+      />
+    </Card>
+  );
+};
+
+export default PageComponent;

--- a/editor.planx.uk/src/@planx/components/Page/model.ts
+++ b/editor.planx.uk/src/@planx/components/Page/model.ts
@@ -1,0 +1,15 @@
+import type { MoreInformation } from "../shared";
+import { parseMoreInformation } from "../shared";
+
+export type UserData = string;
+
+export interface Page extends MoreInformation {
+  title: string;
+  description: string;
+}
+
+export const parsePage = (data: Record<string, any> | undefined): Page => ({
+  title: data?.title || "",
+  description: data?.description || "",
+  ...parseMoreInformation(data),
+});

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -53,6 +53,7 @@ function isTypeForBopsPayload(type?: TYPES) {
     case TYPES.Flow:
     case TYPES.InternalPortal:
     case TYPES.Notice:
+    case TYPES.Page:
     case TYPES.Pay:
     case TYPES.PlanningConstraints:
     case TYPES.Response:

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -69,6 +69,7 @@ const components: {
   [TYPES.InternalPortal]: undefined,
   [TYPES.Notice]: undefined,
   [TYPES.NumberInput]: NumberInput,
+  [TYPES.Page]: undefined,
   [TYPES.Pay]: undefined,
   [TYPES.PlanningConstraints]: undefined,
   [TYPES.Response]: Debug,

--- a/editor.planx.uk/src/@planx/components/types.ts
+++ b/editor.planx.uk/src/@planx/components/types.ts
@@ -17,7 +17,7 @@ export enum TYPES {
   Content = 250,
   InternalPortal = 300,
   ExternalPortal = 310,
-  // Page = 350,
+  Page = 350,
   SetValue = 380,
   Pay = 400,
   Filter = 500,

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -3,6 +3,7 @@ import CallSplit from "@mui/icons-material/CallSplit";
 import CheckBoxOutlined from "@mui/icons-material/CheckBoxOutlined";
 import CloudUpload from "@mui/icons-material/CloudUpload";
 import Create from "@mui/icons-material/Create";
+import Description from "@mui/icons-material/Description";
 import Event from "@mui/icons-material/Event";
 import FunctionsIcon from "@mui/icons-material/Functions";
 import Home from "@mui/icons-material/Home";
@@ -67,6 +68,7 @@ export const ICONS: {
   [TYPES.InternalPortal]: undefined,
   [TYPES.Notice]: ReportProblemOutlined,
   [TYPES.NumberInput]: Pin,
+  [TYPES.Page]: Description,
   [TYPES.Pay]: PaymentOutlined,
   [TYPES.PlanningConstraints]: Map,
   [TYPES.Response]: undefined,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -8,6 +8,7 @@ import Breadcrumb from "./Breadcrumb";
 import Checklist from "./Checklist";
 import Filter from "./Filter";
 import Option from "./Option";
+import Page from "./Page";
 import Portal from "./Portal";
 import Question from "./Question";
 
@@ -117,6 +118,8 @@ const Node: React.FC<any> = (props) => {
       return <Question {...allProps} text={node?.data?.title ?? "Address"} />;
     case TYPES.Flow:
       return null;
+    case TYPES.Page:
+      return <Page {...props} text={node?.data?.title ?? "Page"} />;
     default:
       console.error({ nodeNotFound: props });
       return exhaustiveCheck(type);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Page.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Page.tsx
@@ -1,0 +1,80 @@
+import { TYPES } from "@planx/components/types";
+import classNames from "classnames";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { useDrag } from "react-dnd";
+import { Link } from "react-navi";
+
+import { getParentId } from "../lib/utils";
+import Hanger from "./Hanger";
+import Node from "./Node";
+
+type Props = {
+  type: TYPES;
+};
+
+const Page: React.FC<Props> = (props: any) => {
+  const [isClone, childNodes, copyNode, flow] = useStore((state) => [
+    state.isClone,
+    state.childNodesOf(props.id),
+    state.copyNode,
+    state.flow,
+  ]);
+
+  const parent = getParentId(props.parent);
+
+  const allowedNodeTypes = [];
+  console.log("dragging node", props.id, flow[props.id]?.type);
+
+  const [{ isDragging }, drag] = useDrag({
+    item: {
+      id: props.id,
+      parent,
+      text: props.text,
+    },
+    type: "PAGE",
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
+  let href = `${window.location.pathname}/nodes/${props.id}/edit`;
+  if (parent) {
+    href = `${window.location.pathname}/nodes/${parent}/nodes/${props.id}/edit`;
+  }
+
+  const handleContext = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    copyNode(props.id);
+  };
+
+  return (
+    <>
+      <Hanger hidden={isDragging} before={props.id} parent={parent} />
+      <li
+        className={classNames("card", "page", {
+          isDragging,
+          isClone: isClone(props.id),
+        })}
+      >
+        <Link
+          href={href}
+          prefetch={false}
+          onContextMenu={handleContext}
+          ref={drag}
+        >
+          <span>{props.text}</span>
+        </Link>
+        <ol>
+          {childNodes.map((child: any) => (
+            <Node key={child.id} parent={props.id} {...child} />
+          ))}
+          <Hanger parent={props.id} />
+        </ol>
+      </li>
+    </>
+  );
+};
+
+export default Page;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Page.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Page.tsx
@@ -23,8 +23,8 @@ const Page: React.FC<Props> = (props: any) => {
 
   const parent = getParentId(props.parent);
 
-  const allowedNodeTypes = [];
-  console.log("dragging node", props.id, flow[props.id]?.type);
+  // TODO: Limit Page to non-branching component types, show something in the editor if an invalid type is dragged in
+  const allowedNodeTypes = [TYPES.TextInput, TYPES.NumberInput, TYPES.Content];
 
   const [{ isDragging }, drag] = useDrag({
     item: {

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -75,6 +75,7 @@ const NodeTypeSelect: React.FC<{
         <option value={TYPES.Filter}>Filter</option>
         <option value={TYPES.InternalPortal}>Internal Portal</option>
         <option value={TYPES.ExternalPortal}>External Portal</option>
+        <option value={TYPES.Page}>Page</option>
         <option value={TYPES.SetValue}>Set Value</option>
       </optgroup>
       <optgroup label="Payment">

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/index.ts
@@ -12,6 +12,7 @@ import FindProperty from "@planx/components/FindProperty/Editor";
 import InternalPortal from "@planx/components/InternalPortal/Editor";
 import Notice from "@planx/components/Notice/Editor";
 import NumberInput from "@planx/components/NumberInput/Editor";
+import Page from "@planx/components/Page/Editor";
 import Pay from "@planx/components/Pay/Editor";
 import PlanningConstraints from "@planx/components/PlanningConstraints/Editor";
 import Question from "@planx/components/Question/Editor";
@@ -46,6 +47,7 @@ const components: {
   "internal-portal": InternalPortal,
   notice: Notice,
   "number-input": NumberInput,
+  page: Page,
   pay: Pay,
   "planning-constraints": PlanningConstraints,
   question: Question,

--- a/editor.planx.uk/src/pages/FlowEditor/data/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/data/types.ts
@@ -18,6 +18,7 @@ export const SLUGS: {
   [TYPES.InternalPortal]: "internal-portal",
   [TYPES.Notice]: "notice",
   [TYPES.NumberInput]: "number-input",
+  [TYPES.Page]: "page",
   [TYPES.Pay]: "pay",
   [TYPES.PlanningConstraints]: "planning-constraints",
   [TYPES.Response]: "question",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -416,7 +416,7 @@ export const previewStore = (
 
           const passport = computePassport();
 
-          if (node.type === TYPES.InternalPortal) {
+          if (node.type === TYPES.InternalPortal || node.type === TYPES.Page) {
             return nodeIdsConnectedFrom(id);
           }
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -421,9 +421,12 @@ export const previewStore = (
           }
 
           if (node.type === TYPES.Page && node.edges?.length) {
-            node.edges.forEach((edgeId) => {
-              return nodeIdsConnectedFrom(edgeId);
-            });
+            // TODO: figure out what to do here - my hunch is something like
+            //   - the container Page should be the only component registered in "nextNode" & "back" computations
+            //   - the Page's "edges" are really just a concern of the Public/Preview component?
+            //       - handleSubmit should write all individual passport values
+            //       - mark each edge nodeId as "visited" so it's individually skipped by graph
+            console.log("page stuff here");
           }
 
           const fn = node.type === TYPES.Filter ? "flag" : node.data?.fn;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -416,8 +416,14 @@ export const previewStore = (
 
           const passport = computePassport();
 
-          if (node.type === TYPES.InternalPortal || node.type === TYPES.Page) {
+          if (node.type === TYPES.InternalPortal) {
             return nodeIdsConnectedFrom(id);
+          }
+
+          if (node.type === TYPES.Page && node.edges?.length) {
+            node.edges.forEach((edgeId) => {
+              return nodeIdsConnectedFrom(edgeId);
+            });
           }
 
           const fn = node.type === TYPES.Filter ? "flag" : node.data?.fn;

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -9,6 +9,7 @@ import FileUpload from "@planx/components/FileUpload/Public";
 import FindProperty from "@planx/components/FindProperty/Public";
 import Notice from "@planx/components/Notice/Public";
 import NumberInput from "@planx/components/NumberInput/Public";
+import Page from "@planx/components/Page/Public";
 import { GOV_PAY_PASSPORT_KEY } from "@planx/components/Pay/model";
 import Pay from "@planx/components/Pay/Public";
 import PlanningConstraints from "@planx/components/PlanningConstraints/Public";
@@ -161,6 +162,9 @@ const Node: React.FC<any> = (props: Props) => {
     case TYPES.NumberInput:
       return <NumberInput {...allProps} />;
 
+    case TYPES.Page:
+      return <Page {...allProps} />;
+
     case TYPES.Pay:
       return <Pay {...allProps} />;
 
@@ -233,7 +237,6 @@ const Node: React.FC<any> = (props: Props) => {
     case TYPES.Flow:
     case TYPES.InternalPortal:
     case TYPES.Response:
-    case TYPES.Page:
     case undefined:
       return null;
     default:

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -233,6 +233,7 @@ const Node: React.FC<any> = (props: Props) => {
     case TYPES.Flow:
     case TYPES.InternalPortal:
     case TYPES.Response:
+    case TYPES.Page:
     case undefined:
       return null;
     default:


### PR DESCRIPTION
One of a couple experiments this week related to navigation (see also #1207). This one aims to get closer to Alastair's pie in the sky sketches of arranging multiple components in the Editor to display on a single card to applicants. It reboots the Editor bits here (#103), with the idea that we would limit which component types could be added to a Page, and starts to think through what the Public/Preview representation could be

Pros:
- Flexible editor experience
- Keeps with goal of generalized individual components that can be composed together, rather than introducing new, perhaps too-bespoke, component types

Challenges / open questions / what we'd need to sort out to get this fully working (estimate 5-8):
- Graph considerations: see TODO note [here](https://github.com/theopensystemslab/planx-new/pull/1209/files#diff-d93e4413e0cb16ffeec24f6df1499fd4f24074ba6837ece6c782bb90053e0f37R424)
- Preview considerations: how to strip individual component types out of their `Card` and rollup their `handleSubmit` methods? 
- Accessibility considerations: heirarchy, custom error messages, required/optional, input specifications (width, type, etc), aria descriptors, etc
- Review page: "change" link should point to nodeId of Page, but then individual questions should have focus applied? 
- How is this different than our idea for  "Section markers"? Is it the distinction of allowing logic-branching component types? How would these coexist with section markers / is it too much overlap? 

How we'd know it's "done": 
- Can we retire `AddressInput` & `ContactInput` component types? Can an editor now fully compose the equivalent?