### PR TITLE
fix(ci): add missing env var

### DIFF
--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -16,6 +16,8 @@ jobs:
         uses: pulumi/setup-pulumi@v2
       - run: |
           echo "HASURA_GRAPHQL_ADMIN_SECRET=$(pulumi config get hasura-admin-secret --stack staging)" >> $GITHUB_ENV
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
 Fixes this error

 ```
error: PULUMI_ACCESS_TOKEN must be set for login during non-interactive CLI sessions
```

in the [Weekly staging database sync](https://github.com/theopensystemslab/planx-new/actions/workflows/sync-staging-db.yml) action:

![image](https://user-images.githubusercontent.com/7684574/196174023-7300bee2-497a-4e26-bcff-a4595b07fdef.png)

