### PR TITLE
Fix: Upgrade passport (npm package for auth)

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -28,7 +28,7 @@
     "mime": "^3.0.0",
     "nanoid": "^3.3.4",
     "notifications-node-client": "^5.1.1",
-    "passport": "^0.5.3",
+    "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "pino-noir": "^2.2.1",
     "slack-notify": "^2.0.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -51,7 +51,7 @@ specifiers:
   nock: ^13.2.9
   node-dev: ^7.4.3
   notifications-node-client: ^5.1.1
-  passport: ^0.5.3
+  passport: ^0.6.0
   passport-google-oauth20: ^2.0.0
   pino-noir: ^2.2.1
   prettier: ~2.7.1
@@ -89,7 +89,7 @@ dependencies:
   mime: 3.0.0
   nanoid: 3.3.4
   notifications-node-client: 5.1.1
-  passport: 0.5.3
+  passport: 0.6.0
   passport-google-oauth20: 2.0.0
   pino-noir: 2.2.1
   slack-notify: 2.0.3
@@ -4570,12 +4570,13 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /passport/0.5.3:
-    resolution: {integrity: sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==}
+  /passport/0.6.0:
+    resolution: {integrity: sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       passport-strategy: 1.0.0
       pause: 0.0.1
+      utils-merge: 1.0.1
     dev: false
 
   /path-exists/4.0.0:


### PR DESCRIPTION
Addressing this ticket: https://trello.com/c/BKP8MVAK/2138-upgrade-the-passport-dependency

This is a simple non-breaking version bump to address a security advisory here: https://github.com/theopensystemslab/planx-new/security/dependabot/1

I've tested this locally and all works fine. Happy to take advice on how I go about testing this in staging...
