### PR TITLE
feat: Improvements to help button

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -63,7 +63,7 @@ interface IMoreInfo {
 const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
   <Root
     anchor="right"
-    drawerWidth={400}
+    drawerWidth={600}
     aria-modal="true"
     role="dialog"
     aria-label="Further information about this question and the policies pertaining to it"

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -1,54 +1,57 @@
 import CloseIcon from "@mui/icons-material/Close";
-import Drawer from "@mui/material/Drawer";
+import Drawer, { DrawerProps } from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
-import makeStyles from "@mui/styles/makeStyles";
-import classNames from "classnames";
+import { styled } from "@mui/material/styles";
 import React from "react";
 
-const moreInfoStyles = makeStyles((theme) => ({
-  drawer: (props: { drawerWidth: 400 }) => ({
-    width: props.drawerWidth,
+const PREFIX = "MoreInfo";
+
+const classes = {
+  drawerPaper: `${PREFIX}-drawerPaper`,
+};
+
+interface StyledDrawerProps extends DrawerProps {
+  drawerWidth: number;
+}
+
+const Root = styled(Drawer)<StyledDrawerProps>(
+  ({ theme, drawerWidth, open }) => ({
+    width: drawerWidth,
     flexShrink: 0,
     color: theme.palette.text.primary,
     transition: theme.transitions.create("margin", {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
     }),
-    marginRight: -props.drawerWidth,
+    marginRight: open ? 0 : -drawerWidth,
     [theme.breakpoints.only("xs")]: {
       width: "100%",
       marginRight: "-100%",
     },
-  }),
-  drawerShift: {
-    marginRight: 0,
-  },
-  drawerTitle: {
-    marginTop: theme.spacing(1),
-    fontWeight: 700,
-    fontSize: "1.15rem",
-    flexGrow: 1,
-  },
-  drawerContent: {
-    padding: "0.5rem 1.75rem 1rem",
-    fontSize: "1rem",
-    lineHeight: "1.5",
-  },
-  drawerPaper: (props: { drawerWidth: 400 }) => ({
-    width: props.drawerWidth,
-    backgroundColor: theme.palette.background.default,
-    border: 0,
-    boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
-    [theme.breakpoints.only("xs")]: {
-      width: "100%",
+
+    [`& .${classes.drawerPaper}`]: {
+      width: drawerWidth,
+      backgroundColor: theme.palette.background.default,
+      border: 0,
+      boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
+      [theme.breakpoints.only("xs")]: {
+        width: "100%",
+      },
+      padding: theme.spacing(1),
     },
-    padding: theme.spacing(1),
-  }),
-  close: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "flex-end",
-  },
+  })
+);
+
+const DrawerContent = styled("div")(() => ({
+  padding: "0.5rem 1.75rem 1rem",
+  fontSize: "1rem",
+  lineHeight: "1.5",
+}));
+
+const CloseButton = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
 }));
 
 interface IMoreInfo {
@@ -57,39 +60,34 @@ interface IMoreInfo {
   handleClose: Function;
 }
 
-const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => {
-  const classes = moreInfoStyles({ drawerWidth: 400 } as any);
-  return (
-    <Drawer
-      className={classNames(classes.drawer, {
-        [classes.drawerShift]: open,
-      })}
-      anchor="right"
-      aria-modal="true"
-      role="dialog"
-      aria-label="Further information about this question and the policies pertaining to it"
-      open={open}
-      onClose={() => handleClose()}
-      classes={{
-        paper: classes.drawerPaper,
-      }}
-    >
-      <div className={classes.close}>
-        <IconButton
-          onClick={() => handleClose()}
-          role="button"
-          title="Close panel"
-          aria-label="Close panel"
-          size="large"
-        >
-          <CloseIcon />
-        </IconButton>
-      </div>
-      <div role="main">
-        <div className={classes.drawerContent}>{children}</div>
-      </div>
-    </Drawer>
-  );
-};
+const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
+  <Root
+    anchor="right"
+    drawerWidth={400}
+    aria-modal="true"
+    role="dialog"
+    aria-label="Further information about this question and the policies pertaining to it"
+    open={open}
+    onClose={() => handleClose()}
+    classes={{
+      paper: classes.drawerPaper,
+    }}
+  >
+    <CloseButton>
+      <IconButton
+        onClick={() => handleClose()}
+        role="button"
+        title="Close panel"
+        aria-label="Close panel"
+        size="large"
+      >
+        <CloseIcon />
+      </IconButton>
+    </CloseButton>
+    <div role="main">
+      <DrawerContent>{children}</DrawerContent>
+    </div>
+  </Root>
+);
 
 export default MoreInfo;

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -1,8 +1,8 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import React from "react";
 import MoreInfoIcon from "ui/icons/MoreInfo";
@@ -21,21 +21,20 @@ interface IQuestionHeader {
   definitionImg?: string;
   img?: string;
 }
+const Description = styled(Box)(({ theme }) => ({
+  "& p": {
+    margin: `${theme.spacing(1)} 0`,
+  },
+}));
 
-const useStyles = makeStyles((theme) => ({
-  iconButton: {
-    "&:hover": {
-      backgroundColor: "transparent",
-    },
+const StyledIconButton = styled(IconButton)(() => ({
+  "&:hover": {
+    backgroundColor: "transparent",
   },
-  description: {
-    "& p": {
-      margin: `${theme.spacing(1)} 0`,
-    },
-  },
-  image: {
-    maxWidth: "100%",
-  },
+}));
+
+const Image = styled("img")(() => ({
+  maxWidth: "100%",
 }));
 
 const QuestionHeader: React.FC<IQuestionHeader> = ({
@@ -48,7 +47,6 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
   img,
 }) => {
   const [open, setOpen] = React.useState(false);
-  const classes = useStyles();
   const { trackHelpClick } = useAnalyticsTracking();
 
   const handleHelpClick = () => {
@@ -73,19 +71,18 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
             </Box>
           )}
           {description && (
-            <Box className={classes.description}>
+            <Description>
               <ReactMarkdownOrHtml
                 source={description}
                 id={DESCRIPTION_TEXT}
                 openLinksOnNewTab
               />
-            </Box>
+            </Description>
           )}
         </Grid>
         {!!(info || policyRef || howMeasured) && (
           <Grid item>
-            <IconButton
-              className={classes.iconButton}
+            <StyledIconButton
               title={`More information`}
               aria-label={`See more information about "${title}"`}
               onClick={handleHelpClick}
@@ -93,7 +90,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
               size="large"
             >
               <MoreInfoIcon />
-            </IconButton>
+            </StyledIconButton>
           </Grid>
         )}
       </Grid>
@@ -111,19 +108,13 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
         {howMeasured && (
           <MoreInfoSection title="How is it defined?">
             <>
-              {definitionImg && (
-                <img
-                  src={definitionImg}
-                  alt="definition"
-                  className={classes.image}
-                />
-              )}
+              {definitionImg && <Image src={definitionImg} alt="definition" />}
               <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab />
             </>
           </MoreInfoSection>
         )}
       </MoreInfo>
-      {img && <img src={img} alt="question" className={classes.image} />}
+      {img && <Image src={img} alt="question" />}
     </Box>
   );
 };

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -92,7 +92,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
               aria-haspopup="dialog"
               size="large"
             >
-              <MoreInfoIcon viewBox="0 0 30 30" />
+              <MoreInfoIcon />
             </IconButton>
           </Grid>
         )}
@@ -123,7 +123,6 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           </MoreInfoSection>
         )}
       </MoreInfo>
-
       {img && <img src={img} alt="question" className={classes.image} />}
     </Box>
   );

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -44,7 +44,6 @@ export const linkStyle = {
  * Get Global theme options
  * The global theme is used in editor, and as the base theme in Preview/Unpublished which can be
  * merged with Team specific options
- * @returns {ThemeOptions}
  */
 export const getGlobalThemeOptions = (): ThemeOptions => {
   const themeOptions: ThemeOptions = {
@@ -193,8 +192,12 @@ export const getGlobalThemeOptions = (): ThemeOptions => {
           borderRadius: 0,
           "&:focus-visible": {
             ...focusStyle(themeOptions.palette?.action?.focus),
-            "& svg": {
+            "& svg, div": {
               color: "black",
+              borderColor: "black",
+            },
+            "&>*:hover": {
+              backgroundColor: "transparent",
             },
           },
         },
@@ -245,8 +248,6 @@ export const getGlobalThemeOptions = (): ThemeOptions => {
  * Get team specific theme options
  * Pass in TeamTheme to customise the palette and associated overrides
  * Rules here will only apply in the Preview and Unpublished routes
- * @param {TeamTheme} theme
- * @returns {ThemeOptions}
  */
 export const getTeamThemeOptions = (
   theme: TeamTheme | undefined

--- a/editor.planx.uk/src/ui/icons/MoreInfo.tsx
+++ b/editor.planx.uk/src/ui/icons/MoreInfo.tsx
@@ -1,27 +1,31 @@
-import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
-import makeStyles from "@mui/styles/makeStyles";
+import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import { Box } from "@mui/material";
+import { styled } from "@mui/styles";
 import React from "react";
 
-const useStyles = makeStyles((theme) => ({
-  icon: {
-    borderRadius: 15,
+export default function MoreInfoIcon() {
+  const Root = styled(Box)(({ theme }) => ({
+    border: `3px solid ${theme.palette.primary.main}`,
+    color: theme.palette.primary.main,
+    borderRadius: "50%",
+    height: 32,
+    width: 32,
     "&:hover": {
-      backgroundColor: theme.palette.grey[300],
+      backgroundColor: theme.palette.primary.main,
+      color: "white",
+      borderColor: theme.palette.primary.main,
     },
-  },
-}));
+  }));
 
-export default function MoreInfoIcon(props: SvgIconProps) {
-  const classes = useStyles();
   return (
-    <SvgIcon {...props} className={classes.icon}>
-      <g>
-        <circle cx="15" cy="15" r="14.5" stroke="black" fill="transparent" />
-        <path
-          d="M13.9899 16.9318H15.2683V16.8679C15.2896 15.5469 15.6305 14.9716 16.568 14.3857C17.5055 13.8157 18.0595 12.9954 18.0595 11.8182C18.0595 10.1562 16.845 8.94176 14.97 8.94176C13.2442 8.94176 11.8752 10.0071 11.7953 11.8182H13.1377C13.2176 10.5611 14.0965 10.0497 14.97 10.0497C15.9715 10.0497 16.7811 10.7102 16.7811 11.7543C16.7811 12.6012 16.2964 13.2085 15.6732 13.5866C14.6291 14.2205 14.0059 14.8384 13.9899 16.8679V16.9318ZM14.6717 20.0852C15.1991 20.0852 15.6305 19.6538 15.6305 19.1264C15.6305 18.5991 15.1991 18.1676 14.6717 18.1676C14.1444 18.1676 13.7129 18.5991 13.7129 19.1264C13.7129 19.6538 14.1444 20.0852 14.6717 20.0852Z"
-          fill="black"
-        />
-      </g>
-    </SvgIcon>
+    <Root>
+      <QuestionMarkIcon
+        sx={{
+          position: "absolute",
+          left: 16,
+          top: 16,
+        }}
+      />
+    </Root>
   );
 }

--- a/editor.planx.uk/src/ui/icons/MoreInfo.tsx
+++ b/editor.planx.uk/src/ui/icons/MoreInfo.tsx
@@ -1,6 +1,6 @@
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
 import { Box } from "@mui/material";
-import { styled } from "@mui/styles";
+import { styled } from "@mui/material/styles";
 import React from "react";
 
 export default function MoreInfoIcon() {


### PR DESCRIPTION
## What does this PR do?
 - Changes the help icon style - larger, uses team primary colour, and has a thicker outline
 - Increases `MoreInfo` drawer width from 400px to 600px

### Also...
 - Fixes a style issue when both `:hover` and `:focus-visible` pseudo classes where applied to the button
 - Updates the styles in touched components from JSS to Emotion (part of the MUI v5 upgrade - docs here https://mui.com/material-ui/migration/migrating-from-jss/
 
||Before|After|
|---|---|---|
|**Standard**|<img width="774" alt="image" src="https://user-images.githubusercontent.com/20502206/196893656-514b987a-a09d-4f32-892f-d37a437f000a.png">|<img width="801" alt="image" src="https://user-images.githubusercontent.com/20502206/196894675-274104c6-bfec-44b2-b0a5-221174ec44f9.png">|
|**Focus**|<img width="811" alt="image" src="https://user-images.githubusercontent.com/20502206/196894162-a34d3f15-3ce1-497d-9ef7-1583d880e667.png">|<img width="830" alt="image" src="https://user-images.githubusercontent.com/20502206/196894756-5e3890a9-386e-4dc1-9e40-14d4323cda06.png">|
|**Focus & Hover**|<img width="911" alt="image" src="https://user-images.githubusercontent.com/20502206/196893886-e26426ca-f432-43cf-9f3c-7e339a2af25a.png">|<img width="906" alt="image" src="https://user-images.githubusercontent.com/20502206/196894816-d8f36159-8fe4-4c63-885b-7b29803fe35e.png">| 