### PR TITLE
feat: Increase map size in DrawBoundary

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -7,6 +7,7 @@ import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import type { PublicProps } from "@planx/components/ui";
 import type { Geometry } from "@turf/helpers";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
+import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
 import React, { useEffect, useRef, useState } from "react";
 
 import {
@@ -19,21 +20,31 @@ import Upload, { FileUpload } from "./Upload";
 export type Props = PublicProps<DrawBoundary>;
 export type SelectedFile = FileUpload;
 
-const MapContainer = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(1, 0),
-  width: "100%",
-  height: "50vh",
-  [theme.breakpoints.up("md")]: {
-    height: "80vh",
-    width: "80vw",
-    position: "relative",
-    left: "calc(-40vw + 50%)",
-  },
-  "& my-map": {
+interface MapContainerProps {
+  environment: PreviewEnvironment;
+}
+
+const MapContainer = styled(Box)<MapContainerProps>(
+  ({ theme, environment }) => ({
+    padding: theme.spacing(1, 0),
     width: "100%",
-    height: "100%",
-  },
-}));
+    height: "50vh",
+    // Only increase map size in Preview & Unpublished routes
+    [theme.breakpoints.up("md")]:
+      environment === "standalone"
+        ? {
+            height: "80vh",
+            width: "80vw",
+            position: "relative",
+            left: "calc(-40vw + 50%)",
+          }
+        : {},
+    "& my-map": {
+      width: "100%",
+      height: "100%",
+    },
+  })
+);
 
 const AlternateOption = styled("div")(({ theme }) => ({
   textAlign: "right",
@@ -71,6 +82,7 @@ export default function Component(props: Props) {
     previousFile
   );
   const [area, setArea] = useState<number | undefined>(previousArea);
+  const environment = useStore((state) => state.previewEnvironment);
 
   useEffect(() => {
     if (isMounted.current) setSelectedFile(undefined);
@@ -126,7 +138,7 @@ export default function Component(props: Props) {
             howMeasured={props.howMeasured}
             definitionImg={props.definitionImg}
           />
-          <MapContainer>
+          <MapContainer environment={environment}>
             <p style={visuallyHidden}>
               An interactive map centred on your address, with a red pointer to
               draw your site outline. Click to place points and connect the

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -1,8 +1,6 @@
-import "./map.css";
-
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import makeStyles from "@mui/styles/makeStyles";
+import { styled } from "@mui/material/styles";
 import { visuallyHidden } from "@mui/utils";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
@@ -21,28 +19,39 @@ import Upload, { FileUpload } from "./Upload";
 export type Props = PublicProps<DrawBoundary>;
 export type SelectedFile = FileUpload;
 
-const useClasses = makeStyles((theme) => ({
-  map: {
-    padding: theme.spacing(1, 0),
+const MapContainer = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1, 0),
+  width: "100%",
+  height: "50vh",
+  [theme.breakpoints.up("md")]: {
+    height: "80vh",
+    width: "80vw",
+    position: "relative",
+    left: "calc(-40vw + 50%)",
   },
-  hidden: { display: "none" },
-  uploadInstead: {
-    textAlign: "right",
-    marginTop: theme.spacing(1),
-    "& button": {
-      background: "none",
-      "border-style": "none",
-      color: theme.palette.text.primary,
-      cursor: "pointer",
-      fontSize: "medium",
-      padding: theme.spacing(2),
-    },
-    "& button:hover": {
-      backgroundColor: theme.palette.background.paper,
-    },
-    "& button:disabled": {
-      color: theme.palette.text.disabled,
-    },
+  "& my-map": {
+    width: "100%",
+    height: "100%",
+  },
+}));
+
+const AlternateOption = styled("div")(({ theme }) => ({
+  textAlign: "right",
+  marginTop: theme.spacing(1),
+}));
+
+const AlternateOptionButton = styled(Button)(({ theme }) => ({
+  background: "none",
+  borderStyle: "none",
+  color: theme.palette.text.primary,
+  cursor: "pointer",
+  fontSize: "medium",
+  padding: theme.spacing(2),
+  "& :hover": {
+    backgroundColor: theme.palette.background.paper,
+  },
+  "& :disabled": {
+    color: theme.palette.text.disabled,
   },
 }));
 
@@ -57,7 +66,6 @@ export default function Component(props: Props) {
   const startPage = previousFile ? "upload" : "draw";
   const [page, setPage] = useState<"draw" | "upload">(startPage);
   const passport = useStore((state) => state.computePassport());
-  const classes = useClasses();
   const [boundary, setBoundary] = useState<Boundary>(previousBoundary);
   const [selectedFile, setSelectedFile] = useState<SelectedFile | undefined>(
     previousFile
@@ -118,9 +126,9 @@ export default function Component(props: Props) {
             howMeasured={props.howMeasured}
             definitionImg={props.definitionImg}
           />
-          <Box className={classes.map}>
+          <MapContainer>
             <p style={visuallyHidden}>
-              An interactive map centered on your address, with a red pointer to
+              An interactive map centred on your address, with a red pointer to
               draw your site outline. Click to place points and connect the
               lines to make your site. Once you've closed the site shape, click
               and drag the lines to modify it.
@@ -143,17 +151,17 @@ export default function Component(props: Props) {
               longitude={Number(passport?.data?._address?.longitude)}
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
-          </Box>
+          </MapContainer>
           {!props.hideFileUpload && (
-            <div className={classes.uploadInstead}>
-              <Button
+            <AlternateOption>
+              <AlternateOptionButton
                 data-testid="upload-file-button"
                 onClick={() => setPage("upload")}
                 disabled={Boolean(boundary)}
               >
                 Upload a location plan instead
-              </Button>
-            </div>
+              </AlternateOptionButton>
+            </AlternateOption>
           )}
           <p>
             The boundary you have drawn has an area of{" "}
@@ -163,7 +171,7 @@ export default function Component(props: Props) {
       );
     } else if (page === "upload") {
       return (
-        <div>
+        <>
           <QuestionHeader
             title={props.titleForUploading}
             description={props.descriptionForUploading}
@@ -173,15 +181,15 @@ export default function Component(props: Props) {
             definitionImg={props.definitionImg}
           />
           <Upload setFile={setSelectedFile} initialFile={selectedFile} />
-          <div className={classes.uploadInstead}>
-            <Button
+          <AlternateOption>
+            <AlternateOptionButton
               onClick={() => setPage("draw")}
               disabled={Boolean(selectedFile?.url)}
             >
               Draw the boundary on a map instead
-            </Button>
-          </div>
-        </div>
+            </AlternateOptionButton>
+          </AlternateOption>
+        </>
       );
     }
   }

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/map.css
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/map.css
@@ -1,4 +1,0 @@
-my-map {
-  width: 100%;
-  height: 50vh;
-}

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -1,8 +1,6 @@
-import "./map.css";
-
 import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
-import makeStyles from "@mui/styles/makeStyles";
+import { styled } from "@mui/material/styles";
 import { visuallyHidden } from "@mui/utils";
 import {
   DESCRIPTION_TEXT,
@@ -180,6 +178,23 @@ function Component(props: Props) {
   }
 }
 
+const AutocompleteWrapper = styled(Box)(({ theme }) => ({
+  // Autocomplete style overrides
+  "--autocomplete__label__font-size": "18px",
+  "--autocomplete__input__padding": "6px 40px 7px 12px",
+  "--autocomplete__input__font-size": "15px",
+  "--autocomplete__input__height": "50px",
+  "--autocomplete__dropdown-arrow-down__top": "16px",
+  "--autocomplete__dropdown-arrow-down__z-index": "2",
+  "--autocomplete__option__font-size": "15px",
+  "--autocomplete__option__padding": "6px 12px 7px 12px",
+  "--autocomplete__menu__max-height": "336px",
+  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.grey[800]}`,
+  "--autocomplete__option__hover-border-color": theme.palette.primary.main,
+  "--autocomplete__option__hover-background-color": theme.palette.primary.main,
+  "--autocomplete__font-family": theme.typography.fontFamily,
+}));
+
 function GetAddress(props: {
   setAddress: React.Dispatch<React.SetStateAction<SiteAddress | undefined>>;
   title?: string;
@@ -259,27 +274,6 @@ function GetAddress(props: {
     };
   }, [sanitizedPostcode, setSelectedOption]);
 
-  // Autocomplete overrides
-  const useStyles = makeStyles((theme) => ({
-    autocomplete: {
-      "--autocomplete__label__font-size": "18px",
-      "--autocomplete__input__padding": "6px 40px 7px 12px",
-      "--autocomplete__input__font-size": "15px",
-      "--autocomplete__input__height": "50px",
-      "--autocomplete__dropdown-arrow-down__top": "16px",
-      "--autocomplete__dropdown-arrow-down__z-index": "2",
-      "--autocomplete__option__font-size": "15px",
-      "--autocomplete__option__padding": "6px 12px 7px 12px",
-      "--autocomplete__menu__max-height": "336px",
-      "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.grey[800]}`,
-      "--autocomplete__option__hover-border-color": theme.palette.primary.main,
-      "--autocomplete__option__hover-background-color":
-        theme.palette.primary.main,
-      "--autocomplete__font-family": theme.typography.fontFamily,
-    },
-  }));
-  const classes = useStyles();
-
   const handleCheckPostcode = () => {
     if (!sanitizedPostcode) setShowPostcodeError(true);
   };
@@ -314,7 +308,7 @@ function GetAddress(props: {
         title={props.title || DEFAULT_TITLE}
         description={props.description || ""}
       />
-      <Box className={classes.autocomplete}>
+      <AutocompleteWrapper>
         <InputLabel label="Postcode" htmlFor="postcode-input">
           <Input
             required
@@ -358,7 +352,7 @@ function GetAddress(props: {
             labelStyle="static"
           />
         )}
-      </Box>
+      </AutocompleteWrapper>
       <ExternalPlanningSiteDialog
         purpose={DialogPurpose.MissingAddress}
         teamSettings={props.teamSettings}
@@ -371,20 +365,18 @@ interface Option extends SiteAddress {
   title: string;
 }
 
-const useClasses = makeStyles((theme) => ({
-  map: {
-    padding: theme.spacing(1, 0),
+const MapContainer = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1, 0),
+  "& my-map": {
+    width: "100%",
+    height: "50vh",
   },
-  constraint: {
-    borderLeft: `3px solid rgba(0,0,0,0.3)`,
-    padding: theme.spacing(1, 1.5),
-    marginBottom: theme.spacing(0.5),
-  },
-  propertyDetail: {
-    display: "flex",
-    justifyContent: "flex-start",
-    borderBottom: `1px solid ${theme.palette.background.paper}`,
-  },
+}));
+
+const PropertyDetail = styled(Box)(({ theme }) => ({
+  display: "flex",
+  justifyContent: "flex-start",
+  borderBottom: `1px solid ${theme.palette.background.paper}`,
 }));
 
 export function PropertyInformation(props: any) {
@@ -398,7 +390,6 @@ export function PropertyInformation(props: any) {
     teamColor,
     previousFeedback,
   } = props;
-  const styles = useClasses();
   const formik = useFormik({
     initialValues: {
       feedback: previousFeedback || "",
@@ -417,9 +408,9 @@ export function PropertyInformation(props: any) {
   return (
     <Card handleSubmit={formik.handleSubmit} isValid>
       <QuestionHeader title={title} description={description} />
-      <Box className={styles.map}>
+      <MapContainer>
         <p style={visuallyHidden}>
-          A static map centered on the property address, showing the Ordnance
+          A static map centred on the property address, showing the Ordnance
           Survey basemap features.
         </p>
         {/* @ts-ignore */}
@@ -435,17 +426,17 @@ export function PropertyInformation(props: any) {
           markerLongitude={lng}
           // markerColor={teamColor} // defaults to black
         />
-      </Box>
+      </MapContainer>
       <Box component="dl" mb={3}>
         {propertyDetails.map(({ heading, detail }: any) => (
-          <Box className={styles.propertyDetail} key={heading}>
+          <PropertyDetail key={heading}>
             <Box component="dt" fontWeight={700} flex={"0 0 35%"} py={1}>
               {heading}
             </Box>
             <Box component="dd" flexGrow={1} py={1}>
               {detail}
             </Box>
-          </Box>
+          </PropertyDetail>
         ))}
       </Box>
       <Box color="text.secondary" textAlign="right">

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/map.css
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/map.css
@@ -1,4 +1,0 @@
-my-map {
-  width: 100%;
-  height: 50vh;
-}


### PR DESCRIPTION
## What does this PR do?
 - Above the "md" breakpoint, increase the map size in the DrawBoundary component
 - Below this, keep things as is
 - The new width and height of 80vw x 80vh is chose quite arbitrarily - it seems to allow the map + instructions to appear on the screen at the same time. I expect this could be changed through feedback and UAT.

### Also...
- Tidy up styling, continue to migrate touched components from JSS to Emotion

![image](https://user-images.githubusercontent.com/20502206/197003672-5ca0c5fd-50f8-47b6-b926-41e66437835a.png)

https://user-images.githubusercontent.com/20502206/197004072-10393eb3-ef06-4339-9e5d-071243f92c98.mov
