### PR TITLE
fix: Settings should update in UI after change

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -382,6 +382,7 @@ export const editorStore = (
           ) {
             affected_rows
             returning {
+              id
               slug
               settings
             }


### PR DESCRIPTION
## Problem
- Updating a flow setting _appears_ not to persist the change
- To recreate - 
  - Navigate to a flow in the editor
  - Go to Settings > Service Tab
  - Update Footer text, hit "Save"
  - Navigate to another tab (e.g. Design), then back to Service
  - Your previous change is no longer there ❌ 
- Addresses the following ticket - https://trello.com/c/zTbeUNFt/2143-unable-to-save-changes-to-contact-us-footer-in-the-editor

## What's going on?
 - The update is persisting to the db - we can see this in the network tab, and by refreshing the page after hitting "Save"
 - We're not re-fetching this data from the server on each change of tab
 - The data is coming back form the `InMemoryCache` of our GraphQL client (Apollo)

## Solution
 - Return an id from our `UpdateFlowSettings` mutation, so that the cache is updated correctly

## To test
 - Ensure you can recreate the workflow above on Staging / Production
 - On the Pizza, you should not see this behaviour - changes should persist when jumping from tab to tab

## Also...
 - There's a whole issue here about no UI feedback on "Save". We don't actually have an established pattern for this currently - I've added a card to tackle this here -