### PR TITLE
fix: Use auth for sending applications to BOPS & Uniform

### DIFF
--- a/api.planx.uk/auth/index.ts
+++ b/api.planx.uk/auth/index.ts
@@ -1,13 +1,11 @@
-const crypto = require('crypto');
-const { singleSessionEmailTemplates } = require('../saveAndReturn/utils');
+import { Request, Response, NextFunction } from 'express';
+import crypto from "crypto";
+import { singleSessionEmailTemplates } from '../saveAndReturn/utils';
 
 /**
  * Validate that a provided string (e.g. API key) matches the expected value
- * @param {string} provided 
- * @param {string} expected 
- * @returns {boolean}
  */
-const isEqual = (provided = "", expected) => {
+const isEqual = (provided: string = "", expected: string): boolean => {
   const hash = crypto.createHash('SHA512');
   return crypto.timingSafeEqual(
     hash.copy().update(provided).digest(),
@@ -17,23 +15,17 @@ const isEqual = (provided = "", expected) => {
 
 /**
  * Validate that a request is using the Hasura API key
- * @param {object} req 
- * @param {object} _res 
- * @param {object} next 
  */
-const useHasuraAuth = (req, _res, next) => {
-  const isAuthenticated = isEqual(req.headers.authorization, process.env.HASURA_PLANX_API_KEY);
+const useHasuraAuth = (req: Request, _res: Response, next: NextFunction): NextFunction | void => {
+  const isAuthenticated = isEqual(req.headers.authorization, process.env.HASURA_PLANX_API_KEY!);
   if (!isAuthenticated) return next({ status: 401, message: "Unauthorised" });
   next();
 };
 
 /**
  * Ensure that the correct permissions are used for the /send-email endpoint
- * @param {object} req
- * @param {object} res
- * @param {object} next
  */
-const useSendEmailAuth = (req, res, next) => {
+const useSendEmailAuth = (req: Request, res: Response, next: NextFunction): NextFunction | void => {
   switch (req.params.template) {
     case "reminder":
     case "expiry":

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -54,6 +54,7 @@
     "@types/node": "^16.11.43",
     "@types/passport": "^1.0.11",
     "@types/passport-google-oauth20": "^2.0.11",
+    "@types/supertest": "^2.0.12",
     "dotenv": "^16.0.1",
     "esbuild": "^0.14.49",
     "esbuild-jest": "^0.5.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -19,6 +19,7 @@ specifiers:
   '@types/node': ^16.11.43
   '@types/passport': ^1.0.11
   '@types/passport-google-oauth20': ^2.0.11
+  '@types/supertest': ^2.0.12
   adm-zip: ^0.5.9
   aws-sdk: ^2.1180.0
   axios: ^0.27.2
@@ -96,7 +97,7 @@ dependencies:
   string-to-stream: 3.0.1
 
 devDependencies:
-  '@babel/preset-typescript': 7.18.6
+  '@babel/preset-typescript': 7.18.6_@babel+core@7.15.0
   '@types/body-parser': 1.19.2
   '@types/cookie-parser': 1.4.3
   '@types/cookie-session': 2.0.44
@@ -108,6 +109,7 @@ devDependencies:
   '@types/node': 16.11.47
   '@types/passport': 1.0.11
   '@types/passport-google-oauth20': 2.0.11
+  '@types/supertest': 2.0.12
   dotenv: 16.0.1
   esbuild: 0.14.49
   esbuild-jest: 0.5.0_esbuild@0.14.49
@@ -119,7 +121,7 @@ devDependencies:
   prettier: 2.7.1
   rimraf: 3.0.2
   supertest: 6.2.4
-  ts-jest: 28.0.7_e4vlsll2vsrxuwy4jhlvxjbksa
+  ts-jest: 28.0.7_apsjjld53x5nuipdvkrcv7krlq
   ts-node-dev: 2.0.0_ow5yu25silzxcp7pmv7jv4j54m
   typescript: 4.7.4
 
@@ -230,12 +232,13 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.18.9:
+  /@babel/helper-create-class-features-plugin/7.18.9_@babel+core@7.15.0:
     resolution: {integrity: sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
+      '@babel/core': 7.15.0
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.18.9
@@ -522,15 +525,6 @@ packages:
       '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
-  /@babel/plugin-syntax-typescript/7.18.6:
-    resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.18.9
-    dev: true
-
   /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.15.0:
     resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
     engines: {node: '>=6.9.0'}
@@ -556,28 +550,30 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-typescript/7.18.12:
+  /@babel/plugin-transform-typescript/7.18.12_@babel+core@7.15.0:
     resolution: {integrity: sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.18.9
+      '@babel/core': 7.15.0
+      '@babel/helper-create-class-features-plugin': 7.18.9_@babel+core@7.15.0
       '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-typescript': 7.18.6
+      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.15.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-typescript/7.18.6:
+  /@babel/preset-typescript/7.18.6_@babel+core@7.15.0:
     resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
+      '@babel/core': 7.15.0
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.18.12
+      '@babel/plugin-transform-typescript': 7.18.12_@babel+core@7.15.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1062,6 +1058,10 @@ packages:
       '@types/keygrip': 1.0.2
     dev: true
 
+  /@types/cookiejar/2.1.2:
+    resolution: {integrity: sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==}
+    dev: true
+
   /@types/cors/2.8.12:
     resolution: {integrity: sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==}
     dev: true
@@ -1208,6 +1208,19 @@ packages:
 
   /@types/strip-json-comments/0.0.30:
     resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
+    dev: true
+
+  /@types/superagent/4.1.15:
+    resolution: {integrity: sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==}
+    dependencies:
+      '@types/cookiejar': 2.1.2
+      '@types/node': 16.11.47
+    dev: true
+
+  /@types/supertest/2.0.12:
+    resolution: {integrity: sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==}
+    dependencies:
+      '@types/superagent': 4.1.15
     dev: true
 
   /@types/tough-cookie/4.0.1:
@@ -5428,7 +5441,7 @@ packages:
     hasBin: true
     dev: true
 
-  /ts-jest/28.0.7_e4vlsll2vsrxuwy4jhlvxjbksa:
+  /ts-jest/28.0.7_apsjjld53x5nuipdvkrcv7krlq:
     resolution: {integrity: sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -5449,6 +5462,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.15.0
       bs-logger: 0.2.6
       esbuild: 0.14.49
       fast-json-stable-stringify: 2.1.0

--- a/api.planx.uk/send/bops.test.ts
+++ b/api.planx.uk/send/bops.test.ts
@@ -60,13 +60,14 @@ import app from "../server";
       nock(
         `https://southwark.${bopsApiRootDomain}/api/v1/planning_applications`
       )
-        .post("")
-        .reply(200, {
-          application: "0000123",
-        });
-
+      .post("")
+      .reply(200, {
+        application: "0000123",
+      });
+      
       await supertest(app)
         .post("/bops/southwark")
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
         .send({ payload: { applicationId: 123, planx_debug_data: { session_id: 123 } }})
         .expect(200)
         .then((res) => {
@@ -74,6 +75,13 @@ import app from "../server";
             application: { id: 22, bopsResponse: { application: "0000123" } },
           });
         });
+    });
+
+    it("requires auth", async () => {      
+      await supertest(app)
+        .post("/bops/southwark")
+        .send({ payload: { applicationId: 123, planx_debug_data: { session_id: 123 } }})
+        .expect(401)
     });
   });
 });

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -275,13 +275,15 @@ app.use(helmet());
 // Create "One-off Scheduled Events" in Hasura from Send component for selected destinations
 app.post("/create-send-events/:sessionId", createSendEvents);
 
+assert(process.env.HASURA_PLANX_API_KEY);
+
 assert(process.env.BOPS_API_ROOT_DOMAIN);
 assert(process.env.BOPS_API_TOKEN);
-app.post("/bops/:localAuthority", sendToBOPS);
+app.post("/bops/:localAuthority", useHasuraAuth, sendToBOPS);
 
 assert(process.env.UNIFORM_TOKEN_URL);
 assert(process.env.UNIFORM_SUBMISSION_URL);
-app.post("/uniform/:localAuthority", sendToUniform);
+app.post("/uniform/:localAuthority", useHasuraAuth, sendToUniform);
 
 ["BUCKINGHAMSHIRE", "LAMBETH", "SOUTHWARK"].forEach((authority) => {
   assert(process.env[`GOV_UK_PAY_TOKEN_${authority}`]);
@@ -578,7 +580,6 @@ app.post(
 app.post("/resume-application", sendEmailLimiter, resumeApplication);
 app.post("/validate-session", validateSession);
 
-assert(process.env.HASURA_PLANX_API_KEY);
 app.use("/webhooks/hasura", useHasuraAuth);
 app.post("/webhooks/hasura/delete-expired-sessions", hardDeleteSessions);
 app.post("/webhooks/hasura/create-reminder-event", createReminderEvent);


### PR DESCRIPTION
## Issue
- Sending to BOPS and Uniform via the API does not need to be publicly accessible
- We're already sending the `HASURA_PLANX_API_KEY` secret as a header from the Hasura send event to our API, so it makes sense to leverage this and to restrict our API

## To test
 - You can send an application to both BOPS & Uniform on the Pizza. This can be verified via the audit tables (`unifrom_applications` and `bops_applications`) as well as via the event invocation log in the Hasura console.

### Also...
- Update auth code to TS!

```mermaid
sequenceDiagram
    participant P as PlanX Public Interface
    participant A as API
    participant H as Hasura
    participant BU as BOPS / Uniform

    P->>A: User submits application (public)
    A->>H: Create send events (private)
    H->>A: Call /send endpoint (private)
    A->>BU: Send payload (private)
```