### PR TITLE
fix: Allow public user to select has_user_saved column

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -186,6 +186,7 @@
         columns:
           - created_at
           - data
+          - has_user_saved
           - id
           - updated_at
         filter:

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -273,7 +273,11 @@ describe("lowcal_sessions", () => {
         const res = await gqlPublic(`
           query SelectAllLowcalSessions {
             lowcal_sessions {
+              created_at
+              data
+              has_user_saved
               id
+              updated_at
             }
           }
         `, null, headers);


### PR DESCRIPTION
Fixes the following Airbrake error - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1666791610814459

This allows the public user to access the `has_user_saved` column which was added to the `ValidateSingleSessionRequest` query in #1236 

Please note that users can only select rows they have permissions for - see `filter` in `tables.yaml` immediately below the code change here for details.