### PR TITLE
feat(sync): keep timestamps so that flows appear in the right order

### DIFF
--- a/scripts/seed-database/upsert-production-flows.js
+++ b/scripts/seed-database/upsert-production-flows.js
@@ -47,6 +47,8 @@ const LOCAL_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
           team_id
           settings
           version
+          created_at
+          updated_at
         }
         teams {
           id


### PR DESCRIPTION
Solves the current problem in the sync'ing code in that flows don't show up in order on [staging](https://editor.planx.dev/buckinghamshire).

![image](https://user-images.githubusercontent.com/7684574/198374235-bb318030-b559-4740-a2a4-18c47d02880b.png)
