### PR TITLE
fix: Revert #1164 (Clones re-ordering)

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -123,8 +123,7 @@
     "storybook-addon-material-ui": "^0.9.0-alpha.24",
     "stream-browserify": "^3.0.0",
     "tsconfig-paths-webpack-plugin": "^4.0.0",
-    "typescript": "^4.7.4",
-    "wait-for-expect": "^3.0.2"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "start": "craco start",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -159,7 +159,6 @@ specifiers:
   tsconfig-paths-webpack-plugin: ^4.0.0
   typescript: ^4.7.4
   uuid: ^8.3.2
-  wait-for-expect: ^3.0.2
   wkt: ^0.1.1
   yup: ^0.32.11
   zustand: ^4.1.1
@@ -221,7 +220,7 @@ dependencies:
   react-markdown: 8.0.3_7v64pk2mkrohwh22gx7lrz5ive
   react-navi: 0.15.0_navi@0.15.0+react@18.2.0
   react-navi-helmet-async: 0.15.0_e4zufcmuewgygmkt4h2ll6yape
-  react-scripts: 5.0.1_vh4wxar7p2tjvamau2jk4jtkke
+  react-scripts: 5.0.1_kwg5n3kie4k7un3jwvoet3477e
   react-toastify: 9.0.8_biqbaboplfbrettd7655fr4n2y
   react-use: 17.4.0_biqbaboplfbrettd7655fr4n2y
   reconnecting-websocket: 4.4.0
@@ -240,16 +239,16 @@ devDependencies:
   '@craco/craco': 6.4.5_hsv26antxuqwg6pblgtk7klj5y
   '@react-theming/storybook-addon': 1.1.7_bkjzr6gtllhi6b56bzdkrz5vbm
   '@storybook/addon-actions': 6.5.10_biqbaboplfbrettd7655fr4n2y
-  '@storybook/addon-essentials': 6.5.10_anwffrbdcjg26xymtuekq365vi
+  '@storybook/addon-essentials': 6.5.10_ocy7z5q5teoszq65sdejqtktbq
   '@storybook/addon-links': 6.5.10_biqbaboplfbrettd7655fr4n2y
-  '@storybook/builder-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
-  '@storybook/manager-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+  '@storybook/builder-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
+  '@storybook/manager-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
   '@storybook/node-logger': 6.5.10
-  '@storybook/react': 6.5.10_on3g637n2rrj5gvsz4ayjuwwj4
+  '@storybook/react': 6.5.10_nf4awcmtiuy64v5yaetfcv572e
   '@storybook/theming': 6.5.10_biqbaboplfbrettd7655fr4n2y
   '@testing-library/jest-dom': 5.16.5
   '@testing-library/react': 13.3.0_biqbaboplfbrettd7655fr4n2y
-  '@testing-library/user-event': 14.4.3
+  '@testing-library/user-event': 14.4.3_zqdhmevb64vvgf27bikfwyob6q
   '@turf/helpers': 6.5.0
   '@types/draft-js': 0.11.9
   '@types/jest': 27.5.2
@@ -265,13 +264,13 @@ devDependencies:
   '@types/sharedb': 3.0.0
   '@types/testing-library__jest-dom': 5.14.5
   '@types/uuid': 8.3.4
-  craco-esbuild: 0.5.1_grp3hrkxu6lyjfltr3tvd52hx4
-  css-loader: 6.7.1
+  craco-esbuild: 0.5.1_vjkpjf7ap7ec2tebnthfajwmgi
+  css-loader: 6.7.1_webpack@5.65.0
   esbuild: 0.14.54
   esbuild-jest: 0.5.0_esbuild@0.14.54
-  eslint-plugin-jsx-a11y: 6.6.1
-  eslint-plugin-simple-import-sort: 7.0.0
-  eslint-plugin-testing-library: 5.6.0_typescript@4.7.4
+  eslint-plugin-jsx-a11y: 6.6.1_eslint@8.4.1
+  eslint-plugin-simple-import-sort: 7.0.0_eslint@8.4.1
+  eslint-plugin-testing-library: 5.6.0_nqjrzu6d3irzy6zot23swntkzq
   husky: 8.0.1
   identity-obj-proxy: 3.0.0
   jest-axe: 6.0.0
@@ -281,12 +280,11 @@ devDependencies:
   react-app-rewired: 2.2.1_react-scripts@5.0.1
   react-refresh: 0.14.0
   sass: 1.54.3
-  sass-loader: 13.0.2_sass@1.54.3
-  storybook-addon-material-ui: 0.9.0-alpha.24_y42yuahqiqc7d7qqdirq6d4n3q
+  sass-loader: 13.0.2_sass@1.54.3+webpack@5.65.0
+  storybook-addon-material-ui: 0.9.0-alpha.24_3r362pksqry6kq3xywweucnmge
   stream-browserify: 3.0.0
   tsconfig-paths-webpack-plugin: 4.0.0
   typescript: 4.7.4
-  wait-for-expect: 3.0.2
 
 packages:
 
@@ -2014,7 +2012,7 @@ packages:
       cosmiconfig-typescript-loader: 1.0.3_x2utdhayajzrh747hktprshhby
       cross-spawn: 7.0.3
       lodash: 4.17.21
-      react-scripts: 5.0.1_vh4wxar7p2tjvamau2jk4jtkke
+      react-scripts: 5.0.1_kwg5n3kie4k7un3jwvoet3477e
       semver: 7.3.5
       webpack-merge: 4.2.2
     transitivePeerDependencies:
@@ -3349,7 +3347,7 @@ packages:
       '@react-theming/theme-name': 1.0.3
       '@react-theming/theme-swatch': 1.0.0_react@18.2.0
       '@storybook/addon-devkit': 1.4.2_hfd7r5j37aor7drp5l7dumshdq
-      '@storybook/react': 6.5.10_on3g637n2rrj5gvsz4ayjuwwj4
+      '@storybook/react': 6.5.10_nf4awcmtiuy64v5yaetfcv572e
       '@storybook/theming': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@usulpro/react-json-view': 2.0.1_biqbaboplfbrettd7655fr4n2y
       color-string: 1.9.1
@@ -3503,7 +3501,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q:
+  /@storybook/addon-controls/6.5.10_tmgq24astrn4zautp4tmc3em6e:
     resolution: {integrity: sha512-lC2y3XcolmQAJwFurIyGrynAHPWmfNtTCdu3rQBTVGwyxCoNwdOOeC2jV0BRqX2+CW6OHzJr9frNWXPSaZ8c4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3518,7 +3516,7 @@ packages:
       '@storybook/api': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.10
       '@storybook/store': 6.5.10_biqbaboplfbrettd7655fr4n2y
@@ -3547,7 +3545,7 @@ packages:
       '@reach/rect': 0.2.1_v2m5e27vhdewzwhryxwfaorcca
       '@storybook/addons': 6.4.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/core-events': 6.4.10
-      '@storybook/react': 6.5.10_on3g637n2rrj5gvsz4ayjuwwj4
+      '@storybook/react': 6.5.10_nf4awcmtiuy64v5yaetfcv572e
       '@storybook/theming': 6.5.10_biqbaboplfbrettd7655fr4n2y
       deep-equal: 2.0.4
       prop-types: 15.8.1
@@ -3555,7 +3553,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: true
 
-  /@storybook/addon-docs/6.5.10_udtckcufepcwxjivbvq4bpw3te:
+  /@storybook/addon-docs/6.5.10_mbxbtfi3a7kjfxcvx2yqmv2kzu:
     resolution: {integrity: sha512-1kgjo3f0vL6GN8fTwLL05M/q/kDdzvuqwhxPY/v5hubFb3aQZGr2yk9pRBaLAbs4bez0yG0ASXcwhYnrEZUppg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -3576,7 +3574,7 @@ packages:
       '@storybook/addons': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/api': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/components': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10_biqbaboplfbrettd7655fr4n2y
@@ -3587,7 +3585,7 @@ packages:
       '@storybook/source-loader': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/store': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/theming': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      babel-loader: 8.2.3_@babel+core@7.16.5
+      babel-loader: 8.2.3_eysr5kyjcyvslisuofpotdl4lq
       core-js: 3.24.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -3610,7 +3608,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.10_anwffrbdcjg26xymtuekq365vi:
+  /@storybook/addon-essentials/6.5.10_ocy7z5q5teoszq65sdejqtktbq:
     resolution: {integrity: sha512-PT2aiR4vgAyB0pl3HNBUa4/a7NDRxASxAazz7zt9ZDirkipDKfxwdcLeRoJzwSngVDWEhuz5/paN5x4eNp4Hww==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -3670,22 +3668,23 @@ packages:
       '@babel/core': 7.16.5
       '@storybook/addon-actions': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-backgrounds': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-controls': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
-      '@storybook/addon-docs': 6.5.10_udtckcufepcwxjivbvq4bpw3te
+      '@storybook/addon-controls': 6.5.10_tmgq24astrn4zautp4tmc3em6e
+      '@storybook/addon-docs': 6.5.10_mbxbtfi3a7kjfxcvx2yqmv2kzu
       '@storybook/addon-measure': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-outline': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-toolbars': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-viewport': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/addons': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/api': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/builder-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/node-logger': 6.5.10
       core-js: 3.24.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.0.0
+      webpack: 5.65.0_esbuild@0.14.54
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - eslint
@@ -3915,7 +3914,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q:
+  /@storybook/builder-webpack4/6.5.10_tmgq24astrn4zautp4tmc3em6e:
     resolution: {integrity: sha512-AoKjsCNoQQoZXYwBDxO8s+yVEd5FjBJAaysEuUTHq2fb81jwLrGcEOo6hjw4jqfugZQIzYUEjPazlvubS78zpw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3933,7 +3932,7 @@ packages:
       '@storybook/client-api': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/core-events': 6.5.10
       '@storybook/node-logger': 6.5.10
       '@storybook/preview-web': 6.5.10_biqbaboplfbrettd7655fr4n2y
@@ -3951,7 +3950,7 @@ packages:
       css-loader: 3.6.0_webpack@4.44.2
       file-loader: 6.2.0_webpack@4.44.2
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_7db7cfvs5qrp3bnhg77xjtpjse
+      fork-ts-checker-webpack-plugin: 4.1.6_7sg4umprdujt67wwjlx44oqo7u
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
@@ -3984,7 +3983,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/builder-webpack5/6.5.10_tvujanbhwtieorb7hwimcecxam:
+  /@storybook/builder-webpack5/6.5.10_rseclsx2333fcdnm5fz7qiks3e:
     resolution: {integrity: sha512-Hcsm/TzGRXHndgQCftt+pzI7GQJRqAv8A8ie5b3aFcodhJfK0qzZsQD4Y4ZWxXh1I/xe5t74Kl2qUJ40PX+geA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4002,7 +4001,7 @@ packages:
       '@storybook/client-api': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/core-events': 6.5.10
       '@storybook/node-logger': 6.5.10
       '@storybook/preview-web': 6.5.10_biqbaboplfbrettd7655fr4n2y
@@ -4017,7 +4016,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.24.1
       css-loader: 5.2.7_webpack@5.65.0
-      fork-ts-checker-webpack-plugin: 6.5.0_enkpkivpbeyi6fbcejat26nywe
+      fork-ts-checker-webpack-plugin: 6.5.0_zjtdjsalfozryr2ra6wl2cbklu
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       html-webpack-plugin: 5.5.0_webpack@5.65.0
@@ -4220,7 +4219,7 @@ packages:
       webpack: 5.65.0_esbuild@0.14.54
     dev: true
 
-  /@storybook/core-common/6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q:
+  /@storybook/core-common/6.5.10_tmgq24astrn4zautp4tmc3em6e:
     resolution: {integrity: sha512-Bx+VKkfWdrAmD8T51Sjq/mMhRaiapBHcpG4cU5bc3DMbg+LF2/yrgqv/cjVu+m5gHAzYCac5D7gqzBgvG7Myww==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4264,7 +4263,7 @@ packages:
       express: 4.17.1
       file-system-cache: 1.0.5
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.0_7db7cfvs5qrp3bnhg77xjtpjse
+      fork-ts-checker-webpack-plugin: 6.5.0_7sg4umprdujt67wwjlx44oqo7u
       fs-extra: 9.1.0
       glob: 7.2.0
       handlebars: 4.7.7
@@ -4303,7 +4302,7 @@ packages:
       core-js: 3.24.1
     dev: true
 
-  /@storybook/core-server/6.5.10_ajjfvqyodcjssivd4g2ocuubty:
+  /@storybook/core-server/6.5.10_izfvehiaisgptbakyp2hqi356i:
     resolution: {integrity: sha512-jqwpA0ccA8X5ck4esWBid04+cEIVqirdAcqJeNb9IZAD+bRreO4Im8ilzr7jc5AmQ9fkqHs2NByFKh9TITp8NQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -4320,19 +4319,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@storybook/builder-webpack4': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
-      '@storybook/builder-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+      '@storybook/builder-webpack4': 6.5.10_tmgq24astrn4zautp4tmc3em6e
+      '@storybook/builder-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
       '@storybook/core-client': 6.5.10_eyyjs2ch5sgjxsoozxupplmh5m
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.10
-      '@storybook/manager-webpack4': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
-      '@storybook/manager-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+      '@storybook/manager-webpack4': 6.5.10_tmgq24astrn4zautp4tmc3em6e
+      '@storybook/manager-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
       '@storybook/node-logger': 6.5.10
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/telemetry': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/telemetry': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@types/node': 14.18.0
       '@types/node-fetch': 2.5.7
       '@types/pretty-hrtime': 1.0.1
@@ -4382,7 +4381,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.10_5nk7hlsdamccj43b5dnuucsyiq:
+  /@storybook/core/6.5.10_g757nn5qelsvwsczsmad772toq:
     resolution: {integrity: sha512-K86yYa0tYlMxADlwQTculYvPROokQau09SCVqpsLg3wJCTvYFL4+SIqcYoyBSbFmHOdnYbJgPydjN33MYLiOZQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -4399,10 +4398,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+      '@storybook/builder-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
       '@storybook/core-client': 6.5.10_njcv4xf3lbkruwkwwyhxulwnn4
-      '@storybook/core-server': 6.5.10_ajjfvqyodcjssivd4g2ocuubty
-      '@storybook/manager-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+      '@storybook/core-server': 6.5.10_izfvehiaisgptbakyp2hqi356i
+      '@storybook/manager-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       typescript: 4.7.4
@@ -4474,7 +4473,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q:
+  /@storybook/manager-webpack4/6.5.10_tmgq24astrn4zautp4tmc3em6e:
     resolution: {integrity: sha512-N/TlNDhuhARuFipR/ZJ/xEVESz23iIbCsZ4VNehLHm8PpiGlQUehk+jMjWmz5XV0bJItwjRclY+CU3GjZKblfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4489,7 +4488,7 @@ packages:
       '@babel/preset-react': 7.16.5_@babel+core@7.16.5
       '@storybook/addons': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/core-client': 6.5.10_eyyjs2ch5sgjxsoozxupplmh5m
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/node-logger': 6.5.10
       '@storybook/theming': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.5.10_biqbaboplfbrettd7655fr4n2y
@@ -4532,7 +4531,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack5/6.5.10_tvujanbhwtieorb7hwimcecxam:
+  /@storybook/manager-webpack5/6.5.10_rseclsx2333fcdnm5fz7qiks3e:
     resolution: {integrity: sha512-uRo+6e5MiVOtyFVMYIKVqvpDveCjHyzXBfetSYR7rKEZoaDMEnLLiuF7DIH12lzxwmzCJ1gIc4lf5HFiTMNkgw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4547,7 +4546,7 @@ packages:
       '@babel/preset-react': 7.16.5_@babel+core@7.16.5
       '@storybook/addons': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/core-client': 6.5.10_njcv4xf3lbkruwkwwyhxulwnn4
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/node-logger': 6.5.10
       '@storybook/theming': 6.5.10_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.5.10_biqbaboplfbrettd7655fr4n2y
@@ -4669,7 +4668,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.10_on3g637n2rrj5gvsz4ayjuwwj4:
+  /@storybook/react/6.5.10_nf4awcmtiuy64v5yaetfcv572e:
     resolution: {integrity: sha512-m8S1qQrwA7pDGwdKEvL6LV3YKvSzVUY297Fq+xcTU3irnAy4sHDuFoLqV6Mi1510mErK1r8+rf+0R5rEXB219g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -4702,13 +4701,13 @@ packages:
       '@babel/preset-react': 7.16.5_@babel+core@7.16.5
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.3_lv7vju7f4kmldqnhvouz2eiyt4
       '@storybook/addons': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+      '@storybook/builder-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
       '@storybook/client-logger': 6.5.10
-      '@storybook/core': 6.5.10_5nk7hlsdamccj43b5dnuucsyiq
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core': 6.5.10_g757nn5qelsvwsczsmad772toq
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10_biqbaboplfbrettd7655fr4n2y
-      '@storybook/manager-webpack5': 6.5.10_tvujanbhwtieorb7hwimcecxam
+      '@storybook/manager-webpack5': 6.5.10_rseclsx2333fcdnm5fz7qiks3e
       '@storybook/node-logger': 6.5.10
       '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_enkpkivpbeyi6fbcejat26nywe
       '@storybook/semver': 7.3.2
@@ -4734,6 +4733,7 @@ packages:
       react-refresh: 0.11.0
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
+      require-from-string: 2.0.2
       ts-dedent: 2.0.0
       typescript: 4.7.4
       util-deprecate: 1.0.2
@@ -4850,11 +4850,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q:
+  /@storybook/telemetry/6.5.10_tmgq24astrn4zautp4tmc3em6e:
     resolution: {integrity: sha512-+M5HILDFS8nDumLxeSeAwi1MTzIuV6UWzV4yB2wcsEXOBTdplcl9oYqFKtlst78oOIdGtpPYxYfivDlqxC2K4g==}
     dependencies:
       '@storybook/client-logger': 6.5.10
-      '@storybook/core-common': 6.5.10_xrxvbtylmve4l2tr3vmmqgfp7q
+      '@storybook/core-common': 6.5.10_tmgq24astrn4zautp4tmc3em6e
       chalk: 4.1.2
       core-js: 3.24.1
       detect-package-manager: 2.0.1
@@ -5083,11 +5083,13 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: true
 
-  /@testing-library/user-event/14.4.3:
+  /@testing-library/user-event/14.4.3_zqdhmevb64vvgf27bikfwyob6q:
     resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 8.11.1
     dev: true
 
   /@tootallnate/once/1.1.2:
@@ -5681,23 +5683,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  /@typescript-eslint/utils/5.36.1_typescript@4.7.4:
-    resolution: {integrity: sha512-lNj4FtTiXm5c+u0pUehozaUWhh7UYKnwryku0nxJlYUEWetyG92uw2pr+2Iy4M/u0ONMKzfrx7AsGBTCzORmIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.7.4
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /@typescript-eslint/visitor-keys/5.36.1:
     resolution: {integrity: sha512-ojB9aRyRFzVMN3b5joSYni6FAS10BBSCAfKJhjJAV08t/a95aM6tAhz+O1jF+EtgxktuSO3wJysp2R+Def/IWQ==}
@@ -6474,6 +6459,21 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /autoprefixer/10.4.0_postcss@8.4.16:
+    resolution: {integrity: sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      browserslist: 4.19.1
+      caniuse-lite: 1.0.30001287
+      fraction.js: 4.2.0
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.4.16
+      postcss-value-parser: 4.2.0
+
   /autoprefixer/10.4.0_postcss@8.4.5:
     resolution: {integrity: sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6571,20 +6571,6 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-
-  /babel-loader/8.2.3_@babel+core@7.16.5:
-    resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
-    engines: {node: '>= 8.9'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      webpack: '>=2'
-    dependencies:
-      '@babel/core': 7.16.5
-      find-cache-dir: 3.3.1
-      loader-utils: 1.4.0
-      make-dir: 3.1.0
-      schema-utils: 2.7.1
-    dev: true
 
   /babel-loader/8.2.3_eysr5kyjcyvslisuofpotdl4lq:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
@@ -7861,7 +7847,7 @@ packages:
       - supports-color
     dev: true
 
-  /craco-esbuild/0.5.1_grp3hrkxu6lyjfltr3tvd52hx4:
+  /craco-esbuild/0.5.1_vjkpjf7ap7ec2tebnthfajwmgi:
     resolution: {integrity: sha512-cV10lImVPctQeNAUXi+Gzy/UXXCTHe9Q8lAEJu3t+JVZt+D2uBvZFFqY7sw0dzZq5t+VcKFaVVPX8w5scL7RRw==}
     peerDependencies:
       '@craco/craco': ^6.0.0 || ^7.0.0
@@ -7869,8 +7855,8 @@ packages:
     dependencies:
       '@craco/craco': 6.4.5_hsv26antxuqwg6pblgtk7klj5y
       esbuild-jest: 0.5.0_esbuild@0.14.54
-      esbuild-loader: 2.18.0
-      react-scripts: 5.0.1_vh4wxar7p2tjvamau2jk4jtkke
+      esbuild-loader: 2.18.0_webpack@5.65.0
+      react-scripts: 5.0.1_kwg5n3kie4k7un3jwvoet3477e
     transitivePeerDependencies:
       - esbuild
       - supports-color
@@ -8042,22 +8028,6 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.5
       webpack: 5.65.0_esbuild@0.14.54
-    dev: true
-
-  /css-loader/6.7.1:
-    resolution: {integrity: sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    dependencies:
-      icss-utils: 5.1.0_postcss@8.4.16
-      postcss: 8.4.16
-      postcss-modules-extract-imports: 3.0.0_postcss@8.4.16
-      postcss-modules-local-by-default: 4.0.0_postcss@8.4.16
-      postcss-modules-scope: 3.0.0_postcss@8.4.16
-      postcss-modules-values: 4.0.0_postcss@8.4.16
-      postcss-value-parser: 4.2.0
-      semver: 7.3.5
     dev: true
 
   /css-loader/6.7.1_webpack@5.65.0:
@@ -9109,7 +9079,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-loader/2.18.0:
+  /esbuild-loader/2.18.0_webpack@5.65.0:
     resolution: {integrity: sha512-AKqxM3bI+gvGPV8o6NAhR+cBxVO8+dh+O0OXBHIXXwuSGumckbPWHzZ17subjBGI2YEGyJ1STH7Haj8aCrwL/w==}
     peerDependencies:
       webpack: ^4.40.0 || ^5.0.0
@@ -9119,6 +9089,7 @@ packages:
       json5: 2.2.0
       loader-utils: 2.0.2
       tapable: 2.2.1
+      webpack: 5.65.0_esbuild@0.14.54
       webpack-sources: 2.2.0
     dev: true
 
@@ -9233,7 +9204,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
 
-  /eslint-config-react-app/7.0.1_73cf7v7u32itaug2h6ddw2exmm:
+  /eslint-config-react-app/7.0.1_ppp3kdc37dtqify2fotljjeqq4:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -9251,7 +9222,7 @@ packages:
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
       eslint: 8.4.1
-      eslint-plugin-flowtype: 8.0.3_eslint@8.4.1
+      eslint-plugin-flowtype: 8.0.3_pex26l7yflrhbgizudxlm47cze
       eslint-plugin-import: 2.25.3_6tb2nqnsmdxwl2qbj5bbu73xbi
       eslint-plugin-jest: 25.3.0_x66p4u67uztt5lrqm3mwwccvga
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.4.1
@@ -9301,7 +9272,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-plugin-flowtype/8.0.3_eslint@8.4.1:
+  /eslint-plugin-flowtype/8.0.3_pex26l7yflrhbgizudxlm47cze:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -9309,6 +9280,8 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
+      '@babel/plugin-syntax-flow': 7.16.5_@babel+core@7.16.5
+      '@babel/plugin-transform-react-jsx': 7.16.5_@babel+core@7.16.5
       eslint: 8.4.1
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -9364,27 +9337,6 @@ packages:
       - supports-color
       - typescript
 
-  /eslint-plugin-jsx-a11y/6.6.1:
-    resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      '@babel/runtime': 7.18.9
-      aria-query: 4.2.2
-      array-includes: 3.1.5
-      ast-types-flow: 0.0.7
-      axe-core: 4.4.3
-      axobject-query: 2.2.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      has: 1.0.3
-      jsx-ast-utils: 3.3.3
-      language-tags: 1.0.5
-      minimatch: 3.1.2
-      semver: 6.3.0
-    dev: true
-
   /eslint-plugin-jsx-a11y/6.6.1_eslint@8.4.1:
     resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
     engines: {node: '>=4.0'}
@@ -9436,10 +9388,12 @@ packages:
       semver: 6.3.0
       string.prototype.matchall: 4.0.6
 
-  /eslint-plugin-simple-import-sort/7.0.0:
+  /eslint-plugin-simple-import-sort/7.0.0_eslint@8.4.1:
     resolution: {integrity: sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==}
     peerDependencies:
       eslint: '>=5.0.0'
+    dependencies:
+      eslint: 8.4.1
     dev: true
 
   /eslint-plugin-testing-library/5.6.0_nqjrzu6d3irzy6zot23swntkzq:
@@ -9453,18 +9407,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  /eslint-plugin-testing-library/5.6.0_typescript@4.7.4:
-    resolution: {integrity: sha512-y63TRzPhGCMNsnUwMGJU1MFWc/3GvYw+nzobp9QiyNTTKsgAt5RKAOT1I34+XqVBpX1lC8bScoOjCkP7iRv0Mw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.36.1_typescript@4.7.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /eslint-scope/4.0.3:
     resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
@@ -9487,15 +9429,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-
-  /eslint-utils/3.0.0:
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint-visitor-keys: 2.1.0
-    dev: true
 
   /eslint-utils/3.0.0_eslint@8.4.1:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
@@ -10104,7 +10037,7 @@ packages:
     resolution: {integrity: sha512-ZBbtRiapkZYLsqoPyZOR+uPfto0GRMNQN1GwzZtZt7iZvPPbDDQV0JF5Hx4o/QFQ5c0vyuoZ98T8RSBbopzWtA==}
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6_7db7cfvs5qrp3bnhg77xjtpjse:
+  /fork-ts-checker-webpack-plugin/4.1.6_7sg4umprdujt67wwjlx44oqo7u:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -10120,6 +10053,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.0
       chalk: 2.4.2
+      eslint: 8.4.1
       micromatch: 3.1.10
       minimatch: 3.1.2
       semver: 5.7.1
@@ -10131,7 +10065,7 @@ packages:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.0_7db7cfvs5qrp3bnhg77xjtpjse:
+  /fork-ts-checker-webpack-plugin/6.5.0_7sg4umprdujt67wwjlx44oqo7u:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -10151,6 +10085,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
+      eslint: 8.4.1
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.4.0
@@ -10160,37 +10095,6 @@ packages:
       tapable: 1.1.3
       typescript: 4.7.4
       webpack: 4.44.2
-    dev: true
-
-  /fork-ts-checker-webpack-plugin/6.5.0_enkpkivpbeyi6fbcejat26nywe:
-    resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.16.0
-      '@types/json-schema': 7.0.9
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.2.2
-      fs-extra: 9.1.0
-      glob: 7.2.0
-      memfs: 3.4.0
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.3.5
-      tapable: 1.1.3
-      typescript: 4.7.4
-      webpack: 5.65.0_esbuild@0.14.54
     dev: true
 
   /fork-ts-checker-webpack-plugin/6.5.0_zjtdjsalfozryr2ra6wl2cbklu:
@@ -15568,7 +15472,7 @@ packages:
     peerDependencies:
       react-scripts: '>=2.1.3'
     dependencies:
-      react-scripts: 5.0.1_vh4wxar7p2tjvamau2jk4jtkke
+      react-scripts: 5.0.1_kwg5n3kie4k7un3jwvoet3477e
       semver: 5.7.1
     dev: true
 
@@ -15617,12 +15521,6 @@ packages:
   /react-dev-utils/12.0.1_zjtdjsalfozryr2ra6wl2cbklu:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.16.0
       address: 1.1.2
@@ -15653,7 +15551,9 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
+      - typescript
       - vue-template-compiler
+      - webpack
 
   /react-dnd-html5-backend/16.0.1:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
@@ -15941,7 +15841,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /react-scripts/5.0.1_vh4wxar7p2tjvamau2jk4jtkke:
+  /react-scripts/5.0.1_kwg5n3kie4k7un3jwvoet3477e:
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -15968,7 +15868,7 @@ packages:
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.4.1
-      eslint-config-react-app: 7.0.1_73cf7v7u32itaug2h6ddw2exmm
+      eslint-config-react-app: 7.0.1_ppp3kdc37dtqify2fotljjeqq4
       eslint-webpack-plugin: 3.1.1_arz5zidbbfkszie7dgv4uxhmli
       file-loader: 6.2.0_webpack@5.65.0
       fs-extra: 10.0.0
@@ -15994,7 +15894,7 @@ packages:
       semver: 7.3.5
       source-map-loader: 3.0.0_webpack@5.65.0
       style-loader: 3.3.1_webpack@5.65.0
-      tailwindcss: 3.0.5_postcss@8.4.5
+      tailwindcss: 3.0.5_c2rjb5wq4nyxx5wsmzzdjlv5ga
       terser-webpack-plugin: 5.3.0_tuzcy5jahpcom7uiiwokibsx5a
       typescript: 4.7.4
       webpack: 5.65.0_esbuild@0.14.54
@@ -16702,7 +16602,7 @@ packages:
       sass: 1.54.3
       webpack: 5.65.0_esbuild@0.14.54
 
-  /sass-loader/13.0.2_sass@1.54.3:
+  /sass-loader/13.0.2_sass@1.54.3+webpack@5.65.0:
     resolution: {integrity: sha512-BbiqbVmbfJaWVeOOAu2o7DhYWtcNmTfvroVgFXa6k2hHheMxNAeDHLNoDy/Q5aoaVlz0LH+MbMktKwm9vN/j8Q==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -16724,6 +16624,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.54.3
+      webpack: 5.65.0_esbuild@0.14.54
     dev: true
 
   /sass/1.54.3:
@@ -17315,7 +17216,7 @@ packages:
     resolution: {integrity: sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==}
     dev: true
 
-  /storybook-addon-material-ui/0.9.0-alpha.24_y42yuahqiqc7d7qqdirq6d4n3q:
+  /storybook-addon-material-ui/0.9.0-alpha.24_3r362pksqry6kq3xywweucnmge:
     resolution: {integrity: sha512-Z9S06K/x2lppPofINl/ZM6a1TzeGdy8NZfWwjzyQRXzVf4/ABanhv6Zib2i6ptCxa5AWahZ1HxBqOSQZS4YIHg==}
     peerDependencies:
       '@material-ui/core': ^1.0.0 || ^3.0.0 || ^4.0.0
@@ -17328,10 +17229,12 @@ packages:
       '@emotion/core': 10.1.1_react@18.2.0
       '@emotion/styled': 10.0.27_gj3zb24ilqt4m4c2b65lgbcbsq
       '@material-ui/core': 4.11.0_63dfw6rfgd64rl77ptfma4cvt4
-      '@storybook/react': 6.5.10_on3g637n2rrj5gvsz4ayjuwwj4
+      '@storybook/addons': 6.5.10_biqbaboplfbrettd7655fr4n2y
+      '@storybook/react': 6.5.10_nf4awcmtiuy64v5yaetfcv572e
       '@usulpro/color-picker': 1.1.4_react@18.2.0
       global: 4.4.0
       js-beautify: 1.13.0
+      prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-inspector: 2.3.1_react@18.2.0
@@ -17736,7 +17639,7 @@ packages:
     resolution: {integrity: sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==}
     dev: true
 
-  /tailwindcss/3.0.5_postcss@8.4.5:
+  /tailwindcss/3.0.5_c2rjb5wq4nyxx5wsmzzdjlv5ga:
     resolution: {integrity: sha512-59pNgzx2o+wkAk7IZGIH7H9eNS53gzZGrO3+NPyOEWHDbquHgiLL/c993T5t1vPSAeBxox4X5OgZwNuRvXVf+g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -17745,6 +17648,7 @@ packages:
       postcss: ^8.0.9
     dependencies:
       arg: 5.0.1
+      autoprefixer: 10.4.0_postcss@8.4.16
       chalk: 4.1.2
       chokidar: 3.5.3
       color-name: 1.1.4
@@ -18736,10 +18640,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xml-name-validator: 3.0.0
-
-  /wait-for-expect/3.0.2:
-    resolution: {integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==}
-    dev: true
 
   /walker/1.0.7:
     resolution: {integrity: sha512-cF4je9Fgt6sj1PKfuFt9jpQPeHosM+Ryma/hfY9U7uXGKM7pJCsF0v2r55o+Il54+i77SyYWetB4tD1dEygRkw==}

--- a/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
@@ -2,7 +2,6 @@ import { screen } from "@testing-library/react";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import { axe, setup } from "testUtils";
-import waitForExpect from "wait-for-expect";
 
 import Review from "./Public/Presentational";
 
@@ -135,11 +134,7 @@ it("should render file upload filename", async () => {
 
   const element = getByTestId("file-upload-name");
 
-  await act(async () => {
-    await waitForExpect(() => {
-      expect(element).toHaveTextContent(mockLink);
-    });
-  });
+  await expect(element).toHaveTextContent(mockLink);
 });
 
 it("should render uploaded location plan link", async () => {
@@ -157,11 +152,7 @@ it("should render uploaded location plan link", async () => {
 
   const element = getByTestId("uploaded-plan-name");
 
-  await act(async () => {
-    await waitForExpect(() => {
-      expect(element).toBeInTheDocument();
-    });
-  });
+  await expect(element).toBeInTheDocument();
 });
 
 const fileUploadBreadcrumbs = {

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -440,6 +440,10 @@ export const makeUnique =
       _makeUnique(id, parent, { idFn }, true);
     });
 
+/**
+ * Depth first sort of graph
+ * XXX: Clones will only appear in first graph position
+ */
 const dfs = (graph: Graph) => (startId: string) => {
   const visited = new Set([startId]);
   const crawlFrom = (id: string) => {

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -1,6 +1,5 @@
 import { enablePatches, produceWithPatches } from "immer";
 import difference from "lodash/difference";
-import intersection from "lodash/intersection";
 import trim from "lodash/trim";
 import zip from "lodash/zip";
 import { customAlphabet } from "nanoid-good";
@@ -441,21 +440,17 @@ export const makeUnique =
       _makeUnique(id, parent, { idFn }, true);
     });
 
-/**
- * Depth first sort of graph
- * XXX: Clones will appear in all possible graph positions
- */
 const dfs = (graph: Graph) => (startId: string) => {
-  const visited: string[] = [];
+  const visited = new Set([startId]);
   const crawlFrom = (id: string) => {
     if (!graph[id]) return;
-    visited.push(id);
+    visited.add(id);
     graph[id].edges?.forEach((childId) => {
       crawlFrom(childId);
     });
   };
   crawlFrom(startId);
-  return visited;
+  return [...visited];
 };
 
 const memoizedNodesIdsByGraph = new WeakMap<Graph, string[]>();
@@ -469,13 +464,7 @@ export const sortIdsDepthFirst =
 
     memoizedNodesIdsByGraph.set(graph, allNodeIdsSorted);
 
-    // Return order of nodes within their graph subsection
-    // This prevents clones from being sorted incorrectly (i.e. by their first appearance in the graph)
-    const currentNodeIndex = allNodeIdsSorted.indexOf(
-      nodeIds.values().next().value
+    return Array.from(nodeIds).sort(
+      (a, b) => allNodeIdsSorted.indexOf(a) - allNodeIdsSorted.indexOf(b)
     );
-    const graphSubsection = allNodeIdsSorted.slice(currentNodeIndex);
-    const int = intersection([...nodeIds], graphSubsection);
-
-    return Array.from(nodeIds).sort((a, b) => int.indexOf(a) - int.indexOf(b));
   };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
@@ -27,7 +27,7 @@ describe("Clone order in flow (forwards)", () => {
     expect(upcomingCardIds()).toHaveLength(0);
   });
 
-  test("Right branch is ordered correctly", () => {
+  test.skip("Right branch is ordered correctly", () => {
     setState({ flow: forwardsFlow });
     record("question", { answers: ["rightChoice"] });
     record("rightChoice", { answers: ["rightNotice"] });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview.test.ts
@@ -434,10 +434,8 @@ describe("record", () => {
   });
 });
 
-describe.only("previousCard", () => {
-  test.only("To be the card before the current one", () => {
-    // I don't believe that these are valid breadcrumbs for this flow
-    // Is this because breadcrumb order can change after a review component?
+describe("previousCard", () => {
+  test("To be the card before the current one", () => {
     const breadcrumbs = {
       findProperty: breadcrumbsDependentOnPassport.findProperty,
       text: breadcrumbsDependentOnPassport.text,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -161,7 +161,6 @@ export const previewStore = (
     if (node?.id && shouldUpdateMemoizedValues) {
       memoizedBreadcrumb = breadcrumbs;
       const sorted = sortIdsDepthFirst(flow)(new Set([node.id, ...goBackable]));
-      // TODO: This is the incorrect assumption! This does not allow us to go "back" from a clone (which is not the first one)
       const currentCardIndex = sorted.indexOf(node.id);
       previousCardId =
         currentCardIndex > 0 ? sorted[currentCardIndex - 1] : sorted[0];


### PR DESCRIPTION
## What does this PR do?

 - Reverts logical changes made in https://github.com/theopensystemslab/planx-new/pull/1164
 - Removes redundant `act()` and `waitForExpect()` calls which were throwing "not wrapped in act(...)" errors in test (see https://github.com/theopensystemslab/planx-new/pull/1141 for context)

Pizza passed along to George and Jenna for testing.