### PR TITLE
fix: Update state on refetchPayment

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -157,6 +157,9 @@ function Component(props: Props) {
 
       if (!state.status) throw new Error("Corrupted response from GOV.UK");
 
+      // Update local state with the refetched payment state
+      if (govUkPayment) setGovUkPayment({ ...govUkPayment, state });
+
       switch (state.status) {
         case "success":
           handleSuccess();


### PR DESCRIPTION
## What does this PR do?
Allows a legitimately failed payment to be retried.

## What is the problem?
- When a user returns to PlanX after payment we get their GovUkPayment details from their lowcal_sessions record. This was created before they redirected away to GovPay.
- On return, we reconcile this in the function `refetchPayment()`
- Based on the returned state (e.g. "failed", "success") we decide on how to proceed
- However! In the handler `resumeExistingPayment()` we check the legacy version of GovUkPayment from state, which has not been amended after the `refetchPayment()` call.
- This PR fixes this, and ensures that the updated payment details are stored and referenced consistently.

**To test -** 
 - Try to pay on dummy flow https://1259.planx.pizza/buckinghamshire/daf-pay-test/preview?analytics=false using card number 4000000000000002 (see [GovPay docs](https://docs.payments.service.gov.uk/testing_govuk_pay/#if-you-39-re-using-a-test-39-sandbox-39-account))
 - On return to PlanX the Pay button will still say "Retry" but the link will allow you to enter new card details
 - The equivalent dummy flow on staging (https://editor.planx.dev/buckinghamshire/daf-pay-test) will not allow you to do this, and will keep you "trapped" in an endless loop.