### PR TITLE
fix: rotate production `file-api-key` to be alphanumeric

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -8,7 +8,7 @@ config:
     secure: AAABALRtSjQMRjERtkHs6WBOI7MBMw4bFOuHO8qLLPe9Pfg8Nlbp61XalZA1pmXsRt/T+59fGcdqbKA5WRkOZVibhFo=
   application:cloudflare-zone-id: a9b9933f28e786ec4cfd4bb596f5a519
   application:file-api-key:
-    secure: AAABAFLGsTujL32UhgmSUTXfwXEIhL73gTbgj0U8avZS56Pcw4Q+JIILnsQsuDa/ICM5532baNgIR50vENL/c+Ui4m/hrbq3fM/F+BJMuWW2H4g=
+    secure: AAABAGyTfLujGho+V0tEhFXQRET5FjYK6txyaFTB3gY/VaKzq8yNlocJTAM5nt8mBhF6T+AeQD2GxW63
   application:google-client-id: 987324067365-vpsk3kgeq5n32ihjn760ihf8l7m5rhh8.apps.googleusercontent.com
   application:google-client-secret:
     secure: AAABAN5E+De3A3HtpLVaSNTDwk9Uz4r2d5g8SIRVbNOd2fj3eU+lGJXjVbEAnxezr14hwabbfwW2ptjcFzqkhG7OmQ==


### PR DESCRIPTION
BOPS was failing to download files with the prior production key which had single quote, double quote and back tick characters in it :see_no_evil: 

Hopefully this is a simple step to resolve it! 

If successfully deployed, we need to determine if we need to resubmit session `17a6fa12-6300-4e17-97fb-a055efb48e5a`. I'm guessing we also failed to add the user-uploaded files to the Uniform zip.

To regenerate the key I ran: `pulumi config set --secret file-api-key SECRETTOKEN --stack production`
To retrieve the new value run: `pulumi config get file-api-key --stack production`