### PR TITLE
Reproduce performance issue

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -372,7 +372,7 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
             </InputRow>
 
             <InputRow>
-              <RichTextInput
+              <Input
                 name="description"
                 value={formik.values.description}
                 placeholder="Description"

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -99,7 +99,7 @@ export const MoreInformation = ({
       <ModalSectionContent title="More Information" Icon={InfoOutlined}>
         <InputGroup label="Why it matters">
           <InputRow>
-            <RichTextInput
+            <Input
               multiline
               name="info"
               value={info}
@@ -110,7 +110,7 @@ export const MoreInformation = ({
         </InputGroup>
         <InputGroup label="Policy source">
           <InputRow>
-            <RichTextInput
+            <Input
               multiline
               name="policyRef"
               value={policyRef}
@@ -121,7 +121,7 @@ export const MoreInformation = ({
         </InputGroup>
         <InputGroup label="How it is defined?">
           <InputRow>
-            <RichTextInput
+            <Input
               multiline
               name="howMeasured"
               value={howMeasured}

--- a/editor.planx.uk/src/ui/ListManager.tsx
+++ b/editor.planx.uk/src/ui/ListManager.tsx
@@ -5,6 +5,7 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import makeStyles from "@mui/styles/makeStyles";
 import { arrayMoveImmutable } from "array-move";
+import { update } from "ramda";
 import React, { useRef } from "react";
 import {
   DragDropContext,
@@ -15,7 +16,7 @@ import {
   DropResult,
 } from "react-beautiful-dnd";
 
-import { removeAt, setAt } from "../utils";
+import { removeAt } from "../utils";
 
 export interface EditorProps<T> {
   index?: number;
@@ -70,7 +71,7 @@ export default function ListManager<T, EditorExtraProps>(
                 index={index}
                 value={item}
                 onChange={(newItem) => {
-                  props.onChange(setAt(index, newItem, props.values));
+                  props.onChange(update(index, newItem, props.values));
                 }}
                 {...(props.editorExtraProps || {})}
               />
@@ -149,7 +150,7 @@ export default function ListManager<T, EditorExtraProps>(
                         index={index}
                         value={item}
                         onChange={(newItem) => {
-                          props.onChange(setAt(index, newItem, props.values));
+                          props.onChange(update(index, newItem, props.values));
                         }}
                         {...(props.editorExtraProps || {})}
                       />

--- a/editor.planx.uk/src/ui/RichTextInput.stories.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.stories.tsx
@@ -3,8 +3,11 @@ import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import { Meta } from "@storybook/react/types-6-0";
+import { range } from "ramda";
 import React, { useState } from "react";
 
+import Input from "./Input";
+import ListManager from "./ListManager";
 import RichTextInput, { fromHtml } from "./RichTextInput";
 
 const metadata: Meta = {
@@ -14,6 +17,8 @@ const metadata: Meta = {
     controls: { hideNoControlsWarning: true },
   },
 };
+
+export default metadata;
 
 export const Basic = () => {
   const [value, setValue] = useState<string>(
@@ -68,4 +73,57 @@ export const Basic = () => {
   );
 };
 
-export default metadata;
+interface Item {
+  title: string;
+  body: string;
+  enabled: boolean;
+}
+
+const ItemEditor: React.FC<{
+  value: Item;
+  onChange: (newValue: Item) => void;
+}> = (props) => {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Stack spacing={0.5}>
+        <Input
+          value={props.value.title}
+          onChange={(ev) => {
+            props.onChange({
+              ...props.value,
+              title: ev.target.value,
+            });
+          }}
+        />
+        <RichTextInput
+          placeholder="Add something"
+          value={props.value.body}
+          onChange={(ev) => {
+            props.onChange({
+              ...props.value,
+              body: ev.target.value,
+            });
+          }}
+        />
+      </Stack>
+    </Box>
+  );
+};
+
+export const Performance = () => {
+  const [items, setItems] = useState<Item[]>(
+    range(0, 200).map(() => ({
+      title: "Title",
+      body: "Body",
+      enabled: true,
+    }))
+  );
+  return (
+    <ListManager
+      values={items}
+      onChange={setItems}
+      newValue={() => ({ title: "", body: "", enabled: false })}
+      Editor={ItemEditor}
+    ></ListManager>
+  );
+};

--- a/editor.planx.uk/src/ui/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.tsx
@@ -241,6 +241,8 @@ const RichTextInput: FC<Props> = (props) => {
     string | null
   >(getContentHierarchyError(fromHtml(stringValue)));
 
+  console.log("rendering");
+
   // Handle update events
   const handleUpdate = useCallback(
     (transaction: { editor: Editor }) => {


### PR DESCRIPTION
Setting up a new story to look into performance issues/regressions reported in nodes like https://editor.planx.dev/opensystemslab/permitteddevelopment/nodes/_root/nodes/eiN5C9wgDe/edit.

You can access the story under http://localhost:6006/?path=/story/design-system-atoms-form-elements-richtextinput--performance.

Open questions:
- how much of the performance hit is caused by `RichTextEditor`, `ListManager`, or any Material UI rendering overhead in general? (you can change the editor between `RichTextInput` and `Input` to see the difference).
- where can improvements be made?

<img width="1131" alt="Screen Shot 2022-11-16 at 9 49 30 AM" src="https://user-images.githubusercontent.com/6738398/202133127-4bae5d0c-2c58-4c86-8fb0-620eb8166806.png">

