### PR TITLE
chore(api): use pnpm dev on local environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     restart: unless-stopped
     build:
       context: ./api.planx.uk
-      target: production
+      target: development
     depends_on:
       hasura-proxy:
         condition: service_healthy


### PR DESCRIPTION
Allows for live-reload on development environments.
Doesn't affect staging/production as these are deployed using pulumi (not docker compose).
Might make pizzas slightly less performant but overall shouldn't affect it that much.
