### PR TITLE
fix: adjust Hasura event retries for Send

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -68,8 +68,8 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
-        interval_sec: 10
+        num_retries: 1
+        interval_sec: 30
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -399,8 +399,8 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
-        interval_sec: 10
+        num_retries: 1
+        interval_sec: 30
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:


### PR DESCRIPTION
Previously, we'd retry 3 times after 10s, now we'll just retry 1 time after 30 sec on a failure to Send to BOPS or Uniform. 

As we discussed yesterday, the retries here aren't actually usually succeeding, but more so serve as a flag in the #planx-notifications channel that something went wrong. 1 retry should still give us that little notification nudge, while reducing noise and recognizing our ultimate action is more likely to be manual intervention to resubmit.