### PR TITLE
docs: update .env.example files with FILE_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ AWS_S3_BUCKET=👻
 AWS_ACCESS_KEY=👻
 AWS_SECRET_KEY=👻
 
+# User-uploaded S3 files require token-based access (token is used internally and shared with BOPS; local and pull request environments use the staging token)
+FILE_API_KEY=👻
+
 # Editor/Preview
 EDITOR_URL_EXT=http://localhost:3000
 
@@ -51,7 +54,7 @@ PG_USERNAME=👻
 # ShareDB
 SHAREDB_PORT=7003
 
-# Integrations
+# Integrations (local and pull request environments point to third party staging environments)
 BOPS_API_ROOT_DOMAIN=👻
 BOPS_API_TOKEN=👻
 

--- a/api.planx.uk/.env.test.example
+++ b/api.planx.uk/.env.test.example
@@ -14,6 +14,8 @@ AWS_S3_BUCKET=👻
 AWS_ACCESS_KEY=👻
 AWS_SECRET_KEY=👻
 
+FILE_API_KEY=👻
+
 # Editor
 EDITOR_URL_EXT=example.com
 


### PR DESCRIPTION
minor clarifications!

yesterday we discussed updating the Docker `FILE_API_KEY` value to match staging, which would then enable us to successfully send & test files to BOPS from a pizza environment. If we still agree that's a good way forward, I will additionally update S3 `pizza-secrets` value to do that as a manual step of this PR ! 