### PR TITLE
test: Increase test coverage for API /webhooks & /hasura-metadata dirs

### DIFF
--- a/api.planx.uk/hasura/metadata/index.test.ts
+++ b/api.planx.uk/hasura/metadata/index.test.ts
@@ -1,0 +1,22 @@
+import { createScheduledEvent, RequiredScheduledEventArgs } from "."
+import Axios from 'axios';
+
+jest.mock('axios');
+const mockAxios = Axios as jest.Mocked<typeof Axios>;
+
+const mockScheduledEvent: RequiredScheduledEventArgs = {
+  webhook: "test url",
+  schedule_at: new Date(),
+  comment: "test comment",
+  payload: {}
+}
+
+test("createScheduledEvent returns an error if request fails", async() => {
+  mockAxios.post.mockRejectedValue(new Error());
+  await expect(createScheduledEvent(mockScheduledEvent)).rejects.toThrowError();
+});
+
+test("createScheduledEvent returns response data on success", async() => {
+  mockAxios.post.mockResolvedValue({ data: "test data" });
+  await expect(createScheduledEvent(mockScheduledEvent)).resolves.toBe("test data")
+});

--- a/api.planx.uk/jest.config.ts
+++ b/api.planx.uk/jest.config.ts
@@ -14,7 +14,7 @@ export default {
   collectCoverage: true,
   coverageThreshold: {
     global: {
-      functions: 45,
+      functions: 60,
     },
   },
   coverageReporters: ["lcov", "text-summary"],

--- a/api.planx.uk/webhooks/hardDeleteSessions.test.ts
+++ b/api.planx.uk/webhooks/hardDeleteSessions.test.ts
@@ -3,12 +3,13 @@ import app from "../server";
 import { queryMock } from "../tests/graphqlQueryMock";
 
 const { post } = supertest(app);
+const ENDPOINT = "/webhooks/hasura/delete-expired-sessions";
 
 describe("Delete expired sessions webhook", () => {
   afterEach(() => queryMock.reset());
 
   it("fails without correct authentication", () => {
-    post("/webhooks/hasura/delete-expired-sessions")
+    post(ENDPOINT)
       .expect(401)
       .then((response) => {
         expect(response.body).toEqual({
@@ -33,7 +34,7 @@ describe("Delete expired sessions webhook", () => {
       ]
     });
 
-    await post("/webhooks/hasura/delete-expired-sessions")
+    await post(ENDPOINT)
       .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
       .expect(200)
       .then((response) => {
@@ -55,7 +56,7 @@ describe("Delete expired sessions webhook", () => {
       ]
     });
 
-    await post("/webhooks/hasura/delete-expired-sessions")
+    await post(ENDPOINT)
       .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
       .expect(500)
       .then((response) => {

--- a/api.planx.uk/webhooks/hardDeleteSessions.test.ts
+++ b/api.planx.uk/webhooks/hardDeleteSessions.test.ts
@@ -1,0 +1,66 @@
+import supertest from "supertest";
+import app from "../server";
+import { queryMock } from "../tests/graphqlQueryMock";
+
+const { post } = supertest(app);
+
+describe("Delete expired sessions webhook", () => {
+  afterEach(() => queryMock.reset());
+
+  it("fails without correct authentication", () => {
+    post("/webhooks/hasura/delete-expired-sessions")
+      .expect(401)
+      .then((response) => {
+        expect(response.body).toEqual({
+          error: "Unauthorised",
+        });
+      });
+  });
+
+  it("returns a positive response with authentication", async () => {
+    queryMock.mockQuery({
+      name: "HardDeleteExpiredSessions",
+      data: {
+        delete_lowcal_sessions: {
+          returning: [
+            { id: "abc123" },
+            { id: "xyz789" },
+          ]
+        }
+      },
+      ignoreThesePropertiesInVariables: [
+        "oneWeekAgo"
+      ]
+    });
+
+    await post("/webhooks/hasura/delete-expired-sessions")
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toEqual({
+          deletedSessions: ["abc123", "xyz789"],
+        });
+      });
+  });
+
+  it("returns an error when the query fails", async () => {
+    queryMock.mockQuery({
+      name: "HardDeleteExpiredSessions",
+      data: {},
+      graphqlErrors: [
+        { error: "Query failed"}
+      ],
+      ignoreThesePropertiesInVariables: [
+        "oneWeekAgo"
+      ]
+    });
+
+    await post("/webhooks/hasura/delete-expired-sessions")
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .expect(500)
+      .then((response) => {
+        expect(response.body.error).toMatch(/Failed to delete sessions/)
+      });
+  });
+});
+

--- a/api.planx.uk/webhooks/lowcalSessionEvents.test.ts
+++ b/api.planx.uk/webhooks/lowcalSessionEvents.test.ts
@@ -150,4 +150,3 @@ describe("Create expiry event webhook", () => {
       });
   });
 });
-

--- a/api.planx.uk/webhooks/lowcalSessionEvents.test.ts
+++ b/api.planx.uk/webhooks/lowcalSessionEvents.test.ts
@@ -1,12 +1,8 @@
 import supertest from "supertest";
 import app from "../server";
-// import Axios from "axios";
 import { createScheduledEvent } from "../hasura/metadata";
 
 const { post } = supertest(app);
-
-// jest.mock("axios")
-// const mockedAxios = Axios as jest.Mocked<typeof Axios>
 
 jest.mock("../hasura/metadata")
 const mockedCreateScheduledEvent = createScheduledEvent as jest.MockedFunction<typeof createScheduledEvent>;

--- a/api.planx.uk/webhooks/lowcalSessionEvents.test.ts
+++ b/api.planx.uk/webhooks/lowcalSessionEvents.test.ts
@@ -1,0 +1,157 @@
+import supertest from "supertest";
+import app from "../server";
+// import Axios from "axios";
+import { createScheduledEvent } from "../hasura/metadata";
+
+const { post } = supertest(app);
+
+// jest.mock("axios")
+// const mockedAxios = Axios as jest.Mocked<typeof Axios>
+
+jest.mock("../hasura/metadata")
+const mockedCreateScheduledEvent = createScheduledEvent as jest.MockedFunction<typeof createScheduledEvent>;
+
+describe("Create reminder event webhook", () => {
+  const ENDPOINT = "/webhooks/hasura/create-reminder-event"
+
+  afterEach(() => jest.resetAllMocks());
+
+  it("fails without correct authentication", () => {
+    post(ENDPOINT)
+      .expect(401)
+      .then((response) => {
+        expect(response.body).toEqual({
+          error: "Unauthorised",
+        });
+      });
+  });
+
+  it("returns a 400 if a required value is missing", async () => {
+    const missingCreatedAt = { createdAt: null, payload: {} } 
+    const missingPayload = { createdAt: new Date(), payload: null } 
+
+    for (const body of [ missingCreatedAt, missingPayload ]) {
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+        .send(body)
+        .expect(400)
+        .then((response) => expect(response.body.error).toEqual("Required value missing"));
+    }
+  });
+
+  it("returns a 200 on successful event setup", async () => {
+    const body = { createdAt: new Date(), payload: { sessionId: "123" } };
+    mockedCreateScheduledEvent.mockResolvedValue("test");
+  
+    await post(ENDPOINT)
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .send(body)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toBe("test")
+      });
+  });
+
+  it("passes the correct arguments along to createScheduledEvent", async () => {
+    const body = { createdAt: new Date(), payload: { sessionId: "123" } };
+    mockedCreateScheduledEvent.mockResolvedValue("test");
+  
+    await post(ENDPOINT)
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .send(body)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toBe("test")
+      });
+    const mockArgs = mockedCreateScheduledEvent.mock.calls[0][0];
+    expect(mockArgs.webhook).toBe("{{HASURA_PLANX_API_URL}}/send-email/reminder");
+    expect(mockArgs.payload).toMatchObject(body.payload);
+    expect(mockArgs.comment).toBe(`reminder_${body.payload.sessionId}`);
+  })
+
+  it("returns a 500 on event setup failure", async () => {
+    const body = { createdAt: new Date(), payload: { sessionId: "123" } };
+    mockedCreateScheduledEvent.mockRejectedValue(new Error("Failed!"));
+  
+    await post(ENDPOINT)
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .send(body)
+      .expect(500)
+      .then((response) => {
+        expect(response.body.error).toMatch(/Failed to create reminder event/)
+      });
+  });
+});
+
+describe("Create expiry event webhook", () => {
+  const ENDPOINT = "/webhooks/hasura/create-expiry-event"
+
+  afterEach(() => jest.resetAllMocks());
+
+  it("fails without correct authentication", () => {
+    post(ENDPOINT)
+      .expect(401)
+      .then((response) => {
+        expect(response.body).toEqual({
+          error: "Unauthorised",
+        });
+      });
+  });
+
+  it("returns a 400 if a required value is missing", async () => {
+    const missingCreatedAt = { createdAt: null, payload: {} } 
+    const missingPayload = { createdAt: new Date(), payload: null } 
+
+    for (const body of [ missingCreatedAt, missingPayload ]) {
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+        .send(body)
+        .expect(400)
+        .then((response) => expect(response.body.error).toEqual("Required value missing"));
+    }
+  });
+
+  it("returns a 200 on successful event setup", async () => {
+    const body = { createdAt: new Date(), payload: { sessionId: "123" } };
+    mockedCreateScheduledEvent.mockResolvedValue("test");
+  
+    await post(ENDPOINT)
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .send(body)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toBe("test")
+      });
+  });
+
+  it("passes the correct arguments along to createScheduledEvent", async () => {
+    const body = { createdAt: new Date(), payload: { sessionId: "123" } };
+    mockedCreateScheduledEvent.mockResolvedValue("test");
+  
+    await post(ENDPOINT)
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .send(body)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toBe("test")
+      });
+    const mockArgs = mockedCreateScheduledEvent.mock.calls[0][0];
+    expect(mockArgs.webhook).toBe("{{HASURA_PLANX_API_URL}}/send-email/expiry");
+    expect(mockArgs.payload).toMatchObject(body.payload);
+    expect(mockArgs.comment).toBe(`expiry_${body.payload.sessionId}`);
+  })
+
+  it("returns a 500 on event setup failure", async () => {
+    const body = { createdAt: new Date(), payload: { sessionId: "123" } };
+    mockedCreateScheduledEvent.mockRejectedValue(new Error("Failed!"));
+  
+    await post(ENDPOINT)
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+      .send(body)
+      .expect(500)
+      .then((response) => {
+        expect(response.body.error).toMatch(/Failed to create expiry event/)
+      });
+  });
+});
+

--- a/api.planx.uk/webhooks/sendNotification.test.ts
+++ b/api.planx.uk/webhooks/sendNotification.test.ts
@@ -1,0 +1,167 @@
+import supertest from "supertest";
+import app from "../server";
+// import SlackNotify from "slack-notify";
+
+const ENDPOINT = "/webhooks/hasura/send-slack-notification";
+
+const mockSend = jest.fn()
+jest.mock('slack-notify', () =>
+  jest.fn().mockImplementation(() => {
+    return { send: mockSend };
+  }),
+);
+
+const { post } = supertest(app)
+
+describe("Send Slack notifications endpoint", () => {
+  describe("authentication and validation", () => {
+    it("fails without correct authentication", () => {
+      post(ENDPOINT)
+        .expect(401)
+        .then((response) => {
+          expect(response.body).toEqual({
+            error: "Unauthorised",
+          });
+        });
+    });
+  
+    it("returns a 404 if 'type' is missing", async () => {
+      const body = { event: {} };
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+        .send(body)
+        .expect(404)
+        .then((response) => {
+          expect(response.body).toEqual({
+            message: "Missing info required to send a Slack notification",
+          });
+        });
+    });
+  
+    it("returns a 404 if 'type' is incorrect", async () => {
+      const body = { event: {} };
+      await post(ENDPOINT + "?type=test-submission")
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+        .send(body)
+        .expect(404)
+        .then((response) => {
+          expect(response.body).toEqual({
+            message: "Missing info required to send a Slack notification",
+          });
+        });
+    });
+  
+    it("returns a 404 if 'event' is missing", async () => {
+      await post(ENDPOINT + "?type=bops-submission")
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+        .expect(404)
+        .then((response) => {
+          expect(response.body).toEqual({
+            message: "Missing info required to send a Slack notification",
+          });
+        });
+    });
+  });
+  
+  const destinations = [
+    { 
+      name: "BOPS",
+      type: "bops-submission",
+      stagingBody: {
+        event: {
+          data: {
+            new: {
+              destination_url: "https://www.bops-staging.com",
+            }
+          }
+        }
+      },
+      prodBody: {
+        event: {
+          data: {
+            new: {
+              // destination_url: "https://www.bops-staging.com",
+            }
+          }
+        }
+      }
+    },
+    { 
+      name: "Uniform",
+      type: "uniform-submission",
+      stagingBody: {
+        event: {
+          data: {
+            new: {
+              response: {
+                _links: {
+                  self: {
+                    href: "https://www.bops-staging.com"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      prodBody: {
+        event: {
+          data: {
+            new: {
+              response: {
+                _links: {
+                  self: {
+                    // href: "https://www.bops-staging.com"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+  ]
+
+  for (const destination of destinations) {
+    describe(`${destination.name} notifications`, () => {
+      afterEach(() => jest.clearAllMocks());
+
+      it("skips the staging environment", async () => {
+        await post(ENDPOINT + `?type=${destination.type}`)
+          .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+          .send(destination.stagingBody)
+          .expect(200)
+          .then((response) => {
+            expect(response.body.message).toMatch(/skipping Slack notification/);
+          });
+      });
+
+      it("posts to Slack on success", async () => {
+        mockSend.mockResolvedValue("Success!");
+
+        await post(ENDPOINT + `?type=${destination.type}`)
+          .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+          .send(destination.prodBody)
+          .expect(200)
+          .then((response) => {
+            expect(mockSend).toHaveBeenCalledTimes(1);
+            expect(response.body.message).toBe("Posted to Slack");
+          });
+      });
+
+      it("returns error when Slack fails", async () => {
+        mockSend.mockRejectedValue("Fail!");
+
+        await post(ENDPOINT + `?type=${destination.type}`)
+          .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
+          .send(destination.prodBody)
+          .expect(500)
+          .then((response) => {
+            expect(mockSend).toHaveBeenCalledTimes(1);
+            expect(response.body.error).toMatch(/Failed to send/);
+            expect(response.body.error).toMatch(/Fail!/);
+          });
+      });
+    });
+  }
+});

--- a/api.planx.uk/webhooks/sendNotification.test.ts
+++ b/api.planx.uk/webhooks/sendNotification.test.ts
@@ -1,6 +1,6 @@
 import supertest from "supertest";
 import app from "../server";
-// import SlackNotify from "slack-notify";
+import SlackNotify from "slack-notify";
 
 const ENDPOINT = "/webhooks/hasura/send-slack-notification";
 
@@ -80,7 +80,7 @@ describe("Send Slack notifications endpoint", () => {
         event: {
           data: {
             new: {
-              // destination_url: "https://www.bops-staging.com",
+              destination_url: "https://www.bops-production.com",
             }
           }
         }
@@ -96,7 +96,7 @@ describe("Send Slack notifications endpoint", () => {
               response: {
                 _links: {
                   self: {
-                    href: "https://www.bops-staging.com"
+                    href: "https://www.uniform-staging.com"
                   }
                 }
               }
@@ -111,7 +111,7 @@ describe("Send Slack notifications endpoint", () => {
               response: {
                 _links: {
                   self: {
-                    // href: "https://www.bops-staging.com"
+                    href: "https://www.uniform-production.com"
                   }
                 }
               }
@@ -144,6 +144,7 @@ describe("Send Slack notifications endpoint", () => {
           .send(destination.prodBody)
           .expect(200)
           .then((response) => {
+            expect(SlackNotify).toHaveBeenCalledWith(process.env.SLACK_WEBHOOK_URL);
             expect(mockSend).toHaveBeenCalledTimes(1);
             expect(response.body.message).toBe("Posted to Slack");
           });

--- a/api.planx.uk/webhooks/sendNotifications.ts
+++ b/api.planx.uk/webhooks/sendNotifications.ts
@@ -1,7 +1,7 @@
 import SlackNotify from 'slack-notify';
 import { Request, Response, NextFunction } from 'express';
 
-const sendSlackNotification = (req: Request, res: Response, next: NextFunction): Response | void  => {
+const sendSlackNotification = async (req: Request, res: Response, next: NextFunction): Promise<Response | void>  => {
   const supportedTypes = ["bops-submission", "uniform-submission"];
   if (!req.body?.event || !req.query?.type || !supportedTypes.includes(req.query.type as string)) {
     return res.status(404).send({
@@ -24,11 +24,8 @@ const sendSlackNotification = (req: Request, res: Response, next: NextFunction):
       }
 
       const bopsMessage = `:incoming_envelope: New BOPS submission *${data?.bops_id}* [${data?.destination_url}]`;
-      slack.send(bopsMessage)
-        .then(() => {
-          res.status(200).send({ message: "Posted to Slack", data: bopsMessage });
-        })
-        .catch(error => next(error));
+      await slack.send(bopsMessage);
+      return res.status(200).send({ message: "Posted to Slack", data: bopsMessage });
     }
     
     if (req.query.type === "uniform-submission") {
@@ -40,11 +37,8 @@ const sendSlackNotification = (req: Request, res: Response, next: NextFunction):
       }
 
       const uniformMessage = `:incoming_envelope: New Uniform submission *${data?.idox_submission_id}* [${data?.response?.organisation}]`;
-      slack.send(uniformMessage)
-        .then(() => {
-          res.status(200).send({ message: "Posted to Slack", data: uniformMessage });
-        })
-        .catch(error => next(error));
+      await slack.send(uniformMessage);
+      return res.status(200).send({ message: "Posted to Slack", data: uniformMessage });
     }
   } catch (error) {
     return next({


### PR DESCRIPTION
## What does this PR do?
 - Brings test coverage for the API `/webhook` and `hasura-metadata` modules up to 100%
 - Bumps API global functions coverage threshold to 60%
 - Delivers on this promise from last week 😅 https://github.com/theopensystemslab/planx-new/pull/1252#discussion_r1016424337 