### PR TITLE
feat: Enhance FeedbackFish metadata

### DIFF
--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.test.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.test.ts
@@ -1,0 +1,131 @@
+import { Feedback, parseFeedback } from './downloadFeedbackCSV';
+import supertest from "supertest";
+import app from "../../server";
+import { authHeader } from "../../tests/mockJWT";
+import Axios from "axios";
+
+jest.mock("axios");
+const mockAxios = Axios as jest.Mocked<typeof Axios>;
+
+const ENDPOINT = "/admin/feedback";
+
+const mockFeedback: Feedback = {
+  id: 123,
+  text: "Service feedback",
+  category: "idea",
+  createdAt: "timestamp",
+  location: "http://editor.planx.test/team/service",
+  screenshotUrl: "",
+  device: {
+    client: {
+      name: "Chrome",
+      version: "123"
+    },
+    os: {
+      name: "Linux",
+      version: "123"
+    }
+  },
+  metadata: [
+    {
+      key: "project-type",
+      value: "extension",
+    },
+    {
+      key: "uprn",
+      value: "12345",
+    },
+    {
+      key: "team",
+      value: "test team"
+    },
+    {
+      key: "service",
+      value: "test service"
+    }
+  ]
+}
+
+describe("Download feedback CSV endpoint", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("requires a user to be logged in", async () => {
+    await supertest(app)
+      .get(ENDPOINT)
+      .expect(401)
+      .then(res => expect(res.body).toEqual({
+        error: "No authorization token was found",
+      }));
+  });
+
+  it("requires the 'cookie' query parameter", async () => {
+    await supertest(app)
+      .get(ENDPOINT)
+      .set(authHeader())
+      .expect(401)
+      .then(res => expect(res.body).toEqual({ error: "Missing cookie" }));
+  });
+
+  it("returns an error if request to FeedbackFish fails", async () => {
+    mockAxios.post.mockRejectedValue(new Error("FeedbackFish query failed!"));
+    await supertest(app)
+      .get(ENDPOINT)
+      .set(authHeader())
+      .query({ cookie: "test cookie" })
+      .expect(500)
+      .then(res => expect(res.body.error).toMatch(/FeedbackFish query failed!/));
+  });
+
+  it("passes the provided cookie to FeedbackFish", async () => {
+    mockAxios.post.mockResolvedValue({ data: { data: { feedback: [ mockFeedback ] } } });
+    const cookie = "test cookie"
+    await supertest(app)
+      .get(ENDPOINT)
+      .set(authHeader())
+      .query({ cookie })
+      .expect(200)
+      .then(() => {
+        expect(mockAxios.post).toHaveBeenCalledWith(
+          expect.stringContaining("https"),
+          expect.objectContaining({ query: expect.stringContaining("query") }), 
+          { headers: { cookie } }
+        )
+      });
+  });
+
+  it("returns a CSV file", async () => {
+    mockAxios.post.mockResolvedValue({ data: { data: { feedback: [ mockFeedback ] } } });
+    const cookie = "test cookie"
+    await supertest(app)
+      .get(ENDPOINT)
+      .set(authHeader())
+      .query({ cookie })
+      .expect(200)
+      .expect("content-type", "text/csv; charset=utf-8");
+  });
+});
+
+describe("parseFeedback helper function", () => {
+  it("correctly parses FeedbackFish data", () => {
+    const { metadata, ...restMockFeedback } = mockFeedback
+    const result = parseFeedback([mockFeedback])
+
+    // Metadata is parsed from query result
+    expect(result[0]).toMatchObject({
+      uprn: "12345",
+      team: "test team",
+      service: "test service",
+      "project-type": "extension",
+    });
+
+    // Standard values from FeedbackFish are maintained
+    expect(result[0]).toMatchObject({
+      ...restMockFeedback
+    });
+
+    // Raw metadata from FeedbackFish is stripped out
+    expect(result[0]).not.toMatchObject({
+      metadata
+    });
+  })
+});

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -14,7 +14,9 @@ interface Feedback {
   metadata?: Metadata[]
 }
 
-type MetadataKey = "address" | "uprn" | "title" | "data" | "service" | "team"
+const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "componentMetadata", "reason"] as const;
+
+type MetadataKey = typeof METADATA_KEYS[number]
 
 interface Metadata {
   key: MetadataKey
@@ -61,7 +63,19 @@ export const downloadFeedbackCSV = async (
   try {
     const feedback = await fetchFeedback(cookie, projectId);
     const parsedFeedback = parseFeedback(feedback);
-    const csvStream = stringify(parsedFeedback, { header: true })
+    const csvStream = stringify(parsedFeedback, { 
+      header: true, 
+      columns: [
+        "id",
+        "text",
+        "category",
+        "createdAt",
+        "location",
+        "screenshotUrl",
+        "device",
+        ...METADATA_KEYS
+      ] 
+    });
     res.header("Content-type", "text/csv");
     csvStream.pipe(res);
   } catch (error) {

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -14,7 +14,7 @@ export interface Feedback {
   metadata?: Metadata[]
 }
 
-const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "componentMetadata", "reason", "project-type", "breadcrumbs"] as const;
+const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "component-metadata", "reason", "project-type", "breadcrumbs"] as const;
 
 type MetadataKey = typeof METADATA_KEYS[number]
 

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from "express";
 import Axios from "axios";
 import { stringify } from "csv-stringify";
 
-interface Feedback {
+export interface Feedback {
   id: number
   text: string
   category: string
@@ -47,9 +47,6 @@ export const downloadFeedbackCSV = async (
   res: Response,
   next: NextFunction
 ) => {
-  if (!req.user?.sub)
-    return next({ status: 401, message: "User ID missing from JWT" });
-
   if (!req.query.cookie)
     return next({ status: 401, message: "Missing cookie" });
 
@@ -104,7 +101,7 @@ const fetchFeedback = async (cookie: string): Promise<Feedback[]> => {
   }
 };
 
-const parseFeedback = (feedback: Feedback[]): ParsedFeedback[] => {
+export const parseFeedback = (feedback: Feedback[]): ParsedFeedback[] => {
   const parsedFeedback: ParsedFeedback[] = [...feedback];
   return parsedFeedback.map(item => {
     item.metadata?.forEach(({ key, value }) => item[key] = value);

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -42,11 +42,6 @@ type ParsedFeedback = Feedback & {
   [key in MetadataKey]?: string | Record<string, string>
 }
 
-interface QueryParams {
-  cookie: string
-  projectId: string
-}
-
 export const downloadFeedbackCSV = async (
   req: Request,
   res: Response,
@@ -55,13 +50,11 @@ export const downloadFeedbackCSV = async (
   if (!req.user?.sub)
     return next({ status: 401, message: "User ID missing from JWT" });
 
-  if (!req.query.cookie || !req.query.projectId)
-    return next({ status: 401, message: "Missing cookie and/or projectId" });
-
-  const { cookie, projectId } = req.query as unknown as QueryParams;
+  if (!req.query.cookie)
+    return next({ status: 401, message: "Missing cookie" });
 
   try {
-    const feedback = await fetchFeedback(cookie, projectId);
+    const feedback = await fetchFeedback(req.query.cookie as string);
     const parsedFeedback = parseFeedback(feedback);
     const csvStream = stringify(parsedFeedback, { 
       header: true, 
@@ -83,7 +76,7 @@ export const downloadFeedbackCSV = async (
   }
 };
 
-const fetchFeedback = async (cookie: string, projectId: string): Promise<Feedback[]> => {
+const fetchFeedback = async (cookie: string): Promise<Feedback[]> => {
   const feedbackFishGraphQLEndpoint = "https://graphcdn.api.feedback.fish/"
   const body = {
     query: gql`query getFeedback($projectId: String!) { 
@@ -98,7 +91,7 @@ const fetchFeedback = async (cookie: string, projectId: string): Promise<Feedbac
     }`,
     operationName: "getFeedback",
     variables: {
-      projectId: projectId
+      projectId: "65f02de00b90d1"
     }
   }
 

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -14,7 +14,7 @@ interface Feedback {
   metadata?: Metadata[]
 }
 
-const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "componentMetadata", "reason"] as const;
+const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "componentMetadata", "reason", "project-type"] as const;
 
 type MetadataKey = typeof METADATA_KEYS[number]
 

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -101,11 +101,16 @@ const fetchFeedback = async (cookie: string): Promise<Feedback[]> => {
   }
 };
 
+const generateMetadata = (feedback: ParsedFeedback): ParsedFeedback => {
+  // Transform metadata into kv pairs
+  feedback.metadata?.forEach(({ key, value }) => feedback[key] = value)
+  // Drop redundant raw metadata
+  delete feedback.metadata;
+  return feedback;
+};
+
 export const parseFeedback = (feedback: Feedback[]): ParsedFeedback[] => {
   const parsedFeedback: ParsedFeedback[] = [...feedback];
-  return parsedFeedback.map(item => {
-    item.metadata?.forEach(({ key, value }) => item[key] = value);
-    delete item.metadata;
-    return item;
-  })
+  parsedFeedback.map(generateMetadata);
+  return parsedFeedback
 };

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -1,0 +1,100 @@
+import { gql } from "graphql-request";
+import { Request, Response, NextFunction } from "express";
+import Axios from "axios";
+import { stringify } from "csv-stringify";
+
+interface Feedback {
+  id: number
+  text: string
+  category: string
+  createdAt: string
+  location: string
+  screenshotUrl: string
+  device: Device
+  metadata?: Metadata[]
+}
+
+type MetadataKey = "address" | "uprn" | "title" | "data" | "service" | "team"
+
+interface Metadata {
+  key: MetadataKey
+  value: string | Record<string, string>
+}
+
+interface Device {
+  client: Client
+  os: Os
+}
+
+interface Client {
+  name: string
+  version: string
+}
+
+interface Os {
+  name: string
+  version: string
+}
+
+type ParsedFeedback = Feedback & {
+  [key in MetadataKey]?: string | Record<string, string>
+}
+
+export const downloadFeedbackCSV = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!req.user?.sub)
+    return next({ status: 401, message: "User ID missing from JWT" });
+
+  if (!req.query.cookie)
+    return next({ status: 401, message: "Missing cookie" });
+
+  try {
+    const feedback = await fetchFeedback(req.query.cookie as string);
+    const parsedFeedback = parseFeedback(feedback);
+    const csvStream = stringify(parsedFeedback, { header: true })
+    res.header("Content-type", "text/csv");
+    csvStream.pipe(res);
+  } catch (error) {
+    return next({ message: "Failed to generate FeedbackFish CSV: " + (error as Error).message });
+  }
+};
+
+const fetchFeedback = async (cookie: string): Promise<Feedback[]> => {
+  const feedbackFishGraphQLEndpoint = "https://graphcdn.api.feedback.fish/"
+  const body = {
+    query: gql`query getFeedback($projectId: String!) { 
+      feedback(projectId: $projectId) { 
+        id text category createdAt location screenshotUrl 
+        metadata { key value } 
+        device { 
+          client { name  version } 
+          os { name version } 
+        } 
+      } 
+    }`,
+    operationName: "getFeedback",
+    variables: {
+      projectId: process.env.REACT_APP_FEEDBACK_FISH_ID
+    }
+  }
+
+  try {
+    const result = await Axios.post(feedbackFishGraphQLEndpoint, body, { headers: { cookie } });
+    const feedback: Feedback[] = result.data.data.feedback;
+    return feedback;
+  } catch (error) {
+    throw Error("Failed to connect to FeedbackFish: " + (error as Error).message)
+  }
+};
+
+const parseFeedback = (feedback: Feedback[]): ParsedFeedback[] => {
+  const parsedFeedback: ParsedFeedback[] = [...feedback];
+  return parsedFeedback.map(item => {
+    item.metadata?.forEach(({ key, value }) => item[key] = value);
+    delete item.metadata;
+    return item;
+  })
+};

--- a/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
+++ b/api.planx.uk/admin/feedback/downloadFeedbackCSV.ts
@@ -14,7 +14,7 @@ export interface Feedback {
   metadata?: Metadata[]
 }
 
-const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "componentMetadata", "reason", "project-type"] as const;
+const METADATA_KEYS = ["address", "uprn", "title", "data", "service", "team", "componentMetadata", "reason", "project-type", "breadcrumbs"] as const;
 
 type MetadataKey = typeof METADATA_KEYS[number]
 

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -57,6 +57,7 @@ import { copyFlow } from "./editor/copyFlow";
 import { moveFlow } from "./editor/moveFlow";
 import { useOrdnanceSurveyProxy } from "./proxy/ordnanceSurvey";
 import { usePayProxy } from "./proxy/pay";
+import { downloadFeedbackCSV } from "./admin/feedback/downloadFeedbackCSV";
 
 const router = express.Router();
 
@@ -437,6 +438,8 @@ app.get("/gis/:localAuthority", locationSearch);
 app.get("/", (_req, res) => {
   res.json({ hello: "world" });
 });
+
+app.get("/admin/feedback", useJWT, downloadFeedbackCSV)
 
 // XXX: leaving this in temporarily as a testing endpoint to ensure it
 //      works correctly in staging and production

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -396,10 +396,11 @@ export function PropertyInformation(props: any) {
     },
     onSubmit: (values) => {
       if (values.feedback) {
-        submitFeedback(values.feedback, {
-          reason: "Inaccurate property details",
-          property: propertyDetails,
-        });
+        submitFeedback(
+          values.feedback,
+          "Inaccurate property details",
+          propertyDetails
+        );
       }
       handleSubmit?.(values);
     },

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -209,10 +209,11 @@ function PlanningConstraintsInformation(props: any) {
     },
     onSubmit: (values) => {
       if (values.feedback) {
-        submitFeedback(values.feedback, {
-          reason: "Inaccurate planning constraints",
-          constraints: constraints,
-        });
+        submitFeedback(
+          values.feedback,
+          "Inaccurate planning constraints",
+          constraints
+        );
       }
       handleSubmit?.(values);
     },

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -95,8 +95,7 @@ const Result: React.FC<Props> = ({
     },
     onSubmit: (values, { resetForm }) => {
       if (values.feedback) {
-        submitFeedback(values.feedback, {
-          reason: "Inaccurate Result",
+        submitFeedback(values.feedback, "Inaccurate Result", {
           responses: responses,
         });
         resetForm();

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -7,6 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { getFeedbackMetadata } from "lib/feedback";
 import React, { useEffect, useState } from "react";
 import { Link as ReactNaviLink } from "react-navi";
 
@@ -83,6 +84,8 @@ export default function Footer(props: Props) {
     e.stopPropagation();
   };
 
+  const metadata = getFeedbackMetadata();
+
   return (
     <Root>
       <ButtonGroup>
@@ -112,8 +115,7 @@ export default function Footer(props: Props) {
                 </DialogActions>
               </Dialog>
             )}
-
-            <FeedbackFish projectId={feedbackFishId}>
+            <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
               <Link color="inherit" component="button">
                 <Typography variant="body2">Feedback</Typography>
               </Link>

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -5,6 +5,7 @@ import Link from "@mui/material/Link";
 import { Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
+import { getFeedbackMetadata } from "lib/feedback";
 import React from "react";
 
 const useClasses = makeStyles((theme: Theme) => ({
@@ -31,9 +32,10 @@ const useClasses = makeStyles((theme: Theme) => ({
 export default function PhaseBanner(): FCReturn {
   const classes = useClasses();
   const feedbackFishId = process.env.REACT_APP_FEEDBACK_FISH_ID || "";
+  const metadata = getFeedbackMetadata();
 
   return (
-    <FeedbackFish projectId={feedbackFishId}>
+    <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
       <ButtonBase
         aria-label="This is a new service. Click here to provide feedback."
         className={classes.root}

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -18,7 +18,7 @@ export const submitFeedback = (
       // FeedbackFish requires that Record<string, string> be passed as metadata
       metadata: {
         ...standardMetadata,
-        componentMetadata: JSON.stringify(componentMetadata),
+        "component-metadata": JSON.stringify(componentMetadata),
       },
     }),
   }).catch((err) => console.error(err));
@@ -39,7 +39,7 @@ export const getFeedbackMetadata = (): Record<string, string> => {
     address: passportData?._address?.single_line_address,
     uprn: passportData?._address?.uprn,
     "project-type": passportData?.proposal?.projectType,
-    title: nodeData?.title || nodeData.text,
+    title: nodeData?.title || nodeData?.text,
     data: JSON.stringify(nodeData),
     breadcrumbs: JSON.stringify(breadcrumbs),
     service,

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -35,6 +35,7 @@ export const getFeedbackMetadata = (): Record<string, string> => {
   const feedbackMetadata = {
     address: passportData?._address?.single_line_address,
     uprn: passportData?._address?.uprn,
+    "project-type": passportData?.proposal?.projectType,
     title: currentCard?.data?.title || currentCard?.data?.text,
     data: JSON.stringify(currentCard?.data),
     service,

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -1,3 +1,6 @@
+import { useStore } from "pages/FlowEditor/lib/store";
+import { useCurrentRoute } from "react-navi";
+
 export const submitFeedback = (
   text: string,
   metadata?: { [key: string]: any }
@@ -13,4 +16,22 @@ export const submitFeedback = (
       metadata,
     }),
   }).catch((err) => console.error(err));
+};
+
+export const getFeedbackMetadata = (): Record<string, string> => {
+  const [currentCard, passport] = useStore((state) => [
+    state.currentCard(),
+    state.computePassport().data,
+  ]);
+  const { flowName: service, team } = useCurrentRoute().data;
+
+  const feedbackMetadata = {
+    address: passport?._address?.single_line_address,
+    uprn: passport?._address?.uprn,
+    title: currentCard?.data?.title || currentCard?.data?.text,
+    data: currentCard?.data,
+    service,
+    team,
+  };
+  return feedbackMetadata;
 };

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -27,6 +27,7 @@ export const submitFeedback = (
 export const getFeedbackMetadata = (): Record<string, string> => {
   const currentCard = useStore.getState().currentCard();
   const passportData = useStore.getState().computePassport().data;
+  const breadcrumbs = useStore.getState().breadcrumbs;
   const [team, service] = window.location.pathname
     .split("/")
     .map((value) => value.replaceAll("-", " "))
@@ -38,6 +39,7 @@ export const getFeedbackMetadata = (): Record<string, string> => {
     "project-type": passportData?.proposal?.projectType,
     title: currentCard?.data?.title || currentCard?.data?.text,
     data: JSON.stringify(currentCard?.data),
+    breadcrumbs: JSON.stringify(breadcrumbs),
     service,
     team,
   };

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -25,9 +25,11 @@ export const submitFeedback = (
 };
 
 export const getFeedbackMetadata = (): Record<string, string> => {
-  const currentCard = useStore.getState().currentCard();
-  const passportData = useStore.getState().computePassport().data;
-  const breadcrumbs = useStore.getState().breadcrumbs;
+  const { currentCard, computePassport, breadcrumbs } = useStore.getState();
+
+  const passportData = computePassport().data;
+  const nodeData = currentCard()?.data;
+
   const [team, service] = window.location.pathname
     .split("/")
     .map((value) => value.replaceAll("-", " "))
@@ -37,8 +39,8 @@ export const getFeedbackMetadata = (): Record<string, string> => {
     address: passportData?._address?.single_line_address,
     uprn: passportData?._address?.uprn,
     "project-type": passportData?.proposal?.projectType,
-    title: currentCard?.data?.title || currentCard?.data?.text,
-    data: JSON.stringify(currentCard?.data),
+    title: nodeData?.title || nodeData.text,
+    data: JSON.stringify(nodeData),
     breadcrumbs: JSON.stringify(breadcrumbs),
     service,
     team,


### PR DESCRIPTION
## What does this PR do?
 - Fixes how existing metadata is sent to the FeedbackFish API when user submits information via the "Report an inaccuracy" buttons
 - Send additional ("standard") metadata to allow George and Alastair more context when understanding feedback (e.g. UPRN, proposal.propertyType). This gets sent via the widget and our custom forms.
 - Adds a basic `/admin/feedback` endpoint that allows logged in Editor to download a CSV of feedback

## Context
This ticket has morphed from looking at alternatives to FeedbackFish, to improving the current integration with a view to replacing it with a custom version in the medium term. Tickets for the follow on task of designing and building this have been added to Trello.

I certainly see the current implementation of the "download feedback CSV" endpoint as a temporary measure as it relies on reverse engineering the undocumented FeedbackFish API which could theoretically change at any moment. I'd like to think in future that we could keep the endpoint but switch out the implementation.

This endpoint relies on a cookie I've added this as a query param as opposed to adding it as a secret. The idea here is that this is easier / quicker to update when required as there's no (documented) auth endpoint I can call to generate it.

**Metadata submitted to FeedbackFish**
<img width="703" alt="image" src="https://user-images.githubusercontent.com/20502206/203508009-96bd2675-8b00-4f16-a23b-fcac1d5c3497.png">
