### PR TITLE
fix: Use correct value for aria-valuenow on upload progress bars

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -187,9 +187,7 @@ export default function FileUpload(props: Props) {
             className={classes.progress}
             width={`${Math.min(Math.ceil(slot?.progress * 100), 100)}%`}
             role="progressbar"
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={slot?.progress || 0}
+            aria-valuenow={slot?.progress * 100 || 0}
           />
           <Box className={classes.filePreview}>
             {slot?.file instanceof File &&

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -312,9 +312,7 @@ function Dropzone(props: any) {
               className={classes.progress}
               width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
               role="progressbar"
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-valuenow={progress}
+              aria-valuenow={progress * 100 || 0}
             />
             <Box className={classes.filePreview}>
               {file instanceof File && file?.type?.includes("image") ? (


### PR DESCRIPTION
## What does this PR do?
 - Reports back a correct `aria-valuenow` to screen readers when a file is uploaded
   - Previously this was off by a factor of 100... 👀 
 - Drops redundant `aria-valuemin` and `aria-valuemax` - these are the default values ([docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role))

Note - refactoring the duplicated upload code would be a great win when looking at multiple file upload.

https://user-images.githubusercontent.com/20502206/203310811-e3b666a0-0e39-402a-b8bf-a0672c18b6f8.mov

