### PR TITLE
fix: border-style kebab case warning

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -175,7 +175,7 @@ const useClasses = makeStyles((theme) => ({
     border: `5px solid #E91B0C`,
     "& button": {
       background: "none",
-      "border-style": "none",
+      borderStyle: "none",
       color: "#E91B0C",
       cursor: "pointer",
       fontSize: "medium",

--- a/editor.planx.uk/src/ui/FileDownload.tsx
+++ b/editor.planx.uk/src/ui/FileDownload.tsx
@@ -13,7 +13,7 @@ const Root = styled("div")(({ theme }) => ({
   textAlign: "right",
   "& button": {
     background: "none",
-    "border-style": "none",
+    borderStyle: "none",
     color: theme.palette.text.primary,
     cursor: "pointer",
     fontSize: "inherit",


### PR DESCRIPTION
Quick fix - this is currently logging out an error when displayed, and when Editor tests are running.

![image](https://user-images.githubusercontent.com/20502206/203323567-dd08accd-bf67-41d9-8644-8b666ece6ee4.png)

Visually this still looks as expected - 

![image](https://user-images.githubusercontent.com/20502206/203326453-9ad393bc-3345-49df-990f-61064e647634.png)
![image](https://user-images.githubusercontent.com/20502206/203326602-d0275ba5-1785-4d30-bd7e-b849526331ce.png)
