### PR TITLE
fix: Allow public uploads to be accessed via API

### DIFF
--- a/api.planx.uk/s3/getFile.ts
+++ b/api.planx.uk/s3/getFile.ts
@@ -22,6 +22,7 @@ export const getFileFromS3 = async (fileId: string) => {
       Expires: file.Expires,
       "Last-Modified": file.LastModified,
       ETag: file.ETag,
+      "cross-origin-resource-policy": "same-site",
     },
   };
 };

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -29,7 +29,7 @@ import {
   fixRequestBody,
   Options,
 } from "http-proxy-middleware";
-import helmet, { HelmetOptions } from "helmet";
+import helmet from "helmet";
 import multer from "multer";
 import SlackNotify from "slack-notify";
 
@@ -292,11 +292,7 @@ if (process.env.NODE_ENV !== "test") {
 app.use(apiLimiter);
 
 // Secure Express by setting various HTTP headers
-const helmetOptions: HelmetOptions = {
-  // Allow public images to be served via API
-  crossOriginResourcePolicy: { policy: "same-site" }
-}
-app.use(helmet(helmetOptions));
+app.use(helmet());
 
 // Create "One-off Scheduled Events" in Hasura from Send component for selected destinations
 app.post("/create-send-events/:sessionId", createSendEvents);

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -29,7 +29,7 @@ import {
   fixRequestBody,
   Options,
 } from "http-proxy-middleware";
-import helmet from "helmet";
+import helmet, { HelmetOptions } from "helmet";
 import multer from "multer";
 import SlackNotify from "slack-notify";
 
@@ -292,7 +292,11 @@ if (process.env.NODE_ENV !== "test") {
 app.use(apiLimiter);
 
 // Secure Express by setting various HTTP headers
-app.use(helmet());
+const helmetOptions: HelmetOptions = {
+  // Allow public images to be served via API
+  crossOriginResourcePolicy: { policy: "same-site" }
+}
+app.use(helmet(helmetOptions));
 
 // Create "One-off Scheduled Events" in Hasura from Send component for selected destinations
 app.post("/create-send-events/:sessionId", createSendEvents);


### PR DESCRIPTION
## What's the problem?
- Publicly uploaded files are not accessible currently, and give a CORS error
- This is because files are now being served via the API

![image](https://user-images.githubusercontent.com/20502206/203408040-4a1d59de-4510-4f9c-a445-1d72626f9d81.png)

### Note
 - This may not work still on custom domains - we can change to "cross-origin" if required but this feels worth a shot...!
 - I'm pretty certain that these headers are set via Helmet in Express, but I'm a little unclear on Pulumi / AWS setup here. I see this as a bit of a temporary measure which is worth trying until we nail down the exact fix / implementation. Ideally we'd still limit access to certain domains if at all possible.