### PR TITLE
fix: Set public image CORP to "cross-site"

### DIFF
--- a/api.planx.uk/s3/getFile.ts
+++ b/api.planx.uk/s3/getFile.ts
@@ -22,7 +22,7 @@ export const getFileFromS3 = async (fileId: string) => {
       Expires: file.Expires,
       "Last-Modified": file.LastModified,
       ETag: file.ETag,
-      "cross-origin-resource-policy": "same-site",
+      "cross-origin-resource-policy": "cross-site",
     },
   };
 };


### PR DESCRIPTION
Please see https://github.com/theopensystemslab/planx-new/pull/1289 for context

As suspected, in order to work on custom domains this value needs to be set to `cross-site`.

<img width="609" alt="image" src="https://user-images.githubusercontent.com/20502206/203424412-153a510a-e78c-483c-ad8d-d2358f2ae970.png">

https://planningservices.buckinghamshire.gov.uk/temporary-pay-test