### PR TITLE
wip: sync production users to staging & docker environments

### DIFF
--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -1,9 +1,9 @@
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (1, 'John', 'Rees', 'john@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (6, 'Gunar', 'Gessner', 'gunargessner@gmail.com', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (13, 'Sarah', 'Scott', 'sarah@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (36, 'Benjamin', 'Williams', 'benjamin@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-SELECT setval('users_id_seq', max(id)) FROM users;
-SELECT setval('teams_id_seq', max(id)) FROM teams;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (1, 'John', 'Rees', 'john@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (6, 'Gunar', 'Gessner', 'gunargessner@gmail.com', true) ON CONFLICT (id) DO NOTHING;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (13, 'Sarah', 'Scott', 'sarah@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+-- INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (36, 'Benjamin', 'Williams', 'benjamin@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+-- SELECT setval('users_id_seq', max(id)) FROM users;
+-- SELECT setval('teams_id_seq', max(id)) FROM teams;


### PR DESCRIPTION
**DO NOT MERGE: This code doesn't work, for demonstration & discussion only!**

**Problem:** 
The data sync applies `users` via Hasura Seeds (`users.id` have been manually adjusted to match staging for google oauth). When a new user is added via the Hasura console to a pizza environment, their pizza user id is not going to match their staging user id, therefore triggering a foreign key violation when attempting to edit a flow. 

This pevents planning officers like Emily from UAT'ing a feature that has an Editor representation, for example "Please confirm you can add a ContactInput component to a flow." 

More context here: 
- https://opensystemslab.slack.com/archives/C01E3AC0C03/p1669222564451839
- https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3413445689621976952

**Proposed solutions:**
First attempt / this code:
- Extend the existing data sync script to query `users` from production and insert them into the local instance. Remove the manual Hasura seeds. This means ids would be synced across all environments and we wouldn't have to manually add users to pizzas (obviously it makes a strong case for addressing user permisisons sooner than later, but I don't think the risk of a user accessing a pizza is any greater than their current production/staging access). 
- This doesn't work unless the production graphql client in the data sync script is authenticated. `users` can only (rightly) be queried by the Hasura admin role, whereas other tables we're syncing can be queried by the public role. Authenticating the production graphql client in the data sync script makes this mix of queries & mutations begin to feel very precarious to me, and feels very risky to edit & test.

What I think we should actually do:
- Create a new pg database user with read access to necessary production tables and write access to non-production databases - this user will _only_ be responsible for data syncs
- That user does a pgdump of select tables from production (flows, teams, users, published_flows) and pg_restores into a  local/pizza/staging database where only Hasura migrations have been applied (no seed data)

Thoughts? Other proposed solutions?

**Short term pizza fix:**
Rather than adding new users via the Hasura Console add them via sql tab and match their id to their staging id. 

For example:
```INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true);```
