### PR TITLE
fix: tweak DrawBoundary language and add passport variable for hectares conversion

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
@@ -70,7 +70,7 @@ function DrawBoundaryComponent(props: Props) {
               />
             </InputRow>
           </InputGroup>
-          <InputGroup label="Area data field">
+          <InputGroup label="Area data field (square metres)">
             <InputRow>
               <Input
                 name="dataFieldArea"

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -177,7 +177,7 @@ export default function Component(props: Props) {
             </AlternateOption>
           )}
           <p>
-            The outline you have drawn has an area of{" "}
+            The site outline you have drawn is{" "}
             <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
           </p>
         </>

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -177,8 +177,8 @@ export default function Component(props: Props) {
             </AlternateOption>
           )}
           <p>
-            The boundary you have drawn has an area of{" "}
-            <strong>{area ?? 0} m²</strong>
+            The outline you have drawn has an area of{" "}
+            <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
           </p>
         </>
       );
@@ -218,6 +218,10 @@ export default function Component(props: Props) {
           boundary && props.dataFieldBoundary ? boundary : undefined,
         [props.dataFieldArea]:
           boundary && props.dataFieldBoundary ? area : undefined,
+        [`${props.dataFieldArea}.hectares`]:
+          boundary && area && props.dataFieldBoundary
+            ? area / 10000
+            : undefined,
         [propsDataFieldUrl]:
           selectedFile?.url && propsDataFieldUrl
             ? selectedFile?.url


### PR DESCRIPTION
Three minor changes:
- "boundary" &rarr; "outline" in hardcoded sentence under map
- add comma separator for site areas in the thousands of square metres
- add internal passport variable for hectares conversion (editor-configured area passport variable currently referenced in Calculate etc remains unchanged and still defaults to metres square)