### PR TITLE
feat: Style secondary buttons as links

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
+import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
@@ -43,26 +44,6 @@ const MapContainer = styled(Box)<MapContainerProps>(
     },
   })
 );
-
-const AlternateOption = styled("div")(({ theme }) => ({
-  textAlign: "right",
-  marginTop: theme.spacing(1),
-}));
-
-const AlternateOptionButton = styled(Button)(({ theme }) => ({
-  background: "none",
-  borderStyle: "none",
-  color: theme.palette.text.primary,
-  cursor: "pointer",
-  fontSize: "medium",
-  padding: theme.spacing(2),
-  "& :hover": {
-    backgroundColor: theme.palette.background.paper,
-  },
-  "& :disabled": {
-    color: theme.palette.text.disabled,
-  },
-}));
 
 export default function Component(props: Props) {
   const isMounted = useRef(false);
@@ -164,17 +145,20 @@ export default function Component(props: Props) {
               markerLongitude={Number(passport?.data?._address?.longitude)}
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
-            {!props.hideFileUpload && (
-              <AlternateOption>
-                <AlternateOptionButton
-                  data-testid="upload-file-button"
-                  onClick={() => setPage("upload")}
-                  disabled={Boolean(boundary)}
-                >
+          {!props.hideFileUpload && (
+            <Box sx={{ textAlign: "right" }}>
+              <Link
+                component="button"
+                onClick={() => setPage("upload")}
+                disabled={Boolean(boundary)}
+                data-testid="upload-file-button"
+              >
+                <Typography variant="body2">
                   Upload a location plan instead
-                </AlternateOptionButton>
-              </AlternateOption>
-            )}
+                </Typography>
+              </Link>
+            </Box>
+          )}
           </MapContainer>
           <p>
             The site outline you have drawn is{" "}
@@ -194,14 +178,17 @@ export default function Component(props: Props) {
             definitionImg={props.definitionImg}
           />
           <Upload setFile={setSelectedFile} initialFile={selectedFile} />
-          <AlternateOption>
-            <AlternateOptionButton
+          <Box sx={{ textAlign: "right" }}>
+            <Link
+              component="button"
               onClick={() => setPage("draw")}
               disabled={Boolean(selectedFile?.url)}
             >
-              Draw the boundary on a map instead
-            </AlternateOptionButton>
-          </AlternateOption>
+              <Typography variant="body2">
+                Draw the boundary on a map instead
+              </Typography>
+            </Link>
+          </Box>
         </>
       );
     }

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -439,7 +439,7 @@ export function PropertyInformation(props: any) {
           </PropertyDetail>
         ))}
       </Box>
-      <Box color="text.secondary" textAlign="right">
+      <Box textAlign="right">
         <FeedbackInput
           text="Report an inaccuracy"
           handleChange={formik.handleChange}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -19,7 +19,6 @@ import useSWR from "swr";
 import CollapsibleInput from "ui/CollapsibleInput";
 import { stringify } from "wkt";
 
-import FeedbackInput from "../shared/FeedbackInput";
 import type { PlanningConstraints } from "./model";
 
 type Props = PublicProps<PlanningConstraints>;

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -1,10 +1,9 @@
 import Warning from "@mui/icons-material/WarningOutlined";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
-import { useTheme } from "@mui/material/styles";
+import Link from "@mui/material/Link";
+import { styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
 import FeedbackInput from "@planx/components/shared/FeedbackInput";
 import Card from "@planx/components/shared/Preview/Card";
 import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
@@ -39,25 +38,14 @@ interface Response {
   hidden: boolean;
 }
 
-const useClasses = makeStyles((theme) => ({
-  readMore: {
-    color: theme.palette.text.primary,
-    textDecoration: "underline",
-  },
-  disclaimerContent: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-    color: theme.palette.text.primary,
-  },
-  disclaimerHeading: {
-    marginRight: theme.spacing(1),
-    color: theme.palette.text.primary,
-  },
-  button: {
-    color: theme.palette.text.primary,
-    padding: theme.spacing(0.5),
-  },
+const DisclaimerContent = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(1),
+  marginBottom: theme.spacing(1),
 }));
+
+const DisclaimerHeading = styled(Typography)(({ theme }) => ({
+  marginRight: theme.spacing(1),
+})) as typeof Typography;
 
 const Responses = ({
   responses,
@@ -124,7 +112,6 @@ const Result: React.FC<Props> = ({
     Boolean(handleSubmit)
   );
 
-  const classes = useClasses();
   const theme = useTheme();
 
   useEffect(() => {
@@ -176,33 +163,28 @@ const Result: React.FC<Props> = ({
             <Warning titleAccess="Warning" color="primary" />
             <Box ml={1}>
               <Box display="flex" alignItems="center">
-                <Typography
+                <DisclaimerHeading
                   variant="h6"
                   component="h3"
-                  color="inherit"
-                  className={classes.disclaimerHeading}
+                  color="text.primary"
                 >
                   {disclaimer.heading}
-                </Typography>
-                <Button
-                  className={classes.button}
+                </DisclaimerHeading>
+                <Link
+                  component="button"
                   onClick={() =>
                     setShowDisclaimer((showDisclaimer) => !showDisclaimer)
                   }
                 >
-                  <Typography variant="body2" className={classes.readMore}>
+                  <Typography variant="body2">
                     Read {showDisclaimer ? "less" : "more"}
                   </Typography>
-                </Button>
+                </Link>
               </Box>
               <Collapse in={showDisclaimer}>
-                <Typography
-                  variant="body2"
-                  color="inherit"
-                  className={classes.disclaimerContent}
-                >
+                <DisclaimerContent variant="body2" color="text.primary">
                   {disclaimer.content}
-                </Typography>
+                </DisclaimerContent>
               </Collapse>
             </Box>
           </Box>

--- a/editor.planx.uk/src/@planx/components/shared/FeedbackInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FeedbackInput.tsx
@@ -1,4 +1,5 @@
 import Typography from "@mui/material/Typography";
+import { styled } from "@mui/styles";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import CollapsibleInput from "ui/CollapsibleInput";
@@ -9,10 +10,16 @@ interface Props {
   text: string;
 }
 
+const StyledReactMarkdown = styled(ReactMarkdown)(() => ({
+  "& p": {
+    margin: 0,
+  },
+}));
+
 const FeedbackInput: React.FC<Props> = ({ text, ...componentProps }: Props) => (
   <CollapsibleInput {...componentProps} name="feedback">
     <Typography variant="body2" color="inherit" component="div">
-      <ReactMarkdown>{text}</ReactMarkdown>
+      <StyledReactMarkdown>{text}</StyledReactMarkdown>
     </Typography>
   </CollapsibleInput>
 );

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -3,6 +3,8 @@ import {
   responsiveFontSizes,
   ThemeOptions,
 } from "@mui/material/styles";
+// eslint-disable-next-line no-restricted-imports
+import createPalette from "@mui/material/styles/createPalette";
 
 import { TeamTheme } from "./types";
 
@@ -49,6 +51,30 @@ export const linkStyle = (primaryColor?: string) => ({
  * merged with Team specific options
  */
 export const getGlobalThemeOptions = (): ThemeOptions => {
+  const palette = createPalette({
+    primary: {
+      main: "#000661",
+      contrastText: "#fff",
+    },
+    background: {
+      default: "#fff",
+      paper: "#f2f2f2",
+    },
+    secondary: {
+      main: "#EFEFEF",
+    },
+    text: {
+      secondary: "rgba(0,0,0,0.6)",
+    },
+    action: {
+      selected: "#F8F8F8",
+      focus: GOVUK_YELLOW,
+    },
+    error: {
+      main: "#E91B0C",
+    },
+  });
+
   const themeOptions: ThemeOptions = {
     typography: {
       fontFamily: "'Inter', Arial",
@@ -83,29 +109,7 @@ export const getGlobalThemeOptions = (): ThemeOptions => {
         fontSize: 15,
       },
     },
-    palette: {
-      primary: {
-        main: "#000661",
-        contrastText: "#fff",
-      },
-      background: {
-        default: "#fff",
-        paper: "#f2f2f2",
-      },
-      secondary: {
-        main: "#EFEFEF",
-      },
-      text: {
-        secondary: "rgba(0,0,0,0.6)",
-      },
-      action: {
-        selected: "#F8F8F8",
-        focus: GOVUK_YELLOW,
-      },
-      error: {
-        main: "#E91B0C",
-      },
-    },
+    palette,
     breakpoints: {
       values: {
         xs: 0,
@@ -196,6 +200,17 @@ export const getGlobalThemeOptions = (): ThemeOptions => {
       MuiPaper: {
         defaultProps: {
           elevation: 0,
+        },
+      },
+      MuiLink: {
+        styleOverrides: {
+          root: {
+            "&:disabled": {
+              color: palette.text.disabled,
+              cursor: "default",
+              textDecoration: "none",
+            },
+          },
         },
       },
     },

--- a/editor.planx.uk/src/ui/CollapsibleInput.stories.tsx
+++ b/editor.planx.uk/src/ui/CollapsibleInput.stories.tsx
@@ -9,11 +9,10 @@ const metadata: Meta = {
   component: CollapsibleInput,
 };
 
-export const Basic: Story<Props> = (args: Props) => {
+export const Basic: Story<Props> = (_args: Props) => {
   const [text, setText] = useState("");
   return (
     <FeedbackInput
-      // {...args}
       text="Is this result inaccurate? **tell us why**"
       handleChange={(ev) => {
         setText(ev.target.value);

--- a/editor.planx.uk/src/ui/CollapsibleInput.tsx
+++ b/editor.planx.uk/src/ui/CollapsibleInput.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
-import makeStyles from "@mui/styles/makeStyles";
+import Link from "@mui/material/Link";
 import React, { useState } from "react";
 import Input from "ui/Input";
 
@@ -12,29 +11,18 @@ export interface Props {
   name: string;
 }
 
-const useClasses = makeStyles((theme) => ({
-  button: {
-    color: theme.palette.text.primary,
-    padding: 0,
-  },
-  submit: {
-    marginTop: theme.spacing(2),
-  },
-}));
-
 const CollapsibleInput: React.FC<Props> = (props: Props) => {
   const [expanded, setExpanded] = useState(false);
-  const classes = useClasses();
 
   return (
     <>
-      <Button
-        className={classes.button}
+      <Link
+        component="button"
         onClick={() => setExpanded((x) => !x)}
-        disableRipple
+        sx={{ marginBottom: 2 }}
       >
         {props.children}
-      </Button>
+      </Link>
       <Collapse in={expanded}>
         <Box py={0.5}>
           <Input

--- a/editor.planx.uk/src/ui/ExternalPlanningSiteDialog.tsx
+++ b/editor.planx.uk/src/ui/ExternalPlanningSiteDialog.tsx
@@ -1,33 +1,15 @@
-import Button from "@mui/material/Button";
-import ButtonBase from "@mui/material/ButtonBase";
+import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
 import { visuallyHidden } from "@mui/utils";
 import React from "react";
 import { useState } from "react";
 import { TeamSettings } from "types";
 import { fetchCurrentTeam } from "utils";
-
-const useClasses = makeStyles((theme) => ({
-  container: {
-    display: "flex",
-    justifyContent: "end",
-  },
-  button: {
-    padding: theme.spacing(2),
-    "&:hover": {
-      backgroundColor: theme.palette.background.paper,
-    },
-  },
-  externalLink: {
-    textDecoration: "none",
-  },
-}));
 
 export enum DialogPurpose {
   MissingProjectType,
@@ -80,7 +62,6 @@ export default function ExternalPlanningSiteDialog({
   purpose,
   teamSettings,
 }: Props): FCReturn {
-  const classes = useClasses();
   const [isOpen, setIsOpen] = useState(false);
   const toggleModal = () => setIsOpen(!isOpen);
   const settings = teamSettings || fetchCurrentTeam()?.settings;
@@ -99,26 +80,27 @@ export default function ExternalPlanningSiteDialog({
             </p>
           </DialogContent>
           <DialogActions>
-            <Button onClick={toggleModal}>Return to application</Button>
             <Link
-              href={settings?.externalPlanningSite?.url}
-              target="_blank"
-              className={classes.externalLink}
-              underline="hover"
+              component="button"
+              onClick={toggleModal}
+              sx={{ paddingRight: 2 }}
             >
-              <Button>
+              <Typography variant="body2">Return to application</Typography>
+            </Link>
+            <Link href={settings?.externalPlanningSite?.url} target="_blank">
+              <Typography variant="body2">
                 Go to {settings?.externalPlanningSite?.name}
                 <span style={visuallyHidden}> (opens in a new tab)</span>
-              </Button>
+              </Typography>
             </Link>
           </DialogActions>
         </Dialog>
       )}
-      <div className={classes.container}>
-        <ButtonBase onClick={toggleModal} className={classes.button}>
+      <Box sx={{ textAlign: "right" }}>
+        <Link component="button" onClick={toggleModal}>
           <Typography variant="body2">{title}</Typography>
-        </ButtonBase>
-      </div>
+        </Link>
+      </Box>
     </>
   );
 }

--- a/editor.planx.uk/src/ui/FileDownload.tsx
+++ b/editor.planx.uk/src/ui/FileDownload.tsx
@@ -1,5 +1,7 @@
-import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import React from "react";
 
 export interface Props {
@@ -8,22 +10,9 @@ export interface Props {
   text?: string;
 }
 
-const Root = styled("div")(({ theme }) => ({
+const Root = styled(Box)(({ theme }) => ({
   marginTop: theme.spacing(1),
   textAlign: "right",
-  "& button": {
-    background: "none",
-    borderStyle: "none",
-    color: theme.palette.text.primary,
-    cursor: "pointer",
-    fontSize: "inherit",
-    fontFamily: "inherit",
-    textDecoration: "underline",
-    padding: theme.spacing(2),
-  },
-  "& button:hover": {
-    backgroundColor: theme.palette.background.paper,
-  },
 }));
 
 // Render a button which lets the applicant download their application data as a CSV
@@ -40,7 +29,8 @@ export default function FileDownload(props: Props): FCReturn {
 
   return (
     <Root>
-      <Button
+      <Link
+        component="button"
         onClick={async () => {
           await fetch(`${process.env.REACT_APP_API_URL}/download-application`, {
             method: "POST",
@@ -55,8 +45,10 @@ export default function FileDownload(props: Props): FCReturn {
             .catch((error) => console.log(error));
         }}
       >
-        {props.text || "Download your application (.csv)"}
-      </Button>
+        <Typography variant="body2">
+          {props.text || "Download your application (.csv)"}
+        </Typography>
+      </Link>
     </Root>
   );
 }


### PR DESCRIPTION
## What does this PR do?
 - Styles secondary buttons used throughout the service as links
 - Follows on from the work done in #1294 

## Also...
 - Converts a few components to the MUI v5 style engine 💅 

https://user-images.githubusercontent.com/20502206/204912557-c54cf16e-aa0a-4df0-bcd6-6a86714dd391.mov

I feel like there's a good chance I may have missed some of these - if you spot other instances of secondary buttons, let me know and I'll be happy to address.