### PR TITLE
feat: Increase DrawBoundary map size

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -30,13 +30,13 @@ const MapContainer = styled(Box)<MapContainerProps>(
     width: "100%",
     height: "50vh",
     // Only increase map size in Preview & Unpublished routes
-    // [theme.breakpoints.up("md")]:
-    //   environment === "standalone"
-    //     ? {
-    //         height: "70vh",
-    //         minWidth: "65vw",
-    //       }
-    //     : {},
+    [theme.breakpoints.up("md")]:
+      environment === "standalone"
+        ? {
+            height: "70vh",
+            minWidth: "65vw",
+          }
+        : {},
     "& my-map": {
       width: "100%",
       height: "100%",
@@ -164,18 +164,18 @@ export default function Component(props: Props) {
               markerLongitude={Number(passport?.data?._address?.longitude)}
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
+            {!props.hideFileUpload && (
+              <AlternateOption>
+                <AlternateOptionButton
+                  data-testid="upload-file-button"
+                  onClick={() => setPage("upload")}
+                  disabled={Boolean(boundary)}
+                >
+                  Upload a location plan instead
+                </AlternateOptionButton>
+              </AlternateOption>
+            )}
           </MapContainer>
-          {!props.hideFileUpload && (
-            <AlternateOption>
-              <AlternateOptionButton
-                data-testid="upload-file-button"
-                onClick={() => setPage("upload")}
-                disabled={Boolean(boundary)}
-              >
-                Upload a location plan instead
-              </AlternateOptionButton>
-            </AlternateOption>
-          )}
           <p>
             The site outline you have drawn is{" "}
             <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>


### PR DESCRIPTION
Follow up to implement the changes made in #1225 

Feedback from UR - 

> Tested with 6 people in R.45. I don't think there are lots of feedback on the enlargement of the map. The users didn't really know what it used to be like before the changes and they are still struggling a bit when the map doesn't show the whole of their property and they have to zoom out to see the whole of their site and then they are slightly nervous when the snap points disappear. But map enlarged map appears to be clear to users and doesn't seem to have an issue with the enlarged view.