### PR TITLE
feat: switch to crosshair as drawing cursor

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -152,8 +152,7 @@ export default function Component(props: Props) {
             <my-map
               id="draw-boundary-map"
               drawMode
-              drawPointer="dot"
-              // drawPointer="crosshair"
+              drawPointer="crosshair"
               drawGeojsonData={JSON.stringify(boundary)}
               zoom={20}
               maxZoom={23}


### PR DESCRIPTION
In conclusion of Lam's user-testing feedback: 
> Turn red dot into a crosshair: Tested with 6 people in R.45. All users understood the cross-hair icon as a drawing tool. Don’t seem to mind the over icon also overlapping on it. (Lam: But we should get rid of it when we can)