### PR TITLE
fix: Footer & Content style fixes

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -6,6 +6,7 @@ import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { PublicProps } from "@planx/components/ui";
 import React from "react";
+import { getContrastTextColor } from "styleUtils";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 export type Props = PublicProps<Content>;
@@ -21,6 +22,10 @@ const useClasses = makeStyles<Theme, StyleProps>((theme) => ({
     color: (props) =>
       mostReadable(props.color || "#fff", ["#fff", "#000"])?.toHexString() ||
       "#000",
+    "& a": {
+      color: (props) =>
+        getContrastTextColor(props.color || "#fff", theme.palette.primary.main),
+    },
   },
 }));
 

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -19,8 +19,6 @@ const useClasses = makeStyles((theme) => ({
   },
   buttonGroup: {
     columnGap: theme.spacing(3),
-  },
-  link: {
     textTransform: "capitalize",
   },
   bold: {

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -5,24 +5,28 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
-import classnames from "classnames";
 import React, { useEffect, useState } from "react";
 import { Link as ReactNaviLink } from "react-navi";
 
-const useClasses = makeStyles((theme) => ({
-  root: {
-    color: theme.palette.common.white,
-    backgroundColor: theme.palette.common.black,
-    padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
+const Root = styled("footer")(({ theme }) => ({
+  color: theme.palette.common.white,
+  backgroundColor: theme.palette.common.black,
+  padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
+}));
+
+const ButtonGroup = styled(Box)(({ theme }) => ({
+  columnGap: theme.spacing(3),
+  textTransform: "capitalize",
+  display: "flex",
+  flexWrap: "wrap",
+  [theme.breakpoints.up("xs")]: {
+    flexDirection: "column",
   },
-  buttonGroup: {
-    columnGap: theme.spacing(3),
-    textTransform: "capitalize",
-  },
-  bold: {
-    fontWeight: 800,
+  [theme.breakpoints.up("md")]: {
+    flexDirection: "row",
   },
 }));
 
@@ -40,7 +44,6 @@ export interface Props {
 
 export default function Footer(props: Props) {
   const { items, children } = props;
-  const classes = useClasses();
   const [feedbackPrivacyNoteVisible, setFeedbackPrivacyNoteVisible] =
     useState(false);
 
@@ -82,13 +85,8 @@ export default function Footer(props: Props) {
   };
 
   return (
-    <footer className={classes.root}>
-      <Box
-        display="flex"
-        flexWrap="wrap"
-        flexDirection={{ xs: "column", md: "row" }}
-        className={classes.buttonGroup}
-      >
+    <Root>
+      <ButtonGroup>
         {items
           ?.filter((item) => item.title)
           .map((item) => (
@@ -123,9 +121,9 @@ export default function Footer(props: Props) {
             </FeedbackFish>
           </>
         )}
-      </Box>
+      </ButtonGroup>
       <Box py={4}>{children}</Box>
-    </footer>
+    </Root>
   );
 }
 
@@ -135,12 +133,10 @@ function FooterItem(props: {
   onClick?: () => void;
   bold?: boolean;
 }) {
-  const classes = useClasses();
-
   const title = (
     <Typography
       variant="body2"
-      className={classnames(props.bold && classes.bold)}
+      sx={{ fontWeight: props.bold ? 800 : "regular" }}
     >
       {props.title.toLowerCase()}
     </Typography>

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -7,14 +7,13 @@ import DialogContent from "@mui/material/DialogContent";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
 import React, { useEffect, useState } from "react";
 import { Link as ReactNaviLink } from "react-navi";
 
 const Root = styled("footer")(({ theme }) => ({
   color: theme.palette.common.white,
   backgroundColor: theme.palette.common.black,
-  padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
+  padding: theme.spacing(2, 4),
 }));
 
 const ButtonGroup = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
## What does this PR do?
 - Adds back the missing `capitalize` class from footer links
 - Ensures sufficient contrast on links in `Content` components
 - Updates Footer to the MUI v5 style engine