### PR TITLE
fix: Use isEqual() auth helper for useFilePermission()

### DIFF
--- a/api.planx.uk/auth/index.ts
+++ b/api.planx.uk/auth/index.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import crypto from "crypto";
 import { singleSessionEmailTemplates } from "../saveAndReturn/utils";
+import assert from "assert";
 
 /**
  * Validate that a provided string (e.g. API key) matches the expected value
@@ -26,7 +27,7 @@ const useHasuraAuth = (
     process.env.HASURA_PLANX_API_KEY!
   );
   if (!isAuthenticated) return next({ status: 401, message: "Unauthorised" });
-  next();
+  return next();
 };
 
 /**
@@ -58,4 +59,21 @@ const useSendEmailAuth = (
   }
 };
 
-export { useHasuraAuth, useSendEmailAuth };
+/**
+ * Validate that a request for a private file has the correct authentication
+ */
+assert(process.env.FILE_API_KEY, "Missing environment variable 'FILE_API_KEY'");
+const useFilePermission = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void => {
+  const isAuthenticated = isEqual(
+    req.headers["api-key"] as string,
+    process.env.FILE_API_KEY!,
+  );
+  if (!isAuthenticated) return next({ status: 401, message: "Unauthorised" });
+  return next();
+};
+
+export { useHasuraAuth, useSendEmailAuth, useFilePermission };

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -8,7 +8,6 @@ import { stringify } from "csv-stringify";
 import express, {
   CookieOptions,
   ErrorRequestHandler,
-  NextFunction,
   Response,
 } from "express";
 import { expressjwt, Request } from "express-jwt";
@@ -43,7 +42,7 @@ import {
   sendSaveAndReturnEmail,
 } from "./saveAndReturn";
 import { hardDeleteSessions } from "./webhooks/hardDeleteSessions";
-import { useHasuraAuth, useSendEmailAuth } from "./auth";
+import { useFilePermission, useHasuraAuth, useSendEmailAuth } from "./auth";
 
 // debug, info, warn, error, silent
 const LOG_LEVEL = process.env.NODE_ENV === "test" ? "silent" : "debug";
@@ -271,14 +270,6 @@ const useJWT = expressjwt({
     req.headers.authorization?.match(/^Bearer (\S+)$/)?.[1] ??
     req.query?.token,
 });
-
-assert(process.env.FILE_API_KEY, "Missing environment variable 'FILE_API_KEY'");
-const useFilePermission = (req: Request, res: Response, next: NextFunction) => {
-  if (req.headers["api-key"] !== process.env.FILE_API_KEY) {
-    return next({ status: 403, message: "forbidden" });
-  }
-  return next();
-};
 
 if (process.env.NODE_ENV !== "test") {
   app.use(


### PR DESCRIPTION
Check for API key on `/file/private` should use auth helper function `isEqual()` instead of a simple equality check.