### PR TITLE
fix: Adjust space on 'Upload location plan'

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -27,7 +27,7 @@ interface MapContainerProps {
 
 const MapContainer = styled(Box)<MapContainerProps>(
   ({ theme, environment }) => ({
-    padding: theme.spacing(1, 0),
+    padding: theme.spacing(1, 0, 6, 0),
     width: "100%",
     height: "50vh",
     // Only increase map size in Preview & Unpublished routes
@@ -44,6 +44,12 @@ const MapContainer = styled(Box)<MapContainerProps>(
     },
   })
 );
+
+const MapFooter = styled(Box)(({ theme }) => ({
+  display: "flex",
+  justifyContent: "space-between",
+  paddingTop: theme.spacing(3),
+}));
 
 export default function Component(props: Props) {
   const isMounted = useRef(false);
@@ -145,25 +151,25 @@ export default function Component(props: Props) {
               markerLongitude={Number(passport?.data?._address?.longitude)}
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
-          {!props.hideFileUpload && (
-            <Box sx={{ textAlign: "right" }}>
-              <Link
-                component="button"
-                onClick={() => setPage("upload")}
-                disabled={Boolean(boundary)}
-                data-testid="upload-file-button"
-              >
+            {!props.hideFileUpload && (
+              <MapFooter>
                 <Typography variant="body2">
-                  Upload a location plan instead
+                  The site outline you have drawn is{" "}
+                  <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
                 </Typography>
-              </Link>
-            </Box>
-          )}
+                <Link
+                  component="button"
+                  onClick={() => setPage("upload")}
+                  disabled={Boolean(boundary)}
+                  data-testid="upload-file-button"
+                >
+                  <Typography variant="body2">
+                    Upload a location plan instead
+                  </Typography>
+                </Link>
+              </MapFooter>
+            )}
           </MapContainer>
-          <p>
-            The site outline you have drawn is{" "}
-            <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
-          </p>
         </>
       );
     } else if (page === "upload") {


### PR DESCRIPTION
This is a fix for styling issue I missed when resolving merge conflicts between increasing map size and converting buttons to links.

|Before|After|
|---|---|
|<img width="784" alt="image" src="https://user-images.githubusercontent.com/20502206/205274540-900f7e73-425a-4404-ade2-22e68ab824d3.png">|<img width="1031" alt="image" src="https://user-images.githubusercontent.com/20502206/205274609-d2b43844-83ac-4a1a-9763-3f5faf865ccb.png">|

