### PR TITLE
feat: DrawBoundary map uses trash bin icon stead of arrow

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -148,6 +148,7 @@ export default function Component(props: Props) {
               showMarker
               markerLatitude={Number(passport?.data?._address?.latitude)}
               markerLongitude={Number(passport?.data?._address?.longitude)}
+              resetControlImage="trash"
               osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
             />
             {!props.hideFileUpload && (


### PR DESCRIPTION
User-research wasn't particularly conclusive here, so we made a decision to go this route as it's most distinct from current option: 
> What should we change draw outline icon from :leftwards_arrow_with_hook: to ?
Tested in R.45 with 6 users.
Reset icon: 3/6 users prefer this icon, but a couple of them expect it to only delete one stroke at a time. Also, a user thinks it looks like the refresh button refreshes the whole page
Trash icon: 2/6 prefer this. Users Understood the ‘trash icon’ as ‘Delete’/ ‘Restart’. It feels clear what the button does but a couple of users don’t like it as it feels ‘too serious’/' too strong’
Rubber icon: Only 1 user perfer this and understood this as a rubber. It is not clear what the symbol means to most users. (edited) 