### PR TITLE
refactor: Simplify MUI theme generation

### DIFF
--- a/editor.planx.uk/.storybook/preview.js
+++ b/editor.planx.uk/.storybook/preview.js
@@ -2,14 +2,14 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
+import { defaultTheme } from "../src/theme";
 
-import globalTheme from "../src/theme";
 import { reactNaviDecorator } from "./__mocks__/react-navi";
 
 export const decorators = [
   (Story) => (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={globalTheme}>
+      <ThemeProvider theme={defaultTheme}>
         <CssBaseline />
         <DndProvider backend={HTML5Backend} key={Date.now()}>
           <Story />

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -26,7 +26,7 @@ import { ToastContainer } from "react-toastify";
 import DelayedLoadingIndicator from "./components/DelayedLoadingIndicator";
 import { client } from "./lib/graphql";
 import navigation from "./lib/navigation";
-import globalTheme from "./theme";
+import { defaultTheme } from "./theme";
 
 declare module "@mui/styles/defaultTheme" {
   interface DefaultTheme extends Theme {}
@@ -94,7 +94,7 @@ const Layout: React.FC<{
 
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={globalTheme}>
+      <ThemeProvider theme={defaultTheme}>
         <NotFoundBoundary render={() => <ErrorPage title="Not found" />}>
           {!!isLoading ? (
             <DelayedLoadingIndicator msDelayBeforeVisible={500} />

--- a/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
+++ b/editor.planx.uk/src/pages/Preview/PreviewLayout.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import {
-  createTheme,
   StyledEngineProvider,
   Theme,
   ThemeProvider,
@@ -10,13 +9,12 @@ import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
 import ErrorFallback from "components/ErrorFallback";
 import { clearLocalFlow } from "lib/local";
-import { merge } from "lodash";
 import { NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useCurrentRoute } from "react-navi";
-import { getGlobalThemeOptions, getTeamThemeOptions } from "theme";
+import { generateTeamTheme } from "theme";
 import Logo from "ui/images/OGLLogo.svg";
 
 import Footer from "../../components/Footer";
@@ -140,18 +138,11 @@ const PreviewLayout: React.FC<{
     }
   };
 
-  /**
-   * Generates a MuiTheme by deep merging global and team ThemeOptions
-   */
-  const generatePreviewTheme = (): Theme => {
-    const globalOptions = getGlobalThemeOptions();
-    const teamOptions = getTeamThemeOptions(team.theme);
-    return createTheme(merge(globalOptions, teamOptions));
-  };
+  const teamTheme = generateTeamTheme(team.theme?.primary);
 
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={generatePreviewTheme}>
+      <ThemeProvider theme={teamTheme}>
         <Header
           team={team}
           handleRestart={handleRestart}

--- a/editor.planx.uk/src/testUtils.tsx
+++ b/editor.planx.uk/src/testUtils.tsx
@@ -6,7 +6,7 @@ import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { configureAxe } from "jest-axe";
 import React from "react";
 
-import globalTheme from "../src/theme";
+import { defaultTheme } from "../src/theme";
 
 export const axe = configureAxe({
   rules: {
@@ -25,7 +25,7 @@ export const setup = (
   jsx: JSX.Element
 ): Record<"user", UserEvent> & RenderResult => ({
   user: userEvent.setup(),
-  ...render(<ThemeProvider theme={globalTheme}>{jsx}</ThemeProvider>),
+  ...render(<ThemeProvider theme={defaultTheme}>{jsx}</ThemeProvider>),
 });
 
 /**

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -1,14 +1,41 @@
 import {
   createTheme,
   responsiveFontSizes,
+  Theme,
   ThemeOptions,
 } from "@mui/material/styles";
 // eslint-disable-next-line no-restricted-imports
-import createPalette from "@mui/material/styles/createPalette";
-
-import { TeamTheme } from "./types";
+import createPalette, {
+  PaletteOptions,
+} from "@mui/material/styles/createPalette";
 
 const GOVUK_YELLOW = "#FFDD00";
+
+const DEFAULT_PRIMARY_COLOR = "#000661";
+
+const DEFAULT_PALETTE: Partial<PaletteOptions> = {
+  primary: {
+    main: DEFAULT_PRIMARY_COLOR,
+    contrastText: "#fff",
+  },
+  background: {
+    default: "#fff",
+    paper: "#f2f2f2",
+  },
+  secondary: {
+    main: "#EFEFEF",
+  },
+  text: {
+    secondary: "rgba(0,0,0,0.6)",
+  },
+  action: {
+    selected: "#F8F8F8",
+    focus: GOVUK_YELLOW,
+  },
+  error: {
+    main: "#E91B0C",
+  },
+};
 
 // GOVUK Focus style
 // https://design-system.service.gov.uk/get-started/focus-states/
@@ -45,33 +72,11 @@ export const linkStyle = (primaryColor?: string) => ({
   "&:focus-visible": focusStyle,
 });
 
-/**
- * Get Global theme options
- * The global theme is used in editor, and as the base theme in Preview/Unpublished which can be
- * merged with Team specific options
- */
-export const getGlobalThemeOptions = (): ThemeOptions => {
+const getThemeOptions = (primaryColor: string): ThemeOptions => {
   const palette = createPalette({
+    ...DEFAULT_PALETTE,
     primary: {
-      main: "#000661",
-      contrastText: "#fff",
-    },
-    background: {
-      default: "#fff",
-      paper: "#f2f2f2",
-    },
-    secondary: {
-      main: "#EFEFEF",
-    },
-    text: {
-      secondary: "rgba(0,0,0,0.6)",
-    },
-    action: {
-      selected: "#F8F8F8",
-      focus: GOVUK_YELLOW,
-    },
-    error: {
-      main: "#E91B0C",
+      main: primaryColor,
     },
   });
 
@@ -205,6 +210,7 @@ export const getGlobalThemeOptions = (): ThemeOptions => {
       MuiLink: {
         styleOverrides: {
           root: {
+            ...linkStyle(palette.primary.main),
             "&:disabled": {
               color: palette.text.disabled,
               cursor: "default",
@@ -219,33 +225,16 @@ export const getGlobalThemeOptions = (): ThemeOptions => {
   return themeOptions;
 };
 
-/**
- * Get team specific theme options
- * Pass in TeamTheme to customise the palette and associated overrides
- * Rules here will only apply in the Preview and Unpublished routes
- */
-export const getTeamThemeOptions = (
-  theme: TeamTheme | undefined
-): ThemeOptions => {
-  const primary = theme?.primary || "#2c2c2c";
-  return {
-    palette: {
-      primary: {
-        main: primary,
-      },
-    },
-    components: {
-      MuiLink: {
-        styleOverrides: {
-          root: {
-            ...linkStyle(theme?.primary),
-          },
-        },
-      },
-    },
-  };
+// Generate a MUI theme based on a team's primary color
+const generateTeamTheme = (
+  primaryColor: string = DEFAULT_PRIMARY_COLOR
+): Theme => {
+  const themeOptions = getThemeOptions(primaryColor);
+  const theme = responsiveFontSizes(createTheme(themeOptions));
+  return theme;
 };
 
-const globalTheme = createTheme(getGlobalThemeOptions());
+// A static MUI theme based on PlanX's default palette
+const defaultTheme = generateTeamTheme(DEFAULT_PRIMARY_COLOR);
 
-export default responsiveFontSizes(globalTheme);
+export { defaultTheme, generateTeamTheme };

--- a/editor.planx.uk/src/ui/Palette.stories.tsx
+++ b/editor.planx.uk/src/ui/Palette.stories.tsx
@@ -4,12 +4,11 @@ import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Meta } from "@storybook/react/types-6-0";
 import React from "react";
-
-import theme from "../theme";
+import { defaultTheme } from "theme";
 
 // The `PaletteOptions` exported by Material-UI are expressed as an interface,
 // so this gets us a union type
-type PaletteOption = keyof typeof theme.palette;
+type PaletteOption = keyof typeof defaultTheme.palette;
 
 const metadata: Meta = {
   title: "Design System/Palette",
@@ -71,7 +70,7 @@ const ColorGrid: React.FC<{ option: PaletteOption }> = (props) => {
 };
 
 export const Index = () => {
-  const options = Object.keys(theme.palette) as PaletteOption[];
+  const options = Object.keys(defaultTheme.palette) as PaletteOption[];
   return (
     <>
       {options.map((option, i) => (


### PR DESCRIPTION
## What is the problem?
Currently, due to `createPalette` being called too early in the theme generation process, some styles are not being correctly derived from a team's primary colour. Please see example below where the dark version of PlanX's default colour is being applied on hover, instead of a dark version of the team's primary colour.

|Staging|Pizza|
|---|---|
|![chrome-capture-2022-11-5](https://user-images.githubusercontent.com/20502206/205617717-f729b5df-3836-4322-8b59-8c426fed738d.gif)|![chrome-capture-2022-11-5 (1)](https://user-images.githubusercontent.com/20502206/205617745-c5cf34ac-b98f-43ad-a1f4-2702eb36b200.gif)|

## What does this PR do?
 - Fixes bug by not calling `createPalette()` too early which generates derived colours (e.g. `theme.palette.primary.dark` which is used on hover here). Instead this will only happen when `generateTeamTheme()` is called, by which time we always have a primary (or default) colour set.
 - Simplify generation of `defaultTheme` and `teamTheme`