### PR TITLE
fix: Simplify MUI spacing notation

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -24,7 +24,7 @@ const useClasses = makeStyles((theme) => ({
         border: "none",
       },
       "& td": {
-        padding: `${theme.spacing(1.5)} ${theme.spacing(1)}`,
+        padding: theme.spacing(1.5, 1),
       },
     },
   },

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   description: {
     fontSize: theme.typography.pxToRem(15),
     fontWeight: 400,
-    margin: `${theme.spacing(2)} 0 0 0`,
+    margin: theme.spacing(2, 0, 0, 0),
     "& a": {
       color: (props) =>
         getContrastTextColor(props.color, theme.palette.primary.main),

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ButtonBase.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ButtonBase.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   selected: {
-    backgroundColor: `${theme.palette.primary.main}`,
+    backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
   },
 }));

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -23,7 +23,7 @@ interface IQuestionHeader {
 }
 const Description = styled(Box)(({ theme }) => ({
   "& p": {
-    margin: `${theme.spacing(1)} 0`,
+    margin: theme.spacing(1, 0),
   },
 }));
 

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -13,7 +13,7 @@ const useClasses = makeStyles((theme: Theme) => ({
     display: "flex",
     justifyContent: "start",
     [theme.breakpoints.up("sm")]: {
-      padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+      padding: theme.spacing(1, 2),
     },
   },
   betaIcon: {

--- a/editor.planx.uk/src/ui/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/ColorPicker.tsx
@@ -21,7 +21,7 @@ const useClasses = makeStyles((theme) => ({
   },
   inline: {
     height: 50,
-    padding: `${theme.spacing(2)} 0`,
+    padding: theme.spacing(2, 0),
     "& $popover": {
       top: "calc(100% - 4px)",
     },

--- a/editor.planx.uk/src/ui/ExpandableList.tsx
+++ b/editor.planx.uk/src/ui/ExpandableList.tsx
@@ -16,7 +16,7 @@ const useListClasses = makeStyles((theme) => ({
 
 const useItemClasses = makeStyles((theme) => ({
   root: {
-    padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+    padding: theme.spacing(1, 1.5),
   },
   title: {
     alignItems: "flex-start",


### PR DESCRIPTION
Very minor style tidy up I noticed when working on #1301 

Docs: https://mui.com/material-ui/customization/spacing/#multiple-arity