### PR TITLE
chore: Upgrade Multer (CVE-2022-24434)

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -28,7 +28,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "mime": "^3.0.0",
-    "multer": "^1.4.4",
+    "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.4",
     "notifications-node-client": "^5.1.1",
     "passport": "^0.5.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -62,7 +62,7 @@ specifiers:
   jsonwebtoken: ^8.5.1
   lodash: ^4.17.21
   mime: ^3.0.0
-  multer: ^1.4.4
+  multer: ^1.4.5-lts.1
   nanoid: ^3.3.4
   nock: ^13.2.9
   node-dev: ^7.4.3
@@ -83,7 +83,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-document-review': github.com/theopensystemslab/planx-document-review/8b1adf0ee9ee4db9bb2810c5ecbdb9fe51ba09b4_ijtjzzzckndhine2hcxl76eshe
+  '@opensystemslab/planx-document-review': github.com/theopensystemslab/planx-document-review/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11_ijtjzzzckndhine2hcxl76eshe
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
   axios: 0.27.2
@@ -107,7 +107,7 @@ dependencies:
   jsonwebtoken: 8.5.1
   lodash: 4.17.21
   mime: 3.0.0
-  multer: 1.4.4
+  multer: 1.4.5-lts.1
   nanoid: 3.3.4
   notifications-node-client: 5.1.1
   passport: 0.5.3
@@ -2487,12 +2487,11 @@ packages:
       ieee754: 1.2.1
     dev: true
 
-  /busboy/0.2.14:
-    resolution: {integrity: sha512-InWFDomvlkEj+xWLBfU3AvnbVYqeTWmQopiW0tWWEy5yehYm2YkGEc59sUmw/4ty5Zj/b0WHGs1LgecuBSBGrg==}
-    engines: {node: '>=0.8.0'}
+  /busboy/1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
     dependencies:
-      dicer: 0.2.5
-      readable-stream: 1.1.14
+      streamsearch: 1.1.0
     dev: false
 
   /bytes/3.1.2:
@@ -2956,14 +2955,6 @@ packages:
       asap: 2.0.6
       wrappy: 1.0.2
     dev: true
-
-  /dicer/0.2.5:
-    resolution: {integrity: sha512-FDvbtnq7dzlPz0wyYlOExifDEZcu8h+rErEXgfxqmLfRfC/kJidEFh4+effJRO3P0xmfqyPbSMG0LveNRfTKVg==}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      readable-stream: 1.1.14
-      streamsearch: 0.1.2
-    dev: false
 
   /diff-match-patch/1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
@@ -4567,10 +4558,6 @@ packages:
       is-docker: 2.2.1
     dev: true
 
-  /isarray/0.0.1:
-    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
-    dev: false
-
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -5577,17 +5564,15 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: false
 
-  /multer/1.4.4:
-    resolution: {integrity: sha512-2wY2+xD4udX612aMqMcB8Ws2Voq6NIUPEtD1be6m411T4uDH/VtL9i//xvcyFlTVfRdaBsk7hV5tgrGQqhuBiw==}
-    engines: {node: '>= 0.10.0'}
-    deprecated: Multer 1.x is affected by CVE-2022-24434. This is fixed in v1.4.4-lts.1 which drops support for versions of Node.js before 6. Please upgrade to at least Node.js 6 and version 1.4.4-lts.1 of Multer. If you need support for older versions of Node.js, we are open to accepting patches that would fix the CVE on the main 1.x release line, whilst maintaining compatibility with Node.js 0.10.
+  /multer/1.4.5-lts.1:
+    resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
+    engines: {node: '>= 6.0.0'}
     dependencies:
       append-field: 1.0.0
-      busboy: 0.2.14
+      busboy: 1.6.0
       concat-stream: 1.6.2
       mkdirp: 0.5.6
       object-assign: 4.1.1
-      on-finished: 2.4.1
       type-is: 1.6.18
       xtend: 4.0.2
     dev: false
@@ -6271,15 +6256,6 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /readable-stream/1.1.14:
-    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-
   /readable-stream/2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
     dependencies:
@@ -6696,6 +6672,7 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: false
 
   /split-string/3.1.0:
@@ -6741,9 +6718,9 @@ packages:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
     dev: false
 
-  /streamsearch/0.1.2:
-    resolution: {integrity: sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==}
-    engines: {node: '>=0.8.0'}
+  /streamsearch/1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
     dev: false
 
   /string-length/4.0.2:
@@ -6783,10 +6760,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.20.1
-    dev: false
-
-  /string_decoder/0.10.31:
-    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
     dev: false
 
   /string_decoder/1.1.1:
@@ -7453,9 +7426,9 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/theopensystemslab/planx-document-review/8b1adf0ee9ee4db9bb2810c5ecbdb9fe51ba09b4_ijtjzzzckndhine2hcxl76eshe:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-review/tar.gz/8b1adf0ee9ee4db9bb2810c5ecbdb9fe51ba09b4}
-    id: github.com/theopensystemslab/planx-document-review/8b1adf0ee9ee4db9bb2810c5ecbdb9fe51ba09b4
+  github.com/theopensystemslab/planx-document-review/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11_ijtjzzzckndhine2hcxl76eshe:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-review/tar.gz/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11}
+    id: github.com/theopensystemslab/planx-document-review/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11
     name: '@opensystemslab/planx-document-review'
     version: 1.1.1
     engines: {node: ^16, pnpm: ^7.8.0}


### PR DESCRIPTION
Multer v1.4.4 is vulnerable to CVE-2022-24434 (noticed a warning when running `pnpm i`).

Multer Changelog: https://github.com/expressjs/multer/blob/v1.4.5-lts.1/CHANGELOG.md