### PR TITLE
fix: Different approach on map size increase

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -32,7 +32,7 @@ interface MapContainerProps {
 const dynamicMapSizeStyle = (theme: Theme): Record<string, any> => {
   const mainContainerWidth = `${theme.breakpoints.values.md}px`;
   const mainContainerMargin = `((100vw - ${mainContainerWidth}) / 2)`;
-  const mapMarginRight = "100px";
+  const mapMarginRight = "150px";
 
   const style = {
     [theme.breakpoints.up("md")]: {

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
-import { styled } from "@mui/material/styles";
+import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import Card from "@planx/components/shared/Preview/Card";
@@ -25,23 +25,32 @@ interface MapContainerProps {
   environment: PreviewEnvironment;
 }
 
+/**
+ * Generate a style which increases the map size as the window grows
+ * and maintains a consistent right margin
+ */
+const dynamicMapSizeStyle = (theme: Theme): Record<string, any> => {
+  const mainContainerWidth = `${theme.breakpoints.values.md}px`;
+  const mainContainerMargin = `((100vw - ${mainContainerWidth}) / 2)`;
+  const mapMarginRight = "100px";
+
+  const style = {
+    [theme.breakpoints.up("md")]: {
+      height: "70vh",
+      width: `calc(${mainContainerMargin} + ${mainContainerWidth} - ${mapMarginRight})`,
+    },
+  };
+
+  return style;
+};
+
 const MapContainer = styled(Box)<MapContainerProps>(
   ({ theme, environment }) => ({
     padding: theme.spacing(1, 0, 6, 0),
     width: "100%",
     height: "50vh",
     // Only increase map size in Preview & Unpublished routes
-    ...(environment === "standalone" && {
-      [theme.breakpoints.up("md")]: {
-        height: "70vh",
-      },
-      [theme.breakpoints.up("lg")]: {
-        width: "calc(100% + 200px)",
-      },
-      [theme.breakpoints.up("xl")]: {
-        width: "calc(100% + 400px)",
-      },
-    }),
+    ...(environment === "standalone" && { ...dynamicMapSizeStyle(theme) }),
     "& my-map": {
       width: "100%",
       height: "100%",

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -31,13 +31,17 @@ const MapContainer = styled(Box)<MapContainerProps>(
     width: "100%",
     height: "50vh",
     // Only increase map size in Preview & Unpublished routes
-    [theme.breakpoints.up("md")]:
-      environment === "standalone"
-        ? {
-            height: "70vh",
-            minWidth: "65vw",
-          }
-        : {},
+    ...(environment === "standalone" && {
+      [theme.breakpoints.up("md")]: {
+        height: "70vh",
+      },
+      [theme.breakpoints.up("lg")]: {
+        width: "calc(100% + 200px)",
+      },
+      [theme.breakpoints.up("xl")]: {
+        width: "calc(100% + 400px)",
+      },
+    }),
     "& my-map": {
       width: "100%",
       height: "100%",


### PR DESCRIPTION
Here's a fix for some of the issues encountered with using `vw` units for increasing the map size. 

Using `vw` caused issues when browsers zoomed in and out, and did not produce a consistent right hand margin.

https://user-images.githubusercontent.com/20502206/206158604-2ccaf0b7-b9fd-4df7-b325-1571958d8c9e.mov

