### PR TITLE
fix: Confirm component styling

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -1,10 +1,8 @@
 import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Checkbox from "@mui/material/Checkbox";
 import Container from "@mui/material/Container";
 import Drawer from "@mui/material/Drawer";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
@@ -14,6 +12,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import Card from "@planx/components/shared/Preview/Card";
 import React from "react";
 import Banner from "ui/Banner";
+import ChecklistItem from "ui/ChecklistItem";
 import Input from "ui/Input";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
@@ -139,9 +138,9 @@ function SuggestionDrawer() {
   ];
 
   const [isOpen, setIsOpen] = React.useState(false);
-  const [_checkboxes, setCheckboxes] = React.useState(
-    Object.fromEntries(OTHER_OPTIONS.map(({ name }) => [name, false]))
-  );
+  const [checkboxes, setCheckboxes] = React.useState<{
+    [key: string]: boolean;
+  }>(Object.fromEntries(OTHER_OPTIONS.map(({ name }) => [name, false])));
   const [text, setText] = React.useState("");
 
   const classes = useStyles();
@@ -178,19 +177,18 @@ function SuggestionDrawer() {
             the future:
           </p>
           <FormGroup row>
-            {OTHER_OPTIONS.map((p, i) => (
-              <FormControlLabel
-                key={i}
-                control={<Checkbox name={p.name} />}
-                label={p.label}
-                onChange={(event: React.ChangeEvent<{}>) => {
-                  if (event.target) {
-                    setCheckboxes((acc) => ({
-                      ...acc,
-                      [p.name]: (event.target as any).checked,
-                    }));
-                  }
-                }}
+            {OTHER_OPTIONS.map((option) => (
+              <ChecklistItem
+                label={option.label}
+                checked={checkboxes[option.name]}
+                id={option.name}
+                key={option.name}
+                onChange={() =>
+                  setCheckboxes({
+                    ...checkboxes,
+                    [option.name]: !checkboxes[option.name],
+                  })
+                }
               />
             ))}
           </FormGroup>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -1,15 +1,12 @@
-import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
-import Drawer from "@mui/material/Drawer";
 import FormGroup from "@mui/material/FormGroup";
-import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
-import { Theme } from "@mui/material/styles";
 import { styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import Card from "@planx/components/shared/Preview/Card";
+import MoreInfo from "@planx/components/shared/Preview/MoreInfo";
 import React from "react";
 import Banner from "ui/Banner";
 import ChecklistItem from "ui/ChecklistItem";
@@ -23,18 +20,6 @@ const ErrorSummary = styled(Box)(({ theme }) => ({
   padding: theme.spacing(3),
   border: `5px solid ${theme.palette.error.main}`,
 }));
-
-const drawerPaperSx = (theme: Theme) => ({
-  boxSizing: "border-box",
-  width: 300,
-  [theme.breakpoints.only("xs")]: {
-    width: "100%",
-  },
-  backgroundColor: theme.palette.background.default,
-  border: 0,
-  boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
-  padding: theme.spacing(2),
-});
 
 interface Props {
   title?: string;
@@ -121,7 +106,6 @@ export default function Confirm(props: Props) {
 }
 
 function SuggestionDrawer() {
-  const theme = useTheme();
   const OTHER_OPTIONS = [
     { name: "Apple", label: "Apple Pay" },
     { name: "BACs", label: "Bank transfer by BACs" },
@@ -137,31 +121,15 @@ function SuggestionDrawer() {
   }>(Object.fromEntries(OTHER_OPTIONS.map(({ name }) => [name, false])));
   const [text, setText] = React.useState("");
 
-  const handleLinkClick = () => {
-    setIsOpen((x) => !x);
-  };
-
   return (
     <>
-      <Link component="button" onClick={handleLinkClick}>
+      <Link component="button" onClick={() => setIsOpen(!isOpen)}>
         <Typography variant="body2">
           Tell us other ways you'd like to pay in the future
         </Typography>
       </Link>
-      <Drawer
-        variant="persistent"
-        anchor="right"
-        open={isOpen}
-        PaperProps={{ sx: drawerPaperSx(theme) }}
-      >
+      <MoreInfo open={isOpen} handleClose={() => setIsOpen(!isOpen)}>
         <Box>
-          <IconButton
-            onClick={() => setIsOpen(false)}
-            aria-label="Close Panel"
-            size="large"
-          >
-            <CloseIcon />
-          </IconButton>
           <p>
             What other types of payment would you like this service to accept in
             the future:
@@ -205,7 +173,7 @@ function SuggestionDrawer() {
             </Link>
           </Box>
         </Box>
-      </Drawer>
+      </MoreInfo>
     </>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -6,9 +6,9 @@ import Drawer from "@mui/material/Drawer";
 import FormGroup from "@mui/material/FormGroup";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
-import { useTheme } from "@mui/material/styles";
+import { Theme } from "@mui/material/styles";
+import { styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
 import Card from "@planx/components/shared/Preview/Card";
 import React from "react";
 import Banner from "ui/Banner";
@@ -18,29 +18,23 @@ import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 import { formattedPriceWithCurrencySymbol } from "../model";
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    "& *": {
-      fontFamily: "Inter, sans-serif",
-    },
-  },
-  drawerPaper: {
-    boxSizing: "border-box",
-    width: 300,
-    [theme.breakpoints.only("xs")]: {
-      width: "100%",
-    },
-    backgroundColor: theme.palette.background.default,
-    border: 0,
-    boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
-    padding: theme.spacing(2),
-  },
-  errorSummary: {
-    marginTop: theme.spacing(1),
-    padding: theme.spacing(3),
-    border: `5px solid #E91B0C`,
-  },
+const ErrorSummary = styled(Box)(({ theme }) => ({
+  marginTop: theme.spacing(1),
+  padding: theme.spacing(3),
+  border: `5px solid ${theme.palette.error.main}`,
 }));
+
+const drawerPaperSx = (theme: Theme) => ({
+  boxSizing: "border-box",
+  width: 300,
+  [theme.breakpoints.only("xs")]: {
+    width: "100%",
+  },
+  backgroundColor: theme.palette.background.default,
+  border: 0,
+  boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
+  padding: theme.spacing(2),
+});
 
 interface Props {
   title?: string;
@@ -52,7 +46,6 @@ interface Props {
 }
 
 export default function Confirm(props: Props) {
-  const classes = useStyles();
   const theme = useTheme();
 
   return (
@@ -94,7 +87,7 @@ export default function Confirm(props: Props) {
 
       {!props.error ? (
         <Card>
-          <div className={classes.root}>
+          <Box>
             <Typography variant="h3">How to pay</Typography>
             <Box py={3}>
               <Button
@@ -108,11 +101,11 @@ export default function Confirm(props: Props) {
             </Box>
 
             <SuggestionDrawer />
-          </div>
+          </Box>
         </Card>
       ) : (
         <Card handleSubmit={props.onConfirm} isValid>
-          <div className={classes.errorSummary} role="status">
+          <ErrorSummary role="status">
             <Typography variant="h5" component="h3" gutterBottom>
               {props.error}
             </Typography>
@@ -120,7 +113,7 @@ export default function Confirm(props: Props) {
               Click continue to skip payment and proceed with your application
               for testing.
             </Typography>
-          </div>
+          </ErrorSummary>
         </Card>
       )}
     </Box>
@@ -128,6 +121,7 @@ export default function Confirm(props: Props) {
 }
 
 function SuggestionDrawer() {
+  const theme = useTheme();
   const OTHER_OPTIONS = [
     { name: "Apple", label: "Apple Pay" },
     { name: "BACs", label: "Bank transfer by BACs" },
@@ -142,8 +136,6 @@ function SuggestionDrawer() {
     [key: string]: boolean;
   }>(Object.fromEntries(OTHER_OPTIONS.map(({ name }) => [name, false])));
   const [text, setText] = React.useState("");
-
-  const classes = useStyles();
 
   const handleLinkClick = () => {
     setIsOpen((x) => !x);
@@ -160,11 +152,9 @@ function SuggestionDrawer() {
         variant="persistent"
         anchor="right"
         open={isOpen}
-        classes={{
-          paper: classes.drawerPaper,
-        }}
+        PaperProps={{ sx: drawerPaperSx(theme) }}
       >
-        <div>
+        <Box>
           <IconButton
             onClick={() => setIsOpen(false)}
             aria-label="Close Panel"
@@ -205,12 +195,16 @@ function SuggestionDrawer() {
             }}
             value={text}
           />
-          <p style={{ textAlign: "right" }}>
-            <Link component="button" onClick={() => setIsOpen(false)}>
+          <Box sx={{ textAlign: "right", mt: 2 }}>
+            <Link
+              component="button"
+              variant="body2"
+              onClick={() => setIsOpen(false)}
+            >
               Save
             </Link>
-          </p>
-        </div>
+          </Box>
+        </Box>
       </Drawer>
     </>
   );

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -14,33 +14,33 @@ interface StyledDrawerProps extends DrawerProps {
   drawerWidth: number;
 }
 
-const Root = styled(Drawer)<StyledDrawerProps>(
-  ({ theme, drawerWidth, open }) => ({
+const Root = styled(Drawer, {
+  shouldForwardProp: (prop) => prop !== "drawerWidth",
+})<StyledDrawerProps>(({ theme, drawerWidth, open }) => ({
+  width: drawerWidth,
+  flexShrink: 0,
+  color: theme.palette.text.primary,
+  transition: theme.transitions.create("margin", {
+    easing: theme.transitions.easing.easeOut,
+    duration: theme.transitions.duration.enteringScreen,
+  }),
+  marginRight: open ? 0 : -drawerWidth,
+  [theme.breakpoints.only("xs")]: {
+    width: "100%",
+    marginRight: "-100%",
+  },
+
+  [`& .${classes.drawerPaper}`]: {
     width: drawerWidth,
-    flexShrink: 0,
-    color: theme.palette.text.primary,
-    transition: theme.transitions.create("margin", {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginRight: open ? 0 : -drawerWidth,
+    backgroundColor: theme.palette.background.default,
+    border: 0,
+    boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
     [theme.breakpoints.only("xs")]: {
       width: "100%",
-      marginRight: "-100%",
     },
-
-    [`& .${classes.drawerPaper}`]: {
-      width: drawerWidth,
-      backgroundColor: theme.palette.background.default,
-      border: 0,
-      boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
-      [theme.breakpoints.only("xs")]: {
-        width: "100%",
-      },
-      padding: theme.spacing(1),
-    },
-  })
-);
+    padding: theme.spacing(1),
+  },
+}));
 
 const DrawerContent = styled("div")(() => ({
   padding: "0.5rem 1.75rem 1rem",


### PR DESCRIPTION
## What does this PR do?
 - Consistently styles the `Confirm` component, specifically `SuggestionDrawer`
   - Use PlanX checkboxes, not plain MUI checkboxes
   - Use `MoreInfo` side panel, not plain MUI drawer
   - Update component to Emotion CSS engine
- Fix bug introduced in #1220 which throws an error in the console when opening the `MoreInfo` component

## Also...
This form never submits (and never has...?) 👀 Once #1284 is tested and merged I'll come back and wire this up

|Before|After|
|---|---|
|<img width="1436" alt="image" src="https://user-images.githubusercontent.com/20502206/206037101-b6804da9-99a4-4fcb-a1bf-d3abe7d112a4.png">|<img width="1435" alt="image" src="https://user-images.githubusercontent.com/20502206/206036963-3fa87ccf-cac8-42df-83fe-93eda604d775.png">|