### PR TITLE
Handle empty rich text editor content

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -7,6 +7,7 @@ import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import React from "react";
 import MoreInfoIcon from "ui/icons/MoreInfo";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
+import { emptyContent } from "ui/RichTextInput";
 
 import { DESCRIPTION_TEXT } from "../constants";
 import MoreInfo from "./MoreInfo";
@@ -95,24 +96,24 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
         )}
       </Grid>
       <MoreInfo open={open} handleClose={() => setOpen(false)}>
-        {info && (
+        {info && info !== emptyContent ? (
           <MoreInfoSection title="Why does it matter?">
             <ReactMarkdownOrHtml source={info} openLinksOnNewTab />
           </MoreInfoSection>
-        )}
-        {policyRef && (
+        ) : undefined}
+        {policyRef && policyRef !== emptyContent ? (
           <MoreInfoSection title="Source">
             <ReactMarkdownOrHtml source={policyRef} openLinksOnNewTab />
           </MoreInfoSection>
-        )}
-        {howMeasured && (
+        ) : undefined}
+        {howMeasured && howMeasured !== emptyContent ? (
           <MoreInfoSection title="How is it defined?">
             <>
               {definitionImg && <Image src={definitionImg} alt="definition" />}
               <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab />
             </>
           </MoreInfoSection>
-        )}
+        ) : undefined}
       </MoreInfo>
       {img && <Image src={img} alt="question" />}
     </Box>

--- a/editor.planx.uk/src/ui/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.tsx
@@ -95,6 +95,8 @@ interface VariablesState {
   addVariable: (newVariable: string) => void;
 }
 
+export const emptyContent: string = "<p></p>";
+
 // Specify whether a selection is unsuitable for ensuring accessible links
 const linkSelectionError = (selectionHtml: string): string | null => {
   if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
@@ -119,11 +121,15 @@ const useVariablesStore = create<VariablesState>((set) => ({
 }));
 
 export const toHtml = (doc: JSONContent) => {
-  return generateHTML(doc, conversionExtensions);
+  const outgoingHtml = generateHTML(doc, conversionExtensions);
+  return outgoingHtml === emptyContent ? "" : outgoingHtml;
 };
 
 export const fromHtml = (htmlString: string) => {
-  return generateJSON(htmlString, conversionExtensions);
+  return generateJSON(
+    htmlString === "" ? emptyContent : htmlString,
+    conversionExtensions
+  );
 };
 
 const initialUrlValue = "https://";


### PR DESCRIPTION
Fixes https://trello.com/c/73L0mP1Q/2224-how-is-it-defined-header-should-not-be-visible-in-draw-boundary-component-when-there-is-no-text.

@DafyddLlyr the checks in `QuestionHeader.tsx` won't be necessary after a while, just making sure things will work as expected without needing to do a sweeping `"<p></p>" -> ""`migration.