### PR TITLE
doc: How to add a secret

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,11 +58,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: | 
-          aws s3 cp s3://pizza-secrets/root.env ./.env
-          aws s3 cp s3://pizza-secrets/editor.env ./editor.planx.uk/.env
-          aws s3 cp s3://pizza-secrets/api.env.test ./api.planx.uk/.env.test
-          aws s3 cp s3://pizza-secrets/hasura.env.test ./hasura.planx.uk/.env.test
+        run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
         uses: andstor/file-existence-action@v1
@@ -103,11 +99,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: | 
-          aws s3 cp s3://pizza-secrets/root.env ./.env
-          aws s3 cp s3://pizza-secrets/editor.env ./editor.planx.uk/.env
-          aws s3 cp s3://pizza-secrets/api.env.test ./api.planx.uk/.env.test
-          aws s3 cp s3://pizza-secrets/hasura.env.test ./hasura.planx.uk/.env.test
+        run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
         uses: andstor/file-existence-action@v1
@@ -139,11 +131,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: | 
-          aws s3 cp s3://pizza-secrets/root.env ./.env
-          aws s3 cp s3://pizza-secrets/editor.env ./editor.planx.uk/.env
-          aws s3 cp s3://pizza-secrets/api.env.test ./api.planx.uk/.env.test
-          aws s3 cp s3://pizza-secrets/hasura.env.test ./hasura.planx.uk/.env.test
+        run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
         uses: andstor/file-existence-action@v1
@@ -340,10 +328,7 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
             export AWS_REGION=eu-west-2
 
-            aws s3 cp s3://pizza-secrets/root.env .env
-            aws s3 cp s3://pizza-secrets/editor.env editor.planx.uk/.env
-            aws s3 cp s3://pizza-secrets/api.env.test api.planx.uk/.env.test
-            aws s3 cp s3://pizza-secrets/hasura.env.test hasura.planx.uk/.env.test
+            ./scripts/pull-secrets.sh
 
             echo "
             ROOT_DOMAIN=${{ env.FULL_DOMAIN }}
@@ -373,10 +358,7 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
             export AWS_REGION=eu-west-2
 
-            aws s3 cp s3://pizza-secrets/root.env .env
-            aws s3 cp s3://pizza-secrets/editor.env editor.planx.uk/.env
-            aws s3 cp s3://pizza-secrets/api.env.test api.planx.uk/.env.test
-            aws s3 cp s3://pizza-secrets/hasura.env.test hasura.planx.uk/.env.test
+            ./scripts/pull-secrets.sh
 
             echo "
             ROOT_DOMAIN=${{ env.FULL_DOMAIN }}

--- a/doc/how-to/how-to-add-a-secret.md
+++ b/doc/how-to/how-to-add-a-secret.md
@@ -1,0 +1,71 @@
+# How to add a secret
+This document describes our processes for adding a new secret to the PlanX application, and how to deploy this across Pizza, Staging and Production environments.
+
+This guide will demonstrate how to - 
+ - Added a secret to our local development environment
+ - Push this to S3 for Pizza builds to access
+ - Add a secret to Pulumi for Staging and Production environments
+ - Finally, pass secrets into a Fargate service where it can be referenced by the application
+
+## Process
+
+**Setup**
+1. Generate a secret using the existing process (TODO: create and link a how-to if proposal excepted), or obtain one from a third-party integration
+2. Add to your local `.env` file for local development
+   - Note: This file is never checked into our public repository and is listed in our `.gitignore` config
+3. Document the secret in `.env.example`
+
+**Docker Environments (Local development + Pizza environments)**
+To pass a secret into our Docker Compose setup you will need to map it into the relevant container in `docker-compose.yml`. For example - 
+
+```yml
+  api:
+    build:
+      ...
+    depends_on:
+      ...  
+    environment:
+      YOUR_NEW_SECRET: ${YOUR_NEW_SECRET}
+```
+
+You will then be able to refer to it in code via `process.env.YOUR_NEW_SECRET` and test on your local machine.
+
+When building Pizza environments for testing, GitHub actions access secrets via S3 using the `pull-secrets.sh` script. In order to push changes to your local `.env`, you will need to run the `push-secrets.sh` script which will push your local changes to S3.
+
+> Please be aware that if you are rotating secrets this may affect existing Pizzas which will need to be rebuilt. This can be done manually in GitHub by re-running the latest action associated with affected PRs.
+
+
+**AWS / Pulumi Environments (Staging + Production environments)**
+Secrets for Staging and Production environment are not handled in `.env` files, and are set directly in Pulumi, our Infrastruture as Code (IaC) platform.
+
+These values are set using the [Pulumi CLI](https://www.pulumi.com/docs/reference/cli/)
+
+Here's an example of adding a secret to the `application` layer of the staging and production environments - 
+
+```sh
+cd infrastructure/application
+pulumi config set your-new-secret abc123 --secret --stack staging
+pulumi config set your-new-secret xyz789 --secret --stack production
+```
+
+> ⚠️ Secrets should not be shared across multiple environments
+
+This will then update `Pulumi.staging.yaml` and `Pulumi.production.yaml` with an encrypted copy of the new secret. These files are checked into our repository. Environmental variables which do not require encryption can be stored as plaintext by omitting the `--secret` flag.
+
+These secrets can then be referred to in our Pulumi IaC code using `config.require()`, and passed into services as follows - 
+
+```ts
+const apiService = new awsx.ecs.FargateService("api", {
+  container: {
+    environment: [
+      {
+        name: "YOUR_NEW_SECRET",
+        value: config.require("your-new-secret"),
+      },
+    ],
+  },
+  ...
+});
+```
+
+> Pulumi uses our Docker images to construct Fargate services. This means that the "name" value above must match that used in Docker.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,16 +1,4 @@
 # `/scripts`
-
-## `import-address-base.sh`
-
-Use this script to import the full OrdnanceSurvey AddressBase dataset into postgres.
-Use this script to seed the production environment.
-
-```sh
-$ ./import-address-base <postgres-connection-string> <path-to-csv>
-```
-
-You can download the full dataset at [orders.ordnancesurvey.co.uk]().
-
 ## `upsert-production-flows`
 
 This script is used to pull production data onto the local development environment.
@@ -19,3 +7,20 @@ It upserts teams and flows if the flows table is empty.
 Beware that all teams will be deleted and replaced by the teams on production.
 
 To run it, either run `pnpm upsert-flows` or `docker-compose up` from the root folder.
+
+## `pull-secrets`
+This script is used to pull secrets required for local development of PlanX to a local machine.
+It uses the AWS CLI to copy files from S3. In order to use this you will require - 
+ - The AWS CLI installed locally
+ - AWS credentials stored in the `~/.aws` directory of you machine. These should be generated and shared as part of developer onboarding.
+
+You will need to run this script if a new secret has been added to the application, or as part of initial setup of the repository.
+
+## `push-secrets`
+This script is used to push local secrets to S3 for other developers or CI environments to access.
+
+It uses the AWS CLI to copy files to S3. In order to use this you will require - 
+ - The AWS CLI installed locally
+ - AWS credentials stored in the `~/.aws` directory of you machine. These should be generated and shared as part of developer onboarding.
+
+You will need to run this script if you have added a new secret, or rotated API keys for local or Pizza environments.

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 aws s3 cp s3://pizza-secrets/root.env ./../.env
 aws s3 cp s3://pizza-secrets/api.env.test ./../api.planx.uk/.env

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+aws s3 cp s3://pizza-secrets/root.env ./../.env
+aws s3 cp s3://pizza-secrets/api.env.test ./../api.planx.uk/.env
+aws s3 cp s3://pizza-secrets/editor.env ./../editor.planx.uk/.env
+aws s3 cp s3://pizza-secrets/hasura.env.test ./../hasura.planx.uk/.env.test
+echo "Complete: Secrets from S3 copied to local machine"

--- a/scripts/push-secrets.sh
+++ b/scripts/push-secrets.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+aws s3 cp ./../.env s3://pizza-secrets/root.env
+aws s3 cp ./../api.planx.uk/.env s3://pizza-secrets/api.env.test
+aws s3 cp ./../editor.planx.uk/.env s3://pizza-secrets/editor.env
+aws s3 cp ./../hasura.planx.uk/.env.test s3://pizza-secrets/hasura.env.test
+echo "Complete: Secrets from local machine pushed to S3"

--- a/scripts/push-secrets.sh
+++ b/scripts/push-secrets.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 aws s3 cp ./../.env s3://pizza-secrets/root.env
 aws s3 cp ./../api.planx.uk/.env s3://pizza-secrets/api.env.test


### PR DESCRIPTION
## What does this PR do?
- Documents how to add a secret to the PlanX application
- Adds two helper scripts to assist with this
- Calls these scripts as part of the CI process

### Notes
If running `push-secrets.sh` locally you'll need to have an IAM user on AWS with appropriate permissions, and credentials stored at `~/.aws`. The `ci-user` does not have permissions to push to S3.

If we're averse to using the AWS CLI locally we can use a docker image to run these, something like...

```sh
docker run --rm -it -v ~/.aws:/root/.aws -v $(pwd):/aws public.ecr.aws/aws-cli/aws-cli --version; \
aws s3 cp s3://pizza-secrets/root.env ./../.env; \
aws s3 cp s3://pizza-secrets/api.env.test ./../api.planx.uk/.env; \
aws s3 cp s3://pizza-secrets/editor.env ./../editor.planx.uk/.env; \
aws s3 cp s3://pizza-secrets/hasura.env.test ./../hasura.planx.uk/.env.test; \
echo "Complete: Secrets from S3 copied to local machine"
```