### PR TITLE
chore: remove old pizza link

### DIFF
--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -51,7 +51,6 @@ export const setPath = (flowData: Record<string, any>, req: NaviRequest) => {
 //      So I've hard-coded these domain names until a better solution comes along.
 //
 const PREVIEW_ONLY_DOMAINS = [
-  "1036.planx.pizza",
   "planningservices.buckinghamshire.gov.uk",
   "planningservices.lambeth.gov.uk",
   "planningservices.southwark.gov.uk",


### PR DESCRIPTION
Removes a reference to an old pizza link.
