### PR TITLE
fix: Set correct API .env filename

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,6 +64,7 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, editor.planx.uk/.env, hasura.planx.uk/.env.test"
+          fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
           version: ${{ env.PNPM_VERSION }}
@@ -105,6 +106,7 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, editor.planx.uk/.env, hasura.planx.uk/.env.test"
+          fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
           version: ${{ env.PNPM_VERSION }}
@@ -137,6 +139,7 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, editor.planx.uk/.env, hasura.planx.uk/.env.test"
+          fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
           version: ${{ env.PNPM_VERSION }}

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 aws s3 cp s3://pizza-secrets/root.env ./../.env
-aws s3 cp s3://pizza-secrets/api.env.test ./../api.planx.uk/.env
+aws s3 cp s3://pizza-secrets/api.env.test ./../api.planx.uk/.env.test
 aws s3 cp s3://pizza-secrets/editor.env ./../editor.planx.uk/.env
 aws s3 cp s3://pizza-secrets/hasura.env.test ./../hasura.planx.uk/.env.test
 echo "Complete: Secrets from S3 copied to local machine"


### PR DESCRIPTION
Fixes a bug introduced here, leading to API test suite failing due to missing file - https://github.com/theopensystemslab/planx-new/pull/1322/