### PR TITLE
fix(wip): Fix upload in Docker environments

### DIFF
--- a/api.planx.uk/s3/utils.ts
+++ b/api.planx.uk/s3/utils.ts
@@ -17,7 +17,7 @@ function useMinio() {
   } else {
     // Points to Minio
     return {
-      endpoint: "http://minio:9000",
+      endpoint: "http://127.0.0.1:9000",
       s3ForcePathStyle: true,
       signatureVersion: "v4",
     };

--- a/api.planx.uk/s3/utils.ts
+++ b/api.planx.uk/s3/utils.ts
@@ -17,7 +17,7 @@ function useMinio() {
   } else {
     // Points to Minio
     return {
-      endpoint: "http://127.0.0.1:9000",
+      endpoint: "http://minio:9000",
       s3ForcePathStyle: true,
       signatureVersion: "v4",
     };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     restart: unless-stopped
     build:
       context: ./api.planx.uk
-      target: development
+      target: production
     depends_on:
       hasura-proxy:
         condition: service_healthy


### PR DESCRIPTION
Reverts change made in https://github.com/theopensystemslab/planx-new/pull/1271

This change meant that Pizzas were calling minio to handle file uploads, which isn't running as a service on Pizzas.

This is a quick and pragmatic revert / fix forward, I think more generally it might be more meaningful to have more fine grained values for `NODE_ENV` such as `"production" | "staging" | "pizza" | "test" | "local"`

We could also just override this in `docker-compose.pizza.yaml` if having it locally makes a significant difference 👌 