### PR TITLE
feat: add "copy" to editor-facing flow actions menu

### DIFF
--- a/api.planx.uk/editor/copyFlow.test.ts
+++ b/api.planx.uk/editor/copyFlow.test.ts
@@ -1,0 +1,196 @@
+import supertest from "supertest";
+
+import { queryMock } from "../tests/graphqlQueryMock";
+import { authHeader } from "../tests/mockJWT";
+import app from "../server";
+import { Flow } from "../types";
+
+beforeEach(() => {
+  queryMock.mockQuery({
+    name: "GetFlowData",
+    matchOnVariables: false,
+    data: {
+      flows_by_pk: {
+        data: mockFlowData,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertFlow",
+    matchOnVariables: false,
+    data: {
+      insert_flows_one: {
+        id: 2,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertOperation",
+    matchOnVariables: false,
+    data: {
+      insert_operations_one: {
+        id: 1,
+      },
+    },
+  });
+});
+
+it("returns an error if authorization headers are not set", async () => {
+  const validBody = {
+    insert: false,
+    replaceValue: "T3ST",
+  };
+
+  await supertest(app)
+    .post("/flows/1/copy")
+    .send(validBody)
+    .expect(401)
+    .then((res) => {
+      expect(res.body).toEqual({
+        error: "No authorization token was found"
+      });
+    });
+});
+
+it("returns an error if required replacement characters are not provided in the request body", async () => {
+  const invalidBody = {
+    insert: false,
+  };
+
+  await supertest(app)
+    .post("/flows/1/copy")
+    .send(invalidBody)
+    .set(authHeader())
+    .expect(400)
+    .then((res) => {
+      expect(res.body).toEqual({
+        error: "Missing required values to proceed"
+      });
+    });
+});
+
+it("returns copied unique flow data without inserting a new record", async () => {
+  const body = {
+    insert: false,
+    replaceValue: "T3ST",
+  };
+
+  await supertest(app)
+    .post("/flows/1/copy")
+    .send(body)
+    .set(authHeader())
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual(mockCopyFlowResponse);
+    });
+});
+
+it("inserts copied unique flow data", async () => {
+  const body = {
+    insert: true,
+    replaceValue: "T3ST",
+  };
+
+  await supertest(app)
+    .post("/flows/1/copy")
+    .send(body)
+    .set(authHeader())
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual(mockCopyFlowResponseInserted);
+    });
+});
+
+// the original flow
+const mockFlowData: Flow["data"] = {
+  "_root": {
+    "edges": [
+      "rUilJQTag1",
+      "kNX8Rej9rk"
+    ]
+  },
+  "rUilJQTag1": {
+    "type": 100,
+    "data": {
+      "text": "Copy or paste?"
+    },
+    "edges": [
+      "Yh7t91FisE",
+      "h8DSw40zNr"
+    ]
+  },
+  "Yh7t91FisE": {
+    "type": 200,
+    "data": {
+      "text": "Copy"
+    }
+  },
+  "h8DSw40zNr": {
+    "type": 200,
+    "data": {
+      "text": "Paste"
+    }
+  },
+  "kNX8Rej9rk": {
+    "type": 110,
+    "data": {
+      "title": "Why do you want to copy this flow?",
+      "type": "short"
+    }
+  }
+};
+
+// the copied flow data with unique nodeIds using the replaceValue
+const mockCopiedFlowData: Flow["data"] = {
+  "_root": {
+    edges: [
+      "rUilJQT3ST",
+      "kNX8ReT3ST"
+    ]
+  },
+  "rUilJQT3ST": {
+    "type": 100,
+    "data": {
+      "text": "Copy or paste?"
+    },
+    "edges": [
+      "Yh7t91T3ST",
+      "h8DSw4T3ST"
+    ]
+  },
+  "Yh7t91T3ST": {
+    "type": 200,
+    "data": {
+      "text": "Copy"
+    }
+  },
+  "h8DSw4T3ST": {
+    "type": 200,
+    "data": {
+      "text": "Paste"
+    }
+  },
+  "kNX8ReT3ST": {
+    "type": 110,
+    "data": {
+      "title": "Why do you want to copy this flow?",
+      "type": "short"
+    }
+  }
+};
+
+const mockCopyFlowResponse = {
+  message: `Successfully copied undefined`, // 'undefined' just reflects that we haven't mocked a flow.name here! 
+  inserted: false,
+  replaceValue: "T3ST",
+  data: mockCopiedFlowData,
+};
+
+const mockCopyFlowResponseInserted = {
+  message: `Successfully copied undefined`,
+  inserted: true,
+  replaceValue: "T3ST",
+  data: mockCopiedFlowData,
+};

--- a/api.planx.uk/editor/copyFlow.ts
+++ b/api.planx.uk/editor/copyFlow.ts
@@ -28,7 +28,7 @@ const copyFlow = async (
       const newSlug = flow.slug + "-copy";
       const creatorId = parseInt(req.user.sub, 10);
       // Insert the flow and an associated operation
-      await insertFlow(flow.team_id, newSlug, uniqueFlowData, creatorId);
+      await insertFlow(flow.team_id, newSlug, uniqueFlowData, creatorId, req.params.flowId);
     }
 
     res.status(200).send({

--- a/api.planx.uk/editor/copyFlow.ts
+++ b/api.planx.uk/editor/copyFlow.ts
@@ -23,8 +23,9 @@ const copyFlow = async (
     const shouldInsert = Boolean(req.body?.insert);
     if (shouldInsert) {
       const newSlug = flow.slug + "-copy";
+      const creatorId = parseInt(req.user.sub, 10);
       // Insert the flow and an associated operation
-      await insertFlow(flow.team_id, newSlug, uniqueFlowData);
+      await insertFlow(flow.team_id, newSlug, uniqueFlowData, creatorId);
     }
 
     res.status(200).send({

--- a/api.planx.uk/editor/copyFlow.ts
+++ b/api.planx.uk/editor/copyFlow.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from "express";
+import { makeUniqueFlow, getFlowData, insertFlow } from "../helpers";
+import { Flow } from "../types";
+
+const copyFlow = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | NextFunction | void> => {
+  try {
+    if (!req.user?.sub) {
+      return next({ status: 401, message: "User ID missing from JWT" });
+    }
+
+    // Fetch the original flow
+    const flow: Flow = await getFlowData(req.params.flowId);
+
+    // Ensure the newly copied flow has unique nodeIds
+    const randomReplacementCharacters = Math.random().toString(36).slice(2,6);
+    const uniqueFlowData = makeUniqueFlow(flow.data, randomReplacementCharacters);
+
+    // Check if copied flow data should be inserted into `flows` table, or just returned for reference
+    const shouldInsert = Boolean(req.body?.insert);
+    if (shouldInsert) {
+      const newSlug = flow.slug + "-copy";
+      // Insert the flow and an associated operation
+      await insertFlow(flow.team_id, newSlug, uniqueFlowData);
+    }
+
+    res.status(200).send({
+      message: `Successfully copied ${flow.slug}`,
+      inserted: shouldInsert,
+      replaceValue: randomReplacementCharacters,
+      data: uniqueFlowData,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export { copyFlow };

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -23,16 +23,17 @@ const getFlowData = async (id: string): Promise<Flow> => {
 };
 
 // Insert a new flow into the `flows` table
-const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"], creatorId?: number) => {
+const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"], creatorId?: number, copiedFrom?: Flow["id"]) => {
   const data = await client.request(
     gql`
-      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $creator_id: Int) {
+      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $creator_id: Int, $copied_from: uuid) {
         insert_flows_one(object: {
           team_id: $team_id,
           slug: $slug,
           data: $data,
           version: 1,
           creator_id: $creator_id
+          copied_from: $copied_from
         }) {
           id
         }
@@ -43,6 +44,7 @@ const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"], 
       slug: slug,
       data: flowData,
       creator_id: creatorId,
+      copied_from: copiedFrom,
     }
   );
 

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -23,15 +23,16 @@ const getFlowData = async (id: string): Promise<Flow> => {
 };
 
 // Insert a new flow into the `flows` table
-const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"]) => {
+const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"], creatorId?: number) => {
   const data = await client.request(
     gql`
-      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $version: Int!) {
+      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $version: Int!, $creator_id: Int) {
         insert_flows_one(object: {
           team_id: $team_id,
           slug: $slug,
           data: $data,
-          version: $version
+          version: $version,
+          creator_id: $creator_id
         }) {
           id
         }
@@ -42,6 +43,7 @@ const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"]) 
       slug: slug,
       data: flowData,
       version: 1,
+      creator_id: creatorId,
     }
   );
 

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -26,12 +26,12 @@ const getFlowData = async (id: string): Promise<Flow> => {
 const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"], creatorId?: number) => {
   const data = await client.request(
     gql`
-      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $version: Int!, $creator_id: Int) {
+      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $creator_id: Int) {
         insert_flows_one(object: {
           team_id: $team_id,
           slug: $slug,
           data: $data,
-          version: $version,
+          version: 1,
           creator_id: $creator_id
         }) {
           id
@@ -42,7 +42,6 @@ const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"], 
       team_id: teamId,
       slug: slug,
       data: flowData,
-      version: 1,
       creator_id: creatorId,
     }
   );

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request';
 import { adminGraphQLClient } from "./hasura";
 import { Flow, Node } from "./types";
+
 const client = adminGraphQLClient;
 
 // Get a flow's data (unflattened, without external portal nodes)
@@ -11,6 +12,7 @@ const getFlowData = async (id: string): Promise<Flow> => {
         flows_by_pk(id: $id) {
           slug
           data
+          team_id
         }
       }
       `,
@@ -18,6 +20,51 @@ const getFlowData = async (id: string): Promise<Flow> => {
   );
 
   return data.flows_by_pk;
+};
+
+// Insert a new flow into the `flows` table
+const insertFlow = async (teamId: number, slug: string, flowData: Flow["data"]) => {
+  const data = await client.request(
+    gql`
+      mutation InsertFlow ($team_id: Int!, $slug: String!, $data: jsonb = {}, $version: Int!) {
+        insert_flows_one(object: {
+          team_id: $team_id,
+          slug: $slug,
+          data: $data,
+          version: $version
+        }) {
+          id
+        }
+      }
+    `,
+    {
+      team_id: teamId,
+      slug: slug,
+      data: flowData,
+      version: 1,
+    }
+  );
+
+  if (data) await createAssociatedOperation(data?.insert_flows_one?.id);
+  return data?.insert_flows_one;
+};
+
+// Add a row to `operations` for an inserted flow, otherwise ShareDB throws a silent error when opening the flow in the UI
+const createAssociatedOperation = async (flowId: Flow["id"]) => {
+  const data = await client.request(
+    gql`
+      mutation InsertOperation ($flow_id: uuid!, $data: jsonb = {}) {
+        insert_operations_one(object: { flow_id: $flow_id, version: 1, data: $data }) {
+          id
+        }
+      }
+    `,
+    {
+      flow_id: flowId,
+    }
+  );
+
+  return data?.insert_operations_one;
 };
 
 // Get the most recent version of a published flow's data (flattened, with external portal nodes)
@@ -146,4 +193,5 @@ export {
   dataMerged,
   getChildren,
   makeUniqueFlow,
+  insertFlow,
 };

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -65,6 +65,7 @@ import { sendToBOPS } from "./send/bops";
 import { createSendEvents } from "./send/createSendEvents";
 import { sendToUniform } from "./send/uniform";
 import { sendSlackNotification } from "./webhooks/sendNotifications";
+import { copyFlow } from "./editor/copyFlow";
 
 const router = express.Router();
 
@@ -476,6 +477,9 @@ app.get(
   useJWT,
   graphQLVoyagerHandler({ graphQLURL: "/introspect-all", validateUser: true })
 );
+
+// use with query param `insert=true` (optional)
+app.post("/flows/:flowId/copy", useJWT, copyFlow);
 
 app.post("/flows/:flowId/diff", useJWT, diffFlow);
 

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -478,7 +478,6 @@ app.get(
   graphQLVoyagerHandler({ graphQLURL: "/introspect-all", validateUser: true })
 );
 
-// use with query param `insert=true` (optional)
 app.post("/flows/:flowId/copy", useJWT, copyFlow);
 
 app.post("/flows/:flowId/diff", useJWT, diffFlow);

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -11,6 +11,7 @@ export interface Flow {
   data: {
     [key: string]: Node;
   };
+  team_id: number;
 }
 
 export interface UserData {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -55,6 +55,7 @@ export interface EditorStore extends Store.Store {
   addNode: (node: any, relationships?: any) => void;
   connect: (src: Store.nodeId, tgt: Store.nodeId, object?: any) => void;
   connectTo: (id: Store.nodeId) => void;
+  copyFlow: (flowId: string, teamId: number) => Promise<any>;
   copyNode: (id: Store.nodeId) => void;
   createFlow: (teamId: any, newSlug: any) => Promise<string>;
   deleteFlow: (teamId: number, flowSlug: string) => Promise<object>;
@@ -137,6 +138,22 @@ export const editorStore = (
 
     doc.on("op", (_op: any, isLocalOp?: boolean) =>
       isLocalOp ? cloneStateFromLocalOps() : cloneStateFromRemoteOps()
+    );
+  },
+
+  copyFlow: async (flowId, teamId) => {
+    const token = getCookie("jwt");
+
+    return axios.post(
+      `${process.env.REACT_APP_API_URL}/flows/${flowId}/copy`,
+      {
+        insert: true,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
     );
   },
 

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -195,10 +195,10 @@ const FooterLinks = () => (
 interface FlowItemProps {
   flow: any;
   teamId: number;
-  onSuccess: () => void;
+  refreshFlows: () => void;
 }
 
-const FlowItem: React.FC<FlowItemProps> = ({ flow, teamId, onSuccess }) => {
+const FlowItem: React.FC<FlowItemProps> = ({ flow, teamId, refreshFlows }) => {
   const classes = useStyles();
   const [deleting, setDeleting] = useState(false);
   const handleDelete = () => {
@@ -207,15 +207,15 @@ const FlowItem: React.FC<FlowItemProps> = ({ flow, teamId, onSuccess }) => {
       .deleteFlow(teamId, flow.slug)
       .then(() => {
         setDeleting(false);
-        onSuccess();
+        refreshFlows();
       });
   };
   const handleCopy = () => {
     useStore
       .getState()
-      .copyFlow(flow.id, teamId)
+      .copyFlow(flow.id)
       .then(() => {
-        onSuccess();
+        refreshFlows();
       });
   };
 
@@ -276,7 +276,7 @@ const FlowItem: React.FC<FlowItemProps> = ({ flow, teamId, onSuccess }) => {
                     },
                   });
 
-                  onSuccess();
+                  refreshFlows();
                 }
               },
               label: "Rename",
@@ -331,7 +331,7 @@ const Team: React.FC<{ id: number; slug: string }> = ({ id, slug }) => {
                 flow={flow}
                 key={flow.slug}
                 teamId={id}
-                onSuccess={() => {
+                refreshFlows={() => {
                   fetchFlows();
                 }}
               />

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -195,16 +195,10 @@ const FooterLinks = () => (
 interface FlowItemProps {
   flow: any;
   teamId: number;
-  onDeleteSuccess: () => void;
-  onRenameSuccess: () => void;
+  onSuccess: () => void;
 }
 
-const FlowItem: React.FC<FlowItemProps> = ({
-  flow,
-  teamId,
-  onDeleteSuccess,
-  onRenameSuccess,
-}) => {
+const FlowItem: React.FC<FlowItemProps> = ({ flow, teamId, onSuccess }) => {
   const classes = useStyles();
   const [deleting, setDeleting] = useState(false);
   const handleDelete = () => {
@@ -213,9 +207,18 @@ const FlowItem: React.FC<FlowItemProps> = ({
       .deleteFlow(teamId, flow.slug)
       .then(() => {
         setDeleting(false);
-        onDeleteSuccess();
+        onSuccess();
       });
   };
+  const handleCopy = () => {
+    useStore
+      .getState()
+      .copyFlow(flow.id, teamId)
+      .then(() => {
+        onSuccess();
+      });
+  };
+
   return (
     <>
       {deleting && (
@@ -273,10 +276,16 @@ const FlowItem: React.FC<FlowItemProps> = ({
                     },
                   });
 
-                  onRenameSuccess();
+                  onSuccess();
                 }
               },
               label: "Rename",
+            },
+            {
+              label: "Copy",
+              onClick: () => {
+                handleCopy();
+              },
             },
             {
               label: "Delete",
@@ -322,10 +331,7 @@ const Team: React.FC<{ id: number; slug: string }> = ({ id, slug }) => {
                 flow={flow}
                 key={flow.slug}
                 teamId={id}
-                onDeleteSuccess={() => {
-                  fetchFlows();
-                }}
-                onRenameSuccess={() => {
+                onSuccess={() => {
                   fetchFlows();
                 }}
               />

--- a/hasura.planx.uk/migrations/1671095403563_alter_table_public_flows_add_column_copied_from/down.sql
+++ b/hasura.planx.uk/migrations/1671095403563_alter_table_public_flows_add_column_copied_from/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."flows" drop column "copied_from";

--- a/hasura.planx.uk/migrations/1671095403563_alter_table_public_flows_add_column_copied_from/up.sql
+++ b/hasura.planx.uk/migrations/1671095403563_alter_table_public_flows_add_column_copied_from/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."flows" add column "copied_from" uuid null;


### PR DESCRIPTION
lets editors make a unique copy of a flow within the same team

borrows logic from https://github.com/theopensystemslab/planx-team-onboarding/blob/main/client.js

future scope: 
- "move" flow to a new team
  - for now, a dev can manually hit the endpoint without `insert` param and manually copy/paste response `data` for one-off copy requests _betweeen_ teams or use onboarding script to copy canonical 3 services to a new team :slightly_smiling_face: 
- "copy to flow" action from "internal portal" node menu
- connect planx-team-onboarding scripts to use this endpoint