### PR TITLE
fix: update graphql type to "bigint" on analytics_log.analytics_id mutation

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -116,7 +116,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       mutation: gql`
         mutation InsertNewAnalyticsLog(
           $flow_direction: String
-          $analytics_id: Int
+          $analytics_id: bigint
           $metadata: jsonb
           $node_type: Int
           $node_title: String


### PR DESCRIPTION
should hopefully address the lingering analytics-related Airbrake errors still coming through since yesterday's deployment: 
- https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3432131055656736004
- https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3432158337079285043 
- https://john-opensystemslab-io.airbrake.io/projects/329753/groups/3432136561972581678 etc

builds on this database migration merged as part of #1295 & deployed to prod yesterday:
![Screenshot from 2022-12-20 09-27-29](https://user-images.githubusercontent.com/5132349/208619384-89878471-5c8d-4d48-ad53-adad1f4bcf28.png)
