### PR TITLE
docs: add deployment steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ git push --force
 
 ### Troubleshooting
 
-If the commit history of `main` and `production` diverge and `production` contains commit hashes that are NOT on main, try running this command to reset and then follow the original deploy steps above:
+If the commit history of `main` and `production` diverge and `production` contains commit hashes that are NOT on main, try running this command from `production` to reset and then follow the original deploy steps above:
 ```bash
-git reset --hard <most recent commit hash matching main> && git push --force
+git reset --hard <most recent commit hash **matching** main> && git push --force
 ```
 
+You'll have to temporarily turn off branch protection rules to make this change, so run it by another dev to confirm.
 
 ## Audits
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,39 @@ This project uses Architecture Decision Records (ADRs) to record significant cha
 
 For maximum visibility and discoverability, we recommend using the [GitHub discussions board](https://github.com/theopensystemslab/planx-new/discussions) where possible.
 
+
+## Deployments
+
+Our `main` branch is deployed to AWS staging (editor.planx.dev) and `production` is deployed to our AWS production environment (editor.planx.uk or a custom subdomain like planningservices.{council}.gov.uk) using Github Actions. 
+
+We work in feature branches and open pull requests against `main`. Pull requests will spin up a Vultr server running Docker to test the whole stack (eg database migrations, API changes, frontend changes, Storybook, etc) and generate unique links that can be shared for user-acceptance tesing. Pull request environments use the domain pattern <service>.<PR#>.planx.pizza and are often simply referred to as "pizzas". The only changes which cannot be fully tested on a pizza are changes related to Pulumi infrastructure-as-code because this is only deployed in AWS environments, not via Docker.
+
+We aim to keep a linear commit history between `main` and `production` branches in Github. We "Squash & merge" pull request commits into `main`, and then force push to `production` via the command line following these steps:
+
+1. Open a PR in the web interface from `main` into `production` to generate a visual diff and request approval from @planx team
+- DO NOT MERGE this PR via the web interface using any method ("Squash" or "Rebase") because Github will generate its' own commit hashes in either instance
+- Branch protection rules are in place to restrict running the commands in the next step without explicit "approval" generated via this PR
+
+1. Once approved, switch to your command line and run these commands (starting on `main` branch)
+```bash
+git fetch --all
+git checkout production
+git pull
+git rebase origin/main
+git push --force
+```
+
+1. On success, the PR you opened will automatically close and display as "merged", a Slack notification will be sent to #planx-deployments channel, and the `production` branch should read "This branch is up to date with main."
+
+
+### Troubleshooting
+
+If the commit history of `main` and `production` diverge and `production` contains commit hashes that are NOT on main, try running this command to reset and then follow the original deploy steps above:
+```bash
+git reset --hard <most recent commit hash matching main> && git push --force
+```
+
+
 ## Audits
 
 ### Accessibility


### PR DESCRIPTION
Branch protection rules were recently adjusted, but I realized that I had incorrectly assumed yesterday what that meant for how we should deploy now - so writing down the process as I understand it after getting everything back in alignment today. 

Edits welcome! 