### PR TITLE
fix: render HTML tags in the Contact Us section

### DIFF
--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.test.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.test.tsx
@@ -1,4 +1,7 @@
-import { incrementHeaderElements } from "./ReactMarkdownOrHtml";
+import {
+  incrementHeaderElements,
+  replaceEscapedTags,
+} from "./ReactMarkdownOrHtml";
 
 describe("Header element incrementor", () => {
   it("should return HTML unaltered if it does not contain H1 or H2 tags", () => {
@@ -71,5 +74,32 @@ describe("Header element incrementor", () => {
     `;
     const result = incrementHeaderElements(input);
     expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe("Escaped tag replacer", () => {
+  it("should replace escaped text with HTML tags", () => {
+    const input = `
+      &lt;h1&gt;H1 Element&lt;/h1&gt;
+      &lt;br /&gt;
+      <p>this is bold -&gt &lt;b&gt;text&lt;/b&gt;</p>
+      &lt;&gt;
+    `;
+
+    expect(replaceEscapedTags(input)).toEqual(`
+      <h1>H1 Element</h1>
+      <br />
+      <p>this is bold -&gt <b>text</b></p>
+      &lt;&gt;
+    `);
+  });
+
+  it("should keep string unchanged", () => {
+    const input = `
+      <h1>H1 Element</h1>
+      Unchanged &lt;&gt; &lt; &gt; &lt;/&gt;
+    `;
+
+    expect(replaceEscapedTags(input)).toEqual(input);
   });
 });

--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -23,6 +23,11 @@ export const incrementHeaderElements = (source: string): string => {
   return source.replace(regex, incrementer);
 };
 
+// Replace &lt; and &gt; with < and > to render correct HTML tags when text is escaped in Rich Text Editor
+export const replaceEscapedTags = (source: string): string => {
+  return source.replaceAll(/&lt;(?=\/?[a-z]+\/?)([/a-z1-9 ]+?)&gt;/g, "<$1>");
+};
+
 export default function ReactMarkdownOrHtml(props: {
   source?: string;
   className?: string;
@@ -34,10 +39,16 @@ export default function ReactMarkdownOrHtml(props: {
   if (typeof props.source !== "string") {
     return null;
   }
-  if (props.source.includes("</")) {
-    const replaceTarget = props.openLinksOnNewTab
-      ? props.source.replaceAll(`target="_self"`, `target="_blank" external`)
-      : props.source;
+
+  const isHTMLContent = ["</", "/>"].some((tag) => props.source?.includes(tag));
+
+  if (isHTMLContent) {
+    const replaceTarget = replaceEscapedTags(
+      props.openLinksOnNewTab
+        ? props.source.replaceAll(`target="_self"`, `target="_blank" external`)
+        : props.source
+    );
+
     const incrementHeaders = props.manuallyIncrementHeaders
       ? replaceTarget
       : incrementHeaderElements(replaceTarget);


### PR DESCRIPTION
- Fixes https://trello.com/c/WZOdzJ4c/2227-confirmation-component-contact-us-section-not-rendering-html-content-correctly
- The rich text editor converts chars into their escaped version, `<` turns into `&lt;` for example. To render the tags correctly, a replacement regex was added to "unescape" chars before rendering.
- Alternatively, and to avoid using a regex, we could add a plugin to the tiptap editor to convert the text to Markdown first then convert it back to HTML, which feels less safe than just replacing the escaped chars. Here is an example: https://codesandbox.io/s/tiptap-0sqm3i?file=/src/components/Tiptap.tsx:4861-4920
