### PR TITLE
fix: Send current metadata via FeedbackFish widget, not initial metadata

### DIFF
--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -42,40 +42,53 @@ export interface Props {
   children?: React.ReactNode;
 }
 
+// XXX: This component is located in the DOM within the Footer component, but as it's appearance is controlled by a global window "message" event. This means that its appearance can be controlled by other instances of the FeedbackFish widget (such as in the PhaseBanner)
+const FeedbackPrivacyNote = ({
+  onClose,
+}: {
+  onClose: (e: React.MouseEvent) => void;
+}) => (
+  <Dialog
+    // XXX: only render dialog when visible & open=true by default,
+    //      otherwise clicking modal BG also closes feedback widget
+    open
+    onClose={onClose}
+    // feedback fish uses z-index of 999999 :(
+    style={{ zIndex: 999999 + 1 }}
+    onClick={(e) => e.stopPropagation()}
+  >
+    <DialogContent>
+      Please do not include any personal or financial information in your
+      feedback
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>OK</Button>
+    </DialogActions>
+  </Dialog>
+);
+
 export default function Footer(props: Props) {
   const { items, children } = props;
   const [feedbackPrivacyNoteVisible, setFeedbackPrivacyNoteVisible] =
     useState(false);
+  const [metadata, setMetadata] = useState<Record<string, string>>();
+
+  const feedbackFishId = process.env.REACT_APP_FEEDBACK_FISH_ID;
 
   useEffect(() => {
     let feedbackFishPostMessageWorkingCorrectly: boolean;
     const handleMessage = (event: MessageEvent) => {
-      try {
-        // the feedback fish widget posts a message that's either
-        // {"width":0,"height":0} if the iframe is hidden
-        // or {"width":320,"height":200} if the iframe is visible
-        if (event.origin.endsWith("feedback.fish")) {
-          const { width, height } = JSON.parse(event.data);
-          // XXX: postMessage not working in firefox as expected
-          //      https://trello.com/c/MX1cpAM8 this disables it in FF
-          //      by checking if the initial {"width":0,"height":0} message
-          //      was received. If not then never show feedback warning msg
-          if (width === 0 && height === 0) {
-            feedbackFishPostMessageWorkingCorrectly = true;
-          }
-          setFeedbackPrivacyNoteVisible(
-            width > 0 && height > 0 && feedbackFishPostMessageWorkingCorrectly
-          );
-        }
-      } catch (err) {}
+      setMetadata(getFeedbackMetadata());
+      feedbackFishPostMessageWorkingCorrectly = handleFeedbackPrivacyNoteOpen(
+        event,
+        feedbackFishPostMessageWorkingCorrectly
+      );
     };
     window.addEventListener("message", handleMessage);
     return () => {
       window.removeEventListener("message", handleMessage);
     };
   }, []);
-
-  const feedbackFishId = process.env.REACT_APP_FEEDBACK_FISH_ID;
 
   const handleFeedbackPrivacyNoteClose = (e: React.MouseEvent) => {
     setFeedbackPrivacyNoteVisible(false);
@@ -84,7 +97,30 @@ export default function Footer(props: Props) {
     e.stopPropagation();
   };
 
-  const metadata = getFeedbackMetadata();
+  const handleFeedbackPrivacyNoteOpen = (
+    event: MessageEvent,
+    feedbackFishPostMessageWorkingCorrectly: boolean
+  ): boolean => {
+    try {
+      // the feedback fish widget posts a message that's either
+      // {"width":0,"height":0} if the iframe is hidden
+      // or {"width":320,"height":200} if the iframe is visible
+      if (event.origin.endsWith("feedback.fish")) {
+        const { width, height } = JSON.parse(event.data);
+        // XXX: postMessage not working in firefox as expected
+        //      https://trello.com/c/MX1cpAM8 this disables it in FF
+        //      by checking if the initial {"width":0,"height":0} message
+        //      was received. If not then never show feedback warning msg
+        if (width === 0 && height === 0) {
+          feedbackFishPostMessageWorkingCorrectly = true;
+        }
+        setFeedbackPrivacyNoteVisible(
+          width > 0 && height > 0 && feedbackFishPostMessageWorkingCorrectly
+        );
+      }
+    } catch (err) {}
+    return feedbackFishPostMessageWorkingCorrectly;
+  };
 
   return (
     <Root>
@@ -97,23 +133,7 @@ export default function Footer(props: Props) {
         {feedbackFishId && (
           <>
             {feedbackPrivacyNoteVisible && (
-              <Dialog
-                // XXX: only render dialog when visible & open=true by default,
-                //      otherwise clicking modal BG also closes feedback widget
-                open
-                onClose={handleFeedbackPrivacyNoteClose}
-                // feedback fish uses z-index of 999999 :(
-                style={{ zIndex: 999999 + 1 }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <DialogContent>
-                  Please do not include any personal or financial information in
-                  your feedback
-                </DialogContent>
-                <DialogActions>
-                  <Button onClick={handleFeedbackPrivacyNoteClose}>OK</Button>
-                </DialogActions>
-              </Dialog>
+              <FeedbackPrivacyNote onClose={handleFeedbackPrivacyNoteClose} />
             )}
             <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
               <Link color="inherit" component="button">

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -6,7 +6,7 @@ import { Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
 import { getFeedbackMetadata } from "lib/feedback";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 const useClasses = makeStyles((theme: Theme) => ({
   root: {
@@ -32,7 +32,15 @@ const useClasses = makeStyles((theme: Theme) => ({
 export default function PhaseBanner(): FCReturn {
   const classes = useClasses();
   const feedbackFishId = process.env.REACT_APP_FEEDBACK_FISH_ID || "";
-  const metadata = getFeedbackMetadata();
+  const [metadata, setMetadata] = useState<Record<string, string>>();
+
+  useEffect(() => {
+    const handleMessage = () => setMetadata(getFeedbackMetadata());
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
 
   return (
     <FeedbackFish projectId={feedbackFishId} metadata={metadata}>


### PR DESCRIPTION
## What's the problem?
 Currently the `metadata` passed into the FeedbackFish widget is only calculated on initial render of the `Footer` and `PhaseBanner` components. We want it to be "live" with the applicant's current state, not just the initial state on load.

## How is this fixed?
Call `getFeedbackMetadata()` when the widget is opened (using the `window`'s `message` event).

## Also...
There's a bit of a rearranging of the `Footer` component here to split things up a little bit.

## To test
- Navigate a few questions into a flow and submit feedback via the `Footer` or `PhaseBanner`
- The network tab should show the full "live" metadata being sent (e.g. breadcrumbs)