### PR TITLE
feat: Point MyMap and AddressAutocomplete at proxy endpoint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -205,7 +205,6 @@ jobs:
           REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           # needed because there's no API to change google's allowed OAuth URLs
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
@@ -244,7 +243,6 @@ jobs:
           REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -54,7 +54,6 @@ jobs:
       - run: pnpm build
         working-directory: editor.planx.uk
         env:
-          REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
           REACT_APP_API_URL: https://api.editor.planx.dev
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.editor.planx.dev/v1/graphql

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -54,7 +54,6 @@ jobs:
       - run: pnpm build
         working-directory: editor.planx.uk
         env:
-          REACT_APP_ORDNANCE_SURVEY_KEY: ${{ secrets.ORDNANCE_SURVEY_KEY }}
           REACT_APP_API_URL: https://api.editor.planx.uk
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.editor.planx.uk/v1/graphql

--- a/api.planx.uk/proxy/ordnanceSurvey.ts
+++ b/api.planx.uk/proxy/ordnanceSurvey.ts
@@ -6,7 +6,7 @@ export const OS_DOMAIN = "https://api.os.uk";
 
 const MAP_ALLOWLIST: RegExp[] = [
   // Local development
-  /^http:\/\/(127\.0\.0\.1|localhost):(5173|7007)\/$/i,
+  /^http:\/\/(127\.0\.0\.1|localhost):(3000|5173|6006|7007)\/$/i,
   // Documentation
   /^https:\/\/.*\.netlify\.app\/$/i,
   // PlanX

--- a/editor.planx.uk/.env.example
+++ b/editor.planx.uk/.env.example
@@ -1,7 +1,3 @@
-# Used in all environments
- 
-REACT_APP_ORDNANCE_SURVEY_KEY=👻
-
 # Used in local development and testing, overwritten in .env.production
 
 REACT_APP_AIRBRAKE_PROJECT_ID=👻

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/material": "^5.10.5",
     "@mui/styles": "^5.10.3",
     "@mui/utils": "^5.10.3",
-    "@opensystemslab/map": "^0.6.1",
+    "@opensystemslab/map": "^0.6.3",
     "@tiptap/core": "2.0.0-beta.204",
     "@tiptap/extension-bold": "2.0.0-beta.204",
     "@tiptap/extension-bubble-menu": "2.0.0-beta.204",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -59,7 +59,7 @@ specifiers:
   '@mui/material': ^5.10.5
   '@mui/styles': ^5.10.3
   '@mui/utils': ^5.10.3
-  '@opensystemslab/map': ^0.6.1
+  '@opensystemslab/map': ^0.6.3
   '@react-theming/storybook-addon': ^1.1.7
   '@storybook/addon-actions': ^6.5.10
   '@storybook/addon-essentials': ^6.5.10
@@ -198,7 +198,7 @@ dependencies:
   '@mui/material': 5.10.6_vbxcdxy3bftsefaguotlgalomu
   '@mui/styles': 5.10.6_7v64pk2mkrohwh22gx7lrz5ive
   '@mui/utils': 5.10.6_react@18.2.0
-  '@opensystemslab/map': 0.6.1
+  '@opensystemslab/map': 0.6.3
   '@tiptap/core': 2.0.0-beta.204
   '@tiptap/extension-bold': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
   '@tiptap/extension-bubble-menu': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
@@ -311,7 +311,7 @@ devDependencies:
   esbuild: 0.14.54
   esbuild-jest: 0.5.0_esbuild@0.14.54
   eslint: 8.29.0
-  eslint-plugin-jest: 27.1.6_ixh6nceclvqov4hcu5gszby2fi
+  eslint-plugin-jest: 27.1.6_kkv2tsnmg5we6ee3ny4vbvytka
   eslint-plugin-jsx-a11y: 6.6.1_eslint@8.29.0
   eslint-plugin-simple-import-sort: 7.0.0_eslint@8.29.0
   eslint-plugin-testing-library: 5.6.0_ixh6nceclvqov4hcu5gszby2fi
@@ -3085,8 +3085,8 @@ packages:
       mkdirp: 1.0.4
     dev: true
 
-  /@opensystemslab/map/0.6.1:
-    resolution: {integrity: sha512-er4r4ViRwJNxQDyxYchanr8JaV4Ow02i6KfckvncTW5hKGrcc/bEOHS9F+kjy2w3Y3/mAT3t2dZ+ifQxv+0Cfg==}
+  /@opensystemslab/map/0.6.3:
+    resolution: {integrity: sha512-wHb75VMtM0rD2pRxfTs+J9vxCDjUSWpu2uZpCeuNSDVWosCloFpSq7SRLaO9h32sFEpmF7MaW+x72ZAVjAtPCA==}
     engines: {node: ^16, pnpm: ^7.8.0}
     dependencies:
       '@turf/union': 6.5.0
@@ -9373,7 +9373,7 @@ packages:
       - supports-color
       - typescript
 
-  /eslint-plugin-jest/27.1.6_ixh6nceclvqov4hcu5gszby2fi:
+  /eslint-plugin-jest/27.1.6_kkv2tsnmg5we6ee3ny4vbvytka:
     resolution: {integrity: sha512-XA7RFLSrlQF9IGtAmhddkUkBuICCTuryfOTfCSWcZHiHb69OilIH05oozH2XA6CEOtztnOd0vgXyvxZodkxGjg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -9388,6 +9388,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.36.1_ixh6nceclvqov4hcu5gszby2fi
       eslint: 8.29.0
+      jest: 27.4.5
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/DrawBoundary.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/DrawBoundary.stories.tsx
@@ -24,7 +24,7 @@ export const MapOnly = () => {
         drawMode
         zoom={19}
         maxZoom={20}
-        osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
+        osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
       />
     </>
   );

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -162,7 +162,7 @@ export default function Component(props: Props) {
               markerLatitude={Number(passport?.data?._address?.latitude)}
               markerLongitude={Number(passport?.data?._address?.longitude)}
               resetControlImage="trash"
-              osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
+              osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
             />
             {!props.hideFileUpload && (
               <MapFooter>

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -347,7 +347,7 @@ function GetAddress(props: {
             data-testid="address-autocomplete-web-component"
             postcode={sanitizedPostcode}
             initialAddress={selectedOption?.title || ""}
-            osPlacesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
+            osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
             arrowStyle="light"
             labelStyle="static"
           />
@@ -420,7 +420,7 @@ export function PropertyInformation(props: any) {
           zoom={19.5}
           latitude={lat}
           longitude={lng}
-          osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
+          osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
           hideResetControl
           showMarker
           markerLatitude={lat}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -268,7 +268,7 @@ function DrawBoundary(props: ComponentProps) {
               geojsonColor="#ff0000"
               geojsonFill
               geojsonBuffer="20"
-              osVectorTilesApiKey={process.env.REACT_APP_ORDNANCE_SURVEY_KEY}
+              osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
               hideResetControl
               staticMode
               style={{ width: "100%", height: "30vh" }}


### PR DESCRIPTION
## What does this PR do?
 - It points `MyMap` and `AddressAutocomplete` at the new `/proxy/ordnance-survey` endpoint added in #1334 
 - Removes the `REACT_APP_ORDNANCE_SURVEY_KEY` from the application

## Also...
- This PR (and changes to the GitHub actions) might break the map and address components on open PRs. A rebase to `main` should fix this though.
- Once merged I'll also remove ` {{ secrets.ORDNANCE_SURVEY_KEY }}` from the GitHub environment
- As another PR, I'll tidy up the React app `.env` file - these aren't secrets so we can manage to make this a bit simpler going forward