### PR TITLE
chore: Commit Editor environmental variables

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,7 +63,7 @@ jobs:
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
-          files: ".env, .env.staging, api.planx.uk/.env.test, editor.planx.uk/.env, hasura.planx.uk/.env.test"
+          files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
@@ -124,7 +124,7 @@ jobs:
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
-          files: ".env, .env.staging, api.planx.uk/.env.test, editor.planx.uk/.env, hasura.planx.uk/.env.test"
+          files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
@@ -157,7 +157,7 @@ jobs:
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
-          files: ".env, .env.staging, api.planx.uk/.env.test, editor.planx.uk/.env, hasura.planx.uk/.env.test"
+          files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ editor.planx.uk/.eslintcache
 .env.prod
 .env.temp
 api.planx.uk/.env.test
-editor.planx.uk/.env
 hasura.planx.uk/.env.test
 
 # IDE

--- a/editor.planx.uk/.env
+++ b/editor.planx.uk/.env
@@ -1,7 +1,8 @@
 # Used in local development and testing, overwritten in .env.production
+# This file does not (and should not) contain secrets - all values here are publicly exposed
 
-REACT_APP_AIRBRAKE_PROJECT_ID=👻
-REACT_APP_AIRBRAKE_PROJECT_KEY=👻
+REACT_APP_AIRBRAKE_PROJECT_ID=329753
+REACT_APP_AIRBRAKE_PROJECT_KEY=388fe6f4cc0d6644c923500d5672a5b6
 
 REACT_APP_FEEDBACK_FISH_ID=65f02de00b90d1
 

--- a/editor.planx.uk/.gitignore
+++ b/editor.planx.uk/.gitignore
@@ -18,7 +18,6 @@
 .env.test.local
 .env.production.local
 .envrc
-.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -4,6 +4,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 aws s3 cp s3://pizza-secrets/root.env ./../.env
 aws s3 cp s3://pizza-secrets/api.env.test ./../api.planx.uk/.env.test
-aws s3 cp s3://pizza-secrets/editor.env ./../editor.planx.uk/.env
 aws s3 cp s3://pizza-secrets/hasura.env.test ./../hasura.planx.uk/.env.test
 echo "Complete: Secrets from S3 copied to local machine"

--- a/scripts/push-secrets.sh
+++ b/scripts/push-secrets.sh
@@ -3,7 +3,6 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 aws s3 cp ./../.env s3://pizza-secrets/root.env
-aws s3 cp ./../api.planx.uk/.env s3://pizza-secrets/api.env.test
-aws s3 cp ./../editor.planx.uk/.env s3://pizza-secrets/editor.env
+aws s3 cp ./../api.planx.uk/.env.test s3://pizza-secrets/api.env.test
 aws s3 cp ./../hasura.planx.uk/.env.test s3://pizza-secrets/hasura.env.test
 echo "Complete: Secrets from local machine pushed to S3"


### PR DESCRIPTION
## What does this PR do?
 - Simplify secret management by committing our Editor `.env` file
 - These are all publicly exposed, and are not secrets
 - This work follows on from implementing a proxy for OS API calls #1334 