### PR TITLE
fix: always show DrawBoundary area

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -164,12 +164,12 @@ export default function Component(props: Props) {
               resetControlImage="trash"
               osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
             />
-            {!props.hideFileUpload && (
-              <MapFooter>
-                <Typography variant="body2">
-                  The site outline you have drawn is{" "}
-                  <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
-                </Typography>
+            <MapFooter>
+              <Typography variant="body2">
+                The site outline you have drawn is{" "}
+                <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
+              </Typography>
+              {!props.hideFileUpload && (
                 <Link
                   component="button"
                   onClick={() => setPage("upload")}
@@ -180,8 +180,8 @@ export default function Component(props: Props) {
                     Upload a location plan instead
                   </Typography>
                 </Link>
-              </MapFooter>
-            )}
+              )}
+            </MapFooter>
           </MapContainer>
         </>
       );


### PR DESCRIPTION
was testing FOIYNPP services and noticed that the area calculation was hidden when the file upload option was toggled off, but I think this is probably unintentional and we want to always show the area calculation - it was still being written to the passport in the background! 

now we'll render this when `props.hideFileUpload` is true:
![Screenshot from 2022-12-22 10-52-24](https://user-images.githubusercontent.com/5132349/209108893-c84fa250-e426-4b96-9330-815004d166ec.png)
