### PR TITLE
feat: add geojson and html map-viewer to files sent by email

### DIFF
--- a/api.planx.uk/send/uniform.js
+++ b/api.planx.uk/send/uniform.js
@@ -185,6 +185,7 @@ async function checkUniformAuditTable(sessionId) {
  * Creates a zip folder containing the documents required by Uniform
  * @param {any} stringXml - a string representation of the XML schema, resulting file must be named "proposal.xml"
  * @param {any} csv - an array of objects representing our custom CSV format
+ * @param {any} geojson - the site boundary geojson if the user drew, empty if they uploaded a location plan
  * @param {object[]} files - an array of user-uploaded files
  * @param {string} sessionId
  * @returns {Promise} - name of zip


### PR DESCRIPTION
Adds "boundary.geojson" & "map.html" files to the application file packet sent by email if the user draws their site boundary. If they uploaded a location plan, their uploaded file will be available same as any other user-uploaded files.

I'm purposefully not sending the CSV data as well to the HTML DocumentViewer right now, as send to email services will likely have simpler content and officers just want an easy way to screenshot the map for starters! I'll open a separate PR in the other repo to conditionally display the "Data" column so the boundary-only content looks more intentional
![Screenshot from 2022-12-22 11-41-10](https://user-images.githubusercontent.com/5132349/209118285-86a56044-9aca-45a2-8234-5898e6d70dd0.png)

**To test:**
- Pick a team to test and configure `teams.settings.sendToEmail` to your email (via this pizza's Hasura Console)
- Create a simple test service with FindProperty > DrawBoundary > FileUpload > Send ("Email to planning office") > Confirmation nodes & publish it
- Complete an application, check your email and confirm you can download all the files
