### PR TITLE
tests: add more filter component scenarios for flag paths that have auto-answerable questions

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -118,9 +118,9 @@ describe("Nodes on a filter path should only be auto-answered when the path matc
       auto: true,
     });
 
-    // make sure the auto-answerable question from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
+    // make sure the auto-answerable question and its child from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
     expect(visitedNodes()).not.toContain("AaEuHnVUb4");
-    expect(upcomingCardIds).not.toContain("AaEuHnVUb4");
+    expect(upcomingCardIds).not.toContain("xjcujhpzjs");
   });
 
   test.skip("Filter path nodes are auto-answered correctly when a lower order flag is picked up first", () => {
@@ -148,8 +148,8 @@ describe("Nodes on a filter path should only be auto-answered when the path matc
     });
 
     // TEST-GENERATED BREADCRUMBS DO NOT MATCH PRODUCTION BREADCRUMBS, THIS SHOULD BE FAILING
-    // make sure the auto-answerable question from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
+    // make sure the auto-answerable question and its child from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
     expect(visitedNodes()).not.toContain("AaEuHnVUb4");
-    expect(upcomingCardIds).not.toContain("AaEuHnVUb4");
+    expect(upcomingCardIds).not.toContain("xjcujhpzjs");
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -1,10 +1,19 @@
+import { visitInParallel } from "graphql";
+
 import { vanillaStore } from "../store";
+import flowWithAutoAnsweredFilterPaths from "./mocks/flowWithAutoAnsweredFilterPaths.json";
 import flowWithBranchingFilters from "./mocks/flowWithBranchingFilters.json";
 import flowWithRootFilter from "./mocks/flowWithRootFilter.json";
 
 const { getState, setState } = vanillaStore;
-const { upcomingCardIds, resetPreview, record, currentCard, collectedFlags } =
-  getState();
+const {
+  upcomingCardIds,
+  resetPreview,
+  record,
+  currentCard,
+  collectedFlags,
+  resultData,
+} = getState();
 
 // https://i.imgur.com/k0kkKox.png
 describe("A filter on the root of the graph", () => {
@@ -76,5 +85,71 @@ describe("A filter on a branch", () => {
     // The currentCard returns as "immunityFlag2" which we should not land on -
     // the flags on the first filter are skipped, we go direct from "immunityPath1" to "fork"
     expect(currentCard()?.id).toBe("immunityPath2");
+  });
+});
+
+describe("Nodes on a filter path should only be auto-answered when the path matches the result", () => {
+  beforeEach(() => {
+    resetPreview();
+    setState({ flow: flowWithAutoAnsweredFilterPaths }); // https://editor.planx.uk/testing/flag-order-test-with-autoanswer
+  });
+
+  test("Filter path nodes are auto-answered correctly when the highest order flag is picked up first", () => {
+    let visitedNodes = () => Object.keys(getState().breadcrumbs);
+
+    // go forward manually: select not listed and select an answer with permission needed (higher order) flag
+    record("zlKQyPuKsl", { answers: ["qW1jzS1qPy"], auto: false });
+    record("Ve90wVIXsV", { answers: ["d98AoVIXsV"], auto: false }); // as we pick up this flag, later nodes in matching filter path are auto-answered immediately
+
+    // continue forward manually: select an answer with permitted development (lower order) flag
+    record("TiIuAVIXsV", { answers: ["hdaeOVIXsV"], auto: false });
+
+    // land on the correct result component
+    expect(currentCard()?.id).toBe("seN42VIXsV");
+    expect(getState().resultData()["Planning permission"]).toHaveProperty(
+      "flag.value",
+      "PLANNING_PERMISSION_REQUIRED"
+    );
+
+    // expect the auto-answered question on the permission needed filter path to be in our breadcrumbs
+    expect(visitedNodes()).toContain("1ShlhWrXPl");
+    expect(getState().breadcrumbs["1ShlhWrXPl"]).toEqual({
+      answers: ["tesCNavKYo"],
+      auto: true,
+    });
+
+    // make sure the auto-answerable question from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
+    expect(visitedNodes()).not.toContain("AaEuHnVUb4");
+    expect(upcomingCardIds).not.toContain("AaEuHnVUb4");
+  });
+
+  test.skip("Filter path nodes are auto-answered correctly when a lower order flag is picked up first", () => {
+    let visitedNodes = () => Object.keys(getState().breadcrumbs);
+
+    // go forward manually: select not listed and select an answer with permitted dev (lower order) flag
+    record("zlKQyPuKsl", { answers: ["qW1jzS1qPy"], auto: false });
+    record("Ve90wVIXsV", { answers: ["pghecgQLgs"], auto: false });
+
+    // continue forward manually: select an answer with permission needed (higher order) flag
+    record("TiIuAVIXsV", { answers: ["OPOWoVIXsV"], auto: false });
+
+    // land on the correct result component
+    expect(currentCard()?.id).toBe("seN42VIXsV");
+    expect(getState().resultData()["Planning permission"]).toHaveProperty(
+      "flag.value",
+      "PLANNING_PERMISSION_REQUIRED"
+    );
+
+    // expect the auto-answered question on the permission needed filter path to be in our breadcrumbs
+    expect(visitedNodes()).toContain("1ShlhWrXPl");
+    expect(getState().breadcrumbs["1ShlhWrXPl"]).toEqual({
+      answers: ["tesCNavKYo"],
+      auto: true,
+    });
+
+    // TEST-GENERATED BREADCRUMBS DO NOT MATCH PRODUCTION BREADCRUMBS, THIS SHOULD BE FAILING
+    // make sure the auto-answerable question from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
+    expect(visitedNodes()).not.toContain("AaEuHnVUb4");
+    expect(upcomingCardIds).not.toContain("AaEuHnVUb4");
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -129,9 +129,14 @@ describe("Nodes on a filter path should only be auto-answered when the path matc
     // go forward manually: select not listed and select an answer with permitted dev (lower order) flag
     record("zlKQyPuKsl", { answers: ["qW1jzS1qPy"], auto: false });
     record("Ve90wVIXsV", { answers: ["pghecgQLgs"], auto: false });
+    upcomingCardIds(); // mimic "continue" and properly set visitedNodes()
+
+    // TODO ensure that the auto-answerable question in the permitted dev filter path has not been immediately auto-answered before reaching the filter node
+    expect(visitedNodes()).not.toContain("AaEuHnVUb4");
 
     // continue forward manually: select an answer with permission needed (higher order) flag
     record("TiIuAVIXsV", { answers: ["OPOWoVIXsV"], auto: false });
+    upcomingCardIds();
 
     // land on the correct result component
     expect(currentCard()?.id).toBe("seN42VIXsV");
@@ -146,10 +151,5 @@ describe("Nodes on a filter path should only be auto-answered when the path matc
       answers: ["tesCNavKYo"],
       auto: true,
     });
-
-    // TEST-GENERATED BREADCRUMBS DO NOT MATCH PRODUCTION BREADCRUMBS, THIS SHOULD BE FAILING
-    // make sure the auto-answerable question and its child from the permitted development filter path is not in our breadcrumbs nor upcoming card ids
-    expect(visitedNodes()).not.toContain("AaEuHnVUb4");
-    expect(upcomingCardIds).not.toContain("xjcujhpzjs");
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/flowWithAutoAnsweredFilterPaths.json
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/flowWithAutoAnsweredFilterPaths.json
@@ -1,0 +1,248 @@
+{
+  "_root": {
+    "edges": [
+      "zlKQyPuKsl",
+      "Ve90wVIXsV",
+      "TiIuAVIXsV",
+      "yYSKdVIXsV",
+      "rkqKFVIXsV"
+    ]
+  },
+  "AwAJxVIXsV": {
+    "data": {
+      "val": "IMMUNE",
+      "text": "Immune"
+    },
+    "type": 200
+  },
+  "CXV6wVIXsV": {
+    "data": {
+      "val": "PP-NOT_DEVELOPMENT",
+      "text": "Not development"
+    },
+    "type": 200
+  },
+  "D79fwVIXsV": {
+    "data": {
+      "val": "PRIOR_APPROVAL",
+      "text": "Prior approval"
+    },
+    "type": 200
+  },
+  "DtoqgVIXsV": {
+    "data": {
+      "val": "PP-NOTICE",
+      "text": "Notice"
+    },
+    "type": 200
+  },
+  "GxTpoVIXsV": {
+    "data": {
+      "val": "MISSING_INFO",
+      "text": "Missing information"
+    },
+    "type": 200
+  },
+  "O91ogVIXsV": {
+    "data": {
+      "val": "PLANNING_PERMISSION_REQUIRED",
+      "text": "Permission needed"
+    },
+    "type": 200,
+    "edges": ["seN42VIXsV", "1ShlhWrXPl"]
+  },
+  "OPOWoVIXsV": {
+    "data": {
+      "flag": "PLANNING_PERMISSION_REQUIRED",
+      "text": "Permission needed"
+    },
+    "type": 200
+  },
+  "TiIuAVIXsV": {
+    "data": {
+      "text": "Pick another flag"
+    },
+    "type": 100,
+    "edges": ["OPOWoVIXsV", "hdaeOVIXsV"]
+  },
+  "Ve90wVIXsV": {
+    "data": {
+      "text": "Pick a flag"
+    },
+    "type": 100,
+    "edges": ["d98AoVIXsV", "pghecgQLgs"]
+  },
+  "d98AoVIXsV": {
+    "data": {
+      "flag": "PLANNING_PERMISSION_REQUIRED",
+      "text": "Permission needed",
+      "val": "permissionNeeded"
+    },
+    "type": 200
+  },
+  "hdaeOVIXsV": {
+    "data": {
+      "flag": "NO_APP_REQUIRED",
+      "text": "Permitted dev"
+    },
+    "type": 200
+  },
+  "qmEBoVIXsV": {
+    "data": {
+      "val": "NO_APP_REQUIRED",
+      "text": "Permitted development"
+    },
+    "type": 200,
+    "edges": ["seN42VIXsV", "AaEuHnVUb4"]
+  },
+  "rkqKFVIXsV": {
+    "data": {
+      "color": "#EFEFEF",
+      "title": "End of service!",
+      "resetButton": true
+    },
+    "type": 8
+  },
+  "seN42VIXsV": {
+    "data": {
+      "flagSet": "Planning permission"
+    },
+    "type": 3
+  },
+  "yG4jGVIXsV": {
+    "data": {
+      "text": "(No Result)"
+    },
+    "type": 200
+  },
+  "yYSKdVIXsV": {
+    "data": {
+      "fn": "flag"
+    },
+    "type": 500,
+    "edges": [
+      "AwAJxVIXsV",
+      "GxTpoVIXsV",
+      "O91ogVIXsV",
+      "D79fwVIXsV",
+      "DtoqgVIXsV",
+      "qmEBoVIXsV",
+      "CXV6wVIXsV",
+      "yG4jGVIXsV"
+    ]
+  },
+  "zlKQyPuKsl": {
+    "type": 100,
+    "data": {
+      "fn": "property.constraints.planning",
+      "text": "Is it a listed building?"
+    },
+    "edges": ["8ONxTMoU0b", "qW1jzS1qPy"]
+  },
+  "8ONxTMoU0b": {
+    "type": 200,
+    "data": {
+      "text": "Yes",
+      "val": "listed",
+      "flag": "LB-REQUIRED"
+    }
+  },
+  "qW1jzS1qPy": {
+    "type": 200,
+    "data": {
+      "text": "No",
+      "flag": "LB-NOT_REQUIRED"
+    }
+  },
+  "P9yPvn8JLs": {
+    "type": 250,
+    "data": {
+      "content": "<p>Listed and permitted dev path</p>"
+    }
+  },
+  "1ShlhWrXPl": {
+    "type": 100,
+    "data": {
+      "fn": "property.constraints.planning",
+      "text": "Is any part of the property listed? (PN path)"
+    },
+    "edges": ["gUNLEiv4yh", "tesCNavKYo"]
+  },
+  "gUNLEiv4yh": {
+    "type": 200,
+    "data": {
+      "text": "Yes",
+      "val": "listed"
+    },
+    "edges": ["sSL8kEJ558", "g8efNSpw8h"]
+  },
+  "sSL8kEJ558": {
+    "type": 3,
+    "data": {
+      "flagSet": "Listed building consent",
+      "overrides": {}
+    }
+  },
+  "tesCNavKYo": {
+    "type": 200,
+    "data": {
+      "text": "No"
+    },
+    "edges": ["qSJ2jpVVXb"]
+  },
+  "qSJ2jpVVXb": {
+    "data": {
+      "content": "<p>Not listed and permission needed path</p>"
+    },
+    "type": 250
+  },
+  "AaEuHnVUb4": {
+    "type": 100,
+    "data": {
+      "fn": "property.constraints.planning",
+      "text": "Is any part of the property listed? (PD path)"
+    },
+    "edges": ["hcYEJL5mTW", "WbVIceFvVw"]
+  },
+  "hcYEJL5mTW": {
+    "type": 200,
+    "data": {
+      "text": "Yes",
+      "val": "listed"
+    },
+    "edges": ["Qy3Okt81xb", "P9yPvn8JLs"]
+  },
+  "Qy3Okt81xb": {
+    "type": 3,
+    "data": {
+      "flagSet": "Listed building consent"
+    }
+  },
+  "WbVIceFvVw": {
+    "type": 200,
+    "data": {
+      "text": "No"
+    },
+    "edges": ["xjcujhpzjs"]
+  },
+  "xjcujhpzjs": {
+    "data": {
+      "content": "<p>Not listed and permitted dev path</p>"
+    },
+    "type": 250
+  },
+  "pghecgQLgs": {
+    "type": 200,
+    "data": {
+      "text": "Permitted dev",
+      "val": "permittedDev",
+      "flag": "NO_APP_REQUIRED"
+    }
+  },
+  "g8efNSpw8h": {
+    "type": 250,
+    "data": {
+      "content": "<p>Listed and permission needed path</p>"
+    }
+  }
+}


### PR DESCRIPTION
see conversation here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1671546721333969

based on flow here: https://editor.planx.uk/testing/flag-order-test-with-autoanswer 

first test is a happy path and expected behavior, second fails on production so is still skipped with a clear TODO at the line that we'd expect to pass when we fix filters.