### PR TITLE
feat: Setup alt theme behind feature flag

### DIFF
--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,8 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["DISABLE_SAVE_AND_RETURN"] as const;
+const AVAILABLE_FEATURE_FLAGS = [
+  "DISABLE_SAVE_AND_RETURN",
+  "ALT_THEME",
+] as const;
 
 type featureFlag = typeof AVAILABLE_FEATURE_FLAGS[number];
 

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -9,6 +9,7 @@ import createPalette, {
   PaletteOptions,
 } from "@mui/material/styles/createPalette";
 import { deepmerge } from "@mui/utils";
+import { hasFeatureFlag } from "lib/featureFlags";
 
 const GOVUK_YELLOW = "#FFDD00";
 
@@ -226,11 +227,23 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
   return themeOptions;
 };
 
+const getAltThemeOptions = (primaryColor: string): ThemeOptions => {
+  const themeOptions = getThemeOptions(primaryColor);
+  const altThemeOptions: ThemeOptions = {
+    typography: {
+      fontFamily: "Arial",
+    },
+  };
+  return deepmerge(themeOptions, altThemeOptions);
+};
+
 // Generate a MUI theme based on a team's primary color
 const generateTeamTheme = (
   primaryColor: string = DEFAULT_PRIMARY_COLOR
 ): Theme => {
-  const themeOptions = getThemeOptions(primaryColor);
+  const themeOptions = hasFeatureFlag("ALT_THEME")
+    ? getAltThemeOptions(primaryColor)
+    : getThemeOptions(primaryColor);
   const theme = responsiveFontSizes(createTheme(themeOptions));
   return theme;
 };


### PR DESCRIPTION
This PR sets up an alternate theme which can be toggled using the `ALT_THEME` feature flag. This will allow @ianjon3s to work on theming in relative isolation.