### PR TITLE
fix: populate flow name in "Submission" email template and mark associated session as submitted

### DIFF
--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -3,6 +3,7 @@ import { stringify } from "csv-stringify";
 import { NextFunction, Request, Response } from "express";
 import fs from "fs";
 import { gql } from "graphql-request";
+import capitalize from "lodash/capitalize";
 import os from "os";
 import path from "path";
 
@@ -35,7 +36,7 @@ const sendToEmail = async(req: Request, res: Response, next: NextFunction) => {
       const config: EmailSubmissionNotifyConfig = {
         personalisation: {
           emailReplyToId: notify_personalisation.emailReplyToId,
-          serviceName: payload?.flowName[0]?.toUpperCase() || "PlanX",
+          serviceName: capitalize(payload?.flowName) || "PlanX",
           sessionId: payload.sessionId,
           applicantEmail: payload.email,
           downloadLink: `${process.env.API_URL_EXT}/download-application-files/${payload.sessionId}?email=${settings.sendToEmail}&localAuthority=${req.params.localAuthority}`,

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -7,7 +7,7 @@ import os from "os";
 import path from "path";
 
 import { adminGraphQLClient } from "../hasura";
-import { convertSlugToName, sendEmail } from "../saveAndReturn/utils";
+import { markSessionAsSubmitted, sendEmail } from "../saveAndReturn/utils";
 import { EmailSubmissionNotifyConfig } from "../types";
 import { generateDocumentReviewStream } from "./documentReview";
 import { deleteFile, downloadFile } from "./helpers";
@@ -35,7 +35,7 @@ const sendToEmail = async(req: Request, res: Response, next: NextFunction) => {
       const config: EmailSubmissionNotifyConfig = {
         personalisation: {
           emailReplyToId: notify_personalisation.emailReplyToId,
-          serviceName: "Test",
+          serviceName: payload?.flowName[0]?.toUpperCase() || "PlanX",
           sessionId: payload.sessionId,
           applicantEmail: payload.email,
           downloadLink: `${process.env.API_URL_EXT}/download-application-files/${payload.sessionId}?email=${settings.sendToEmail}&localAuthority=${req.params.localAuthority}`,
@@ -44,9 +44,21 @@ const sendToEmail = async(req: Request, res: Response, next: NextFunction) => {
 
       // Send the email
       const response = await sendEmail("submit", settings.sendToEmail, config);
-      return res.json(response);
+      if (response?.message === "Success") {
+        // Mark session as submitted so that reminder and expiry emails are not triggered
+        markSessionAsSubmitted(payload.sessionId);
 
-      // TODO Mark lowcal_session as submitted, create/update audit table (and setup Slack notification trigger?)
+        // TODO create audit table entry? setup event trigger for slack notification on new row?
+
+        return res.status(200).send({
+          message: `Successfully sent "Submit" email`,
+        });
+      } else {
+        return next({
+          status: 500,
+          message: `Failed to send "Submit" email: ${response?.message}`,
+        });
+      }
     } else {
       return next({
         status: 400,

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect } from "react";
+import { useCurrentRoute } from "react-navi";
 import { useAsync } from "react-use";
 
 import { useTeamSlug } from "../shared/hooks";
@@ -73,6 +74,8 @@ const SendComponent: React.FC<Props> = ({
   }
 
   // Format application user data for email
+  const route = useCurrentRoute();
+
   if (destinations.includes(Destination.Email)) {
     combinedEventsPayload[Destination.Email] = {
       localAuthority: teamSlug,
@@ -80,6 +83,7 @@ const SendComponent: React.FC<Props> = ({
         sessionId: sessionId,
         email: email,
         csv: makeCsvData(breadcrumbs, flow, passport, sessionId),
+        flowName: route?.data?.flowName,
       },
     };
   }


### PR DESCRIPTION
I expect Emily's going to be doing some testing on "Send to email" this week, so two quick tidy-ups: 
- Mark the associated lowcal_session as submitted on success to avoid any confusing expiry reminder emails later
- Populate the Planx flow name in the email template

How to test:
- Add `"sendToEmail":"<your email>"` to `team.settings` on this pizza (pick any un-assigned team for testing)
- Edit a flow within that team: make sure it has a Send component with "Email to planning office" selected and the content is published
- Submit a test application 
- Check that: you have received an email; the template shows the name of your flow without hyphens; and your lowcal_session has a `submitted_at` timestamp in Hasura