### PR TITLE
fix: make "application_type" dynamic in `getBOPSParams` for non-LDC services 

### DIFF
--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -127,17 +127,17 @@ const downloadApplicationFiles = async(req: Request, res: Response, next: NextFu
         const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
         zip.addFile("boundary.geojson", geoBuff);
 
-        const mapViewPath = path.join(tmpDir, "application.html");
-        const mapViewFile = fs.createWriteStream(mapViewPath);
-        const mapViewStream = generateDocumentReviewStream({ csv: sessionData?.csv, files: [], geojson: geojson }).pipe(mapViewFile);
+        // const mapViewPath = path.join(tmpDir, "application.html");
+        // const mapViewFile = fs.createWriteStream(mapViewPath);
+        // const mapViewStream = generateDocumentReviewStream({ csv: sessionData?.csv, files: [], geojson: geojson }).pipe(mapViewFile);
 
-        await new Promise((resolve, reject) => {
-          mapViewStream.on("error", reject);
-          mapViewStream.on("finish", resolve);
-        });
+        // await new Promise((resolve, reject) => {
+        //   mapViewStream.on("error", reject);
+        //   mapViewStream.on("finish", resolve);
+        // });
 
-        zip.addLocalFile(mapViewPath);
-        deleteFile(mapViewPath);
+        // zip.addLocalFile(mapViewPath);
+        // deleteFile(mapViewPath);
       }
 
       // Next iterate through the passport and pull out the urls of any user-uploaded files

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -121,7 +121,7 @@ const downloadApplicationFiles = async(req: Request, res: Response, next: NextFu
         deleteFile(csvPath);
       }
 
-      // If the user drew a red line boundary, add a geojson file and a html map-viewer
+      // If the user drew a red line boundary, add a geojson file and HTML to display map
       const geojson = sessionData.passport?.data?.["property.boundary.site"];
       if (geojson) {
         const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -127,9 +127,9 @@ const downloadApplicationFiles = async(req: Request, res: Response, next: NextFu
         const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
         zip.addFile("boundary.geojson", geoBuff);
 
-        const mapViewPath = path.join(tmpDir, "map.html");
+        const mapViewPath = path.join(tmpDir, "application.html");
         const mapViewFile = fs.createWriteStream(mapViewPath);
-        const mapViewStream = generateDocumentReviewStream({ geojson }).pipe(mapViewFile);
+        const mapViewStream = generateDocumentReviewStream({ csv: sessionData?.csv, files: [], geojson: geojson }).pipe(mapViewFile);
 
         await new Promise((resolve, reject) => {
           mapViewStream.on("error", reject);

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/applicationType.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/applicationType.test.ts
@@ -1,0 +1,47 @@
+import * as ReactNavi from "react-navi";
+
+import { getBOPSParams } from "..";
+
+const default_application_type = "lawfulness_certificate";
+
+describe("application_type is set correctly based on flowName", () => {
+  test("it defaults to `lawfulness_certificate` if we can't fetch current route", () => {
+    jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+      () =>
+        ({
+          data: undefined,
+        } as any)
+    );
+
+    const result = getBOPSParams({}, {}, {}, "session-123");
+    expect(result.application_type).toEqual(default_application_type);
+  });
+
+  test("it sets to `lawfulness_certificate` for LDC services", () => {
+    jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+      () =>
+        ({
+          data: {
+            flowName: "apply for a lawful development certificate",
+          },
+        } as any)
+    );
+
+    const result = getBOPSParams({}, {}, {}, "session-123");
+    expect(result.application_type).toEqual(default_application_type);
+  });
+
+  test("it sets to flowName for non-LDC services", () => {
+    jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+      () =>
+        ({
+          data: {
+            flowName: "apply for prior approval",
+          },
+        } as any)
+    );
+
+    const result = getBOPSParams({}, {}, {}, "session-123");
+    expect(result.application_type).toEqual("Apply for prior approval");
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/fileDescriptions.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/fileDescriptions.test.ts
@@ -1,8 +1,18 @@
 import { Store, vanillaStore } from "pages/FlowEditor/lib/store";
+import * as ReactNavi from "react-navi";
 
 import { getBOPSParams } from "..";
 
 const { getState, setState } = vanillaStore;
+
+jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+  () =>
+    ({
+      data: {
+        flowName: "apply for a lawful development certificate",
+      },
+    } as any)
+);
 
 // https://i.imgur.com/MsCF14s.png
 const flow: Store.flow = {

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/files.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/files.test.ts
@@ -1,8 +1,18 @@
 import { Store } from "pages/FlowEditor/lib/store";
+import * as ReactNavi from "react-navi";
 
 import { PASSPORT_UPLOAD_KEY } from "../../../DrawBoundary/model";
 import { extractTagsFromPassportKey, getBOPSParams } from "../../bops";
 import type { FileTag } from "../../model";
+
+jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+  () =>
+    ({
+      data: {
+        flowName: "apply for a lawful development certificate",
+      },
+    } as any)
+);
 
 const flow: Store.flow = {
   _root: {

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/flags.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/flags.test.ts
@@ -1,6 +1,16 @@
 import { Store } from "pages/FlowEditor/lib/store";
+import * as ReactNavi from "react-navi";
 
 import { getBOPSParams } from "..";
+
+jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+  () =>
+    ({
+      data: {
+        flowName: "apply for a lawful development certificate",
+      },
+    } as any)
+);
 
 // PlanX ALWAYS sends a flag result & optional override description (test 2)
 // to BOPS, even if (1) no flag result component is shown to the applicant,

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
@@ -1,6 +1,16 @@
 import { Store } from "pages/FlowEditor/lib/store";
+import * as ReactNavi from "react-navi";
 
 import { makePayload } from "..";
+
+jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+  () =>
+    ({
+      data: {
+        flowName: "apply for a lawful development certificate",
+      },
+    } as any)
+);
 
 const flow: Store.flow = {
   _root: {

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/userRole.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/userRole.test.ts
@@ -1,7 +1,17 @@
 import { Store } from "pages/FlowEditor/lib/store";
+import * as ReactNavi from "react-navi";
 
 import { USER_ROLES } from "../../model";
 import { getBOPSParams } from "..";
+
+jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
+  () =>
+    ({
+      data: {
+        flowName: "apply for a lawful development certificate",
+      },
+    } as any)
+);
 
 // https://i.imgur.com/KhUnUte.png
 const flow: Store.flow = {

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -232,10 +232,11 @@ export function getBOPSParams(
 ) {
   const data = {} as BOPSFullPayload;
 
-  // Default application type expected by BOPS
+  // Default application type accepted by BOPS
   data.application_type = "lawfulness_certificate";
 
   // Overwrite application type if this isn't an LDC (relies on LDC flows having consistent slug)
+  //   eg because makeCsvData which is used acrossed services calls this method
   const flowName = useCurrentRoute()?.data?.flowName;
   if (flowName && flowName !== "apply for a lawful development certificate") {
     data.application_type = capitalize(flowName);

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -5,8 +5,10 @@
 // https://southwark.preview.bops.services/api-docs/index.html
 
 import { reportError } from "airbrake";
+import capitalize from "lodash/capitalize";
 import { flatFlags } from "pages/FlowEditor/data/flags";
 import { getResultData } from "pages/FlowEditor/lib/store/preview";
+import { useCurrentRoute } from "react-navi";
 import { GovUKPayment } from "types";
 
 import { Store } from "../../../../pages/FlowEditor/lib/store";
@@ -230,8 +232,14 @@ export function getBOPSParams(
 ) {
   const data = {} as BOPSFullPayload;
 
-  // XXX: Hardcode application type for now
+  // Default application type expected by BOPS
   data.application_type = "lawfulness_certificate";
+
+  // Overwrite application type if this isn't an LDC (relies on LDC flows having consistent slug)
+  const flowName = useCurrentRoute()?.data?.flowName;
+  if (flowName && flowName !== "apply for a lawful development certificate") {
+    data.application_type = capitalize(flowName);
+  }
 
   // 1a. address
 

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -25,7 +25,7 @@ export const USER_ROLES = ["applicant", "agent", "proxy"] as const;
 // See minimum POST schema for /api/v1/planning_applications
 // https://ripa.bops.services/api-docs/index.html
 interface BOPSMinimumPayload {
-  application_type: "lawfulness_certificate";
+  application_type: "lawfulness_certificate" | string;
   site: {
     uprn: string;
     address_1: string;


### PR DESCRIPTION
Replaces hardcoded instances of `application_type = "lawfulness_certificate"` with flow name when calling this method to generate CSV's for non-LDC services. Additionally adds BOPS unit tests to confirm we set `application_type` correctly in different scenarios. 

Still essentially replacing a hardcoded instance with a different version of hardcoding/relying on a flow name, and will need to be adjusted if we send different types of applications to BOPS in the future, but makes the CSV more usable for other services (eg Prior approvals) in the shortterm.

To test:
- Make a simple flow with some questions and either a Confirmation page or Send component (so S&R is enabled)
- Open `/preview` and go through flow, click "Save and return later" or reach Confirmation page and click "Download your application (.csv)" link, ensure that the row "application_type" reflects your flow's name

This PR originally included another change to the document packet for "send to email", but that's omitted until we've sorted the `decodeURI` bug and I'll plan to adjust in a future PR. 