### PR TITLE
fix: Reinstante port 4000 on API

### DIFF
--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -14,6 +14,8 @@ RUN pnpm prune --production
 
 COPY . .
 
+EXPOSE 4000
+
 FROM node:16.13.1-alpine as production
 WORKDIR /api
 ENV NODE_ENV production


### PR DESCRIPTION
Undoes change made here - https://github.com/theopensystemslab/planx-new/pull/1323/files#diff-9fee14c6790003e5ec78ba098a0e86794e0aeaac6a5ca302dc10ad9ae9d2aae8

Currently, API endpoint which end in `next()` seem to be throwing an instant 500 since the most recent deploy.

This seems to be the only significant change in the recent deploy (#1375