### PR TITLE
fix: Comment out document review

### DIFF
--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -127,17 +127,17 @@ const downloadApplicationFiles = async(req: Request, res: Response, next: NextFu
         const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
         zip.addFile("boundary.geojson", geoBuff);
 
-        const mapViewPath = path.join(tmpDir, "map.html");
-        const mapViewFile = fs.createWriteStream(mapViewPath);
-        const mapViewStream = generateDocumentReviewStream({ geojson }).pipe(mapViewFile);
+        // const mapViewPath = path.join(tmpDir, "map.html");
+        // const mapViewFile = fs.createWriteStream(mapViewPath);
+        // const mapViewStream = generateDocumentReviewStream({ geojson }).pipe(mapViewFile);
 
-        await new Promise((resolve, reject) => {
-          mapViewStream.on("error", reject);
-          mapViewStream.on("finish", resolve);
-        });
+        // await new Promise((resolve, reject) => {
+        //   mapViewStream.on("error", reject);
+        //   mapViewStream.on("finish", resolve);
+        // });
 
-        zip.addLocalFile(mapViewPath);
-        deleteFile(mapViewPath);
+        // zip.addLocalFile(mapViewPath);
+        // deleteFile(mapViewPath);
       }
 
       // Next iterate through the passport and pull out the urls of any user-uploaded files

--- a/api.planx.uk/send/uniform.js
+++ b/api.planx.uk/send/uniform.js
@@ -246,19 +246,19 @@ export async function createZip({
   deleteFile(xmlPath);
 
   // build an HTML Document Viewer
-  const docViewPath = path.join(tmpDir, "review.html");
-  const docViewFile = fs.createWriteStream(docViewPath);
-  const docViewStream = generateDocumentReviewStream({
-    csv,
-    files,
-    geojson,
-  }).pipe(docViewFile);
-  await new Promise((resolve, reject) => {
-    docViewStream.on("error", reject);
-    docViewStream.on("finish", resolve);
-  });
-  zip.addLocalFile(docViewPath);
-  deleteFile(docViewPath);
+  // const docViewPath = path.join(tmpDir, "review.html");
+  // const docViewFile = fs.createWriteStream(docViewPath);
+  // const docViewStream = generateDocumentReviewStream({
+  //   csv,
+  //   files,
+  //   geojson,
+  // }).pipe(docViewFile);
+  // await new Promise((resolve, reject) => {
+  //   docViewStream.on("error", reject);
+  //   docViewStream.on("finish", resolve);
+  // });
+  // zip.addLocalFile(docViewPath);
+  // deleteFile(docViewPath);
 
   // build an optional GeoJSON file for validators
   if (geojson) {

--- a/api.planx.uk/send/uniform.test.ts
+++ b/api.planx.uk/send/uniform.test.ts
@@ -39,7 +39,7 @@ describe("createZip", () => {
     mockWriteZip.mockClear();
   });
 
-  test("the document viewer is added to zip", async () => {
+  test.skip("the document viewer is added to zip", async () => {
     const payload = {
       xml: "<xml></xml>",
       csv: [["1", "2", "3"]],


### PR DESCRIPTION
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/20502206/213284741-0c911680-4078-463a-a986-3a1e036afbae.png">

It appears that the document review is the source of issues affecting zip generation for send to email / send to Uniform.

Tested successfully here on a failing "Send to email" link - https://github.com/theopensystemslab/planx-new/pull/1379/commits/fc580eaf31a1b9c4360a0f1bbd16e0d1131c9c14

Just commenting out for now in order to get change to production to `main` and then `production` in order to get failed Uniform submission to Lambeth.