### PR TITLE
chore: Reinstate document review

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-document-review": "git://github.com/theopensystemslab/planx-document-review.git#v1.1.1",
+    "@opensystemslab/planx-document-review": "git://github.com/theopensystemslab/planx-document-review.git#v1.1.2",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",
     "axios": "^0.27.2",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-document-review': git://github.com/theopensystemslab/planx-document-review.git#v1.1.1
+  '@opensystemslab/planx-document-review': git://github.com/theopensystemslab/planx-document-review.git#v1.1.2
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
   '@types/cookie-parser': ^1.4.3
@@ -85,7 +85,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-document-review': github.com/theopensystemslab/planx-document-review/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11_jzv7rnwsgseitriorngd2zrk2i
+  '@opensystemslab/planx-document-review': github.com/theopensystemslab/planx-document-review/e79e00325c8bf3e3c6e9f06c89e028a670982591_jzv7rnwsgseitriorngd2zrk2i
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
   axios: 0.27.2
@@ -7864,11 +7864,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/theopensystemslab/planx-document-review/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11_jzv7rnwsgseitriorngd2zrk2i:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-review/tar.gz/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11}
-    id: github.com/theopensystemslab/planx-document-review/32bb1aaf556b27ef49d48f49ef828e3bf63d7b11
+  github.com/theopensystemslab/planx-document-review/e79e00325c8bf3e3c6e9f06c89e028a670982591_jzv7rnwsgseitriorngd2zrk2i:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-review/tar.gz/e79e00325c8bf3e3c6e9f06c89e028a670982591}
+    id: github.com/theopensystemslab/planx-document-review/e79e00325c8bf3e3c6e9f06c89e028a670982591
     name: '@opensystemslab/planx-document-review'
-    version: 1.1.1
+    version: 1.1.2
     engines: {node: ^16, pnpm: ^7.8.0}
     dependencies:
       '@emotion/react': 11.10.5_vxtkgrldwlig4u66iz5soeq2cu

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -127,17 +127,17 @@ const downloadApplicationFiles = async(req: Request, res: Response, next: NextFu
         const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
         zip.addFile("boundary.geojson", geoBuff);
 
-        // const mapViewPath = path.join(tmpDir, "map.html");
-        // const mapViewFile = fs.createWriteStream(mapViewPath);
-        // const mapViewStream = generateDocumentReviewStream({ geojson }).pipe(mapViewFile);
+        const mapViewPath = path.join(tmpDir, "map.html");
+        const mapViewFile = fs.createWriteStream(mapViewPath);
+        const mapViewStream = generateDocumentReviewStream({ geojson }).pipe(mapViewFile);
 
-        // await new Promise((resolve, reject) => {
-        //   mapViewStream.on("error", reject);
-        //   mapViewStream.on("finish", resolve);
-        // });
+        await new Promise((resolve, reject) => {
+          mapViewStream.on("error", reject);
+          mapViewStream.on("finish", resolve);
+        });
 
-        // zip.addLocalFile(mapViewPath);
-        // deleteFile(mapViewPath);
+        zip.addLocalFile(mapViewPath);
+        deleteFile(mapViewPath);
       }
 
       // Next iterate through the passport and pull out the urls of any user-uploaded files

--- a/api.planx.uk/send/uniform.js
+++ b/api.planx.uk/send/uniform.js
@@ -246,19 +246,19 @@ export async function createZip({
   deleteFile(xmlPath);
 
   // build an HTML Document Viewer
-  // const docViewPath = path.join(tmpDir, "review.html");
-  // const docViewFile = fs.createWriteStream(docViewPath);
-  // const docViewStream = generateDocumentReviewStream({
-  //   csv,
-  //   files,
-  //   geojson,
-  // }).pipe(docViewFile);
-  // await new Promise((resolve, reject) => {
-  //   docViewStream.on("error", reject);
-  //   docViewStream.on("finish", resolve);
-  // });
-  // zip.addLocalFile(docViewPath);
-  // deleteFile(docViewPath);
+  const docViewPath = path.join(tmpDir, "review.html");
+  const docViewFile = fs.createWriteStream(docViewPath);
+  const docViewStream = generateDocumentReviewStream({
+    csv,
+    files,
+    geojson,
+  }).pipe(docViewFile);
+  await new Promise((resolve, reject) => {
+    docViewStream.on("error", reject);
+    docViewStream.on("finish", resolve);
+  });
+  zip.addLocalFile(docViewPath);
+  deleteFile(docViewPath);
 
   // build an optional GeoJSON file for validators
   if (geojson) {

--- a/api.planx.uk/send/uniform.test.ts
+++ b/api.planx.uk/send/uniform.test.ts
@@ -39,7 +39,7 @@ describe("createZip", () => {
     mockWriteZip.mockClear();
   });
 
-  test.skip("the document viewer is added to zip", async () => {
+  test("the document viewer is added to zip", async () => {
     const payload = {
       xml: "<xml></xml>",
       csv: [["1", "2", "3"]],


### PR DESCRIPTION
This undoes the temporary changes made in #1383 and bumps the document review library to v1.1.2 which should resolve the issues previously described.