### PR TITLE
chore: upgrade to @opensystemslab/map v0.7.0 and update geojson change handler

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/material": "^5.10.5",
     "@mui/styles": "^5.10.3",
     "@mui/utils": "^5.10.3",
-    "@opensystemslab/map": "^0.6.3",
+    "@opensystemslab/map": "^0.7.0",
     "@tiptap/core": "2.0.0-beta.204",
     "@tiptap/extension-bold": "2.0.0-beta.204",
     "@tiptap/extension-bubble-menu": "2.0.0-beta.204",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -59,7 +59,7 @@ specifiers:
   '@mui/material': ^5.10.5
   '@mui/styles': ^5.10.3
   '@mui/utils': ^5.10.3
-  '@opensystemslab/map': ^0.6.3
+  '@opensystemslab/map': ^0.7.0
   '@react-theming/storybook-addon': ^1.1.7
   '@storybook/addon-actions': ^6.5.10
   '@storybook/addon-essentials': ^6.5.10
@@ -198,7 +198,7 @@ dependencies:
   '@mui/material': 5.10.6_vbxcdxy3bftsefaguotlgalomu
   '@mui/styles': 5.10.6_7v64pk2mkrohwh22gx7lrz5ive
   '@mui/utils': 5.10.6_react@18.2.0
-  '@opensystemslab/map': 0.6.3
+  '@opensystemslab/map': 0.7.0
   '@tiptap/core': 2.0.0-beta.204
   '@tiptap/extension-bold': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
   '@tiptap/extension-bubble-menu': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
@@ -311,7 +311,7 @@ devDependencies:
   esbuild: 0.14.54
   esbuild-jest: 0.5.0_esbuild@0.14.54
   eslint: 8.29.0
-  eslint-plugin-jest: 27.1.6_kkv2tsnmg5we6ee3ny4vbvytka
+  eslint-plugin-jest: 27.1.6_ixh6nceclvqov4hcu5gszby2fi
   eslint-plugin-jsx-a11y: 6.6.1_eslint@8.29.0
   eslint-plugin-simple-import-sort: 7.0.0_eslint@8.29.0
   eslint-plugin-testing-library: 5.6.0_ixh6nceclvqov4hcu5gszby2fi
@@ -3085,8 +3085,8 @@ packages:
       mkdirp: 1.0.4
     dev: true
 
-  /@opensystemslab/map/0.6.3:
-    resolution: {integrity: sha512-wHb75VMtM0rD2pRxfTs+J9vxCDjUSWpu2uZpCeuNSDVWosCloFpSq7SRLaO9h32sFEpmF7MaW+x72ZAVjAtPCA==}
+  /@opensystemslab/map/0.7.0:
+    resolution: {integrity: sha512-Tm3qkuATRPUk1kTWr6nTzIKwTTg/BFBiHXLgd38bEHZ9GdkIZL2jQDaBno2s3636towsNHAymRdg3benK9dLzg==}
     engines: {node: ^16, pnpm: ^7.8.0}
     dependencies:
       '@turf/union': 6.5.0
@@ -9373,7 +9373,7 @@ packages:
       - supports-color
       - typescript
 
-  /eslint-plugin-jest/27.1.6_kkv2tsnmg5we6ee3ny4vbvytka:
+  /eslint-plugin-jest/27.1.6_ixh6nceclvqov4hcu5gszby2fi:
     resolution: {integrity: sha512-XA7RFLSrlQF9IGtAmhddkUkBuICCTuryfOTfCSWcZHiHb69OilIH05oozH2XA6CEOtztnOd0vgXyvxZodkxGjg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -9388,7 +9388,6 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.36.1_ixh6nceclvqov4hcu5gszby2fi
       eslint: 8.29.0
-      jest: 27.4.5
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -92,9 +92,9 @@ export default function Component(props: Props) {
     };
 
     const geojsonChangeHandler = ({ detail: geojson }: any) => {
-      if (geojson.features) {
+      if (geojson["EPSG:3857"]?.features) {
         // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
-        setBoundary(geojson.features[0]);
+        setBoundary(geojson["EPSG:3857"].features[0]);
       } else {
         // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined
         setBoundary(undefined);


### PR DESCRIPTION
context https://github.com/theopensystemslab/map/pull/255

no changes to our passport data, this just reflects the new event data structure and continues to store `property.boundary.site` geojson in EPSG:3857