### PR TITLE
chore: Remove exposure of port 4000 from Dockerfiles

### DIFF
--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -14,8 +14,6 @@ RUN pnpm prune --production
 
 COPY . .
 
-EXPOSE 4000
-
 FROM node:16.13.1-alpine as production
 WORKDIR /api
 ENV NODE_ENV production

--- a/sharedb.planx.uk/Dockerfile
+++ b/sharedb.planx.uk/Dockerfile
@@ -4,7 +4,6 @@ FROM node:16.13.1-alpine as base
 WORKDIR /sharedb
 RUN npm install -g pnpm@7.8.0
 COPY pnpm-lock.yaml .
-EXPOSE 4000
 
 FROM base as production
 ENV NODE_ENV production


### PR DESCRIPTION
Originally spotted by @builditben here - https://github.com/theopensystemslab/planx-new/pull/1323/files#diff-9fee14c6790003e5ec78ba098a0e86794e0aeaac6a5ca302dc10ad9ae9d2aae8

Reinstated in #1380 as a poor attempt at troubleshooting API issues...!

Everything works fine locally without this, and there's not other references to port 4000 in the codebase.