### PR TITLE
fix: Correctly rename queries for ReconciliationRequests

### DIFF
--- a/api.planx.uk/webhooks/sanitiseApplicationData/mocks/queries.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/mocks/queries.ts
@@ -42,11 +42,11 @@ export const mockSanitiseBOPSApplicationsMutation = {
   },
 };
 
-export const mockSanitiseReconciliationRequestsMutation = {
-  name: "SanitiseReconciliationRequests",
+export const mockDeleteReconciliationRequestsMutation = {
+  name: "DeleteReconciliationRequests",
   matchOnVariables: false,
   data: {
-    update_reconciliation_requests: {
+    delete_reconciliation_requests: {
       returning: mockIds,
     }
   },

--- a/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
@@ -4,7 +4,7 @@ import {
   mockIds,
   mockSanitiseBOPSApplicationsMutation,
   mockSanitiseLowcalSessionsMutation,
-  mockSanitiseReconciliationRequestsMutation,
+  mockDeleteReconciliationRequestsMutation,
   mockSanitiseSessionBackupsMutation,
   mockSanitiseUniformApplicationsMutation,
 } from "./mocks/queries";
@@ -14,7 +14,7 @@ import {
   operationHandler,
   sanitiseBOPSApplications,
   sanitiseLowcalSessions,
-  sanitiseReconciliationRequests,
+  deleteReconciliationRequests,
   sanitiseSessionBackups,
   sanitiseUniformApplications,
 } from "./operations";
@@ -76,8 +76,8 @@ describe("Data sanitation operations", () => {
         query: mockSanitiseBOPSApplicationsMutation,
       },
       {
-        operation: sanitiseReconciliationRequests,
-        query: mockSanitiseReconciliationRequestsMutation,
+        operation: deleteReconciliationRequests,
+        query: mockDeleteReconciliationRequestsMutation,
       },
     ];
 

--- a/api.planx.uk/webhooks/sanitiseApplicationData/operations.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/operations.ts
@@ -20,7 +20,7 @@ export const getRetentionPeriod = () => subMonths(new Date(), RETENTION_PERIOD_M
   sanitiseSessionBackups,
   sanitiseUniformApplications,
   sanitiseBOPSApplications,
-  sanitiseReconciliationRequests,
+  deleteReconciliationRequests,
 
   // Event logs
   deleteHasuraEventLogs,
@@ -167,9 +167,9 @@ export const sanitiseBOPSApplications: Operation = async () => {
   return result;
 };
 
-export const sanitiseReconciliationRequests: Operation = async () => {
+export const deleteReconciliationRequests: Operation = async () => {
   const mutation = gql`
-    mutation SanitiseReconciliationRequests($retentionPeriod: timestamptz) {
+    mutation DeleteReconciliationRequests($retentionPeriod: timestamptz) {
       delete_reconciliation_requests(
         where: {
           created_at: { _lt: $retentionPeriod }
@@ -181,7 +181,7 @@ export const sanitiseReconciliationRequests: Operation = async () => {
       } 
     }
   `;
-  const { update_reconciliation_requests: {
+  const { delete_reconciliation_requests: {
     returning: result
   } } = await adminGraphQLClient.request(
     mutation,


### PR DESCRIPTION
**Problem**
Since merging https://github.com/theopensystemslab/planx-new/pull/1325 the `sanitiseReconciliationRequests` operation has been failing. This can be seen in the Hasura logs on `.dev` and Slack errors in the `#planx-notifications-internal` channel.

**Cause**
This is caused by refactoring `sanitiseReconciliationRequests` to delete instead of sanitising, without properly updating how the request was being destructured.

**Solution**
Update queries and variables to better reflect what's happening here - `sanitiseReconciliationRequests` consistently becomes `deleteReconciliationRequests`, and queries are updated accordingly.