### PR TITLE
fix: Data sanitation cronjob environment

### DIFF
--- a/api.planx.uk/helpers.test.ts
+++ b/api.planx.uk/helpers.test.ts
@@ -1,0 +1,34 @@
+import { getEnvironment } from "./helpers";
+
+describe("getEnvironment function", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("Production env", () => {
+    process.env.API_URL_EXT = "https://api.editor.planx.uk/"
+    expect(getEnvironment()).toBe("Production");
+  });
+  
+  test("Staging env", () => {
+    process.env.API_URL_EXT = "https://api.editor.planx.dev/"
+    expect(getEnvironment()).toBe("Staging");
+  });
+
+  test("Pizza env", () => {
+    process.env.API_URL_EXT = "https://api.123.planx.pizza/"
+    expect(getEnvironment()).toBe("Pizza 123");
+  });
+
+  test("Development env", () => {
+    process.env.API_URL_EXT = "localhost:7002"
+    expect(getEnvironment()).toBe("Development");
+  });
+})

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { gql } from 'graphql-request';
 import { adminGraphQLClient } from "./hasura";
 import { Flow, Node } from "./types";
@@ -189,6 +190,14 @@ const makeUniqueFlow = (flowData: Flow["data"], replaceValue: string): Flow["dat
   return flowData;
 };
 
+const getEnvironment = (): string | void => {
+  const url = new URL(process.env.API_URL_EXT!);
+  if (url.hostname.endsWith(".uk")) return "Production"
+  if (url.hostname.endsWith(".dev")) return "Staging"
+  if (url.hostname.endsWith(".pizza")) return `Pizza ${url.href.split(".")[1]}`
+  if (url.href.includes("localhost")) return "Development"
+};
+
 export {
   getFlowData,
   getMostRecentPublishedFlow,
@@ -197,4 +206,5 @@ export {
   getChildren,
   makeUniqueFlow,
   insertFlow,
+  getEnvironment,
 };

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -190,7 +190,7 @@ const makeUniqueFlow = (flowData: Flow["data"], replaceValue: string): Flow["dat
   return flowData;
 };
 
-const getEnvironment = (): string | void => {
+const getEnvironment = (): string | undefined => {
   const url = new URL(process.env.API_URL_EXT!);
   if (url.hostname.endsWith(".uk")) return "Production"
   if (url.hostname.endsWith(".dev")) return "Staging"

--- a/api.planx.uk/webhooks/sanitiseApplicationData/index.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/index.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from "express";
 
 import { getOperations, operationHandler } from "./operations";
 import { OperationResult } from "./types";
+import { getEnvironment } from '../../helpers';
 
 /**
  * Called by Hasura cron job `sanitise_application_data` on a nightly basis
@@ -39,11 +40,10 @@ const postToSlack = async (results: OperationResult[]) => {
   const text = results.map(result => result.status === "failure" 
     ? `:x: ${result.operationName} failed. Error: ${result.errorMessage}` 
     : `:white_check_mark: ${result.operationName} succeeded`)
-  const environment = process.env.NODE_ENV;
 
   await slack.send({
     channel: "#planx-notifications-internal",
     text: text.join("\n"),
-    username: `Data Sanitation Cron Job (${environment})`
+    username: `Data Sanitation Cron Job (${getEnvironment()})`
   });
 };

--- a/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -3,11 +3,6 @@
   schedule: 0 2 * * *
   include_in_metadata: true
   payload: {}
-  retry_conf:
-    num_retries: 3
-    timeout_seconds: 60
-    tolerance_seconds: 21600
-    retry_interval_seconds: 10
   headers:
     - name: authorization
       value_from_env: HASURA_PLANX_API_KEY


### PR DESCRIPTION
## What does this PR do?
 - Correctly set the environment for Slack notifications
 - Drop cronjob retries - a single failure and notification in Slack should be fine

**Comments**
I think a better way forward here in the short / medium term is probably to meaningfully set `process.env.NODE_ENV` to one of Production / Staging / Pizza / Development - I think this has come up before. I've added it to the agenda for the dev call tomorrow 👍 