### PR TITLE
fix: add new column `teams.submission_email` so we can safely sync `teams.settings` across environments

### DIFF
--- a/api.planx.uk/send/email.test.ts
+++ b/api.planx.uk/send/email.test.ts
@@ -5,10 +5,10 @@ import app from "../server";
 describe(`sending an application by email to a planning office`, () => {
   beforeEach(() => {
     queryMock.mockQuery({
-      name: "getTeamSettings",
+      name: "getTeamEmailSettings",
       matchOnVariables: false,
       data: {
-        teams: [{ settings: { "sendToEmail": "planners@southwark.gov.uk" } }]
+        teams: [{ submission_email: "planners@southwark.gov.uk" }]
       },
       variables: { slug: "southwark" },
     });
@@ -65,7 +65,7 @@ describe(`sending an application by email to a planning office`, () => {
       });
   });
 
-  it.skip("errors if this team does not have a 'sendToEmail' configured in teams.settings", async () => {      
+  it.skip("errors if this team does not have a 'submission_email' configured in teams", async () => {      
     await supertest(app)
       .post("/email-submission/other-council")
       .set({ Authorization: process.env.HASURA_PLANX_API_KEY })
@@ -82,10 +82,10 @@ describe(`sending an application by email to a planning office`, () => {
 describe(`downloading application data received by email`, () => {
   beforeEach(() => {
     queryMock.mockQuery({
-      name: "GetTeamSettings",
+      name: "GetTeamEmailSettings",
       matchOnVariables: false,
       data: {
-        teams: [{ settings: { "sendToEmail": "planners@southwark.gov.uk" } }]
+        teams: [{ submission_email: "planners@southwark.gov.uk" }]
       },
       variables: { slug: "southwark" },
     });

--- a/hasura.planx.uk/migrations/1674571117161_alter_table_public_teams_add_column_submission_email/down.sql
+++ b/hasura.planx.uk/migrations/1674571117161_alter_table_public_teams_add_column_submission_email/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."teams" drop column "submission_email" cascade;

--- a/hasura.planx.uk/migrations/1674571117161_alter_table_public_teams_add_column_submission_email/up.sql
+++ b/hasura.planx.uk/migrations/1674571117161_alter_table_public_teams_add_column_submission_email/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."teams" add column "submission_email" text null;
+comment on column "public"."teams"."submission_email" is E'Referenced by Send component when configured to email planning office';

--- a/scripts/seed-database/upsert-production-flows.js
+++ b/scripts/seed-database/upsert-production-flows.js
@@ -74,6 +74,7 @@ const LOCAL_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
           name
           slug
           theme
+          settings
           notify_personalisation
         }
       }


### PR DESCRIPTION
Better solution to quick bug fix last week #1390 &larr; full context in this PR

When merged to production, I'll manually migrate the handful of values in `teams` table to populate `submission_email` and remove `settings.sendToEmail` so that prior approval/send to email testing is uninterrupted.

