### PR TITLE
fix: adjust error messages to align with content guide

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -13,11 +13,11 @@ export type Address = {
 };
 
 export const userDataSchema: SchemaOf<Address> = object({
-  line1: string().required("Address line 1 is required"),
+  line1: string().required("Enter the first line of an address"),
   line2: string(),
-  town: string().required("Town is required"),
+  town: string().required("Enter a town"),
   county: string(),
-  postcode: string().required("Postcode is required"),
+  postcode: string().required("Enter a postcode"),
   country: string(),
 });
 

--- a/editor.planx.uk/src/@planx/components/ContactInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/ContactInput/model.ts
@@ -14,11 +14,15 @@ export type Contact = {
 
 export const userDataSchema: SchemaOf<Contact> = object({
   title: string(),
-  firstName: string().required("First name is required"),
-  lastName: string().required("Last name is required"),
+  firstName: string().required("Enter a first name"),
+  lastName: string().required("Enter a last name"),
   organisation: string(),
-  phone: string().required("Phone number is required"),
-  email: string().email("Enter a valid email").required("Email is required"),
+  phone: string().required("Enter a phone number"),
+  email: string()
+    .email(
+      "Enter an email address in the correct format, like name@example.com"
+    )
+    .required("Enter an email address"),
 });
 
 export interface ContactInput extends MoreInformation {

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -31,7 +31,7 @@ export const userDataSchema = (type?: TextInputType): SchemaOf<UserData> =>
           return "Your answer must be 250 characters or fewer.";
         }
         if (type === TextInputType.Email) {
-          return "Enter a valid email.";
+          return "Enter an email address in the correct format, like name@example.com";
         }
         if (type === TextInputType.Phone) {
           return "Enter a valid phone number.";


### PR DESCRIPTION
Alice flagged `ContactInput` directly, quickly updated other similar offenders that I found too to match

See "Error messages" section of content guide here: https://www.notion.so/30313a55fc5b4499846e32e88b1cf76a#f4b90732e686447d9c36ab137908876f