### PR TITLE
feat: Display env details in Slack notifications

### DIFF
--- a/api.planx.uk/helpers.test.ts
+++ b/api.planx.uk/helpers.test.ts
@@ -1,0 +1,34 @@
+import { getFormattedEnvironment } from "./helpers";
+
+describe("getEnvironment function", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("Production env", () => {
+    process.env.NODE_ENV = "production";
+    expect(getFormattedEnvironment()).toBe("Production");
+  });
+
+  test("Staging env", () => {
+    process.env.NODE_ENV = "staging";
+    expect(getFormattedEnvironment()).toBe("Staging");
+  });
+
+  test("Pizza env", () => {
+    process.env.NODE_ENV = "pizza";
+    process.env.API_URL_EXT = "https://api.123.planx.pizza/";
+    expect(getFormattedEnvironment()).toBe("Pizza 123");
+  });
+
+  test("Development env", () => {
+    process.env.NODE_ENV = "development";
+    expect(getFormattedEnvironment()).toBe("Development");
+  });
+})

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -1,4 +1,5 @@
 import { gql } from 'graphql-request';
+import { capitalize } from 'lodash';
 import { adminGraphQLClient } from "./hasura";
 import { Flow, Node } from "./types";
 
@@ -190,6 +191,17 @@ const makeUniqueFlow = (flowData: Flow["data"], replaceValue: string): Flow["dat
 };
 
 const isLiveEnv = () => (["production", "staging", "pizza"].includes(process.env.NODE_ENV || ""));
+/**
+ * Get current environment, formatted for display
+ */
+const getFormattedEnvironment = (): string => {
+  let environment = process.env.NODE_ENV;
+  if (environment === "pizza") {
+    const pizzaNumber = new URL(process.env.API_URL_EXT!).href.split(".")[1]
+    environment += ` ${pizzaNumber}`
+  };
+  return capitalize(environment);
+};
 
 export {
   getFlowData,
@@ -200,4 +212,5 @@ export {
   makeUniqueFlow,
   insertFlow,
   isLiveEnv,
+  getFormattedEnvironment,
 };

--- a/api.planx.uk/webhooks/sanitiseApplicationData/index.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/index.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from "express";
 
 import { getOperations, operationHandler } from "./operations";
 import { OperationResult } from "./types";
+import { getFormattedEnvironment } from '../../helpers';
 
 /**
  * Called by Hasura cron job `sanitise_application_data` on a nightly basis
@@ -39,11 +40,11 @@ const postToSlack = async (results: OperationResult[]) => {
   const text = results.map(result => result.status === "failure" 
     ? `:x: ${result.operationName} failed. Error: ${result.errorMessage}` 
     : `:white_check_mark: ${result.operationName} succeeded`)
-  const environment = process.env.NODE_ENV;
+  const env = getFormattedEnvironment();
 
   await slack.send({
     channel: "#planx-notifications-internal",
     text: text.join("\n"),
-    username: `Data Sanitation Cron Job (${environment})`
+    username: `Data Sanitation Cron Job (${env})`
   });
 };


### PR DESCRIPTION
Branches from #1412 which should be merged first.

Resolves issue of data sanitation Slack messages logging out to `#planx-notifications-internal` without the proper context.