### PR TITLE
fix: glitch in description button

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useWindowSize } from "react-use";
 
 import ButtonBase, { Props as ButtonProps } from "./ButtonBase";
@@ -14,20 +14,24 @@ export interface Props extends ButtonProps {
 
 export default function DescriptionButton(props: Props) {
   const { title, description } = props;
+  const [buttonWidth, setButtonWidth] = useState(0);
   const buttonRef = useRef<HTMLDivElement>();
   // rerender component on windowSize change
   useWindowSize();
 
+  useEffect(() => {
+    setButtonWidth(buttonRef.current?.offsetWidth || 0);
+  });
+
   return (
     <ButtonBase {...props}>
       <Box
-        // @ts-ignore-next-line - material ui did not include `ref` to the types definition
         ref={buttonRef}
         display="flex"
         flexDirection="column"
         alignItems="flex-start"
         height="100%"
-        minHeight={buttonRef.current?.offsetWidth}
+        minHeight={buttonWidth}
         width="100%"
         position="relative"
         p={2}

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/DescriptionButton.tsx
@@ -17,11 +17,11 @@ export default function DescriptionButton(props: Props) {
   const [buttonWidth, setButtonWidth] = useState(0);
   const buttonRef = useRef<HTMLDivElement>();
   // rerender component on windowSize change
-  useWindowSize();
+  const { height, width } = useWindowSize();
 
   useEffect(() => {
     setButtonWidth(buttonRef.current?.offsetWidth || 0);
-  });
+  }, [height, width]);
 
   return (
     <ButtonBase {...props}>


### PR DESCRIPTION
# Before

![gif](https://trello.com/1/cards/638a6a24b22aa9010184b891/attachments/638a6a69e399f600c9de7183/download/glitch.gif)

# After

![216468846-8c81debd-8292-4a40-84b4-ffd225a0627e](https://user-images.githubusercontent.com/7684574/216662849-9a0d17ce-f3a0-4f05-ab28-327dde8ec26f.gif)
