### PR TITLE
feat: Session XML endpoint

### DIFF
--- a/api.planx.uk/admin/session/oneAppXML.test.ts
+++ b/api.planx.uk/admin/session/oneAppXML.test.ts
@@ -5,7 +5,7 @@ import { authHeader } from "../../tests/mockJWT";
 
 const endpoint = (strings: TemplateStringsArray) => `/admin/session/${strings[0]}/xml`;
 
-describe("Download feedback CSV endpoint", () => {
+describe("OneApp XML endpoint", () => {
   beforeEach(() => {
     queryMock.mockQuery({
       name: "GetUniformApplicationBySessionID",

--- a/api.planx.uk/admin/session/oneAppXML.test.ts
+++ b/api.planx.uk/admin/session/oneAppXML.test.ts
@@ -1,0 +1,62 @@
+import supertest from "supertest";
+import app from "../../server";
+import { queryMock } from "../../tests/graphqlQueryMock";
+import { authHeader } from "../../tests/mockJWT";
+
+const endpoint = (strings: TemplateStringsArray) => `/admin/session/${strings[0]}/xml`;
+
+describe("Download feedback CSV endpoint", () => {
+  beforeEach(() => {
+    queryMock.mockQuery({
+      name: "GetUniformApplicationBySessionID",
+      variables: {
+        submission_reference: "abc123",
+      },
+      data: {
+        uniform_applications: [
+          { payload: "<dummy:xml></dummy:xml>"}
+        ]
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetUniformApplicationBySessionID",
+      variables: {
+        submission_reference: "xyz789",
+      },
+      data: {
+        uniform_applications: []
+      },
+    });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("requires a user to be logged in", async () => {
+    await supertest(app)
+      .get(endpoint`abc123`)
+      .expect(401)
+      .then(res => expect(res.body).toEqual({
+        error: "No authorization token was found",
+      }));
+  });
+
+  it("returns an error if sessionID is invalid", async () => {
+    await supertest(app)
+      .get(endpoint`xyz789`)
+      .set(authHeader())
+      .expect(500)
+      .then(res => expect(res.body.error).toMatch(/Invalid sessionID/));
+  });
+
+  it("returns XML", async () => {
+    await supertest(app)
+      .get(endpoint`abc123`)
+      .set(authHeader())
+      .expect(200)
+      .expect("content-type", "text/xml; charset=utf-8")
+      .then(res => {
+        expect(res.text).toBe("<dummy:xml></dummy:xml>")
+      })
+  });
+});

--- a/api.planx.uk/admin/session/oneAppXML.ts
+++ b/api.planx.uk/admin/session/oneAppXML.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-request";
 import { Request, Response, NextFunction } from "express";
-import { adminGraphQLClient } from "../../hasura";
+import { adminGraphQLClient as client } from "../../hasura"
 
 export const getOneAppXML = async (
   req: Request,
@@ -18,7 +18,6 @@ export const getOneAppXML = async (
 
 const fetchSessionXML = async (sessionId: string) => {
   try {
-    const client = adminGraphQLClient;
     const query = gql`
       query GetUniformApplicationBySessionID($submission_reference: String) {
         uniform_applications(

--- a/api.planx.uk/admin/session/oneAppXML.ts
+++ b/api.planx.uk/admin/session/oneAppXML.ts
@@ -1,0 +1,42 @@
+import { gql } from "graphql-request";
+import { Request, Response, NextFunction } from "express";
+import { adminGraphQLClient } from "../../hasura";
+
+export const getOneAppXML = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const xml = await fetchSessionXML(req.params.sessionId);
+    res.set("content-type", "text/xml")
+    return res.send(xml)
+  } catch (error) {
+    return next({ message: "Failed to get OneApp XML: " + (error as Error).message });
+  }
+};
+
+const fetchSessionXML = async (sessionId: string) => {
+  try {
+    const client = adminGraphQLClient;
+    const query = gql`
+      query GetUniformApplicationBySessionID($submission_reference: String) {
+        uniform_applications(
+          where: { submission_reference: { _eq: $submission_reference } }
+        ) {
+          payload(path: "xml")
+        }
+      }
+    `;
+    const { uniform_applications } = await client.request(
+      query, 
+      { submission_reference: sessionId }
+    );
+
+    if (!uniform_applications?.length) throw Error("Invalid sessionID");
+
+    return uniform_applications[0].payload;
+} catch (error) {
+    throw Error("Unable to fetch session XML: " + (error as Error).message);
+  }
+};

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -61,6 +61,7 @@ import { downloadFeedbackCSV } from "./admin/feedback/downloadFeedbackCSV";
 import { sanitiseApplicationData } from "./webhooks/sanitiseApplicationData";
 import { isLiveEnv } from "./helpers";
 import { logPaymentStatus } from "./send/helpers";
+import { getOneAppXML } from "./admin/session/oneAppXML";
 
 const router = express.Router();
 
@@ -476,7 +477,9 @@ app.get("/", (_req, res) => {
   res.json({ hello: "world" });
 });
 
-app.get("/admin/feedback", useJWT, downloadFeedbackCSV);
+app.use("/admin", useJWT)
+app.get("/admin/feedback", downloadFeedbackCSV);
+app.get("/admin/session/:sessionId/xml", getOneAppXML);
 
 // XXX: leaving this in temporarily as a testing endpoint to ensure it
 //      works correctly in staging and production


### PR DESCRIPTION
Wish I'd done this sooner...!

This takes away the pain and time of getting a Uniform submission XML from Hasura, formatting it, and checking it out.

We could add an explicit validation check here, but the browser will generally show this if there's an issue. If it's something we hit often we can add it in to get errors which are more nicely formatted. Theoretically, as we're using a library to build the XML this shouldn't really be an issue.

Example url (must be logged in) - https://api.1424.planx.pizza/admin/session/dummy_submission_ref_123/xml