### PR TITLE
fix: Update getAddressForPerson() - address is required

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/UniformPayload/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/UniformPayload/model.ts
@@ -206,13 +206,7 @@ export class UniformPayload implements IUniformPayload {
 
   private getAddressForPerson = (
     person: "applicant.agent" | "applicant"
-  ): ExternalAddress | undefined => {
-    const isResident =
-      this.passport.data?.["applicant.resident"]?.[0]?.toLowerCase() === "true";
-    // Passports of resident applicants will not have an "application.address" value
-    // This must be generated from their siteAddress
-    if (person === "applicant" && isResident)
-      return this.getAddressFromSiteAddress();
+  ): ExternalAddress => {
     const address: Address = this.passport.data?.[`${person}.address`];
     if (address)
       return {
@@ -227,11 +221,14 @@ export class UniformPayload implements IUniformPayload {
           "apd:InternationalPostCode": address?.postcode,
         },
       };
+
+    // If we do not have an address for the person, derive one from the SiteAddress which will always be present
+    return this.getAddressFromSiteAddress();
   };
 
   private getAddressFromSiteAddress = (): ExternalAddress => ({
     "common:InternationalAddress": {
-      "apd:IntAddressLine": this.siteAddress.title?.split(", "),
+      "apd:IntAddressLine": this.siteAddress?.title?.split(", "),
       "apd:InternationalPostCode": this.siteAddress?.postcode,
     },
   });


### PR DESCRIPTION
# What does this PR do?
 - Ensures that `getAddressForPerson()` always returns an `ExternalAddress`
 - Due to a content bug (now fixed), it was previously possible to submit an application without an applicant address when submitted by an agent
 - This requires a site address in the passport. We'll need to revisit this assumption when an applicant has a site without an address.

This type of issue raises a whole load of questions for me about how we validate and understand passports, and how we handle this. The approach implemented here is still prone to content bugs (for example, if we don't ask for the agents address it will provide the site address).

## Why is this important?
A number of recent Uniform submissions have failed, all of which did not have an applicant address. The following message from Idox suggests that this is the cause of the issues we've been facing - 

> There is an issue where Applicant or Agent Address Details are not being passed in the appication.xml

## Context
Copied from `#planx` Slack thread - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1675676050572899

> We’ve worked under the following assumptions -
>  - If an applicant is a resident, don’t ask extra questions in PlanX
>    - Derive address from site location, pass this along to Uniform as the applicant’s address
> - If they are not resident, ask the applicant for address details in PlanX
>   - Pass `applicant.address` to Uniform as the applicant’s address
> - If we don’t have an address, that’s fine it’s not required in the OneApp schema anyway
>   - ⚠️ I’m guessing this is where the issue is with Uniform - it looks like they may require this?
>
> What I think this means in the realm of content is that -
> - We always need to know an applicant’s address
> - We probably always need to ask the `applicant.resident` question to determine this
