### PR TITLE
chore: Update `.gitignore` for VSCode devcontainers tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ hasura.planx.uk/.env.test
 /test-results/
 /playwright-report/
 /playwright/.cache/
+api.planx.uk/tmp/


### PR DESCRIPTION
After the latest update, when I'm running a dev container in VSCode a temporary json file with env secrets is now stored. 

I'll look at the setup to see why this is happening or if it's required, but this seems a sensible precaution for now.

Tactfully cropped screenshot showing file -
<img width="492" alt="image" src="https://user-images.githubusercontent.com/20502206/216999191-f3299f81-19d1-4c22-a465-476d9456228b.png">
