### PR TITLE
fix: give editors feedback on publishing errors

### DIFF
--- a/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -1,6 +1,10 @@
 import { TYPES } from "@planx/components/types";
 import { useFormik } from "formik";
 import React from "react";
+import ModalSection from "ui/ModalSection";
+import ModalSectionContent from "ui/ModalSectionContent";
+
+import { ICONS } from "../ui";
 
 interface Flow {
   id: string;
@@ -28,19 +32,33 @@ const ExternalPortalForm: React.FC<{
 
   return (
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">
-      <select
-        data-testid="flowId"
-        name="flowId"
-        value={formik.values.flowId}
-        onChange={formik.handleChange}
-      >
-        {!id && <option value="" />}
-        {flows.map((flow) => (
-          <option key={flow.id} value={flow.id}>
-            {flow.text}
-          </option>
-        ))}
-      </select>
+      <ModalSection>
+        <ModalSectionContent
+          title="External portal"
+          Icon={ICONS[TYPES.ExternalPortal]}
+        >
+          <span>
+            External portals let you reference all content from another flow
+            inline within this service. Deleting this node does NOT delete the
+            flow that it references.
+          </span>
+        </ModalSectionContent>
+        <ModalSectionContent title="Pick a flow">
+          <select
+            data-testid="flowId"
+            name="flowId"
+            value={formik.values.flowId}
+            onChange={formik.handleChange}
+          >
+            {!id && <option value="" />}
+            {flows.map((flow) => (
+              <option key={flow.id} value={flow.id}>
+                {flow.text}
+              </option>
+            ))}
+          </select>
+        </ModalSectionContent>
+      </ModalSection>
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -3,6 +3,7 @@ import CallSplit from "@mui/icons-material/CallSplit";
 import CheckBoxOutlined from "@mui/icons-material/CheckBoxOutlined";
 import CloudUpload from "@mui/icons-material/CloudUpload";
 import ContactPage from "@mui/icons-material/ContactPage";
+import CopyAll from "@mui/icons-material/CopyAll";
 import Create from "@mui/icons-material/Create";
 import Event from "@mui/icons-material/Event";
 import FunctionsIcon from "@mui/icons-material/Functions";
@@ -61,7 +62,7 @@ export const ICONS: {
   [TYPES.Confirmation]: TextFields,
   [TYPES.DateInput]: Event,
   [TYPES.DrawBoundary]: SquareFoot,
-  [TYPES.ExternalPortal]: undefined,
+  [TYPES.ExternalPortal]: CopyAll,
   [TYPES.FileUpload]: CloudUpload,
   [TYPES.Filter]: undefined,
   [TYPES.FindProperty]: SearchOutlined,

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -202,6 +202,12 @@ const PreviewBrowser: React.FC<{
                   );
                   setDialogOpen(true);
                 } catch (error) {
+                  setLastPublishedTitle(
+                    "Error checking for changes to publish"
+                  );
+                  alert(
+                    `Error checking for changes to publish. Confirm that your graph does not have any corrupted nodes and that all external portals are valid. \n${error}`
+                  );
                   console.log(error);
                 }
               }}


### PR DESCRIPTION
two quick improvements from this thread: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1675688673788069

1. Add alert on error when calling `diffFlow` to check for changes to publish. this now matches the error handling for `publishFlow`, which wasn't actually being reached if the first diff-ing for changes step failed
![Screenshot from 2023-02-06 16-17-33](https://user-images.githubusercontent.com/5132349/217011925-70e9a659-c761-4390-b7af-2f88e6063c01.png)

2. Improve editor UI for "external portals" to give more context to what's actually being edited
![Screenshot from 2023-02-06 15-56-25](https://user-images.githubusercontent.com/5132349/217012250-2d7b1e8c-c181-464f-9b3f-678614078f06.png)

before:
![Screenshot from 2023-02-06 16-18-07](https://user-images.githubusercontent.com/5132349/217012278-80221612-f758-40b1-a3c6-e3215b7e739a.png)
