### PR TITLE
fix(wip): Use pull_request.number instead of event.number

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   DOMAIN: planx.pizza
-  PULLREQUEST_ID: ${{ github.event.number }}
+  PULLREQUEST_ID: ${{ github.event.pull_request.number }}
 
 jobs:
   teardown_pizza:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,8 @@ on:
 
 env:
   DOMAIN: planx.pizza
-  FULL_DOMAIN: ${{ github.event.number }}.planx.pizza
-  PULLREQUEST_ID: ${{ github.event.number }}
+  FULL_DOMAIN: ${{ github.event.pull_request.number }}.planx.pizza
+  PULLREQUEST_ID: ${{ github.event.pull_request.number }}
   EDITOR_DIRECTORY: editor.planx.uk
   PNPM_VERSION: 7.8.0
   NODE_VERSION: 16.13.1 # 16.13.1 = LTS


### PR DESCRIPTION
#1434 has had an issue with this variable not being set - possibly because I've just been re-triggering actions? 

Just a test to see if this works - wondering if there's a chance that this explains the Vultr tear down failures also.

<img width="551" alt="image" src="https://user-images.githubusercontent.com/20502206/217559405-84e8fe1e-9658-4e9e-9f5e-6c3e415e5344.png">


<img width="674" alt="image" src="https://user-images.githubusercontent.com/20502206/217559438-ee887a7f-0836-489a-8a97-c56f2168a6e0.png">
