### PR TITLE
fix: can't proceed past checklists on production

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -657,7 +657,7 @@ export const removeOrphansFromBreadcrumbs = ({
   | Store.cachedBreadcrumbs
   | Store.breadcrumbs => {
   const idsToRemove =
-    flow[id].edges?.filter(
+    flow[id]?.edges?.filter(
       (edge) => !(userData?.answers ?? []).includes(edge)
     ) ?? [];
 


### PR DESCRIPTION
while testing property component changes on prod, I noticed that I couldn't proceed past a checklist. dev is OK - so this likely stems from a content bug somewhere? i can reproduce locally with content synced from production ~3 days ago. 

try: https://editor.planx.uk/southwark/find-out-if-you-need-planning-permission/preview?analytics=false

production console shows this on clicking "continue" & doens't proceed:
![Screenshot from 2023-02-10 10-57-14](https://user-images.githubusercontent.com/5132349/218063893-4274c859-7e48-4799-9a65-cb31c7a24906.png)

local console shows:
![Screenshot from 2023-02-10 11-00-13](https://user-images.githubusercontent.com/5132349/218063837-7a875547-a5eb-4070-a5c1-bdc6229f1a33.png)

this small type adjustment allows me to successfully click the "continue" button now, but there's likely still a corrupted node somewhere in a content graph that needs to be fixed too outside of code as well. 