### PR TITLE
fix: log corrupted node errors to Airbrake in future

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -657,7 +657,7 @@ export const removeOrphansFromBreadcrumbs = ({
   | Store.cachedBreadcrumbs
   | Store.breadcrumbs => {
   const idsToRemove =
-    flow[id].edges?.filter(
+    flow[id]?.edges?.filter(
       (edge) => !(userData?.answers ?? []).includes(edge)
     ) ?? [];
 


### PR DESCRIPTION
extends #1446, further context over here https://opensystemslab.slack.com/archives/C5Q59R3HB/p1676032127570869

since this is an error that stems from content editing, seems sensible to log it via Airbrake so we get visibility as soon as possible as we're less likely to catch them in local code changes & testing