### PR TITLE
fix: Pass integer coords to Uniform

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/uniform/UniformPayload/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/UniformPayload/model.ts
@@ -87,8 +87,8 @@ export class UniformPayload implements IUniformPayload {
           "bs7666:UniquePropertyReferenceNumber": this.siteAddress?.uprn,
         },
         "common:SiteGridRefence": {
-          "bs7666:X": this.siteAddress?.x,
-          "bs7666:Y": this.siteAddress?.y,
+          "bs7666:X": Math.round(this.siteAddress?.x),
+          "bs7666:Y": Math.round(this.siteAddress?.y),
         },
       },
       "portaloneapp:ApplicationScenario": {


### PR DESCRIPTION
Not yet spotted where this regression has come from. I've confirmed the following - 

  - OS API returns value to 2 decimal places (docs: https://osdatahub.os.uk/docs/places/technicalSpecification)
  - OneApp requires integer (see XML below)

```xml
<!--  Coordinate Definition  -->
<xsd:complexType name="CoordinateStructure">
    <xsd:annotation>
        <xsd:documentation>Coordinate Point based on UK National Grid</xsd:documentation>
    </xsd:annotation>
    <xsd:sequence>
        <xsd:element name="X">
            <xsd:annotation>
                <xsd:documentation>Easting Field</xsd:documentation>
            </xsd:annotation>
            <xsd:simpleType>
                <xsd:restriction base="xsd:unsignedLong">
                    <xsd:minInclusive value="0" />
                    <xsd:maxInclusive value="9999999" />
                </xsd:restriction>
            </xsd:simpleType>
        </xsd:element>
        <xsd:element name="Y">
            <xsd:annotation>
                <xsd:documentation>Northing Field</xsd:documentation>
            </xsd:annotation>
            <xsd:simpleType>
                <xsd:restriction base="xsd:unsignedLong">
                    <xsd:minInclusive value="0" />
                    <xsd:maxInclusive value="9999999" />
                </xsd:restriction>
            </xsd:simpleType>
        </xsd:element>
    </xsd:sequence>
</xsd:complexType>
```