### PR TITLE
fix: Fetch only most recent submission

### DIFF
--- a/api.planx.uk/admin/session/oneAppXML.test.ts
+++ b/api.planx.uk/admin/session/oneAppXML.test.ts
@@ -8,7 +8,7 @@ const endpoint = (strings: TemplateStringsArray) => `/admin/session/${strings[0]
 describe("OneApp XML endpoint", () => {
   beforeEach(() => {
     queryMock.mockQuery({
-      name: "GetUniformApplicationBySessionID",
+      name: "GetMostRecentUniformApplicationBySessionID",
       variables: {
         submission_reference: "abc123",
       },
@@ -20,7 +20,7 @@ describe("OneApp XML endpoint", () => {
     });
 
     queryMock.mockQuery({
-      name: "GetUniformApplicationBySessionID",
+      name: "GetMostRecentUniformApplicationBySessionID",
       variables: {
         submission_reference: "xyz789",
       },

--- a/api.planx.uk/admin/session/oneAppXML.ts
+++ b/api.planx.uk/admin/session/oneAppXML.ts
@@ -19,10 +19,11 @@ export const getOneAppXML = async (
 const fetchSessionXML = async (sessionId: string) => {
   try {
     const query = gql`
-      query GetUniformApplicationBySessionID($submission_reference: String) {
+      query GetMostRecentUniformApplicationBySessionID($submission_reference: String) {
         uniform_applications(
           where: { submission_reference: { _eq: $submission_reference } },
-          order_by: { created_at: desc }
+          order_by: { created_at: desc },
+          limit: 1
         ) {
           payload(path: "xml")
         }

--- a/api.planx.uk/admin/session/oneAppXML.ts
+++ b/api.planx.uk/admin/session/oneAppXML.ts
@@ -21,7 +21,8 @@ const fetchSessionXML = async (sessionId: string) => {
     const query = gql`
       query GetUniformApplicationBySessionID($submission_reference: String) {
         uniform_applications(
-          where: { submission_reference: { _eq: $submission_reference } }
+          where: { submission_reference: { _eq: $submission_reference } },
+          order_by: { created_at: desc }
         ) {
           payload(path: "xml")
         }


### PR DESCRIPTION
Adding an `order_by` here means we just display the most recently submitted payload, which is really the intention.

Multiple records will be returned when an application has been re-submitted.