### PR TITLE
feat: Write flowName to store

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -1,17 +1,7 @@
 import React from "react";
-import * as ReactNavi from "react-navi";
 import { axe, setup } from "testUtils";
 
 import ConfirmationComponent from "./Public";
-
-jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
-  () =>
-    ({
-      data: {
-        flowName: "apply for a lawful development certificate",
-      },
-    } as any)
-);
 
 it("should not have any accessibility violations", async () => {
   const { container } = setup(

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -12,7 +12,6 @@ import NumberedList from "ui/NumberedList";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 import { makeCsvData } from "../Send/uniform";
-import { useFlowName } from "../shared/hooks";
 import type { Confirmation } from "./model";
 
 const useClasses = makeStyles((theme) => ({
@@ -37,13 +36,15 @@ const useClasses = makeStyles((theme) => ({
 export type Props = PublicProps<Confirmation>;
 
 export default function ConfirmationComponent(props: Props) {
-  const [breadcrumbs, flow, passport, sessionId] = useStore((state) => [
-    state.breadcrumbs,
-    state.flow,
-    state.computePassport(),
-    state.sessionId,
-  ]);
-  const flowName = useFlowName();
+  const [breadcrumbs, flow, passport, sessionId, flowName] = useStore(
+    (state) => [
+      state.breadcrumbs,
+      state.flow,
+      state.computePassport(),
+      state.sessionId,
+      state.flowName,
+    ]
+  );
 
   // make a CSV data structure based on the payloads we Send to BOPs/Uniform
   const data = makeCsvData({

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -3,11 +3,10 @@ import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect } from "react";
-import { useCurrentRoute } from "react-navi";
 import { useAsync } from "react-use";
 
 import { publicClient } from "../../../client";
-import { useFlowName,useTeamSlug } from "../shared/hooks";
+import { useTeamSlug } from "../shared/hooks";
 import Card from "../shared/Preview/Card";
 import { makeData, useStagingUrlIfTestApplication } from "../shared/utils";
 import { PublicProps } from "../ui";
@@ -37,18 +36,17 @@ const SendComponent: React.FC<Props> = ({
   destinations = [DEFAULT_DESTINATION],
   ...props
 }) => {
-  const [breadcrumbs, flow, passport, flowId, sessionId, email] = useStore(
-    (state) => [
+  const [breadcrumbs, flow, passport, flowId, sessionId, email, flowName] =
+    useStore((state) => [
       state.breadcrumbs,
       state.flow,
       state.computePassport(),
       state.id,
       state.sessionId,
       state.saveToEmail,
-    ]
-  );
+      state.flowName,
+    ]);
   let teamSlug = useTeamSlug();
-  const flowName = useFlowName();
 
   // Send makes a single request to create scheduled events in Hasura, then those events make the actual submission requests with retries etc
   const url = `${process.env.REACT_APP_API_URL}/create-send-events/${sessionId}`;

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/applicationType.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/applicationType.test.ts
@@ -21,7 +21,7 @@ describe("application_type is set correctly based on flowName", () => {
       flow: {},
       passport: {},
       sessionId: "session-123",
-      flowName: "apply for a lawful development certificate",
+      flowName: "Apply for a lawful development certificate",
     });
     expect(result.application_type).toEqual(default_application_type);
   });
@@ -32,7 +32,7 @@ describe("application_type is set correctly based on flowName", () => {
       flow: {},
       passport: {},
       sessionId: "session-123",
-      flowName: "apply for prior approval",
+      flowName: "Apply for prior approval",
     });
     expect(result.application_type).toEqual("Apply for prior approval");
   });

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/fileDescriptions.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/fileDescriptions.test.ts
@@ -1,18 +1,8 @@
 import { Store, vanillaStore } from "pages/FlowEditor/lib/store";
-import * as ReactNavi from "react-navi";
 
 import { getBOPSParams } from "..";
 
 const { getState, setState } = vanillaStore;
-
-jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
-  () =>
-    ({
-      data: {
-        flowName: "apply for a lawful development certificate",
-      },
-    } as any)
-);
 
 // https://i.imgur.com/MsCF14s.png
 const flow: Store.flow = {
@@ -151,7 +141,7 @@ describe("BOPS files[*].applicant_description", () => {
           flow,
           passport: computePassport(),
           sessionId,
-          flowName: "apply for a lawful development certificate",
+          flowName: "Apply for a lawful development certificate",
         }).files?.forEach((file) => {
           expect(file.applicant_description).toStrictEqual(expected);
         });

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/files.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/files.test.ts
@@ -1,18 +1,8 @@
 import { Store } from "pages/FlowEditor/lib/store";
-import * as ReactNavi from "react-navi";
 
 import { PASSPORT_UPLOAD_KEY } from "../../../DrawBoundary/model";
 import { extractTagsFromPassportKey, getBOPSParams } from "../../bops";
 import type { FileTag } from "../../model";
-
-jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
-  () =>
-    ({
-      data: {
-        flowName: "apply for a lawful development certificate",
-      },
-    } as any)
-);
 
 const flow: Store.flow = {
   _root: {
@@ -79,7 +69,7 @@ test("makes file object", () => {
     flow,
     passport,
     sessionId: "123",
-    flowName: "apply for a lawful development certificate",
+    flowName: "Apply for a lawful development certificate",
   }).files;
 
   const expected = [

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/flags.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/flags.test.ts
@@ -1,16 +1,6 @@
 import { Store } from "pages/FlowEditor/lib/store";
-import * as ReactNavi from "react-navi";
 
 import { getBOPSParams } from "..";
-
-jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
-  () =>
-    ({
-      data: {
-        flowName: "apply for a lawful development certificate",
-      },
-    } as any)
-);
 
 // PlanX ALWAYS sends a flag result & optional override description (test 2)
 // to BOPS, even if (1) no flag result component is shown to the applicant,
@@ -29,7 +19,7 @@ test("sends flag result despite no result component", () => {
   const passport: Store.passport = {
     data: {},
   };
-  const flowName = "apply for a lawful development certificate";
+  const flowName = "Apply for a lawful development certificate";
 
   const actual = getBOPSParams({
     breadcrumbs,
@@ -90,7 +80,7 @@ test("sends override description with flag result", () => {
       "application.resultOverride.reason": "i don't agree",
     },
   };
-  const flowName = "apply for a lawful development certificate";
+  const flowName = "Apply for a lawful development certificate";
 
   const actual = getBOPSParams({
     breadcrumbs,
@@ -146,7 +136,7 @@ test("sends 'no result' to BOPS when there is no collected flag", () => {
   const passport: Store.passport = {
     data: {},
   };
-  const flowName = "apply for a lawful development certificate";
+  const flowName = "Apply for a lawful development certificate";
 
   const actual = getBOPSParams({
     breadcrumbs,

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/makePayload.test.ts
@@ -1,16 +1,6 @@
 import { Store } from "pages/FlowEditor/lib/store";
-import * as ReactNavi from "react-navi";
 
 import { makePayload } from "..";
-
-jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
-  () =>
-    ({
-      data: {
-        flowName: "apply for a lawful development certificate",
-      },
-    } as any)
-);
 
 const flow: Store.flow = {
   _root: {

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/userRole.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/userRole.test.ts
@@ -1,17 +1,7 @@
 import { Store } from "pages/FlowEditor/lib/store";
-import * as ReactNavi from "react-navi";
 
 import { USER_ROLES } from "../../model";
 import { getBOPSParams } from "..";
-
-jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
-  () =>
-    ({
-      data: {
-        flowName: "apply for a lawful development certificate",
-      },
-    } as any)
-);
 
 // https://i.imgur.com/KhUnUte.png
 const flow: Store.flow = {
@@ -91,7 +81,7 @@ describe("when user.role =", () => {
         flow,
         passport,
         sessionId: "FAKE-SESSION-ID",
-        flowName: "apply for a lawful development certificate",
+        flowName: "Apply for a lawful development certificate",
       });
 
       expect(result.user_role).toEqual(bopsValue);

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -5,10 +5,8 @@
 // https://southwark.preview.bops.services/api-docs/index.html
 
 import { logger } from "airbrake";
-import capitalize from "lodash/capitalize";
 import { flatFlags } from "pages/FlowEditor/data/flags";
 import { getResultData } from "pages/FlowEditor/lib/store/preview";
-import { useCurrentRoute } from "react-navi";
 import { GovUKPayment } from "types";
 
 import { Store } from "../../../../pages/FlowEditor/lib/store";
@@ -245,9 +243,9 @@ export function getBOPSParams({
   data.application_type = "lawfulness_certificate";
 
   // Overwrite application type if this isn't an LDC (relies on LDC flows having consistent slug)
-  //   eg because makeCsvData which is used acrossed services calls this method
-  if (flowName && flowName !== "apply for a lawful development certificate") {
-    data.application_type = capitalize(flowName);
+  //   eg because makeCsvData which is used across services calls this method
+  if (flowName && flowName !== "Apply for a lawful development certificate") {
+    data.application_type = flowName;
   }
 
   // 1a. address

--- a/editor.planx.uk/src/@planx/components/shared/hooks.ts
+++ b/editor.planx.uk/src/@planx/components/shared/hooks.ts
@@ -14,11 +14,6 @@ export const useTeamSlug = () => {
   return route?.data?.team;
 };
 
-export const useFlowName = () => {
-  const route = useCurrentRoute();
-  return route?.data?.flowName;
-};
-
 export type UseFileUrlProps =
   | { file: File }
   | { url: string }

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -1,5 +1,7 @@
 import { screen } from "@testing-library/react";
+import { vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import * as ReactNavi from "react-navi";
 import { axe, setup } from "testUtils";
 import { Team } from "types";
@@ -30,7 +32,6 @@ jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
         username: "Test User",
         team: mockTeam1.slug,
         flow: "test-flow",
-        flowName: "test flow",
       },
     } as any)
 );
@@ -85,8 +86,11 @@ describe("Header Component - Public Routes", () => {
     expect(screen.getByText("Plan✕")).toBeInTheDocument();
   });
 
-  it("parses the url pathname and displays a service title", () => {
+  it("displays service title from the store", () => {
     setup(<Header variant={HeaderVariant.Preview} team={mockTeam1}></Header>);
+    const { setState } = vanillaStore;
+    act(() => setState({ flowName: "test flow" }));
+
     expect(screen.getByTestId("service-title")).toBeInTheDocument();
     expect(screen.getByText("test flow")).toBeInTheDocument();
   });

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -110,9 +110,6 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 700,
     paddingLeft: theme.spacing(2),
     paddingBottom: theme.spacing(1),
-    "&::first-letter": {
-      textTransform: "capitalize",
-    },
   },
 }));
 
@@ -214,7 +211,7 @@ const PublicToolbar: React.FC<{
         ) : (
           <Breadcrumbs route={route} handleClick={navigate}></Breadcrumbs>
         )}
-        {showCenteredServiceTitle && <ServiceTitle route={route} />}
+        {showCenteredServiceTitle && <ServiceTitle />}
         <IconButton
           color="secondary"
           onClick={handleRestart}
@@ -224,18 +221,16 @@ const PublicToolbar: React.FC<{
           <Reset color="secondary" />
         </IconButton>
       </Toolbar>
-      {!showCenteredServiceTitle && <ServiceTitle route={route} />}
+      {!showCenteredServiceTitle && <ServiceTitle />}
       <AnalyticsDisabledBanner />
       <PhaseBanner />
     </>
   );
 };
 
-const ServiceTitle: React.FC<{
-  route: Route;
-}> = ({ route }) => {
+const ServiceTitle: React.FC = () => {
   const classes = useStyles();
-  const { flowName } = route.data;
+  const flowName = useStore((state) => state.flowName);
 
   return (
     <span data-testid="service-title" className={classes.serviceTitle}>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -8,10 +8,20 @@ export interface SharedStore extends Store.Store {
   breadcrumbs: Store.breadcrumbs;
   childNodesOf: (id?: Store.nodeId) => Store.node[];
   flow: Store.flow;
+  flowSlug: string;
+  flowName: string;
   id: string;
   getNode: (id: Store.nodeId) => Store.node;
   resetPreview: () => void;
-  setFlow: (id: string, flow: Store.flow) => void;
+  setFlow: ({
+    id,
+    flow,
+    flowSlug,
+  }: {
+    id: string;
+    flow: Store.flow;
+    flowSlug: string;
+  }) => void;
   wasVisited: (id: Store.nodeId) => boolean;
   previewEnvironment: PreviewEnvironment;
   setPreviewEnvironment: (previewEnvironment: PreviewEnvironment) => void;
@@ -29,6 +39,10 @@ export const sharedStore = (
   },
 
   flow: {},
+
+  flowSlug: "",
+
+  flowName: "",
 
   id: "",
   previewEnvironment: "standalone",
@@ -55,8 +69,9 @@ export const sharedStore = (
     });
   },
 
-  setFlow(id, flow) {
-    set({ id, flow });
+  setFlow({ id, flow, flowSlug }) {
+    set({ id, flow, flowSlug });
+    set({ flowName: flowSlug.replaceAll?.("-", " ") });
   },
 
   wasVisited(id) {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -1,4 +1,5 @@
 import { ROOT_NODE_KEY } from "@planx/graph";
+import { capitalize } from "lodash";
 import type { GetState, SetState } from "zustand/vanilla";
 
 import type { Store } from ".";
@@ -70,8 +71,8 @@ export const sharedStore = (
   },
 
   setFlow({ id, flow, flowSlug }) {
-    set({ id, flow, flowSlug });
-    set({ flowName: flowSlug.replaceAll?.("-", " ") });
+    const flowName = capitalize(flowSlug.replaceAll?.("-", " "));
+    set({ id, flow, flowSlug, flowName });
   },
 
   wasVisited(id) {

--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -10,7 +10,6 @@ import React from "react";
 import Banner from "ui/Banner";
 
 import { makeCsvData } from "../../@planx/components/Send/uniform";
-import { useFlowName } from "../../@planx/components/shared/hooks";
 import FileDownload from "../../ui/FileDownload";
 
 interface Props {
@@ -38,14 +37,15 @@ const StatusPage: React.FC<Props> = ({
   additionalOption,
   children,
 }) => {
-  const [breadcrumbs, flow, passport, sessionId] = useStore((state) => [
-    state.breadcrumbs,
-    state.flow,
-    state.computePassport(),
-    state.sessionId,
-  ]);
-
-  const flowName = useFlowName();
+  const [breadcrumbs, flow, passport, sessionId, flowName] = useStore(
+    (state) => [
+      state.breadcrumbs,
+      state.flow,
+      state.computePassport(),
+      state.sessionId,
+      state.flowName,
+    ]
+  );
 
   // make a CSV data structure based on the payloads we Send to BOPs/Uniform
   const data = makeCsvData({

--- a/editor.planx.uk/src/routes/preview.tsx
+++ b/editor.planx.uk/src/routes/preview.tsx
@@ -21,7 +21,7 @@ import React from "react";
 import { View } from "react-navi";
 import { Flow, GlobalSettings, Maybe } from "types";
 
-import { extractFlowNameFromReq, getTeamFromDomain, setPath } from "./utils";
+import { getTeamFromDomain, setPath } from "./utils";
 
 const routes = compose(
   withData(async (req) => {
@@ -33,11 +33,11 @@ const routes = compose(
       mountpath: req.mountpath,
       team: req.params.team || externalDomainTeam,
       isPreviewOnlyDomain: Boolean(externalDomainTeam),
-      flowName: extractFlowNameFromReq(req),
     };
   }),
 
   withView(async (req) => {
+    const flowSlug = req.params.flow.split(",")[0];
     const externalTeamName = await getTeamFromDomain(window.location.hostname);
 
     // XXX: Prevents accessing a different team than the one associated with the custom domain.
@@ -78,7 +78,7 @@ const routes = compose(
         }
       `,
       variables: {
-        flowSlug: req.params.flow.split(",")[0],
+        flowSlug,
         teamSlug: req.params.team || externalTeamName,
       },
     });
@@ -99,7 +99,7 @@ const routes = compose(
 
     // XXX: necessary as long as not every flow is published; aim to remove dataMergedHotfix.ts in future
     // load pre-flattened published flow if exists, else load & flatten flow
-    useStore.getState().setFlow(flow.id, flowData);
+    useStore.getState().setFlow({ id: flow.id, flow: flowData, flowSlug });
 
     return (
       <PreviewContext.Provider value={{ flow, globalSettings }}>

--- a/editor.planx.uk/src/routes/unpublished.tsx
+++ b/editor.planx.uk/src/routes/unpublished.tsx
@@ -22,17 +22,18 @@ import { View } from "react-navi";
 import { Flow, GlobalSettings, Maybe } from "types";
 
 import { setPath } from "./utils";
-import { extractFlowNameFromReq, getTeamFromDomain } from "./utils";
+import { getTeamFromDomain } from "./utils";
 
 const routes = compose(
   withData(async (req) => ({
     mountpath: req.mountpath,
     team:
       req.params.team || (await getTeamFromDomain(window.location.hostname)),
-    flowName: extractFlowNameFromReq(req),
   })),
 
   withView(async (req) => {
+    const flowSlug = req.params.flow.split(",")[0];
+
     const { data } = await client.query({
       query: gql`
         query GetFlow($flowSlug: String!, $teamSlug: String!) {
@@ -57,7 +58,7 @@ const routes = compose(
         }
       `,
       variables: {
-        flowSlug: req.params.flow.split(",")[0],
+        flowSlug,
         teamSlug:
           req.params.team ||
           (await getTeamFromDomain(window.location.hostname)),
@@ -73,7 +74,7 @@ const routes = compose(
     if (!flow) throw new NotFoundError();
 
     const flowData = await dataMerged(flow.id);
-    useStore.getState().setFlow(flow.id, flowData);
+    useStore.getState().setFlow({ id: flow.id, flow: flowData, flowSlug });
 
     setPath(flowData, req);
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -82,8 +82,3 @@ export const getTeamFromDomain = pMemoize(async (domain: string) => {
 
   return teams?.[0]?.slug;
 });
-
-// NB: In the database `flowName` and `slug` are (now) synonymous.
-export const extractFlowNameFromReq = (req: NaviRequest<object>) => {
-  return req.params.flow?.replaceAll?.("-", " ");
-};


### PR DESCRIPTION
Quick refactor based on [comments here](https://github.com/theopensystemslab/planx-new/pull/1436) which means we can more readily get the `flowName` and `flowSlug` without having to call a hook.