### PR TITLE
fix: sort breadcrumbs when overriding answer and improve test

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/overrideAnswer.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/overrideAnswer.test.ts
@@ -56,6 +56,7 @@ test("it clears the correct breadcrumb and navigates back to the right node", as
 });
 
 // mimic having completed a FindProperty search and landing on PropertyInformation
+//   reminder breadcrumb order is _not_ guaranteed, eg "FirstPropertyTypeQuestionNodeId" may be last entry
 const propertySearchBreadcrumb = {
   FindPropertyNodeId: {
     auto: false,
@@ -84,12 +85,12 @@ const propertySearchBreadcrumb = {
       "property.region": ["South East"],
     },
   },
-  FirstPropertyTypeQuestionNodeId: {
-    answers: ["HouseResponseNodeId"],
-    auto: true,
-  },
   SecondPropertyTypeQuestionNodeId: {
     answers: ["SemiDetachedResponseNodeId"],
+    auto: true,
+  },
+  FirstPropertyTypeQuestionNodeId: {
+    answers: ["HouseResponseNodeId"],
     auto: true,
   },
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/overrideAnswer.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/overrideAnswer.test.ts
@@ -2,35 +2,62 @@ import { vanillaStore } from "../store";
 
 const { getState, setState } = vanillaStore;
 
-const { overrideAnswer, currentCard } = getState();
+const { overrideAnswer, currentCard, upcomingCardIds, record } = getState();
 
 test("it clears the correct breadcrumb and navigates back to the right node", async () => {
+  // set up initial state, confirm our passport computes as expected
   setState({
     flow: flowWithPropertyTypeOverride,
     breadcrumbs: propertySearchBreadcrumb,
   });
+  const initialPassport = getState().computePassport();
+  expect(initialPassport.data).toHaveProperty(
+    ["property.type"],
+    ["residential.dwelling.house.semiDetached"]
+  );
 
+  // override answer
   overrideAnswer("property.type");
 
   // confirm we've cleared the provided passport variable from the first node that set it
   const afterOverrideBreadcrumb = getState().breadcrumbs;
-  const addressData: any = afterOverrideBreadcrumb?.["ZcIDY8Ak5t"]?.data;
-  expect(Object.keys(addressData)).toHaveLength(3);
-  expect(Object.keys(addressData)).not.toContain("property.type");
+  const addressBreadcrumb: any =
+    afterOverrideBreadcrumb?.["FindPropertyNodeId"]?.data;
+  expect(Object.keys(addressBreadcrumb)).toHaveLength(3);
+  expect(addressBreadcrumb).not.toHaveProperty(["property.type"]);
+
+  const afterOverridePassport = getState().computePassport();
+  expect(afterOverridePassport.data).toBeDefined();
+  expect(afterOverridePassport.data).not.toHaveProperty(["property.type"]);
 
   // confirm we've stored a copy of the original value in the first node that set it
-  const overrideData: any = afterOverrideBreadcrumb?.["ZcIDY8Ak5t"]?.override;
+  const overrideData: any =
+    afterOverrideBreadcrumb?.["FindPropertyNodeId"]?.override;
   expect(overrideData).toEqual({
     "property.type": ["residential.dwelling.house.semiDetached"],
   });
 
-  // confirm we've navigated back to the right node
-  expect(currentCard()?.id).toEqual("IuTOXkwbGk");
+  // confirm we've navigated back to the right node, and that PropertyInformation is queued up again in upcoming cards
+  expect(currentCard()?.id).toEqual("FirstPropertyTypeQuestionNodeId");
+  expect(upcomingCardIds()).toContain("PropertyInformationNodeId");
+
+  // select a new answer, confirm our passport has updated
+  record("FirstPropertyTypeQuestionNodeId", {
+    answers: ["FlatResponseNodeId"],
+  });
+  expect(upcomingCardIds()).toEqual(["PropertyInformationNodeId"]);
+  expect(upcomingCardIds()).not.toContain("SecondPropertyTypeQuestionNodeId");
+
+  const afterAnswerPassport = getState().computePassport();
+  expect(afterAnswerPassport.data).toHaveProperty(
+    ["property.type"],
+    ["residential.dwelling.flat"]
+  );
 });
 
-// mimic having completed a property search and landing on PropertyInformation
+// mimic having completed a FindProperty search and landing on PropertyInformation
 const propertySearchBreadcrumb = {
-  ZcIDY8Ak5t: {
+  FindPropertyNodeId: {
     auto: false,
     data: {
       _address: {
@@ -57,54 +84,92 @@ const propertySearchBreadcrumb = {
       "property.region": ["South East"],
     },
   },
-  IuTOXkwbGk: {
-    answers: ["mZGNiRT2bc"],
+  FirstPropertyTypeQuestionNodeId: {
+    answers: ["HouseResponseNodeId"],
+    auto: true,
+  },
+  SecondPropertyTypeQuestionNodeId: {
+    answers: ["SemiDetachedResponseNodeId"],
     auto: true,
   },
 };
 
 const flowWithPropertyTypeOverride = {
   _root: {
-    edges: ["ZcIDY8Ak5t", "IuTOXkwbGk", "ju7Lg0BgJ0"],
+    edges: [
+      "FindPropertyNodeId",
+      "FirstPropertyTypeQuestionNodeId",
+      "PropertyInformationNodeId",
+    ],
   },
-  ZcIDY8Ak5t: {
+  FlatResponseNodeId: {
+    data: {
+      val: "residential.dwelling.flat",
+      text: "Flat",
+    },
+    type: 200,
+  },
+  FirstPropertyTypeQuestionNodeId: {
+    data: {
+      fn: "property.type",
+      text: "What type of property is it?",
+    },
+    type: 100,
+    edges: ["HouseResponseNodeId", "FlatResponseNodeId", "Qn8eJF7JRN"],
+  },
+  Qn8eJF7JRN: {
+    data: {
+      text: "Neither a house nor a flat",
+    },
+    type: 200,
+  },
+  FindPropertyNodeId: {
     type: 9,
   },
-  ju7Lg0BgJ0: {
-    type: 12,
+  PropertyInformationNodeId: {
     data: {
       title: "About the property",
       description:
         "This is the information we currently have about the property",
       showPropertyTypeOverride: true,
     },
+    type: 12,
   },
-  IuTOXkwbGk: {
+  HouseResponseNodeId: {
+    data: {
+      val: "residential.dwelling.house",
+      text: "House",
+    },
+    type: 200,
+    edges: ["SecondPropertyTypeQuestionNodeId"],
+  },
+  SecondPropertyTypeQuestionNodeId: {
     type: 100,
     data: {
       fn: "property.type",
-      text: "What type of property is it?",
+      text: "What type of house is it?",
     },
-    edges: ["mZGNiRT2bc", "5tAEd1U7jb", "Qn8eJF7JRN"],
+    edges: ["uKbMIB3Ou7", "SemiDetachedResponseNodeId", "X4Tq79FrNT"],
   },
-  mZGNiRT2bc: {
+  uKbMIB3Ou7: {
     type: 200,
     data: {
-      text: "House",
-      val: "residential.dwelling.house",
+      text: "Detached",
+      val: "residential.dwelling.house.detached",
     },
   },
-  "5tAEd1U7jb": {
+  SemiDetachedResponseNodeId: {
     type: 200,
     data: {
-      text: "Flat",
-      val: "residential.dwelling.flat",
+      text: "Semi-detached",
+      val: "residential.dwelling.house.semiDetached",
     },
   },
-  Qn8eJF7JRN: {
+  X4Tq79FrNT: {
     type: 200,
     data: {
-      text: "Neither a house nor a flat",
+      text: "End terrace",
+      val: "residential.dwelling.house.terrace.end",
     },
   },
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -574,9 +574,12 @@ export const previewStore = (
     // Similar to 'changeAnswer', but enables navigating backwards to and overriding a previously **auto-answered** question which would typically be hidden
     const { breadcrumbs, flow, record, changeAnswer } = get();
 
+    // Order of breadcrumb insertion is not guaranteed, sort upfront to match flow order so that later "find()" methods behave as expected
+    const sortedBreadcrumbs = sortBreadcrumbs(breadcrumbs, flow);
+
     // The first nodeId that set the passport value (fn) being changed (eg FindProperty)
     const originalNodeId: Node["id"] | undefined = Object.entries(
-      breadcrumbs
+      sortedBreadcrumbs
     ).find(
       ([_nodeId, breadcrumb]) => breadcrumb.data && fn in breadcrumb.data
     )?.[0];
@@ -595,7 +598,7 @@ export const previewStore = (
     // The first nodeId that is configured by an editor to manually set the passport value being changed (eg Question "What type of property is it?").
     //   This node has likely been auto-answered by the originalNodeId and we leave its' breadcrumbs.data intact so that the original answer is highlighted later
     const overrideNodeId: Node["id"] | undefined = Object.entries(
-      breadcrumbs
+      sortedBreadcrumbs
     ).find(
       ([nodeId, _breadcrumb]) =>
         flow[nodeId].data?.fn === fn || flow[nodeId].data?.val === fn


### PR DESCRIPTION
I was recently using property override and noticed some strange behavior that was inconsistent with original feature intention. 

:bulb: The order of breadcrumbs is _not_ guaranteed to match the order nodes are asked in the graph, and therefore using `find()` to set "overrideNodeId" could behave unexpectedly :bulb: 

Test flows:
- Prod: https://editor.planx.uk/testing/change-property-test (use to re-create buggy behavior)
- Pizza: https://1473.planx.pizza/testing/change-property-test (use to test this fix)

Steps to reproduce: 
- Search UB9 4AP &rarr; 6, WILLOW CRESCENT EAST, NEW DENHAM
- OS says this address is a Semi-detached house aka `"residential.dwelling.house.semiDetached"`
- Clicking "change" _should_ completely clear the "property.type" variable from the breadcrumb of the FindProperty nodeId, and therefore the passport, and navigate back to the question "What type of property is it?"
- Instead, "change" was navigating back to the question "What type of _house_ it it?" because it found the second question first, and still had a breadcrumb for the first which allowed it to be auto-answered (this made it appear that rather than removing the passport variable, "change" was instead stripping off the right-most granular value of the passport variable because it was being immediately removed then partially auto-answered)