### PR TITLE
feat: add checks in the editor for adding, moving, and cloning section nodes

### DIFF
--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -58,10 +58,10 @@ it("does not update if there are sections in an external portal", async () => {
   const alteredFlow = {
     ...mockFlowData,
     "externalPortalNodeId": {
-      edges: ["sectionNodeId"],
+      edges: ["newSectionNodeId"],
       type: 310,
     },
-    "sectionNodeId": {
+    "newSectionNodeId": {
       type: 360,
     },
   };
@@ -77,15 +77,48 @@ it("does not update if there are sections in an external portal", async () => {
   });
 
   await supertest(app)
-  .post("/flows/1/publish")
-  .set(authHeader())
-  .expect(200)
-  .then((res) => {
-    expect(res.body).toEqual({
-      alteredNodes: null,
-      message: "Error publishing: found Sections in one or more External Portals",
+    .post("/flows/1/publish")
+    .set(authHeader())
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual({
+        alteredNodes: null,
+        message: "Error publishing: found Sections in one or more External Portals, but Sections are only allowed in main flow",
+      });
     });
+});
+
+it("does not update if there are sections, but there is not a section in the first position", async () => {
+  const flowWithSections: Flow["data"] = {
+    _root: {
+      edges: ["questionNode", "sectionNode"]
+    },
+    questionNode: {},
+    sectionNode: {
+      type: 360,
+    },
+  };
+
+  queryMock.mockQuery({
+    name: "GetFlowData",
+    matchOnVariables: false,
+    data: {
+      flows_by_pk: {
+        data: flowWithSections,
+      },
+    },
   });
+
+  await supertest(app)
+    .post("/flows/1/publish")
+    .set(authHeader())
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual({
+        alteredNodes: null,
+        message: "Error publishing: when using Sections, your flow needs to start with a Section",
+      });
+    });
 });
 
 it("updates published flow and returns altered nodes if there have been changes", async () => {
@@ -151,6 +184,7 @@ it("updates published flow and returns altered nodes if there have been changes"
 const mockFlowData: Flow["data"] = {
   _root: {
     edges: [
+      "sectionNodeId",
       "RYYckLE2cH",
       "R99ncwKifm",
       "3qssvGXmMO",
@@ -159,6 +193,12 @@ const mockFlowData: Flow["data"] = {
       "4CJgXe8Ttl",
       "dnVqd6zt4N",
     ],
+  },
+  "sectionNodeId": {
+    type: 360,
+    data: {
+      title: "Section 1",
+    },
   },
   "3qssvGXmMO": {
     type: 9,

--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -54,6 +54,40 @@ it("does not update if there are no new changes", async () => {
     });
 });
 
+it("does not update if there are sections in an external portal", async () => {
+  const alteredFlow = {
+    ...mockFlowData,
+    "externalPortalNodeId": {
+      edges: ["sectionNodeId"],
+      type: 310,
+    },
+    "sectionNodeId": {
+      type: 360,
+    },
+  };
+
+  queryMock.mockQuery({
+    name: "GetFlowData",
+    matchOnVariables: false,
+    data: {
+      flows_by_pk: {
+        data: alteredFlow,
+      },
+    },
+  });
+
+  await supertest(app)
+  .post("/flows/1/publish")
+  .set(authHeader())
+  .expect(200)
+  .then((res) => {
+    expect(res.body).toEqual({
+      alteredNodes: null,
+      message: "Error publishing: found Sections in one or more External Portals",
+    });
+  });
+});
+
 it("updates published flow and returns altered nodes if there have been changes", async () => {
   const alteredFlow = {
     ...mockFlowData,

--- a/api.planx.uk/editor/publish.ts
+++ b/api.planx.uk/editor/publish.ts
@@ -4,7 +4,6 @@ import { adminGraphQLClient as adminClient } from "../hasura";
 import { dataMerged, getMostRecentPublishedFlow } from "../helpers";
 import { gql } from "graphql-request";
 import intersection from "lodash/intersection";
-import { flattenDeep } from "lodash";
 
 const diffFlow = async (
   req: Request,

--- a/api.planx.uk/editor/publish.ts
+++ b/api.planx.uk/editor/publish.ts
@@ -4,6 +4,7 @@ import { adminGraphQLClient as adminClient } from "../hasura";
 import { dataMerged, getMostRecentPublishedFlow } from "../helpers";
 import { gql } from "graphql-request";
 import intersection from "lodash/intersection";
+import { flattenDeep } from "lodash";
 
 const diffFlow = async (
   req: Request,
@@ -50,19 +51,23 @@ const publishFlow = async (
   try {
     const flattenedFlow = await dataMerged(req.params.flowId);
 
-    // Check the flattened flow to ensure that all sections (type 360) are still in valid positions (eg within `_root: { edges: [...]}`, not the edge of a portal)
-    //   If any are not, don't proceed with publishing and return a message to display in the Editor
-    const sectionTypeNodeIds = Object.entries(flattenedFlow).filter(([_nodeId, nodeData]) => nodeData?.type === 360).map(([nodeId, _nodeData]) => nodeId);
-    const intersectingNodeIds = intersection(flattenedFlow["_root"].edges, sectionTypeNodeIds);
-    if (intersectingNodeIds.length !== sectionTypeNodeIds.length) {
-      return res.json({
-        alteredNodes: null,
-        message: "Error publishing: found Sections in one or more External Portals"
-      });
+    // If the flattened flow (including external portals) has sections, handle validations
+    if (getSectionNodeIds(flattenedFlow)?.length > 0) {
+      if (!sectionIsInFirstPosition(flattenedFlow)) {
+        return res.json({
+          alteredNodes: null,
+          message: "Error publishing: when using Sections, your flow needs to start with a Section"
+        });
+      } 
+      if (!allSectionsOnRoot(flattenedFlow)) {
+        return res.json({
+          alteredNodes: null,
+          message: "Error publishing: found Sections in one or more External Portals, but Sections are only allowed in main flow"
+        });
+      }
     }
 
     const mostRecent = await getMostRecentPublishedFlow(req.params.flowId);
-
     const delta = jsondiffpatch.diff(mostRecent, flattenedFlow);
 
     if (delta) {
@@ -117,6 +122,21 @@ const publishFlow = async (
   } catch (error) {
     return next(error);
   }
+};
+
+const getSectionNodeIds = (flow: Record<string, any>): string[] => {
+  return Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === 360)?.map(([nodeId, _nodeData]) => nodeId);
+};
+
+const sectionIsInFirstPosition = (flow: Record<string, any>): boolean => {
+  const firstNodeId = flow["_root"].edges[0];
+  return flow[firstNodeId].type === 360;
+};
+
+const allSectionsOnRoot = (flow: Record<string, any>): boolean => {
+  const sectionTypeNodeIds = getSectionNodeIds(flow);
+  const intersectingNodeIds = intersection(flow["_root"].edges, sectionTypeNodeIds);
+  return intersectingNodeIds.length === sectionTypeNodeIds.length;
 };
 
 export { diffFlow, publishFlow };

--- a/editor.planx.uk/src/@planx/graph/__tests__/add.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/add.test.ts
@@ -218,6 +218,28 @@ test("with parent, before item", () => {
   ]);
 });
 
+test("can add sections on the root of the graph", () => {
+  const [graph, ops] = add(
+    { id: "sectionNodeId", type: 360 },
+    { before: "b", parent: "_root" }
+  )({
+    _root: { edges: ["a", "b"] },
+    a: {},
+    b: {},
+  });
+  expect(graph).toEqual({
+    _root: { edges: ["a", "sectionNodeId", "b"] },
+    a: {},
+    b: {},
+    sectionNodeId: { type: 360 },
+  });
+  expect(ops).toEqual([
+    { ld: "b", li: "sectionNodeId", p: ["_root", "edges", 1] },
+    { li: "b", p: ["_root", "edges", 2] },
+    { oi: { type: 360 }, p: ["sectionNodeId"] },
+  ]);
+});
+
 describe("error handling", () => {
   test("invalid parent", () => {
     expect(() => add({ id: "c" }, { parent: "x" })()).toThrow(
@@ -244,5 +266,18 @@ describe("error handling", () => {
         b: {},
       })
     ).toThrow("before not found");
+  });
+
+  test("cannot add sections in positions with non-root parents", () => {
+    expect(() =>
+      add(
+        { type: 360, data: { title: "Section 1" } },
+        { parent: "b" }
+      )({
+        _root: { edges: ["a", "b"] },
+        a: {},
+        b: {},
+      })
+    ).toThrow("cannot add sections on branches or in portals");
   });
 });

--- a/editor.planx.uk/src/@planx/graph/__tests__/clone.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/clone.test.ts
@@ -106,4 +106,16 @@ describe("error handling", () => {
       })
     ).toThrow("same parent");
   });
+
+  test("cannot clone sections", () => {
+    expect(() =>
+      clone("sectionNodeId", { toParent: "a" })({
+        _root: {
+          edges: ["a", "sectionNodeId"],
+        },
+        a: {},
+        sectionNodeId: { type: 360 },
+      })
+    ).toThrow("cannot clone sections");
+  });
 });

--- a/editor.planx.uk/src/@planx/graph/__tests__/move.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/move.test.ts
@@ -21,6 +21,27 @@ test("move within same parent", () => {
   ]);
 });
 
+test("move sections within same root parent", () => {
+  const [graph, ops] = move("sectionNodeId", "_root", { toBefore: "a" })({
+    _root: {
+      edges: ["a", "sectionNodeId"],
+    },
+    a: {},
+    sectionNodeId: { type: 360 },
+  });
+  expect(graph).toEqual({
+    _root: {
+      edges: ["sectionNodeId", "a"],
+    },
+    a: {},
+    sectionNodeId: { type: 360 },
+  });
+  expect(ops).toEqual([
+    { ld: "a", li: "sectionNodeId", p: ["_root", "edges", 0] },
+    { ld: "sectionNodeId", li: "a", p: ["_root", "edges", 1] },
+  ]);
+});
+
 describe("different parent", () => {
   test("move", () => {
     const [graph, ops] = move("b", "_root", { toParent: "a" })({
@@ -157,5 +178,17 @@ describe("error handling", () => {
         clone: {},
       })
     ).toThrow("same parent");
+  });
+
+  test("cannot move a section onto non-root parent", () => {
+    expect(() =>
+      move("sectionNodeId", "_root", { toParent: "a" })({
+        _root: {
+          edges: ["a", "sectionNodeId"],
+        },
+        a: {},
+        sectionNodeId: { type: 360 },
+      })
+    ).toThrow("cannot move sections onto branches, must be on center of graph");
   });
 });

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -163,9 +163,9 @@ const _add = (
 
   if (isSectionNodeType(id, draft) && parent !== ROOT_NODE_KEY) {
     alert(
-      "cannot add sections to branches, must be on center of graph. close this window & try again"
+      "cannot add sections on branches or in portals, must be on center of main graph. close this window & try again"
     );
-    throw new Error("cannot add sections on brances");
+    throw new Error("cannot add sections on branches or in portals");
   }
 
   if (before) {

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -1,3 +1,4 @@
+import { TYPES } from "@planx/components/types";
 import { enablePatches, produceWithPatches } from "immer";
 import difference from "lodash/difference";
 import trim from "lodash/trim";
@@ -37,7 +38,7 @@ const isSomething = (x: any): boolean =>
   x !== null && x !== undefined && x !== "";
 
 const isSectionNodeType = (id: string, graph: Graph): boolean =>
-  graph[id]?.type === 360;
+  graph[id]?.type === TYPES.Section;
 
 const sanitize = (x: any) => {
   if ((x && typeof x === "string") || x instanceof String) {

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -36,6 +36,9 @@ export const isClone = (id: string, graph: Graph): boolean =>
 const isSomething = (x: any): boolean =>
   x !== null && x !== undefined && x !== "";
 
+const isSectionNodeType = (id: string, graph: Graph): boolean =>
+  graph[id]?.type === 360;
+
 const sanitize = (x: any) => {
   if ((x && typeof x === "string") || x instanceof String) {
     return trim(x.replace(/[\u200B-\u200D\uFEFF↵]/g, ""));
@@ -158,6 +161,13 @@ const _add = (
 
   draft[id] = sanitize(nodeData);
 
+  if (isSectionNodeType(id, draft) && parent !== ROOT_NODE_KEY) {
+    alert(
+      "cannot add sections to branches, must be on center of graph. close this window & try again"
+    );
+    throw new Error("cannot add sections on brances");
+  }
+
   if (before) {
     const idx = parentNode.edges.indexOf(before);
     if (idx >= 0) {
@@ -209,6 +219,8 @@ export const clone =
       else if (!draft[toParent]) throw new Error("toParent not found");
       else if (draft[toParent].edges?.includes(id))
         throw new Error("cannot clone to same parent");
+      else if (isSectionNodeType(id, graph))
+        throw new Error("cannot clone sections");
 
       const toParentNode = draft[toParent];
 
@@ -250,6 +262,11 @@ export const move =
 
       const parentNode = draft[parent];
       parentNode.edges = parentNode.edges || [];
+
+      if (isSectionNodeType(id, graph) && toParent !== ROOT_NODE_KEY)
+        throw new Error(
+          "cannot move sections onto branches, must be on center of graph"
+        );
 
       let idx = parentNode.edges.indexOf(id);
       if (idx >= 0) {

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -262,7 +262,8 @@ const PreviewBrowser: React.FC<{
                       setLastPublishedTitle(
                         publishedFlow?.data.alteredNodes
                           ? `Successfully published changes to ${publishedFlow.data.alteredNodes.length} node(s)`
-                          : "No new changes to publish"
+                          : `${publishedFlow?.data?.message}` ||
+                              "No new changes to publish"
                       );
                     } catch (error) {
                       setLastPublishedTitle("Error trying to publish");


### PR DESCRIPTION
Rules for working with Sections in the Editor:
- [x] only allowed to add sections on the "center of graph" aka "root" (eg `_root: { edges: ["sectionNodeId"] }`)
  - [x] not allowed to add inside an internal portal (implicitly enforced because parent is portal node type, never `_root`)
  - [x] not allowed to add inside an external portal (this is validated at point of publish because that is when external portals are "flattened" and merged with the outer graph)
- [x] only allowed to move to other positions on the `_root`; not allowed to move onto branches
- [x] cannot clone sections
- [x] when using sections, a section should be in the first position of the graph (validated at point of publish only for now, see discussion here https://github.com/theopensystemslab/planx-new/pull/1478#discussion_r1115510847)

Other changes here:
- [x] show the editor some basic feedback when they violate the rules
- [x] add unit tests

To test: 
- Spend some in test flows on this pizza adding and dragging and cloning sections! (to clone = right click existing node, then click on "open circle" on another branch to attempt to place)
- Confirm that you are seeing error messages when appropriate
- Keep your console open and confirm that there is _not_ an operation logged when errors are thrown