### PR TITLE
fix: add type declaration for planx-document-templates for successful CI

### DIFF
--- a/api.planx.uk/@types/planx-document-templates.d.ts
+++ b/api.planx.uk/@types/planx-document-templates.d.ts
@@ -1,0 +1,1 @@
+declare module "@opensystemslab/planx-document-templates";

--- a/editor.planx.uk/types.d.ts
+++ b/editor.planx.uk/types.d.ts
@@ -9,3 +9,4 @@ declare module "draftjs-to-html";
 declare module "mathjs";
 declare module "@opensystemslab/map";
 declare module "wkt";
+declare module "@opensystemslab/planx-document-templates";


### PR DESCRIPTION
Recent PRs & local docker "up"s have been failing on the Build React App step (see #1482, #1483 etc)

Based on the timing and error, I think this was likely introduced on this merge - https://github.com/theopensystemslab/planx-document-templates/pull/11 ? I'm not entirely sure if intentional or not (I definitely missed during code review!), so this might be best addressed as a two-part/two-repo fix, but this should clear up our planx-new CI in the meantime :checkered_flag: 