### PR TITLE
feat: Save session on payment responses

### DIFF
--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -1919,7 +1919,7 @@ packages:
     resolution: {integrity: sha512-GWP9AZW7foLd4YQxyFZDBepl0lPsWLMEXDZUjQ/c1gqVPDPECrRZyEzuhJdnPWioFCq3Tv0qoGpMD6U+ygd4ZA==}
     dependencies:
       '@types/caseless': 0.12.2
-      '@types/node': 18.13.0
+      '@types/node': 16.18.3
       '@types/tough-cookie': 4.0.1
       form-data: 2.5.1
     dev: false
@@ -5125,7 +5125,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.13.0
+      '@types/node': 16.18.3
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -5352,7 +5352,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 18.13.0
+      '@types/node': 16.18.3
       chalk: 4.1.2
       graceful-fs: 4.2.10
       is-ci: 2.0.0

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "playwright test",
     "check": "tsc && eslint './src/*.{js,ts}'",
-    "test:server": "serve ../editor.planx.uk/build --single --listen 3000",
+    "test:server": "NODE_ENV=test serve ../editor.planx.uk/build --single --listen 3000",
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config({ path: "../.env" });
 const config: PlaywrightTestConfig = {
   testDir: "./src",
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 45 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/e2e/src/context.ts
+++ b/e2e/src/context.ts
@@ -146,6 +146,18 @@ export async function findSessionId(
 }
 
 async function deleteSession(adminGQLClient: GraphQLClient, context) {
+  if (context.sessionIds) {
+    for (const sessionId of context.sessionIds) {
+      await adminGQLClient.request(
+        `mutation DeleteTestSession( $sessionId: uuid!) {
+          delete_lowcal_sessions_by_pk(id: $sessionId) {
+            id
+          }
+        }`,
+        { sessionId }
+      );
+    }
+  }
   const sessionId = await findSessionId(adminGQLClient, context);
   if (sessionId) {
     log(`deleting session id: ${sessionId}`);
@@ -155,7 +167,7 @@ async function deleteSession(adminGQLClient: GraphQLClient, context) {
           id
         }
       }`,
-      { sessionId: sessionId }
+      { sessionId }
     );
   }
 }

--- a/e2e/src/pay.spec.ts
+++ b/e2e/src/pay.spec.ts
@@ -63,7 +63,7 @@ test.describe("Payment flow", async () => {
       cardNumber: cards.successful_card_number,
     });
     await page.locator("#confirm").click();
-    const { paymentId, status } = await waitForPaymentResponse(page);
+    const { paymentId } = await waitForPaymentResponse(page);
     expect(paymentId).toBeTruthy();
 
     // ensure a audit log entry was created
@@ -94,10 +94,8 @@ test.describe("Payment flow", async () => {
     await fillGovUkCardDetails({ page, cardNumber: cards.invalid_card_number });
     await page.locator("#return-url").click();
 
-    const { paymentId: failedPaymentRef, status } =
-      await waitForPaymentResponse(page);
+    const { paymentId: failedPaymentRef } = await waitForPaymentResponse(page);
     expect(failedPaymentRef).toBeTruthy();
-    expect(status).toBe("failed");
 
     // ensure a audit log entry was created
     expect(
@@ -151,11 +149,8 @@ test.describe("Payment flow", async () => {
     await page.getByText("Pay using GOV.UK Pay").click();
     await page.locator("#cancel-payment").click();
     await page.locator("#return-url").click();
-    const { paymentId: failedPaymentRef, state } = await waitForPaymentResponse(
-      page
-    );
+    const { paymentId: failedPaymentRef } = await waitForPaymentResponse(page);
     expect(failedPaymentRef).toBeTruthy();
-    expect(state?.status).toBe("failed");
 
     // ensure a audit log entry was created
     expect(
@@ -195,9 +190,7 @@ test.describe("Payment flow", async () => {
     await expect(page.getByText(paymentId!)).toBeVisible();
   });
 
-  test.only("a retry attempt for an abandoned GOV.UK payment", async ({
-    page,
-  }) => {
+  test("a retry attempt for an abandoned GOV.UK payment", async ({ page }) => {
     const sessionId = await navigateToPayComponent(page);
     context.sessionIds.push(sessionId);
 
@@ -282,8 +275,7 @@ test.describe("Payment flow", async () => {
       cardNumber: cards.successful_card_number,
     });
     await page.locator("#confirm").click();
-    const { paymentId: actualPaymentId, status: actualStatus } =
-      await waitForPaymentResponse(page);
+    const { paymentId: actualPaymentId } = await waitForPaymentResponse(page);
 
     // ensure that data stored in the session matches the latest payment attempt
     const session = await findSession({

--- a/editor.planx.uk/src/lib/lowcalStorage.ts
+++ b/editor.planx.uk/src/lib/lowcalStorage.ts
@@ -97,7 +97,8 @@ class LowcalStorage {
       variables: {
         id,
         data: JSON.parse(value),
-        email: useStore.getState().saveToEmail,
+        // email may be absent for non save and return journeys
+        email: useStore.getState().saveToEmail || "",
         flowId: useStore.getState().id,
       },
       ...getPublicContext(id),
@@ -145,7 +146,9 @@ const getPublicContext = (sessionId: string) => ({
   context: {
     headers: {
       "x-hasura-lowcal-session-id": sessionId,
-      "x-hasura-lowcal-email": useStore.getState().saveToEmail?.toLowerCase(),
+      "x-hasura-lowcal-email":
+        // email may be absent for non save and return journeys
+        useStore.getState().saveToEmail?.toLowerCase() || "",
     },
   },
 });

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -150,3 +150,7 @@ export type Session = {
   id: SharedStore["id"];
   govUkPayment?: GovUKPayment;
 };
+
+// re-export store types
+export interface Passport extends Store.passport {}
+export interface Breadcrumbs extends Store.breadcrumbs {}

--- a/hasura.planx.uk/.env.test.example
+++ b/hasura.planx.uk/.env.test.example
@@ -1,4 +1,5 @@
 # Used in local testing
 
 HASURA_ADMIN_SECRET=👻
+HASURA_HOST=0.0.0.0
 HASURA_PORT=7000

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -210,13 +210,6 @@
                 _is_null: true
             - deleted_at:
                 _is_null: true
-        check:
-          email:
-            _and:
-              - email:
-                _eq: x-hasura-lowcal-email
-              - email:
-                  _neq: ""
   update_permissions:
     - role: public
       permission:
@@ -233,9 +226,7 @@
                 _is_null: true
             - deleted_at:
                 _is_null: true
-        check:
-          email:
-            _eq: x-hasura-lowcal-email
+        check: {}
   event_triggers:
     - name: email_user_submission_confirmation
       definition:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -206,6 +206,8 @@
                 _is_null: true
             - deleted_at:
                 _is_null: true
+            - email:
+                _neq: ""
   update_permissions:
     - role: public
       permission:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -181,12 +181,14 @@
   insert_permissions:
     - role: public
       permission:
-        check: {}
         columns:
           - data
           - email
           - flow_id
           - id
+        check:
+          email:
+            _eq: x-hasura-lowcal-email
   select_permissions:
     - role: public
       permission:
@@ -202,12 +204,19 @@
                 _eq: x-hasura-lowcal-session-id
             - email:
                 _eq: x-hasura-lowcal-email
+            - email:
+                _neq: ""
             - submitted_at:
                 _is_null: true
             - deleted_at:
                 _is_null: true
-            - email:
-                _neq: ""
+        check:
+          email:
+            _and:
+              - email:
+                _eq: x-hasura-lowcal-email
+              - email:
+                  _neq: ""
   update_permissions:
     - role: public
       permission:
@@ -224,7 +233,9 @@
                 _is_null: true
             - deleted_at:
                 _is_null: true
-        check: {}
+        check:
+          email:
+            _eq: x-hasura-lowcal-email
   event_triggers:
     - name: email_user_submission_confirmation
       definition:

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -211,7 +211,7 @@ describe("lowcal_sessions", () => {
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
-      test("Alice can update (but not select) her own existing session with an empty email ", async () => {
+      test("Alice cannot update her own existing session with an empty email ", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
           "x-hasura-lowcal-email": ""
@@ -301,7 +301,7 @@ describe("lowcal_sessions", () => {
         expect(res.data.update_lowcal_sessions_by_pk.data).toHaveProperty("x", 1);
       });
 
-      test("Alice can update her session with an empty email", async () => {
+      test("Alice cannot update her session with an empty email", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
           "x-hasura-lowcal-email": ""

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -211,6 +211,15 @@ describe("lowcal_sessions", () => {
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
+      test("Alice can update (but not select) her own existing session with an empty email ", async () => {
+        const headers = {
+          "x-hasura-lowcal-session-id": alice1,
+          "x-hasura-lowcal-email": ""
+        };
+        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
+      });
+
       test("Mallory cannot update Alice's session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": uuidV4(),
@@ -253,15 +262,6 @@ describe("lowcal_sessions", () => {
         `, null, headers);
         expect(res.data.update_lowcal_sessions.returning).toHaveLength(1);
         expect(res.data.update_lowcal_sessions.returning[0].id).toEqual(bob1);
-      });
-
-      test("Alice can update (but not select) her own existing session with an empty email ", async () => {
-        const headers = {
-          "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": ""
-        };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
-        expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
       test("Anonymous users can upsert their own session with an empty email", async () => {

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -1,7 +1,7 @@
 const fetch = require("isomorphic-fetch");
 
 async function gqlAdmin(query, variables = {}) {
-  const res = await fetch(`http://0.0.0.0:${process.env.HASURA_PORT}/v1/graphql`, {
+  const res = await fetch(`http://${process.env.HASURA_HOST}:${process.env.HASURA_PORT}/v1/graphql`, {
     method: "POST",
     headers: {
       "X-Hasura-Admin-Secret": process.env.HASURA_ADMIN_SECRET,
@@ -16,7 +16,7 @@ async function gqlAdmin(query, variables = {}) {
 }
 
 async function gqlPublic(query, variables = {}, headers = {}) {
-  const res = await fetch(`http://0.0.0.0:${process.env.HASURA_PORT}/v1/graphql`, {
+  const res = await fetch(`http://${process.env.HASURA_HOST}:${process.env.HASURA_PORT}/v1/graphql`, {
     method: "POST",
     headers: headers,
     body: JSON.stringify({ query: query, variables }),


### PR DESCRIPTION
Save a lowcal session before redirecting to GovPay.

This PR introduces a change which adds a lowcal session entry on pay interactions.

I considered only updating the lowcal session on new payments or only on success but decided to update on every request to resolve the payment response from the proxy. This means that the lowcal session is always up to date with the latest payment information (including status). GovPay will only allow one payment at a time so keeping track of the latest payment requested will always result in tracking any payments that actually succeed.

To test this in detail, you would need to set up some additional logging to validate the payment_id tracks correctly. The audit table is also a helpful tool for testing here. Have a look at the E2E test scenarios which should cover all relevant test cases (let me know if you think something is missing).

**EDIT**
Also, a user should not be able to query the API to retrieve stored session information (unless this is also part of a save-and-return journey and they provide their email address).