### PR TITLE
fix: Add env vars back to React build in CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -202,10 +202,6 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm build-storybook
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
         env:
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
@@ -214,6 +210,20 @@ jobs:
           REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           # needed because there's no API to change google's allowed OAuth URLs
+          REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
+          REACT_APP_ENV: pizza
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm build-storybook
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+        env:
+          # same env as above, if it's job.env it can't access existing env.[variable]
+          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
+          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
+          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
+          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza
 


### PR DESCRIPTION
Undoes change made here - https://github.com/theopensystemslab/planx-new/pull/1480/files#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L206-L215

Currently, Pizzas are pointing to localhost:XXXX indicating that these values have not been correctly overwritten for the Pizza environment as part of the CI (I think!).