### PR TITLE
fix: Handle missing node id in Editor route

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -12,7 +12,7 @@ export interface SharedStore extends Store.Store {
   flowSlug: string;
   flowName: string;
   id: string;
-  getNode: (id: Store.nodeId) => Store.node;
+  getNode: (id: Store.nodeId) => Store.node | undefined;
   resetPreview: () => void;
   setFlow: ({
     id,
@@ -53,9 +53,11 @@ export const sharedStore: StateCreator<SharedStore, [], [], SharedStore> = (
   },
 
   getNode(id) {
+    const node = get().flow[id];
+    if (!node) return;
     return {
       id,
-      ...get().flow[id],
+      ...node,
     };
   },
 

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -2,7 +2,17 @@ import { gql } from "@apollo/client";
 import { TYPES } from "@planx/components/types";
 import ErrorFallback from "components/ErrorFallback";
 import natsort from "natsort";
-import { compose, lazy, mount, route, withData, withView } from "navi";
+import {
+  compose,
+  lazy,
+  map,
+  Matcher,
+  mount,
+  redirect,
+  route,
+  withData,
+  withView,
+} from "navi";
 import mapAccum from "ramda/src/mapAccum";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -86,58 +96,69 @@ const newNode = route(async (req) => {
   };
 });
 
-const editNode = route(async (req) => {
-  const { id, before = undefined, parent = undefined } = req.params;
+// If nodeId is invalid (e.g. a deleted node), fall back to flow
+const validateEdit = (route: Matcher<object, object>) =>
+  map((req) => {
+    const { team, flow, id } = req.params;
+    const node = useStore.getState().getNode(id);
+    if (!node) return redirect(`/${team}/${flow}`);
+    return route;
+  });
 
-  const node = useStore.getState().getNode(id) as {
-    type: TYPES;
-    [key: string]: any;
-  };
+const editNode = validateEdit(
+  route(async (req) => {
+    const { id, before = undefined, parent = undefined } = req.params;
 
-  const extraProps = {} as any;
+    const node = useStore.getState().getNode(id) as {
+      type: TYPES;
+      [key: string]: any;
+    };
 
-  if (node.type === TYPES.ExternalPortal)
-    extraProps.flows = await getExternalPortals();
+    const extraProps = {} as any;
 
-  const type = SLUGS[node.type];
+    if (node.type === TYPES.ExternalPortal)
+      extraProps.flows = await getExternalPortals();
 
-  if (type === "checklist" || type === "question") {
-    const childNodes = useStore.getState().childNodesOf(id);
-    if (node.data?.categories) {
-      extraProps.groupedOptions = mapAccum(
-        (index: number, category: { title: string; count: number }) => [
-          index + category.count,
-          {
-            title: category.title,
-            children: childNodes.slice(index, index + category.count),
-          },
-        ],
-        0,
-        node.data.categories
-      )[1];
-    } else {
-      extraProps.options = childNodes;
+    const type = SLUGS[node.type];
+
+    if (type === "checklist" || type === "question") {
+      const childNodes = useStore.getState().childNodesOf(id);
+      if (node.data?.categories) {
+        extraProps.groupedOptions = mapAccum(
+          (index: number, category: { title: string; count: number }) => [
+            index + category.count,
+            {
+              title: category.title,
+              children: childNodes.slice(index, index + category.count),
+            },
+          ],
+          0,
+          node.data.categories
+        )[1];
+      } else {
+        extraProps.options = childNodes;
+      }
     }
-  }
 
-  return {
-    title: makeTitle(`Edit ${type}`),
-    view: (
-      <FormModal
-        type={type}
-        Component={components[type]}
-        extraProps={extraProps}
-        node={node}
-        id={id}
-        handleDelete={() => {
-          useStore.getState().removeNode(id, parent!);
-        }}
-        before={before}
-        parent={parent}
-      />
-    ),
-  };
-});
+    return {
+      title: makeTitle(`Edit ${type}`),
+      view: (
+        <FormModal
+          type={type}
+          Component={components[type]}
+          extraProps={extraProps}
+          node={node}
+          id={id}
+          handleDelete={() => {
+            useStore.getState().removeNode(id, parent!);
+          }}
+          before={before}
+          parent={parent}
+        />
+      ),
+    };
+  })
+);
 
 const nodeRoutes = mount({
   "/new/:before": newNode,

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -97,7 +97,7 @@ const newNode = route(async (req) => {
 });
 
 // If nodeId is invalid (e.g. a deleted node), fall back to flow
-const validateEdit = (route: Matcher<object, object>) =>
+const validateNodeRoute = (route: Matcher<object, object>) =>
   map((req) => {
     const { team, flow, id } = req.params;
     const node = useStore.getState().getNode(id);
@@ -105,7 +105,7 @@ const validateEdit = (route: Matcher<object, object>) =>
     return route;
   });
 
-const editNode = validateEdit(
+const editNode = validateNodeRoute(
   route(async (req) => {
     const { id, before = undefined, parent = undefined } = req.params;
 


### PR DESCRIPTION
# What does this PR do?
- Adds an additional validation step in the Editor to ensure that users cannot navigate to an invalid route


## Context
See PlanX Slack here - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1677159875899169

To recreate - 
- Delete a node
- Hit back in the browser so your URL is now `…nodes/<DELTED_NODE_ID>/edit`
- Invalid URL - Error! ❌ 

The above steps cannot be recreate on the Pizza, invalid routes will just redirect to the main flow.
