### PR TITLE
fix: `:nth-child` CSS warning thrown by Emotion

### DIFF
--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -236,15 +236,15 @@ const PropertyDetailsList = styled(Box)(({ theme }) => ({
     padding: 0,
     margin: 0,
   },
-  "& >:nth-child(3n+1)": {
+  "& dt": {
     // left column
     fontWeight: 700,
   },
-  "& >:nth-child(3n+2)": {
+  "& dd:nth-of-type(n)": {
     // middle column
     paddingLeft: "10px",
   },
-  "& >:nth-child(3n+3)": {
+  "& dd:nth-of-type(2n)": {
     // right column
     textAlign: "right",
   },

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -1,5 +1,5 @@
 import Link from "@mui/material/Link";
-import makeStyles from "@mui/styles/makeStyles";
+import { styled } from "@mui/material/styles";
 import { visuallyHidden } from "@mui/utils";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { TYPES } from "@planx/components/types";
@@ -9,37 +9,35 @@ import React from "react";
 
 export default SummaryList;
 
-const useStyles = makeStyles((theme) => ({
-  grid: {
-    display: "grid",
-    gridTemplateColumns: "1fr 2fr 100px",
-    gridRowGap: "10px",
-    marginTop: theme.spacing(4),
-    marginBottom: theme.spacing(4),
-    "& > *": {
-      borderBottom: "1px solid grey",
-      paddingBottom: theme.spacing(2),
-      paddingTop: theme.spacing(2),
-      verticalAlign: "top",
-      margin: 0,
-    },
-    "& ul": {
-      listStylePosition: "inside",
-      padding: 0,
-      margin: 0,
-    },
-    "& >:nth-child(3n+1)": {
-      // left column
-      fontWeight: 700,
-    },
-    "& >:nth-child(3n+2)": {
-      // middle column
-      paddingLeft: "10px",
-    },
-    "& >:nth-child(3n+3)": {
-      // right column
-      textAlign: "right",
-    },
+const Grid = styled("dl")(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "1fr 2fr 100px",
+  gridRowGap: "10px",
+  marginTop: theme.spacing(4),
+  marginBottom: theme.spacing(4),
+  "& > *": {
+    borderBottom: "1px solid grey",
+    paddingBottom: theme.spacing(2),
+    paddingTop: theme.spacing(2),
+    verticalAlign: "top",
+    margin: 0,
+  },
+  "& ul": {
+    listStylePosition: "inside",
+    padding: 0,
+    margin: 0,
+  },
+  "& dt": {
+    // left column
+    fontWeight: 700,
+  },
+  "& dd:nth-of-type(n)": {
+    // middle column
+    paddingLeft: "10px",
+  },
+  "& dd:nth-of-type(2n)": {
+    // right column
+    textAlign: "right",
   },
 }));
 
@@ -88,14 +86,12 @@ interface SummaryListProps {
 // For applicable component types, display a list of their question & answers with a "change" link
 //  ref https://design-system.service.gov.uk/components/summary-list/
 function SummaryList(props: SummaryListProps) {
-  const { grid } = useStyles();
-
   const handleClick = (nodeId: string) => {
     props.changeAnswer(nodeId);
   };
 
   return (
-    <dl className={grid}>
+    <Grid>
       {
         // XXX: This works because since ES2015 key order is guaranteed to be the insertion order
         Object.entries(props.breadcrumbs)
@@ -139,7 +135,7 @@ function SummaryList(props: SummaryListProps) {
             );
           })
       }
-    </dl>
+    </Grid>
   );
 }
 


### PR DESCRIPTION
# Problem
The following warning is thrown in console when navigating to the FindProperty and SummaryList components in local dev - 

<img width="561" alt="Screenshot 2023-02-24 at 09 40 36" src="https://user-images.githubusercontent.com/20502206/221145537-30baafc2-79d3-4ae4-a9a8-c2dcca2ab163.png">

# Solution
Change from `:nth-child` selector to `:nth-of-type` selector.

Display after this change is still consistent - 

<img width="791" alt="Screenshot 2023-02-24 at 09 37 34" src="https://user-images.githubusercontent.com/20502206/221144984-85c05219-0f5c-4fc5-8a57-c98f889be31d.png">

<img width="804" alt="Screenshot 2023-02-24 at 09 39 33" src="https://user-images.githubusercontent.com/20502206/221145108-48ced1c4-4a0f-45ac-92df-8358134d6714.png">
