### PR TITLE
feat: sections overview page with dynamic status tags

### DIFF
--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -1,16 +1,135 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import type { PublicProps } from "@planx/components/ui";
-import { useEffect } from "react";
+import { hasFeatureFlag } from "lib/featureFlags";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useEffect } from "react";
 
+import Card from "../shared/Preview/Card";
+import QuestionHeader from "../shared/Preview/QuestionHeader";
 import type { Section } from "./model";
 
 export type Props = PublicProps<Section>;
 
+enum SectionStatus {
+  NotStarted = "CANNOT START YET",
+  ReadyToStart = "READY TO START",
+  Completed = "COMPLETED",
+  NeedsUpdated = "NEEDS UPDATED", // future reconciliation scenario, not used yet
+}
+
 export default function Component(props: Props) {
+  const showSection = hasFeatureFlag("NAVIGATION_UI");
+
+  const [
+    flowName,
+    currentSectionIndex,
+    sectionCount,
+    sectionNodes,
+    currentCard,
+    upcomingCardIds,
+  ] = useStore((state) => [
+    state.flowName,
+    state.currentSectionIndex,
+    state.sectionCount,
+    state.sectionNodes,
+    state.currentCard(),
+    state.upcomingCardIds(),
+  ]);
+
   useEffect(() => {
-    props.handleSubmit?.({
-      auto: true, // hides this node when navigating through cards in a flow
-    });
+    !showSection &&
+      props.handleSubmit?.({
+        auto: true, // hides this node when navigating through cards in a flow if the feature flag is toggled off
+      });
   }, []);
 
-  return null;
+  const getStatus = (
+    sectionId: string,
+    currentCardId: string | undefined,
+    upcomingCardIds: string[] | undefined
+  ): SectionStatus => {
+    if (currentCardId === sectionId) {
+      return SectionStatus.ReadyToStart;
+    } else if (upcomingCardIds?.includes(sectionId)) {
+      return SectionStatus.NotStarted;
+    } else {
+      return SectionStatus.Completed;
+    }
+  };
+
+  return !showSection ? null : (
+    <Card isValid handleSubmit={props.handleSubmit}>
+      <QuestionHeader title={flowName} />
+      <Box sx={{ lineHeight: ".5em" }}>
+        <Typography variant="body1" component="h2" sx={{ fontWeight: "bold" }}>
+          Application incomplete.
+        </Typography>
+        <Typography variant="body2">
+          {`You have completed ${
+            Object.keys(sectionNodes)[0] === currentCard?.id
+              ? 0
+              : currentSectionIndex
+          } of ${sectionCount} sections`}
+        </Typography>
+      </Box>
+      <DescriptionList>
+        {Object.entries(sectionNodes).map(([sectionId, sectionNode]) => (
+          <React.Fragment key={sectionId}>
+            <dt>{sectionNode.data.title}</dt>
+            <dd>
+              <Tag>
+                {getStatus(sectionId, currentCard?.id, upcomingCardIds)}
+              </Tag>
+            </dd>
+          </React.Fragment>
+        ))}
+      </DescriptionList>
+    </Card>
+  );
 }
+
+const Tag = styled("div")(({ theme }) => ({
+  backgroundColor: "lightgrey",
+  paddingTop: theme.spacing(0.5),
+  paddingBottom: theme.spacing(0.5),
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+}));
+
+const Grid = styled("dl")(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "1fr 175px",
+  gridRowGap: "5px",
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(2),
+  "& > *": {
+    borderBottom: "1px solid grey",
+    paddingBottom: theme.spacing(2),
+    paddingTop: theme.spacing(2),
+    verticalAlign: "top",
+    margin: 0,
+  },
+  "& ul": {
+    listStylePosition: "inside",
+    padding: 0,
+    margin: 0,
+  },
+  "& dt": {
+    // left column
+    fontWeight: 500,
+  },
+  "& dd:nth-of-type(1n)": {
+    // right column
+    textAlign: "center",
+  },
+}));
+
+interface DescriptionListProps {
+  children: React.ReactNode;
+}
+
+const DescriptionList: React.FC<DescriptionListProps> = ({ children }) => {
+  return <Grid>{children}</Grid>;
+};

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -39,9 +39,10 @@ export default function Component(props: Props) {
   ]);
 
   useEffect(() => {
+    // if the feature flag is toggled off, hide this node (by auto-answering it) when navigating through a flow
     !showSection &&
       props.handleSubmit?.({
-        auto: true, // hides this node when navigating through cards in a flow if the feature flag is toggled off
+        auto: true,
       });
   }, []);
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -73,15 +73,12 @@ export const navigationStore: StateCreator<
 
     const breadcrumbIds = Object.keys(breadcrumbs);
     const sectionIds = Object.keys(sectionNodes);
-    const mostRecentSectionId = findLast(
-      breadcrumbIds,
-      (breadcrumbId: string) => sectionIds.includes(breadcrumbId)
-    );
 
-    // This should not happen - if we have sections, we should have a most recent section
-    // Failing noisily for now will help identify issues whilst this is being developed & tested
-    // TODO: Fail more gracefully once feature is complete
-    if (!mostRecentSectionId) throw Error("Error finding mostRecentSectionId");
+    // Fallback to the first sectionId, which allows us to have a mostRecentSectionId on the first node ("Card") before it exists in breadcrumbs (eg "Continue" hasn't been clicked yet)
+    const mostRecentSectionId =
+      findLast(breadcrumbIds, (breadcrumbId: string) =>
+        sectionIds.includes(breadcrumbId)
+      ) || sectionIds[0];
 
     // Update section
     const currentSectionTitle = sectionNodes[mostRecentSectionId].data.title;


### PR DESCRIPTION
First draft at the public "overview page" display of a "Section" node per Figma (linked in Trello)

Changes here (demo flow https://1491.planx.pizza/doncaster/test-service-with-sections):
- When the `NAVIGATION_UI` feature flag is toggled on, a Section node has a public-facing card in the graph (if the feature flag is off, it is hidden)
- The overview list correctly displays all Setions found in this flow
- The status tag updates correctly as you go forward and answer questions in a section

![Screenshot from 2023-02-24 15-31-14](https://user-images.githubusercontent.com/5132349/221203877-8202838e-c9be-4621-ad08-cd5eeb5d0594.png)

Future scope:
- Confirm & add tests for status tag behavior (eg back, "change" from Review, etc) & clean up tag styles (colours, etc) ([Trello ticket](https://trello.com/c/yNUyIP2I/2307-08-completed-not-started-ready-to-start-tags-for-sections-on-overview))
- If status = "Completed", then style section title as a link & navigate back to that section on click ([Trello ticket](https://trello.com/c/wf4Q6g4y/2308-08-connect-title-to-change-behavior-on-overview-page))