### PR TITLE
refact(ci): extract reusable workflow

### DIFF
--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -47,12 +47,12 @@ jobs:
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
           REACT_APP_API_URL: https://api.${{ inputs.target }}
+          REACT_APP_ENV: ${{ inputs.environment }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.${{ inputs.target }}/v1/graphql
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.target }}
           # needed because there's no API to change google's allowed OAuth URLs
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: "${{ inputs.environment == 'pizza' && 'https://api.editor.planx.dev' || '' }}"
-          REACT_APP_ENV: ${{ inputs.environment }}
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}-${{ inputs.target }}
+          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}-${{ inputs.environment }}
       - uses: pnpm/action-setup@v2.2.2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -1,17 +1,8 @@
 on:
   workflow_call:
     inputs:
-      PNPM_VERSION:
-        required: true
-        type: string
-      EDITOR_DIRECTORY:
-        required: true
-        type: string
-      NODE_VERSION:
-        required: true
-        type: string
-      FULL_DOMAIN:
-        required: true
+      example:
+        required: false
         type: string
 
 jobs:
@@ -20,51 +11,59 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+      - uses: cardinalby/export-env-action@v2
+        with:
+          envFile: '.github/workflows/constants.env'
+          expand: true
+          expandWithJobEnv: true
+      - name: print all env vars
+        run: |
+          env
       - name: Cache build assets
         id: cache-react-build-assets
         uses: actions/cache@v3
         with:
-          path: ./${{ inputs.EDITOR_DIRECTORY }}/build
+          path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}
       - uses: pnpm/action-setup@v2.2.2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
-          version: ${{ inputs.PNPM_VERSION }}
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
-          node-version: ${{ inputs.NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
-      - run: pnpm distribute ../${{ inputs.EDITOR_DIRECTORY }}
+      - run: pnpm distribute ../${{ env.EDITOR_DIRECTORY }}
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         working-directory: core
       - run: pnpm install --frozen-lockfile
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ inputs.EDITOR_DIRECTORY }}
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         env:
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ inputs.FULL_DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ inputs.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.FULL_DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           # needed because there's no API to change google's allowed OAuth URLs
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza
-        working-directory: ${{ inputs.EDITOR_DIRECTORY }}
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build-storybook
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ inputs.EDITOR_DIRECTORY }}
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
         env:
           # same env as above, if it's job.env it can't access existing env.[variable]
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ inputs.FULL_DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ inputs.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.FULL_DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -1,8 +1,11 @@
 on:
   workflow_call:
     inputs:
-      example:
-        required: false
+      target:
+        required: true
+        type: string
+      environment:
+        required: true
         type: string
 
 jobs:
@@ -10,21 +13,24 @@ jobs:
     name: Build React App
     runs-on: ubuntu-22.04
     steps:
+      - name: test conditional env
+        run: |
+          echo "${{ true && 'true' || 'false' }}"
+          echo "${{ false && 'true' || 'false' }}"
+          echo "${{ true && 'something' || '' }}"
+          echo "${{ false && 'something' || '' }}"
       - uses: actions/checkout@v2
       - uses: cardinalby/export-env-action@v2
         with:
           envFile: '.github/workflows/constants.env'
           expand: true
           expandWithJobEnv: true
-      - name: print all env vars
-        run: |
-          env
       - name: Cache build assets
         id: cache-react-build-assets
         uses: actions/cache@v3
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}
+          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}-${{ inputs.target }}
       - uses: pnpm/action-setup@v2.2.2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
@@ -46,14 +52,21 @@ jobs:
         env:
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ github.event.number }}.${{ env.DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ inputs.target }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ github.event.number }}.${{ env.DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ github.event.number }}.${{ env.DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ inputs.target }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.target }}
+          # TODO: this shouldn't be set for staging
           # needed because there's no API to change google's allowed OAuth URLs
-          REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
-          REACT_APP_ENV: pizza
+          REACT_APP_GOOGLE_OAUTH_OVERRIDE: "${{ inputs.environment == 'pizza' && 'https://api.editor.planx.dev' || '' }}"
+          REACT_APP_ENV: ${{ inputs.environment }}
         working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: ./editor.planx.uk/build
+          if-no-files-found: error
       - run: pnpm build-storybook
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.EDITOR_DIRECTORY }}
@@ -66,4 +79,4 @@ jobs:
           REACT_APP_HASURA_URL: https://hasura.${{ github.event.number }}.${{ env.DOMAIN }}/v1/graphql
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ github.event.number }}.${{ env.DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
-          REACT_APP_ENV: pizza
+          REACT_APP_ENV: ${{ inputs.environment }}

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -1,9 +1,18 @@
 on:
   workflow_call:
-#     inputs:
-#       config-path:
-#         required: true
-#         type: string
+    inputs:
+      PNPM_VERSION:
+        required: true
+        type: string
+      EDITOR_DIRECTORY:
+        required: true
+        type: string
+      NODE_VERSION:
+        required: true
+        type: string
+      FULL_DOMAIN:
+        required: true
+        type: string
 
 jobs:
   build_react:
@@ -15,47 +24,47 @@ jobs:
         id: cache-react-build-assets
         uses: actions/cache@v3
         with:
-          path: ./${{ env.EDITOR_DIRECTORY }}/build
+          path: ./${{ inputs.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}
       - uses: pnpm/action-setup@v2.2.2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ inputs.PNPM_VERSION }}
       - uses: actions/setup-node@v2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ inputs.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
-      - run: pnpm distribute ../${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm distribute ../${{ inputs.EDITOR_DIRECTORY }}
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         working-directory: core
       - run: pnpm install --frozen-lockfile
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+        working-directory: ${{ inputs.EDITOR_DIRECTORY }}
       - run: pnpm build
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         env:
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ inputs.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ inputs.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.FULL_DOMAIN }}
           # needed because there's no API to change google's allowed OAuth URLs
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+        working-directory: ${{ inputs.EDITOR_DIRECTORY }}
       - run: pnpm build-storybook
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+        working-directory: ${{ inputs.EDITOR_DIRECTORY }}
         env:
           # same env as above, if it's job.env it can't access existing env.[variable]
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ inputs.FULL_DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ inputs.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.FULL_DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -46,10 +46,10 @@ jobs:
         env:
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ github.event.number }}.${{ env.DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ github.event.number }}.${{ env.DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ github.event.number }}.${{ env.DOMAIN }}
           # needed because there's no API to change google's allowed OAuth URLs
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza
@@ -61,9 +61,9 @@ jobs:
           # same env as above, if it's job.env it can't access existing env.[variable]
           REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_API_URL: https://api.${{ github.event.number }}.${{ env.DOMAIN }}
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
+          REACT_APP_HASURA_URL: https://hasura.${{ github.event.number }}.${{ env.DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ github.event.number }}.${{ env.DOMAIN }}
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           REACT_APP_ENV: pizza

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -1,0 +1,61 @@
+on:
+  workflow_call:
+#     inputs:
+#       config-path:
+#         required: true
+#         type: string
+
+jobs:
+  build_react:
+    name: Build React App
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache build assets
+        id: cache-react-build-assets
+        uses: actions/cache@v3
+        with:
+          path: ./${{ env.EDITOR_DIRECTORY }}/build
+          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}
+      - uses: pnpm/action-setup@v2.2.2
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v2
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - run: pnpm distribute ../${{ env.EDITOR_DIRECTORY }}
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        working-directory: core
+      - run: pnpm install --frozen-lockfile
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm build
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        env:
+          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
+          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
+          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
+          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
+          # needed because there's no API to change google's allowed OAuth URLs
+          REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
+          REACT_APP_ENV: pizza
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm build-storybook
+        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+        env:
+          # same env as above, if it's job.env it can't access existing env.[variable]
+          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
+          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
+          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
+          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
+          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
+          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
+          REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
+          REACT_APP_ENV: pizza

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -13,12 +13,6 @@ jobs:
     name: Build React App
     runs-on: ubuntu-22.04
     steps:
-      - name: test conditional env
-        run: |
-          echo "${{ true && 'true' || 'false' }}"
-          echo "${{ false && 'true' || 'false' }}"
-          echo "${{ true && 'something' || '' }}"
-          echo "${{ false && 'something' || '' }}"
       - uses: actions/checkout@v2
       - uses: cardinalby/export-env-action@v2
         with:
@@ -56,7 +50,6 @@ jobs:
           REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
           REACT_APP_HASURA_URL: https://hasura.${{ inputs.target }}/v1/graphql
           REACT_APP_SHAREDB_URL: wss://sharedb.${{ inputs.target }}
-          # TODO: this shouldn't be set for staging
           # needed because there's no API to change google's allowed OAuth URLs
           REACT_APP_GOOGLE_OAUTH_OVERRIDE: "${{ inputs.environment == 'pizza' && 'https://api.editor.planx.dev' || '' }}"
           REACT_APP_ENV: ${{ inputs.environment }}

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_react:
-    name: Build React App
+    name: Build
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/constants.env
+++ b/.github/workflows/constants.env
@@ -1,6 +1,4 @@
 DOMAIN=planx.pizza
-FULL_DOMAIN=${github.event.number}.planx.pizza
-PULLREQUEST_ID=${github.event.number}
 EDITOR_DIRECTORY=editor.planx.uk
 PNPM_VERSION=7.8.0
 NODE_VERSION=16.13.1  # 16.13.1 = LTS

--- a/.github/workflows/constants.env
+++ b/.github/workflows/constants.env
@@ -1,0 +1,6 @@
+DOMAIN=planx.pizza
+FULL_DOMAIN=${github.event.number}.planx.pizza
+PULLREQUEST_ID=${github.event.number}
+EDITOR_DIRECTORY=editor.planx.uk
+PNPM_VERSION=7.8.0
+NODE_VERSION=16.13.1  # 16.13.1 = LTS

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -176,11 +176,6 @@ jobs:
     needs: [changes]
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     uses: ./.github/workflows/build-react.yml
-    with:
-      PNPM_VERSION: ${{ env.PNPM_VERSION }}
-      EDITOR_DIRECTORY: ${{ env.EDITOR_DIRECTORY }}
-      NODE_VERSION: ${{ env.NODE_VERSION }}
-      FULL_DOMAIN: ${{ env.FULL_DOMAIN }}
 
   pulumi_preview:
     name: Run Pulumi Preview

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -205,11 +205,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download React build assets
-        id: cache-react-build-assets
         uses: actions/cache@v3
         with:
+          fail-on-cache-miss: true
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}
+          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}-pizza
       - uses: pulumi/actions@v3
         with:
           command: preview
@@ -323,11 +323,11 @@ jobs:
 
       - uses: actions/checkout@v2
       - name: Download React build assets
-        id: cache-react-build-assets
         uses: actions/cache@v3
         with:
+          fail-on-cache-miss: true
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}
+          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}-pizza
       - name: upload built editor
         uses: appleboy/scp-action@master
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -170,7 +170,7 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   build_react_app:
-    name: Build React App
+    name: React App
     needs: [changes]
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     uses: ./.github/workflows/build-react.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ env:
   PULLREQUEST_ID: ${{ github.event.number }}
   EDITOR_DIRECTORY: editor.planx.uk
   PNPM_VERSION: 7.8.0
-  NODE_VERSION: 16.13.1 # 16.13.1 = LTS
+  NODE_VERSION: 16.13.1  # 16.13.1 = LTS
 
 jobs:
   changes:
@@ -172,60 +172,10 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   build_react_app:
+    uses: ./.github/workflows/build-react.yml
     name: Build React App
-    runs-on: ubuntu-22.04
     needs: [changes]
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache build assets
-        id: cache-react-build-assets
-        uses: actions/cache@v3
-        with:
-          path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}
-      - uses: pnpm/action-setup@v2.2.2
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v2
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - run: pnpm distribute ../${{ env.EDITOR_DIRECTORY }}
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: core
-      - run: pnpm install --frozen-lockfile
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm build
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        env:
-          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
-          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
-          # needed because there's no API to change google's allowed OAuth URLs
-          REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
-          REACT_APP_ENV: pizza
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm build-storybook
-        if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-        env:
-          # same env as above, if it's job.env it can't access existing env.[variable]
-          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
-          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
-          REACT_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
-          REACT_APP_ENV: pizza
 
   pulumi_preview:
     name: Run Pulumi Preview
@@ -427,13 +377,13 @@ jobs:
         uses: treosh/lighthouse-ci-action@v9
         id: LHCIAction
         with:
-          urls: | 
+          urls: |
             https://editor.planx.dev/buckinghamshire/find-out-if-you-need-planning-permission/preview
             https://${{ env.FULL_DOMAIN }}/buckinghamshire/find-out-if-you-need-planning-permission/preview
             https://editor.planx.dev/testing/lighthouse-canary-flow/unpublished
             https://${{ env.FULL_DOMAIN }}/testing/lighthouse-canary-flow/unpublished
-          uploadArtifacts: true # save results as an action artifacts
-          temporaryPublicStorage: true # upload lighthouse report to the temporary storage
+          uploadArtifacts: true  # save results as an action artifacts
+          temporaryPublicStorage: true  # upload lighthouse report to the temporary storage
       - name: Interpolate comment text
         id: text
         uses: actions/github-script@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -175,7 +175,10 @@ jobs:
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     uses: ./.github/workflows/build-react.yml
     with:
-      target: "${{ github.event.number }}.${{ env.DOMAIN }}"
+      # TODO: replace `planx.pizza` for `${{ env.DOMAIN }}`
+      #       although it's not possible to use env variables in `with` section
+      #       you might be able to use `env` section to set `DOMAIN` variable
+      target: "${{ github.event.number }}.planx.pizza"
       environment: "pizza"
 
   pulumi_preview:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -174,6 +174,9 @@ jobs:
     needs: [changes]
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     uses: ./.github/workflows/build-react.yml
+    with:
+      target: "${{ github.event.number }}.${{ env.DOMAIN }}"
+      environment: "pizza"
 
   pulumi_preview:
     name: Run Pulumi Preview

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,8 +9,6 @@ on:
 
 env:
   DOMAIN: planx.pizza
-  FULL_DOMAIN: ${{ github.event.number }}.planx.pizza
-  PULLREQUEST_ID: ${{ github.event.number }}
   EDITOR_DIRECTORY: editor.planx.uk
   PNPM_VERSION: 7.8.0
   NODE_VERSION: 16.13.1  # 16.13.1 = LTS
@@ -226,7 +224,7 @@ jobs:
         id: hasura-change
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          hasura_endpoint: https://hasura.${{ env.FULL_DOMAIN }}
+          hasura_endpoint: https://hasura.${{ github.event.number }}.${{ env.DOMAIN }}
           project_dir: ./hasura.planx.uk
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{steps.hasura-change.outputs.change_html != ''}}
@@ -256,7 +254,7 @@ jobs:
           domain: ${{ env.DOMAIN }}
           os_id: 1743
           plan: vc2-1c-1gb
-          pullrequest_id: ${{ env.PULLREQUEST_ID }}
+          pullrequest_id: ${{ github.event.number }}
           region: lhr
           tag: pullrequest
 
@@ -266,14 +264,14 @@ jobs:
         name: Create commands
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ env.FULL_DOMAIN }}
+          host: ${{ github.event.number }}.${{ env.DOMAIN }}
           username: root
           password: ${{ steps.create.outputs.default_password }}
           command_timeout: 20m
           script: |
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
             cd planx-new
-            git fetch origin "pull/${{ env.PULLREQUEST_ID }}/head" && git checkout FETCH_HEAD
+            git fetch origin "pull/${{ github.event.number }}/head" && git checkout FETCH_HEAD
 
             apt-get install awscli -y
             export AWS_ACCESS_KEY_ID=${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
@@ -282,7 +280,7 @@ jobs:
 
             ./scripts/pull-secrets.sh
 
-            echo -e "\nROOT_DOMAIN=${{ env.FULL_DOMAIN }}\n" > .env.temp
+            echo -e "\nROOT_DOMAIN=${{ github.event.number }}.${{ env.DOMAIN }}\n" > .env.temp
             cat .env .env.temp .env.staging > .env.pizza
 
             SSH_PASSWORD=${{ secrets.SSH_PASSWORD }} ./scripts/pullrequest/create.sh
@@ -293,7 +291,7 @@ jobs:
         name: Update commands
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ env.FULL_DOMAIN }}
+          host: ${{ github.event.number }}.${{ env.DOMAIN }}
           username: root
           password: ${{ secrets.SSH_PASSWORD }}
           command_timeout: 10m
@@ -301,7 +299,7 @@ jobs:
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
             cd planx-new
             git add . && git stash
-            git fetch origin "pull/${{ env.PULLREQUEST_ID }}/head" && git checkout FETCH_HEAD
+            git fetch origin "pull/${{ github.event.number }}/head" && git checkout FETCH_HEAD
 
             apt-get install awscli -y
             export AWS_ACCESS_KEY_ID=${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
@@ -310,7 +308,7 @@ jobs:
 
             ./scripts/pull-secrets.sh
 
-            echo -e "\nROOT_DOMAIN=${{ env.FULL_DOMAIN }}\n" > .env.temp
+            echo -e "\nROOT_DOMAIN=${{ github.event.number }}.${{ env.DOMAIN }}\n" > .env.temp
             cat .env .env.temp .env.staging > .env.pizza
 
             ./scripts/pullrequest/update.sh
@@ -327,7 +325,7 @@ jobs:
       - name: upload built editor
         uses: appleboy/scp-action@master
         with:
-          host: ${{ env.FULL_DOMAIN }}
+          host: ${{ github.event.number }}.${{ env.DOMAIN }}
           username: root
           password: ${{ secrets.SSH_PASSWORD }}
           source: "./${{ env.EDITOR_DIRECTORY }}/build"
@@ -340,14 +338,14 @@ jobs:
           message: |
             ## Pizza
 
-            Deployed ${{ github.sha }} to https://${{ env.FULL_DOMAIN }}.
+            Deployed ${{ github.sha }} to https://${{ github.event.number }}.${{ env.DOMAIN }}.
 
             Useful links:
-              - [Editor](https://${{ env.FULL_DOMAIN }})
-              - [Storybook](https://storybook.${{ env.FULL_DOMAIN }})
-              - [Hasura](https://hasura.${{ env.FULL_DOMAIN }})
-              - [API](https://api.${{ env.FULL_DOMAIN }})
-              - [ShareDB](https://sharedb.${{ env.FULL_DOMAIN }})
+              - [Editor](https://${{ github.event.number }}.${{ env.DOMAIN }})
+              - [Storybook](https://storybook.${{ github.event.number }}.${{ env.DOMAIN }})
+              - [Hasura](https://hasura.${{ github.event.number }}.${{ env.DOMAIN }})
+              - [API](https://api.${{ github.event.number }}.${{ env.DOMAIN }})
+              - [ShareDB](https://sharedb.${{ github.event.number }}.${{ env.DOMAIN }})
 
   healthcheck:
     name: Run Healthcheck on Pizza Services
@@ -356,15 +354,15 @@ jobs:
     steps:
       - name: API healthcheck
         run: |
-          timeout 150s bash -c "until curl --fail https://api.${{ env.FULL_DOMAIN }}; do sleep 1; done"
+          timeout 150s bash -c "until curl --fail https://api.${{ github.event.number }}.${{ env.DOMAIN }}; do sleep 1; done"
 
       - name: Hasura healthcheck
         run: |
-          timeout 150s bash -c "until curl --fail https://hasura.${{ env.FULL_DOMAIN }}/healthz; do sleep 1; done"
+          timeout 150s bash -c "until curl --fail https://hasura.${{ github.event.number }}.${{ env.DOMAIN }}/healthz; do sleep 1; done"
 
       - name: Editor healthcheck
         run: |
-          timeout 150s bash -c "until curl --fail https://${{ env.FULL_DOMAIN }}; do sleep 1; done"
+          timeout 150s bash -c "until curl --fail https://${{ github.event.number }}.${{ env.DOMAIN }}; do sleep 1; done"
 
 
   lighthouse:
@@ -379,9 +377,9 @@ jobs:
         with:
           urls: |
             https://editor.planx.dev/buckinghamshire/find-out-if-you-need-planning-permission/preview
-            https://${{ env.FULL_DOMAIN }}/buckinghamshire/find-out-if-you-need-planning-permission/preview
+            https://${{ github.event.number }}.${{ env.DOMAIN }}/buckinghamshire/find-out-if-you-need-planning-permission/preview
             https://editor.planx.dev/testing/lighthouse-canary-flow/unpublished
-            https://${{ env.FULL_DOMAIN }}/testing/lighthouse-canary-flow/unpublished
+            https://${{ github.event.number }}.${{ env.DOMAIN }}/testing/lighthouse-canary-flow/unpublished
           uploadArtifacts: true  # save results as an action artifacts
           temporaryPublicStorage: true  # upload lighthouse report to the temporary storage
       - name: Interpolate comment text

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -172,10 +172,15 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   build_react_app:
-    uses: ./.github/workflows/build-react.yml
     name: Build React App
     needs: [changes]
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
+    uses: ./.github/workflows/build-react.yml
+    with:
+      PNPM_VERSION: ${{ env.PNPM_VERSION }}
+      EDITOR_DIRECTORY: ${{ env.EDITOR_DIRECTORY }}
+      NODE_VERSION: ${{ env.NODE_VERSION }}
+      FULL_DOMAIN: ${{ env.FULL_DOMAIN }}
 
   pulumi_preview:
     name: Run Pulumi Preview

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -175,9 +175,6 @@ jobs:
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     uses: ./.github/workflows/build-react.yml
     with:
-      # TODO: replace `planx.pizza` for `${{ env.DOMAIN }}`
-      #       although it's not possible to use env variables in `with` section
-      #       you might be able to use `env` section to set `DOMAIN` variable
       target: "${{ github.event.number }}.planx.pizza"
       environment: "pizza"
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -22,10 +22,6 @@ jobs:
     with:
       target: editor.planx.dev
       environment: staging
-    steps:
-      - run: pnpm build
-        working-directory: editor.planx.uk
-        env:
 
   pulumi:
     name: Pulumi Up

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,59 +15,17 @@ env:
 
 jobs:
   build_react:
-    name: Build React
-    runs-on: ubuntu-22.04
+    name: Build React App
+    needs: [changes]
+    if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
+    uses: ./.github/workflows/build-react.yml
+    with:
+      target: editor.planx.dev
+      environment: staging
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
-      - name: NPM cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-npm
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: PNPM cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-pnpm
-        with:
-          # pnpm cache files are stored in `~/.local/share/pnpm/store` on Linux
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: npm install -g pnpm@${{ env.PNPM_VERSION }}
-      - run: pnpm distribute ../editor.planx.uk
-        working-directory: core
-      - run: pnpm install --frozen-lockfile
-        working-directory: editor.planx.uk
       - run: pnpm build
         working-directory: editor.planx.uk
         env:
-          REACT_APP_API_URL: https://api.editor.planx.dev
-          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.editor.planx.dev/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.editor.planx.dev
-          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_ENV: staging
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: ./editor.planx.uk/build
-          if-no-files-found: error
 
   pulumi:
     name: Pulumi Up

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build_react:
-    name: Build React App
+    name: React App
     needs: [changes]
     uses: ./.github/workflows/build-react.yml
     with:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -17,7 +17,6 @@ jobs:
   build_react:
     name: Build React App
     needs: [changes]
-    if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     uses: ./.github/workflows/build-react.yml
     with:
       target: editor.planx.dev

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -69,7 +69,7 @@ jobs:
           path: ./editor.planx.uk/build
           if-no-files-found: error
 
-  preview:
+  pulumi:
     name: Pulumi Up
     needs: build_react
     runs-on: ubuntu-22.04
@@ -105,7 +105,7 @@ jobs:
 
   notifications:
     name: Notifications
-    needs: preview
+    needs: pulumi
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -15,59 +15,12 @@ env:
 
 jobs:
   build_react:
-    name: Test and Build
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
-      - name: NPM cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-npm
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: PNPM cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-pnpm
-        with:
-          # pnpm cache files are stored in `~/.local/share/pnpm/store` on Linux
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: npm install -g pnpm@${{ env.PNPM_VERSION }}
-      - run: pnpm distribute ../editor.planx.uk
-        working-directory: core
-      - run: pnpm install --frozen-lockfile
-        working-directory: editor.planx.uk
-      - run: pnpm build
-        working-directory: editor.planx.uk
-        env:
-          REACT_APP_API_URL: https://api.editor.planx.uk
-          REACT_APP_FEEDBACK_FISH_ID: 65f02de00b90d1
-          REACT_APP_HASURA_URL: https://hasura.editor.planx.uk/v1/graphql
-          REACT_APP_SHAREDB_URL: wss://sharedb.editor.planx.uk
-          REACT_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          REACT_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          REACT_APP_ENV: production
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: ./editor.planx.uk/build
-          if-no-files-found: error
+    name: Build React App
+    needs: [changes]
+    uses: ./.github/workflows/build-react.yml
+    with:
+      target: editor.planx.uk
+      environment: production
 
   preview:
     name: Pulumi Up

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build_react:
-    name: Build React App
+    name: React App
     needs: [changes]
     uses: ./.github/workflows/build-react.yml
     with:

--- a/editor.planx.uk/src/pages/Login.tsx
+++ b/editor.planx.uk/src/pages/Login.tsx
@@ -4,7 +4,7 @@ const Login: React.FC = () => {
   return (
     <a
       href={`${
-        process.env.REACT_APP_GOOGLE_OAUTH_OVERRIDE ??
+        process.env.REACT_APP_GOOGLE_OAUTH_OVERRIDE ||
         process.env.REACT_APP_API_URL
       }/auth/google`}
     >


### PR DESCRIPTION
This PR DRYes the CI job that builds the React App. Similar code was being repeated in `pull-request.yml`, `push-main.yml`, and `push-production.yml`, and according to the rule of three it's time to refactor it.

The refactoring was not the sole goal though. This is a step towards #1442. In order to roll back a failed deployment, we have to actually roll forward. This means re-build (or possibly pull from cache) the frontend and any other dependencies. So really this PR came into existence to avoid adding yet another place (it'd be the 4th place) where CI builds the react app.

Rolling back failed deployments (#1442)  will unblock scheduled production deployments (#1409).