### PR TITLE
feat: return granular Article 4 data in Newcastle GIS searches

### DIFF
--- a/api.planx.uk/gis/digitalLand.js
+++ b/api.planx.uk/gis/digitalLand.js
@@ -10,6 +10,7 @@ const localAuthorityMetadata = {
   doncaster: require("./local_authorities/metadata/doncaster.js"),
   lambeth: require("./local_authorities/metadata/lambeth.js"),
   medway: require("./local_authorities/metadata/medway.js"),
+  newcastle: require("./local_authorities/metadata/newcastle.js"),
   southwark: require("./local_authorities/metadata/southwark.js"),
 };
 

--- a/api.planx.uk/gis/local_authorities/metadata/newcastle.js
+++ b/api.planx.uk/gis/local_authorities/metadata/newcastle.js
@@ -1,0 +1,35 @@
+/*
+LAD20CD: E08000021
+LAD20NM: Newcastle
+LAD20NMW:
+FID: 
+
+https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geometry_curie=statistical-geography%3AE08000021&entries=all&entry_date_day=&entry_date_month=&entry_date_year=
+https://docs.google.com/spreadsheets/d/1GhxQEuKeSnrchZ_quxg6Rg7fHEWPDUr7/edit#gid=915271261
+*/
+
+const planningConstraints = {
+  article4: {
+    // Planx granular values link to Newcastle's source data in the following ways:
+    //   * exact match of Digital Land's entity.reference
+    records: {
+      "article4.newcastle.brandyVaults": "A4BV",
+      "article4.newcastle.dukesCottage": "A4DC",
+      "article4.newcastle.hmo1": "A4HMO1",
+      "article4.newcastle.hmo2": "A4HMO2",
+      "article4.newcastle.hmo3": "A4HMO3",
+      "article4.newcastle.northumberlandGardens": "A4NG",
+      "article4.newcastle.northumberlandGardens2": "A4NG/E",
+      "article4.newcastle.saintPetersBasin1": "A4SPB1",
+      "article4.newcastle.saintPetersBasin2": "A4SPB2",
+      "article4.newcastle.saintPetersBasin3": "A4SPB3",
+      "article4.newcastle.saintPetersBasin4": "A4SPB4",
+      "article4.newcastle.saintPetersBasin5": "A4SPB5",
+      "article4.newcastle.summerhill": "A4SH",
+    },
+  },
+};
+
+export {
+  planningConstraints,
+};


### PR DESCRIPTION
To test:
- https://1504.planx.pizza/newcastle/find-out-if-you-need-planning-permission/preview
- TILLEY'S, 105, WESTGATE ROAD, NE1 4AG
- Picks up `article4.newcastle.brandyVaults` (prod currently knows it's an `article4`, but not _which_)


https://api.1504.planx.pizza/gis/newcastle?geom=POLYGON+%28%28-1.620696634054177+54.9705222120086%2C+-1.6207368671894007+54.97043060677049%2C+-1.620527654886239+54.97039981504693%2C+-1.620503515005105+54.970494499521635%2C+-1.620696634054177+54.9705222120086%29%29