### PR TITLE
feat: Confirmation page "application type" reflects service name

### DIFF
--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -53,6 +53,7 @@ const Node: React.FC<any> = (props: Props) => {
     resetPreview,
     sessionId,
     cachedBreadcrumbs,
+    flowName,
   ] = useStore((state) => [
     state.childNodesOf,
     state.resultData,
@@ -62,6 +63,7 @@ const Node: React.FC<any> = (props: Props) => {
     state.resetPreview,
     state.sessionId,
     state.cachedBreadcrumbs,
+    state.flowName,
   ]);
 
   const handleSubmit = isFinalCard ? undefined : props.handleSubmit;
@@ -111,14 +113,12 @@ const Node: React.FC<any> = (props: Props) => {
         passport.data?.[GOV_PAY_PASSPORT_KEY];
 
       const details = {
-        "Planning Application Reference": payment?.reference ?? sessionId,
+        "Planning application reference": payment?.reference ?? sessionId,
 
-        "Property Address": passport.data?._address?.title,
+        "Property address": passport.data?._address?.title,
 
         "Application type": [
-          // XXX: application type currently hardcoded as it's the only one being
-          //      tested, but this will need to become dynamic.
-          "Application for a Certificate of Lawfulness",
+          flowName.replace("Apply", "Application"),
           getWorkStatus(passport),
         ]
           .filter(Boolean)


### PR DESCRIPTION
Originally thought we should just make this configurable in the Editor, but that's annoyingly tricky currently because "Application type" is one row within a table of data points generated by `props.details`.

So, instead, trying this which I think still satisfies the original problem! 

**"Application type" will reflect the `flowName` with a few rules applied:**
- If the flowName is phrased as "apply-for-", we'll display the application type as "Application for..." (this service name pattern is agreed upon by content team according to govuk standards, so unlikely to change I think!)
- If there's a "work status" in the passport (eg "existing" or "proposed"), it'll be tacked onto the end of the flow name

On production, on an LDC Confirmation page, now: "Application for a Certificate of Lawfulness - Proposed"
After this change: "Application for a lawful development certificate - proposed"

Casing changes, but will actually be _more_ consistent with what is sent via emails etc now since it's calling flowName from state, so hopefully fine?