### PR TITLE
feat: Handle sections in flow reconciliations

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#1cfd019",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#aa46c2e",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#c6dee14",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#5e932c3",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#1cfd019",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#c6dee14",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",
@@ -67,6 +67,7 @@
     "@types/passport": "^1.0.11",
     "@types/passport-google-oauth20": "^2.0.11",
     "@types/supertest": "^2.0.12",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "dotenv": "^16.0.1",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#1cfd019
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#aa46c2e
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#c6dee14
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -83,7 +83,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/1cfd019
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/aa46c2e
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/c6dee14_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -7911,8 +7911,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/theopensystemslab/planx-core/1cfd019:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1cfd019}
+  github.com/theopensystemslab/planx-core/aa46c2e:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/aa46c2e}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#5e932c3
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#1cfd019
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#c6dee14
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -28,6 +28,7 @@ specifiers:
   '@types/passport': ^1.0.11
   '@types/passport-google-oauth20': ^2.0.11
   '@types/supertest': ^2.0.12
+  '@types/uuid': ^9.0.1
   '@typescript-eslint/eslint-plugin': ^5.42.0
   '@typescript-eslint/parser': ^5.42.0
   adm-zip: ^0.5.9
@@ -82,7 +83,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/5e932c3
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/1cfd019
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/c6dee14_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -136,6 +137,7 @@ devDependencies:
   '@types/passport': 1.0.11
   '@types/passport-google-oauth20': 2.0.11
   '@types/supertest': 2.0.12
+  '@types/uuid': 9.0.1
   '@typescript-eslint/eslint-plugin': 5.43.0_qkzzhbbraoydjxplhj4djkikc4
   '@typescript-eslint/parser': 5.43.0_2uhzae5rel2qyw7fhfmxrmdt3q
   dotenv: 16.0.1
@@ -1970,6 +1972,10 @@ packages:
   /@types/trusted-types/2.0.2:
     resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
     dev: false
+
+  /@types/uuid/9.0.1:
+    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
+    dev: true
 
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
@@ -7905,8 +7911,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/theopensystemslab/planx-core/5e932c3:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5e932c3}
+  github.com/theopensystemslab/planx-core/1cfd019:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1cfd019}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/saveAndReturn/validateSession.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.ts
@@ -66,10 +66,8 @@ export async function validateSession(
         }));
         if (alteredNodes.length) {
           // each EnrichedCrumb will include a sectionId where relevant (used later)
-          const enrichedAndOrderedBreadcrumbs: Array<EnrichedCrumb> = sortBreadcrumbs(
-            savedFlow,
-            sessionData.data.breadcrumbs
-          );
+          const enrichedAndOrderedBreadcrumbs: Array<EnrichedCrumb> =
+            sortBreadcrumbs(savedFlow, sessionData.data.breadcrumbs);
           const removedBreadcrumbs: Breadcrumb = {};
           alteredNodes.forEach((node) => {
             // if the session breadcrumbs include any altered content,
@@ -77,7 +75,7 @@ export async function validateSession(
             const affectedBreadcrumb = enrichedAndOrderedBreadcrumbs.find(
               (crumb: EnrichedCrumb) => crumb.id == node.id!
             );
-            if (affectedBreadcrumb) {
+            if (affectedBreadcrumb && sessionData.data.breadcrumbs[node.id!]) {
               // remove affected breadcrumbs
               removedBreadcrumbs[node.id!] =
                 sessionData.data.breadcrumbs[node.id!];
@@ -85,7 +83,10 @@ export async function validateSession(
 
               // also remove the associated section
               const affectedSectionId = affectedBreadcrumb.sectionId;
-              if (affectedSectionId) {
+              if (
+                affectedSectionId &&
+                sessionData.data.breadcrumbs[affectedSectionId]
+              ) {
                 removedBreadcrumbs[affectedSectionId] =
                   sessionData.data.breadcrumbs[affectedSectionId];
                 delete sessionData.data.breadcrumbs[affectedSectionId];

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -1,6 +1,8 @@
 import { v4 as uuidV4 } from "uuid";
+import type { Flow } from "../../types";
 
 export const mockTeam = {
+  id: 1,
   slug: "test-team",
   name: "Test Team",
   notifyPersonalisation: {
@@ -34,21 +36,37 @@ export const mockLowcalSession = {
   created_at: "2022-01-04T01:02:03.865452+00:00",
 };
 
-export const mockFlow = {
+export const mockFlow: Flow = {
   id: "dcfd4f07-76da-4b67-9822-2aca92b27551",
   slug: "slug",
-  team: mockTeam,
+  team_id: mockTeam.id,
+  data: {
+    _root: {
+      edges: ["one"],
+    },
+    one: {
+      data: {},
+    },
+  },
 };
 
-export const mockFindSession = {
+export const mockFindSession = (breadcrumbs = {}) => ({
   name: "FindSession",
   data: {
-    lowcal_sessions: [mockLowcalSession],
+    lowcal_sessions: [
+      {
+        ...mockLowcalSession,
+        data: {
+          ...mockLowcalSession.data,
+          breadcrumbs,
+        },
+      },
+    ],
   },
   variables: {
     sessionId: mockLowcalSession.id,
   },
-};
+});
 
 export const mockNotFoundSession = {
   name: "FindSession",
@@ -60,7 +78,7 @@ export const mockNotFoundSession = {
   },
 };
 
-export const mockGetMostRecentPublishedFlow = (data) => ({
+export const mockGetMostRecentPublishedFlow = (data: Flow["data"]) => ({
   name: "GetMostRecentPublishedFlow",
   data: {
     flows_by_pk: {
@@ -90,7 +108,7 @@ export const stubUpdateLowcalSessionData = {
   matchOnVariables: false,
 };
 
-export const mockGetPublishedFlowByDate = (data) => ({
+export const mockGetPublishedFlowByDate = (data: Flow["data"]) => ({
   name: "GetPublishedFlowByDate",
   data: {
     flows_by_pk: {


### PR DESCRIPTION
This adds handling for section reconciliation. My understanding of how this should behave is described in the automated tests - please review those tests and also let me know if there are any additional behaviors that need testing here. 

This depends on a change to planx-core here: https://github.com/theopensystemslab/planx-core/pull/2
 