### PR TITLE
refactor: Move section chunking to store

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -5,7 +5,6 @@ import { visuallyHidden } from "@mui/utils";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { TYPES } from "@planx/components/types";
 import format from "date-fns/format";
-import pick from "lodash/pick";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
@@ -82,41 +81,16 @@ interface SummaryListsBySectionsProps extends SummaryListProps {
 }
 
 function SummaryListsBySections(props: SummaryListsBySectionsProps) {
-  const [hasSections, sectionNodes] = useStore((state) => [
+  const [hasSections, getSortedBreadcrumbsBySection] = useStore((state) => [
     state.hasSections,
-    state.sectionNodes,
+    state.getSortedBreadcrumbsBySection,
   ]);
 
-  // if this flow has sections, split the breadcrumbs up by sections,
-  //    so we can render section node titles as h2s and the following nodes as individual SummaryLists
-  const sortedBreadcrumbsBySection: Store.breadcrumbs[] = [];
-  if (hasSections) {
-    const sortedNodeIdsBySection: string[][] = [];
-    Object.keys(sectionNodes).forEach((sectionId, i) => {
-      const nextSectionId: string = Object.keys(sectionNodes)[i + 1];
-      const isLastSection: boolean =
-        Object.keys(sectionNodes).pop() === sectionId;
-
-      // get the nodeIds in order for each section, where the first nodeId in an array should always be a section type
-      sortedNodeIdsBySection.push(
-        Object.keys(props.breadcrumbs).slice(
-          Object.keys(props.breadcrumbs).indexOf(sectionId),
-          isLastSection
-            ? undefined
-            : Object.keys(props.breadcrumbs).indexOf(nextSectionId)
-        )
-      );
-    });
-
-    // chunk the breadcrumbs based on the nodeIds in a given section
-    sortedNodeIdsBySection.forEach((nodeIds) => {
-      sortedBreadcrumbsBySection.push(pick(props.breadcrumbs, nodeIds));
-    });
-  }
+  const sections = getSortedBreadcrumbsBySection();
 
   return hasSections ? (
     <>
-      {sortedBreadcrumbsBySection.map((sectionBreadcrumbs, i) => (
+      {sections.map((sectionBreadcrumbs, i) => (
         <React.Fragment key={i}>
           <Typography component={props.sectionComponent || "h2"} variant="h5">
             {props.flow[`${Object.keys(sectionBreadcrumbs)[0]}`]?.data?.title}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -1,6 +1,6 @@
 import { TYPES } from "@planx/components/types";
 import { hasFeatureFlag } from "lib/featureFlags";
-import { findLast } from "lodash";
+import { findLast, pick } from "lodash";
 import { Store } from "pages/FlowEditor/lib/store";
 import type { StateCreator } from "zustand";
 
@@ -21,6 +21,7 @@ export interface NavigationStore {
   initNavigationStore: () => void;
   updateSectionData: () => void;
   filterFlowByType: (type: TYPES) => Store.flow;
+  getSortedBreadcrumbsBySection: () => Store.breadcrumbs[];
 }
 
 export const navigationStore: StateCreator<
@@ -99,5 +100,37 @@ export const navigationStore: StateCreator<
         .sort(([idA], [idB]) => rootEdges.indexOf(idA) - rootEdges.indexOf(idB))
     );
     return filteredFlow;
+  },
+
+  // if this flow has sections, split the breadcrumbs up by sections,
+  //    so we can render section node titles as h2s and the following nodes as individual SummaryLists
+  getSortedBreadcrumbsBySection: () => {
+    const { breadcrumbs, sectionNodes, hasSections } = get();
+    const sortedBreadcrumbsBySection: Store.breadcrumbs[] = [];
+    if (hasSections) {
+      const sortedNodeIdsBySection: string[][] = [];
+      Object.keys(sectionNodes).forEach((sectionId, i) => {
+        const nextSectionId: string = Object.keys(sectionNodes)[i + 1];
+        const isLastSection: boolean =
+          Object.keys(sectionNodes).pop() === sectionId;
+
+        // get the nodeIds in order for each section, where the first nodeId in an array should always be a section type
+        sortedNodeIdsBySection.push(
+          Object.keys(breadcrumbs).slice(
+            Object.keys(breadcrumbs).indexOf(sectionId),
+            isLastSection
+              ? undefined
+              : Object.keys(breadcrumbs).indexOf(nextSectionId)
+          )
+        );
+      });
+
+      // chunk the breadcrumbs based on the nodeIds in a given section
+      sortedNodeIdsBySection.forEach((nodeIds) => {
+        sortedBreadcrumbsBySection.push(pick(breadcrumbs, nodeIds));
+      });
+    }
+
+    return sortedBreadcrumbsBySection;
   },
 });


### PR DESCRIPTION
This is a quick refactor to move the section chunking logic to the store for reuse.

The plan was to add tests and modify the export data structure so that we have access to these chunks in the document template data structure, but I'll handle that as a follow on PR so that this can get shared / reviewed sooner.

Please see PlanX Slack discussion here for context - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1678185974650719