### PR TITLE
feat: Add custom Medway domain

### DIFF
--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -55,6 +55,7 @@ const PREVIEW_ONLY_DOMAINS = [
   "planningservices.lambeth.gov.uk",
   "planningservices.southwark.gov.uk",
   "planningservices.doncaster.gov.uk",
+  "planningservices.medway.gov.uk",
   // XXX: un-comment the next line to test custom domains locally
   // "localhost",
 ];


### PR DESCRIPTION
Medway have now confirmed that their CNAME record has been setup.

`team.domain` has also been populated on the production db.