### PR TITLE
fix: Treat section card as first of next section

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -13,6 +13,7 @@ import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { styled } from "@mui/styles";
+import { TYPES } from "@planx/components/types";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { capitalize } from "lodash";
 import { Route } from "navi";
@@ -203,15 +204,19 @@ const Breadcrumbs: React.FC<{
 
 const NavBar: React.FC = () => {
   const [
+    currentCard,
     currentSectionIndex,
     sectionCount,
+    sectionNodes,
     currentSectionTitle,
     hasSections,
     saveToEmail,
     path,
   ] = useStore((state) => [
+    state.currentCard(),
     state.currentSectionIndex,
     state.sectionCount,
+    state.sectionNodes,
     state.currentSectionTitle,
     state.hasSections,
     state.saveToEmail,
@@ -224,13 +229,23 @@ const NavBar: React.FC = () => {
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
   const isVisible =
     hasSections && !isSaveAndReturnLandingPage && !isContentPage;
+  const isSectionCard = currentCard?.type == TYPES.Section;
+
+  // Section data is calculated from breadcrumbs, but we want section cards to appear as the first node in their sections
+  // We can read data from currentCard() instead of the NavigationStore to acheive this
+  const [title, index] = isSectionCard
+    ? [
+        currentCard.data.title,
+        Object.keys(sectionNodes).indexOf(currentCard.id!) + 1,
+      ]
+    : [currentSectionTitle, currentSectionIndex];
 
   return (
     <>
       {isVisible && (
         <StyledNavBar data-testid="navigation-bar">
-          <SectionCount>{`Section ${currentSectionIndex} of ${sectionCount}`}</SectionCount>
-          <SectionName>{capitalize(currentSectionTitle)}</SectionName>
+          <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
+          <SectionName>{capitalize(title)}</SectionName>
         </StyledNavBar>
       )}
     </>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -84,11 +84,13 @@ export const navigationStore: StateCreator<
     const breadcrumbIds = Object.keys(breadcrumbs);
     const sectionIds = Object.keys(sectionNodes);
 
-    // Fallback to the first sectionId, which allows us to have a mostRecentSectionId on the first node ("Card") before it exists in breadcrumbs (eg "Continue" hasn't been clicked yet)
-    const mostRecentSectionId =
-      findLast(breadcrumbIds, (breadcrumbId: string) =>
-        sectionIds.includes(breadcrumbId)
-      ) || sectionIds[0];
+    const mostRecentSectionId = findLast(
+      breadcrumbIds,
+      (breadcrumbId: string) => sectionIds.includes(breadcrumbId)
+    );
+
+    // No sections in breadcrumbs, first section values already set in store
+    if (!mostRecentSectionId) return;
 
     // Update section
     const currentSectionTitle = sectionNodes[mostRecentSectionId].data.title;


### PR DESCRIPTION
## Problem
Currently, the section banner does not display the correct data when reaching a section card. It should treat the section card as the first card of the _next_ section. 

## Solution
As we rely on breadcrumbs to calculate the current section and update this on `record()`, it's always backwards looking. By using `currentCard()` we can always display the correct section title and index.

## Testing
TODO: Link to example on Pizza

The section banner displays the correct information...

  - On the initial section card
  - On subsequent sections when navigating forwards
  - On previous sections when navigating via the "Back" button
  - On previous sections when navigating via the links on the section page