### PR TITLE
chore: rotate `hasura-admin-secret` across all AWS environments

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -21,7 +21,7 @@ config:
   application:govuk-notify-api-key:
     secure: AAABADo05EPv/HWj7Rkf19nBeTcPJd4pEcRi2/uhyB3agraFODpLvNMx2bXfISf5pZ4HA41GYCE4f7OLcJN6hIV6ZMWUlEriPzvkoUAixbLlz1LIERiyk73R8E4F2bV65/9aFqi4l7caLS5c8iDJrE+JAvu2i7oS
   application:hasura-admin-secret:
-    secure: AAABAEtfaS9JI9yVKU3VM4YWI2Lzd2rEYdwlGt6QtDyJEWr1gYXLdxniq+cIJCKLMI7z9O36pA7JBLGpdEFsxQ==
+    secure: AAABAKtJJtogD8G+Tgr94r9ZnB0H1upTM2aN5qaZe+veQFezOQe0z0yYkxMREw5BIxOaQOBJRVvoD61+k9H4yA==
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
   application:jwt-secret:

--- a/infrastructure/application/Pulumi.sandbox.yaml
+++ b/infrastructure/application/Pulumi.sandbox.yaml
@@ -14,7 +14,7 @@ config:
   application:govuk-notify-api-key:
     secure: AAABAN6by1UpKop5de/dlYA003xrp1LMzLG60J2asKxioUMoUS0SsP7N+1KT53aKnux45aUZ6J+ryYpGge4+FkDhEZEC85Sw0+q/bMzKy1VER9BFIU6Qzxr/shdSVwzOW1ZZQNc/Q1cZjfY4umGbEiBipz1f
   application:hasura-admin-secret:
-    secure: AAABADc3VLm2XyLMC0Ap/5n9dk7qZnu2QdE4UYLHWbjtukjefJxLD85nQpPftKH7yPWF8FyS4wETj3xoLux+EVcRkwkP8674E/3shA==
+    secure: AAABAGxe3VrlLZWcmzAkh1Ng2amkOcn1cd4f7tDt7+bq2o1V3pJZfcRJZ1UiUjRfsbxIJbF/CoInGehJIWHfHQ==
   application:hasura-planx-api-key:
     secure: AAABAKVQcDltAw2qwW7xlZJ22Squvgir7cRker6goWiV194dWlaGtmwOPjC0HZXexoYfm8O4pFSSRCLQZhan/Ta1/vY=
   application:jwt-secret:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -22,7 +22,7 @@ config:
   application:govuk-notify-api-key:
     secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
   application:hasura-admin-secret:
-    secure: AAABAFWrfRcYR8kWrKVhFQ+PedyHB+Op5r4yl5VGOfQR0DmEauoCg5lqY16fPu/vNaFc4lte0rPznxg6ak+CaOLovjE=
+    secure: AAABAGDAQe8KyGWt1sT/psdS282GOGBjHfI/KThzfcoixsDT0s/jBSnFGjwuTrAUvrDEc06hy5jhfO1rxnsLtQ==
   application:hasura-planx-api-key:
     secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
   application:jwt-secret:


### PR DESCRIPTION
What I did:
- Generated 3 new secrets as 32-character alphanumeric strings using 1pass generator
- Ran `pulumi config set --secret hasura-admin-secret $NEW_VALUE --stack $ENV` x3 for `production`, `staging` & `sandbox`

What happens next:
- Once deployed, we should all be prompted to login fresh to the Hasura web console and any "remembered" passwords/connections will be invalid
- You can access the new secrets by running `pulumi config get hasura-admin-secret --stack $ENV`

Future todo:
- Rotate the docker `HASURA_ADMIN_SECRET`. I didn't include this here since it will effect all open pull requests, and pizzas are isolated envs without user data anyways so far fewer concerns about maintaining access to application data 