### PR TITLE
fix: Update user pk, use port env var

### DIFF
--- a/hasura.planx.uk/config.yaml
+++ b/hasura.planx.uk/config.yaml
@@ -1,4 +1,4 @@
 version: 2
-endpoint: http://localhost:7000
+endpoint: http://localhost:${HASURA_PROXY_PORT}
 metadata_directory: metadata
 admin_secret: ${HASURA_ADMIN_SECRET}

--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -2,6 +2,6 @@ INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2,
 INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
 INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
 INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (36, 'Benjamin', 'Williams', 'benjamin@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (43, 'Ian', 'Jones', 'ian@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (65, 'Ian', 'Jones', 'ian@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
 SELECT setval('users_id_seq', max(id)) FROM users;
 SELECT setval('teams_id_seq', max(id)) FROM teams;


### PR DESCRIPTION
A few little issues hit with getting Ian up and running on PlanX.

- Some Mac versions use port 7000 for Airdrop, but this needs to be updated in multiple places in the `.env` to work correctly. Alternatively, Airdrop can be disabled.
- Ian wasn't listed on prod and staging dbs, likely overwritten by the new data sync