### PR TITLE
chore: Disable Medway CDN

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -43,10 +43,11 @@ const CUSTOM_DOMAINS =
           domain: "planningservices.doncaster.gov.uk",
           name: "doncaster",
         },
-        {
-          domain: "planningservices.medway.gov.uk",
-          name: "medway",
-        },
+        // Disabled until we have an updated certificate, this is currently causing production deploys to fail
+        // {
+        //   domain: "planningservices.medway.gov.uk",
+        //   name: "medway",
+        // },
       ]
     : [];
 


### PR DESCRIPTION
Commented out until we receive updated certificates, this will allow production deploys to succeed.