### PR TITLE
fix: Re-enable Minio locally

### DIFF
--- a/api.planx.uk/s3/utils.test.ts
+++ b/api.planx.uk/s3/utils.test.ts
@@ -12,7 +12,7 @@ describe("s3 Factory", () => {
   });
 
   it("returns Minio config for local development", () => {
-    expect(s3Factory()).toHaveProperty("endpoint.host", "127.0.0.1:9000");
+    expect(s3Factory()).toHaveProperty("endpoint.host", "minio");
   });
 
   ["pizza", "staging", "production"].forEach(env => {

--- a/api.planx.uk/s3/utils.ts
+++ b/api.planx.uk/s3/utils.ts
@@ -18,7 +18,7 @@ function useMinio() {
   } else {
     // Points to Minio
     return {
-      endpoint: "http://127.0.0.1:9000",
+      endpoint: `http://minio:${process.env.MINIO_PORT}`,
       s3ForcePathStyle: true,
       signatureVersion: "v4",
     };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,6 +164,7 @@ services:
       FILE_API_KEY: ${FILE_API_KEY}
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
       ORDNANCE_SURVEY_API_KEY: ${ORDNANCE_SURVEY_API_KEY}
+      MINIO_PORT: ${MINIO_PORT}
 
   sharedb:
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
     "docker:logs": "docker compose logs --tail 10 -f",
-    "docker:up": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml up --quiet-pull --renew-anon-volumes -d",
+    "docker:up": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up --quiet-pull --renew-anon-volumes -d",
     "docker:down": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml down",
-    "docker:recreate": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml up -d --build --force-recreate",
+    "docker:recreate": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --build --force-recreate",
     "docker:destroy": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml down --remove-orphans -v",
     "docker:tests": "./scripts/start-containers-for-tests.sh"
   }


### PR DESCRIPTION
## Problem
I'm currently getting the following error when running the app locally and trying to upload files - 

`{"error":"Inaccessible host: '127.0.0.1' at port '9000'. This service may not be available in the 'eu-west-2' region."}`

Is anybody else having this issue?

## Solution
- Always run Minio on local dev
- Use docker networking address
