### PR TITLE
chore: rotate `db-password` across all AWS environments

### DIFF
--- a/infrastructure/data/Pulumi.production.yaml
+++ b/infrastructure/data/Pulumi.production.yaml
@@ -1,3 +1,3 @@
 config:
   data:db-password:
-    secure: AAABAJekEkTZff0LMK4PazFRkBOmtOUQHseg8jrOqFlVl0IQ00rZsOp1pCrP17gRnU9JqQDxJfvKnmKkkMsG5w==
+    secure: AAABAHMuRHvJZ4Ud7qphhSLHensW6rQulduIyom3lzAjgj7dlpbqVkziY3lbJBp3yKXp8/tgchq9aA+KLFHymg==

--- a/infrastructure/data/Pulumi.sandbox.yaml
+++ b/infrastructure/data/Pulumi.sandbox.yaml
@@ -1,3 +1,3 @@
 config:
   data:db-password:
-    secure: AAABAOYvZlzSXN3ulqa00WfBzx6JqffoWUDVvDUodoo0IeiC2ib/Vlh65EiNot5AQ+fRzKIY+VEu5RG7FWo=
+    secure: AAABAEMA8sHI6sqPqDbAjjqLq1YB4CklJuqUwlnKM85TAWCiMZsdu8C3+Sc40nm8MmGWBjtR9d90uj7N0/UODg==

--- a/infrastructure/data/Pulumi.staging.yaml
+++ b/infrastructure/data/Pulumi.staging.yaml
@@ -1,4 +1,4 @@
 config:
   aws:region: eu-west-2
   data:db-password:
-    secure: AAABABqUnOA/XqhK2TWSgGSdM5/rJBgRKp1l7iBAWPd0wtvkZ79UVADoAqJwk5ztITIwx+1jp9h4jkneTU9GIy+PkDaAwQe8gIc6pdj83Gg22kh4lyFzMw==
+    secure: AAABAEsQNs60gXhWC+qP2ZRkhkq2g52XbzbkTnR2K7MqMF0dzPCNvSro4Zs041AKks75gqwhkPT53bSQ5bs8Aw==


### PR DESCRIPTION
same methodology as #1526, but Pulumi CLI commands ran in `infrastructure/data` rather than `infrastructure/application`