### PR TITLE
fix: sync postgres version in Pulumi

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -14,7 +14,7 @@ const db = new aws.rds.Instance("app", {
   engine: "postgres",
   // Available versions:
   // $ aws rds describe-db-engine-versions --default-only --engine postgres
-  engineVersion: "14.6",
+  engineVersion: "12.11",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
   instanceClass: env === "production" ? "db.t3.medium" : "db.t3.micro",
   allocatedStorage: env === "production" ? 100 : 20,


### PR DESCRIPTION
this was causing `pulumi up` to fail and pick up a larger diff (db password _and_ `engineVersion`). 

now this reflects the version that our staging & production AWS RDS databases are actually running on. 

we suspect the sandbox environment _only_ was installed at v14.6. we may need to manually adjust this when rotating creds there.