### PR TITLE
chore: Disable Medway CDN

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -43,10 +43,10 @@ const CUSTOM_DOMAINS =
           domain: "planningservices.doncaster.gov.uk",
           name: "doncaster",
         },
-        {
-          domain: "planningservices.medway.gov.uk",
-          name: "medway",
-        },
+        // {
+        //   domain: "planningservices.medway.gov.uk",
+        //   name: "medway",
+        // },
       ]
     : [];
 


### PR DESCRIPTION
Prod deploy currently failing with the following error - 

```shell
    aws:cloudfront:Distribution (planningservices.medway.gov.uk-cdn):
      error: 1 error occurred:
      	* error creating CloudFront Distribution: InvalidViewerCertificate: The certificate that is attached to your distribution was not issued by a trusted Certificate Authority. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements
```

Disabling this until the morning will allow us to continue with a production deployment.