### PR TITLE
chore: Remove section navbar from section components

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -204,38 +204,28 @@ const Breadcrumbs: React.FC<{
 );
 
 const NavBar: React.FC = () => {
-  const [
-    currentSectionIndex,
-    sectionCount,
-    sectionNodes,
-    currentSectionTitle,
-    hasSections,
-    saveToEmail,
-    path,
-  ] = useStore((state) => [
-    state.currentSectionIndex,
-    state.sectionCount,
-    state.sectionNodes,
-    state.currentSectionTitle,
-    state.hasSections,
-    state.saveToEmail,
-    state.path,
-  ]);
+  const [index, sectionCount, title, hasSections, saveToEmail, path] = useStore(
+    (state) => [
+      state.currentSectionIndex,
+      state.sectionCount,
+      state.currentSectionTitle,
+      state.hasSections,
+      state.saveToEmail,
+      state.path,
+    ]
+  );
   const isSaveAndReturnLandingPage =
     path !== ApplicationPath.SingleSession &&
     !Boolean(saveToEmail) &&
     !hasFeatureFlag("DISABLE_SAVE_AND_RETURN");
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
-  const isVisible =
-    hasSections && !isSaveAndReturnLandingPage && !isContentPage;
   const { node } = useAnalyticsTracking();
   const isSectionCard = node?.type == TYPES.Section;
-
-  // Section data is calculated from breadcrumbs, but we want section cards to appear as the first node in their sections
-  // We can read data from currentCard() instead of the NavigationStore to acheive this
-  const [title, index] = isSectionCard
-    ? [node.data.title, Object.keys(sectionNodes).indexOf(node.id!) + 1]
-    : [currentSectionTitle, currentSectionIndex];
+  const isVisible =
+    hasSections &&
+    !isSaveAndReturnLandingPage &&
+    !isContentPage &&
+    !isSectionCard;
 
   return (
     <>


### PR DESCRIPTION
From @ianjon3s - 

> the navigation pages should not have the navigation banner present as they are intermediate states that mark milestone positions in the journey (they also give a more detailed breakdown of navigation status in the table). Scroll position isn't a concern here as we are jumping out of the user-flow of repetitive question patterns to signify the milestone has been reached.