### PR TITLE
chore: Update Metabase to v0.45.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   metabase:
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.43.4
+    image: metabase/metabase:v0.45.3
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -157,7 +157,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.43.4",
+        image: "metabase/metabase:v0.45.3",
         portMappings: [metabaseListenerHttps],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
The main motivation here is in order to access better dashboard duplication features to make onboarding Medway and Canterbury a smoother process.

Release notes: https://www.metabase.com/releases/Metabase-0.45

Once done, I'll also update our docs to reflect any changes in the process.