### PR TITLE
chore: Convert `send/uniform` to TypeScript

### DIFF
--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -100,7 +100,7 @@ dependencies:
   form-data: 4.0.0
   graphql: 16.5.0
   graphql-request: 4.3.0_graphql@16.5.0
-  graphql-voyager: 1.0.0-rc.31_graphql@16.5.0
+  graphql-voyager: 1.0.0-rc.31_phmus7xcbidy3raesi6r6zwaqe
   helmet: 5.1.1
   http-proxy-middleware: 2.0.6_@types+express@4.17.14
   isomorphic-fetch: 3.0.0
@@ -1292,7 +1292,7 @@ packages:
       '@lit-labs/ssr-dom-shim': 1.0.0
     dev: false
 
-  /@material-ui/core/3.9.4:
+  /@material-ui/core/3.9.4_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1305,8 +1305,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.6
-      '@material-ui/system': 3.0.0-alpha.2
-      '@material-ui/utils': 3.0.0-alpha.3
+      '@material-ui/system': 3.0.0-alpha.2_biqbaboplfbrettd7655fr4n2y
+      '@material-ui/utils': 3.0.0-alpha.3_biqbaboplfbrettd7655fr4n2y
       '@types/jss': 9.5.8
       '@types/react-transition-group': 2.9.2
       brcast: 3.0.2
@@ -1327,13 +1327,15 @@ packages:
       normalize-scroll-left: 0.1.2
       popper.js: 1.16.1
       prop-types: 15.8.1
-      react-event-listener: 0.6.6
-      react-transition-group: 2.9.0
-      recompose: 0.30.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-event-listener: 0.6.6_react@18.2.0
+      react-transition-group: 2.9.0_biqbaboplfbrettd7655fr4n2y
+      recompose: 0.30.0_react@18.2.0
       warning: 4.0.3
     dev: false
 
-  /@material-ui/system/3.0.0-alpha.2:
+  /@material-ui/system/3.0.0-alpha.2_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1348,10 +1350,12 @@ packages:
       '@babel/runtime': 7.20.13
       deepmerge: 3.3.0
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       warning: 4.0.3
     dev: false
 
-  /@material-ui/utils/3.0.0-alpha.3:
+  /@material-ui/utils/3.0.0-alpha.3_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1365,6 +1369,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-is: 16.13.1
     dev: false
 
@@ -4311,7 +4317,7 @@ packages:
       - encoding
     dev: false
 
-  /graphql-voyager/1.0.0-rc.31_graphql@16.5.0:
+  /graphql-voyager/1.0.0-rc.31_phmus7xcbidy3raesi6r6zwaqe:
     resolution: {integrity: sha512-eCaFL8niR3DZo1LUcFV8txwR+MDVIQsrFPmFC7Zwab8UyH5x3SLhx3aDrt998RVJRmY5aFP4q79RY2F3QtGRqA==}
     peerDependencies:
       graphql: '>=14.0.0'
@@ -4324,13 +4330,15 @@ packages:
         optional: true
     dependencies:
       '@f/animate': 1.0.1
-      '@material-ui/core': 3.9.4
+      '@material-ui/core': 3.9.4_biqbaboplfbrettd7655fr4n2y
       classnames: 2.3.2
       clipboard: 2.0.11
       commonmark: 0.29.3
       graphql: 16.5.0
       lodash: 4.17.21
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       svg-pan-zoom: 3.6.1
       viz.js: 2.1.2
     dev: false
@@ -6621,7 +6629,7 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-event-listener/0.6.6:
+  /react-event-listener/0.6.6_react@18.2.0:
     resolution: {integrity: sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==}
     peerDependencies:
       react: ^16.3.0
@@ -6631,6 +6639,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       prop-types: 15.8.1
+      react: 18.2.0
       warning: 4.0.3
     dev: false
 
@@ -6645,7 +6654,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-transition-group/2.9.0:
+  /react-transition-group/2.9.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
     peerDependencies:
       react: '>=15.0.0'
@@ -6659,6 +6668,8 @@ packages:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-lifecycles-compat: 3.0.4
     dev: false
 
@@ -6730,7 +6741,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: false
 
-  /recompose/0.30.0:
+  /recompose/0.30.0_react@18.2.0:
     resolution: {integrity: sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==}
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
@@ -6742,6 +6753,7 @@ packages:
       change-emitter: 0.1.6
       fbjs: 0.8.18
       hoist-non-react-statics: 2.5.5
+      react: 18.2.0
       react-lifecycles-compat: 3.0.4
       symbol-observable: 1.2.0
     dev: false

--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -121,6 +121,7 @@ const sendToUniform = async (req: Request, res: Response, next: NextFunction) =>
       idoxSubmissionId,
       zipPath
     );
+    if (attachmentAdded) deleteFile(zipPath);
 
     // 4/4 - Get submission details and create audit record
     const submissionDetails = await retrieveSubmission(
@@ -174,9 +175,6 @@ async function checkUniformAuditTable(sessionId: string): Promise<UniformSubmiss
   return application?.uniform_applications[0]?.response;
 }
 
-/**
- * Creates a zip folder containing the documents required by Uniform
- */
 export async function createUniformSubmissionZip({
   csv,
   files,
@@ -398,8 +396,7 @@ async function attachArchive(token: string, submissionId: string, zipPath: strin
 
   const response = await axios.request(attachArchiveConfig)
   // successful upload returns 204 No Content without body
-  const isSuccess = response.status === 204
-  if (isSuccess) deleteFile(zipPath);
+  const isSuccess = response.status === 204;
   return isSuccess
 }
 

--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -237,7 +237,7 @@ export async function createUniformSubmissionZip({
   deleteFile(overviewPath);
 
   // add an optional GeoJSON file to zip
-  const geojson = passport.data["property.boundary.site"];
+  const geojson = passport?.data["property.boundary.site"];
   if (geojson) {
     const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
     zip.addFile("LocationPlanGeoJSON.geojson", geoBuff);
@@ -252,28 +252,30 @@ export async function createUniformSubmissionZip({
   }
 
   // generate and add additional submission documents
-  for (const templateName of templateNames) {
-    let isTemplateSupported = false;
-    try {
-      isTemplateSupported = hasRequiredDataForTemplate({
-        passport,
-        templateName,
-      });
-    } catch (e) {
-      console.log(`Template "${templateName}" could not be generated so has been skipped`);
-      console.log(e)
-      continue
-    }
-    if (isTemplateSupported) {
-      const templatePath = path.join(tmpDir, `${templateName}.doc`);
-      const templateFile = fs.createWriteStream(templatePath);
-      const templateStream = generateDocxTemplateStream({
-        passport,
-        templateName,
-      }).pipe(templateFile);
-      await resolveStream(templateStream);
-      zip.addLocalFile(templatePath);
-      deleteFile(templatePath);
+  if (templateNames?.length) { 
+    for (const templateName of templateNames) {
+      let isTemplateSupported = false;
+      try {
+        isTemplateSupported = hasRequiredDataForTemplate({
+          passport,
+          templateName,
+        });
+      } catch (e) {
+        console.log(`Template "${templateName}" could not be generated so has been skipped`);
+        console.log(e)
+        continue
+      }
+      if (isTemplateSupported) {
+        const templatePath = path.join(tmpDir, `${templateName}.doc`);
+        const templateFile = fs.createWriteStream(templatePath);
+        const templateStream = generateDocxTemplateStream({
+          passport,
+          templateName,
+        }).pipe(templateFile);
+        await resolveStream(templateStream);
+        zip.addLocalFile(templatePath);
+        deleteFile(templatePath);
+      }
     }
   }
 

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -38,7 +38,7 @@ export interface Team {
 }
 
 export interface Passport {
-  data?: Record<string, any>;
+  data: Record<string, any>;
 }
 
 export interface LowCalSession {


### PR DESCRIPTION
Been meaning to get round to this one for a while!

A few small refactors that should help with testing also, will look at bumping up test coverage in another PR.

I can successfully send dummy submissions locally and via the Pizza, but would appreciate another dev please testing this if possible.