### PR TITLE
chore: link up new overview.html changes in planx

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@airbrake/node": "^2.1.7",
     "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#aa46c2e",
-    "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#c6dee14",
+    "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",
     "axios": "^0.27.2",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
   '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#aa46c2e
-  '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#c6dee14
+  '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
   '@types/cookie-parser': ^1.4.3
@@ -84,7 +84,7 @@ specifiers:
 dependencies:
   '@airbrake/node': 2.1.7
   '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/aa46c2e
-  '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/c6dee14_@babel+core@7.19.6
+  '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
   axios: 0.27.2
@@ -5701,6 +5701,10 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.groupby/4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+    dev: false
+
   /lodash.includes/4.3.0:
     resolution: {integrity: sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=}
     dev: false
@@ -7926,9 +7930,9 @@ packages:
       - encoding
     dev: false
 
-  github.com/theopensystemslab/planx-document-templates/c6dee14_@babel+core@7.19.6:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/c6dee14}
-    id: github.com/theopensystemslab/planx-document-templates/c6dee14
+  github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/debaeca}
+    id: github.com/theopensystemslab/planx-document-templates/debaeca
     name: '@opensystemslab/planx-document-templates'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}
@@ -7941,6 +7945,7 @@ packages:
       '@mui/material': 5.11.9_5rzy53przelm5jchjmb5vr6dxy
       '@rollup/plugin-commonjs': 23.0.7
       docx: 7.8.2
+      lodash.groupby: 4.6.0
       lodash.startcase: 4.4.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "5.11.9",
     "@opensystemslab/map": "^0.7.4",
     "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#5e932c3",
-    "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#c6dee14",
+    "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "@tiptap/core": "2.0.0-beta.204",
     "@tiptap/extension-bold": "2.0.0-beta.204",
     "@tiptap/extension-bubble-menu": "2.0.0-beta.204",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -61,7 +61,7 @@ specifiers:
   '@mui/utils': 5.11.9
   '@opensystemslab/map': ^0.7.4
   '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#5e932c3
-  '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#c6dee14
+  '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@react-theming/storybook-addon': ^1.1.7
   '@storybook/addon-actions': ^6.5.10
   '@storybook/addon-essentials': ^6.5.10
@@ -205,7 +205,7 @@ dependencies:
   '@mui/utils': 5.11.9_react@18.2.0
   '@opensystemslab/map': 0.7.4
   '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/5e932c3
-  '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/c6dee14_a7krn2kytpcoapplqdxaq5aiqm
+  '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_a7krn2kytpcoapplqdxaq5aiqm
   '@tiptap/core': 2.0.0-beta.204
   '@tiptap/extension-bold': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
   '@tiptap/extension-bubble-menu': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
@@ -13284,6 +13284,10 @@ packages:
     resolution: {integrity: sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==}
     dev: true
 
+  /lodash.groupby/4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+    dev: false
+
   /lodash.kebabcase/4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
     dev: false
@@ -20087,9 +20091,9 @@ packages:
       - encoding
     dev: false
 
-  github.com/theopensystemslab/planx-document-templates/c6dee14_a7krn2kytpcoapplqdxaq5aiqm:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/c6dee14}
-    id: github.com/theopensystemslab/planx-document-templates/c6dee14
+  github.com/theopensystemslab/planx-document-templates/debaeca_a7krn2kytpcoapplqdxaq5aiqm:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/debaeca}
+    id: github.com/theopensystemslab/planx-document-templates/debaeca
     name: '@opensystemslab/planx-document-templates'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}
@@ -20102,6 +20106,7 @@ packages:
       '@mui/material': 5.11.9_o3jv4iu7e2dnl425vnr2xredky
       '@rollup/plugin-commonjs': 23.0.7
       docx: 7.8.2
+      lodash.groupby: 4.6.0
       lodash.startcase: 4.4.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0


### PR DESCRIPTION
this bumps up our commit reference to pick up the styled overview.html & addition of section headers if the flow is using sections.

testing: `application.html` is currently part of the packet of documents in "send to email", so add your email in `teams.submission_email` and make/publish a test flow