### PR TITLE
fix: Handle file uploads in standard format

### DIFF
--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -157,12 +157,7 @@ const downloadApplicationFiles = async(req: Request, res: Response, next: NextFu
               files.push(url);
             });
           });
-        
-        // Additionally check if they uploaded a location plan instead of drawing
-        if (sessionData.passport?.data?.["proposal.drawing.locationPlan"]) {
-          files.push(sessionData.passport.data["proposal.drawing.locationPlan"]);
-        }
-  
+
         // Download files from S3 and add them to the zip folder
         if (files.length > 0) {
           for (const file of files) {

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -9,26 +9,30 @@ test("recovers previously submitted files when clicking the back button", async 
   const previouslySubmittedData = {
     "proposal.drawing.locationPlan":
       "http://localhost:7002/file/private/slb56xfv/placeholder.png",
-    "property.uploadedFile": {
-      file: {
-        path: "placeholder.png",
-        size: 6146,
+    "property.uploadedFile": [
+      {
+        file: {
+          path: "placeholder.png",
+          size: 6146,
+        },
+        status: "success",
+        progress: 1,
+        id: "43sDL_JNJ6JgYxd_WUYW-",
+        url: "http://localhost:7002/file/private/slb56xfv/placeholder.png",
       },
-      status: "success",
-      progress: 1,
-      id: "43sDL_JNJ6JgYxd_WUYW-",
-      url: "http://localhost:7002/file/private/slb56xfv/placeholder.png",
-    },
-    cachedFile: {
-      file: {
-        path: "placeholder.png",
-        size: 6146,
+    ],
+    cachedFile: [
+      {
+        file: {
+          path: "placeholder.png",
+          size: 6146,
+        },
+        status: "success",
+        progress: 1,
+        id: "43sDL_JNJ6JgYxd_WUYW-",
+        url: "http://localhost:7002/file/private/slb56xfv/placeholder.png",
       },
-      status: "success",
-      progress: 1,
-      id: "43sDL_JNJ6JgYxd_WUYW-",
-      url: "http://localhost:7002/file/private/slb56xfv/placeholder.png",
-    },
+    ],
   };
 
   const { user } = setup(

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -30,7 +30,7 @@ export default function Component(props: Props) {
     props.previouslySubmittedData?.data?.[props.dataFieldBoundary];
   const previousArea =
     props.previouslySubmittedData?.data?.[props.dataFieldArea];
-  const previousFile = props.previouslySubmittedData?.data?.cachedFile;
+  const previousFile = props.previouslySubmittedData?.data?.cachedFile?.[0];
   const startPage = previousFile ? "upload" : "draw";
   const [page, setPage] = useState<"draw" | "upload">(startPage);
   const passport = useStore((state) => state.computePassport());
@@ -193,16 +193,18 @@ export default function Component(props: Props) {
             ? selectedFile?.url
             : undefined,
         [PASSPORT_UPLOADED_FILE_KEY]:
-          selectedFile && propsDataFieldUrl ? selectedFile : undefined,
+          selectedFile && propsDataFieldUrl ? [selectedFile] : undefined,
         cachedFile: selectedFile
-          ? {
-              ...selectedFile,
-              file: {
-                path: selectedFile.file.path,
-                size: selectedFile.file.size,
-                type: selectedFile.file.type,
+          ? [
+              {
+                ...selectedFile,
+                file: {
+                  path: selectedFile.file.path,
+                  size: selectedFile.file.size,
+                  type: selectedFile.file.type,
+                },
               },
-            }
+            ]
           : undefined,
       };
     })();

--- a/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
@@ -225,15 +225,17 @@ const uploadedPlansBreadcrumb = {
     auto: false,
     data: {
       "proposal.drawing.locationPlan": uploadedPlanUrl,
-      "property.uploadedFile": {
-        file: {
-          path: "fut.email.png",
+      "property.uploadedFile": [
+        {
+          file: {
+            path: "fut.email.png",
+          },
+          status: "success",
+          progress: 1,
+          id: "u6jFS4xJ-MM9Gsg1o2ZsI",
+          url: uploadedPlanUrl,
         },
-        status: "success",
-        progress: 1,
-        id: "u6jFS4xJ-MM9Gsg1o2ZsI",
-        url: uploadedPlanUrl,
-      },
+      ],
     },
   },
 };
@@ -260,9 +262,11 @@ const uploadedPlansPassport = {
     "property.type": ["residential.dwelling.house.terrace"],
     "property.localAuthorityDistrict": ["Southwark"],
     "property.region": ["London"],
-    "proposal.drawing.locationPlan": {
-      url: uploadedPlanUrl,
-    },
+    "proposal.drawing.locationPlan": [
+      {
+        url: uploadedPlanUrl,
+      },
+    ],
     "property.uploadedFile": {
       file: {
         path: "fut.email.png",

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -316,20 +316,6 @@ export function getBOPSParams({
       });
     });
 
-  // 2a. property boundary file if the user didn't draw
-
-  if (passport?.data?.[PASSPORT_UPLOAD_KEY]) {
-    data.files = data.files || [];
-    data.files.push({
-      filename: passport.data[PASSPORT_UPLOAD_KEY],
-      tags: extractTagsFromPassportKey(PASSPORT_UPLOAD_KEY),
-      applicant_description: extractFileDescriptionForPassportKey(
-        passport.data,
-        PASSPORT_UPLOAD_KEY
-      ),
-    });
-  }
-
   // 3. constraints
 
   const constraints = (


### PR DESCRIPTION
I hit this issue when looking at attach files for sendToEmail. Because the passport variable assigned in DrawBoundary is not the same as normal file upload we need some additional code to get the file based on the passport variable as opposed to relying on the structure of the object.

Before we jump into multiple file upload I'd be interested in wider refactor of some of this shared upload logic, but this feels like a decent light touch for now.

**What this fixes**
 - Manually having to find `DrawBoundary` files when parsing the passport
 - This file isn't being currently handled in `planx-core` when generating a OneApp payload, or when we delete files by parsing the passport