### PR TITLE
refactor: Simplify Editor file upload logic

### DIFF
--- a/api.planx.uk/send/uniform.test.ts
+++ b/api.planx.uk/send/uniform.test.ts
@@ -34,6 +34,9 @@ jest.mock("@opensystemslab/planx-document-templates", () => {
 const mockGenerateOneAppXML = jest.fn().mockResolvedValue("<dummy:xml></dummy:xml>");
 jest.mock("@opensystemslab/planx-core", () => {
   return {
+    Passport: jest.fn().mockImplementation(() => ({
+      getFiles: jest.fn().mockImplementation(() => []),
+    })),
     CoreDomainClient: jest.fn().mockImplementation(() => ({
       generateOneAppXML: () => mockGenerateOneAppXML(),
       getDocumentTemplateNamesForSession: jest.fn().mockResolvedValue(["X", "Y"]),

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/styles": "5.11.9",
     "@mui/utils": "5.11.9",
     "@opensystemslab/map": "^0.7.4",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#5e932c3",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core.git#acef72a",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "@tiptap/core": "2.0.0-beta.204",
     "@tiptap/extension-bold": "2.0.0-beta.204",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -60,7 +60,7 @@ specifiers:
   '@mui/styles': 5.11.9
   '@mui/utils': 5.11.9
   '@opensystemslab/map': ^0.7.4
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#5e932c3
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core.git#acef72a
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@react-theming/storybook-addon': ^1.1.7
   '@storybook/addon-actions': ^6.5.10
@@ -201,7 +201,7 @@ dependencies:
   '@mui/styles': 5.11.9_7v64pk2mkrohwh22gx7lrz5ive
   '@mui/utils': 5.11.9_react@18.2.0
   '@opensystemslab/map': 0.7.4
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/5e932c3
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/acef72a
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_bmxldjpgqrh5iboessqya77r7u
   '@tiptap/core': 2.0.0-beta.204
   '@tiptap/extension-bold': 2.0.0-beta.204_bv566pzu4gfcw3675d5jwhi56i
@@ -10200,6 +10200,13 @@ packages:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
     dev: false
 
+  /fast-xml-parser/4.1.3:
+    resolution: {integrity: sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
+
   /fastest-stable-stringify/2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
     dev: false
@@ -13269,8 +13276,16 @@ packages:
     resolution: {integrity: sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==}
     dev: true
 
+  /lodash.get/4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: false
+
   /lodash.groupby/4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+    dev: false
+
+  /lodash.has/4.5.2:
+    resolution: {integrity: sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==}
     dev: false
 
   /lodash.kebabcase/4.1.1:
@@ -18125,6 +18140,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  /strnum/1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
+
   /style-loader/1.3.0_webpack@4.44.2:
     resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}
     engines: {node: '>= 8.9.0'}
@@ -18801,6 +18820,11 @@ packages:
   /type-fest/2.17.0:
     resolution: {integrity: sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==}
     engines: {node: '>=12.20'}
+    dev: false
+
+  /type-fest/3.7.0:
+    resolution: {integrity: sha512-A2qUJ/j8vkKIT+UorxayZjFJoEdNkIPZkjOJSWezoAbRQd7QEhnz2iJlfVy4Or0GuEnCXts5cNorQNUvdLkaSQ==}
+    engines: {node: '>=14.16'}
     dev: false
 
   /type-is/1.6.18:
@@ -20023,6 +20047,10 @@ packages:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
     dev: false
 
+  /zod/3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: false
+
   /zustand/4.3.3_immer@9.0.15+react@18.2.0:
     resolution: {integrity: sha512-x2jXq8S0kfLGNwGh87nhRfEc2eZy37tSatpSoSIN+O6HIaBhgQHSONV/F9VNrNcBcKQu/E80K1DeHDYQC/zCrQ==}
     engines: {node: '>=12.7.0'}
@@ -20044,17 +20072,22 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/theopensystemslab/planx-core/5e932c3:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5e932c3}
+  github.com/theopensystemslab/planx-core/acef72a:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/acef72a}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}
     prepare: true
     requiresBuild: true
     dependencies:
+      fast-xml-parser: 4.1.3
       graphql: 16.6.0
       graphql-request: 5.1.0_graphql@16.6.0
+      lodash.get: 4.4.2
+      lodash.has: 4.5.2
       lodash.kebabcase: 4.1.1
+      type-fest: 3.7.0
+      zod: 3.21.4
     transitivePeerDependencies:
       - encoding
     dev: false

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -19,18 +19,6 @@ test("recovers previously submitted files when clicking the back button", async 
         url: "http://localhost:7002/file/private/slb56xfv/placeholder.png",
       },
     ],
-    cachedFile: [
-      {
-        file: {
-          path: "placeholder.png",
-          size: 6146,
-        },
-        status: "success",
-        progress: 1,
-        id: "43sDL_JNJ6JgYxd_WUYW-",
-        url: "http://localhost:7002/file/private/slb56xfv/placeholder.png",
-      },
-    ],
   };
 
   const { user } = setup(

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -7,9 +7,7 @@ import DrawBoundary from "./";
 test("recovers previously submitted files when clicking the back button", async () => {
   const handleSubmit = jest.fn();
   const previouslySubmittedData = {
-    "proposal.drawing.locationPlan":
-      "http://localhost:7002/file/private/slb56xfv/placeholder.png",
-    "property.uploadedFile": [
+    "proposal.drawing.locationPlan": [
       {
         file: {
           path: "placeholder.png",

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import Card from "@planx/components/shared/Preview/Card";
@@ -26,7 +25,8 @@ export default function Component(props: Props) {
     props.previouslySubmittedData?.data?.[props.dataFieldBoundary];
   const previousArea =
     props.previouslySubmittedData?.data?.[props.dataFieldArea];
-  const previousFile = props.previouslySubmittedData?.data?.cachedFile?.[0];
+  const previousFile =
+    props.previouslySubmittedData?.data?.[PASSPORT_UPLOAD_KEY]?.[0];
   const startPage = previousFile ? "upload" : "draw";
   const [page, setPage] = useState<"draw" | "upload">(startPage);
   const passport = useStore((state) => state.computePassport());
@@ -182,18 +182,6 @@ export default function Component(props: Props) {
             ? area / 10000
             : undefined,
         [PASSPORT_UPLOAD_KEY]: selectedFile ? [selectedFile] : undefined,
-        cachedFile: selectedFile
-          ? [
-              {
-                ...selectedFile,
-                file: {
-                  path: selectedFile.file.path,
-                  size: selectedFile.file.size,
-                  type: selectedFile.file.type,
-                },
-              },
-            ]
-          : undefined,
       };
     })();
 

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -14,11 +14,7 @@ import type { Geometry } from "@turf/helpers";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
 
-import {
-  DrawBoundary,
-  PASSPORT_UPLOAD_KEY,
-  PASSPORT_UPLOADED_FILE_KEY,
-} from "../model";
+import { DrawBoundary, PASSPORT_UPLOAD_KEY } from "../model";
 import Upload, { FileUpload } from "./Upload";
 
 export type Props = PublicProps<DrawBoundary>;
@@ -175,9 +171,6 @@ export default function Component(props: Props) {
 
   function handleSubmit() {
     const data: Store.userData["data"] = (() => {
-      // XXX: we haven't added a custom upload field name in the editor yet
-      const propsDataFieldUrl = PASSPORT_UPLOAD_KEY;
-
       // set userData depending if user draws boundary or uploads file
       return {
         [props.dataFieldBoundary]:
@@ -188,12 +181,7 @@ export default function Component(props: Props) {
           boundary && area && props.dataFieldBoundary
             ? area / 10000
             : undefined,
-        [propsDataFieldUrl]:
-          selectedFile?.url && propsDataFieldUrl
-            ? selectedFile?.url
-            : undefined,
-        [PASSPORT_UPLOADED_FILE_KEY]:
-          selectedFile && propsDataFieldUrl ? [selectedFile] : undefined,
+        [PASSPORT_UPLOAD_KEY]: selectedFile ? [selectedFile] : undefined,
         cachedFile: selectedFile
           ? [
               {

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -32,4 +32,3 @@ export const DEFAULT_PASSPORT_AREA_KEY = "property.boundary.area" as const;
 export const DEFAULT_TITLE = "Draw the boundary of the property" as const;
 export const DEFAULT_TITLE_FOR_UPLOADING = "Upload a location plan" as const;
 export const PASSPORT_UPLOAD_KEY = "proposal.drawing.locationPlan" as const; // not added to editor yet
-export const PASSPORT_UPLOADED_FILE_KEY = "property.uploadedFile";

--- a/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public.test.tsx
@@ -224,8 +224,7 @@ const uploadedPlansBreadcrumb = {
   EO6DzPso8o: {
     auto: false,
     data: {
-      "proposal.drawing.locationPlan": uploadedPlanUrl,
-      "property.uploadedFile": [
+      "proposal.drawing.locationPlan": [
         {
           file: {
             path: "fut.email.png",
@@ -264,18 +263,15 @@ const uploadedPlansPassport = {
     "property.region": ["London"],
     "proposal.drawing.locationPlan": [
       {
+        file: {
+          path: "fut.email.png",
+        },
+        status: "success",
+        progress: 1,
+        id: "u6jFS4xJ-MM9Gsg1o2ZsI",
         url: uploadedPlanUrl,
       },
     ],
-    "property.uploadedFile": {
-      file: {
-        path: "fut.email.png",
-      },
-      status: "success",
-      progress: 1,
-      id: "u6jFS4xJ-MM9Gsg1o2ZsI",
-      url: uploadedPlanUrl,
-    },
   },
 };
 

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -11,7 +11,6 @@ import { getResultData } from "pages/FlowEditor/lib/store/preview";
 import { GovUKPayment } from "types";
 
 import { Store } from "../../../../pages/FlowEditor/lib/store";
-import { PASSPORT_UPLOAD_KEY } from "../../DrawBoundary/model";
 import { GOV_PAY_PASSPORT_KEY, toPence } from "../../Pay/model";
 import { removeNilValues } from "../../shared/utils";
 import { TYPES } from "../../types";

--- a/editor.planx.uk/src/@planx/components/Send/uniform/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/uniform/index.ts
@@ -4,11 +4,6 @@ import { Store } from "../../../../pages/FlowEditor/lib/store";
 import { getBOPSParams } from "../bops";
 import { CSVData } from "../model";
 
-type UniformFile = {
-  name: string;
-  url: string;
-};
-
 export function getUniformParams({
   breadcrumbs,
   flow,
@@ -22,38 +17,9 @@ export function getUniformParams({
   passport: Store.passport;
   sessionId: string;
 }) {
-  // make a list of all S3 URLs & filenames from uploaded files
-  const files: UniformFile[] = [];
-  Object.entries(passport.data || {})
-    // add any files uploaded via a FileUpload component
-    .filter(([, v]: any) => v?.[0]?.url)
-    .forEach(([key, arr]) => {
-      (arr as any[]).forEach(({ url, filename }) => {
-        try {
-          files.push({ url: url, name: filename });
-        } catch (err) {}
-      });
-    });
-
-  // additionally add the property boundary file if the user didn't draw
-  if (passport?.data?.["property.uploadedFile"]) {
-    const boundaryFile = passport.data["property.uploadedFile"];
-    files.push({ url: boundaryFile.url, name: boundaryFile.file.path });
-  }
-
-  // applicants may upload the same file in multiple slots,
-  //  but we only want to send a single copy of each file to Uniform
-  const uniqueFiles: string[] = [];
-  files.forEach((file) => {
-    if (!uniqueFiles.includes(file.url)) {
-      uniqueFiles.push(file.url);
-    }
-  });
-
   // this is the body we'll POST to the /uniform endpoint - the endpoint will handle file & .zip generation
   return {
     csv: makeCsvData({ breadcrumbs, flow, flowName, passport, sessionId }),
-    files: uniqueFiles,
     passport,
     sessionId,
   };

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -297,7 +297,7 @@ function DrawBoundary(props: ComponentProps) {
   const geodata = props.userData?.data?.[props.node.data?.dataFieldBoundary];
   const locationPlan = props.userData?.data?.[PASSPORT_UPLOAD_KEY];
 
-  const fileName = locationPlan ? locationPlan.split("/").pop() : "";
+  const fileName = locationPlan ? locationPlan[0].url.split("/").pop() : "";
 
   if (!geodata && !locationPlan && !props.node.data?.hideFileUpload) {
     // XXX: we always expect to have data, this is for temporary debugging


### PR DESCRIPTION
# What does this PR do?
 - Generates list of files on the backend, no longer needs a list sent via `getUniformParams()`
 - Simplifies duplicated keys set by `DrawBoundary`
   - See comment here - https://github.com/theopensystemslab/planx-new/pull/1568#pullrequestreview-1356945031
   - `cachedFile` removed
   - `uploadedFile` removed
   - `proposal.drawing.locationPlan` kept in format which more closely matches other file upload data objects.

## Testing
There's certainly more scope for unit testing or E2E testing here, but I'd be a bit more keen to pick that up once we move more Submission logic to the backend. If you feel it's more appropriate to increase coverage at this stage to describe the current Editor behaviour I'm happy to pick that up.

**To test**
 - Upload file via `DrawBoundary`
   - If I navigate "Back" to this component file still persists (`cachedFile` behaviour)
 - If I submit a `DrawBoundary` upload to BOPS...
   - It is correctly added to the payload
   - It is correctly tagged in the payload
   - It is only listed once in the payload (and passport)
- I can submit a Uniform submission and files are correctly added to Zip file and `payload.xml`