### PR TITLE
feat: Lock lowcal sessions

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -237,6 +237,8 @@
                 _is_null: true
             - deleted_at:
                 _is_null: true
+            - read_only:
+                _ne: true
         check: {}
   event_triggers:
     - name: email_user_submission_confirmation

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -237,8 +237,8 @@
                 _is_null: true
             - deleted_at:
                 _is_null: true
-            - read_only:
-                _ne: true
+            - locked_at:
+                _is_null: true
         check: {}
   event_triggers:
     - name: email_user_submission_confirmation

--- a/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/down.sql
+++ b/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "public"."lowcal_sessions" DROP COLUMN "read_only";
+ALTER TABLE "public"."lowcal_sessions" DROP COLUMN "locked_at";

--- a/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/down.sql
+++ b/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."lowcal_sessions" DROP COLUMN "read_only";

--- a/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/up.sql
+++ b/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."lowcal_sessions" ADD COLUMN "read_only" BOOLEAN NOT NULL DEFAULT 'false';

--- a/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/up.sql
+++ b/hasura.planx.uk/migrations/1679922513351_alter_table_public_lowcal_sessions_add_column_read_only/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "public"."lowcal_sessions" ADD COLUMN "read_only" BOOLEAN NOT NULL DEFAULT 'false';
+ALTER TABLE "public"."lowcal_sessions" ADD COLUMN "locked_at" TIMESTAMPTZ NULL;

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -28,8 +28,9 @@ describe("lowcal_sessions", () => {
       bob1,
       bob2,
       mallory1,
+      robert1,
       anon1
-    ] = [...Array(6)].map(() => uuidV4());
+    ] = [...Array(7)].map(() => uuidV4());
 
     const insertSession = `
       mutation InsertLowcalSession(
@@ -107,6 +108,13 @@ describe("lowcal_sessions", () => {
                 flow_id: "${flowId}"
                 id: "${mallory1}"
               }
+              {
+                email: "robert@opensystemslab.io"
+                data: { r: 1 }
+                read_only: true
+                flow_id: "${flowId}"
+                id: "${robert1}"
+              }
             ]
           ) {
             returning {
@@ -117,7 +125,7 @@ describe("lowcal_sessions", () => {
       `
       let res = await gqlAdmin(query);
       ids = res.data.insert_lowcal_sessions.returning.map((row) => row.id);
-      assert.strictEqual(ids.length, 4);
+      assert.strictEqual(ids.length, 5);
     });
   
     afterAll(async () => {
@@ -307,6 +315,16 @@ describe("lowcal_sessions", () => {
           "x-hasura-lowcal-email": ""
         };
         const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        expect(res).not.toHaveProperty("errors");
+        expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
+      });
+
+      test("Robert cannot update his read-only session", async () => {
+        const headers = {
+          "x-hasura-lowcal-session-id": robert1,
+          "x-hasura-lowcal-email": "robert@opensystemslab.io"
+        };
+        const res = await gqlPublic(updateByPK, { sessionId: robert1, data: { x: 1 } }, headers);
         expect(res).not.toHaveProperty("errors");
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -111,7 +111,7 @@ describe("lowcal_sessions", () => {
               {
                 email: "robert@opensystemslab.io"
                 data: { r: 1 }
-                read_only: true
+                locked_at: "2022-03-28T17:30:15+01:00"
                 flow_id: "${flowId}"
                 id: "${robert1}"
               }


### PR DESCRIPTION
This PR adds a `locked_at` column to the lowcal_sessions table.

Before a 'payment request" is created, the associated lowcal session should be locked and future updates should not be allowed.