### PR TITLE
feat: Initial Invite to pay API

### DIFF
--- a/api.planx.uk/errors/ServerError.ts
+++ b/api.planx.uk/errors/ServerError.ts
@@ -1,0 +1,25 @@
+export class ServerError extends Error {
+  message: string;
+  status: number;
+  cause: unknown;
+
+  constructor({
+    message,
+    status,
+    cause,
+  }: {
+    message: string;
+    status?: number;
+    cause?: unknown;
+  }) {
+    super(message);
+    this.message = message;
+    this.status = status || 500;
+    if (cause) {
+      this.cause = cause;
+    }
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, ServerError.prototype);
+  }
+}

--- a/api.planx.uk/errors/ServerError.ts
+++ b/api.planx.uk/errors/ServerError.ts
@@ -1,7 +1,7 @@
 export class ServerError extends Error {
   message: string;
   status: number;
-  cause: unknown;
+  cause: unknown | undefined;
 
   constructor({
     message,

--- a/api.planx.uk/errors/index.ts
+++ b/api.planx.uk/errors/index.ts
@@ -1,0 +1,1 @@
+export { ServerError } from "./ServerError"

--- a/api.planx.uk/inviteToPay/index.ts
+++ b/api.planx.uk/inviteToPay/index.ts
@@ -1,0 +1,1 @@
+export { inviteToPay } from "./inviteToPay";

--- a/api.planx.uk/inviteToPay/inviteToPay.test.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.test.ts
@@ -7,6 +7,7 @@ import {
   notFoundLockSessionQueryMock,
   detailedValidSessionQueryMock,
   lockSessionQueryMock,
+  unlockSessionQueryMock,
   createPaymentRequestQueryMock,
 } from "../tests/mocks/inviteToPayMocks";
 import {
@@ -34,6 +35,7 @@ describe("Invite to pay API route", () => {
   beforeEach(() => {
     queryMock.mockQuery(validSessionQueryMock);
     queryMock.mockQuery(lockSessionQueryMock);
+    queryMock.mockQuery(unlockSessionQueryMock);
     queryMock.mockQuery(notFoundQueryMock);
     queryMock.mockQuery(notFoundLockSessionQueryMock);
     queryMock.mockQuery(detailedValidSessionQueryMock);
@@ -62,7 +64,7 @@ describe("Invite to pay API route", () => {
     });
 
     test("a missing payee name", async () => {
-      const invalidPostBody = { ...validPostBody, payeeName: null  };
+      const invalidPostBody = { ...validPostBody, payeeName: null };
       await supertest(app)
         .post(validSessionURL)
         .send(invalidPostBody)
@@ -76,7 +78,7 @@ describe("Invite to pay API route", () => {
     });
 
     test("a missing payee email address", async () => {
-      const invalidPostBody = { ...validPostBody, payeeEmail: null  };
+      const invalidPostBody = { ...validPostBody, payeeEmail: null };
       await supertest(app)
         .post(validSessionURL)
         .send(invalidPostBody)

--- a/api.planx.uk/inviteToPay/inviteToPay.test.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.test.ts
@@ -1,0 +1,91 @@
+import supertest from "supertest";
+import app from "../server";
+import { queryMock } from "../tests/graphqlQueryMock";
+import {
+  validSessionQueryMock,
+  notFoundQueryMock,
+  lockSessionQueryMock,
+  createPaymentRequestQueryMock,
+} from "../tests/mocks/inviteToPayMocks";
+import {
+  validSession,
+  notFoundSession,
+  validEmail,
+  newPaymentRequest,
+} from "../tests/mocks/inviteToPayData";
+
+describe("validateSessionIsEligibleForInviteToPay", () => {
+  test.todo("session validation");
+});
+
+describe("Invite to pay API route", () => {
+  const inviteToPayBaseRoute = "/invite-to-pay";
+  const validSessionURL = `${inviteToPayBaseRoute}/${validSession.id}`;
+  const notFoundSessionURL = `${inviteToPayBaseRoute}/${notFoundSession.id}`;
+  const validPostBody = { payeeEmail: validEmail };
+
+  beforeEach(() => {
+    queryMock.mockQuery(validSessionQueryMock);
+    queryMock.mockQuery(lockSessionQueryMock);
+    queryMock.mockQuery(notFoundQueryMock);
+    queryMock.mockQuery(createPaymentRequestQueryMock);
+  });
+
+  afterEach(() => {
+    queryMock.reset();
+  });
+
+  describe("valid request scenarios", () => {
+    test("a valid sessionId", async () => {
+      await supertest(app)
+        .post(validSessionURL)
+        .send(validPostBody)
+        .expect(200)
+        .then((response) => {
+          expect(response.body).toEqual(newPaymentRequest);
+        });
+    });
+  });
+
+  describe("invalid request scenarios", () => {
+    test("route without a sessionId parameter", async () => {
+      await supertest(app).post("/invite-to-pay").expect(404);
+    });
+
+    test("an invalid UUID", async () => {
+      await supertest(app)
+        .post("/invite-to-pay/abc")
+        .expect(400)
+        .then((response) => {
+          expect(response.body).toHaveProperty(
+            "error",
+            "invalid sessionId parameter"
+          );
+        });
+    });
+
+    test("a missing payee email address", async () => {
+      const invalidPostBody = {};
+      await supertest(app)
+        .post(validSessionURL)
+        .send(invalidPostBody)
+        .expect(400)
+        .then((response) => {
+          expect(response.body).toHaveProperty(
+            "error",
+            "JSON body must contain payeeEmail"
+          );
+        });
+    });
+
+    test("a sessionId that cannot be found", async () => {
+      await supertest(app)
+        .post(notFoundSessionURL)
+        .send(validPostBody)
+        .expect(404)
+        .then((response) => {
+          expect(response.body).toHaveProperty("error", "session not found");
+        });
+    });
+  });
+});

--- a/api.planx.uk/inviteToPay/inviteToPay.test.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.test.ts
@@ -61,8 +61,8 @@ describe("Invite to pay API route", () => {
       await supertest(app).post("/invite-to-pay").expect(404);
     });
 
-    test("a missing agent name", async () => {
-      const invalidPostBody = {};
+    test("a missing payee name", async () => {
+      const invalidPostBody = { ...validPostBody, payeeName: null  };
       await supertest(app)
         .post(validSessionURL)
         .send(invalidPostBody)
@@ -70,13 +70,13 @@ describe("Invite to pay API route", () => {
         .then((response) => {
           expect(response.body).toHaveProperty(
             "error",
-            "JSON body must contain payeeEmail"
+            "JSON body must contain payeeName"
           );
         });
     });
 
     test("a missing payee email address", async () => {
-      const invalidPostBody = {};
+      const invalidPostBody = { ...validPostBody, payeeEmail: null  };
       await supertest(app)
         .post(validSessionURL)
         .send(invalidPostBody)

--- a/api.planx.uk/inviteToPay/inviteToPay.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.ts
@@ -1,0 +1,102 @@
+import { NextFunction, Request, Response } from "express";
+import { validate as validateUUID, version as getUUIDVersion } from "uuid";
+import type {
+  Session,
+  PaymentRequest,
+} from "@opensystemslab/planx-core/types/types";
+
+import { ServerError } from "../errors";
+import { _admin } from "../client";
+
+export async function inviteToPay(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const sessionId = req.params.sessionId;
+  const payeeEmail = req.body.payeeEmail;
+
+  if (!isValidIdFormat(sessionId)) {
+    return next(
+      new ServerError({
+        message: "invalid sessionId parameter",
+        status: 400,
+      })
+    );
+  }
+
+  if (!payeeEmail) {
+    return next(
+      new ServerError({
+        message: "JSON body must contain payeeEmail",
+        status: 400,
+      })
+    );
+  }
+
+  const session: Session = await _admin.getSessionById(sessionId);
+
+  if (!session) {
+    return next(
+      new ServerError({
+        message: "session not found",
+        status: 404,
+      })
+    );
+  }
+
+  // posts to this endpoint are expected to occur only for valid scenarios
+  // any validation errors are logged but undisclosed to the caller
+  const canInviteToPay = validateSessionIsEligibleForInviteToPay({
+    email: payeeEmail,
+    session,
+  });
+  if (!canInviteToPay) {
+    return next(
+      new ServerError({
+        message: "invalid invite to pay session",
+        status: 422,
+      })
+    );
+  }
+
+  let paymentRequest: PaymentRequest | undefined;
+  try {
+    // make session read-only before creating a payment request
+    await _admin.lockSession(sessionId);
+    paymentRequest = await _admin.createPaymentRequest({
+      sessionId,
+      payeeEmail,
+    });
+  } catch (e: unknown) {
+    console.log(e);
+    return next(
+      new ServerError({
+        message: "Could not initiate payment request",
+        status: 500,
+        cause: e,
+      })
+    );
+  }
+
+  res.json(paymentRequest);
+}
+
+export function validateSessionIsEligibleForInviteToPay({
+  email,
+  session,
+}: {
+  email: string;
+  session: Session;
+}): boolean {
+  // TODO
+  // validate breadcrumbs
+  // - includes Pay
+  // - payee email
+  // - flow is complete (session is locked)
+  return !!email && !!session;
+}
+
+function isValidIdFormat(id: string): boolean {
+  return validateUUID(id) && getUUIDVersion(id) === 4;
+}

--- a/api.planx.uk/inviteToPay/inviteToPay.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.ts
@@ -41,7 +41,10 @@ export async function inviteToPay(
   try {
     // lock session before creating a payment request
     // createPaymentRequest will fail if the session fails to lock
-    await _admin.lockSession(sessionId);
+    const locked = await _admin.lockSession(sessionId);
+    if (!locked) {
+      throw new Error("session could not be locked")
+    }
     paymentRequest = await _admin.createPaymentRequest({
       sessionId,
       payeeName,
@@ -59,7 +62,7 @@ export async function inviteToPay(
     } else {
       return next(
         new ServerError({
-          message: "Could not initiate payment request",
+          message: "could not initiate payment request",
           status: 500,
           cause: e,
         })

--- a/api.planx.uk/inviteToPay/inviteToPay.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.ts
@@ -39,7 +39,7 @@ export async function inviteToPay(
 
   let paymentRequest: PaymentRequest | undefined;
   try {
-    // make session read-only before creating a payment request
+    // lock session before creating a payment request
     // createPaymentRequest will fail if the session fails to lock
     await _admin.lockSession(sessionId);
     paymentRequest = await _admin.createPaymentRequest({

--- a/api.planx.uk/inviteToPay/inviteToPay.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.ts
@@ -69,7 +69,6 @@ export async function inviteToPay(
       payeeEmail,
     });
   } catch (e: unknown) {
-    console.log(e);
     return next(
       new ServerError({
         message: "Could not initiate payment request",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#6138ff0",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#d0c08d7",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#db35305",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#b34531c",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#1f7e963",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#db35305",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#d0c08d7",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#1f7e963",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#b34531c",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#5cf3c8b",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "adm-zip": "^0.5.9",
     "aws-sdk": "^2.1180.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -67,7 +67,6 @@
     "@types/passport": "^1.0.11",
     "@types/passport-google-oauth20": "^2.0.11",
     "@types/supertest": "^2.0.12",
-    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "dotenv": "^16.0.1",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -67,6 +67,7 @@
     "@types/passport": "^1.0.11",
     "@types/passport-google-oauth20": "^2.0.11",
     "@types/supertest": "^2.0.12",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "dotenv": "^16.0.1",
@@ -85,7 +86,8 @@
     "supertest": "^6.2.4",
     "ts-jest": "^28.0.8",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "uuid": "^9.0.0"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -28,7 +28,6 @@ specifiers:
   '@types/passport': ^1.0.11
   '@types/passport-google-oauth20': ^2.0.11
   '@types/supertest': ^2.0.12
-  '@types/uuid': ^9.0.1
   '@typescript-eslint/eslint-plugin': ^5.42.0
   '@typescript-eslint/parser': ^5.42.0
   adm-zip: ^0.5.9
@@ -101,7 +100,7 @@ dependencies:
   form-data: 4.0.0
   graphql: 16.5.0
   graphql-request: 4.3.0_graphql@16.5.0
-  graphql-voyager: 1.0.0-rc.31_phmus7xcbidy3raesi6r6zwaqe
+  graphql-voyager: 1.0.0-rc.31_graphql@16.5.0
   helmet: 5.1.1
   http-proxy-middleware: 2.0.6_@types+express@4.17.14
   isomorphic-fetch: 3.0.0
@@ -137,7 +136,6 @@ devDependencies:
   '@types/passport': 1.0.11
   '@types/passport-google-oauth20': 2.0.11
   '@types/supertest': 2.0.12
-  '@types/uuid': 9.0.1
   '@typescript-eslint/eslint-plugin': 5.43.0_qkzzhbbraoydjxplhj4djkikc4
   '@typescript-eslint/parser': 5.43.0_2uhzae5rel2qyw7fhfmxrmdt3q
   dotenv: 16.0.1
@@ -1294,7 +1292,7 @@ packages:
       '@lit-labs/ssr-dom-shim': 1.0.0
     dev: false
 
-  /@material-ui/core/3.9.4_biqbaboplfbrettd7655fr4n2y:
+  /@material-ui/core/3.9.4:
     resolution: {integrity: sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1307,8 +1305,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.6
-      '@material-ui/system': 3.0.0-alpha.2_biqbaboplfbrettd7655fr4n2y
-      '@material-ui/utils': 3.0.0-alpha.3_biqbaboplfbrettd7655fr4n2y
+      '@material-ui/system': 3.0.0-alpha.2
+      '@material-ui/utils': 3.0.0-alpha.3
       '@types/jss': 9.5.8
       '@types/react-transition-group': 2.9.2
       brcast: 3.0.2
@@ -1329,15 +1327,13 @@ packages:
       normalize-scroll-left: 0.1.2
       popper.js: 1.16.1
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-event-listener: 0.6.6_react@18.2.0
-      react-transition-group: 2.9.0_biqbaboplfbrettd7655fr4n2y
-      recompose: 0.30.0_react@18.2.0
+      react-event-listener: 0.6.6
+      react-transition-group: 2.9.0
+      recompose: 0.30.0
       warning: 4.0.3
     dev: false
 
-  /@material-ui/system/3.0.0-alpha.2_biqbaboplfbrettd7655fr4n2y:
+  /@material-ui/system/3.0.0-alpha.2:
     resolution: {integrity: sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1352,12 +1348,10 @@ packages:
       '@babel/runtime': 7.20.13
       deepmerge: 3.3.0
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       warning: 4.0.3
     dev: false
 
-  /@material-ui/utils/3.0.0-alpha.3_biqbaboplfbrettd7655fr4n2y:
+  /@material-ui/utils/3.0.0-alpha.3:
     resolution: {integrity: sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1371,8 +1365,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       react-is: 16.13.1
     dev: false
 
@@ -1978,10 +1970,6 @@ packages:
   /@types/trusted-types/2.0.2:
     resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
     dev: false
-
-  /@types/uuid/9.0.1:
-    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
-    dev: true
 
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
@@ -4330,7 +4318,7 @@ packages:
       - encoding
     dev: false
 
-  /graphql-voyager/1.0.0-rc.31_phmus7xcbidy3raesi6r6zwaqe:
+  /graphql-voyager/1.0.0-rc.31_graphql@16.5.0:
     resolution: {integrity: sha512-eCaFL8niR3DZo1LUcFV8txwR+MDVIQsrFPmFC7Zwab8UyH5x3SLhx3aDrt998RVJRmY5aFP4q79RY2F3QtGRqA==}
     peerDependencies:
       graphql: '>=14.0.0'
@@ -4343,15 +4331,13 @@ packages:
         optional: true
     dependencies:
       '@f/animate': 1.0.1
-      '@material-ui/core': 3.9.4_biqbaboplfbrettd7655fr4n2y
+      '@material-ui/core': 3.9.4
       classnames: 2.3.2
       clipboard: 2.0.11
       commonmark: 0.29.3
       graphql: 16.5.0
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       svg-pan-zoom: 3.6.1
       viz.js: 2.1.2
     dev: false
@@ -6654,7 +6640,7 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-event-listener/0.6.6_react@18.2.0:
+  /react-event-listener/0.6.6:
     resolution: {integrity: sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==}
     peerDependencies:
       react: ^16.3.0
@@ -6664,7 +6650,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       prop-types: 15.8.1
-      react: 18.2.0
       warning: 4.0.3
     dev: false
 
@@ -6679,7 +6664,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-transition-group/2.9.0_biqbaboplfbrettd7655fr4n2y:
+  /react-transition-group/2.9.0:
     resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
     peerDependencies:
       react: '>=15.0.0'
@@ -6693,8 +6678,6 @@ packages:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       react-lifecycles-compat: 3.0.4
     dev: false
 
@@ -6766,7 +6749,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: false
 
-  /recompose/0.30.0_react@18.2.0:
+  /recompose/0.30.0:
     resolution: {integrity: sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==}
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
@@ -6778,7 +6761,6 @@ packages:
       change-emitter: 0.1.6
       fbjs: 0.8.18
       hoist-non-react-statics: 2.5.5
-      react: 18.2.0
       react-lifecycles-compat: 3.0.4
       symbol-observable: 1.2.0
     dev: false
@@ -7741,10 +7723,12 @@ packages:
 
   /uuid/8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
     dev: false
 
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
     dev: true
 
   /v8-compile-cache-lib/3.0.1:

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#b34531c
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#5cf3c8b
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -84,7 +84,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/b34531c
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/5cf3c8b
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -7960,8 +7960,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b34531c:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b34531c}
+  github.com/theopensystemslab/planx-core/5cf3c8b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5cf3c8b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -931,10 +931,10 @@ packages:
       '@f/map-obj': 1.2.2
     dev: false
 
-  /@graphql-typed-document-node/core/3.2.0_graphql@16.6.0:
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+  /@graphql-typed-document-node/core/3.1.1_graphql@16.6.0:
+    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 16.6.0
     dev: false
@@ -4312,12 +4312,12 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request/5.2.0_graphql@16.6.0:
-    resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
+  /graphql-request/5.1.0_graphql@16.6.0:
+    resolution: {integrity: sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0_graphql@16.6.0
+      '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
@@ -7614,8 +7614,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest/3.7.2:
-    resolution: {integrity: sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA==}
+  /type-fest/3.6.1:
+    resolution: {integrity: sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==}
     engines: {node: '>=14.16'}
     dev: false
 
@@ -7970,13 +7970,13 @@ packages:
     dependencies:
       fast-xml-parser: 4.1.3
       graphql: 16.6.0
-      graphql-request: 5.2.0_graphql@16.6.0
+      graphql-request: 5.1.0_graphql@16.6.0
       lodash.get: 4.4.2
       lodash.has: 4.5.2
       lodash.kebabcase: 4.1.1
       lodash.property: 4.4.2
       lodash.set: 4.3.2
-      type-fest: 3.7.2
+      type-fest: 3.6.1
       zod: 3.21.4
     transitivePeerDependencies:
       - encoding

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -28,6 +28,7 @@ specifiers:
   '@types/passport': ^1.0.11
   '@types/passport-google-oauth20': ^2.0.11
   '@types/supertest': ^2.0.12
+  '@types/uuid': ^9.0.1
   '@typescript-eslint/eslint-plugin': ^5.42.0
   '@typescript-eslint/parser': ^5.42.0
   adm-zip: ^0.5.9
@@ -79,6 +80,7 @@ specifiers:
   ts-jest: ^28.0.8
   ts-node-dev: ^2.0.0
   typescript: ^4.7.4
+  uuid: ^9.0.0
 
 dependencies:
   '@airbrake/node': 2.1.7
@@ -136,6 +138,7 @@ devDependencies:
   '@types/passport': 1.0.11
   '@types/passport-google-oauth20': 2.0.11
   '@types/supertest': 2.0.12
+  '@types/uuid': 9.0.1
   '@typescript-eslint/eslint-plugin': 5.43.0_qkzzhbbraoydjxplhj4djkikc4
   '@typescript-eslint/parser': 5.43.0_2uhzae5rel2qyw7fhfmxrmdt3q
   dotenv: 16.0.1
@@ -155,6 +158,7 @@ devDependencies:
   ts-jest: 28.0.8_4cm5zoywkbnhjzcl7fbzz77jxq
   ts-node-dev: 2.0.0_jyxu4bw6aqgjw6ykt6t6hx4o6e
   typescript: 4.7.4
+  uuid: 9.0.0
 
 packages:
 
@@ -1970,6 +1974,10 @@ packages:
   /@types/trusted-types/2.0.2:
     resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
     dev: false
+
+  /@types/uuid/9.0.1:
+    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
+    dev: true
 
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
@@ -7736,6 +7744,11 @@ packages:
 
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: true
+
+  /uuid/9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
     dev: true
 

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#d0c08d7
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#1f7e963
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -84,7 +84,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/d0c08d7
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/1f7e963
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -931,10 +931,10 @@ packages:
       '@f/map-obj': 1.2.2
     dev: false
 
-  /@graphql-typed-document-node/core/3.1.1_graphql@16.6.0:
-    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
+  /@graphql-typed-document-node/core/3.2.0_graphql@16.6.0:
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
     dev: false
@@ -4312,12 +4312,12 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request/5.1.0_graphql@16.6.0:
-    resolution: {integrity: sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==}
+  /graphql-request/5.2.0_graphql@16.6.0:
+    resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
+      '@graphql-typed-document-node/core': 3.2.0_graphql@16.6.0
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
@@ -7614,8 +7614,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest/3.6.1:
-    resolution: {integrity: sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==}
+  /type-fest/3.7.2:
+    resolution: {integrity: sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA==}
     engines: {node: '>=14.16'}
     dev: false
 
@@ -7960,8 +7960,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/d0c08d7:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d0c08d7}
+  github.com/theopensystemslab/planx-core/1f7e963:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1f7e963}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}
@@ -7970,13 +7970,13 @@ packages:
     dependencies:
       fast-xml-parser: 4.1.3
       graphql: 16.6.0
-      graphql-request: 5.1.0_graphql@16.6.0
+      graphql-request: 5.2.0_graphql@16.6.0
       lodash.get: 4.4.2
       lodash.has: 4.5.2
       lodash.kebabcase: 4.1.1
       lodash.property: 4.4.2
       lodash.set: 4.3.2
-      type-fest: 3.6.1
+      type-fest: 3.7.2
       zod: 3.21.4
     transitivePeerDependencies:
       - encoding

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#db35305
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#b34531c
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -84,7 +84,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/db35305
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/b34531c
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -7960,8 +7960,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/db35305:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/db35305}
+  github.com/theopensystemslab/planx-core/b34531c:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b34531c}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#1f7e963
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#db35305
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -84,7 +84,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/1f7e963
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/db35305
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -7960,8 +7960,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/1f7e963:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1f7e963}
+  github.com/theopensystemslab/planx-core/db35305:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/db35305}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#6138ff0
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#d0c08d7
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -82,7 +82,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/6138ff0
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/d0c08d7
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   adm-zip: 0.5.9
   aws-sdk: 2.1180.0
@@ -927,10 +927,10 @@ packages:
       '@f/map-obj': 1.2.2
     dev: false
 
-  /@graphql-typed-document-node/core/3.1.1_graphql@16.6.0:
-    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
+  /@graphql-typed-document-node/core/3.2.0_graphql@16.6.0:
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
     dev: false
@@ -4304,12 +4304,12 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request/5.1.0_graphql@16.6.0:
-    resolution: {integrity: sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==}
+  /graphql-request/5.2.0_graphql@16.6.0:
+    resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
+      '@graphql-typed-document-node/core': 3.2.0_graphql@16.6.0
       cross-fetch: 3.1.5
       extract-files: 9.0.0
       form-data: 3.0.1
@@ -5752,6 +5752,14 @@ packages:
 
   /lodash.once/4.1.1:
     resolution: {integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=}
+    dev: false
+
+  /lodash.property/4.4.2:
+    resolution: {integrity: sha512-WVnsHSCea5NFrsWGdZilCFJWhHFtb/nqVrDXzR1bIXmOxIykrsAKOpRaYu9rCYoHYuq1SnG6G4A0inMwShV4dg==}
+    dev: false
+
+  /lodash.set/4.3.2:
+    resolution: {integrity: sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==}
     dev: false
 
   /lodash.startcase/4.4.0:
@@ -7598,8 +7606,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest/3.6.1:
-    resolution: {integrity: sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==}
+  /type-fest/3.7.2:
+    resolution: {integrity: sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA==}
     engines: {node: '>=14.16'}
     dev: false
 
@@ -7939,8 +7947,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6138ff0:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6138ff0}
+  github.com/theopensystemslab/planx-core/d0c08d7:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d0c08d7}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}
@@ -7949,11 +7957,13 @@ packages:
     dependencies:
       fast-xml-parser: 4.1.3
       graphql: 16.6.0
-      graphql-request: 5.1.0_graphql@16.6.0
+      graphql-request: 5.2.0_graphql@16.6.0
       lodash.get: 4.4.2
       lodash.has: 4.5.2
       lodash.kebabcase: 4.1.1
-      type-fest: 3.6.1
+      lodash.property: 4.4.2
+      lodash.set: 4.3.2
+      type-fest: 3.7.2
       zod: 3.21.4
     transitivePeerDependencies:
       - encoding

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -691,6 +691,7 @@ const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
         message: errorObject.message.concat(", this error has been logged"),
       };
     } else {
+      console.log(errorObject);
       return errorObject;
     }
   })();

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -682,21 +682,20 @@ app.get("/error", async (res, req, next) => {
   }
 });
 
-const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
+const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {
-    if (errorObject instanceof ServerError && airbrake) {
+    if (airbrake) {
+      airbrake.notify(err);
+    } else {
+      console.log("Error: ", err);
+    }
+    if (err instanceof Error || err instanceof ServerError) {
       return {
-        status: errorObject.status,
-        message: errorObject.message.concat(", this error has been logged"),
-      };
-    } else if (errorObject instanceof Error && airbrake) {
-      airbrake.notify(errorObject);
-      return {
-        ...errorObject,
-        message: errorObject.message.concat(", this error has been logged"),
+        ...err,
+        message: err.message.concat(", this error has been logged"),
       };
     } else {
-      return errorObject;
+      return err;
     }
   })();
 

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -23,6 +23,7 @@ import helmet from "helmet";
 import multer from "multer";
 import SlackNotify from "slack-notify";
 
+import { ServerError } from "./errors";
 import { locationSearch } from "./gis/index";
 import { diffFlow, publishFlow } from "./editor/publish";
 import { findAndReplaceInFlow } from "./editor/findReplace";
@@ -32,6 +33,7 @@ import {
   validateSession,
   sendSaveAndReturnEmail,
 } from "./saveAndReturn";
+import { inviteToPay } from "./inviteToPay";
 import { useFilePermission, useHasuraAuth, useSendEmailAuth } from "./auth";
 
 import airbrake from "./airbrake";
@@ -662,6 +664,8 @@ app.post(
 app.post("/resume-application", sendEmailLimiter, resumeApplication);
 app.post("/validate-session", validateSession);
 
+app.post("/invite-to-pay/:sessionId", inviteToPay);
+
 app.use("/webhooks/hasura", useHasuraAuth);
 app.post("/webhooks/hasura/create-reminder-event", createReminderEvent);
 app.post("/webhooks/hasura/create-expiry-event", createExpiryEvent);
@@ -680,7 +684,12 @@ app.get("/error", async (res, req, next) => {
 
 const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {
-    if (errorObject instanceof Error && airbrake) {
+    if (errorObject instanceof ServerError && airbrake) {
+      return {
+        status: errorObject.status,
+        message: errorObject.message.concat(", this error has been logged"),
+      };
+    } else if (errorObject instanceof Error && airbrake) {
       airbrake.notify(errorObject);
       return {
         ...errorObject,

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -684,17 +684,16 @@ app.get("/error", async (res, req, next) => {
 
 const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {
-    if (airbrake) {
+    if (airbrake && (err instanceof Error || err instanceof ServerError)) {
       airbrake.notify(err);
-    } else {
-      console.log("Error: ", err);
-    }
-    if (err instanceof Error || err instanceof ServerError) {
       return {
         ...err,
         message: err.message.concat(", this error has been logged"),
       };
     } else {
+      if (Boolean(process.env.DEBUG) === true) {
+        console.log("Error: ", err);
+      }
       return err;
     }
   })();

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -682,19 +682,16 @@ app.get("/error", async (res, req, next) => {
   }
 });
 
-const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
+const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {
-    if (airbrake && (err instanceof Error || err instanceof ServerError)) {
-      airbrake.notify(err);
+    if (airbrake && (errorObject instanceof Error || errorObject instanceof ServerError)) {
+      airbrake.notify(errorObject);
       return {
-        ...err,
-        message: err.message.concat(", this error has been logged"),
+        ...errorObject,
+        message: errorObject.message.concat(", this error has been logged"),
       };
     } else {
-      if (Boolean(process.env.DEBUG) === true) {
-        console.log("Error: ", err);
-      }
-      return err;
+      return errorObject;
     }
   })();
 

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -2,8 +2,22 @@ import type { Session, PaymentRequest } from "@opensystemslab/planx-core";
 
 export const validEmail = "the-payee@opensystemslab.io";
 
+export const payee = {
+  name: "Pay Ee",
+  email: validEmail,
+};
+
 export const notFoundSession: Partial<Session> = {
   id: "3da7734f-d5c5-4f69-a261-1b31c2adf6fc",
+};
+
+export const sessionPreviewData = {
+  _address: {
+    title: "1 House, Street, Town, City, PO27 0DE",
+  },
+  "applicant.agent.name.first": "Jo",
+  "applicant.agent.name.last": "Smith",
+  "proposal.projectType": "new.office",
 };
 
 export const validSession: Session = {
@@ -12,35 +26,16 @@ export const validSession: Session = {
   data: {
     id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
     passport: {
-      data: {
-        _address: {
-          single_line_address: "1 House, Street, Town, City, PO27 0DE",
-        },
-        "applicant.agent.name.first": "Jo",
-        "applicant.agent.name.last": "Smith",
-        "proposal.projectType": "new.office",
-        someKey: "someValue",
-        some: {
-          nested: {
-            set: [1, 2, 3],
-          },
-        },
-      },
+      data: sessionPreviewData,
     },
     breadcrumbs: {},
   },
 };
 
-export const paymentRequestSessionPreview: PaymentRequest["sessionPreviewData"] =
-  {
-    agentName: "Jo Smith",
-    address: "1 House, Street, Town, City, PO27 0DE",
-    projectType: "new.office",
-  };
-
 export const newPaymentRequest: PaymentRequest = {
   id: "09655c28-3f34-4619-9385-cd57312acc44",
   sessionId: validSession.id,
-  payeeEmail: validEmail,
-  sessionPreviewData: paymentRequestSessionPreview,
+  payeeName: payee.name,
+  payeeEmail: payee.email,
+  sessionPreviewData: sessionPreviewData,
 };

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -1,8 +1,4 @@
-import type {
-  Session,
-  PaymentRequest,
-  PaymentRequestSessionPreview,
-} from "@opensystemslab/planx-core/types/types";
+import type { Session, PaymentRequest } from "@opensystemslab/planx-core";
 
 export const validEmail = "the-payee@opensystemslab.io";
 
@@ -12,7 +8,7 @@ export const notFoundSession: Partial<Session> = {
 
 export const validSession: Session = {
   id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
-  flowId: "", // TODO
+  flowId: "741a2372-b0b4-4f30-98a8-7c98c6464954",
   data: {
     id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
     passport: {
@@ -23,21 +19,28 @@ export const validSession: Session = {
         "applicant.agent.name.first": "Jo",
         "applicant.agent.name.last": "Smith",
         "proposal.projectType": "new.office",
+        someKey: "someValue",
+        some: {
+          nested: {
+            set: [1, 2, 3],
+          },
+        },
       },
     },
-    breadcrumbs: {}, // TODO
+    breadcrumbs: {},
   },
 };
 
-export const paymentRequestSessionPreview: PaymentRequestSessionPreview = {
-  agentName: "Jo Smith",
-  address: "1 House, Street, Town, City, PO27 0DE",
-  projectType: "new.office",
-};
+export const paymentRequestSessionPreview: PaymentRequest["sessionPreviewData"] =
+  {
+    agentName: "Jo Smith",
+    address: "1 House, Street, Town, City, PO27 0DE",
+    projectType: "new.office",
+  };
 
 export const newPaymentRequest: PaymentRequest = {
   id: "09655c28-3f34-4619-9385-cd57312acc44",
   sessionId: validSession.id,
   payeeEmail: validEmail,
-  data: paymentRequestSessionPreview,
+  sessionPreviewData: paymentRequestSessionPreview,
 };

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -1,0 +1,43 @@
+import type {
+  Session,
+  PaymentRequest,
+  PaymentRequestSessionPreview,
+} from "@opensystemslab/planx-core/types/types";
+
+export const validEmail = "the-payee@opensystemslab.io";
+
+export const notFoundSession: Partial<Session> = {
+  id: "3da7734f-d5c5-4f69-a261-1b31c2adf6fc",
+};
+
+export const validSession: Session = {
+  id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
+  flowId: "", // TODO
+  data: {
+    id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
+    passport: {
+      data: {
+        _address: {
+          single_line_address: "1 House, Street, Town, City, PO27 0DE",
+        },
+        "applicant.agent.name.first": "Jo",
+        "applicant.agent.name.last": "Smith",
+        "proposal.projectType": "new.office",
+      },
+    },
+    breadcrumbs: {}, // TODO
+  },
+};
+
+export const paymentRequestSessionPreview: PaymentRequestSessionPreview = {
+  agentName: "Jo Smith",
+  address: "1 House, Street, Town, City, PO27 0DE",
+  projectType: "new.office",
+};
+
+export const newPaymentRequest: PaymentRequest = {
+  id: "09655c28-3f34-4619-9385-cd57312acc44",
+  sessionId: validSession.id,
+  payeeEmail: validEmail,
+  data: paymentRequestSessionPreview,
+};

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -1,0 +1,55 @@
+import {
+  notFoundSession,
+  validSession,
+  validEmail,
+  paymentRequestSessionPreview,
+  newPaymentRequest,
+} from "./inviteToPayData";
+
+export const notFoundQueryMock = {
+  name: "GetSessionById",
+  data: {
+    lowcal_sessions_by_pk: null,
+  },
+  variables: {
+    id: notFoundSession.id,
+  },
+};
+
+export const validSessionQueryMock = {
+  name: "GetSessionById",
+  data: {
+    lowcal_sessions_by_pk: {
+      id: validSession.id,
+      flow_id: validSession.flowId,
+      data: validSession.data,
+    },
+  },
+  variables: {
+    id: validSession.id,
+  },
+};
+
+export const lockSessionQueryMock = {
+  name: "LockSession",
+  data: {
+    read_only: true,
+  },
+  variables: {
+    id: validSession.id,
+  },
+};
+
+export const createPaymentRequestQueryMock = {
+  name: "CreatePaymentRequest",
+  data: {
+    insert_payment_requests_one: {
+      ...newPaymentRequest,
+    },
+  },
+  variables: {
+    sessionId: validSession.id,
+    payeeEmail: validEmail,
+    data: paymentRequestSessionPreview,
+  },
+};

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -48,8 +48,8 @@ export const notFoundQueryMock = {
 export const notFoundLockSessionQueryMock = {
   name: "LockSession",
   data: {
-    update_lowcal_sessions_by_pk: {
-      locked_at: null,
+    update_lowcal_sessions: {
+      returning: [],
     },
   },
   ignoreThesePropertiesInVariables: ["timestamp"],
@@ -61,8 +61,12 @@ export const notFoundLockSessionQueryMock = {
 export const lockSessionQueryMock = {
   name: "LockSession",
   data: {
-    update_lowcal_sessions_by_pk: {
-      locked_at: new Date("28 May 2023 12:00 UTC+1").toISOString(),
+    update_lowcal_sessions: {
+      returning: [
+        {
+          locked_at: new Date("28 May 2023 12:00 UTC+1").toISOString(),
+        },
+      ],
     },
   },
   ignoreThesePropertiesInVariables: ["timestamp"],

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -33,7 +33,22 @@ export const validSessionQueryMock = {
 export const lockSessionQueryMock = {
   name: "LockSession",
   data: {
-    read_only: true,
+    update_lowcal_sessions_by_pk: {
+      locked_at: new Date("28 May 2023 12:00 UTC+1").toISOString(),
+    },
+  },
+  ignoreThesePropertiesInVariables: ["timestamp"],
+  variables: {
+    id: validSession.id,
+  },
+};
+
+export const checkSessionLockQueryMock = {
+  name: "CheckSessionLock",
+  data: {
+    lowcal_sessions_by_pk: {
+      locked_at: null,
+    },
   },
   variables: {
     id: validSession.id,

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -1,13 +1,42 @@
 import {
   notFoundSession,
   validSession,
-  validEmail,
-  paymentRequestSessionPreview,
+  payee,
+  sessionPreviewData,
   newPaymentRequest,
 } from "./inviteToPayData";
 
-export const notFoundQueryMock = {
+export const validSessionQueryMock = {
   name: "GetSessionById",
+  data: {
+    lowcal_sessions_by_pk: {
+      id: validSession.id,
+      flowId: validSession.flowId,
+      data: validSession.data,
+    },
+  },
+  variables: {
+    id: validSession.id,
+  },
+};
+
+export const detailedValidSessionQueryMock = {
+  name: "GetSessionDetails",
+  data: {
+    lowcal_sessions_by_pk: {
+      id: validSession.id,
+      flowId: validSession.flowId,
+      lockedAt: new Date("28 May 2023 12:00 UTC+1").toISOString(),
+      data: validSession.data,
+    },
+  },
+  variables: {
+    id: validSession.id,
+  },
+};
+
+export const notFoundQueryMock = {
+  name: "GetSessionDetails",
   data: {
     lowcal_sessions_by_pk: null,
   },
@@ -16,17 +45,16 @@ export const notFoundQueryMock = {
   },
 };
 
-export const validSessionQueryMock = {
-  name: "GetSessionById",
+export const notFoundLockSessionQueryMock = {
+  name: "LockSession",
   data: {
-    lowcal_sessions_by_pk: {
-      id: validSession.id,
-      flow_id: validSession.flowId,
-      data: validSession.data,
+    update_lowcal_sessions_by_pk: {
+      locked_at: null,
     },
   },
+  ignoreThesePropertiesInVariables: ["timestamp"],
   variables: {
-    id: validSession.id,
+    id: notFoundSession.id,
   },
 };
 
@@ -43,18 +71,6 @@ export const lockSessionQueryMock = {
   },
 };
 
-export const checkSessionLockQueryMock = {
-  name: "CheckSessionLock",
-  data: {
-    lowcal_sessions_by_pk: {
-      locked_at: null,
-    },
-  },
-  variables: {
-    id: validSession.id,
-  },
-};
-
 export const createPaymentRequestQueryMock = {
   name: "CreatePaymentRequest",
   data: {
@@ -64,7 +80,8 @@ export const createPaymentRequestQueryMock = {
   },
   variables: {
     sessionId: validSession.id,
-    payeeEmail: validEmail,
-    data: paymentRequestSessionPreview,
+    payeeName: payee.name,
+    payeeEmail: payee.email,
+    sessionPreviewData: sessionPreviewData,
   },
 };

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -52,7 +52,6 @@ export const notFoundLockSessionQueryMock = {
       returning: [],
     },
   },
-  ignoreThesePropertiesInVariables: ["timestamp"],
   variables: {
     id: notFoundSession.id,
   },
@@ -69,7 +68,6 @@ export const lockSessionQueryMock = {
       ],
     },
   },
-  ignoreThesePropertiesInVariables: ["timestamp"],
   variables: {
     id: validSession.id,
   },

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -73,6 +73,22 @@ export const lockSessionQueryMock = {
   },
 };
 
+export const unlockSessionQueryMock = {
+  name: "UnlockSession",
+  data: {
+    update_lowcal_sessions: {
+      returning: [
+        {
+          locked_at: null,
+        },
+      ],
+    },
+  },
+  variables: {
+    id: validSession.id,
+  },
+};
+
 export const createPaymentRequestQueryMock = {
   name: "CreatePaymentRequest",
   data: {


### PR DESCRIPTION
Adds a simple endpoint to initiate a payment request for invite to pay.

Once called, the session will be locked and a payment request will be created.

The caller is responsible for setting which `sessionPreviewKeys` are used to store a `sessionPreviewData` object. The API (via planx-core) looks up those values from a locked session to ensure the stored preview data is available and an accurate reflection of what has been stored on the session.

Change depends on: https://github.com/theopensystemslab/planx-core/pull/7

Notes:
* The endpoint is public and anyone can lock a session that meets the invite to pay criteria.
* A session that has been locked already is currently showing as "session not found". Locked sessions cannot use this feature.
* Currently this doesn't validate breadcrumbs beyond checking for the `sessionPreviewKeys`. Adding a check for completion of the pay component would be a good idea and a nice quick update for a follow-on PR.

To test:
```
curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" --data '{ "payeeEmail": "benjamin@opensytemslab.io", "payeeName": "Benjamin", "sessionPreviewKeys": [["_address", "title"]] }' https://api.1577.planx.pizza/invite-to-pay/$SESSION_ID
```