### PR TITLE
build: revert to old update script using docker-compose for tpx demo env

### DIFF
--- a/scripts/pullrequest/update.sh
+++ b/scripts/pullrequest/update.sh
@@ -1,16 +1,5 @@
-#!/usr/bin/env bash
-set -o errexit -o pipefail
-
-# run from project root
-cd "$(dirname $0)/../.."
-
-# set env for this shell
-set -o allexport
-source .env.pizza
-DOCKER_BUILDKIT=1
-set +o allexport
-
-docker compose \
+#!/bin/bash
+DOCKER_BUILDKIT=1 docker-compose --env-file .env.prod \
   -f docker-compose.yml \
   -f docker-compose.pizza.yml \
-  up --build --renew-anon-volumes --force-recreate --remove-orphans --wait
+  up --build --renew-anon-volumes --force-recreate --remove-orphans -d


### PR DESCRIPTION
the TPX pizza was created 2 months ago when we were still using `docker-compose`, so when I rebased and tried to push GIS changes today it errored because now we're using `docker compose`.

 i want to avoid destroying & re-creating the whole vultr instance because they've been editing content in at least ~10 flows.

how i expect this to work: 
- reverts pull request update script to use `docker-compose` like here: https://github.com/theopensystemslab/planx-new/pull/1333/files#diff-e82530b26a3296f5accde8f5cb20952d0b84ab13d94eb03f32b8477be20926bc
- docker-compose.yml still matches main and has `["seed"]` profile, so update _should not_ re-seed the database

anything i might be missing here? 

i tried running this locally and got this error, but I'm hoping that already in use port might just be a local quirk and will behave differently on vultr. 
![Screenshot from 2023-03-30 20-25-13](https://user-images.githubusercontent.com/5132349/228930402-f69d2858-b770-460d-bd9a-a7bec0cd8802.png)

if this doesn't work, i have a copy of the edited content and could manually recreate/update flows if necessary. 