### PR TITLE
fix: on reconciliation, previously "completed" sections should still be tagged as "completed" not "ready to continue"

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/navigation.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/navigation.test.ts
@@ -218,3 +218,48 @@ test("sectionStatuses() applies the NEW INFORMATION NEEDED status if a section w
     thirdSection: "CANNOT CONTINUE YET",
   });
 });
+
+test("sectionStatuses() corrects multiple in-progress statuses on reconciliation to reflect completed sections", () => {
+  setState({ flow: flowWithThreeSections });
+  initNavigationStore();
+
+  // Navigate forwards
+  record("firstSection", { auto: false });
+  record("firstQuestion", { answers: ["firstAnswer"] });
+  record("secondSection", { auto: false });
+  record("secondQuestion", { answers: ["secondAnswer"] });
+
+  // Mimic "reconciliation" by explicitly passing breadcrumbs instead of relying on cachedBreadcrumbs, assume no content has changed
+  const breadcrumbs = getState().breadcrumbs;
+  const statuses = sectionStatuses(breadcrumbs);
+
+  expect(statuses).toEqual({
+    firstSection: "COMPLETED",
+    secondSection: "COMPLETED",
+    thirdSection: "READY TO CONTINUE",
+  });
+});
+
+test("sectionStatuses() applies the NEW INFORMATION NEEDED status and corrects multiple in-progress statuses on reconciliation", () => {
+  setState({ flow: flowWithThreeSections });
+  initNavigationStore();
+
+  // Navigate forwards
+  record("firstSection", { auto: false });
+  record("firstQuestion", { answers: ["firstAnswer"] });
+  record("secondSection", { auto: false });
+  record("secondQuestion", { answers: ["secondAnswer"] });
+
+  // Mimic "reconciliation" by explicitly passing breadcrumbs instead of relying on cachedBreadcrumbs and mocking updated content in firstSection
+  const breadcrumbs = getState().breadcrumbs;
+  const statuses = sectionStatuses(breadcrumbs, [
+    "firstSection",
+    "firstQuestion",
+  ]);
+
+  expect(statuses).toEqual({
+    firstSection: "NEW INFORMATION NEEDED",
+    secondSection: "COMPLETED",
+    thirdSection: "READY TO CONTINUE",
+  });
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -119,11 +119,11 @@ export const navigationStore: StateCreator<
 
   /**
    * Calculate the status of each section node based on the current position in a flow (eg state.cachedBreadcrumbs) or provided breadcrumbs (eg on reconciliation)
-   *   Pass updatedSectionNodeIds on reconiliation to ensure we set an accurrate status for every previously seen section because updated sections are removed from breadcrumbs during reconciliation
+   *   Pass updatedNodeIds on reconiliation to ensure we set an accurrate status for every previously seen section because updated sections are removed from breadcrumbs during reconciliation
    */
   sectionStatuses: (
     breadcrumbs?: Store.breadcrumbs,
-    updatedSectionNodeIds?: string[]
+    updatedNodeIds?: string[]
   ): Record<string, SectionStatus> => {
     const { sectionNodes, currentCard, upcomingCardIds, cachedBreadcrumbs } =
       get();
@@ -133,7 +133,7 @@ export const navigationStore: StateCreator<
 
     const sectionStatuses: Record<string, SectionStatus> = {};
     Object.keys(sectionNodes).forEach((sectionId) => {
-      if (updatedSectionNodeIds?.includes(sectionId)) {
+      if (updatedNodeIds?.includes(sectionId)) {
         // We only expect to receive updatedSectionNodeIds argument on reconciliation, therefore
         //   this status should never apply to regular forwards/back/change navigation
         sectionStatuses[sectionId] = SectionStatus.NeedsUpdated;
@@ -148,6 +148,22 @@ export const navigationStore: StateCreator<
         sectionStatuses[sectionId] = SectionStatus.Completed;
       }
     });
+
+    // If there is more than one in-progress section, correct all but most recent one to display as complete
+    //   ** this scenario should only be possible on reconcilation when cachedBreadcrumbs are unavailable
+    if (
+      Object.values(sectionStatuses).filter(
+        (status) => status === SectionStatus.InProgress
+      ).length > 1
+    ) {
+      const inProgressSectionIds = Object.keys(sectionStatuses).filter(
+        (sectionId) => sectionStatuses[sectionId] === SectionStatus.InProgress
+      );
+      const completedSectionIds = inProgressSectionIds.slice(0, -1);
+      completedSectionIds.forEach((sectionId) => {
+        sectionStatuses[sectionId] = SectionStatus.Completed;
+      });
+    }
 
     return sectionStatuses;
   },


### PR DESCRIPTION
testing out a quick new thought I had around how we can correct section statues on reconciliation without needing to calculate whole paths using the breadcrumbs.

because we have distinct statuses and only allow continuous forward travel (eg no jumping ahead to non-consecutive sections), I think we can simply check:
- does more than one section currently have the status "READY TO CONTINUE"?
- if yes, keep that status for the most recently seen section node only (the one latest in order), but update each prior to be "COMPLETED" (because of forward travel rule, it _must_ have all been seen, and if it hasn't because of a content change it will have been already tagged as "NEW INFORMATION NEEDED")

i'm not sure this would hold up as neatly if we introduced all of the original "middle statuses" (eg "READY TO CONTINUE", "IN PROGRESS", and "READY TO START" that are trickier to distinguish), but that hasn't come up in feedback yet and i think this satisfies our current context :crossed_fingers: 

poking holes in this logic very welcome though! 