### PR TITLE
feat: Add works dates to BOPS payload

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/works.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/works.test.ts
@@ -1,0 +1,53 @@
+import { getBOPSParams } from "..";
+
+test("Start date is set in the payload when present in passport", () => {
+  const result = getBOPSParams({
+    breadcrumbs: {},
+    flow: {},
+    passport: {
+      data: {
+        "proposal.started.date": "2025-02-03",
+      },
+    },
+    sessionId: "session-123",
+    flowName: "Apply for a lawful development certificate",
+  });
+  expect(result.works?.start_date).toEqual("2025-02-03");
+});
+
+test("Start date is not set in the payload when not present in passport", () => {
+  const result = getBOPSParams({
+    breadcrumbs: {},
+    flow: {},
+    passport: {},
+    sessionId: "session-123",
+    flowName: "Apply for a lawful development certificate",
+  });
+  expect(result).not.toHaveProperty("works");
+});
+
+test("Completion date is set in the payload when present in passport", () => {
+  const result = getBOPSParams({
+    breadcrumbs: {},
+    flow: {},
+    passport: {
+      data: {
+        "proposal.completion.date": "2025-02-03",
+      },
+    },
+    sessionId: "session-123",
+    flowName: "Apply for a lawful development certificate",
+  });
+  expect(result.works?.finish_date).toEqual("2025-02-03");
+});
+
+test("Completion date is not set in the payload when not present in passport", () => {
+  const result = getBOPSParams({
+    breadcrumbs: {},
+    flow: {},
+    passport: {},
+    sessionId: "session-123",
+    flowName: "Apply for a lawful development certificate",
+  });
+  expect(result).not.toHaveProperty("works");
+});

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -147,7 +147,10 @@ export interface BOPSFullPayload extends BOPSMinimumPayload {
   planx_debug_data?: Record<string, unknown>;
   // typeof arr[number] > https://steveholgado.com/typescript-types-from-arrays
   user_role?: typeof USER_ROLES[number];
-  proposal_completion_date?: string;
+  works?: {
+    start_date?: string;
+    finish_date?: string;
+  };
 }
 
 export interface QuestionMetaData {


### PR DESCRIPTION
Please see discussions on ODP Slack here - https://opendigitalplanning.slack.com/archives/C0182MVK4AW/p1680010700510649

I've not added the `immune` key as I think what we're doing in `result` should be enough and duplicating it doesn't make a whole load of sense to me but happy to get feedback from BoPS and we can take it from there.