### PR TITLE
fix: Use `address.title` as fallback

### DIFF
--- a/api.planx.uk/saveAndReturn/resumeApplication.ts
+++ b/api.planx.uk/saveAndReturn/resumeApplication.ts
@@ -1,3 +1,4 @@
+import { SiteAddress } from '@opensystemslab/planx-core/types/types';
 import { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 import { adminGraphQLClient as adminClient } from "../hasura";
@@ -121,13 +122,14 @@ const buildContentFromSessions = async (
 ): Promise<string> => {
   const contentBuilder = async (session: LowCalSession) => {
     const service = convertSlugToName(session.flow.slug);
-    const address = session.data?.passport?.data?._address?.single_line_address;
+    const address: SiteAddress | undefined = session.data?.passport?.data?._address;
+    const addressLine = address?.single_line_address || address?.title;
     const projectType = await getHumanReadableProjectType(session);
     const resumeLink = getResumeLink(session, team, session.flow.slug);
     const expiryDate = calculateExpiryDate(session.created_at);
 
     return `Service: ${service}
-      Address: ${address || "Address not submitted"}
+      Address: ${addressLine || "Address not submitted"}
       Project type: ${projectType || "Project type not submitted"}
       Expiry Date: ${expiryDate}
       Link: ${resumeLink}`;

--- a/api.planx.uk/saveAndReturn/utils.ts
+++ b/api.planx.uk/saveAndReturn/utils.ts
@@ -1,3 +1,4 @@
+import { SiteAddress } from "@opensystemslab/planx-core/types/types";
 import { format, addDays } from "date-fns";
 import { gql, GraphQLClient } from "graphql-request";
 import {
@@ -210,10 +211,11 @@ const getSessionDetails = async (
   session: LowCalSession
 ): Promise<SessionDetails> => {
   const projectTypes = await getHumanReadableProjectType(session);
-  const address = session?.data?.passport?.data?._address?.single_line_address;
+  const address: SiteAddress | undefined = session.data?.passport?.data?._address;
+  const addressLine = address?.single_line_address || address?.title;
 
   return {
-    address: address || "Address not submitted",
+    address: addressLine || "Address not submitted",
     projectType: projectTypes || "Project type not submitted",
     id: session.id,
     expiryDate: calculateExpiryDate(session.created_at),

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -36,7 +36,9 @@ export const getFeedbackMetadata = (): Record<string, string> => {
     .slice(1, 3);
 
   const feedbackMetadata = {
-    address: passportData?._address?.single_line_address,
+    address:
+      passportData?._address?.single_line_address ||
+      passportData?._address?.title,
     uprn: passportData?._address?.uprn,
     "project-type": passportData?.proposal?.projectType,
     title: nodeData?.title || nodeData?.text,


### PR DESCRIPTION
Something that came up on the dev call the other day - `address.title` should always be set, `address.single_line_address` may not be set.

As `address.single_line_address` includes postcode, I've used this as the first option.

Going forward it will be nice to roll this logic up in the `Passport()` class in `planx-core` 👍 