### PR TITLE
chore: Tidy up duplicated `getFiles()` logic

### DIFF
--- a/api.planx.uk/session/files.test.ts
+++ b/api.planx.uk/session/files.test.ts
@@ -1,46 +1,15 @@
 import { queryMock } from "../tests/graphqlQueryMock";
-import { extractFileURLsFromPassportData, getFilesForSession } from "./files"
-import { multipleFileQuestions, multipleFilesMultipleQuestions, noFiles, singleFileQuestion } from "./mocks/passports"
+import { getFilesForSession } from "./files"
+import { multipleFilesMultipleQuestions } from "./mocks/passports"
 
-describe("extractFileURLsFromPassportData() helper function", () => {
-  it("handles Passports without files", () => {
-    const passportData = noFiles
-    expect(extractFileURLsFromPassportData(passportData)).toEqual([])
-  });
+const mockGetFiles = jest.fn();
 
-  it("handles Passports with a single file question", () => {
-    const passportData = singleFileQuestion
-    const result = extractFileURLsFromPassportData(passportData)
-    expect(result).toHaveLength(1)
-    expect(result).toEqual([
-      passportData["property.drawing.elevation"][0].url
-    ])
-  });
-
-  it("handles Passports with multiple file questions", () => {
-    const passportData = multipleFileQuestions;
-    const result = extractFileURLsFromPassportData(passportData)
-    expect(result).toHaveLength(2)
-    expect(result).toEqual([
-      passportData["property.drawing.elevation"][0].url,
-      passportData["proposal.drawing.elevation"][0].url,
-    ])
-  });
-
-  it("handles Passports with multiple files, across multiple questions", () => {
-    const passportData = multipleFilesMultipleQuestions;
-    const result = extractFileURLsFromPassportData(passportData)
-    expect(result).toHaveLength(7)
-    expect(result).toEqual([
-      passportData["property.drawing.elevation"][0].url,
-      passportData["property.drawing.elevation"][1].url,
-      passportData["proposal.drawing.elevation"][0].url,
-      passportData["property.drawing.sitePlan"][0].url,
-      passportData["property.drawing.sitePlan"][1].url,
-      passportData["property.drawing.sitePlan"][2].url,
-      passportData["proposal.drawing.sitePlan"][0].url,
-    ])
-  });
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    Passport: jest.fn().mockImplementation(() => ({
+      getFiles: mockGetFiles,
+    })),
+  }
 });
 
 describe("getFilesForSession()", () => {
@@ -54,7 +23,7 @@ describe("getFilesForSession()", () => {
         },
       },
     });
-    
+    mockGetFiles.mockResolvedValue(new Array(0));
     expect(await getFilesForSession("sessionId")).toEqual([])
   });
 
@@ -68,7 +37,7 @@ describe("getFilesForSession()", () => {
         },
       },
     });
-
+    mockGetFiles.mockResolvedValue(new Array(7));
     expect(await getFilesForSession("sessionId")).toHaveLength(7);
   });
 

--- a/api.planx.uk/session/files.ts
+++ b/api.planx.uk/session/files.ts
@@ -1,19 +1,17 @@
+import { Passport } from '@opensystemslab/planx-core';
 import { gql } from "graphql-request";
 import { adminGraphQLClient as adminClient } from "../hasura";
-import { Passport } from "../types";
-import has from "lodash/has";
-
-type Question = Record<string, any>[];
+import { Passport as IPassport } from "../types";
 
 export const getFilesForSession = async (sessionId: string): Promise<string[]> => {
   const passportData = await getPassportDataForSession(sessionId);
   if (!passportData) return [];
   
-  const files = extractFileURLsFromPassportData(passportData);
+  const files = new Passport(passportData).getFiles();
   return files;
 }
 
-const getPassportDataForSession = async (sessionId: string): Promise<Passport["data"]> => {
+const getPassportDataForSession = async (sessionId: string): Promise<IPassport["data"]> => {
   try {
     const query = gql`
       query GetPassportDataForSession($sessionId: uuid!) {
@@ -31,15 +29,4 @@ const getPassportDataForSession = async (sessionId: string): Promise<Passport["d
   } catch (error) {
     throw new Error(`Error fetching Passport Data for session ${sessionId}`);
   }
-}
-
-export const extractFileURLsFromPassportData = (passportData: Record<string, any>) => {
-  const isFileUploadQuestion = (question: Question) => has(question[0], "url");
-  const getFileURLs = (questionWithFiles: Question) => questionWithFiles.map(question => question.url);
-
-  const files = Object.values(passportData)
-    .filter(isFileUploadQuestion)
-    .map(getFileURLs)
-    .flat();
-  return files;
-}
+};

--- a/api.planx.uk/session/mocks/passports.ts
+++ b/api.planx.uk/session/mocks/passports.ts
@@ -154,65 +154,6 @@ export const noFiles = {
   "application.resubmission.original.applicationReference": "ff"
 }
 
-export const singleFileQuestion = {
-  ...noFiles,
-  "property.drawing.elevation": [
-    {
-      "url": "https://api.1434.planx.pizza/file/private/4senippj/Screenshot%202023-02-08%20at%2009.13.55.png",
-      "filename": "Screenshot 2023-02-08 at 09.13.55.png",
-      "cachedSlot": {
-        "id": "QZYeaycqQhpZoX7qd1Tns",
-        "url": "https://api.1434.planx.pizza/file/private/4senippj/Screenshot%202023-02-08%20at%2009.13.55.png",
-        "file": {
-          "path": "Screenshot 2023-02-08 at 09.13.55.png",
-          "size": 33803,
-          "type": "image/png"
-        },
-        "status": "success",
-        "progress": 1
-      }
-    }
-  ],
-}
-
-export const multipleFileQuestions = {
-  ...noFiles,
-  "property.drawing.elevation": [
-    {
-      "url": "https://api.1434.planx.pizza/file/private/4senippj/Screenshot%202023-02-08%20at%2009.13.55.png",
-      "filename": "Screenshot 2023-02-08 at 09.13.55.png",
-      "cachedSlot": {
-        "id": "QZYeaycqQhpZoX7qd1Tns",
-        "url": "https://api.1434.planx.pizza/file/private/4senippj/Screenshot%202023-02-08%20at%2009.13.55.png",
-        "file": {
-          "path": "Screenshot 2023-02-08 at 09.13.55.png",
-          "size": 33803,
-          "type": "image/png"
-        },
-        "status": "success",
-        "progress": 1
-      }
-    }
-  ],
-  "proposal.drawing.elevation": [
-    {
-      "url": "https://api.1434.planx.pizza/file/private/vsvv8987/Screenshot%202023-02-08%20at%2009.13.55.png",
-      "filename": "Screenshot 2023-02-08 at 09.13.55.png",
-      "cachedSlot": {
-        "id": "tUrm4syFWyH-oInuaDoiv",
-        "url": "https://api.1434.planx.pizza/file/private/vsvv8987/Screenshot%202023-02-08%20at%2009.13.55.png",
-        "file": {
-          "path": "Screenshot 2023-02-08 at 09.13.55.png",
-          "size": 33803,
-          "type": "image/png"
-        },
-        "status": "success",
-        "progress": 1
-      }
-    }
-  ],
-}
-
 export const multipleFilesMultipleQuestions = {
   ...noFiles,
   "property.drawing.elevation": [

--- a/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
@@ -24,6 +24,15 @@ import {
 jest.mock("../../hasura/schema")
 const mockRunSQL = runSQL as jest.MockedFunction<typeof runSQL>;
 
+const mockGetFiles = jest.fn();
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    Passport: jest.fn().mockImplementation(() => ({
+      getFiles: mockGetFiles,
+    })),
+  }
+});
+
 const s3Mock = () => {
   return {
     deleteObjects: jest.fn(() => ({
@@ -132,9 +141,10 @@ describe("Data sanitation operations", () => {
     it("returns a QueryResult on success", async () => {
       queryMock.mockQuery(mockGetExpiredSessionIdsQuery)
       queryMock.mockQuery(mockGetPassportDataForSessionQuery)
+      const filesPerMockSessionCount = 7
+      mockGetFiles.mockResolvedValue(new Array(filesPerMockSessionCount))
       const deletedFiles = await deleteApplicationFiles();
-      const filePerMockSessionCount = 7
-      const fileCount = mockIds.length * filePerMockSessionCount
+      const fileCount = mockIds.length * filesPerMockSessionCount
       expect(deletedFiles).toHaveLength(fileCount)
     });
   });


### PR DESCRIPTION
The logic and associated tests for `Passport().getFiles()` was originally taken from https://github.com/theopensystemslab/planx-new/pull/1444 and moved to `planx-core` in this PR - https://github.com/theopensystemslab/planx-core/pull/3

This just tidies things up by pointing at the functionality in `planx-core` as opposed to keeping a duplicate of it.