### PR TITLE
build: rotate postgres secrets and update metabase provider

### DIFF
--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -30,7 +30,7 @@ config:
   application:metabase-encryption-secret-key:
     secure: AAABAGmfVICD8sR+IE6mHC8BNUY1WQXGCbv5F3C1fSgA+1ADiRem3GNrwY0YRZociRYuPIo3MIRS0aIg44jt10SBCE0ik58wHamcKA==
   application:metabasePgPassword:
-    secure: AAABAJuCf0VM94OcWtNzAKIcYixovSFdfhtQ1wHEVqu3xjFUpBhptTARUaEbWmmy5wQWi9UWiLPOGIlyNNKU21e8i+9t/e00wTYDuA==
+    secure: AAABADQYBB4/QIWKVrjBPU9A3x5KTEGlI5NcvP66CotIcn+ie2bUfApaBj3LCxxDIBI68i4DS4WEHgf9RotLhg==
   application:ordnance-survey-api-key:
     secure: AAABAKhzYRhAmGmoBY1fPF75JWSWMOTORRCUAPKqvFUJMA60U5IFDUvPZ1Y+FuLtQ6Y1sQ8Q3laXGbp0f9j3Lw==
   application:session-secret:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -67,7 +67,7 @@ export = async () => {
 
   // ----------------------- Metabase
   const pgRoot = url.parse(dbRootUrl);
-  const provider = new postgres.Provider("metabase", {
+  const provider = new postgres.Provider("metabaseNew", {
     host: pgRoot.hostname as string,
     port: Number(pgRoot.port),
     username: pgRoot.auth!.split(":")[0] as string,

--- a/infrastructure/data/Pulumi.staging.yaml
+++ b/infrastructure/data/Pulumi.staging.yaml
@@ -1,4 +1,4 @@
 config:
   aws:region: eu-west-2
   data:db-password:
-    secure: AAABALUU0VTDdIvX286ULdrgdRgBwpiLEoA8C4sWbqD2XlBKVV13vjaSKnsoNXkcHe+byQavA5kYRnbDbAqD4bJPSePK/rQYFUoo5FFEPQ95yTjeZFyMVg==
+    secure: AAABAITyXpt2+HqrVK8nO9AT0SLFZBx8XBHprCgUkaDMZjuV1y+EQkrh53de4WsLb6wtWTKvb56VNDUYtWUfuw==


### PR DESCRIPTION
Continues from https://opensystemslab.slack.com/archives/C01E3AC0C03/p1679661932799729

We expect our prior failures were due to actual metabase "database" resources not being picked up in the diff nor updated, even though the stored secrets were rotated. By updating `postgres.Provider("metabaseNew")`, we expect the "provider" to now update and read in the updated root URL.

How we'll merge this: 
- Let CI complete
- Manually deploy data layer
- Merge to automatically deploy application layer
- Test staging on success, or rollback on failure