### PR TITLE
build: don't change metabase provider yet

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -67,7 +67,7 @@ export = async () => {
 
   // ----------------------- Metabase
   const pgRoot = url.parse(dbRootUrl);
-  const provider = new postgres.Provider("metabaseNew", {
+  const provider = new postgres.Provider("metabase", {
     host: pgRoot.hostname as string,
     port: Number(pgRoot.port),
     username: pgRoot.auth!.split(":")[0] as string,


### PR DESCRIPTION
if we run `pulumi up --stack staging **--refresh**` in the data layer, we think the original rotation will work without having to update all of metabase