### PR TITLE
infra: only run 'pulumi up', not 'pulumi refresh' on staging deploys

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -97,7 +97,6 @@ jobs:
           stack-name: staging
           work-dir: infrastructure/application
           edit-pr-comment: true
-          refresh: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 


### PR DESCRIPTION
https://github.com/pulumi/pulumi/issues/10084

Pulumi refresh was pushed directly to main without explanation when troubleshooting certificates: 