### PR TITLE
fix: Show toast on GraphQL error

### DIFF
--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -19,7 +19,9 @@ const customFetch = async (
   init?: RequestInit
 ): Promise<Response> => {
   const fetchResult = await fetch(input, init);
-  const isSuccess = fetchResult.status >= 200 && fetchResult.status <= 299;
+  const isGraphQLError = fetchResult.body?.hasOwnProperty("errors");
+  const isSuccess =
+    isGraphQLError || (fetchResult.status >= 200 && fetchResult.status <= 299);
   if (isSuccess) {
     // NB: it's okay if toast.dismiss() gets called more than once
     toast.dismiss(toastId);


### PR DESCRIPTION
Hit an issue earlier when rotating db connection details - Hasura returns as `200 OK` if the db connection string is invalid, alongside an error message.