### PR TITLE
infra: rotate postgres root user and metabase roles on production

### DIFF
--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -99,7 +99,6 @@ jobs:
           stack-name: production
           work-dir: infrastructure/application
           edit-pr-comment: true
-          refresh: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 

--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -29,7 +29,7 @@ config:
   application:metabase-encryption-secret-key:
     secure: AAABAKQ6L5aOwZWpj9YOsaW8bOOukjt1mZuTgdKjM/3nSmF/0nM/f9c9W9DXygUFj2wtq5/iugo1UTS0+bhEn8Dr9k1Qzr2EmuGpQw==
   application:metabasePgPassword:
-    secure: AAABAN1bRAyO0jk0n4rfVAntYPWNat+naRsld87v3I18Bn9Iu5HGHmdKyF8Z0qpKoa7Sm88hmxlYsOb9wxQi0Yxtl7sdGZvodD6iLg==
+    secure: AAABANGc7cWKYdBBYoZ/JPID/Azlwto7QzfUR+Ds7rtui4yMfWmbVEH22ig189/UV3GHI/Dx4x64VWpNjHJzxg==
   application:ordnance-survey-api-key:
     secure: AAABAE+wD6ahxO45tq/JWp6odrHX9jOhdjlMsCqS6kFqBgJ+3T56fOSgpZ26nEftv9IwWZQh/v93tRtTDEb+uw==
   application:session-secret:

--- a/infrastructure/data/Pulumi.production.yaml
+++ b/infrastructure/data/Pulumi.production.yaml
@@ -1,3 +1,3 @@
 config:
   data:db-password:
-    secure: AAABAJekEkTZff0LMK4PazFRkBOmtOUQHseg8jrOqFlVl0IQ00rZsOp1pCrP17gRnU9JqQDxJfvKnmKkkMsG5w==
+    secure: AAABAA4wzAobUbUswrNarVYoJzFXyz+E0fubHXDuMS1Uun4mAg44jMPG+CLxSsJ/2iGdHtlp2Gxey7zcuPiGoQ==


### PR DESCRIPTION
after some trial & error we successfully rotated credentials on staging ([thread here](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1679661932799729)); this PR repeats the process for production. 

**DO NOT MERGE** until scheduled maintenance window is decided ([thread here](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1680531568429899)).

to deploy: 
- first, manually deploy the data layer change by running `pulumi up --stack production` from this branch in the `infrastructure/data` subdirectory
- then, merge this PR to automatically deploy the application layer
- confirm that all services are back up, including custom subdomains

future steps:
- display either error toast or downtime page, but not a blank white screen #1590
- determine why `refresh: true` was added to our Pulumi deployment jobs in the first place; this was directly commited to `main` [here](https://github.com/theopensystemslab/planx-new/commit/5f369df99674b290b143fa653b1d4858d51d2296) as part of custom subdomain troubleshooting to our best guess. Is it still needed? Would we expect it to fail next time certificates need to be added?
- refine the metabase role to have stricter access permissions, ensure consistency across staging & production
- move the metabase database & role definitions to the data layer of Pulumi, and consume via a simplified connection string in the application layer?
- revisit the aws sandbox environment. we successfully rotated the dbuser credential there, but don't yet have a very clear understanding of how to check if services are healthy there / which are expected to be running (eg metabase is not?)