### PR TITLE
feat: Toggle maintenance page GitHub action

### DIFF
--- a/.github/workflows/toggle-maintenance-page.yml
+++ b/.github/workflows/toggle-maintenance-page.yml
@@ -1,0 +1,31 @@
+name: Toggle PlanX maintenance page
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: Must be one of "staging" or "production"
+
+jobs:
+  toggle_maintenance_page:
+    name: Toggle maintenance page
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (Staging)
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ github.event.inputs.environment }} == "staging"
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_PIZZA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_PIZZA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Configure AWS credentials (Production)
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ github.event.inputs.environment }} == "production"
+        with:
+          aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Run script
+        run: ./scripts/toggle-maintenance-page.sh ${{ github.event.inputs.environment }}

--- a/scripts/toggle-maintenance-page.sh
+++ b/scripts/toggle-maintenance-page.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script toggle the default root object of our CloudFront CDN which serves PlanX
+# Use this to turn on/off the maintenance page during planned downtime
+# 
+# Arguments: 
+# $1 ENVIRONMENT (Must be one of "staging" or "production")
+# e.g. bash toggle-maintenance-page.sh staging
+
+if [[ "$1" == "staging" ]]
+  then ENVIRONMENT="editor.planx.dev";
+elif [[ "$1" == "production" ]];
+  then ENVIRONMENT="editor.planx.uk"; 
+fi;
+
+[ -z "$ENVIRONMENT" ] && echo "Error: Environment required" && exit;
+
+CLOUDFRONT_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[*].{id:Id,alias:Aliases.Items[0]}[?alias=='${ENVIRONMENT}'].id" --output text)
+
+[ -z "$CLOUDFRONT_ID" ] && echo "Error: CloudFront ID not found" && exit;
+
+CURRENT_PAGE=$(aws cloudfront get-distribution --id $CLOUDFRONT_ID --query "Distribution.DistributionConfig.DefaultRootObject")
+
+if [[ "$CURRENT_PAGE" == \"index.html\" ]]
+  then NEW_PAGE="error.html";
+else
+  NEW_PAGE="index.html"; 
+fi;
+
+aws cloudfront update-distribution --id $CLOUDFRONT_ID --default-root-object $NEW_PAGE
+
+echo "Complete - please visit https://${ENVIRONMENT} to test";


### PR DESCRIPTION
GitHub action which toggles the default root object in CloudFront in order to swap in the `error.html` maintenance page and `index.html` page as we're organising planned downtime.

Script tested locally and works using my (staging) AWS credentials, action not tested yet but keen to give it a go once merged against staging.