### PR TITLE
feat: Validate Pay amount for invite-to-pay

### DIFF
--- a/api.planx.uk/inviteToPay/inviteToPay.test.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.test.ts
@@ -13,9 +13,10 @@ import {
 } from "../tests/mocks/inviteToPayMocks";
 import {
   payee,
+  applicant,
   validSession,
   notFoundSession,
-  newPaymentRequest,
+  paymentRequestResponse,
 } from "../tests/mocks/inviteToPayData";
 
 describe("Invite to pay API route", () => {
@@ -23,15 +24,10 @@ describe("Invite to pay API route", () => {
   const validSessionURL = `${inviteToPayBaseRoute}/${validSession.id}`;
   const notFoundSessionURL = `${inviteToPayBaseRoute}/${notFoundSession.id}`;
   const validPostBody = {
+    applicantName: applicant.name,
     payeeEmail: payee.email,
     payeeName: payee.name,
-    sessionPreviewKeys: [
-      ["_address", "title"],
-      ["applicant.agent.name.first"],
-      ["applicant.agent.name.last"],
-      ["proposal.projectType"],
-      ["fee"],
-    ],
+    sessionPreviewKeys: [["_address", "title"], ["proposal.projectType"]],
   };
 
   beforeEach(() => {
@@ -56,7 +52,7 @@ describe("Invite to pay API route", () => {
         .send(validPostBody)
         .expect(200)
         .then((response) => {
-          expect(response.body).toEqual(newPaymentRequest);
+          expect(response.body).toEqual(paymentRequestResponse);
         });
     });
   });

--- a/api.planx.uk/inviteToPay/inviteToPay.test.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.test.ts
@@ -8,6 +8,7 @@ import {
   detailedValidSessionQueryMock,
   lockSessionQueryMock,
   unlockSessionQueryMock,
+  getPublishedFlowDataQueryMock,
   createPaymentRequestQueryMock,
 } from "../tests/mocks/inviteToPayMocks";
 import {
@@ -40,6 +41,7 @@ describe("Invite to pay API route", () => {
     queryMock.mockQuery(notFoundQueryMock);
     queryMock.mockQuery(notFoundLockSessionQueryMock);
     queryMock.mockQuery(detailedValidSessionQueryMock);
+    queryMock.mockQuery(getPublishedFlowDataQueryMock);
     queryMock.mockQuery(createPaymentRequestQueryMock);
   });
 

--- a/api.planx.uk/inviteToPay/inviteToPay.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.ts
@@ -13,28 +13,29 @@ export async function inviteToPay(
   const {
     payeeEmail,
     payeeName,
+    applicantName,
     sessionPreviewKeys,
   }: {
     payeeEmail: string;
     payeeName: string;
+    applicantName: string;
     sessionPreviewKeys: Array<KeyPath>;
   } = req.body;
 
-  if (!payeeEmail) {
-    return next(
-      new ServerError({
-        message: "JSON body must contain payeeEmail",
-        status: 400,
-      })
-    );
-  }
-  if (!payeeName) {
-    return next(
-      new ServerError({
-        message: "JSON body must contain payeeName",
-        status: 400,
-      })
-    );
+  for (const [requiredFieldName, requiredFieldValue] of Object.entries({
+    sessionId,
+    applicantName,
+    payeeName,
+    payeeEmail,
+  })) {
+    if (!requiredFieldValue) {
+      return next(
+        new ServerError({
+          message: `JSON body must contain ${requiredFieldName}`,
+          status: 400,
+        })
+      );
+    }
   }
 
   // lock session before creating a payment request
@@ -61,6 +62,7 @@ export async function inviteToPay(
   try {
     paymentRequest = await _admin.createPaymentRequest({
       sessionId,
+      applicantName,
       payeeName,
       payeeEmail,
       sessionPreviewKeys,

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#fba1cb5",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#778956f",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.9",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#778956f",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#6d98527",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.9",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#5cf3c8b",
+    "@opensystemslab/planx-core": "git://github.com/theopensystemslab/planx-core#fba1cb5",
     "@opensystemslab/planx-document-templates": "git://github.com/theopensystemslab/planx-document-templates#debaeca",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.9",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#778956f
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#6d98527
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -85,7 +85,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/778956f
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/6d98527
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   '@types/isomorphic-fetch': 0.0.36
   adm-zip: 0.5.9
@@ -7956,8 +7956,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/778956f:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/778956f}
+  github.com/theopensystemslab/planx-core/6d98527:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6d98527}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#5cf3c8b
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#fba1cb5
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -85,7 +85,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/5cf3c8b
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/fba1cb5
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   '@types/isomorphic-fetch': 0.0.36
   adm-zip: 0.5.9
@@ -7956,8 +7956,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/5cf3c8b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5cf3c8b}
+  github.com/theopensystemslab/planx-core/fba1cb5:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fba1cb5}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@airbrake/node': ^2.1.7
   '@babel/core': ^7.19.6
   '@babel/preset-typescript': ^7.18.6
-  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#fba1cb5
+  '@opensystemslab/planx-core': git://github.com/theopensystemslab/planx-core#778956f
   '@opensystemslab/planx-document-templates': git://github.com/theopensystemslab/planx-document-templates#debaeca
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -85,7 +85,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.7
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/fba1cb5
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/778956f
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@babel+core@7.19.6
   '@types/isomorphic-fetch': 0.0.36
   adm-zip: 0.5.9
@@ -7956,8 +7956,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/fba1cb5:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fba1cb5}
+  github.com/theopensystemslab/planx-core/778956f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/778956f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/saveAndReturn/validateSession.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.ts
@@ -10,7 +10,7 @@ import {
   getSaveAndReturnPublicHeaders,
   stringifyWithRootKeysSortedAlphabetically,
 } from "./utils";
-import { normalizeFlow, sortBreadcrumbs } from "@opensystemslab/planx-core";
+import { sortBreadcrumbs } from "@opensystemslab/planx-core";
 import type {
   OrderedBreadcrumbs,
   NormalizedCrumb,
@@ -70,7 +70,7 @@ export async function validateSession(
         if (alteredNodes.length) {
           // each NormalizedCrumb will include a sectionId where relevant (used later)
           const orderedBreadcrumbs: OrderedBreadcrumbs = sortBreadcrumbs(
-            normalizeFlow(savedFlow),
+            savedFlow,
             sessionData.data.breadcrumbs
           );
           const removedBreadcrumbs: Breadcrumb = {};

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -26,7 +26,6 @@ export const sessionPreviewData = {
     title: "1 House, Street, Town, City, PO27 0DE",
   },
   "proposal.projectType": "new.office",
-  "fee": 103,
 };
 
 export const validSession: Session = {

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -1,4 +1,8 @@
-import type { Session, PaymentRequest } from "@opensystemslab/planx-core";
+import type {
+  Session,
+  PaymentRequest,
+  FlowGraph,
+} from "@opensystemslab/planx-core/types/types";
 
 export const validEmail = "the-payee@opensystemslab.io";
 
@@ -27,7 +31,10 @@ export const validSession: Session = {
   data: {
     id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
     passport: {
-      data: sessionPreviewData,
+      data: {
+        amountToPay: 5,
+        ...sessionPreviewData,
+      },
     },
     breadcrumbs: {},
   },
@@ -65,5 +72,36 @@ export const validPaymentRequest = {
         },
       },
     },
+  },
+};
+
+export const flowGraph: FlowGraph = {
+  _root: {
+    edges: ["NATwM9rXTQ", "fgl2iSPlB7"],
+  },
+  NATwM9rXTQ: {
+    data: {
+      fn: "amountToPay",
+      val: "5",
+    },
+    type: 380,
+  },
+  fgl2iSPlB7: {
+    data: {
+      fn: "amountToPay",
+      color: "#EFEFEF",
+      title: "Pay for your application",
+      bannerTitle: "The planning fee for this application is",
+      description:
+        "The planning fee covers the cost of processing your application",
+      allowInviteToPay: true,
+      inviteToPayTitle: "Details of your nominee",
+      instructionsTitle: "How to pay",
+      inviteToPayDescription:
+        "You can invite someone else to pay for your application.",
+      instructionsDescription:
+        "You can pay for your application by using GOV.UK Pay.",
+    },
+    type: 400,
   },
 };

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -11,6 +11,12 @@ export const payee = {
   email: validEmail,
 };
 
+export const applicant = {
+  name: "Applic Ant",
+};
+
+export const paymentAmount = 12000;
+
 export const notFoundSession: Partial<Session> = {
   id: "3da7734f-d5c5-4f69-a261-1b31c2adf6fc",
 };
@@ -19,8 +25,6 @@ export const sessionPreviewData = {
   _address: {
     title: "1 House, Street, Town, City, PO27 0DE",
   },
-  "applicant.agent.name.first": "Jo",
-  "applicant.agent.name.last": "Smith",
   "proposal.projectType": "new.office",
   "fee": 103,
 };
@@ -32,19 +36,26 @@ export const validSession: Session = {
     id: "e62fc9fd-4acb-4bdd-9dbb-01fb996c656c",
     passport: {
       data: {
-        amountToPay: 5,
+        amountToPay: paymentAmount,
         ...sessionPreviewData,
       },
     },
-    breadcrumbs: {},
+    // breadcrumbs is missing the pay component to refect current implementation
+    breadcrumbs: {
+      NATwM9rXTQ: {
+        auto: false,
+      },
+    },
   },
 };
 
-export const newPaymentRequest: PaymentRequest = {
+export const paymentRequestResponse: PaymentRequest = {
   id: "09655c28-3f34-4619-9385-cd57312acc44",
   sessionId: validSession.id,
+  applicantName: applicant.name,
   payeeName: payee.name,
   payeeEmail: payee.email,
+  paymentAmount,
   sessionPreviewData: sessionPreviewData,
 };
 
@@ -56,6 +67,7 @@ export const validPaymentRequest = {
   session_preview_data: sessionPreviewData,
   created_at: new Date("01 Apr 2023 12:00 UTC+1").toISOString(),
   paid_at: null,
+  payment_amount: paymentAmount,
   session: {
     email: "the-agent@opensystemslab.io",
     flow: {
@@ -82,7 +94,7 @@ export const flowGraph: FlowGraph = {
   NATwM9rXTQ: {
     data: {
       fn: "amountToPay",
-      val: "5",
+      val: paymentAmount,
     },
     type: 380,
   },

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -2,9 +2,11 @@ import {
   notFoundSession,
   validSession,
   payee,
+  applicant,
+  paymentAmount,
   sessionPreviewData,
   flowGraph,
-  newPaymentRequest,
+  paymentRequestResponse,
   validPaymentRequest,
 } from "./inviteToPayData";
 
@@ -109,11 +111,13 @@ export const createPaymentRequestQueryMock = {
   name: "CreatePaymentRequest",
   data: {
     insert_payment_requests_one: {
-      ...newPaymentRequest,
+      ...paymentRequestResponse,
     },
   },
   variables: {
     sessionId: validSession.id,
+    applicantName: applicant.name,
+    paymentAmount,
     payeeName: payee.name,
     payeeEmail: payee.email,
     sessionPreviewData: sessionPreviewData,
@@ -124,10 +128,10 @@ export const validatePaymentRequestQueryMock = {
   name: "ValidatePaymentRequest",
   data: {
     payment_requests_by_pk: {
-      ...validPaymentRequest
-    }
+      ...validPaymentRequest,
+    },
   },
   variables: {
-    paymentRequestId: newPaymentRequest.id,
+    paymentRequestId: validPaymentRequest.id,
   },
 };

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -3,6 +3,7 @@ import {
   validSession,
   payee,
   sessionPreviewData,
+  flowGraph,
   newPaymentRequest,
   validPaymentRequest,
 } from "./inviteToPayData";
@@ -87,6 +88,20 @@ export const unlockSessionQueryMock = {
   },
   variables: {
     id: validSession.id,
+  },
+};
+
+export const getPublishedFlowDataQueryMock = {
+  name: "GetLatestPublishedFlowData",
+  data: {
+    published_flows: [
+      {
+        data: flowGraph,
+      },
+    ],
+  },
+  variables: {
+    flowId: validSession.flowId,
   },
 };
 


### PR DESCRIPTION
Validates that the session flow includes a pay component and that the passport contains a valid payment amount. The payment request will fail to create if a payment amount cannot be found.

Depends on https://github.com/theopensystemslab/planx-core/pull/13

To test, send an API request to set the session as invite to pay with something like this:
```
curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" --data '{ "payeeEmail": "...", "payeeName": "...", "sessionPreviewKeys": [["_address", "title"]] }' https://api.1597.planx.pizza/invite-to-pay/$SESSION_ID
```