### PR TITLE
fix: Increase Axios limit to 1GB for Uniform submissions

### DIFF
--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -356,6 +356,9 @@ async function attachArchive(token: string, submissionId: string, zipPath: strin
       Authorization: `Bearer ${token}`,
     },
     data: formData,
+    // Restrict to 1GB
+    maxBodyLength: 1e+9,
+    maxContentLength: 1e+9,
   };
 
   const response = await axios.request(attachArchiveConfig)


### PR DESCRIPTION
Regression introduced here when switching from `fetch` to `axios` - https://github.com/theopensystemslab/planx-new/pull/1551

Axios has a default `maxBodyLength` of 10MB which is increased to 1GB in this PR.

Tested locally - 
- On `main`, zip file greater than 10MB fails to send to Uniform with `Failed to send to Uniform. Error [ERR_FR_MAX_BODY_LENGTH_EXCEEDED]: Request body larger than maxBodyLength limit` error
- On `dp/axios-maxBodyLength` the same payload succeeds and is sent to the Uniform staging environment