### PR TITLE
chore: Remove `NAVIGATION_UI` feature flag

### DIFF
--- a/e2e/src/sections.spec.ts
+++ b/e2e/src/sections.spec.ts
@@ -64,7 +64,6 @@ test.describe("Sections", () => {
   test.beforeEach(async ({ page }) => {
     const previewURL = `/${context.team?.slug}/${context.flow?.slug}/preview?analytics=false`;
     await page.goto(previewURL);
-    await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
   });
 
   test.afterAll(async () => {

--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from "@testing-library/react";
-import { toggleFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import { axe, setup } from "testUtils";
 import { SectionStatus } from "types";
@@ -7,24 +6,8 @@ import { SectionStatus } from "types";
 import Section, { SectionsOverviewList } from "./Public";
 
 describe("Section component", () => {
-  it("renders correctly when the NAVIGATION_UI feature flag is toggled off (default state)", () => {
+  it("renders correctly", () => {
     const handleSubmit = jest.fn();
-
-    setup(<Section title="Section one" handleSubmit={handleSubmit} />);
-
-    expect(
-      screen.queryByText("Application incomplete.")
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Continue")).not.toBeInTheDocument();
-
-    // handleSubmit is still called by useEffect to set auto = true so the Section isn't seen in card sequence
-    expect(handleSubmit).toHaveBeenCalled();
-  });
-
-  it("renders correctly when the NAVIGATION_UI feature flag is toggled on", () => {
-    const handleSubmit = jest.fn();
-
-    toggleFeatureFlag("NAVIGATION_UI");
     setup(<Section title="Section one" handleSubmit={handleSubmit} />);
 
     expect(screen.getByText("Application incomplete.")).toBeInTheDocument();
@@ -35,7 +18,6 @@ describe("Section component", () => {
   it("should not have any accessibility violations", async () => {
     const handleSubmit = jest.fn();
 
-    toggleFeatureFlag("NAVIGATION_UI");
     const { container } = setup(
       <Section title="Section one" handleSubmit={handleSubmit} />
     );
@@ -93,7 +75,7 @@ describe("SectionsOverviewList component", () => {
     },
   };
 
-  it("renders correctly when the NAVIGATION_UI feature flag is toggled on", () => {
+  it("renders correctly", () => {
     setup(<SectionsOverviewList {...defaultProps} />);
 
     const changeLink = screen.getByText("Change Section one");
@@ -108,15 +90,13 @@ describe("SectionsOverviewList component", () => {
   });
 
   it("does not link section header text when showChange is false", () => {
-    toggleFeatureFlag("NAVIGATION_UI");
     setup(<SectionsOverviewList {...defaultProps} showChange={false} />);
 
     expect(screen.getByText("Section one")).toBeInTheDocument();
     expect(screen.queryByText("Change Section one")).not.toBeInTheDocument();
   });
 
-  it("should not have any accessiblity violations", async () => {
-    toggleFeatureFlag("NAVIGATION_UI");
+  it("should not have any accessibility violations", async () => {
     const { container } = setup(<SectionsOverviewList {...defaultProps} />);
 
     const results = await axe(container);

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -5,7 +5,6 @@ import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import Tag, { TagType } from "@planx/components/shared/Buttons/Tag";
 import type { PublicProps } from "@planx/components/ui";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect } from "react";
 import { SectionNode, SectionStatus } from "types";
@@ -18,7 +17,6 @@ import { computeSectionStatuses } from "./model";
 export type Props = PublicProps<Section>;
 
 export default function Component(props: Props) {
-  const showSection = hasFeatureFlag("NAVIGATION_UI");
   const [
     flow,
     flowName,
@@ -49,7 +47,7 @@ export default function Component(props: Props) {
       });
   }, []);
 
-  return !showSection ? null : (
+  return (
     <Card isValid handleSubmit={props.handleSubmit}>
       <QuestionHeader title={flowName} />
       <Box sx={{ lineHeight: ".5em" }}>

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/sectionName.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/sectionName.test.ts
@@ -1,5 +1,4 @@
-import { act, waitFor } from "@testing-library/react";
-import { toggleFeatureFlag } from "lib/featureFlags";
+import { act } from "@testing-library/react";
 import { FullStore, Store } from "pages/FlowEditor/lib/store";
 import { vanillaStore } from "pages/FlowEditor/lib/store";
 
@@ -97,7 +96,6 @@ const simpleFlow: Store.flow = {
 describe("Flow with sections", () => {
   beforeAll(() => {
     initialState = getState();
-    toggleFeatureFlag("NAVIGATION_UI");
     act(() =>
       setState({ flow: flowWithThreeSections, breadcrumbs: sectionBreadcrumbs })
     );
@@ -105,7 +103,6 @@ describe("Flow with sections", () => {
   });
 
   afterAll(() => {
-    toggleFeatureFlag("NAVIGATION_UI");
     setState(initialState);
   });
 

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from "@testing-library/react";
-import { hasFeatureFlag, toggleFeatureFlag } from "lib/featureFlags";
 import { vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
@@ -158,54 +157,25 @@ describe("Section navigation bar", () => {
   });
 
   describe("Flow without sections", () => {
-    it("does not display if the feature flag is disabled", () => {
-      setup(<Header />);
+    it("does not display", () => {
+      setup(<Header/>);
       act(() => setState({ flow: flowWithoutSections }));
       act(() => getState().initNavigationStore());
 
-      expect(hasFeatureFlag("NAVIGATION_UI")).toBe(false);
-      expect(screen.queryByTestId("navigation-bar")).not.toBeInTheDocument();
-    });
-
-    it("does not display if the feature flag is enabled", () => {
-      toggleFeatureFlag("NAVIGATION_UI");
-      setup(<Header />);
-      act(() => setState({ flow: flowWithoutSections }));
-      act(() => getState().initNavigationStore());
-
-      expect(hasFeatureFlag("NAVIGATION_UI")).toBe(true);
       expect(screen.queryByTestId("navigation-bar")).not.toBeInTheDocument();
     });
   });
 
   describe("Flow with sections", () => {
-    beforeEach(() => {
-      if (hasFeatureFlag("NAVIGATION_UI")) {
-        toggleFeatureFlag("NAVIGATION_UI");
-      }
-    });
-
-    it("does not display if the feature flag is disabled", () => {
+    it("displays as expected", () => {
       act(() => setState({ flow: flowWithThreeSections }));
       act(() => getState().initNavigationStore());
       setup(<Header />);
 
-      expect(hasFeatureFlag("NAVIGATION_UI")).toBe(false);
-      expect(screen.queryByTestId("navigation-bar")).not.toBeInTheDocument();
-    });
-
-    it("displays if the feature flag is enabled", () => {
-      toggleFeatureFlag("NAVIGATION_UI");
-      act(() => setState({ flow: flowWithThreeSections }));
-      act(() => getState().initNavigationStore());
-      setup(<Header />);
-
-      expect(hasFeatureFlag("NAVIGATION_UI")).toBe(true);
       expect(screen.getByTestId("navigation-bar")).toBeInTheDocument();
     });
 
     it("display the correct information from the store", () => {
-      toggleFeatureFlag("NAVIGATION_UI");
       act(() => setState({ flow: flowWithThreeSections }));
       act(() => getState().initNavigationStore());
       setup(<Header />);
@@ -215,7 +185,6 @@ describe("Section navigation bar", () => {
     });
 
     it("should not have any accessibility violations", async () => {
-      toggleFeatureFlag("NAVIGATION_UI");
       act(() => setState({ flow: flowWithThreeSections }));
       act(() => getState().initNavigationStore());
       const { container } = setup(<Header />);

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -2,7 +2,6 @@
 const AVAILABLE_FEATURE_FLAGS = [
   "DISABLE_SAVE_AND_RETURN",
   "ALT_THEME",
-  "NAVIGATION_UI",
   "INVITE_TO_PAY",
 ] as const;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/navigation.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/navigation.test.ts
@@ -1,5 +1,4 @@
 import { TYPES } from "@planx/components/types";
-import { hasFeatureFlag, toggleFeatureFlag } from "lib/featureFlags";
 import { SectionStatus } from "types";
 
 import { FullStore, vanillaStore } from "../store";
@@ -14,9 +13,6 @@ let initialState: FullStore;
 
 beforeEach(() => {
   initialState = getState();
-  if (hasFeatureFlag("NAVIGATION_UI")) {
-    toggleFeatureFlag("NAVIGATION_UI");
-  }
 });
 
 afterEach(() => setState(initialState));
@@ -77,25 +73,6 @@ test("initNavigationStore() sets expected initial values for flow with sections"
   );
 });
 
-test("initNavigationStore() sets 'hasSections' to false when feature flag not enabled", () => {
-  setState({ flow: flowWithThreeSections });
-  initNavigationStore();
-  const { hasSections } = getState();
-
-  expect(hasFeatureFlag("NAVIGATION_UI")).toBe(false);
-  expect(hasSections).toBe(false);
-});
-
-test("initNavigationStore() sets 'hasSections' to true when feature flag enabled", () => {
-  toggleFeatureFlag("NAVIGATION_UI");
-  setState({ flow: flowWithThreeSections });
-  initNavigationStore();
-  const { hasSections } = getState();
-
-  expect(hasFeatureFlag("NAVIGATION_UI")).toBe(true);
-  expect(hasSections).toBe(true);
-});
-
 test("updateSectionData() does not update state if there are no sections in the flow", () => {
   setState({ flow: flowWithoutSections });
   initNavigationStore();
@@ -115,7 +92,6 @@ test("updateSectionData() does not update state if there are no sections in the 
 });
 
 test("updateSectionData() updates section title and index correctly", () => {
-  toggleFeatureFlag("NAVIGATION_UI");
   let currentSectionTitle, currentSectionIndex;
   setState({ flow: flowWithThreeSections });
   initNavigationStore();

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -1,5 +1,4 @@
 import { TYPES } from "@planx/components/types";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { findLast, pick } from "lodash";
 import { Store } from "pages/FlowEditor/lib/store";
 import type { StateCreator } from "zustand";
@@ -52,9 +51,7 @@ export const navigationStore: StateCreator<
       SectionNode
     >;
     const sectionCount = Object.keys(sectionNodes).length;
-    const hasSections = Boolean(
-      sectionCount && hasFeatureFlag("NAVIGATION_UI")
-    );
+    const hasSections = Boolean(sectionCount);
     const currentSectionTitle = Object.values(sectionNodes)[0]?.data.title;
 
     set({


### PR DESCRIPTION
Removes the `NAVIGATION_UI` feature flag enabling sections for all users.

Here's a flow to test with:
https://1609.planx.pizza/testing/sections-nav-test
https://1609.planx.pizza/testing/sections-nav-test/preview?analytics=false
