### PR TITLE
fix: add transition group props to Card fade

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -43,7 +43,12 @@ const Card: React.FC<Props> = ({
     path === ApplicationPath.SaveAndReturn && handleSubmit;
 
   return (
-    <Fade in={true} timeout={theme.transitions.duration.enteringScreen}>
+    <Fade
+      in={true}
+      timeout={theme.transitions.duration.enteringScreen}
+      mountOnEnter={true}
+      unmountOnExit={true}
+    >
       <Container maxWidth="md">
         <Box
           className={classes.container}


### PR DESCRIPTION
something that came up in Sections & Navigation feedback is slow navigation between cards, especially when going "back" to a previous section. this has also been a known issue with rendering the long "Project type" Checklist and when using the "change" link from Review ([ticket](https://trello.com/c/zoYs9u8U/2204-text-input-takes-1s-to-respond-to-keyboard-input)).

i think adding these props very mildly helps, but i honestly didn't come up with a great way to measure this and am definitley still experiencing some lag in my own test runs through LDCs. i think most of our lag is likely still in `handleSubmit` method on "continue", rather than the transition/rendering of the Card itself, which we can turn more attention to in a near-future logic sprint.

https://mui.com/material-ui/transitions/#performance-amp-seo
https://reactcommunity.org/react-transition-group/transition#Transition-prop-mountOnEnter