### PR TITLE
feat: Payment request pay APIs

### DIFF
--- a/api.planx.uk/inviteToPay/index.ts
+++ b/api.planx.uk/inviteToPay/index.ts
@@ -1,5 +1,3 @@
-import { inviteToPay } from "./inviteToPay";
-import { sendSinglePaymentEmail } from "./sendPaymentEmail";
-
-export { inviteToPay, sendSinglePaymentEmail };
-
+export * from "./inviteToPay";
+export * from "./paymentRequest";
+export { sendSinglePaymentEmail } from "./sendPaymentEmail";

--- a/api.planx.uk/inviteToPay/paymentRequest.ts
+++ b/api.planx.uk/inviteToPay/paymentRequest.ts
@@ -17,7 +17,7 @@ export async function fetchPaymentRequestDetails(
   next: NextFunction
 ) {
   const query = gql`
-    query GetPaymentRequestByID($paymentRequestId: uuid!) {
+    query GetPaymentRequestDetails($paymentRequestId: uuid!) {
       payment_requests_by_pk(id: $paymentRequestId) {
         session_id
         payment_amount

--- a/api.planx.uk/inviteToPay/paymentRequest.ts
+++ b/api.planx.uk/inviteToPay/paymentRequest.ts
@@ -1,0 +1,104 @@
+import { gql } from "graphql-request";
+import { NextFunction, Request, Response } from "express";
+import { adminGraphQLClient as client } from "../hasura";
+import { ServerError } from "../errors";
+
+// middleware used by routes:
+//  * /payment-request/:paymentRequest/pay
+//  * /payment-request/:paymentRequest/payment/:paymentId
+export async function fetchPaymentRequestDetails(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const query = gql`
+    query GetPaymentRequestByID($paymentRequestId: uuid!) {
+      payment_requests_by_pk(id: $paymentRequestId) {
+        session_id
+        session {
+          flow_id
+          flow {
+            team {
+              slug
+            }
+          }
+        }
+      }
+    }
+  `;
+  const { payment_requests_by_pk } = await client.request(query, {
+    paymentRequestId: req.params.paymentRequest,
+  });
+  if (!payment_requests_by_pk) {
+    return next(
+      new ServerError({
+        message: "payment request not found",
+        status: 404,
+      })
+    );
+  }
+  const sessionId = payment_requests_by_pk.session_id;
+  if (sessionId) req.query.sessionId = sessionId;
+
+  const localAuthority = payment_requests_by_pk.session?.flow?.team?.slug;
+  if (localAuthority) req.params.localAuthority = localAuthority;
+
+  const flowId = payment_requests_by_pk.session?.flow_id;
+  if (flowId) req.query.flowId = flowId;
+
+  //TODO paymentAmount
+  next();
+}
+
+// middleware used by /payment-request/:paymentRequest/pay?returnURL=...
+export async function buildPaymentPayload(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  if (!req.query.returnURL) {
+    return next(
+      new ServerError({
+        message: "missing required returnURL query param",
+        status: 400,
+      })
+    );
+  }
+  req.body = {
+    amount: 10, // TODO req.params.paymentAmount,
+    reference: req.query.sessionId,
+    description: "New application (nominated payee)",
+    return_url: req.query.returnURL,
+  };
+  next();
+}
+
+// middleware used by /payment-request/:paymentRequest/pay
+export async function updatePaymentRequest(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const query = gql`
+    mutation UpdatePaymentRequestPaidAt($paymentRequestId: uuid!) {
+      update_payment_requests(
+        where: { id: { _eq: $paymentRequestId } }
+        _set: { paid_at: "now()" }
+      ) {
+        affected_rows
+      }
+    }
+  `;
+  const { update_payment_requests } = await client.request(query, {
+    paymentRequestId: req.params.paymentRequest,
+  });
+  if (!update_payment_requests?.affected_rows) {
+    return next(
+      new ServerError({
+        message: "payment request not updated",
+        status: 500,
+      })
+    );
+  }
+  next();
+}

--- a/api.planx.uk/inviteToPay/paymentRequest.ts
+++ b/api.planx.uk/inviteToPay/paymentRequest.ts
@@ -20,6 +20,7 @@ export async function fetchPaymentRequestDetails(
     query GetPaymentRequestByID($paymentRequestId: uuid!) {
       payment_requests_by_pk(id: $paymentRequestId) {
         session_id
+        payment_amount
         session {
           flow_id
           flow {
@@ -51,7 +52,9 @@ export async function fetchPaymentRequestDetails(
   const flowId = payment_requests_by_pk.session?.flow_id;
   if (flowId) req.query.flowId = flowId;
 
-  //TODO paymentAmount
+  const paymentAmount = payment_requests_by_pk.payment_amount;
+  if (paymentAmount) req.params.paymentAmount = paymentAmount;
+
   next();
 }
 
@@ -70,7 +73,7 @@ export async function buildPaymentPayload(
     );
   }
   req.body = {
-    amount: 10, // TODO req.params.paymentAmount,
+    amount: req.params.paymentAmount,
     reference: req.query.sessionId,
     description: "New application (nominated payee)",
     return_url: req.query.returnURL,

--- a/api.planx.uk/pay/index.ts
+++ b/api.planx.uk/pay/index.ts
@@ -1,0 +1,1 @@
+export * from "./pay"

--- a/api.planx.uk/pay/pay.ts
+++ b/api.planx.uk/pay/pay.ts
@@ -1,0 +1,111 @@
+import assert from "assert";
+import { NextFunction, Request, Response } from "express";
+import { responseInterceptor } from "http-proxy-middleware";
+import SlackNotify from "slack-notify";
+import { logPaymentStatus } from "../send/helpers";
+import { usePayProxy } from "./proxy";
+
+assert(process.env.SLACK_WEBHOOK_URL);
+
+// exposed as /pay/:localAuthority and also used as middleware
+// returns the url to make a gov uk payment
+export async function makePaymentViaProxy(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  // confirm that this local authority (aka team) has a pay token configured before creating the proxy
+  const isSupported =
+    process.env[`GOV_UK_PAY_TOKEN_${req.params.localAuthority.toUpperCase()}`];
+
+  const flowId = req.query?.flowId as string | undefined;
+  const sessionId = req.query?.sessionId as string | undefined;
+  const teamSlug = req.params.localAuthority;
+
+  if (isSupported) {
+    // drop req.params.localAuthority from the path when redirecting
+    // so redirects to plain [GOV_UK_PAY_URL] with correct bearer token
+    usePayProxy(
+      {
+        pathRewrite: (path) => path.replace(/^\/pay.*$/, ""),
+        selfHandleResponse: true,
+        onProxyRes: responseInterceptor(
+          async (responseBuffer, _proxyRes, _req, _res) => {
+            const responseString = responseBuffer.toString("utf8");
+            const govUkResponse = JSON.parse(responseString);
+            await logPaymentStatus({
+              sessionId,
+              flowId,
+              teamSlug,
+              govUkResponse,
+            });
+            return responseBuffer;
+          }
+        ),
+      },
+      req
+    )(req, res, next);
+  } else {
+    next({
+      status: 400,
+      message: `GOV.UK Pay is not enabled for this local authority`,
+    });
+  }
+}
+
+// exposed as /pay/:localAuthority/:paymentId and also used as middleware
+// fetches the status of the payment
+export async function fetchPaymentViaProxy(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const flowId = req.query?.flowId as string | undefined;
+  const sessionId = req.query?.sessionId as string | undefined;
+  const teamSlug = req.params.localAuthority;
+
+  // will redirect to [GOV_UK_PAY_URL]/:paymentId with correct bearer token
+  usePayProxy(
+    {
+      pathRewrite: () => `/${req.params.paymentId}`,
+      selfHandleResponse: true,
+      onProxyRes: responseInterceptor(async (responseBuffer) => {
+        const govUkResponse = JSON.parse(responseBuffer.toString("utf8"));
+
+        await logPaymentStatus({
+          sessionId,
+          flowId,
+          teamSlug,
+          govUkResponse,
+        });
+
+        // if it's a prod payment, notify #planx-notifications so we can monitor for subsequent submissions
+        if (govUkResponse?.payment_provider !== "sandbox") {
+          try {
+            const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
+            const getStatus = (state: Record<string, string>) =>
+              state.status + (state.message ? ` (${state.message})` : "");
+            const payMessage = `:coin: New GOV Pay payment *${
+              govUkResponse.payment_id
+            }* with status *${getStatus(govUkResponse.state)}* [${
+              req.params.localAuthority
+            }]`;
+            await slack.send(payMessage);
+            console.log("Payment notification posted to Slack");
+          } catch (error) {
+            next(error);
+            return "";
+          }
+        }
+
+        // only return payment status, filter out PII
+        return JSON.stringify({
+          payment_id: govUkResponse.payment_id,
+          amount: govUkResponse.amount,
+          state: govUkResponse.state,
+        });
+      }),
+    },
+    req
+  )(req, res, next);
+}

--- a/api.planx.uk/pay/pay.ts
+++ b/api.planx.uk/pay/pay.ts
@@ -112,7 +112,13 @@ export async function postPaymentNotificationToSlack(
   // if it's a prod payment, notify #planx-notifications so we can monitor for subsequent submissions
   if (govUkResponse?.payment_provider !== "sandbox") {
     const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
-    const payMessage = `:coin: New GOV Pay payment ${label} *${govUkResponse.payment_id}* with status *${govUkResponse.state.status}* [${req.params.localAuthority}]`;
+    const getStatus = (state: GovUKPayment["state"]) =>
+      state.status + (state.message ? ` (${state.message})` : "");
+    const payMessage = `:coin: New GOV Pay payment ${label} *${
+      govUkResponse.payment_id
+    }* with status *${getStatus(govUkResponse.state)}* [${
+      req.params.localAuthority
+    }]`;
     await slack.send(payMessage);
     console.log("Payment notification posted to Slack");
   }

--- a/api.planx.uk/pay/proxy.ts
+++ b/api.planx.uk/pay/proxy.ts
@@ -1,6 +1,6 @@
 import { Request } from "express";
 import { fixRequestBody, Options } from "http-proxy-middleware";
-import { useProxy } from ".";
+import { useProxy } from "../proxy";
 
 export const usePayProxy = (options: Partial<Options>, req: Request) => {
   return useProxy({

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -36,7 +36,7 @@ import {
   inviteToPay,
   fetchPaymentRequestDetails,
   buildPaymentPayload,
-  updatePaymentRequest,
+  fetchPaymentRequestViaProxy
 } from "./inviteToPay";
 import { useFilePermission, useHasuraAuth, useSendEmailAuth } from "./auth";
 
@@ -320,13 +320,12 @@ app.post(
   fetchPaymentRequestDetails,
   buildPaymentPayload,
   makePaymentViaProxy,
-  updatePaymentRequest
 );
 
 app.get(
   "/payment-request/:paymentRequest/payment/:paymentId",
   fetchPaymentRequestDetails,
-  fetchPaymentViaProxy
+  fetchPaymentRequestViaProxy
 );
 
 // needed for storing original URL to redirect to in login flow

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -18,10 +18,8 @@ import {
   Profile,
   VerifyCallback,
 } from "passport-google-oauth20";
-import { responseInterceptor } from "http-proxy-middleware";
 import helmet from "helmet";
 import multer from "multer";
-import SlackNotify from "slack-notify";
 
 import { ServerError } from "./errors";
 import { locationSearch } from "./gis/index";
@@ -33,7 +31,13 @@ import {
   validateSession,
   routeSendEmailRequest,
 } from "./saveAndReturn";
-import { inviteToPay } from "./inviteToPay";
+import { makePaymentViaProxy, fetchPaymentViaProxy } from "./pay";
+import {
+  inviteToPay,
+  fetchPaymentRequestDetails,
+  buildPaymentPayload,
+  updatePaymentRequest,
+} from "./inviteToPay";
 import { useFilePermission, useHasuraAuth, useSendEmailAuth } from "./auth";
 
 import airbrake from "./airbrake";
@@ -58,11 +62,9 @@ import { sendSlackNotification } from "./webhooks/sendNotifications";
 import { copyFlow } from "./editor/copyFlow";
 import { moveFlow } from "./editor/moveFlow";
 import { useOrdnanceSurveyProxy } from "./proxy/ordnanceSurvey";
-import { usePayProxy } from "./proxy/pay";
 import { downloadFeedbackCSV } from "./admin/feedback/downloadFeedbackCSV";
 import { sanitiseApplicationData } from "./webhooks/sanitiseApplicationData";
 import { isLiveEnv } from "./helpers";
-import { logPaymentStatus } from "./send/helpers";
 import { getOneAppXML } from "./admin/session/oneAppXML";
 import { gql } from "graphql-request";
 import { createPaymentExpiryEvents, createPaymentInvitationEvents, createPaymentReminderEvents } from "./webhooks/paymentRequestEvents";
@@ -308,101 +310,24 @@ app.get("/download-application-files/:sessionId", downloadApplicationFiles);
 });
 
 // used by startNewPayment() in @planx/components/Pay/Public/Pay.tsx
-// returns the url to make a gov uk payment
-app.post("/pay/:localAuthority", (req, res, next) => {
-  // confirm that this local authority (aka team) has a pay token configured before creating the proxy
-  const isSupported =
-    process.env[`GOV_UK_PAY_TOKEN_${req.params.localAuthority.toUpperCase()}`];
-
-  const flowId = req.query?.flowId as string | undefined;
-  const sessionId = req.query?.sessionId as string | undefined;
-  const teamSlug = req.params.localAuthority;
-
-  if (isSupported) {
-    // drop req.params.localAuthority from the path when redirecting
-    // so redirects to plain [GOV_UK_PAY_URL] with correct bearer token
-    usePayProxy(
-      {
-        pathRewrite: (path) => path.replace(/^\/pay.*$/, ""),
-        selfHandleResponse: true,
-        onProxyRes: responseInterceptor(
-          async (responseBuffer, _proxyRes, _req, _res) => {
-            const responseString = responseBuffer.toString("utf8");
-            const govUkResponse = JSON.parse(responseString);
-            await logPaymentStatus({
-              sessionId,
-              flowId,
-              teamSlug,
-              govUkResponse,
-            });
-            return responseBuffer;
-          }
-        ),
-      },
-      req
-    )(req, res, next);
-  } else {
-    next({
-      status: 400,
-      message: `GOV.UK Pay is not enabled for this local authority`,
-    });
-  }
-});
-
-assert(process.env.SLACK_WEBHOOK_URL);
+app.post("/pay/:localAuthority", makePaymentViaProxy);
 
 // used by refetchPayment() in @planx/components/Pay/Public/Pay.tsx
-// fetches the status of the payment
-app.get("/pay/:localAuthority/:paymentId", (req, res, next) => {
-  const flowId = req.query?.flowId as string | undefined;
-  const sessionId = req.query?.sessionId as string | undefined;
-  const teamSlug = req.params.localAuthority;
+app.get("/pay/:localAuthority/:paymentId", fetchPaymentViaProxy);
 
-  // will redirect to [GOV_UK_PAY_URL]/:paymentId with correct bearer token
-  usePayProxy(
-    {
-      pathRewrite: () => `/${req.params.paymentId}`,
-      selfHandleResponse: true,
-      onProxyRes: responseInterceptor(async (responseBuffer) => {
-        const govUkResponse = JSON.parse(responseBuffer.toString("utf8"));
+app.post(
+  "/payment-request/:paymentRequest/pay",
+  fetchPaymentRequestDetails,
+  buildPaymentPayload,
+  makePaymentViaProxy,
+  updatePaymentRequest
+);
 
-        await logPaymentStatus({
-          sessionId,
-          flowId,
-          teamSlug,
-          govUkResponse,
-        });
-
-        // if it's a prod payment, notify #planx-notifications so we can monitor for subsequent submissions
-        if (govUkResponse?.payment_provider !== "sandbox") {
-          try {
-            const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
-            const getStatus = (state: Record<string, string>) =>
-              state.status + (state.message ? ` (${state.message})` : "");
-            const payMessage = `:coin: New GOV Pay payment *${
-              govUkResponse.payment_id
-            }* with status *${getStatus(govUkResponse.state)}* [${
-              req.params.localAuthority
-            }]`;
-            await slack.send(payMessage);
-            console.log("Payment notification posted to Slack");
-          } catch (error) {
-            next(error);
-            return "";
-          }
-        }
-
-        // only return payment status, filter out PII
-        return JSON.stringify({
-          payment_id: govUkResponse.payment_id,
-          amount: govUkResponse.amount,
-          state: govUkResponse.state,
-        });
-      }),
-    },
-    req
-  )(req, res, next);
-});
+app.get(
+  "/payment-request/:paymentRequest/payment/:paymentId",
+  fetchPaymentRequestDetails,
+  fetchPaymentViaProxy
+);
 
 // needed for storing original URL to redirect to in login flow
 app.use(

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -115,7 +115,7 @@ export interface GovUKPayment {
   amount: number;
   reference?: string;
   state: {
-    // https://docs.payments.service.gov.uk/api_reference/#status-and-finished
+    // https://docs.payments.service.gov.uk/api_reference/#payment-status-meanings
     status:
       | "created"
       | "started"
@@ -126,6 +126,7 @@ export interface GovUKPayment {
       | "cancelled"
       | "error";
     finished: boolean;
+    message?: string;
   };
   payment_id: string;
   payment_provider: string;

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -128,6 +128,7 @@ export interface GovUKPayment {
     finished: boolean;
   };
   payment_id: string;
+  payment_provider: string;
   created_date?: string;
   _links?: {
     self: {


### PR DESCRIPTION
This PR adds two API endpoints for managing the invite-to-pay payments. It also includes a refactor of the pay proxy to allow those functions to be reused for invite-to-pay.

Testing is a bit of a pain to set up:
 * create a lowcal session
 * create a payment request with that lowcal session
 * post to the API endpoint https://api.1612.planx.pizza/payment-request/:paymentRequestId/pay?returnURL=https://example.com
 * complete the payment by manually navigating to the response's `next_url`
 * get the API endpoint https://api.1612.planx.pizza/payment-request/:paymentRequestId/payment/:paymentId using the payment id from the completed payment
 
 Existing pay endpoints should be covered by the end-to-end tests. Do shout if you think that assumption doesn't hold.