### PR TITLE
feat: Add columns to payment request table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -351,8 +351,10 @@
     - role: public
       permission:
         columns:
+          - applicant_name
           - created_at
           - id
+          - payment_amount
           - session_preview_data
         filter:
           id:

--- a/hasura.planx.uk/migrations/1681301564609_add_payment_amount_and_applicant_name/down.sql
+++ b/hasura.planx.uk/migrations/1681301564609_add_payment_amount_and_applicant_name/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."payment_requests" drop column "payment_amount";
+
+alter table "public"."payment_requests" drop column "applicant_name";

--- a/hasura.planx.uk/migrations/1681301564609_add_payment_amount_and_applicant_name/up.sql
+++ b/hasura.planx.uk/migrations/1681301564609_add_payment_amount_and_applicant_name/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."payment_requests" add column "payment_amount" integer
+ not null;
+
+alter table "public"."payment_requests" add column "applicant_name" text
+ not null;

--- a/hasura.planx.uk/tests/payment_requests.test.js
+++ b/hasura.planx.uk/tests/payment_requests.test.js
@@ -137,6 +137,8 @@ const insertPaymentRequests = async (sessionIds, paymentRequestIds) => {
           {
             payee_email: "test1@opensystemslab.io",
             payee_name: "test1"
+            applicant_name: "Agent1"
+            payment_amount: 11700
             id: "${paymentRequestIds[0]}", 
             session_id: "${sessionIds[0]}", 
             session_preview_data: { test1: "test1" }
@@ -144,6 +146,8 @@ const insertPaymentRequests = async (sessionIds, paymentRequestIds) => {
           {
             payee_email: "test2@opensystemslab.io",
             payee_name: "test2"
+            applicant_name: "Agent1"
+            payment_amount: 10300
             id: "${paymentRequestIds[1]}", 
             session_id: "${sessionIds[1]}", 
             session_preview_data: { test2: "test2" }


### PR DESCRIPTION
This adds `applicant_name` and `payment_amount` to the payment request table.

`applicant_name` is the provided name of the person/company submitting the application on behalf of the nominee.

`payment_amount` is the total application fee payable by the nominated payee.