### PR TITLE
fix: Use correct passport variable for BoPS payload `start_date`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/works.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/works.test.ts
@@ -6,7 +6,7 @@ test("Start date is set in the payload when present in passport", () => {
     flow: {},
     passport: {
       data: {
-        "proposal.started.date": "2025-02-03",
+        "proposal.start.date": "2025-02-03",
       },
     },
     sessionId: "session-123",

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -406,7 +406,7 @@ export function getBOPSParams({
   // 10. Works
   const works: BOPSFullPayload["works"] = {};
 
-  const startedDate = parseDate(passport?.data?.["proposal.started.date"]);
+  const startedDate = parseDate(passport?.data?.["proposal.start.date"]);
   if (startedDate) works.start_date = startedDate;
 
   const completionDate = parseDate(


### PR DESCRIPTION
Follows on from https://github.com/theopensystemslab/planx-new/pull/1581