### PR TITLE
feat(ci): Action failure notification

### DIFF
--- a/.github/workflows/action-failure.yml
+++ b/.github/workflows/action-failure.yml
@@ -1,0 +1,22 @@
+name: Action failure notification
+
+on: 
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+
+jobs:
+  notifications:
+    name: Failure notifications
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: planx-notifications-internal
+          SLACK_USERNAME: PlanX Action Failure
+          SLACK_COLOR: "#FF5733"
+          SLACK_TITLE: ${{ inputs.environment }} deploy failure
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK }}

--- a/.github/workflows/action-failure.yml
+++ b/.github/workflows/action-failure.yml
@@ -16,7 +16,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: planx-notifications-internal
-          SLACK_USERNAME: PlanX Action Failure
+          SLACK_USERNAME: GitHub Actions
           SLACK_COLOR: "#FF5733"
           SLACK_TITLE: ${{ inputs.environment }} deploy failure
           SLACK_WEBHOOK: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -409,7 +409,6 @@ jobs:
         run: |
           timeout 150s bash -c "until curl --fail https://${{ env.FULL_DOMAIN }}; do sleep 1; done"
 
-
   lighthouse:
     name: Lighthouse
     needs: [create_or_update_vultr_instance]
@@ -516,3 +515,10 @@ jobs:
           name: playwright-report
           path: e2e/test-results/
           retention-days: 3
+
+  failure_notification:
+    name: Send failure notification
+    if: failure()
+    uses: ./.github/workflows/action-failure.yml
+    with:
+      environment: pizza


### PR DESCRIPTION
This introduces a new action which should run when an action fails. 

For now, I'm running on `pull_request` but I think this will actually just be unnecessary noise - we want it just to run on failed staging and prod deploys.

Next steps...
 - Merge this to `main` so we can run it
 - Open a PR with a failing test to force failure, and triggering of this action
 - If this action is triggered, update workflow to run on staging and prod deploys