### PR TITLE
fix: Drop NOT NULL constraint on users.email

### DIFF
--- a/hasura.planx.uk/migrations/1681463096461_alter_table_public_users_alter_column_email/down.sql
+++ b/hasura.planx.uk/migrations/1681463096461_alter_table_public_users_alter_column_email/down.sql
@@ -1,0 +1,2 @@
+comment on column "public"."users"."email" is E'Create multiple entries if a user\'s email includes "." or "@googlemail.com"; replace address with "_REMOVED_" to restrict access but retain their edits/`operations` until soft deletes are implemented';
+alter table "public"."users" alter column "email" set not null;

--- a/hasura.planx.uk/migrations/1681463096461_alter_table_public_users_alter_column_email/up.sql
+++ b/hasura.planx.uk/migrations/1681463096461_alter_table_public_users_alter_column_email/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."users" alter column "email" drop not null;
+comment on column "public"."users"."email" is E'Create multiple entries if a user\'s email includes "." or "@googlemail.com"; set email to NULL to delete a user';


### PR DESCRIPTION
A more fully fleshed version which is basically a soft delete would be better and can maybe be implemented when we have a delete users function available to admins in the frontend?