### PR TITLE
fix: Inherit secrets in failure notification workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -521,5 +521,6 @@ jobs:
     needs: [healthcheck, lighthouse]
     if: failure()
     uses: ./.github/workflows/action-failure.yml
+    secrets: inherit
     with:
       environment: pizza


### PR DESCRIPTION
Action failed due to the following error - `[ERROR] Secret `SLACK_WEBHOOK` is missing. Please add it to this action for proper execution.`

https://github.com/theopensystemslab/planx-new/actions/runs/4699099376/jobs/8332639317