### PR TITLE
chore: Update passport to v0.6.0

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -1,3 +1,4 @@
+import { NextFunction, Response, Request } from 'express';
 import { gql } from "graphql-request";
 import { capitalize } from "lodash";
 import { adminGraphQLClient as adminClient } from "./hasura";
@@ -226,6 +227,28 @@ const getFormattedEnvironment = (): string => {
   return capitalize(environment);
 };
 
+// Add dummy implementation of methods that passport 0.6.0 expects the request to have, if not present
+// See issue https://github.com/jaredhanson/passport/issues/904
+const passportPolyfill = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+  ) => {
+  type CallbackFunction = () => void
+
+  if (req.session && !req.session.regenerate) {
+    req.session.regenerate = (cb: CallbackFunction) => {
+      cb()
+    }
+  }
+  if (req.session && !req.session.save) {
+    req.session.save = (cb: CallbackFunction) => {
+      cb()
+    }
+  }
+  next();
+};
+
 export {
   getFlowData,
   getMostRecentPublishedFlow,
@@ -236,4 +259,5 @@ export {
   insertFlow,
   isLiveEnv,
   getFormattedEnvironment,
+  passportPolyfill,
 };

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -34,7 +34,7 @@
     "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.4",
     "notifications-node-client": "^5.1.1",
-    "passport": "^0.5.3",
+    "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "pino-noir": "^2.2.1",
     "slack-notify": "^2.0.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -70,7 +70,7 @@ specifiers:
   nock: ^13.2.9
   node-dev: ^7.4.3
   notifications-node-client: ^5.1.1
-  passport: ^0.5.3
+  passport: ^0.6.0
   passport-google-oauth20: ^2.0.0
   pino-noir: ^2.2.1
   prettier: ~2.7.1
@@ -104,7 +104,7 @@ dependencies:
   form-data: 4.0.0
   graphql: 16.5.0
   graphql-request: 4.3.0_graphql@16.5.0
-  graphql-voyager: 1.0.0-rc.31_graphql@16.5.0
+  graphql-voyager: 1.0.0-rc.31_phmus7xcbidy3raesi6r6zwaqe
   helmet: 5.1.1
   http-proxy-middleware: 2.0.6_@types+express@4.17.14
   isomorphic-fetch: 3.0.0
@@ -115,7 +115,7 @@ dependencies:
   multer: 1.4.5-lts.1
   nanoid: 3.3.4
   notifications-node-client: 5.1.1
-  passport: 0.5.3
+  passport: 0.6.0
   passport-google-oauth20: 2.0.0
   pino-noir: 2.2.1
   slack-notify: 2.0.3
@@ -1298,7 +1298,7 @@ packages:
       '@lit-labs/ssr-dom-shim': 1.0.0
     dev: false
 
-  /@material-ui/core/3.9.4:
+  /@material-ui/core/3.9.4_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1311,8 +1311,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.6
-      '@material-ui/system': 3.0.0-alpha.2
-      '@material-ui/utils': 3.0.0-alpha.3
+      '@material-ui/system': 3.0.0-alpha.2_biqbaboplfbrettd7655fr4n2y
+      '@material-ui/utils': 3.0.0-alpha.3_biqbaboplfbrettd7655fr4n2y
       '@types/jss': 9.5.8
       '@types/react-transition-group': 2.9.2
       brcast: 3.0.2
@@ -1333,13 +1333,15 @@ packages:
       normalize-scroll-left: 0.1.2
       popper.js: 1.16.1
       prop-types: 15.8.1
-      react-event-listener: 0.6.6
-      react-transition-group: 2.9.0
-      recompose: 0.30.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-event-listener: 0.6.6_react@18.2.0
+      react-transition-group: 2.9.0_biqbaboplfbrettd7655fr4n2y
+      recompose: 0.30.0_react@18.2.0
       warning: 4.0.3
     dev: false
 
-  /@material-ui/system/3.0.0-alpha.2:
+  /@material-ui/system/3.0.0-alpha.2_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1354,10 +1356,12 @@ packages:
       '@babel/runtime': 7.20.13
       deepmerge: 3.3.0
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       warning: 4.0.3
     dev: false
 
-  /@material-ui/utils/3.0.0-alpha.3:
+  /@material-ui/utils/3.0.0-alpha.3_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -1371,6 +1375,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-is: 16.13.1
     dev: false
 
@@ -4325,7 +4331,7 @@ packages:
       - encoding
     dev: false
 
-  /graphql-voyager/1.0.0-rc.31_graphql@16.5.0:
+  /graphql-voyager/1.0.0-rc.31_phmus7xcbidy3raesi6r6zwaqe:
     resolution: {integrity: sha512-eCaFL8niR3DZo1LUcFV8txwR+MDVIQsrFPmFC7Zwab8UyH5x3SLhx3aDrt998RVJRmY5aFP4q79RY2F3QtGRqA==}
     peerDependencies:
       graphql: '>=14.0.0'
@@ -4338,13 +4344,15 @@ packages:
         optional: true
     dependencies:
       '@f/animate': 1.0.1
-      '@material-ui/core': 3.9.4
+      '@material-ui/core': 3.9.4_biqbaboplfbrettd7655fr4n2y
       classnames: 2.3.2
       clipboard: 2.0.11
       commonmark: 0.29.3
       graphql: 16.5.0
       lodash: 4.17.21
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       svg-pan-zoom: 3.6.1
       viz.js: 2.1.2
     dev: false
@@ -6344,12 +6352,13 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /passport/0.5.3:
-    resolution: {integrity: sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==}
+  /passport/0.6.0:
+    resolution: {integrity: sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       passport-strategy: 1.0.0
       pause: 0.0.1
+      utils-merge: 1.0.1
     dev: false
 
   /path-exists/4.0.0:
@@ -6651,7 +6660,7 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-event-listener/0.6.6:
+  /react-event-listener/0.6.6_react@18.2.0:
     resolution: {integrity: sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==}
     peerDependencies:
       react: ^16.3.0
@@ -6661,6 +6670,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       prop-types: 15.8.1
+      react: 18.2.0
       warning: 4.0.3
     dev: false
 
@@ -6675,7 +6685,7 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-transition-group/2.9.0:
+  /react-transition-group/2.9.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
     peerDependencies:
       react: '>=15.0.0'
@@ -6689,6 +6699,8 @@ packages:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-lifecycles-compat: 3.0.4
     dev: false
 
@@ -6760,7 +6772,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: false
 
-  /recompose/0.30.0:
+  /recompose/0.30.0_react@18.2.0:
     resolution: {integrity: sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==}
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
@@ -6772,6 +6784,7 @@ packages:
       change-emitter: 0.1.6
       fbjs: 0.8.18
       hoist-non-react-statics: 2.5.5
+      react: 18.2.0
       react-lifecycles-compat: 3.0.4
       symbol-observable: 1.2.0
     dev: false

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -64,7 +64,7 @@ import { moveFlow } from "./editor/moveFlow";
 import { useOrdnanceSurveyProxy } from "./proxy/ordnanceSurvey";
 import { downloadFeedbackCSV } from "./admin/feedback/downloadFeedbackCSV";
 import { sanitiseApplicationData } from "./webhooks/sanitiseApplicationData";
-import { isLiveEnv } from "./helpers";
+import { isLiveEnv, passportPolyfill } from "./helpers";
 import { getOneAppXML } from "./admin/session/oneAppXML";
 import { gql } from "graphql-request";
 import { createPaymentExpiryEvents, createPaymentInvitationEvents, createPaymentReminderEvents } from "./webhooks/paymentRequestEvents";
@@ -336,6 +336,9 @@ app.use(
     secret: process.env.SESSION_SECRET,
   })
 );
+
+// Register regenerate & save after the cookieSession middleware initialization
+app.use(passportPolyfill)
 
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
Follows on from https://github.com/theopensystemslab/planx-new/pull/1185

Neither `passport` not `cookie-session` have yet had an update that addresses this compatibility issue.

This solution was sourced [here](https://github.com/jaredhanson/passport/issues/904#issuecomment-1307558283) and is worth testing on staging as it will allow us to resolve this long running issue if it works.