### PR TITLE
Revert "infra: rotate postgres & metabase passwords on aws production" [skip pizza]

### DIFF
--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -99,6 +99,7 @@ jobs:
           stack-name: production
           work-dir: infrastructure/application
           edit-pr-comment: true
+          refresh: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 

--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -29,7 +29,7 @@ config:
   application:metabase-encryption-secret-key:
     secure: AAABAKQ6L5aOwZWpj9YOsaW8bOOukjt1mZuTgdKjM/3nSmF/0nM/f9c9W9DXygUFj2wtq5/iugo1UTS0+bhEn8Dr9k1Qzr2EmuGpQw==
   application:metabasePgPassword:
-    secure: AAABANGc7cWKYdBBYoZ/JPID/Azlwto7QzfUR+Ds7rtui4yMfWmbVEH22ig189/UV3GHI/Dx4x64VWpNjHJzxg==
+    secure: AAABAN1bRAyO0jk0n4rfVAntYPWNat+naRsld87v3I18Bn9Iu5HGHmdKyF8Z0qpKoa7Sm88hmxlYsOb9wxQi0Yxtl7sdGZvodD6iLg==
   application:ordnance-survey-api-key:
     secure: AAABAE+wD6ahxO45tq/JWp6odrHX9jOhdjlMsCqS6kFqBgJ+3T56fOSgpZ26nEftv9IwWZQh/v93tRtTDEb+uw==
   application:session-secret:

--- a/infrastructure/data/Pulumi.production.yaml
+++ b/infrastructure/data/Pulumi.production.yaml
@@ -1,4 +1,3 @@
 config:
-  aws:region: eu-west-2
   data:db-password:
-    secure: AAABAA4wzAobUbUswrNarVYoJzFXyz+E0fubHXDuMS1Uun4mAg44jMPG+CLxSsJ/2iGdHtlp2Gxey7zcuPiGoQ==
+    secure: AAABAJekEkTZff0LMK4PazFRkBOmtOUQHseg8jrOqFlVl0IQ00rZsOp1pCrP17gRnU9JqQDxJfvKnmKkkMsG5w==


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#1634

We were able to successfully deploy the data layer and see the new database URL reflected back, but our existing db connection never went down as expected and the application layer failed to deploy with error (same result with & without `--refresh` flag and IAM user region set): https://github.com/theopensystemslab/planx-new/actions/runs/4728804304/jobs/8390982698
![Screenshot from 2023-04-18 07-41-34](https://user-images.githubusercontent.com/5132349/232681671-c4e6ba23-9f27-4119-9e1c-cc998ed3e5c8.png)

To research next: 
- How to reconcile Pulumi stack changes with actual AWS resources
