### PR TITLE
fix: make sure `teams` seed scripts references same columns

### DIFF
--- a/scripts/seed-database/container.sql
+++ b/scripts/seed-database/container.sql
@@ -4,7 +4,7 @@ TRUNCATE TABLE users, teams CASCADE;
 
 \COPY users FROM '/tmp/users.csv' (FORMAT CSV, DELIMITER ';');
 
-\COPY teams (id, name, slug, theme, settings, domain, notify_personalisation) FROM '/tmp/teams.csv' (FORMAT CSV, DELIMITER ';')
+\COPY teams (id, name, slug, theme, settings, notify_personalisation) FROM '/tmp/teams.csv' (FORMAT CSV, DELIMITER ';')
 
 \COPY flows FROM '/tmp/flows.csv' (FORMAT CSV, DELIMITER ';');
 UPDATE flows SET version = 1;


### PR DESCRIPTION
followup to #1633 

`pnpm docker:seed` was throwing this error because `domain` was only removed from the `container.sh` script, not `container.sql`  - I admittedly am not sure why both are still needed, seems like something we should look into simplifying - but this fixes local dev environment in short term!

![Screenshot from 2023-04-19 12-10-04](https://user-images.githubusercontent.com/5132349/233046308-773e8768-a08c-48fb-bc5e-45e846b1c799.png)
