### PR TITLE
update: mobile UI tidy up

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -49,12 +49,12 @@ const Card: React.FC<Props> = ({
       mountOnEnter={true}
       unmountOnExit={true}
     >
-      <Container maxWidth="md">
+      <Container disableGutters maxWidth="md">
         <Box
           className={classes.container}
           bgcolor="background.default"
           py={{ xs: 2, md: 4 }}
-          px={{ xs: 2, md: 0 }}
+          px={{ xs: 2, md: 3, lg: 0 }}
           mb={4}
           {...props}
         >

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -60,7 +60,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
       <Grid container justifyContent="space-between" wrap="nowrap">
         <Grid item>
           {title && (
-            <Box mr={1} pt={1.5}>
+            <Box mr={1} pt={0.5}>
               <Typography
                 variant="h3"
                 role="heading"

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -73,7 +73,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           )}
           {description && (
             <Description>
-              <Typography variant="subtitle1" component="div">
+              <Typography variant="subtitle2" component="div">
                 <ReactMarkdownOrHtml
                   source={description}
                   id={DESCRIPTION_TEXT}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
@@ -17,7 +17,7 @@ const SaveResumeButton: React.FC = () => {
     <>
       <Typography variant="body1">or</Typography>
       <Link component="button" onClick={onClick}>
-        <Typography variant="body1">
+        <Typography variant="body1" textAlign="left">
           {Boolean(saveToEmail)
             ? "Save and return to this application later"
             : "Resume an application you have already started"}

--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -9,7 +9,7 @@ import AnalyticsChart from "ui/icons/AnalyticsChart";
 const AnalyticsWarning = styled(Box)(({ theme }) => ({
   display: "flex",
   backgroundColor: "#FFFB00",
-  padding: `0 ${theme.spacing(4)}`,
+  padding: theme.spacing(0.5, 2),
   color: "#070707",
   justifyContent: "space-between",
   alignItems: "center",
@@ -33,10 +33,10 @@ const AnalyticsDisabledBanner: React.FC = () => {
         <AnalyticsWarning>
           <Box display="flex" alignItems="center">
             <AnalyticsChart />
-            <Typography variant="body2">
-              <b>Analytics off</b> This is a preview link for testing. No usage
-              data is being recorded.{"  "}
-              <Link href={enableAnalytics()} color="inherit">
+            <Typography variant="body2" ml={1}>
+              <strong>Analytics off</strong> This is a preview link for testing.
+              No usage data is being recorded.{"  "}
+              <Link href={enableAnalytics()} color="inherit" mr={1}>
                 Go to normal link
               </Link>
             </Typography>

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -15,7 +15,13 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 const Root = styled("footer")(({ theme }) => ({
   color: theme.palette.common.white,
   backgroundColor: theme.palette.common.black,
-  padding: theme.spacing(2, 4),
+  padding: theme.spacing(2, 2),
+  [theme.breakpoints.up("md")]: {
+    padding: theme.spacing(3, 3),
+  },
+  [theme.breakpoints.up("lg")]: {
+    padding: theme.spacing(3, 4),
+  },
 }));
 
 const ButtonGroup = styled(Box)(({ theme }) => ({
@@ -125,7 +131,7 @@ export default function Footer(props: Props) {
 
   return (
     <Root>
-      <ButtonGroup>
+      <ButtonGroup py={0.5}>
         {items
           ?.filter((item) => item.title)
           .map((item) => (
@@ -138,13 +144,15 @@ export default function Footer(props: Props) {
             )}
             <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
               <Link color="inherit" component="button">
-                <Typography variant="body2">Feedback</Typography>
+                <Typography variant="body2" textAlign="left">
+                  Feedback
+                </Typography>
               </Link>
             </FeedbackFish>
           </>
         )}
       </ButtonGroup>
-      <Box py={4}>{children}</Box>
+      <Box py={2}>{children}</Box>
     </Root>
   );
 }

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -25,7 +25,12 @@ import {
   useCurrentRoute,
   useNavigation,
 } from "react-navi";
-import { borderedFocusStyle, focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import {
+  borderedFocusStyle,
+  focusStyle,
+  FONT_WEIGHT_SEMI_BOLD,
+  LINE_HEIGHT_BASE,
+} from "theme";
 import { ApplicationPath, Team } from "types";
 import Reset from "ui/icons/Reset";
 
@@ -50,23 +55,35 @@ const BreadcrumbLink = styled(ReactNaviLink)(() => ({
 }));
 
 const StyledToolbar = styled(MuiToolbar)(({ theme }) => ({
-  paddingLeft: theme.spacing(4),
-  paddingRight: theme.spacing(4),
-  marginTop: theme.spacing(1),
-  height: HEADER_HEIGHT,
+  minHeight: HEADER_HEIGHT,
   display: "flex",
   alignItems: "center",
+  justifyContent: "space-between",
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  [theme.breakpoints.up("md")]: {
+    paddingLeft: theme.spacing(3),
+    paddingRight: theme.spacing(3),
+  },
+  [theme.breakpoints.up("lg")]: {
+    paddingLeft: theme.spacing(4),
+    paddingRight: theme.spacing(4),
+  },
 }));
 
 const LeftBox = styled(Box)(() => ({
   display: "flex",
-  flex: 1,
+  flexGrow: 0,
+  flexShrink: 0,
+  flexBasis: "140px",
   justifyContent: "start",
 }));
 
 const RightBox = styled(Box)(() => ({
   display: "flex",
-  flex: 1,
+  flexGrow: 0,
+  flexShrink: 0,
+  flexBasis: "140px",
   justifyContent: "end",
 }));
 
@@ -100,11 +117,13 @@ const Logo = styled("img")(() => ({
   height: HEADER_HEIGHT - 5,
   width: "100%",
   maxWidth: 140,
+  maxHeight: HEADER_HEIGHT - 20,
   objectFit: "contain",
 }));
 
 const LogoLink = styled(Link)(() => ({
-  display: "inline-block",
+  display: "flex",
+  alignItems: "center",
   "&:focus-visible": borderedFocusStyle,
 }));
 
@@ -129,9 +148,17 @@ const SkipLink = styled("a")(({ theme }) => ({
 }));
 
 const ServiceTitleRoot = styled("span")(({ theme }) => ({
+  display: "flex",
+  flexGrow: 0,
+  flexShrink: 1,
+  lineHeight: LINE_HEIGHT_BASE,
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
   paddingLeft: theme.spacing(2),
-  paddingBottom: theme.spacing(1),
+  paddingRight: theme.spacing(2),
+  paddingBottom: theme.spacing(1.5),
+  [theme.breakpoints.up("md")]: {
+    paddingBottom: 0,
+  },
 }));
 
 const StyledNavBar = styled("nav")(({ theme }) => ({
@@ -262,7 +289,7 @@ const PublicToolbar: React.FC<{
 
   // Center the service title on desktop layouts, or drop it to second line on mobile
   // ref https://design-system.service.gov.uk/styles/page-template/
-  const showCentredServiceTitle = useMediaQuery("(min-width:600px)");
+  const showCentredServiceTitle = useMediaQuery("(min-width:768px)");
 
   const handleRestart = async () => {
     if (

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -9,6 +9,7 @@ import Link from "@mui/material/Link";
 import MenuItem from "@mui/material/MenuItem";
 import Paper from "@mui/material/Paper";
 import Popover from "@mui/material/Popover";
+import { Theme } from "@mui/material/styles";
 import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -289,7 +290,9 @@ const PublicToolbar: React.FC<{
 
   // Center the service title on desktop layouts, or drop it to second line on mobile
   // ref https://design-system.service.gov.uk/styles/page-template/
-  const showCentredServiceTitle = useMediaQuery("(min-width:768px)");
+  const showCentredServiceTitle = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.up("md")
+  );
 
   const handleRestart = async () => {
     if (

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -73,7 +73,7 @@ const StyledToolbar = styled(MuiToolbar)(({ theme }) => ({
 
 const LeftBox = styled(Box)(() => ({
   display: "flex",
-  flexGrow: 0,
+  flexGrow: 1,
   flexShrink: 0,
   flexBasis: "140px",
   justifyContent: "start",
@@ -149,7 +149,7 @@ const SkipLink = styled("a")(({ theme }) => ({
 
 const ServiceTitleRoot = styled("span")(({ theme }) => ({
   display: "flex",
-  flexGrow: 0,
+  flexGrow: 1,
   flexShrink: 1,
   lineHeight: LINE_HEIGHT_BASE,
   fontWeight: FONT_WEIGHT_SEMI_BOLD,

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -1,3 +1,4 @@
+import { Span } from "@airbrake/browser/dist/metrics";
 import { FeedbackFish } from "@feedback-fish/react";
 import Box from "@mui/material/Box";
 import ButtonBase from "@mui/material/ButtonBase";
@@ -14,8 +15,13 @@ const Root = styled(ButtonBase)(({ theme }) => ({
   backgroundColor: "white",
   display: "flex",
   justifyContent: "start",
-  [theme.breakpoints.up("sm")]: {
-    padding: theme.spacing(1, 2),
+  alignItems: "start",
+  padding: theme.spacing(1, 2),
+  [theme.breakpoints.up("md")]: {
+    padding: theme.spacing(1, 3),
+  },
+  [theme.breakpoints.up("lg")]: {
+    padding: theme.spacing(1, 4),
   },
 }));
 
@@ -51,19 +57,25 @@ export default function PhaseBanner(): FCReturn {
           bgcolor="primary.main"
           color="white"
           display="flex"
-          alignItems="center"
+          alignItems="flex-start"
           flexBasis={0}
-          px={2}
-          mr={2}
+          px={1}
+          mr={1}
           py={0.5}
-          fontSize={15}
+          fontSize={14}
           textAlign="center"
           whiteSpace="nowrap"
           fontWeight={600}
         >
           PUBLIC BETA
         </BetaFlag>
-        <Typography variant="body2" color="textPrimary">
+        <Typography
+          variant="body2"
+          fontSize={14}
+          color="textPrimary"
+          textAlign="left"
+          mt="0.25em"
+        >
           This is a new service. Your <Link>feedback</Link> will help us improve
           it.
         </Typography>

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -17,8 +17,8 @@ import Node, { handleSubmit } from "./Node";
 
 const useClasses = makeStyles((theme) => ({
   backButton: {
-    marginLeft: "10px",
-    marginBottom: "10px",
+    marginLeft: theme.spacing(2),
+    marginBottom: theme.spacing(1),
     visibility: "visible",
     pointerEvents: "auto",
     display: "flex",
@@ -30,8 +30,9 @@ const useClasses = makeStyles((theme) => ({
     border: "none",
     columnGap: theme.spacing(1),
     padding: theme.spacing(1, 1, 1, 0),
+    textDecoration: "underline",
     "&:hover": {
-      textDecoration: "underline",
+      textDecorationThickness: "3px",
     },
   },
   hidden: {

--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -67,7 +67,7 @@ const PublicFooter: React.FC = () => {
       <PhaseBanner />
       <Footer items={[...footerItems]}>
         <Box display="flex" alignItems="center">
-          <Box pr={3} display="flex">
+          <Box pr={2} display="flex">
             <img src={Logo} alt="Open Government License Logo" />
           </Box>
           <Typography variant="body2">

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -18,8 +18,6 @@ const TEXT_COLOR_PRIMARY = "#0B0C0C";
 const TEXT_COLOR_SECONDARY = "#505A5F";
 const BG_COLOR_DEFAULT = "#FFFFFF";
 
-const BREAKPOINT_MD = "768";
-
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
 export const FONT_WEIGHT_BOLD = "700";

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -212,6 +212,10 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
           sizeLarge: {
             fontSize: "1.188rem",
             fontWeight: FONT_WEIGHT_SEMI_BOLD,
+            width: "100%",
+            "@media (min-width: 768px)": {
+              width: "auto",
+            },
           },
         },
       },

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -18,6 +18,8 @@ const TEXT_COLOR_PRIMARY = "#0B0C0C";
 const TEXT_COLOR_SECONDARY = "#505A5F";
 const BG_COLOR_DEFAULT = "#FFFFFF";
 
+const BREAKPOINT_MD = "768";
+
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
 export const FONT_WEIGHT_BOLD = "700";
@@ -45,7 +47,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     focus: GOVUK_YELLOW,
   },
   error: {
-    main: "#E91B0C",
+    main: "#D4351C",
   },
   success: {
     main: "#4CAF50",
@@ -56,9 +58,9 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
 // https://design-system.service.gov.uk/get-started/focus-states/
 // https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/helpers/_focused.scss
 export const focusStyle = {
-  color: "black",
+  color: TEXT_COLOR_PRIMARY,
   backgroundColor: GOVUK_YELLOW,
-  boxShadow: `0 -2px ${GOVUK_YELLOW}, 0 4px black`,
+  boxShadow: `0 -2px ${GOVUK_YELLOW}, 0 4px ${TEXT_COLOR_PRIMARY}`,
   textDecoration: "none",
   outline: "3px solid transparent",
 };
@@ -68,7 +70,7 @@ export const borderedFocusStyle = {
   outline: `3px solid ${GOVUK_YELLOW}`,
   outlineOffset: 0,
   zIndex: 1,
-  boxShadow: "inset 0 0 0 2px black",
+  boxShadow: `inset 0 0 0 2px ${TEXT_COLOR_PRIMARY}`,
   backgroundColor: "transparent",
 };
 
@@ -172,7 +174,7 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
             "&:focus-visible": {
               ...focusStyle,
               // !important is required here as setting disableElevation = true removes boxShadow
-              boxShadow: `inset 0 -4px 0 black !important`,
+              boxShadow: `inset 0 -4px 0 ${TEXT_COLOR_PRIMARY} !important`,
               // Hover should not overwrite focus
               "&:hover": focusStyle,
             },

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -21,8 +21,8 @@ const BG_COLOR_DEFAULT = "#FFFFFF";
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
 export const FONT_WEIGHT_BOLD = "700";
+export const LINE_HEIGHT_BASE = "1.33";
 const SPACING_TIGHT = "-0.02em";
-const LINE_HEIGHT_BASE = "1.33";
 
 const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   primary: {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -127,6 +127,11 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
         lineHeight: LINE_HEIGHT_BASE,
         color: TEXT_COLOR_SECONDARY,
       },
+      subtitle2: {
+        fontSize: "1.375rem",
+        lineHeight: LINE_HEIGHT_BASE,
+        color: TEXT_COLOR_SECONDARY,
+      },
       body1: {
         fontSize: "1.188rem",
       },

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -36,7 +36,7 @@ export const useClasses = makeStyles<Theme, Props>((theme) => ({
     },
   },
   bordered: {
-    border: `2px solid #0B0C0C`,
+    border: `2px solid ${theme.palette.text.primary}`,
   },
   inputMultiline: {
     height: "auto",

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -36,7 +36,7 @@ export const useClasses = makeStyles<Theme, Props>((theme) => ({
     },
   },
   bordered: {
-    border: `2px solid #000`,
+    border: `2px solid #0B0C0C`,
   },
   inputMultiline: {
     height: "auto",

--- a/editor.planx.uk/src/ui/icons/MoreInfo.tsx
+++ b/editor.planx.uk/src/ui/icons/MoreInfo.tsx
@@ -10,6 +10,7 @@ export default function MoreInfoIcon() {
     borderRadius: "50%",
     height: 32,
     width: 32,
+    padding: 0,
     "&:hover": {
       backgroundColor: theme.palette.primary.main,
       color: "white",
@@ -22,8 +23,9 @@ export default function MoreInfoIcon() {
       <QuestionMarkIcon
         sx={{
           position: "absolute",
-          left: 16,
-          top: 16,
+          left: 18,
+          top: 15,
+          width: 20,
         }}
       />
     </Root>


### PR DESCRIPTION
PR is forked from / dependent on font sizes update - https://github.com/theopensystemslab/planx-new/pull/1616 (now merged)

Summary of changes:

- General tidy up of padding/gutters at smaller breakpoints
- Adding more control over header columns to prevent logo shrinking as viewport width is decreased
- Tidy up of analytics off banner layout
- Tidy up of phase banner layout
- Exporting of line-height and letter-spacing variable from theme.ts for use in components

Visual preview (before/after) of 390px width viewport:

![planx-ui](https://user-images.githubusercontent.com/51156018/233067430-860a4933-c917-4d6a-a9fa-b79f8b2b7548.jpg)