### PR TITLE
fix: update Pay content copy, add secondary page title to Editor fields

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -33,7 +33,11 @@ function Component(props: any) {
          <p>Your application will be sent after you have paid the fee. \
          Wait until you see an application sent message before closing your browser.</p>`,
       allowInviteToPay: props.node?.data?.allowInviteToPay ?? true,
-      nomineeTitle: props.node?.data?.nomineeTitle || "Details of your nominee",
+      secondaryPageTitle:
+        props.node?.data?.secondaryPageTitle ||
+        "Invite someone else to pay for this application",
+      nomineeTitle:
+        props.node?.data?.nomineeTitle || "Details of the person paying",
       nomineeDescription:
         props.node?.data?.nomineeDescription ||
         `<p>You can invite someone else to pay for your application.</p>\
@@ -43,7 +47,7 @@ function Component(props: any) {
       yourDetailsTitle: props.node?.data?.yourDetailsTitle || "Your details",
       yourDetailsDescription:
         props.node?.data?.yourDetailsDescription ||
-        "How should we refer to you in communications with your nominee?",
+        "How should we refer to you in communications with the person paying?",
       yourDetailsLabel:
         props.node?.data?.yourDetailsLabel || "Your name or organisation name",
       ...parseMoreInformation(props.node?.data),
@@ -98,7 +102,7 @@ function Component(props: any) {
             />
           </InputRow>
         </ModalSectionContent>
-        <ModalSectionContent title="Instructions">
+        <ModalSectionContent>
           <InputRow>
             <Input
               format="large"
@@ -135,6 +139,18 @@ function Component(props: any) {
             {formik.values.allowInviteToPay ? (
               <>
                 <Box>
+                  <InputRow>
+                    <Input
+                      required
+                      format="large"
+                      name="secondaryPageTitle"
+                      placeholder="Card title"
+                      value={formik.values.secondaryPageTitle}
+                      onChange={formik.handleChange}
+                    />
+                  </InputRow>
+                </Box>
+                <Box pt={4}>
                   <InputRow>
                     <Input
                       required

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -26,6 +26,7 @@ export interface Props {
   instructionsTitle?: string;
   instructionsDescription?: string;
   showInviteToPay?: boolean;
+  secondaryPageTitle?: string;
   nomineeTitle?: string;
   nomineeDescription?: string;
   yourDetailsTitle?: string;
@@ -223,7 +224,7 @@ export default function Confirm(props: Props) {
       <>
         <Container maxWidth="md">
           <Typography variant="h1" gutterBottom align="left">
-            {props.title}
+            {page === "Pay" ? props.title : props.secondaryPageTitle}
           </Typography>
         </Container>
         <Banner

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -13,6 +13,7 @@ export interface Pay extends MoreInformation {
   instructionsTitle?: string;
   instructionsDescription?: string;
   allowInviteToPay?: boolean;
+  secondaryPageTitle?: string;
   nomineeTitle?: string;
   nomineeDescription?: string;
   yourDetailsTitle?: string;


### PR DESCRIPTION
A small tweak that came up in conversation with Ian yesterday ! Additionally better aligns other default text to the newest Figma. I expect this is still one of few default content iterations, but will give me a slightly more realistic heirarchy of headers to expect for #1646 

![Screenshot from 2023-04-20 09-26-43](https://user-images.githubusercontent.com/5132349/233292445-c5a61621-2736-4b88-8294-2bc3114a703c.png)
