### PR TITLE
chore: remove "other ways to pay" suggestion drawer from Pay component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -1,18 +1,13 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
-import FormGroup from "@mui/material/FormGroup";
 import Link from "@mui/material/Link";
 import { styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import Card from "@planx/components/shared/Preview/Card";
-import MoreInfo from "@planx/components/shared/Preview/MoreInfo";
-import { submitFeedback } from "lib/feedback";
 import React, { useState } from "react";
 import { PaymentStatus } from "types";
 import Banner from "ui/Banner";
-import ChecklistItem from "ui/ChecklistItem";
-import Input from "ui/Input";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 import { formattedPriceWithCurrencySymbol } from "../model";
@@ -83,7 +78,7 @@ const PayBody: React.FC<PayBodyProps> = (props) => (
           >
             {props.buttonTitle || "Pay using GOV.UK Pay"}
           </Button>
-          {props.showInviteToPay ? (
+          {props.showInviteToPay && (
             <>
               <Typography variant="body2">or</Typography>
               <Link
@@ -97,8 +92,6 @@ const PayBody: React.FC<PayBodyProps> = (props) => (
                 </Typography>
               </Link>
             </>
-          ) : (
-            <SuggestionDrawer />
           )}
         </PayText>
       </Card>
@@ -117,84 +110,6 @@ const PayBody: React.FC<PayBodyProps> = (props) => (
     )}
   </>
 );
-
-function SuggestionDrawer() {
-  const OTHER_OPTIONS = [
-    { name: "Apple", label: "Apple Pay" },
-    { name: "BACs", label: "Bank transfer by BACs" },
-    { name: "Cheque", label: "Cheque" },
-    { name: "PayPal", label: "PayPal" },
-    { name: "Phone", label: "Phone" },
-    { name: "Other", label: "Other" },
-  ];
-
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [checkboxes, setCheckboxes] = React.useState<{
-    [key: string]: boolean;
-  }>(Object.fromEntries(OTHER_OPTIONS.map(({ name }) => [name, false])));
-  const [text, setText] = React.useState("");
-
-  const sendFeedback = () => {
-    submitFeedback(text, "Alternate payment methods", checkboxes);
-    setIsOpen(false);
-  };
-
-  return (
-    <>
-      <Link component="button" onClick={() => setIsOpen(!isOpen)}>
-        <Typography variant="body2">
-          Tell us other ways you'd like to pay in the future
-        </Typography>
-      </Link>
-      <MoreInfo open={isOpen} handleClose={() => setIsOpen(!isOpen)}>
-        <Box>
-          <p>
-            What other types of payment would you like this service to accept in
-            the future:
-          </p>
-          <FormGroup row>
-            {OTHER_OPTIONS.map((option) => (
-              <ChecklistItem
-                label={option.label}
-                checked={checkboxes[option.name]}
-                id={option.name}
-                key={option.name}
-                onChange={() =>
-                  setCheckboxes({
-                    ...checkboxes,
-                    [option.name]: !checkboxes[option.name],
-                  })
-                }
-              />
-            ))}
-          </FormGroup>
-          <p>Why would you prefer to use this form of payment?</p>
-
-          <Input
-            aria-label="Reason for selected form of payments"
-            bordered
-            multiline={true}
-            rows={3}
-            style={{ width: "100%" }}
-            onChange={(ev) => {
-              setText(ev.target.value);
-            }}
-            value={text}
-          />
-          <Box sx={{ textAlign: "right", mt: 2 }}>
-            <Link
-              component="button"
-              variant="body2"
-              onClick={() => sendFeedback()}
-            >
-              Save
-            </Link>
-          </Box>
-        </Box>
-      </MoreInfo>
-    </>
-  );
-}
 
 export default function Confirm(props: Props) {
   const theme = useTheme();

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -56,21 +56,6 @@ describe("Confirm component without inviteToPay", () => {
     expect(screen.getByText("£103.00")).toBeInTheDocument();
   });
 
-  it("shows the SuggestionDrawer link by default", async () => {
-    const feedbackPrompt = "Tell us other ways you'd like to pay in the future";
-    const { user } = setup(<Confirm {...defaultProps} />);
-
-    expect(screen.getByText(feedbackPrompt)).toBeInTheDocument();
-
-    // open the side panel
-    await user.click(screen.getByText(feedbackPrompt));
-    expect(
-      screen.getByText(
-        "What other types of payment would you like this service to accept in the future:"
-      )
-    ).toBeInTheDocument();
-  });
-
   it("displays an error and continue-with-testing button if Pay is not enabled for this team", async () => {
     const handleSubmit = jest.fn();
     const errorMessage = "No pay token found for this team!";
@@ -118,15 +103,6 @@ describe("Confirm component with inviteToPay", () => {
 
   const invitePrompt = "Invite someone else to pay for this application";
   const payPrompt = "Pay for this application myself instead";
-
-  it("shows the invite link and hides the SuggestionDrawer link", () => {
-    setup(<Confirm {...inviteProps} />);
-
-    expect(screen.getByText(invitePrompt)).toBeInTheDocument();
-    expect(
-      screen.queryByText("Tell us other ways you'd like to pay in the future")
-    ).not.toBeInTheDocument();
-  });
 
   it("switches pages when you click the invite link", async () => {
     const { user } = setup(<Confirm {...inviteProps} />);


### PR DESCRIPTION
**note: this is not behind the feature flag & will disable the feedback option immediately** 

Alastair & George confirmed that this is both rarely filled out/collected in the learning log and not a particularly relevant roadmap topic, therefore we can remove it.

https://trello.com/c/45whNb0u/2385-99-outstanding-itp-tasks