### PR TITLE
fix: subheader descriptions shouldn't be required on invite to pay form

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -38,16 +38,9 @@ function Component(props: any) {
         "Invite someone else to pay for this application",
       nomineeTitle:
         props.node?.data?.nomineeTitle || "Details of the person paying",
-      nomineeDescription:
-        props.node?.data?.nomineeDescription ||
-        `<p>You can invite someone else to pay for your application.</p>\
-         <p>They will receive an email with a link to pay using GOV.UK Pay that will be \
-         valid for 28 days. Upon successful payment, this application will be \
-         sent and you will both receive a confirmation email.</p>`,
+      nomineeDescription: props.node?.data?.nomineeDescription,
       yourDetailsTitle: props.node?.data?.yourDetailsTitle || "Your details",
-      yourDetailsDescription:
-        props.node?.data?.yourDetailsDescription ||
-        "How should we refer to you in communications with the person paying?",
+      yourDetailsDescription: props.node?.data?.yourDetailsDescription,
       yourDetailsLabel:
         props.node?.data?.yourDetailsLabel || "Your name or organisation name",
       ...parseMoreInformation(props.node?.data),
@@ -163,7 +156,6 @@ function Component(props: any) {
                   </InputRow>
                   <InputRow>
                     <RichTextInput
-                      required
                       name="nomineeDescription"
                       placeholder="Description"
                       value={formik.values.nomineeDescription}
@@ -184,7 +176,6 @@ function Component(props: any) {
                   </InputRow>
                   <InputRow>
                     <RichTextInput
-                      required
                       name="yourDetailsDescription"
                       placeholder="Description"
                       value={formik.values.yourDetailsDescription}

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -1,5 +1,4 @@
 import ErrorOutline from "@mui/icons-material/ErrorOutline";
-import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
@@ -43,13 +42,17 @@ type CreatePaymentRequest = {
 type FormValues = Omit<CreatePaymentRequest, "sessionPreviewKeys">;
 
 const validationSchema = object({
-  payeeName: string().trim().required("Nominee name required"),
+  payeeName: string()
+    .trim()
+    .required("Enter the full name of the person paying"),
   payeeEmail: string()
     .email(
       "Enter an email address in the correct format, like name@example.com"
     )
-    .required("Email address required"),
-  applicantName: string().trim().required("Your details required"),
+    .required("Enter the email address of the person paying"),
+  applicantName: string()
+    .trim()
+    .required("Enter your name or organisation name"),
 });
 
 const StyledForm = styled("form")(({ theme }) => ({
@@ -140,13 +143,18 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
     <DelayedLoadingIndicator />
   ) : (
     <Card>
-      <Typography variant="h3" component="h2">
-        {nomineeTitle}
-      </Typography>
-      <Typography variant="body2">
-        <ReactMarkdownOrHtml source={nomineeDescription} openLinksOnNewTab />
-      </Typography>
       <StyledForm onSubmit={formik.handleSubmit}>
+        <Typography variant="h3" component="h2">
+          {nomineeTitle}
+        </Typography>
+        {nomineeDescription && (
+          <Typography variant="body2">
+            <ReactMarkdownOrHtml
+              source={nomineeDescription}
+              openLinksOnNewTab
+            />
+          </Typography>
+        )}
         <InputLabel label="Full name" htmlFor="payeeName">
           <Input
             bordered
@@ -192,17 +200,17 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
             }}
           />
         </InputLabel>
-        <Box>
-          <Typography variant="h3" component="h2" pt={3} pb={2}>
-            {yourDetailsTitle}
-          </Typography>
+        <Typography variant="h3" component="h2" pt={2}>
+          {yourDetailsTitle}
+        </Typography>
+        {yourDetailsDescription && (
           <Typography variant="body2">
             <ReactMarkdownOrHtml
               source={yourDetailsDescription}
               openLinksOnNewTab
             />
           </Typography>
-        </Box>
+        )}
         <InputLabel label={yourDetailsLabel || ""} htmlFor="applicantName">
           <Input
             bordered

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -86,7 +86,7 @@ export const validationSchema = object({
   title: string().trim().required(),
   bannerTitle: string().trim().required(),
   description: string().trim().required(),
-  fn: string().trim().required(),
+  fn: string().trim().required("Data field is required"),
   instructionsTitle: string().trim().required(),
   instructionsDescription: string().trim().required(),
   allowInviteToPay: boolean(),
@@ -96,7 +96,7 @@ export const validationSchema = object({
   }),
   nomineeDescription: string().trim().when("allowInviteToPay", {
     is: true,
-    then: string().required(),
+    then: string(),
   }),
   yourDetailsTitle: string().trim().when("allowInviteToPay", {
     is: true,
@@ -104,7 +104,7 @@ export const validationSchema = object({
   }),
   yourDetailsDescription: string().trim().when("allowInviteToPay", {
     is: true,
-    then: string().required(),
+    then: string(),
   }),
   yourDetailsLabel: string().trim().when("allowInviteToPay", {
     is: true,


### PR DESCRIPTION
better aligns Editior defaults to Figma! 
![Screenshot from 2023-04-21 10-02-51](https://user-images.githubusercontent.com/5132349/233579786-a2a76ad3-75d3-4719-9a09-827c18ce4b65.png)
