### PR TITLE
feat: Get formatted project types from `planx-core`

### DIFF
--- a/api.planx.uk/inviteToPay/sendPaymentEmail.test.ts
+++ b/api.planx.uk/inviteToPay/sendPaymentEmail.test.ts
@@ -1,18 +1,23 @@
 import supertest from "supertest";
 import app from "../server";
 import { queryMock } from "../tests/graphqlQueryMock";
-import { validatePaymentRequestNotFoundQueryMock, getHumanReadableProjectTypeQueryMock, validatePaymentRequestQueryMock } from "../tests/mocks/inviteToPayMocks";
-import { mockGetHumanReadableProjectType } from "../tests/mocks/saveAndReturnMocks";
+import { validatePaymentRequestNotFoundQueryMock,validatePaymentRequestQueryMock } from "../tests/mocks/inviteToPayMocks";
+
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    CoreDomainClient: jest.fn().mockImplementation(() => ({
+      formatRawProjectTypes: jest.fn().mockResolvedValue(["New office premises"]),
+    }))
+  }
+});
 
 const TEST_PAYMENT_REQUEST_ID = "09655c28-3f34-4619-9385-cd57312acc44";
 
 describe("Send email endpoint for invite to pay templates", () => {
   beforeEach(() => {
     queryMock.reset();
-    queryMock.mockQuery(mockGetHumanReadableProjectType);
     queryMock.mockQuery(validatePaymentRequestQueryMock);
     queryMock.mockQuery(validatePaymentRequestNotFoundQueryMock);
-    queryMock.mockQuery(getHumanReadableProjectTypeQueryMock);
   });
 
   describe("All invite to pay templates require authorisation", () => {

--- a/api.planx.uk/inviteToPay/sendPaymentEmail.ts
+++ b/api.planx.uk/inviteToPay/sendPaymentEmail.ts
@@ -1,9 +1,10 @@
 import { gql } from "graphql-request";
-import { calculateExpiryDate, convertSlugToName, getHumanReadableProjectType, getServiceLink } from "../saveAndReturn/utils";
+import { calculateExpiryDate, convertSlugToName, getServiceLink } from "../saveAndReturn/utils";
 import { Template, getClientForTemplate, sendEmail } from "../notify/utils";
 import { InviteToPayNotifyConfig } from "../types";
 import { Team } from '../types';
 import type { PaymentRequest } from "@opensystemslab/planx-core/types";
+import { _admin } from '../client';
 
 interface SessionDetails {
   email: string;
@@ -88,7 +89,7 @@ const getInviteToPayNotifyConfig = async (session: SessionDetails, paymentReques
     agentName: paymentRequest.applicantName,
     address: (paymentRequest.sessionPreviewData?._address as Record<"title", string>).title,
     fee: getFee(paymentRequest),
-    projectType: await getHumanReadableProjectType(paymentRequest.sessionPreviewData) || "Project type not submitted",
+    projectType: await _admin.formatRawProjectTypes(paymentRequest.sessionPreviewData?.["proposal.projectType"] as string[]) || "Project type not submitted",
     serviceName: convertSlugToName(session.flow.slug),
     serviceLink: getServiceLink(session.flow.team, session.flow.slug),
     expiryDate: calculateExpiryDate(paymentRequest.createdAt),

--- a/api.planx.uk/notify/routeSendEmailRequest.test.ts
+++ b/api.planx.uk/notify/routeSendEmailRequest.test.ts
@@ -3,7 +3,6 @@ import app from "../server";
 import { queryMock } from "../tests/graphqlQueryMock";
 import {
   mockFlow,
-  mockGetHumanReadableProjectType,
   mockLowcalSession,
   mockSetupEmailNotifications,
   mockSoftDeleteLowcalSession,
@@ -14,10 +13,17 @@ import {
 const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk";
 const SAVE_ENDPOINT = "/send-email/save";
 
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    CoreDomainClient: jest.fn().mockImplementation(() => ({
+      formatRawProjectTypes: jest.fn().mockResolvedValue(["New office premises"]),
+    }))
+  }
+});
+
 describe("Send Email endpoint", () => {
   beforeEach(() => {
     queryMock.reset();
-    queryMock.mockQuery(mockGetHumanReadableProjectType);
     queryMock.mockQuery(mockValidateSingleSessionRequest);
     queryMock.mockQuery(mockSoftDeleteLowcalSession);
     queryMock.mockQuery(mockSetupEmailNotifications);
@@ -86,16 +92,6 @@ describe("Send Email endpoint", () => {
         data: {
           flows_by_pk: mockFlow,
           lowcal_sessions: [],
-        },
-      });
-
-      queryMock.mockQuery({
-        name: "GetHumanReadableProjectType",
-        data: {
-          project_types: [{ description: "New office premises" }],
-        },
-        variables: {
-          rawList: ["new.office"],
         },
       });
 
@@ -244,7 +240,6 @@ describe("Setting up send email events", () => {
 
   beforeEach(() => {
     queryMock.reset();
-    queryMock.mockQuery(mockGetHumanReadableProjectType);
     queryMock.mockQuery(mockSoftDeleteLowcalSession);
     queryMock.mockQuery(mockSetupEmailNotifications);
   });

--- a/api.planx.uk/saveAndReturn/resumeApplication.test.ts
+++ b/api.planx.uk/saveAndReturn/resumeApplication.test.ts
@@ -12,22 +12,17 @@ type DeepPartial<T> = T extends object ? {
   [P in keyof T]?: DeepPartial<T[P]>;
 } : T;
 
-describe("buildContentFromSessions function", () => {
+const mockFormatRawProjectTypes = jest.fn().mockResolvedValue(["New office premises"]);
 
-  beforeEach(() => {
-    queryMock.reset();
-    queryMock.mockQuery({
-      name: "GetHumanReadableProjectType",
-      data: {
-        project_types: [
-          { description: "New office premises" }
-        ],
-      },
-      variables: {
-        rawList: ["new.office"],
-      }
-    });
-  });
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    CoreDomainClient: jest.fn().mockImplementation(() => ({
+      formatRawProjectTypes: () => mockFormatRawProjectTypes(),
+    }))
+  }
+});
+
+describe("buildContentFromSessions function", () => {
 
   it("should return correctly formatted content for a single session", async () => {
     const sessions: DeepPartial<LowCalSession>[] = [{
@@ -150,6 +145,7 @@ describe("buildContentFromSessions function", () => {
   });
 
   it("should handle an empty project type field", async () => {
+    mockFormatRawProjectTypes.mockResolvedValueOnce("");
     const sessions: DeepPartial<LowCalSession>[] = [{
       data: {
         passport: {
@@ -157,7 +153,6 @@ describe("buildContentFromSessions function", () => {
             _address: {
               single_line_address: "1 High Street"
             },
-            // Missing project type
           }
         }
       },
@@ -179,21 +174,6 @@ describe("buildContentFromSessions function", () => {
 });
 
 describe("Resume Application endpoint", () => {
-
-  beforeEach(() => {
-    queryMock.reset();
-    queryMock.mockQuery({
-      name: "GetHumanReadableProjectType",
-      data: {
-        project_types: [
-          { description: "New office premises" }
-        ],
-      },
-      variables: {
-        rawList: ["new.office"],
-      }
-    });
-  });
 
   it("throws an error for if required data is missing", async () => {
 

--- a/api.planx.uk/saveAndReturn/resumeApplication.ts
+++ b/api.planx.uk/saveAndReturn/resumeApplication.ts
@@ -6,10 +6,10 @@ import {
   convertSlugToName,
   getResumeLink,
   calculateExpiryDate,
-  getHumanReadableProjectType,
 } from "./utils";
 import { sendEmail } from "../notify/utils";
 import type { SiteAddress } from "@opensystemslab/planx-core/types";
+import { _admin } from '../client';
 
 /**
  * Send a "Resume" email to an applicant which list all open applications for a given council (team)
@@ -125,9 +125,7 @@ const buildContentFromSessions = async (
     const address: SiteAddress | undefined =
       session.data?.passport?.data?._address;
     const addressLine = address?.single_line_address || address?.title;
-    const projectType = await getHumanReadableProjectType(
-      session?.data?.passport?.data
-    );
+    const projectType = await _admin.formatRawProjectTypes(session.data?.passport?.data?.["proposal.projectType"])
     const resumeLink = getResumeLink(session, team, session.flow.slug);
     const expiryDate = calculateExpiryDate(session.created_at);
 

--- a/api.planx.uk/saveAndReturn/utils.ts
+++ b/api.planx.uk/saveAndReturn/utils.ts
@@ -2,11 +2,11 @@ import { SiteAddress } from "@opensystemslab/planx-core/types";
 import { format, addDays } from "date-fns";
 import { gql } from "graphql-request";
 import {
-  publicGraphQLClient as publicClient,
   adminGraphQLClient as adminClient,
 } from "../hasura";
 import { LowCalSession, Team } from "../types";
 import { Template, getClientForTemplate, sendEmail } from "../notify/utils";
+import { _admin } from "../client";
 
 const DAYS_UNTIL_EXPIRY = 28;
 
@@ -138,7 +138,7 @@ interface SessionDetails {
 const getSessionDetails = async (
   session: LowCalSession
 ): Promise<SessionDetails> => {
-  const projectTypes = await getHumanReadableProjectType(session?.data?.passport?.data);
+  const projectTypes = await _admin.formatRawProjectTypes(session.data.passport?.data?.["proposal.projectType"]);
   const address: SiteAddress | undefined = session.data?.passport?.data?._address;
   const addressLine = address?.single_line_address || address?.title;
 
@@ -215,46 +215,6 @@ const markSessionAsSubmitted = async (sessionId: string) => {
 };
 
 /**
- * Get formatted list of the session's project types
- */
-const getHumanReadableProjectType = async (
-  sessionData: LowCalSession["data"]["passport"]["data"] | Record<string, any>
-): Promise<string | undefined> => {
-  const rawProjectType =
-    sessionData?.["proposal.projectType"];
-  if (!rawProjectType) return;
-  // Get human readable values from db
-  const humanReadableList = await getReadableProjectTypeFromRaw(rawProjectType);
-  // Join in readable format - en-US ensures we use Oxford commas
-  const formatter = new Intl.ListFormat("en-US", { type: "conjunction" });
-  const joinedList = formatter.format(humanReadableList);
-  // Convert first character to uppercase
-  const humanReadableString =
-    joinedList.charAt(0).toUpperCase() + joinedList.slice(1);
-  return humanReadableString;
-};
-
-/**
- * Query DB to get human readable project type values, based on passport variables
- */
-const getReadableProjectTypeFromRaw = async (
-  rawList: string[]
-): Promise<string[]> => {
-  const query = gql`
-    query GetHumanReadableProjectType($rawList: [String!]) {
-      project_types(where: { value: { _in: $rawList } }) {
-        description
-      }
-    }
-  `;
-  const { project_types } = await publicClient.request(query, { rawList });
-  const list = project_types.map(
-    (result: { description: string }) => result.description
-  );
-  return list;
-};
-
-/**
  * Scope Save & Return requests for Public role
  * SessionId and Email is required to access a lowcal_sessions record
  */
@@ -298,6 +258,5 @@ export {
   markSessionAsSubmitted,
   DAYS_UNTIL_EXPIRY,
   calculateExpiryDate,
-  getHumanReadableProjectType,
   softDeleteSession,
 };

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -145,15 +145,3 @@ export const validatePaymentRequestNotFoundQueryMock = {
     paymentRequestId: "123-wrong-456",
   },
 };
-
-export const getHumanReadableProjectTypeQueryMock = {
-  name: "GetHumanReadableProjectType",
-  data: {
-    project_types: [
-      { description: "New office premises" }
-    ],
-  },
-  variables: {
-    rawList: ["new.office"],
-  }
-};

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -120,16 +120,6 @@ export const mockGetFlowDiff = (diff: Flow["data"] | null) => ({
   matchOnVariables: false,
 });
 
-export const mockGetHumanReadableProjectType = {
-  name: "GetHumanReadableProjectType",
-  data: {
-    project_types: [{ description: "New office premises" }],
-  },
-  variables: {
-    rawList: ["new.office"],
-  },
-};
-
 export const mockValidateSingleSessionRequest = {
   name: "ValidateSingleSessionRequest",
   data: {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#80a2178",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#077fe4b",
     "axios": "^1.3.6",
     "dotenv": "^16.0.3",
     "graphql": "^16.6.0",

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#80a2178
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#077fe4b
   '@playwright/test': ^1.28.1
   '@types/dotenv': ^8.2.0
   '@types/node': ^18.16.0
@@ -19,7 +19,7 @@ specifiers:
   typescript: ^4.9.5
 
 dependencies:
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/80a2178
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/077fe4b
   axios: 1.3.6
   dotenv: 16.0.3
   graphql: 16.6.0
@@ -2565,8 +2565,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/80a2178:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/80a2178}
+  github.com/theopensystemslab/planx-core/077fe4b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/077fe4b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/styles": "5.11.9",
     "@mui/utils": "5.11.9",
     "@opensystemslab/map": "^0.7.4",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#80a2178",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#077fe4b",
     "@opensystemslab/planx-document-templates": "github:theopensystemslab/planx-document-templates#debaeca",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -60,7 +60,7 @@ specifiers:
   '@mui/styles': 5.11.9
   '@mui/utils': 5.11.9
   '@opensystemslab/map': ^0.7.4
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#80a2178
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#077fe4b
   '@opensystemslab/planx-document-templates': github:theopensystemslab/planx-document-templates#debaeca
   '@react-theming/storybook-addon': ^1.1.10
   '@storybook/addon-actions': ^6.5.16
@@ -203,7 +203,7 @@ dependencies:
   '@mui/styles': 5.11.9_yuz6bkerhkjfjuf6zeb7j6ybc4
   '@mui/utils': 5.11.9_react@18.2.0
   '@opensystemslab/map': 0.7.4
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/80a2178_swbholdm6gktzi6tajgqaxwuv4
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/077fe4b_swbholdm6gktzi6tajgqaxwuv4
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_swbholdm6gktzi6tajgqaxwuv4
   '@tiptap/core': 2.0.3_@tiptap+pm@2.0.3
   '@tiptap/extension-bold': 2.0.3_@tiptap+core@2.0.3
@@ -20182,9 +20182,9 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/theopensystemslab/planx-core/80a2178_swbholdm6gktzi6tajgqaxwuv4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/80a2178}
-    id: github.com/theopensystemslab/planx-core/80a2178
+  github.com/theopensystemslab/planx-core/077fe4b_swbholdm6gktzi6tajgqaxwuv4:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/077fe4b}
+    id: github.com/theopensystemslab/planx-core/077fe4b
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/editor.planx.uk/src/pages/Pay/MakePayment.tsx
+++ b/editor.planx.uk/src/pages/Pay/MakePayment.tsx
@@ -4,6 +4,7 @@ import { lighten, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { PaymentRequest } from "@opensystemslab/planx-core/types";
 import axios from "axios";
+import { _public } from "client";
 import { format } from "date-fns";
 import { getExpiryDateForPaymentRequest } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -167,6 +168,18 @@ export default function MakePayment({
     );
 
   const PaymentDetails = () => {
+    const [projectType, setProjectType] = useState<string | undefined>();
+
+    useEffect(() => {
+      const fetchProjectType = async () => {
+        const projectType = await _public.formatRawProjectTypes(
+          rawProjectTypes
+        );
+        setProjectType(projectType);
+      };
+      fetchProjectType();
+    }, []);
+
     const data = [
       { term: "Application type", details: flowName },
       {
@@ -179,7 +192,7 @@ export default function MakePayment({
       },
       {
         term: "Project type",
-        details: rawProjectTypes.join(", "),
+        details: projectType || "Project type not submitted",
       },
     ];
 


### PR DESCRIPTION
## What does this PR do?
 - Picks up formatted project types from `planx-core` for Invite to pay, and Save and Return emails
 - Updates tests and mocks