### PR TITLE
fix: Allow public access (with headers) to new `payment_requests` columns

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -361,7 +361,9 @@
         columns:
           - applicant_name
           - created_at
+          - govpay_payment_id
           - id
+          - paid_at
           - payment_amount
           - session_preview_data
         filter:


### PR DESCRIPTION
This issue has caught me out on a number of previous occasions... 🤦 

`paid_at` and `govpay_payment_id` columns were added to the `payment_requests` table, but the permissions for the public role was not updated at the same time.

This means that certain pages/routes fail if you're logged out as the public role does not have access to these columns. Both are required to handle payment completion, and to display meaningful data to the user. 

Test links - 
 - Nominee confirmation page - https://1670.planx.pizza/buckinghamshire/invite-to-pay-test/pay?paymentRequestId=1a4d21f2-439b-4e3a-a3fa-255f78754ded 
 - Applicant confirmation page - https://1670.planx.pizza/buckinghamshire/invite-to-pay-test/pay/invite?paymentRequestId=1a4d21f2-439b-4e3a-a3fa-255f78754ded

If the `INVITE_TO_PAY` feature flag is not enabled, you'll get a page not found error with the following in the console - `URL not found: /pay`
