### PR TITLE
feat: add all section statuses

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,8 +4,8 @@ on:
     types:
       - opened
       - synchronize
-    branches:
-      - main
+    branches-ignore:
+      - production
 
 env:
   DOMAIN: planx.pizza

--- a/e2e/src/flows/sections-flow.ts
+++ b/e2e/src/flows/sections-flow.ts
@@ -4,89 +4,94 @@ import type { FlowGraph } from "@opensystemslab/planx-core/types";
 export const flow: FlowGraph = {
   _root: {
     edges: [
-      "XBZN1QCNo9",
-      "3DI2GtpCAb",
-      "4veEdqnLTW",
-      "Z1R1LRmLbY",
-      "vPr0ukG8JE",
-      "pWCcG9ToZY",
-      "Fz3VuXRlTb",
-      "NUpGwW4Pqe",
-      "rZePKmcD73",
+      "Section1",
+      "Question1",
+      "Section2",
+      "Question2",
+      "EndOfSection2Notice",
+      "Section3",
+      "PreSendContent",
+      "Send",
+      "Confirmation",
     ],
   },
-  "1hJpwGw4Je": {
+  ChecklistOptionC: {
     data: { text: "C" },
     type: ComponentType.Answer,
-    edges: ["7URtB1N5zG"],
+    edges: ["NoticeC"],
   },
-  "3DI2GtpCAb": {
+  Question1: {
     data: { text: "Question 1" },
     type: ComponentType.Question,
-    edges: ["kLK7wbmOEZ", "5bebjoffUb", "JHLgiz66t4"],
+    edges: ["Question1AnswerA", "Question1AnswerB", "Question1AnswerC"],
   },
-  "4veEdqnLTW": { data: { title: "Section Two" }, type: ComponentType.Section },
-  "5bebjoffUb": { data: { text: "B" }, type: ComponentType.Answer },
-  "7URtB1N5zG": {
+  Section2: { data: { title: "Section Two" }, type: ComponentType.Section },
+  Question1AnswerB: { data: { text: "B" }, type: ComponentType.Answer },
+  NoticeC: {
     data: { color: "#EFEFEF", title: "Reached C", resetButton: false },
     type: ComponentType.Notice,
   },
-  Fz3VuXRlTb: {
+  PreSendContent: {
     data: { content: "<p>About to send</p>" },
     type: ComponentType.Content,
   },
-  JHLgiz66t4: { data: { text: "C" }, type: ComponentType.Answer },
-  NUFNkSkxqR: {
+  Question1AnswerC: { data: { text: "C" }, type: ComponentType.Answer },
+  NoticeB: {
     data: { color: "#EFEFEF", title: "Reached B", resetButton: false },
     type: ComponentType.Notice,
   },
-  NUpGwW4Pqe: {
+  Send: {
     data: { title: "Send", destinations: ["email"] },
     type: ComponentType.Send,
   },
-  OzCQoqgcAs: {
+  NoticeD: {
     data: { color: "#EFEFEF", title: "Reached D", resetButton: false },
     type: ComponentType.Notice,
   },
-  PErULqxbIf: {
+  NoticeA: {
     data: { color: "#EFEFEF", title: "Reached A", resetButton: false },
     type: ComponentType.Notice,
   },
-  SBzvpSq8DD: {
+  ChecklistOptionB: {
     data: { text: "B" },
     type: ComponentType.Answer,
-    edges: ["NUFNkSkxqR"],
+    edges: ["NoticeB"],
   },
-  T1X91EICsC: {
+  Checklist1: {
     data: { text: "Multi-select", allRequired: false },
     type: ComponentType.Checklist,
-    edges: ["oLkOyC2LeL", "SBzvpSq8DD", "1hJpwGw4Je", "WdKErxvyoo"],
+    edges: [
+      "ChecklistOptionA",
+      "ChecklistOptionB",
+      "ChecklistOptionC",
+      "ChecklistOptionD",
+    ],
   },
-  WMwJZHKJE3: { data: { text: "A" }, type: ComponentType.Answer },
-  WdKErxvyoo: {
+  Question2AnswerA: { data: { text: "A" }, type: ComponentType.Answer },
+  ChecklistOptionD: {
     data: { text: "D" },
     type: ComponentType.Answer,
-    edges: ["OzCQoqgcAs"],
+    edges: ["NoticeD"],
   },
-  XBZN1QCNo9: { data: { title: "Section One" }, type: ComponentType.Section },
-  Z1R1LRmLbY: {
+  Section1: { data: { title: "Section One" }, type: ComponentType.Section },
+  Question2: {
     data: { text: "Question 2" },
     type: ComponentType.Question,
-    edges: ["WMwJZHKJE3", "nSBYMoHnwE"],
+    edges: ["Question2AnswerA", "Question2AnswerB"],
   },
-  kLK7wbmOEZ: { data: { text: "A" }, type: ComponentType.Answer },
-  nSBYMoHnwE: {
+  Question1AnswerA: { data: { text: "A" }, type: ComponentType.Answer },
+  Question2AnswerB: {
     data: { text: "B" },
     type: ComponentType.Answer,
-    edges: ["T1X91EICsC"],
+    edges: ["Checklist1"],
   },
-  oLkOyC2LeL: {
+  ChecklistOptionA: {
     data: { text: "A" },
     type: ComponentType.Answer,
-    edges: ["PErULqxbIf"],
+    edges: ["NoticeA"],
   },
-  pWCcG9ToZY: { data: { title: "Section Three" }, type: ComponentType.Section },
-  rZePKmcD73: {
+  Section3: { data: { title: "Section Three" }, type: ComponentType.Section },
+  Confirmation: {
     data: {
       heading: "Application sent",
       moreInfo: "<h2>You will be contacted</h2>",
@@ -94,7 +99,7 @@ export const flow: FlowGraph = {
     },
     type: ComponentType.Confirmation,
   },
-  vPr0ukG8JE: {
+  EndOfSection2Notice: {
     data: {
       color: "#EFEFEF",
       title: "Reached the end of section two",
@@ -102,4 +107,10 @@ export const flow: FlowGraph = {
     },
     type: ComponentType.Notice,
   },
+};
+
+export const updatedQuestionAnswers = {
+  Question1AnswerA: { data: { text: "Aaa" }, type: ComponentType.Answer },
+  Question1AnswerB: { data: { text: "Bee" }, type: ComponentType.Answer },
+  Question1AnswerC: { data: { text: "Cee" }, type: ComponentType.Answer },
 };

--- a/e2e/src/save-and-return.spec.ts
+++ b/e2e/src/save-and-return.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { GraphQLClient, gql } from "graphql-request";
+import { gql } from "graphql-request";
 import {
   simpleSendFlow,
   modifiedSimpleSendFlow,
@@ -81,7 +81,7 @@ test.describe("Save and return", () => {
       await clickContinue({ page, waitForResponse: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       const sessionId = await saveSession({ page, context });
       if (!sessionId) test.fail();
@@ -106,7 +106,7 @@ test.describe("Save and return", () => {
       await clickContinue({ page, waitForResponse: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       let secondQuestion = await findQuestion({ page, title: "Question 2" });
       await expect(secondQuestion).toBeVisible();
@@ -131,7 +131,7 @@ test.describe("Save and return", () => {
       await clickContinue({ page, waitForResponse: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       let secondQuestion = await findQuestion({ page, title: "Question 2" });
       await expect(secondQuestion).toBeVisible();
@@ -156,7 +156,7 @@ test.describe("Save and return", () => {
       await clickContinue({ page, waitForResponse: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       const secondQuestion = await findQuestion({ page, title: "Question 2" });
       await expect(secondQuestion).toBeVisible();

--- a/e2e/src/sections.spec.ts
+++ b/e2e/src/sections.spec.ts
@@ -26,7 +26,7 @@ import type { FlowGraph } from "@opensystemslab/planx-core/types";
 export enum SectionStatus {
   NeedsUpdated = "NEW INFORMATION NEEDED",
   ReadyToContinue = "READY TO CONTINUE",
-  Started = "STARTED",
+  Started = "CANNOT CONTINUE YET",
   ReadyToStart = "READY TO START",
   NotStarted = "CANNOT START YET",
   Completed = "COMPLETED",

--- a/e2e/src/sections.spec.ts
+++ b/e2e/src/sections.spec.ts
@@ -22,7 +22,7 @@ import type { Context } from "./context";
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
 
 // TODO: move this type to planx-core
-// also defined in editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+// also defined in editor.planx.uk/src/types.ts
 export enum SectionStatus {
   NeedsUpdated = "NEW INFORMATION NEEDED",
   ReadyToContinue = "READY TO CONTINUE",
@@ -51,7 +51,6 @@ test.describe("Sections", () => {
       data: flow,
     },
   };
-  const previewURL = `/${context.team?.slug}/${context.flow?.slug}/preview?analytics=false`;
 
   test.beforeAll(async () => {
     try {
@@ -62,6 +61,12 @@ test.describe("Sections", () => {
     }
   });
 
+  test.beforeEach(async ({ page }) => {
+    const previewURL = `/${context.team?.slug}/${context.flow?.slug}/preview?analytics=false`;
+    await page.goto(previewURL);
+    await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
+  });
+
   test.afterAll(async () => {
     await tearDownTestContext(context);
   });
@@ -70,9 +75,6 @@ test.describe("Sections", () => {
     test("not started, ready to start and complete statuses", async ({
       page,
     }) => {
-      await page.goto(previewURL);
-      await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
-
       await fillInEmail({ page, context });
       await clickContinue({ page, waitForResponse: true });
 
@@ -93,10 +95,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectSections({
         page,
@@ -115,29 +117,29 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 2", answer: "B" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerChecklist({
         page,
         title: "Multi-select",
         answers: ["B", "C", "D"],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectNotice({ page, text: "Reached B" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectNotice({ page, text: "Reached C" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectNotice({ page, text: "Reached D" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectNotice({ page, text: "Reached the end of section two" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectSections({
         page,
@@ -156,18 +158,15 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       // send
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectConfirmation({ page, text: "Application Sent" });
     });
 
     test("started and ready to continue", async ({ page }) => {
-      await page.goto(previewURL);
-      await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
-
       await fillInEmail({ page, context });
       await clickContinue({ page, waitForResponse: true });
 
@@ -188,10 +187,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectSections({
         page,
@@ -210,10 +209,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 2", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       // back to Question 2
       await clickBack({ page });
@@ -238,13 +237,13 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       // skip Question 2
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       // skip end of section 2 notice
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectSections({
         page,
@@ -263,7 +262,7 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       // back to Section Three Overview
       await clickBack({ page });
@@ -325,11 +324,8 @@ test.describe("Sections", () => {
     test("not started, ready to start and complete statuses", async ({
       page,
     }) => {
-      await page.goto(previewURL);
-      await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
-
       await fillInEmail({ page, context });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForResponse: true });
 
       await expectSections({
         page,
@@ -348,10 +344,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       const sectionsBeforeSaveAndReturn = [
         {
@@ -385,11 +381,8 @@ test.describe("Sections", () => {
     });
 
     test("the ready to continue status", async ({ page }) => {
-      await page.goto(previewURL);
-      await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
-
       await fillInEmail({ page, context });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForResponse: true });
 
       await expectSections({
         page,
@@ -408,10 +401,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectSections({
         page,
@@ -430,10 +423,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 2", answer: "B" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       const sessionId = await saveSession({ page, context });
       if (!sessionId) test.fail();
@@ -462,11 +455,8 @@ test.describe("Sections", () => {
 
   test.describe("save and return with service changes (reconciliation)", () => {
     test("needs new information and started", async ({ page }) => {
-      await page.goto(previewURL);
-      await page.evaluate('featureFlags.toggle("NAVIGATION_UI")');
-
       await fillInEmail({ page, context });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForResponse: true });
 
       await expectSections({
         page,
@@ -485,10 +475,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 1", answer: "A" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await expectSections({
         page,
@@ -507,10 +497,10 @@ test.describe("Sections", () => {
           },
         ],
       });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       await answerQuestion({ page, title: "Question 2", answer: "B" });
-      await clickContinue({ page });
+      await clickContinue({ page, waitForLogEvent: true });
 
       const sessionId = await saveSession({ page, context });
       if (!sessionId) test.fail();

--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -1,8 +1,8 @@
 import { screen } from "@testing-library/react";
 import { toggleFeatureFlag } from "lib/featureFlags";
-import { SectionStatus } from "pages/FlowEditor/lib/store/navigation";
 import React from "react";
 import { axe, setup } from "testUtils";
+import { SectionStatus } from "types";
 
 import Section, { SectionsOverviewList } from "./Public";
 
@@ -66,19 +66,26 @@ describe("SectionsOverviewList component", () => {
       },
     },
   };
-  const mockSectionStatuses = {
-    section1: SectionStatus.Completed,
-    section2: SectionStatus.Started,
-    section3: SectionStatus.NotStarted,
-  };
   const defaultProps = {
     sectionNodes: mockSectionNodes,
-    sectionStatuses: mockSectionStatuses,
     showChange: true,
+    isReconciliation: false,
+    currentCard: null,
+    breadcrumbs: {
+      section1: {
+        auto: false,
+      },
+      firstQuestion: {
+        auto: false,
+        answers: ["firstAnswer"],
+      },
+      secondSection: {
+        auto: false,
+      },
+    },
   };
 
   it("renders correctly when the NAVIGATION_UI feature flag is toggled on", () => {
-    toggleFeatureFlag("NAVIGATION_UI");
     setup(<SectionsOverviewList {...defaultProps} />);
 
     expect(screen.getByText("Section one")).toBeInTheDocument();
@@ -86,7 +93,7 @@ describe("SectionsOverviewList component", () => {
     expect(screen.getByText(SectionStatus.Completed)).toBeInTheDocument();
 
     expect(screen.getByText("Section two")).toBeInTheDocument();
-    expect(screen.getByText(SectionStatus.Started)).toBeInTheDocument();
+    expect(screen.getByText(SectionStatus.ReadyToStart)).toBeInTheDocument();
 
     expect(screen.getByText("Section three")).toBeInTheDocument();
     expect(screen.getByText(SectionStatus.NotStarted)).toBeInTheDocument();

--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -68,7 +68,7 @@ describe("SectionsOverviewList component", () => {
   };
   const mockSectionStatuses = {
     section1: SectionStatus.Completed,
-    section2: SectionStatus.InProgress,
+    section2: SectionStatus.Started,
     section3: SectionStatus.NotStarted,
   };
   const defaultProps = {
@@ -86,7 +86,7 @@ describe("SectionsOverviewList component", () => {
     expect(screen.getByText(SectionStatus.Completed)).toBeInTheDocument();
 
     expect(screen.getByText("Section two")).toBeInTheDocument();
-    expect(screen.getByText(SectionStatus.InProgress)).toBeInTheDocument();
+    expect(screen.getByText(SectionStatus.Started)).toBeInTheDocument();
 
     expect(screen.getByText("Section three")).toBeInTheDocument();
     expect(screen.getByText(SectionStatus.NotStarted)).toBeInTheDocument();

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -133,10 +133,12 @@ export function SectionsOverviewList(props: SectionsOverviewListProps) {
 
 const getTagBackgroundColor = (theme: Theme, title: string): string => {
   const backgroundColors: Record<string, string> = {
-    [SectionStatus.NotStarted]: theme.palette.grey[200],
-    [SectionStatus.InProgress]: lighten(theme.palette.primary.main, 0.9),
-    [SectionStatus.Completed]: theme.palette.success.main,
     [SectionStatus.NeedsUpdated]: theme.palette.action.focus, // GOV UK YELLOW for now, check Figma
+    [SectionStatus.ReadyToContinue]: lighten(theme.palette.primary.main, 0.9),
+    [SectionStatus.ReadyToStart]: lighten(theme.palette.primary.main, 0.9),
+    [SectionStatus.Started]: lighten(theme.palette.primary.main, 0.8),
+    [SectionStatus.NotStarted]: theme.palette.grey[200],
+    [SectionStatus.Completed]: theme.palette.success.main,
   };
 
   return backgroundColors[title];
@@ -144,12 +146,14 @@ const getTagBackgroundColor = (theme: Theme, title: string): string => {
 
 const getTagTextColor = (theme: Theme, title: string): string => {
   const textColors: Record<string, string> = {
+    [SectionStatus.NeedsUpdated]: "#000",
+    [SectionStatus.ReadyToContinue]: "#000",
+    [SectionStatus.ReadyToStart]: "#000",
+    [SectionStatus.Started]: theme.palette.primary.main,
     [SectionStatus.NotStarted]: theme.palette.getContrastText(
       theme.palette.grey[200]
     ),
-    [SectionStatus.InProgress]: theme.palette.primary.main,
     [SectionStatus.Completed]: "#FFF",
-    [SectionStatus.NeedsUpdated]: "#000",
   };
 
   return textColors[title];

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -5,16 +5,14 @@ import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import type { PublicProps } from "@planx/components/ui";
 import { hasFeatureFlag } from "lib/featureFlags";
-import { useStore } from "pages/FlowEditor/lib/store";
-import {
-  SectionNode,
-  SectionStatus,
-} from "pages/FlowEditor/lib/store/navigation";
+import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect } from "react";
+import { SectionNode, SectionStatus } from "types";
 
 import Card from "../shared/Preview/Card";
 import QuestionHeader from "../shared/Preview/QuestionHeader";
 import type { Section } from "./model";
+import { computeSectionStatuses } from "./model";
 
 export type Props = PublicProps<Section>;
 
@@ -26,18 +24,20 @@ export default function Component(props: Props) {
     currentSectionIndex,
     sectionCount,
     sectionNodes,
-    sectionStatuses,
     currentCard,
     changeAnswer,
+    breadcrumbs,
+    cachedBreadcrumbs,
   ] = useStore((state) => [
     state.flow,
     state.flowName,
     state.currentSectionIndex,
     state.sectionCount,
     state.sectionNodes,
-    state.sectionStatuses(),
     state.currentCard(),
     state.changeAnswer,
+    state.breadcrumbs,
+    state.cachedBreadcrumbs,
   ]);
 
   useEffect(() => {
@@ -72,29 +72,46 @@ export default function Component(props: Props) {
         </Typography>
       </Box>
       <SectionsOverviewList
-        sectionNodes={sectionNodes}
-        sectionStatuses={sectionStatuses}
         showChange={true}
         changeFirstAnswerInSection={changeFirstAnswerInSection}
+        sectionNodes={sectionNodes}
+        currentCard={currentCard}
+        breadcrumbs={breadcrumbs}
+        cachedBreadcrumbs={cachedBreadcrumbs}
       />
     </Card>
   );
 }
 
-interface SectionsOverviewListProps {
-  sectionNodes: Record<string, SectionNode>;
-  sectionStatuses: Record<string, SectionStatus>;
+type SectionsOverviewListProps = {
   showChange: boolean;
   changeFirstAnswerInSection?: (sectionId: string) => void;
-}
+  sectionNodes: Record<string, SectionNode>;
+  currentCard: Store.node | null;
+  breadcrumbs: Store.breadcrumbs;
+  cachedBreadcrumbs?: Store.cachedBreadcrumbs;
+  isReconciliation?: boolean;
+  alteredSectionIds?: string[];
+};
 
-export function SectionsOverviewList(props: SectionsOverviewListProps) {
-  const {
+export function SectionsOverviewList({
+  showChange,
+  changeFirstAnswerInSection,
+  sectionNodes,
+  currentCard,
+  breadcrumbs,
+  cachedBreadcrumbs,
+  isReconciliation,
+  alteredSectionIds,
+}: SectionsOverviewListProps) {
+  const sectionStatuses = computeSectionStatuses({
     sectionNodes,
-    sectionStatuses,
-    showChange,
-    changeFirstAnswerInSection,
-  } = props;
+    currentCard,
+    breadcrumbs,
+    cachedBreadcrumbs,
+    isReconciliation,
+    alteredSectionIds,
+  });
 
   return (
     <DescriptionList>

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
-import { lighten, styled, Theme } from "@mui/material/styles";
+import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import type { PublicProps } from "@planx/components/ui";
@@ -150,12 +150,12 @@ export function SectionsOverviewList({
 
 const getTagBackgroundColor = (theme: Theme, title: string): string => {
   const backgroundColors: Record<string, string> = {
-    [SectionStatus.NeedsUpdated]: theme.palette.action.focus, // GOV UK YELLOW for now, check Figma
-    [SectionStatus.ReadyToContinue]: lighten(theme.palette.primary.main, 0.9),
-    [SectionStatus.ReadyToStart]: lighten(theme.palette.primary.main, 0.9),
-    [SectionStatus.Started]: lighten(theme.palette.primary.main, 0.8),
-    [SectionStatus.NotStarted]: theme.palette.grey[200],
-    [SectionStatus.Completed]: theme.palette.success.main,
+    [SectionStatus.NeedsUpdated]: "#FAFF00",
+    [SectionStatus.ReadyToContinue]: "#E8F1EC",
+    [SectionStatus.ReadyToStart]: "#E8F1EC",
+    [SectionStatus.Started]: theme.palette.background.paper,
+    [SectionStatus.NotStarted]: theme.palette.background.paper,
+    [SectionStatus.Completed]: theme.palette.success.dark,
   };
 
   return backgroundColors[title];
@@ -163,14 +163,12 @@ const getTagBackgroundColor = (theme: Theme, title: string): string => {
 
 const getTagTextColor = (theme: Theme, title: string): string => {
   const textColors: Record<string, string> = {
-    [SectionStatus.NeedsUpdated]: "#000",
-    [SectionStatus.ReadyToContinue]: "#000",
-    [SectionStatus.ReadyToStart]: "#000",
-    [SectionStatus.Started]: theme.palette.primary.main,
-    [SectionStatus.NotStarted]: theme.palette.getContrastText(
-      theme.palette.grey[200]
-    ),
-    [SectionStatus.Completed]: "#FFF",
+    [SectionStatus.NeedsUpdated]: theme.palette.text.primary,
+    [SectionStatus.ReadyToContinue]: theme.palette.success.dark,
+    [SectionStatus.ReadyToStart]: theme.palette.success.dark,
+    [SectionStatus.Started]: theme.palette.text.secondary,
+    [SectionStatus.NotStarted]: theme.palette.text.secondary,
+    [SectionStatus.Completed]: "#FFFFF",
   };
 
   return textColors[title];

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -168,7 +168,7 @@ const getTagTextColor = (theme: Theme, title: string): string => {
     [SectionStatus.ReadyToStart]: theme.palette.success.dark,
     [SectionStatus.Started]: theme.palette.text.secondary,
     [SectionStatus.NotStarted]: theme.palette.text.secondary,
-    [SectionStatus.Completed]: "#FFFFF",
+    [SectionStatus.Completed]: "#FFFFFF",
   };
 
   return textColors[title];

--- a/editor.planx.uk/src/@planx/components/Section/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.test.ts
@@ -1,0 +1,150 @@
+import { TYPES } from "@planx/components/types";
+import { SectionNode, SectionStatus } from "types";
+
+import { computeSectionStatuses } from "./model";
+
+const flowSections: { [key: string]: SectionNode } = {
+  firstSection: {
+    data: {
+      title: "First section",
+    },
+    type: TYPES.Section,
+  },
+  secondSection: {
+    data: {
+      title: "Second section",
+    },
+    type: TYPES.Section,
+  },
+  thirdSection: {
+    data: {
+      title: "Third section",
+    },
+    type: TYPES.Section,
+  },
+};
+
+describe("computeSectionStatuses", () => {
+  test("the initial statuses of a flow with sections", () => {
+    // Get initial statuses
+    const statuses = computeSectionStatuses({
+      sectionNodes: flowSections,
+      currentCard: null,
+      breadcrumbs: {},
+    });
+
+    // There's a status entry per section node in the test flow
+    expect(Object.keys(statuses)).toHaveLength(3);
+
+    // Initial statuses are calculated correctly
+    expect(statuses).toEqual({
+      firstSection: SectionStatus.ReadyToStart,
+      secondSection: SectionStatus.NotStarted,
+      thirdSection: SectionStatus.NotStarted,
+    });
+  });
+
+  test("the status of sections in a flow as you navigate forwards", () => {
+    // Get statuses
+    const statuses = computeSectionStatuses({
+      sectionNodes: flowSections,
+      currentCard: null,
+      breadcrumbs: {
+        firstSection: { auto: false },
+        firstQuestion: { answers: ["firstAnswer"] },
+      },
+    });
+
+    // Confirm statuses have been updated correctly
+    expect(statuses).toEqual({
+      firstSection: SectionStatus.Completed,
+      secondSection: SectionStatus.ReadyToStart,
+      thirdSection: SectionStatus.NotStarted,
+    });
+
+    const newStatuses = computeSectionStatuses({
+      sectionNodes: flowSections,
+      currentCard: null,
+      breadcrumbs: {
+        firstSection: { auto: false },
+        firstQuestion: { answers: ["firstAnswer"] },
+        secondSection: { auto: false },
+        secondQuestion: { answers: ["secondAnswer"] },
+      },
+    });
+
+    // Confirm statuses have been updated correctly
+    expect(newStatuses).toEqual({
+      firstSection: SectionStatus.Completed,
+      secondSection: SectionStatus.Completed,
+      thirdSection: SectionStatus.ReadyToStart,
+    });
+  });
+
+  test("a section was updated during reconciliation", () => {
+    // breadcrumbs and alteredSectionIds are passed in at reconciliation
+    const statuses = computeSectionStatuses({
+      sectionNodes: flowSections,
+      isReconciliation: true,
+      currentCard: {
+        id: "firstQuestion",
+      },
+      breadcrumbs: {
+        firstSection: { auto: false },
+        firstQuestion: { answers: ["firstAnswer"] },
+      },
+      alteredSectionIds: ["firstSection"],
+    });
+
+    expect(statuses).toEqual({
+      firstSection: SectionStatus.NeedsUpdated, // no longer considered Completed
+      secondSection: SectionStatus.NotStarted,
+      thirdSection: SectionStatus.NotStarted,
+    });
+  });
+
+  test("completed sections on reconciliation", () => {
+    const statuses = computeSectionStatuses({
+      sectionNodes: flowSections,
+      isReconciliation: true,
+      currentCard: {
+        id: "thirdSection",
+      },
+      breadcrumbs: {
+        firstSection: { auto: false },
+        firstQuestion: { answers: ["firstAnswer"] },
+        secondSection: { auto: false },
+        secondQuestion: { answers: ["secondAnswer"] },
+      },
+    });
+
+    expect(statuses).toEqual({
+      firstSection: SectionStatus.Completed,
+      secondSection: SectionStatus.Completed,
+      thirdSection: SectionStatus.ReadyToStart,
+    });
+  });
+
+  test("NEW INFORMATION NEEDED statuses on reconciliation", () => {
+    const statuses = computeSectionStatuses({
+      sectionNodes: flowSections,
+      isReconciliation: true,
+      currentCard: {
+        id: "firstQuestion",
+      },
+      breadcrumbs: {
+        firstSection: { auto: false },
+        firstQuestion: { answers: ["firstAnswer"] },
+        secondSection: { auto: false },
+        secondQuestion: { answers: ["secondAnswer"] },
+      },
+      alteredSectionIds: ["firstSection"],
+    });
+
+    expect(statuses).toEqual({
+      firstSection: SectionStatus.NeedsUpdated,
+      secondSection: SectionStatus.Started,
+      thirdSection: SectionStatus.NotStarted,
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -1,3 +1,6 @@
+import type { Store } from "pages/FlowEditor/lib/store";
+import { SectionNode, SectionStatus } from "types";
+
 import { MoreInformation, parseMoreInformation } from "../shared";
 
 export interface Section extends MoreInformation {
@@ -10,3 +13,71 @@ export const parseSection = (
   title: data?.title || "",
   ...parseMoreInformation(data),
 });
+
+export function computeSectionStatuses({
+  sectionNodes,
+  currentCard,
+  breadcrumbs,
+  cachedBreadcrumbs,
+  isReconciliation,
+  alteredSectionIds,
+}: {
+  sectionNodes: Record<string, SectionNode>;
+  currentCard: Store.node | null;
+  breadcrumbs: Store.breadcrumbs;
+  cachedBreadcrumbs?: Store.cachedBreadcrumbs;
+  isReconciliation?: boolean;
+  alteredSectionIds?: string[];
+}): Record<string, SectionStatus> {
+  const seenPastNodeIds = Object.keys({ ...breadcrumbs });
+  const seenUpcomingNodeIds = cachedBreadcrumbs
+    ? Object.keys({ ...cachedBreadcrumbs })
+    : [];
+  const allSeenNodeIds = [...seenPastNodeIds, ...seenUpcomingNodeIds];
+  const currentCardId = currentCard?.id;
+  const sectionNodeIds = Object.keys(sectionNodes);
+
+  let hasPastCurrentSection = false;
+  let sectionStatuses: Record<string, SectionStatus> = {};
+  for (const [index, sectionId] of Object.entries(sectionNodeIds)) {
+    // check for an altered sections
+    if (alteredSectionIds && alteredSectionIds!.includes(sectionId)) {
+      sectionStatuses[sectionId] = SectionStatus.NeedsUpdated;
+      hasPastCurrentSection = true;
+      continue;
+    }
+    // check for seen/current sections
+    if (!hasPastCurrentSection) {
+      const nextSectionId = sectionNodeIds.at(Number(index) + 1);
+      const seenNextSection =
+        nextSectionId && allSeenNodeIds.includes(nextSectionId);
+      if (
+        !allSeenNodeIds.includes(sectionId) ||
+        (isReconciliation && !seenNextSection && currentCardId === sectionId)
+      ) {
+        sectionStatuses[sectionId] = SectionStatus.ReadyToStart;
+        hasPastCurrentSection = true;
+      } else if (
+        seenUpcomingNodeIds.includes(sectionId) ||
+        (isReconciliation &&
+          !seenNextSection &&
+          currentCardId !== sectionId &&
+          !sectionNodeIds.includes(currentCardId!))
+      ) {
+        sectionStatuses[sectionId] = SectionStatus.ReadyToContinue;
+        hasPastCurrentSection = true;
+      } else {
+        sectionStatuses[sectionId] = SectionStatus.Completed;
+      }
+      continue;
+    }
+    // check for unseen sections
+    if (allSeenNodeIds.includes(sectionId)) {
+      sectionStatuses[sectionId] = SectionStatus.Started;
+    } else {
+      sectionStatuses[sectionId] = SectionStatus.NotStarted;
+    }
+  }
+
+  return sectionStatuses;
+}

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -114,7 +114,8 @@ const addSectionName = (
 ): QuestionMetaData => {
   const { hasSections, getSectionForNode } = useStore.getState();
   if (hasSections) {
-    metadata.section_name = getSectionForNode(id).data.title;
+    const section = getSectionForNode(id);
+    if (section?.data?.title) metadata.section_name = section.data.title;
   }
   return metadata;
 };

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -35,26 +35,20 @@ const ReconciliationPage: React.FC<Props> = ({
   buttonText,
   onButtonClick,
 }) => {
-  const [flow, hasSections, sectionNodes, sectionStatuses, changeAnswer] =
-    useStore((state) => [
+  const [flow, hasSections, sectionNodes, currentCard, changeAnswer] = useStore(
+    (state) => [
       state.flow,
       state.hasSections,
       state.sectionNodes,
-      state.sectionStatuses,
+      state.currentCard(),
       state.changeAnswer,
-    ]);
+    ]
+  );
 
   const sortedBreadcrumbs = sortBreadcrumbs(
     reconciliationResponse.reconciledSessionData.breadcrumbs,
     flow
   );
-
-  // Calculate the section statuses based on the response data from /validate-session, before it's been updated in app state
-  const reconciledSectionStatuses = sectionStatuses({
-    sortedBreadcrumbs,
-    isReconciliation: reconciliationResponse.changesFound !== null,
-    alteredSectionIds: reconciliationResponse.alteredSectionIds,
-  });
 
   const theme = useTheme();
   const classes = useStyles();
@@ -90,9 +84,12 @@ const ReconciliationPage: React.FC<Props> = ({
         </Typography>
         {hasSections ? (
           <SectionsOverviewList
-            sectionNodes={sectionNodes}
-            sectionStatuses={reconciledSectionStatuses}
+            alteredSectionIds={reconciliationResponse.alteredSectionIds}
             showChange={false}
+            isReconciliation={true}
+            sectionNodes={sectionNodes}
+            currentCard={currentCard}
+            breadcrumbs={sortedBreadcrumbs}
           />
         ) : (
           <SummaryListsBySections

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -50,10 +50,11 @@ const ReconciliationPage: React.FC<Props> = ({
   );
 
   // Calculate the section statuses based on the response data from /validate-session, before it's been updated in app state
-  const reconciledSectionStatuses = sectionStatuses(
+  const reconciledSectionStatuses = sectionStatuses({
     sortedBreadcrumbs,
-    reconciliationResponse.alteredSectionIds
-  );
+    isReconciliation: reconciliationResponse.changesFound !== null,
+    alteredSectionIds: reconciliationResponse.alteredSectionIds,
+  });
 
   const theme = useTheme();
   const classes = useStyles();

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -169,3 +169,18 @@ export interface ReconciliationResponse {
 // re-export store types
 export interface Passport extends Store.passport {}
 export interface Breadcrumbs extends Store.breadcrumbs {}
+
+export enum SectionStatus {
+  NeedsUpdated = "NEW INFORMATION NEEDED",
+  ReadyToContinue = "READY TO CONTINUE",
+  Started = "STARTED",
+  ReadyToStart = "READY TO START",
+  NotStarted = "CANNOT START YET",
+  Completed = "COMPLETED",
+}
+
+export interface SectionNode extends Store.node {
+  data: {
+    title: string;
+  };
+}

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -173,7 +173,7 @@ export interface Breadcrumbs extends Store.breadcrumbs {}
 export enum SectionStatus {
   NeedsUpdated = "NEW INFORMATION NEEDED",
   ReadyToContinue = "READY TO CONTINUE",
-  Started = "STARTED",
+  Started = "CANNOT CONTINUE YET",
   ReadyToStart = "READY TO START",
   NotStarted = "CANNOT START YET",
   Completed = "COMPLETED",


### PR DESCRIPTION
This PR changes and adds some new section states: 

Change:
 :heavy_minus_sign:  `NotStarted: "CANNOT CONTINUE YET"`
 :heavy_plus_sign:  `NotStarted: "CANNOT START YET"`
 
Change:
:heavy_minus_sign:  `InProgress: "READY TO CONTINUE"`
:heavy_plus_sign:   `ReadyToContinue: "READY TO CONTINUE"`
  
 Additions:
 :heavy_plus_sign: `Started: "CANNOT CONTINUE YET"`
 :heavy_plus_sign:  `ReadyToStart: "READY TO START"`
 
These may not be the final text for each sections but the focus of this PR is the functionality for each of these scenarios.
This ticket took a stab at styling the new statuses but any suggestions welcome (or that could be part of the clickable tags PR).

The PR adds some end-to-end tests and updates some unit tests for a `computeSectionStatuses` function. If you spot any scenarios not covered, please do suggest them.

Computing sections no longer requires a call to `upcomingCardIds()` which is a computationally expensive function so this _may_ resolve some performance issues.

Testing: 

This flow should allow all test scenarios (feel free to make edits if not): https://1674.planx.pizza/testing/sections-test
![image](https://user-images.githubusercontent.com/109954107/236144691-9df89d15-851e-4199-b60a-d4b6bbede896.png)

This ticket is branched from #1562 so testing save and return journeys with both states of `featureFlags.toggle("NAVIGATION_UI")` on and off should test most of the scenarios in that ticket too.