### PR TITLE
fix: Standard error handling on `InviteToPayForm`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -176,7 +176,6 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
         </InputLabel>
         <InputLabel label="Email" htmlFor="payeeEmail">
           <Input
-            required
             bordered
             name="payeeEmail"
             id="payeeEmail"

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -165,7 +165,7 @@ describe("Confirm component with inviteToPay", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays an error if you submit an applicant display name", async () => {
+  it("displays an error if do not submit an applicant display name", async () => {
     const { user } = setup(<Confirm {...inviteProps} />);
 
     // Switch to "InviteToPay" page

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -149,6 +149,42 @@ describe("Confirm component with inviteToPay", () => {
     ).toBeInTheDocument();
   });
 
+  it("displays an error if do not submit a nominee name", async () => {
+    const { user } = setup(<Confirm {...inviteProps} />);
+
+    // Switch to "InviteToPay" page
+    await user.click(screen.getByText(invitePrompt));
+    expect(screen.getByText("Details of your nominee")).toBeInTheDocument();
+
+    await user.type(
+      await screen.findByLabelText("Email"),
+      "test@opensystemslab.io{enter}"
+    );
+    expect(
+      await screen.findByText("Enter the full name of the person paying")
+    ).toBeInTheDocument();
+  });
+
+  it("displays an error if you submit an applicant display name", async () => {
+    const { user } = setup(<Confirm {...inviteProps} />);
+
+    // Switch to "InviteToPay" page
+    await user.click(screen.getByText(invitePrompt));
+    expect(screen.getByText("Details of your nominee")).toBeInTheDocument();
+
+    await user.type(
+      await screen.findByLabelText("Email"),
+      "test@opensystemslab.io"
+    );
+    await user.type(
+      await screen.findByLabelText("Full name"),
+      "Mr Nominee{enter}"
+    );
+    expect(
+      await screen.findByText("Enter your name or organisation name")
+    ).toBeInTheDocument();
+  });
+
   it("disables the invite link if you already have an in-progress payment", async () => {
     setup(
       <Confirm


### PR DESCRIPTION
Removes browser validation, in favour of validation via Formik