### PR TITLE
feat: Clean-up ITP emails on changes to `paid_at`

### DIFF
--- a/hasura.planx.uk/migrations/1683197635599_delete_payment_request_events_on_paid/down.sql
+++ b/hasura.planx.uk/migrations/1683197635599_delete_payment_request_events_on_paid/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS delete_payment_request_scheduled_email_events_trigger ON payment_requests;
+DROP FUNCTION IF EXISTS delete_payment_request_scheduled_email_events;

--- a/hasura.planx.uk/migrations/1683197635599_delete_payment_request_events_on_paid/up.sql
+++ b/hasura.planx.uk/migrations/1683197635599_delete_payment_request_events_on_paid/up.sql
@@ -1,0 +1,21 @@
+DROP FUNCTION IF EXISTS delete_payment_request_scheduled_email_events;
+CREATE OR REPLACE FUNCTION delete_payment_request_scheduled_email_events()
+RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM hdb_catalog.hdb_scheduled_events
+  WHERE comment IN (
+    'payment_reminder_' || OLD.id,
+    'payment_expiry_' || OLD.id
+  );
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql VOLATILE;
+
+DROP TRIGGER IF EXISTS delete_payment_request_scheduled_email_events_trigger ON payment_requests;
+CREATE TRIGGER delete_payment_request_scheduled_email_events_trigger
+AFTER UPDATE OF paid_at ON payment_requests FOR EACH ROW
+EXECUTE PROCEDURE delete_payment_request_scheduled_email_events();
+
+COMMENT ON TRIGGER delete_payment_request_scheduled_email_events_trigger ON payment_requests
+IS 'Delete scheduled events (reminder and expiry emails) when paid_at is populated';
+

--- a/hasura.planx.uk/migrations/1683197635599_delete_payment_request_events_on_paid/up.sql
+++ b/hasura.planx.uk/migrations/1683197635599_delete_payment_request_events_on_paid/up.sql
@@ -1,19 +1,26 @@
+-- function to clean up expiry and reminder emails
 DROP FUNCTION IF EXISTS delete_payment_request_scheduled_email_events;
+
 CREATE OR REPLACE FUNCTION delete_payment_request_scheduled_email_events()
 RETURNS TRIGGER AS $$
 BEGIN
   DELETE FROM hdb_catalog.hdb_scheduled_events
-  WHERE comment IN (
+  WHERE COMMENT IN (
     'payment_reminder_' || OLD.id,
-    'payment_expiry_' || OLD.id
+    'payment_reminder_agent_' || OLD.id,
+    'payment_expiry_' || OLD.id,
+    'payment_expiry_agent_' || OLD.id
   );
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql VOLATILE;
 
+-- trigger to set up function
 DROP TRIGGER IF EXISTS delete_payment_request_scheduled_email_events_trigger ON payment_requests;
+
 CREATE TRIGGER delete_payment_request_scheduled_email_events_trigger
 AFTER UPDATE OF paid_at ON payment_requests FOR EACH ROW
+WHEN (NEW.paid_at IS NOT NULL)
 EXECUTE PROCEDURE delete_payment_request_scheduled_email_events();
 
 COMMENT ON TRIGGER delete_payment_request_scheduled_email_events_trigger ON payment_requests


### PR DESCRIPTION
This trigger and stored procedure cleans up hasura events when `paid_at` is updated to a non-null value.

Testing via direct db manipulation:

1. create a lowcal session
2. create a payment requests for that session
3. Note the creation of pending events at https://hasura.1679.planx.pizza/console/events/one-off-scheduled-events/pending
4. set the `paid_at` field in the payment request to `now()`
5. Note the removal of pending events for that payment request at https://hasura.1679.planx.pizza/console/events/one-off-scheduled-events/pending