### PR TITLE
chore: Delete payment requests older than retention period

### DIFF
--- a/api.planx.uk/webhooks/sanitiseApplicationData/mocks/queries.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/mocks/queries.ts
@@ -44,6 +44,16 @@ export const mockDeleteReconciliationRequestsMutation = {
   },
 };
 
+export const mockDeletePaymentRequests = {
+  name: "DeletePaymentRequests",
+  matchOnVariables: false,
+  data: {
+    delete_payment_requests: {
+      returning: mockIds,
+    }
+  },
+};
+
 export const mockGetExpiredSessionIdsQuery = {
   name: "GetExpiredSessionIds",
   matchOnVariables: false,

--- a/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
@@ -8,6 +8,7 @@ import {
   mockSanitiseUniformApplicationsMutation,
   mockGetExpiredSessionIdsQuery,
   mockGetPassportDataForSessionQuery,
+  mockDeletePaymentRequests,
 } from "./mocks/queries";
 import {
   deleteHasuraEventLogs,
@@ -19,6 +20,7 @@ import {
   sanitiseUniformApplications,
   getExpiredSessionIds,
   deleteApplicationFiles,
+  deletePaymentRequests,
 } from "./operations";
 
 jest.mock("../../hasura/schema")
@@ -114,6 +116,10 @@ describe("Data sanitation operations", () => {
       {
         operation: deleteReconciliationRequests,
         query: mockDeleteReconciliationRequestsMutation,
+      },
+      {
+        operation: deletePaymentRequests,
+        query: mockDeletePaymentRequests,
       },
     ];
 


### PR DESCRIPTION
## What does this PR do?
 - Ensures that `payment_request` record are deleted after out retention period (currently 6 months)
 - Due to the foreign key relationship with `lowcal_sessions` they will get deleted when an associated session is dropped (currently deleted after 1 year, sanitised after 6 months)

## Next steps
- I think an E2E test of the sanitation process (inc. file deletion with minion) would be more robust than the API tests and mocks here - very much a nice to have!
 - I've created a `payment_request` record on staging and bumped back it's `created_at` date which should get deleted overnight once this PR is merged - id 
3e9229e8-23ef-40c4-a9e5-0d340da1214e