### PR TITLE
feat: Make next section tag clickable

### DIFF
--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -96,8 +96,8 @@ describe("SectionsOverviewList component", () => {
   it("renders correctly when the NAVIGATION_UI feature flag is toggled on", () => {
     setup(<SectionsOverviewList {...defaultProps} />);
 
-    expect(screen.getByText("Section one")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toHaveTextContent("Section one");
+    const changeLink = screen.getByText("Change Section one");
+    expect(screen.getByText("Section one")).toContainElement(changeLink);
     expect(screen.getByText(SectionStatus.Completed)).toBeInTheDocument();
 
     expect(screen.getByText("Section two")).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe("SectionsOverviewList component", () => {
     setup(<SectionsOverviewList {...defaultProps} showChange={false} />);
 
     expect(screen.getByText("Section one")).toBeInTheDocument();
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText("Change Section one")).not.toBeInTheDocument();
   });
 
   it("should not have any accessiblity violations", async () => {

--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -67,8 +67,16 @@ describe("SectionsOverviewList component", () => {
     },
   };
   const defaultProps = {
+    flow: {
+      _root: {
+        edges: ["section1", "section2", "section3"],
+      },
+      ...mockSectionNodes,
+    },
     sectionNodes: mockSectionNodes,
     showChange: true,
+    changeAnswer: () => {},
+    nextQuestion: () => {},
     isReconciliation: false,
     currentCard: null,
     breadcrumbs: {

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -3,6 +3,7 @@ import Link from "@mui/material/Link";
 import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
+import Tag, { TagType } from "@planx/components/shared/Buttons/Tag";
 import type { PublicProps } from "@planx/components/ui";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
@@ -119,6 +120,29 @@ export function SectionsOverviewList({
     }
   };
 
+  const getTag = (section: SectionStatus) => {
+    const tagTypes: Record<SectionStatus, TagType> = {
+      [SectionStatus.NeedsUpdated]: TagType.Alert,
+      [SectionStatus.ReadyToStart]: TagType.Active,
+      [SectionStatus.ReadyToContinue]: TagType.Active,
+      [SectionStatus.Started]: TagType.Notice,
+      [SectionStatus.NotStarted]: TagType.Notice,
+      [SectionStatus.Completed]: TagType.Success,
+    };
+    const type = tagTypes[section];
+
+    const onClick =
+      type == TagType.Alert || type == TagType.Active
+        ? () => nextQuestion()
+        : () => {}; // no-op
+
+    return (
+      <Tag type={type} onClick={onClick}>
+        {section}
+      </Tag>
+    );
+  };
+
   return (
     <DescriptionList>
       {Object.entries(sectionNodes).map(([sectionId, sectionNode]) => (
@@ -140,81 +164,12 @@ export function SectionsOverviewList({
               sectionNode.data.title
             )}
           </dt>
-          <dd>
-            <Tag
-              title={sectionStatuses[sectionId]}
-              onClick={
-                getTagClickability(sectionStatuses[sectionId])
-                  ? () => nextQuestion()
-                  : () => {} // no-op
-              }
-            >
-              {sectionStatuses[sectionId]}
-            </Tag>
-          </dd>
+          <dd> {getTag(sectionStatuses[sectionId])} </dd>
         </React.Fragment>
       ))}
     </DescriptionList>
   );
 }
-
-const getTagClickability = (section: SectionStatus): boolean => {
-  return [
-    SectionStatus.NeedsUpdated,
-    SectionStatus.ReadyToContinue,
-    SectionStatus.ReadyToStart,
-  ].includes(section)
-    ? true
-    : false;
-};
-
-const getTagBackgroundColor = (theme: Theme, title: SectionStatus): string => {
-  const backgroundColors: Record<SectionStatus, string> = {
-    [SectionStatus.NeedsUpdated]: "#FAFF00",
-    [SectionStatus.ReadyToContinue]: "#E8F1EC",
-    [SectionStatus.ReadyToStart]: "#E8F1EC",
-    [SectionStatus.Started]: theme.palette.background.paper,
-    [SectionStatus.NotStarted]: theme.palette.background.paper,
-    [SectionStatus.Completed]: theme.palette.success.dark,
-  };
-  return backgroundColors[title];
-};
-
-const getTagTextColor = (theme: Theme, title: SectionStatus): string => {
-  const textColors: Record<SectionStatus, string> = {
-    [SectionStatus.NeedsUpdated]: theme.palette.text.primary,
-    [SectionStatus.ReadyToContinue]: theme.palette.success.dark,
-    [SectionStatus.ReadyToStart]: theme.palette.success.dark,
-    [SectionStatus.Started]: theme.palette.text.secondary,
-    [SectionStatus.NotStarted]: theme.palette.text.secondary,
-    [SectionStatus.Completed]: "#FFFFFF",
-  };
-  return textColors[title];
-};
-
-const Tag = styled("div", {
-  // Configure which props should be forwarded on DOM
-  shouldForwardProp: (prop) => prop !== "title",
-})(({ title, theme }) => {
-  const sectionStatus = title as SectionStatus;
-  return {
-    backgroundColor: title
-      ? getTagBackgroundColor(theme, sectionStatus)
-      : undefined,
-    color: title ? getTagTextColor(theme, sectionStatus) : undefined,
-    fontWeight: 600,
-    cursor: getTagClickability(sectionStatus) ? "pointer" : "default",
-    paddingTop: theme.spacing(0.5),
-    paddingBottom: theme.spacing(0.5),
-    paddingLeft: theme.spacing(1.5),
-    paddingRight: theme.spacing(1.5),
-    "&:hover": {
-      backgroundColor: getTagClickability(sectionStatus)
-        ? darken(getTagBackgroundColor(theme, sectionStatus), 0.05)
-        : getTagBackgroundColor(theme, sectionStatus),
-    },
-  };
-});
 
 const Grid = styled("dl")(({ theme }) => ({
   display: "grid",

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
@@ -1,0 +1,71 @@
+import MuiButtonBase from "@mui/material/ButtonBase";
+import { darken } from "@mui/material/styles";
+import makeStyles from "@mui/styles/makeStyles";
+import classNames from "classnames";
+import React from "react";
+
+export enum TagType {
+  Alert = "alert",
+  Active = "active",
+  Notice = "notice",
+  Success = "success",
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: 600,
+    width: "100%",
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    paddingLeft: theme.spacing(1.5),
+    paddingRight: theme.spacing(1.5),
+  },
+  [TagType.Alert]: {
+    color: theme.palette.text.primary,
+    backgroundColor: "#FAFF00",
+    "&:hover": {
+      backgroundColor: darken("#FAFF00", 0.05),
+    },
+  },
+  [TagType.Active]: {
+    backgroundColor: "#E8F1EC",
+    color: theme.palette.success.dark,
+    "&:hover": {
+      backgroundColor: darken("#E8F1EC", 0.05),
+    },
+  },
+  [TagType.Notice]: {
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.secondary,
+  },
+  [TagType.Success]: {
+    backgroundColor: theme.palette.success.dark,
+    color: "#FFFFFF",
+  },
+}));
+
+export interface Props {
+  id?: string;
+  className?: string;
+  type: TagType;
+  onClick: (event?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+  children?: React.ReactNode;
+}
+
+export default function Tag(props: Props): FCReturn {
+  const { id, className, type, onClick, children } = props;
+  const classes = useStyles();
+
+  return (
+    <MuiButtonBase
+      href=""
+      disabled={type == TagType.Notice || type == TagType.Success}
+      className={classNames(classes.root, classes[type], className)}
+      onClick={onClick}
+      id={id}
+    >
+      {children}
+    </MuiButtonBase>
+  );
+}

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -84,7 +84,10 @@ const ReconciliationPage: React.FC<Props> = ({
         </Typography>
         {hasSections ? (
           <SectionsOverviewList
+            flow={flow}
             alteredSectionIds={reconciliationResponse.alteredSectionIds}
+            changeAnswer={changeAnswer}
+            nextQuestion={onButtonClick!}
             showChange={false}
             isReconciliation={true}
             sectionNodes={sectionNodes}


### PR DESCRIPTION
This is a response to user research where people sometimes attempt to click the tag instead of the continue button.

Rather than making the tag a full-fledged button (i.e. with accessibility features) my approach here is to retain the emphasis on the "Continue" button as the primary navigation but to also allow the tag to be clickable. I think this adds the least confusion and complexity while allowing user expectations to be met. The tag has a hover state when clickable but otherwise doesn't advertise itself as a button.

**Testing**:

This flow contains sections and a send component: https://1686.planx.pizza/testing/new-sections-test/preview?analytics=false

The "NEEDS UPDATED", "READY TO CONTINUE" and "READY TO START" tags should link to the same location as the "Continue" button. The other tags should not have any changed styles or behavior.