### PR TITLE
fix: Handle abandoned payments

### DIFF
--- a/api.planx.uk/server.test.js
+++ b/api.planx.uk/server.test.js
@@ -152,6 +152,20 @@ describe("fetching status of a GOV.UK payment", () => {
     payment_provider: "sandbox", // don't trigger a Slack notification
     provider_id: "10987654321",
     return_url: "https://your.service.gov.uk/completed",
+    _links: {
+      self: {
+        href: "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93",
+        method: "GET",
+      },
+      events: {
+        href: "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93/events",
+        method: "GET",
+      },
+      refunds: {
+        href: "https://publicapi.payments.service.gov.uk/v1/payments/hu20sqlact5260q2nanm0q8u93/refunds",
+        method: "GET",
+      },
+    },
   };
 
   it("proxies request and returns filtered response object", async () => {
@@ -176,6 +190,7 @@ describe("fetching status of a GOV.UK payment", () => {
             status: "success",
             finished: true,
           },
+          _links: {}
         });
       });
   });


### PR DESCRIPTION
This PR allows `next_url` links to be passed back to the client when fetching a previous payment. This means that previous payments can be resumed if they are still in an active state.

This changes the Pay proxy but cancelled/abandoned payments in the normal pay journey should continue to work as before.