### PR TITLE
chore: Add manually triggered CI test suite

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -1,0 +1,162 @@
+name: Automated Tests
+on:
+  workflow_dispatch:
+
+env:
+  EDITOR_DIRECTORY: editor.planx.uk
+  PNPM_VERSION: 7.8.0
+  NODE_VERSION: 16.13.1
+
+jobs:
+  integration_tests:
+    name: Run Integration tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
+        run: ./scripts/pull-secrets.sh
+      - name: Check if .env files exist
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
+          fail: true
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - run: pnpm install --frozen-lockfile
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - name: Start test containers
+        run: ./scripts/start-containers-for-tests.sh
+      - name: Postgres Tests
+        run: ./hasura.planx.uk/run-postgres-tests.sh
+      - run: pnpm i -g hasura-cli
+      - name: Hasura Tests
+        run: pnpm install --frozen-lockfile && pnpm test
+        working-directory: hasura.planx.uk/tests
+
+  api_tests:
+    name: Run API Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
+        run: ./scripts/pull-secrets.sh
+      - name: Check if .env files exist
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
+          fail: true
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: api.planx.uk
+      - name: Run API Tests
+        run: pnpm install --frozen-lockfile && pnpm check --quiet && pnpm test
+        working-directory: api.planx.uk
+
+  test_react:
+    name: Run React Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
+        run: ./scripts/pull-secrets.sh
+      - name: Check if .env files exist
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
+          fail: true
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - run: pnpm install --frozen-lockfile
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm build
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm test
+        working-directory: ${{ env.EDITOR_DIRECTORY }}
+
+  end_to_end_tests:
+    name: E2E tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
+        run: ./scripts/pull-secrets.sh
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2.2.2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: PNPM Install
+        run: pnpm install --frozen-lockfile
+        working-directory: e2e
+      - name: Code checks
+        run:  pnpm check
+        working-directory: e2e
+      - name: Install Playwright Dependencies
+        run: pnpm playwright install --with-deps
+        working-directory: e2e
+      - name: Start test containers
+        run: ./scripts/start-containers-for-tests.sh
+      - name: Playwright Tests
+        run:  pnpm test
+        working-directory: e2e
+      - name: Archive Playwright Test Results
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: e2e/test-results/
+          retention-days: 3


### PR DESCRIPTION
To validate the state of a particular branch, it is helpful to be able to trigger just the automated tests for that branch.

This PR adds a CI workflow to run automated tests on demand.