### PR TITLE
fix: disable checking classified roads in scottish services

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -98,7 +98,7 @@ function Component(props: Props) {
   const classifiedRoadsEndpoint: string = `${process.env.REACT_APP_API_URL}/roads`;
   const { data: roads, isValidating: isValidatingRoads } = useSWR(
     () =>
-      usrn && teamSlug !== "scotland"
+      usrn && digitalLandOrganisations.includes(teamSlug)
         ? classifiedRoadsEndpoint + `?usrn=${usrn}`
         : null,
     fetcher,

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -97,7 +97,10 @@ function Component(props: Props) {
   //   skip if the applicant plotted a new non-UPRN address on the map
   const classifiedRoadsEndpoint: string = `${process.env.REACT_APP_API_URL}/roads`;
   const { data: roads, isValidating: isValidatingRoads } = useSWR(
-    () => (usrn ? classifiedRoadsEndpoint + `?usrn=${usrn}` : null),
+    () =>
+      usrn && teamSlug !== "scotland"
+        ? classifiedRoadsEndpoint + `?usrn=${usrn}`
+        : null,
     fetcher,
     {
       shouldRetryOnError: true,


### PR DESCRIPTION
TPX folks reported the classified roads check was particularly slow on their services which they've been actively demo'ing - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1683742850624589

theoretically the OS data has the same availability in Scotland, but USRNs may work a bit different? 

for now, disabling the extra roads query for any team that is not fetching Digital Land data (eg Scotland and Braintree) so that only their custom planning constraints are shown.  


https://1689.planx.pizza/scotland/check-what-permissions-your-building-project-is-likely-to-need/preview
![Screenshot from 2023-05-11 08-55-22](https://github.com/theopensystemslab/planx-new/assets/5132349/5ecaee7b-9d5f-413f-bacd-6660e171744b)

