### PR TITLE
feat: validate flow content on publish if Invite to Pay is enabled

### DIFF
--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -124,7 +124,7 @@ it("does not update if there are sections, but there is not a section in the fir
 });
 
 it("does not update if invite to pay is enabled, but there is not a Send component", async () => {  
-  let { "Send": _, ...invalidatedFlow } = flowWithInviteToPay;
+  const { Send, ...invalidatedFlow } = flowWithInviteToPay;
   invalidatedFlow["_root"].edges?.splice(invalidatedFlow["_root"].edges?.indexOf("Send"));
   
   queryMock.mockQuery({
@@ -148,7 +148,7 @@ it("does not update if invite to pay is enabled, but there is not a Send compone
 });
 
 it("does not update if invite to pay is enabled, but there is not a FindProperty (`_address`) component", async () => {
-  let { "FindProperty": _, ...invalidatedFlow } = flowWithInviteToPay;
+  const { FindProperty, ...invalidatedFlow } = flowWithInviteToPay;
   invalidatedFlow["_root"].edges?.splice(invalidatedFlow["_root"].edges?.indexOf("FindProperty"));
   
   queryMock.mockQuery({
@@ -172,7 +172,7 @@ it("does not update if invite to pay is enabled, but there is not a FindProperty
 });
 
 it("does not update if invite to pay is enabled, but there is not a Checklist that sets `proposal.projectType`", async () => {
-  let { "Checklist": _, "ChecklistOptionOne": __, "ChecklistOptionTwo": ___, ...invalidatedFlow } = flowWithInviteToPay;
+  const { Checklist, ChecklistOptionOne, ChecklistOptionTwo, ...invalidatedFlow } = flowWithInviteToPay;
   invalidatedFlow["_root"].edges?.splice(invalidatedFlow["_root"].edges?.indexOf("Checklist"));
   
   queryMock.mockQuery({

--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -49,7 +49,7 @@ it("does not update if there are no new changes", async () => {
     .then((res) => {
       expect(res.body).toEqual({
         alteredNodes: null,
-        message: "No new changes",
+        message: "No new changes to publish",
       });
     });
 });
@@ -77,13 +77,14 @@ it("does not update if there are sections in an external portal", async () => {
   });
 
   await supertest(app)
-    .post("/flows/1/publish")
+    .post("/flows/1/diff")
     .set(authHeader())
     .expect(200)
     .then((res) => {
       expect(res.body).toEqual({
         alteredNodes: null,
-        message: "Error publishing: found Sections in one or more External Portals, but Sections are only allowed in main flow",
+        message: "Cannot publish an invalid flow",
+        description: "Found Sections in one or more External Portals, but Sections are only allowed in main flow",
       });
     });
 });
@@ -110,16 +111,23 @@ it("does not update if there are sections, but there is not a section in the fir
   });
 
   await supertest(app)
-    .post("/flows/1/publish")
+    .post("/flows/1/diff")
     .set(authHeader())
     .expect(200)
     .then((res) => {
       expect(res.body).toEqual({
         alteredNodes: null,
-        message: "Error publishing: when using Sections, your flow needs to start with a Section",
+        message: "Cannot publish an invalid flow",
+        description: "When using Sections, your flow must start with a Section"
       });
     });
 });
+
+it.todo("does not update if invite to pay is enabled, but there is not a Send component");
+
+it.todo("does not update if invite to pay is enabled, but there is not a FindProperty (`_address`) component");
+
+it.todo("does not update if invite to pay is enabled, but there is not a Checklist that sets `proposal.projectType`");
 
 it("updates published flow and returns altered nodes if there have been changes", async () => {
   const alteredFlow = {

--- a/api.planx.uk/editor/publish.ts
+++ b/api.planx.uk/editor/publish.ts
@@ -210,7 +210,7 @@ const inviteToPayEnabled = (flow: Record<string, any>): boolean => {
 };
 
 const hasComponentType = (flow: Record<string, any>, type: ComponentType, fn?: string): boolean => {
-  let nodeIds = Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === type);
+  const nodeIds = Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === type);
   if (fn) {
     nodeIds?.filter(([_nodeId, nodeData]) => nodeData?.data.fn === fn)?.map(([nodeId, _nodeData]) => nodeId);
   } else {

--- a/api.planx.uk/editor/publish.ts
+++ b/api.planx.uk/editor/publish.ts
@@ -4,6 +4,7 @@ import { adminGraphQLClient as adminClient } from "../hasura";
 import { dataMerged, getMostRecentPublishedFlow } from "../helpers";
 import { gql } from "graphql-request";
 import intersection from "lodash/intersection";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 
 const diffFlow = async (
   req: Request,
@@ -15,8 +16,26 @@ const diffFlow = async (
 
   try {
     const flattenedFlow = await dataMerged(req.params.flowId);
-    const mostRecent = await getMostRecentPublishedFlow(req.params.flowId);
 
+    const { isValid: sectionsAreValid, message: sectionsValidationMessage, description: sectionsValidationDescription } = validateSections(flattenedFlow);
+    if (!sectionsAreValid) {
+      return res.json({
+        alteredNodes: null,
+        message: sectionsValidationMessage,
+        description: sectionsValidationDescription
+      });
+    }
+
+    const { isValid: payIsValid, message: payValidationMessage, description: payValidationDescription } = validateInviteToPay(flattenedFlow);
+    if (!payIsValid) {
+      return res.json({
+        alteredNodes: null,
+        message: payValidationMessage,
+        description: payValidationDescription
+      });
+    }
+
+    const mostRecent = await getMostRecentPublishedFlow(req.params.flowId);
     const delta = jsondiffpatch.diff(mostRecent, flattenedFlow);
 
     if (delta) {
@@ -31,7 +50,7 @@ const diffFlow = async (
     } else {
       return res.json({
         alteredNodes: null,
-        message: "No new changes",
+        message: "No new changes to publish",
       });
     }
   } catch (error) {
@@ -49,23 +68,6 @@ const publishFlow = async (
 
   try {
     const flattenedFlow = await dataMerged(req.params.flowId);
-
-    // If the flattened flow (including external portals) has sections, handle validations
-    if (getSectionNodeIds(flattenedFlow)?.length > 0) {
-      if (!sectionIsInFirstPosition(flattenedFlow)) {
-        return res.json({
-          alteredNodes: null,
-          message: "Error publishing: when using Sections, your flow needs to start with a Section"
-        });
-      } 
-      if (!allSectionsOnRoot(flattenedFlow)) {
-        return res.json({
-          alteredNodes: null,
-          message: "Error publishing: found Sections in one or more External Portals, but Sections are only allowed in main flow"
-        });
-      }
-    }
-
     const mostRecent = await getMostRecentPublishedFlow(req.params.flowId);
     const delta = jsondiffpatch.diff(mostRecent, flattenedFlow);
 
@@ -115,7 +117,7 @@ const publishFlow = async (
     } else {
       return res.json({
         alteredNodes: null,
-        message: "No new changes",
+        message: "No new changes to publish",
       });
     }
   } catch (error) {
@@ -123,19 +125,92 @@ const publishFlow = async (
   }
 };
 
+type ValidationResponse = {
+  isValid: boolean,
+  message: string;
+  description?: string,
+}
+
+const validateSections = (flow: Record<string, any>): ValidationResponse => {
+  if (getSectionNodeIds(flow)?.length > 0) {
+    if (!sectionIsInFirstPosition(flow)) {
+      return {
+        isValid: false,
+        message: "Cannot publish an invalid flow",
+        description: "When using Sections, your flow must start with a Section"
+      };
+    }
+
+    if (!allSectionsOnRoot(flow)) {
+      return {
+        isValid: false,
+        message: "Cannot publish an invalid flow",
+        description: "Found Sections in one or more External Portals, but Sections are only allowed in main flow",
+      };
+    }
+  }
+
+  return { 
+    isValid: true, 
+    message: "This flow has valid Sections or is not using Sections" 
+  };
+};
+
 const getSectionNodeIds = (flow: Record<string, any>): string[] => {
-  return Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === 360)?.map(([nodeId, _nodeData]) => nodeId);
+  return Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === ComponentType.Section)?.map(([nodeId, _nodeData]) => nodeId);
 };
 
 const sectionIsInFirstPosition = (flow: Record<string, any>): boolean => {
   const firstNodeId = flow["_root"].edges[0];
-  return flow[firstNodeId].type === 360;
+  return flow[firstNodeId].type === ComponentType.Section;
 };
 
 const allSectionsOnRoot = (flow: Record<string, any>): boolean => {
   const sectionTypeNodeIds = getSectionNodeIds(flow);
   const intersectingNodeIds = intersection(flow["_root"].edges, sectionTypeNodeIds);
   return intersectingNodeIds.length === sectionTypeNodeIds.length;
+};
+
+const validateInviteToPay = (flow: Record<string, any>): ValidationResponse => {
+  if (inviteToPayEnabled(flow)) {
+    if (!hasFindPropertyOnRoot(flow)) {
+      return {
+        isValid: false,
+        message: "Cannot publish an invalid flow",
+        description: "When using Invite to Pay, your flow must have a FindProperty node on the _root",
+      };
+    }
+    if (!setsPassportVariableOnRoot(flow, "proposal.projectType")) {
+      return {
+        isValid: false,
+        message: "Cannot publish an invalid flow",
+        description: "When using Invite to Pay, your flow must set the passport variable `proposal.projectType` on a _root node",
+      };
+    }
+  }
+
+  return {
+    isValid: true,
+    message: "This flow is valid for Invite to Pay or is not using Invite to Pay",
+  };
+};
+
+const inviteToPayEnabled = (flow: Record<string, any>): boolean => {
+  // TODO account for flows with > 1 Pay node in future, if any have InviteToPay enabled then return true
+  const firstPayNode = Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === ComponentType.Pay)[0][1];
+  return firstPayNode?.data.allowInviteToPay;
+};
+
+const hasFindPropertyOnRoot = (flow: Record<string, any>): boolean => {
+  const findPropertyNodeIds = Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.type === ComponentType.FindProperty)?.map(([nodeId, _nodeData]) => nodeId);
+  const intersectingNodeIds = intersection(flow["_root"].edges, findPropertyNodeIds);
+  return Boolean(intersectingNodeIds.length);
+};
+
+const setsPassportVariableOnRoot = (flow: Record<string, any>, fn: string): boolean => {
+  const nodeIds = Object.entries(flow).filter(([_nodeId, nodeData]) => nodeData?.data?.fn === fn)?.map(([nodeId, _nodeData]) => nodeId);
+  const intersectingNodeIds = intersection(flow["_root"].edges, nodeIds);
+  return Boolean(intersectingNodeIds.length);
 };
 
 export { diffFlow, publishFlow };

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -23,7 +23,7 @@ import multer from "multer";
 
 import { ServerError } from "./errors";
 import { locationSearch } from "./gis/index";
-import { diffFlow, publishFlow } from "./editor/publish";
+import { validateAndDiffFlow, publishFlow } from "./editor/publish";
 import { findAndReplaceInFlow } from "./editor/findReplace";
 import { copyPortalAsFlow } from "./editor/copyPortalAsFlow";
 import {
@@ -442,7 +442,7 @@ app.get(
 
 app.post("/flows/:flowId/copy", useJWT, copyFlow);
 
-app.post("/flows/:flowId/diff", useJWT, diffFlow);
+app.post("/flows/:flowId/diff", useJWT, validateAndDiffFlow);
 
 app.post("/flows/:flowId/move/:teamSlug", useJWT, moveFlow);
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -104,14 +104,14 @@ const PreviewBrowser: React.FC<{
     publishFlow,
     lastPublished,
     lastPublisher,
-    diffFlow,
+    validateAndDiffFlow,
   ] = useStore((state) => [
     state.id,
     state.resetPreview,
     state.publishFlow,
     state.lastPublished,
     state.lastPublisher,
-    state.diffFlow,
+    state.validateAndDiffFlow,
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
@@ -188,7 +188,7 @@ const PreviewBrowser: React.FC<{
               onClick={async () => {
                 try {
                   setLastPublishedTitle("Checking for changes...");
-                  const alteredFlow = await diffFlow(flowId);
+                  const alteredFlow = await validateAndDiffFlow(flowId);
                   setAlteredNodes(
                     alteredFlow?.data.alteredNodes
                       ? alteredFlow.data.alteredNodes

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -117,6 +117,7 @@ const PreviewBrowser: React.FC<{
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
     "This flow is not published yet"
   );
+  const [validationMessage, setValidationMessage] = useState<string>();
   const [alteredNodes, setAlteredNodes] = useState<object[]>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
@@ -196,8 +197,9 @@ const PreviewBrowser: React.FC<{
                   setLastPublishedTitle(
                     alteredFlow?.data.alteredNodes
                       ? `Found changes to ${alteredFlow.data.alteredNodes.length} node(s)`
-                      : "No new changes to publish"
+                      : alteredFlow?.data.message
                   );
+                  setValidationMessage(alteredFlow?.data.description);
                   setDialogOpen(true);
                 } catch (error) {
                   setLastPublishedTitle(
@@ -242,8 +244,10 @@ const PreviewBrowser: React.FC<{
                       onChange={(e) => setSummary(e.target.value)}
                     />
                   </>
+                ) : validationMessage ? (
+                  validationMessage
                 ) : (
-                  `No new changes to publish`
+                  lastPublishedTitle
                 )}
               </DialogContent>
               <DialogActions>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -62,7 +62,7 @@ export interface EditorStore extends Store.Store {
   copyNode: (id: Store.nodeId) => void;
   createFlow: (teamId: any, newSlug: any) => Promise<string>;
   deleteFlow: (teamId: number, flowSlug: string) => Promise<object>;
-  diffFlow: (flowId: string) => Promise<any>;
+  validateAndDiffFlow: (flowId: string) => Promise<any>;
   getFlows: (teamId: number) => Promise<any>;
   isClone: (id: Store.nodeId) => boolean;
   lastPublished: (flowId: string) => Promise<string>;
@@ -237,7 +237,7 @@ export const editorStore: StateCreator<
     return response;
   },
 
-  diffFlow(flowId: string) {
+  validateAndDiffFlow(flowId: string) {
     const token = getCookie("jwt");
 
     return axios.post(


### PR DESCRIPTION
**Validation rules introduced:**
If Invite to Pay is enabled, check that:
- There is at least one Send component
- There is at least one FindProperty (this component type sets `_address` by default)
- There is at least one Checklist that sets the passport variable `proposal.projectType` (we could be more flexible about component type here, but I think Checklist actually makes sense because a) it matches all existing content patterns and b) we expect to parse a _list_ of one or many project types answers)

This validation checks for the _existance_ of these components, but doesn't actually do any path calculations to ensure that all paths that reach the Pay node also are guaranteed to pass through the prior required nodes. That would be an interesting challenge to solve next! 

**Other changes:**
- Moves validation checks from `publishFlow` to `diffFlow` so we can check for & show validation errors earlier, _before_ being prompted to review altered nodes
- Refactors `lastPublishedTitle` & the publish dialog content in the `PreviewBrowser` to more clearly display validation warning messages if there are any (previously these showed up under publish button only)
![Screenshot from 2023-05-10 22-15-45](https://github.com/theopensystemslab/planx-new/assets/5132349/1da160d1-6972-4494-8950-9d347261e7ff)
- Renames `diffFlow` to `validateAndDiffFlow` to be explicit about what it's doing now - splitting these into two separate functions is obviously an appealing option too, but keeping as one right now allows for a more minimal refactor of how the publish change button & dialog UI behave in the Editor