### PR TITLE
feat: create an audit table for email submissions and send a slack notification

### DIFF
--- a/api.planx.uk/send/email.test.ts
+++ b/api.planx.uk/send/email.test.ts
@@ -54,6 +54,28 @@ describe(`sending an application by email to a planning office`, () => {
       },
       variables: { sessionId: 123 },
     });
+
+    queryMock.mockQuery({
+      name: "CreateEmailApplication",
+      matchOnVariables: false,
+      data: {
+        insert_email_applications_one: { id: 1 }
+      },
+      variables: { 
+        sessionId: 123,
+        teamSlug: "southwark",
+        recipient: "planning.office.example@southwark.gov.uk",
+        request: {
+          personalisation: {
+            serviceName: "Apply for something",
+            downloadLink: "https://api.editor.planx.uk/test/123",
+          }
+        },
+        response: {
+          message: "Success"
+        }
+      },
+    });
   });
 
   it("succeeds when provided with valid data", async () => {

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -63,7 +63,8 @@ const sendToEmail = async(req: Request, res: Response, next: NextFunction) => {
     // Mark session as submitted so that reminder and expiry emails are not triggered
     markSessionAsSubmitted(payload.sessionId);
 
-    // TODO create audit table entry? setup event trigger for slack notification on new row?
+    // Create audit table entry, which triggers a Slack notification on `insert` if production
+    insertAuditEntry(payload.sessionId, req.params.localAuthority, sendToEmail, config, response);
 
     return res.status(200).send({
       message: `Successfully sent "Submit" email`,
@@ -262,6 +263,47 @@ async function downloadPassportFiles(
       await downloadFile(file, filePath, zip);
     }
   }
+}
+
+async function insertAuditEntry(
+  sessionId: string, 
+  teamSlug: string, 
+  recipient: string, 
+  notifyRequest: EmailSubmissionNotifyConfig,
+  sendEmailResponse: {
+    message: string;
+    expiryDate?: string;
+  }) {
+  const response = await adminClient.request(
+    gql`
+      mutation CreateEmailApplication(
+        $session_id: String = "",
+        $team_slug: String = "",
+        $recipient: String = "",
+        $request: jsonb = "",
+        $response: jsonb = ""
+      ) {
+        insert_email_applications_one(object: {
+          session_id: $session_id,
+          team_slug: $team_slug,
+          recipient: $recipient,
+          request: $request,
+          response: $response
+        }) {
+          id
+        }
+      }
+    `,
+    {
+      session_id: sessionId,
+      team_slug: teamSlug,
+      recipient: recipient,
+      request: notifyRequest,
+      response: sendEmailResponse
+    }
+  );
+
+  return response?.insert_email_applications_one?.id;
 }
 
 export { sendToEmail, downloadApplicationFiles };

--- a/api.planx.uk/webhooks/sanitiseApplicationData/mocks/queries.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/mocks/queries.ts
@@ -34,6 +34,16 @@ export const mockSanitiseBOPSApplicationsMutation = {
   },
 };
 
+export const mockSanitiseEmailApplicationsMutation = {
+  name: "SanitiseEmailApplications",
+  matchOnVariables: false,
+  data: {
+    update_email_applications: {
+      returning: mockIds,
+    }
+  },
+};
+
 export const mockDeleteReconciliationRequestsMutation = {
   name: "DeleteReconciliationRequests",
   matchOnVariables: false,

--- a/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/operations.test.ts
@@ -3,6 +3,7 @@ import { queryMock } from "../../tests/graphqlQueryMock";
 import {
   mockIds,
   mockSanitiseBOPSApplicationsMutation,
+  mockSanitiseEmailApplicationsMutation,
   mockSanitiseLowcalSessionsMutation,
   mockDeleteReconciliationRequestsMutation,
   mockSanitiseUniformApplicationsMutation,
@@ -15,6 +16,7 @@ import {
   getRetentionPeriod,
   operationHandler,
   sanitiseBOPSApplications,
+  sanitiseEmailApplications,
   sanitiseLowcalSessions,
   deleteReconciliationRequests,
   sanitiseUniformApplications,
@@ -112,6 +114,10 @@ describe("Data sanitation operations", () => {
       {
         operation: sanitiseBOPSApplications,
         query: mockSanitiseBOPSApplicationsMutation,
+      },
+      {
+        operation: sanitiseEmailApplications,
+        query: mockSanitiseEmailApplicationsMutation,
       },
       {
         operation: deleteReconciliationRequests,

--- a/api.planx.uk/webhooks/sanitiseApplicationData/operations.ts
+++ b/api.planx.uk/webhooks/sanitiseApplicationData/operations.ts
@@ -24,6 +24,7 @@ export const getOperations = (): Operation[] => [
   // Audit records
   sanitiseUniformApplications,
   sanitiseBOPSApplications,
+  sanitiseEmailApplications,
   deleteReconciliationRequests,
 
   // Event logs
@@ -165,6 +166,30 @@ export const sanitiseBOPSApplications: Operation = async () => {
   `;
   const {
     update_bops_applications: { returning: result },
+  } = await adminGraphQLClient.request(mutation, {
+    retentionPeriod: getRetentionPeriod(),
+  });
+  return result;
+};
+
+export const sanitiseEmailApplications: Operation = async () => {
+  const mutation = gql`
+    mutation SanitiseEmailApplications($retentionPeriod: timestamptz) {
+      update_email_applications(
+        _set: { request: {}, sanitised_at: "now()" }
+        where: {
+          sanitised_at: { _is_null: true }
+          created_at: { _lt: $retentionPeriod }
+        }
+      ) {
+        returning {
+          id
+        }
+      }
+    }
+  `;
+  const { 
+    update_email_applications: { returning: result },
   } = await adminGraphQLClient.request(mutation, {
     retentionPeriod: getRetentionPeriod(),
   });

--- a/api.planx.uk/webhooks/sendNotifications.ts
+++ b/api.planx.uk/webhooks/sendNotifications.ts
@@ -40,6 +40,19 @@ const sendSlackNotification = async (req: Request, res: Response, next: NextFunc
       await slack.send(uniformMessage);
       return res.status(200).send({ message: "Posted to Slack", data: uniformMessage });
     }
+
+    if (req.query.type === "email-submission") {
+      const isEmailStaging = !data?.response?.personalisation?.downloadLink?.startsWith("https://api.editor.planx.uk");
+      if (isEmailStaging) {
+        return res.status(200).send({
+          message: `Staging application submitted, skipping Slack notification`
+        });
+      }
+
+      const emailMessage = `:incoming_envelope: New email submission "${data?.request?.personalisation?.serviceName}" *${data?.session_id}* [${data?.team_slug}]`;
+      await slack.send(emailMessage);
+      return res.status(200).send({ message: "Posted to Slack", data: emailMessage });
+    }
   } catch (error) {
     return next({
       error,

--- a/api.planx.uk/webhooks/sendNotifications.ts
+++ b/api.planx.uk/webhooks/sendNotifications.ts
@@ -42,7 +42,7 @@ const sendSlackNotification = async (req: Request, res: Response, next: NextFunc
     }
 
     if (req.query.type === "email-submission") {
-      const isEmailStaging = !data?.response?.personalisation?.downloadLink?.startsWith("https://api.editor.planx.uk");
+      const isEmailStaging = !data?.request?.personalisation?.downloadLink?.startsWith("https://api.editor.planx.uk");
       if (isEmailStaging) {
         return res.status(200).send({
           message: `Staging application submitted, skipping Slack notification`

--- a/api.planx.uk/webhooks/sendNotifications.ts
+++ b/api.planx.uk/webhooks/sendNotifications.ts
@@ -2,7 +2,7 @@ import SlackNotify from 'slack-notify';
 import { Request, Response, NextFunction } from 'express';
 
 const sendSlackNotification = async (req: Request, res: Response, next: NextFunction): Promise<Response | void>  => {
-  const supportedTypes = ["bops-submission", "uniform-submission"];
+  const supportedTypes = ["bops-submission", "uniform-submission", "email-submission"];
   if (!req.body?.event || !req.query?.type || !supportedTypes.includes(req.query.type as string)) {
     return res.status(404).send({
       message: "Missing info required to send a Slack notification"

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -89,6 +89,27 @@
 - table:
     schema: public
     name: email_applications
+  event_triggers:
+    - name: setup_email_applications_notifications
+      definition:
+        enable_manual: false
+        insert:
+          columns: '*'
+      retry_conf:
+        num_retries: 1
+        interval_sec: 30
+        timeout_sec: 60
+      webhook_from_env: HASURA_PLANX_API_URL
+      headers:
+        - name: authorization
+          value_from_env: HASURA_PLANX_API_KEY
+      request_transform:
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        method: POST
+        version: 2
+        query_params:
+          type: email-submission
+        template_engine: Kriti
 - table:
     schema: public
     name: flow_document_templates

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -88,6 +88,9 @@
   is_enum: true
 - table:
     schema: public
+    name: email_applications
+- table:
+    schema: public
     name: flow_document_templates
   object_relationships:
     - name: flow

--- a/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/down.sql
+++ b/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."email_applications";

--- a/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/up.sql
+++ b/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "public"."email_applications" (
   "id" serial NOT NULL, 
-  "session_id" text NOT NULL, 
+  "session_id" uuid NOT NULL, 
   "team_slug" text NOT NULL, 
   "recipient" text NOT NULL, 
   "request" jsonb NOT NULL,
@@ -8,6 +8,7 @@ CREATE TABLE "public"."email_applications" (
   "created_at" timestamptz NOT NULL DEFAULT now(), 
   "sanitised_at" timestamptz, 
   PRIMARY KEY ("id"), 
+  FOREIGN KEY ("session_id") REFERENCES "public"."lowcal_sessions"("id") ON UPDATE restrict ON DELETE cascade,
   UNIQUE ("id")
 );
 

--- a/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/up.sql
+++ b/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/up.sql
@@ -5,9 +5,9 @@ CREATE TABLE "public"."email_applications" (
   "recipient" text NOT NULL, 
   "request" jsonb NOT NULL,
   "response" jsonb NOT NULL, 
-  "created_at" Timestamp NOT NULL DEFAULT now(), 
+  "created_at" timestamptz NOT NULL DEFAULT now(), 
   "sanitised_at" timestamptz, 
-  PRIMARY KEY ("id") , 
+  PRIMARY KEY ("id"), 
   UNIQUE ("id")
 );
 

--- a/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/up.sql
+++ b/hasura.planx.uk/migrations/1683874331828_create_table_public_email_applications/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "public"."email_applications" (
+  "id" serial NOT NULL, 
+  "session_id" text NOT NULL, 
+  "team_slug" text NOT NULL, 
+  "recipient" text NOT NULL, 
+  "request" jsonb NOT NULL,
+  "response" jsonb NOT NULL, 
+  "created_at" Timestamp NOT NULL DEFAULT now(), 
+  "sanitised_at" timestamptz, 
+  PRIMARY KEY ("id") , 
+  UNIQUE ("id")
+);
+
+COMMENT ON TABLE "public"."email_applications" IS E'Stores a receipt of applications submitted via email using GOVUK Notify';

--- a/hasura.planx.uk/tests/email_applications.test.js
+++ b/hasura.planx.uk/tests/email_applications.test.js
@@ -1,0 +1,33 @@
+const { introspectAs } = require("./utils");
+
+describe("email_applications", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query email applications", () => {
+      expect(i.queries).not.toContain("email_applications");
+    });
+
+    test("cannot create, update, or delete email applications", () => {
+      expect(i).toHaveNoMutationsFor("email_applications");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate email appliations", () => {
+      expect(i.queries).toContain("email_applications");
+      expect(i.mutations).toContain("insert_email_applications");
+      expect(i.mutations).toContain("insert_email_applications_one");
+      expect(i.mutations).toContain("update_email_applications_by_pk");
+      expect(i.mutations).toContain("delete_email_applications");
+    });
+  });
+});


### PR DESCRIPTION
Sets up Slack notifications for "Send to email" production services (will mostly capture activity from Buck's "Report a breach" service!)

![Screenshot from 2023-05-12 15-56-12](https://github.com/theopensystemslab/planx-new/assets/5132349/57c8cad8-7416-42c6-9e4e-0a2d40461564)

**Changes:** 
- Adds `email_applications` audit table, the Slack notification is then configured to trigger on `insert` to this table same as our other send notifications
- Adds introspection tests for `email_applications` (no public access)
- Adds sanitasion operations for `email_applications`