### PR TITLE
fix: Remove duplicated outline on success icon

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -1,4 +1,4 @@
-import Check from "@mui/icons-material/CheckCircleOutlineOutlined";
+import Check from "@mui/icons-material/Check";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/cf90a1b6-ee5f-4011-bc15-0ebed9fc1481) | ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/158f88f3-4959-476f-9822-3736a134843e) |

Follow up for issue that was introduced in the following PR where the outline was added as a style to the banner - https://github.com/theopensystemslab/planx-new/pull/1669