### PR TITLE
FIX: font import weights

### DIFF
--- a/editor.planx.uk/.storybook/preview-head.html
+++ b/editor.planx.uk/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
   rel="stylesheet"
 />
 <!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->

--- a/editor.planx.uk/src/app.css
+++ b/editor.planx.uk/src/app.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
The current app imports the following font weights for Inter:

400 regular
600 semi-bold
800 extra-bold

This means that any bold text is being rendered at 800 weight, despite being referred to at bold or 700 weight in the CSS.

PR to correct the imports to be 400, 600, 700.