### PR TITLE
fix: Fix resume state on reconciliation

### DIFF
--- a/api.planx.uk/saveAndReturn/validateSession.test.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.test.ts
@@ -16,6 +16,11 @@ import type { Node, Flow, Breadcrumb } from "../types";
 const validateSessionPath = "/validate-session";
 
 describe("Validate Session endpoint", () => {
+  const reconciledData = {
+    ...mockLowcalSession.data,
+    passport: { data: {} },
+  };
+
   afterEach(() => {
     queryMock.reset();
   });
@@ -76,9 +81,7 @@ describe("Validate Session endpoint", () => {
     const expected = {
       message: "No content changes since last save point",
       changesFound: false,
-      reconciledSessionData: {
-        ...mockLowcalSession.data,
-      },
+      reconciledSessionData: reconciledData,
     };
 
     await supertest(app)
@@ -101,11 +104,11 @@ describe("Validate Session endpoint", () => {
         type: 100,
       },
       one: {
-        data: { val: "answer", text: "1" },
+        data: { val: "answer1", text: "1" },
         type: 200,
       },
       two: {
-        data: { val: "answer", text: "2" },
+        data: { val: "answer2", text: "2" },
         type: 200,
       },
     };
@@ -116,8 +119,8 @@ describe("Validate Session endpoint", () => {
         edges: ["one", "two"],
         type: 100,
       },
-      one: { data: { text: "1", val: "answer" }, type: 200 },
-      two: { data: { text: "2", val: "answer" }, type: 200 },
+      one: { data: { text: "1", val: "answer1" }, type: 200 },
+      two: { data: { text: "2", val: "answer2" }, type: 200 },
     };
 
     mockQueryWithFlowDiff({ flow, diff });
@@ -130,9 +133,7 @@ describe("Validate Session endpoint", () => {
     };
 
     const expected = {
-      reconciledSessionData: {
-        ...mockLowcalSession.data,
-      },
+      reconciledSessionData: reconciledData,
       message:
         "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue.",
       alteredSectionIds: [],
@@ -164,19 +165,19 @@ describe("Validate Session endpoint", () => {
         edges: ["a", "b"],
       },
       one: {
-        data: { val: "answer", text: "One (1)" },
+        data: { val: "answer1", text: "One (1)" },
         type: 200,
       },
       two: {
-        data: { val: "answer", text: "Two (2)" },
+        data: { val: "answer2", text: "Two (2)" },
         type: 200,
       },
       a: {
-        data: { val: "answer", text: "A" },
+        data: { val: "answerA", text: "A" },
         type: 200,
       },
       b: {
-        data: { val: "answer", text: "B or Other" },
+        data: { val: "answerB", text: "B or Other" },
         type: 200,
       },
     };
@@ -194,11 +195,11 @@ describe("Validate Session endpoint", () => {
 
     const diff = {
       one: {
-        data: { val: "answer", text: "One (1)" },
+        data: { val: "answer1", text: "One (1)" },
         type: 200,
       },
       two: {
-        data: { val: "answer", text: "Two (2)" },
+        data: { val: "answer2", text: "Two (2)" },
         type: 200,
       },
     };
@@ -214,7 +215,7 @@ describe("Validate Session endpoint", () => {
 
     const expected = {
       reconciledSessionData: {
-        ...mockLowcalSession.data,
+        ...reconciledData,
         breadcrumbs: {
           question2: {
             auto: false,
@@ -262,11 +263,11 @@ describe("Validate Session endpoint", () => {
         edges: ["one", "two"],
       },
       one: {
-        data: { val: "answer", text: "One" },
+        data: { val: "answer1", text: "One" },
         type: 200,
       },
       two: {
-        data: { val: "answer", text: "Two" },
+        data: { val: "answer2", text: "Two" },
         type: 200,
       },
       question2: {
@@ -275,11 +276,11 @@ describe("Validate Session endpoint", () => {
         edges: ["yes", "no"],
       },
       yes: {
-        data: { val: "answer", text: "Yes" },
+        data: { val: "answerYes", text: "Yes" },
         type: 200,
       },
       no: {
-        data: { val: "answer", text: "No" },
+        data: { val: "answerNo", text: "No" },
         type: 200,
       },
       section2: {
@@ -294,11 +295,11 @@ describe("Validate Session endpoint", () => {
         edges: ["a", "b"],
       },
       a: {
-        data: { val: "answer", text: "A" },
+        data: { val: "answerA", text: "A" },
         type: 200,
       },
       b: {
-        data: { val: "answer", text: "B" },
+        data: { val: "answerB", text: "B" },
         type: 200,
       },
     };
@@ -348,7 +349,7 @@ describe("Validate Session endpoint", () => {
 
     const expected = {
       reconciledSessionData: {
-        ...mockLowcalSession.data,
+        ...reconciledData,
         breadcrumbs: {
           section2: {
             auto: false,
@@ -467,7 +468,7 @@ describe("Validate Session endpoint", () => {
 
     const expected = {
       reconciledSessionData: {
-        ...mockLowcalSession.data,
+        ...reconciledData,
         breadcrumbs,
       },
       message:
@@ -486,6 +487,97 @@ describe("Validate Session endpoint", () => {
           objectContainsKeys(
             response.body.reconciledSessionData.breadcrumbs,
             []
+          )
+        ).toBe(false);
+      });
+  });
+
+  test('auto-answered breadcrumbs with matching "data.val" values are also removed', async () => {
+    const flow: Flow["data"] = {
+      _root: {
+        edges: ["question1", "question2"],
+      },
+      question1: {
+        data: { fn: "question", text: "Is it 'X' or 'Y'" },
+        type: 100,
+        edges: ["one", "two"],
+      },
+      question2: {
+        data: { fn: "question", text: "Is it 'X' or 'Y'" },
+        type: 100,
+        edges: ["a", "b"],
+      },
+      one: {
+        data: { val: "question.x", text: "1: X" },
+        type: 200,
+      },
+      two: {
+        data: { val: "question.y", text: "2: Y" },
+        type: 200,
+      },
+      a: {
+        data: { val: "question.x", text: "A: X" },
+        type: 200,
+      },
+      b: {
+        data: { val: "question.y", text: "B: Y" },
+        type: 200,
+      },
+    };
+
+    const breadcrumbs: Breadcrumb = {
+      question1: {
+        auto: false,
+        answers: ["two"],
+      },
+      question2: {
+        auto: true,
+        answers: ["b"],
+      },
+    };
+
+    // a change to answer "two" means that "question1" should be removed
+    // but it also means that the auto-answered "question2" should be removed
+    // because the question's answer "b" shares the same "val"
+    const diff = {
+      two: {
+        data: { val: "question.y", text: "2: YYY" },
+        type: 200,
+      },
+    };
+
+    mockQueryWithFlowDiff({ flow, diff, breadcrumbs });
+
+    const data = {
+      payload: {
+        sessionId: mockLowcalSession.id,
+        email: mockLowcalSession.email,
+      },
+    };
+
+    const expected = {
+      reconciledSessionData: {
+        ...reconciledData,
+        breadcrumbs: {},
+      },
+      message:
+        "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue.",
+      alteredSectionIds: [],
+      changesFound: true,
+    };
+
+    const removedBreadcrumbIds = ["question1", "question2"];
+
+    await supertest(app)
+      .post(validateSessionPath)
+      .send(data)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toEqual(expected);
+        expect(
+          objectContainsKeys(
+            response.body.reconciledSessionData.breadcrumbs,
+            removedBreadcrumbIds
           )
         ).toBe(false);
       });

--- a/api.planx.uk/saveAndReturn/validateSession.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.ts
@@ -96,13 +96,6 @@ export async function validateSession(
     const { reconciledSessionData, alteredSectionIds } =
       await reconcileSessionData({ sessionData, alteredNodes });
 
-    // store reconciled session data
-    await updateLowcalSessionData({
-      sessionId,
-      sessionData: reconciledSessionData,
-      email,
-    });
-
     const responseData: ValidationResponse = {
       message:
         "This service has been updated since you last saved your application." +
@@ -255,34 +248,6 @@ async function findSession({
   return response.lowcal_sessions.length
     ? response.lowcal_sessions[0]
     : undefined;
-}
-
-async function updateLowcalSessionData({
-  sessionId,
-  sessionData,
-  email,
-}: {
-  sessionId: string;
-  sessionData: LowCalSession["data"];
-  email: string;
-}): Promise<LowCalSession> {
-  const query = gql`
-    mutation UpdateLowcalSessionData($sessionId: uuid!, $data: jsonb!) {
-      update_lowcal_sessions_by_pk(
-        pk_columns: { id: $sessionId }
-        _set: { data: $data }
-      ) {
-        data
-      }
-    }
-  `;
-  const headers = getSaveAndReturnPublicHeaders(sessionId, email);
-  const response = await publicClient.request(
-    query,
-    { sessionId, data: sessionData },
-    headers
-  );
-  return response.update_lowcal_sessions_by_pk?.data;
 }
 
 async function createAuditEntry(

--- a/api.planx.uk/saveAndReturn/validateSession.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.ts
@@ -4,7 +4,6 @@ import {
   adminGraphQLClient as adminClient,
   publicGraphQLClient as publicClient,
 } from "../hasura";
-import { getSaveAndReturnPublicHeaders } from "./utils";
 import { getMostRecentPublishedFlow } from "../helpers";
 import { sortBreadcrumbs } from "@opensystemslab/planx-core";
 import { ComponentType } from "@opensystemslab/planx-core/types";
@@ -29,7 +28,6 @@ export type ReconciledSession = {
 
 // TODO - Ensure reconciliation handles:
 //  * collected flags
-//  * auto-answered
 //  * component dependencies like FindProperty, DrawBoundary, PlanningConstraints
 export async function validateSession(
   req: Request,
@@ -56,7 +54,12 @@ export async function validateSession(
         message: "Unable to find your session",
       });
     }
-    const sessionData = fetchedSession.data!;
+
+    const sessionData = {
+      ...fetchedSession.data!,
+      // remove passport data (reconstructed in the editor by `computePassport`)
+      passport: { data: {} },
+    };
     const sessionUpdatedAt = fetchedSession.updated_at!;
     const flowId = fetchedSession.flow_id!;
 
@@ -123,9 +126,15 @@ async function reconcileSessionData({
   alteredNodes: Array<Node>;
 }): Promise<ReconciledSession> {
   const sessionData = { ...originalData }; // copy original data for modification
-  const alteredSectionIds: string[] = [];
+  const alteredSectionIds = new Set<string>();
 
   const currentFlow = await getMostRecentPublishedFlow(sessionData.id);
+
+  // create ordered breadcrumbs to be able to look up section IDs later
+  const orderedBreadcrumbs: OrderedBreadcrumbs = sortBreadcrumbs(
+    currentFlow as FlowGraph,
+    sessionData.breadcrumbs
+  );
 
   const findParentNode = (nodeId: string): string | undefined => {
     const [parentId, _] =
@@ -135,66 +144,51 @@ async function reconcileSessionData({
     return parentId;
   };
 
-  // create ordered breadcrumbs to be able to look up section IDs later
-  const orderedBreadcrumbs: OrderedBreadcrumbs = sortBreadcrumbs(
-    currentFlow as FlowGraph,
-    sessionData.breadcrumbs
-  );
-
-  const removeBreadcrumb = (nodeId: string) => {
-    if (sessionData.breadcrumbs[nodeId]) {
-      delete sessionData.breadcrumbs[nodeId];
-    }
-    const crumb: NormalizedCrumb | undefined = orderedBreadcrumbs.find(
-      (crumb) => crumb.id === nodeId!
+  const removeAlteredAndAffectedBreadcrumb = (nodeId: string) => {
+    const foundParentId = findParentNode(nodeId);
+    const matchingCrumbs: NormalizedCrumb[] = orderedBreadcrumbs.filter(
+      (crumb) =>
+        crumb.id === nodeId || (foundParentId && crumb.id === foundParentId)
     );
-    if (
-      crumb &&
-      crumb?.sectionId &&
-      sessionData.breadcrumbs[crumb.sectionId!]
-    ) {
-      delete sessionData.breadcrumbs[crumb.sectionId!];
-      alteredSectionIds.push(crumb.sectionId);
+
+    for (const crumb of matchingCrumbs) {
+      // delete crumb
+      if (sessionData.breadcrumbs[crumb.id]) {
+        delete sessionData.breadcrumbs[crumb.id];
+      }
+
+      // delete crumb's section
+      if (
+        crumb &&
+        crumb?.sectionId &&
+        sessionData.breadcrumbs[crumb.sectionId!]
+      ) {
+        delete sessionData.breadcrumbs[crumb.sectionId!];
+        alteredSectionIds.add(crumb.sectionId);
+      }
     }
   };
 
-  // TODO - ensure all passport keys are cleaned up
-  const removePassportValue = (nodeId: string) => {
-    // a flow schema can store the planx variable name under any of these keys
-    const planx_keys = ["fn", "val", "output", "dataFieldBoundary"];
-    planx_keys.forEach((key) => {
-      // check if a removed breadcrumb has a passport var based on the published content at save point
-      if (sessionData && currentFlow[nodeId]?.data?.[key]) {
-        // if it does, remove that passport variable from our session so we don't auto-answer changed questions before the user sees them
-        delete sessionData.passport?.data?.[currentFlow[nodeId].data?.[key]];
-      }
-    });
-  };
+  // remove all auto-answered breadcrumbs
+  // (auto-answers are reconstructed in the editor by `upcomingCards`)
+  for (const [id, crumb] of Object.entries(sessionData.breadcrumbs)) {
+    if (crumb.auto === true && sessionData.breadcrumbs[id]) {
+      delete sessionData.breadcrumbs[id];
+    }
+  }
 
-  const removeSessionDataForNodeId = (nodeId: string) => {
-    removeBreadcrumb(nodeId);
-    removePassportValue(nodeId);
-  };
-
-  // update breadcrumbs
+  // remove any altered or affected breadcrumbs
   for (const node of alteredNodes) {
+    // ignore section content changes and do not included these in alteredSectionIds
     if (node.type === ComponentType.Section) {
-      // ignore section content changes and do not included these in alteredSectionIds
       continue;
     }
-    removeSessionDataForNodeId(node.id!);
-    // if an answer has changed, find it's parent and remove that from breadcrumbs
-    if (node.type === ComponentType.Answer) {
-      const parentId = findParentNode(node.id!);
-      if (parentId && sessionData.breadcrumbs[parentId!]) {
-        removeSessionDataForNodeId(parentId!);
-      }
-    }
+    if (node.id) removeAlteredAndAffectedBreadcrumb(node.id);
   }
 
   return {
     reconciledSessionData: sessionData,
-    alteredSectionIds,
+    alteredSectionIds: [...alteredSectionIds],
   };
 }
 

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -58,7 +58,7 @@ export default function Component(props: Props) {
         flow={flow}
         showChange={true}
         changeAnswer={changeAnswer}
-        nextQuestion={props.handleSubmit!}
+        nextQuestion={() => props.handleSubmit && props.handleSubmit()}
         sectionNodes={sectionNodes}
         currentCard={currentCard}
         breadcrumbs={breadcrumbs}

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -105,9 +105,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
       setPreviewEnvironment(previewEnvironment);
       if (isStandalone) {
         NEW.getLocalFlow(sessionId).then((state) => {
-          if (state) {
-            resumeSession(state);
-          }
+          // session data is resumed by ./ResumePage.tsx
           createAnalytics(state ? "resume" : "init");
           setGotFlow(true);
         });

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -7,6 +7,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import { SectionsOverviewList } from "@planx/components/Section/Public";
 import Card from "@planx/components/shared/Preview/Card";
 import SummaryListsBySections from "@planx/components/shared/Preview/SummaryList";
+import { TYPES } from "@planx/components/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { sortBreadcrumbs } from "pages/FlowEditor/lib/store/preview";
 import React from "react";
@@ -35,15 +36,25 @@ const ReconciliationPage: React.FC<Props> = ({
   buttonText,
   onButtonClick,
 }) => {
-  const [flow, hasSections, sectionNodes, currentCard, changeAnswer] = useStore(
-    (state) => [
+  const [flow, hasSections, sectionNodes, currentCard, changeAnswer, record] =
+    useStore((state) => [
       state.flow,
       state.hasSections,
       state.sectionNodes,
       state.currentCard(),
       state.changeAnswer,
-    ]
-  );
+      state.record,
+    ]);
+
+  const nextQuestion = () => {
+    if (onButtonClick) {
+      onButtonClick();
+    }
+    // skip current card if it is a section
+    if (currentCard && currentCard.id && currentCard.type === TYPES.Section) {
+      record(currentCard.id, { auto: false });
+    }
+  };
 
   const sortedBreadcrumbs = sortBreadcrumbs(
     reconciliationResponse.reconciledSessionData.breadcrumbs,
@@ -87,7 +98,7 @@ const ReconciliationPage: React.FC<Props> = ({
             flow={flow}
             alteredSectionIds={reconciliationResponse.alteredSectionIds}
             changeAnswer={changeAnswer}
-            nextQuestion={onButtonClick!}
+            nextQuestion={nextQuestion}
             showChange={false}
             isReconciliation={true}
             sectionNodes={sectionNodes}
@@ -110,7 +121,7 @@ const ReconciliationPage: React.FC<Props> = ({
             color="primary"
             size="large"
             data-testid="continue-button"
-            onClick={onButtonClick}
+            onClick={nextQuestion}
           >
             {buttonText}
           </Button>

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -178,6 +178,7 @@ const ResumePage: React.FC = () => {
   }, [email]);
 
   const teamSlug = useStore((state) => state.teamSlug);
+  const resumeSession = useStore((state) => state.resumeSession);
 
   /**
    * Continue application following successful validation & reconciliation
@@ -228,7 +229,7 @@ const ResumePage: React.FC = () => {
         if (response.data) {
           const reconciledSessionData = response.data.reconciledSessionData;
           setReconciliationResponse(response.data);
-          useStore.getState().resumeSession(reconciledSessionData);
+          resumeSession(reconciledSessionData);
           // Skip reconciliation page if applicant has started payment
           isPaymentCreated(reconciledSessionData)
             ? continueApplication()


### PR DESCRIPTION
This change allows sections to behave as expected during reconciliation.

The ResumePage component is no longer competing with the Question component to update state after reconciliation. 

I attempted to solve some of the strange behavior we had noticed around state updating in unexpected ways but it looks like some weird behaviours are rooted in how `upcomingCards` and/or `computePassport` work. 

Here's my current theory about outstanding issues with reconciliation:
It seems that the preemptive auto-answering in `upcomingCards` can create new breadcrumb entries for auto-answerable cards. Reconciliation removes altered breadcrumbs but it doesn't remove breadcrumbs with matching "automations". When `upcomingCards` runs again (and it is called many times) it reconstructs and re-adds the removed breadcrumbs based on the computed passport (which is a core to the auto-answer feature). If I'm correct, an update to the reconciliation API could be the simplest way to resolve this (see #1704 ).

TLDR; This change does not fix issues with auto-answering in big LDC flows but follow-on PR #1704 does.