### PR TITLE
feat: Add scroll to top behaviour

### DIFF
--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -127,6 +127,11 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     }, [gotFlow, breadcrumbs, passport, sessionId, id, govUkPayment]);
   }
 
+  // scroll to top on any update to breadcrumbs
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [breadcrumbs]);
+
   const handleSubmit =
     (id: string): handleSubmit =>
     (userData) => {


### PR DESCRIPTION
Every question transition should trigger the scroll position being reset to the top of the page.