### PR TITLE
chore: Tidy up e2e test context and add test annotations

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,6 +2,8 @@
   "private": true,
   "scripts": {
     "test": "playwright test",
+    "test:ours": "playwright test --grep-invert @integration",
+    "test:integrations": "playwright test --grep @integration",
     "test:debug": "DEBUG_LOG=true pnpm test",
     "test:server": "NODE_ENV=test serve ../editor.planx.uk/build --single --listen 3000",
     "lint": "eslint './src/*.{js,ts}' && prettier -c ./src",

--- a/e2e/src/context.ts
+++ b/e2e/src/context.ts
@@ -28,6 +28,23 @@ export interface Context {
   sessionIds?: string[];
 }
 
+export const contextDefaults = {
+  user: {
+    firstName: "Test",
+    lastName: "Test",
+    // Gov.uk Notify requests testing service use smoke test email addresses
+    // see https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing
+    email: "simulate-delivered@notifications.service.gov.uk",
+  },
+  team: {
+    name: "E2E Test Team",
+    slug: "e2e-test-team",
+    logo: "https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/planx-testing.svg",
+    primaryColor: "#444444",
+    homepage: "planx.uk",
+  },
+};
+
 export async function setUpTestContext(
   initialContext: Context
 ): Promise<Context> {

--- a/e2e/src/create-flow.spec.ts
+++ b/e2e/src/create-flow.spec.ts
@@ -1,22 +1,15 @@
 import { test, expect, Browser } from "@playwright/test";
-import { setUpTestContext, tearDownTestContext } from "./context";
+import {
+  contextDefaults,
+  setUpTestContext,
+  tearDownTestContext,
+} from "./context";
 import { getTeamPage, createAuthenticatedSession } from "./helpers";
 import type { Context } from "./context";
 
 test.describe("Navigation", () => {
   let context: Context = {
-    user: {
-      firstName: "test",
-      lastName: "test",
-      email: "e2etest@test.com",
-    },
-    team: {
-      name: "E2E Navigation Test",
-      slug: "e2e-navigation-test",
-      logo: "https://placedog.net/250/250",
-      primaryColor: "#000000",
-      homepage: "example.com",
-    },
+    ...contextDefaults,
   };
   const serviceProps = {
     name: "A Test Service",

--- a/e2e/src/login.spec.ts
+++ b/e2e/src/login.spec.ts
@@ -1,21 +1,15 @@
 import { test, expect } from "@playwright/test";
 import { createAuthenticatedSession } from "./helpers";
-import { setUpTestContext, tearDownTestContext } from "./context";
+import {
+  contextDefaults,
+  setUpTestContext,
+  tearDownTestContext,
+} from "./context";
 import type { Context } from "./context";
 
 test.describe("Login", () => {
   let context: Context = {
-    user: {
-      firstName: "test",
-      lastName: "test",
-      email: "e2etest@test.com",
-    },
-    team: {
-      name: "BadInternetClub",
-      logo: "https://placedog.net/250/250",
-      primaryColor: "#000000",
-      homepage: "example.com",
-    },
+    ...contextDefaults,
   };
 
   test.beforeAll(async () => {

--- a/e2e/src/pay.spec.ts
+++ b/e2e/src/pay.spec.ts
@@ -6,21 +6,18 @@ import { gql, GraphQLClient } from "graphql-request";
 import type { SessionData } from "@opensystemslab/planx-core/types";
 import type { Context } from "./context";
 import {
+  contextDefaults,
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
 } from "./context";
 
 let context: Context = {
-  user: {
-    firstName: "test",
-    lastName: "test",
-    email: "e2epaytest@test.com",
-  },
+  ...contextDefaults,
   team: {
     name: "Buckinghamshire",
     slug: "buckinghamshire",
-    logo: "https://placedog.net/250/250",
+    logo: "https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/planx-testing.svg",
     primaryColor: "#F30415",
     homepage: "example.com",
   },
@@ -40,7 +37,7 @@ const cards = {
 };
 const payButtonText = "Pay now using GOV.UK Pay";
 
-test.describe("Payment flow", async () => {
+test.describe("Gov Pay @integration", async () => {
   const adminGQLClient = getGraphQLClient();
 
   test.beforeAll(async () => {

--- a/e2e/src/save-and-return.spec.ts
+++ b/e2e/src/save-and-return.spec.ts
@@ -5,6 +5,7 @@ import {
   modifiedSimpleSendFlow,
 } from "./flows/save-and-return-flows";
 import {
+  contextDefaults,
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
@@ -21,18 +22,7 @@ import type { Context } from "./context";
 
 test.describe("Save and return", () => {
   let context: Context = {
-    user: {
-      firstName: "test",
-      lastName: "test",
-      email: "e2etest@test.com",
-    },
-    team: {
-      name: "E2E Test Team",
-      slug: "e2e-test-team",
-      logo: "https://placedog.net/250/250",
-      primaryColor: "#F30415",
-      homepage: "example.com",
-    },
+    ...contextDefaults,
     flow: {
       slug: "e2e-save-and-return-test-flow",
       data: simpleSendFlow,

--- a/e2e/src/sections.spec.ts
+++ b/e2e/src/sections.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { flow, updatedQuestionAnswers } from "./flows/sections-flow";
 import {
+  contextDefaults,
   setUpTestContext,
   tearDownTestContext,
   getGraphQLClient,
@@ -34,18 +35,7 @@ export enum SectionStatus {
 
 test.describe("Sections", () => {
   let context: Context = {
-    user: {
-      firstName: "test",
-      lastName: "test",
-      email: "e2etest@test.com",
-    },
-    team: {
-      name: "E2E Test Team",
-      slug: "e2e-test-team",
-      logo: "https://placedog.net/250/250",
-      primaryColor: "#F30415",
-      homepage: "example.com",
-    },
+    ...contextDefaults,
     flow: {
       slug: "sections-test-flow",
       data: flow,


### PR DESCRIPTION
* Shares context defaults
    - adds a new planx testing logo
    - uses smoke testing email address (as recommended [here](https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing))
    - reduces duplication
* Adds the "@integration" test annotation for test calling 3rd party services
* Adds commands for `test:ours` and `test:integrations` to run annotation sensitive tests

Whether we run every e2e test on every PR change or only a subset is still up for discussion but this PR provides a methodology for setting-up selective test runs.