### PR TITLE
feat: Better error handling for ITP

### DIFF
--- a/editor.planx.uk/src/lib/pay.ts
+++ b/editor.planx.uk/src/lib/pay.ts
@@ -1,4 +1,4 @@
-import { addDays, format } from "date-fns";
+import { addDays, format, subDays } from "date-fns";
 
 // Must value set in api.planx.uk/saveAndReturn/utils.ts
 // This ensures that dates will be aligned in the public interface and in emails
@@ -9,3 +9,5 @@ export const getExpiryDateForPaymentRequest = (createdAt: string) => {
   const formattedExpiryDate = format(expiryDate, "dd MMMM yyyy");
   return formattedExpiryDate;
 };
+
+export const getRetentionPeriod = () => subDays(new Date(), DAYS_UNTIL_EXPIRY);

--- a/editor.planx.uk/src/pages/ErrorPage.tsx
+++ b/editor.planx.uk/src/pages/ErrorPage.tsx
@@ -1,46 +1,47 @@
 import Box from "@mui/material/Box";
-import { Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
-import React from "react";
+import { styled } from "@mui/styles";
+import React, { PropsWithChildren } from "react";
 
-const useStyles = makeStyles<Theme>((theme) => ({
-  root: {
-    backgroundColor: "#fff",
-    color: "#2C2C2C",
-    width: "100%",
-    flex: 1,
-    justifyContent: "flex-start",
-    alignItems: "center",
-  },
-  dashboard: {
-    backgroundColor: "#fff",
-    color: "#2C2C2C",
-    width: "100%",
-    maxWidth: 600,
-    margin: "auto",
-    padding: theme.spacing(8, 0, 4, 0),
-  },
+const Root = styled(Box)(() => ({
+  backgroundColor: "#fff",
+  color: "#2C2C2C",
+  width: "100%",
+  flex: 1,
+  justifyContent: "flex-start",
+  alignItems: "center",
 }));
 
-const ErrorPage: React.FC<{ title: string }> = ({ title }) => {
-  const classes = useStyles();
+const Dashboard = styled(Box)(({ theme }) => ({
+  backgroundColor: "#fff",
+  color: "#2C2C2C",
+  width: "100%",
+  maxWidth: 600,
+  margin: "auto",
+  padding: theme.spacing(8, 0, 4, 0),
+}));
 
-  return (
-    <Box className={classes.root}>
-      <Box className={classes.dashboard}>
-        <Box pl={2} pb={2}>
-          <Typography variant="h1" gutterBottom>
-            {title}
-          </Typography>
-          <Typography variant="body1">
-            This bug has been automatically logged and our team will see it
-            soon. Refreshing this page will not resolve the issue.
-          </Typography>
-        </Box>
+interface ErrorPageProps {
+  title: string;
+}
+
+const DEFAULT_MESSAGE =
+  "This bug has been automatically logged and our team will see it soon. Refreshing this page will not resolve the issue.";
+
+const ErrorPage: React.FC<PropsWithChildren<ErrorPageProps>> = ({
+  title,
+  children,
+}) => (
+  <Root>
+    <Dashboard>
+      <Box pl={2} pb={2}>
+        <Typography variant="h1" gutterBottom>
+          {title}
+        </Typography>
+        <Typography variant="body1">{children || DEFAULT_MESSAGE}</Typography>
       </Box>
-    </Box>
-  );
-};
+    </Dashboard>
+  </Root>
+);
 
 export default ErrorPage;


### PR DESCRIPTION
## What does this PR do?
Adds a custom error page if we're unable to display a payment request. I've gone for a single, generic message as opposed to one for each possible failure method - opinions welcome here!

The copy is just a placeholder, a ticket for content has been generated on the green Trello here - https://trello.com/c/2jSoPczy/1236-write-copy-for-invite-to-pay-error-pages

Please toggle `INVITE_TO_PAY` feature flag to test this.

**Test URLs** (E2E tests of this feature are on another branch incoming shortly)
 - Valid payment request link - https://1706.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/pay?paymentRequestId=11c95bc2-b99c-4d81-8b02-7e35a883a3fd
 - Missing `paymentRequestId` param - https://1706.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/pay?wrongParam=true
 - Expired `paymentRequest` - https://1706.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/pay?paymentRequestId=22c95bc2-b99c-4d81-8b02-7e35a883a3fd
 - `paymentRequest` already paid - https://1706.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/pay?paymentRequestId=33c95bc2-b99c-4d81-8b02-7e35a883a3fd