### PR TITLE
fix: Add "locked application" warning, fix E2E tests

### DIFF
--- a/api.planx.uk/saveAndReturn/validateSession.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.ts
@@ -52,7 +52,7 @@ export async function validateSession(
       });
     }
 
-    if (fetchedSession.locked_at) {
+    if (fetchedSession.lockedAt) {
       return res.status(403).send({
         status: 403,
         message: "Session locked",
@@ -241,7 +241,7 @@ async function findSession({
             flow_id
             data
             updated_at
-            locked_at
+            lockedAt: locked_at
             paymentRequests: payment_requests {
               id
               payeeName: payee_name

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -72,7 +72,7 @@ export interface LowCalSession {
   flow: {
     slug: string;
   };
-  locked_at?: string;
+  lockedAt?: string;
   paymentRequests?: Pick<PaymentRequest, "id" | "payeeEmail" | "payeeName">[]
 }
 

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -1,3 +1,5 @@
+import { PaymentRequest } from "@opensystemslab/planx-core/dist/types";
+
 export interface Node {
   id?: string;
   data?: Record<string, any>;
@@ -70,6 +72,8 @@ export interface LowCalSession {
   flow: {
     slug: string;
   };
+  locked_at?: string;
+  paymentRequests?: Pick<PaymentRequest, "id" | "payeeEmail" | "payeeName">[]
 }
 
 type MinimumNotifyPersonalisation = {

--- a/e2e/src/context.ts
+++ b/e2e/src/context.ts
@@ -27,7 +27,6 @@ export interface Context {
     data?: object;
   };
   sessionIds?: string[];
-  paymentRequest?: Partial<PaymentRequest>;
 }
 
 export const contextDefaults = {

--- a/e2e/src/context.ts
+++ b/e2e/src/context.ts
@@ -3,6 +3,7 @@ import { log } from "./helpers";
 import { sign } from "jsonwebtoken";
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { GraphQLClient, gql } from "graphql-request";
+import { PaymentRequest } from "@opensystemslab/planx-core/types";
 
 export interface Context {
   user: {
@@ -26,6 +27,7 @@ export interface Context {
     data?: object;
   };
   sessionIds?: string[];
+  paymentRequest?: Partial<PaymentRequest>;
 }
 
 export const contextDefaults = {

--- a/e2e/src/flows/invite-to-pay-flow.ts
+++ b/e2e/src/flows/invite-to-pay-flow.ts
@@ -33,7 +33,7 @@ const flow: FlowGraph = {
       val: "swimmingPool",
       text: "Swimming pool",
     },
-    type: ComponentType.Answer
+    type: ComponentType.Answer,
   },
   LohvWDYd36: {
     data: {
@@ -53,14 +53,14 @@ const flow: FlowGraph = {
       val: "extension",
       text: "Extension",
     },
-    type: ComponentType.Answer
+    type: ComponentType.Answer,
   },
   mgKUfcwq4Z: {
     data: {
       val: "solarPanels",
       text: "Solar Panels",
     },
-    type: ComponentType.Answer
+    type: ComponentType.Answer,
   },
   yWXG2AYoq2: {
     data: {

--- a/e2e/src/flows/invite-to-pay-flow.ts
+++ b/e2e/src/flows/invite-to-pay-flow.ts
@@ -33,7 +33,7 @@ const flow: FlowGraph = {
       val: "swimmingPool",
       text: "Swimming pool",
     },
-    type: ComponentType.Response,
+    type: ComponentType.Answer
   },
   LohvWDYd36: {
     data: {
@@ -53,14 +53,14 @@ const flow: FlowGraph = {
       val: "extension",
       text: "Extension",
     },
-    type: ComponentType.Response,
+    type: ComponentType.Answer
   },
   mgKUfcwq4Z: {
     data: {
       val: "solarPanels",
       text: "Solar Panels",
     },
-    type: ComponentType.Response,
+    type: ComponentType.Answer
   },
   yWXG2AYoq2: {
     data: {

--- a/e2e/src/flows/invite-to-pay-flow.ts
+++ b/e2e/src/flows/invite-to-pay-flow.ts
@@ -30,10 +30,10 @@ const flow: FlowGraph = {
   },
   IfcqOHdMyi: {
     data: {
-      val: "alter.internal.walls",
-      text: "Alter internal walls",
+      val: "swimmingPool",
+      text: "Swimming pool",
     },
-    type: ComponentType.Answer,
+    type: ComponentType.Response,
   },
   LohvWDYd36: {
     data: {
@@ -50,17 +50,17 @@ const flow: FlowGraph = {
   },
   kId6RbgUtl: {
     data: {
-      val: "alter.decks",
-      text: "Addition or alteration of a deck",
+      val: "extension",
+      text: "Extension",
     },
-    type: ComponentType.Answer,
+    type: ComponentType.Response,
   },
   mgKUfcwq4Z: {
     data: {
-      val: "extend.porch.side",
-      text: "Addition of a side porch",
+      val: "solarPanels",
+      text: "Solar Panels",
     },
-    type: ComponentType.Answer,
+    type: ComponentType.Response,
   },
   yWXG2AYoq2: {
     data: {

--- a/e2e/src/flows/invite-to-pay-flow.ts
+++ b/e2e/src/flows/invite-to-pay-flow.ts
@@ -30,8 +30,8 @@ const flow: FlowGraph = {
   },
   IfcqOHdMyi: {
     data: {
-      val: "swimmingPool",
-      text: "Swimming pool",
+      val: "alter.internal.walls",
+      text: "Alter internal walls",
     },
     type: ComponentType.Answer,
   },
@@ -50,15 +50,15 @@ const flow: FlowGraph = {
   },
   kId6RbgUtl: {
     data: {
-      val: "extension",
-      text: "Extension",
+      val: "alter.decks",
+      text: "Addition or alteration of a deck",
     },
     type: ComponentType.Answer,
   },
   mgKUfcwq4Z: {
     data: {
-      val: "solarPanels",
-      text: "Solar Panels",
+      val: "extend.porch.side",
+      text: "Addition of a side porch",
     },
     type: ComponentType.Answer,
   },

--- a/e2e/src/invite-to-pay/agent.spec.ts
+++ b/e2e/src/invite-to-pay/agent.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from "@playwright/test";
 import {
   setFeatureFlag,
   addSessionToContext,
-  cards,
-  fillGovUkCardDetails,
   modifyFlow,
 } from "../helpers";
 import inviteToPayFlow from "../flows/invite-to-pay-flow";
@@ -108,7 +106,7 @@ test.describe("Agent journey", async () => {
     expect(toggleInviteToPayButton).toBeDisabled();
   });
 
-  test.fixme(
+  test(
     "agent cannot make changes after sending a payment request - session is locked",
     async ({ page: firstPage, context: browserContext }) => {
       const sessionId = await makePaymentRequest({ page: firstPage, context });
@@ -126,66 +124,19 @@ test.describe("Agent journey", async () => {
       await secondPage.getByLabel("Email address").fill(context.user.email);
       await secondPage.getByTestId("continue-button").click();
 
-      // Cannot click "back" or make changes
       expect(
         await secondPage.getByRole("heading", {
-          name: "Resume your application",
+          name: "Your application is locked",
         })
       ).toBeVisible();
-      await secondPage.getByTestId("continue-button").click();
-      const backButton = await secondPage
-        .locator("#main-content")
-        .getByRole("button", { name: "Back" });
-      expect(backButton).not.toBeVisible();
+      expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
     }
   );
 
-  test.fixme(
-    "agent cannot pay after sending a payment request",
+  test(
+    "reconciliation does not apply to sessions with open payment requests",
     async ({ page: firstPage, context: browserContext }) => {
       const sessionId = await makePaymentRequest({ page: firstPage, context });
-
-      // Resume session
-      const resumeLink = `/${context.team!.slug!}/${context.flow!
-        .slug!}/preview?analytics=false&sessionId=${sessionId}`;
-      const secondPage = await browserContext.newPage();
-      await secondPage.goto(resumeLink);
-      expect(
-        await secondPage.getByRole("heading", {
-          name: "Resume your application",
-        })
-      ).toBeVisible();
-      await secondPage.getByLabel("Email address").fill(context.user.email);
-      await secondPage.getByTestId("continue-button").click();
-
-      // TODO: Check desired behaviour and fix this
-      // Make payment
-      expect(
-        await secondPage.getByRole("heading", {
-          name: "Resume your application",
-        })
-      ).toBeVisible();
-      await secondPage.getByTestId("continue-button").click();
-      expect(
-        await secondPage.getByRole("heading", {
-          name: "Pay for your application",
-        })
-      ).toBeVisible();
-      await secondPage.getByText("Pay now using GOV.UK Pay").click();
-      await fillGovUkCardDetails({
-        page: secondPage,
-        cardNumber: cards.successful_card_number,
-      });
-      await secondPage.getByRole("button", { name: "Confirm payment" }).click();
-
-      // FAIL: Session is locked and cannot be modified so payment not registered
-    }
-  );
-
-  test.fixme(
-    "reconciliation does not apply to sessions with open payment requests",
-    async ({ page, context: browserContext }) => {
-      const sessionId = await makePaymentRequest({ page, context });
 
       // Make change to flow, publish it
       await modifyFlow({ context, modifiedFlow: modifiedInviteToPayFlow });
@@ -193,21 +144,27 @@ test.describe("Agent journey", async () => {
       // Navigate to resume session link
       const resumeLink = `/${context.team!.slug!}/${context.flow!
         .slug!}/preview?analytics=false&sessionId=${sessionId}`;
-      const newPage = await browserContext.newPage();
-      await newPage.goto(resumeLink);
+      const secondPage = await browserContext.newPage();
+      await secondPage.goto(resumeLink);
       expect(
-        await newPage.getByRole("heading", { name: "Resume your application" })
+        await secondPage.getByRole("heading", { name: "Resume your application" })
       ).toBeVisible();
-      await newPage.getByLabel("Email address").fill(context.user.email);
-      await newPage.getByTestId("continue-button").click();
+      await secondPage.getByLabel("Email address").fill(context.user.email);
+      await secondPage.getByTestId("continue-button").click();
 
       // Reconciliation ignored
-      const reconciliationText = await newPage.getByText(
+      const reconciliationText = await secondPage.getByText(
         "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue."
       );
       expect(reconciliationText).not.toBeVisible();
 
-      // FAIL: Reconciliation text displayed
+      // Locked application message displayed
+      expect(
+        await secondPage.getByRole("heading", {
+          name: "Your application is locked",
+        })
+      ).toBeVisible();
+      expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
     }
   );
 });

--- a/e2e/src/invite-to-pay/agent.spec.ts
+++ b/e2e/src/invite-to-pay/agent.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from "@playwright/test";
-import {
-  setFeatureFlag,
-  addSessionToContext,
-  modifyFlow,
-} from "../helpers";
+import { setFeatureFlag, addSessionToContext, modifyFlow } from "../helpers";
 import inviteToPayFlow from "../flows/invite-to-pay-flow";
 import {
   Context,
@@ -106,65 +102,65 @@ test.describe("Agent journey", async () => {
     expect(toggleInviteToPayButton).toBeDisabled();
   });
 
-  test(
-    "agent cannot make changes after sending a payment request - session is locked",
-    async ({ page: firstPage, context: browserContext }) => {
-      const sessionId = await makePaymentRequest({ page: firstPage, context });
+  test("agent cannot make changes after sending a payment request - session is locked", async ({
+    page: firstPage,
+    context: browserContext,
+  }) => {
+    const sessionId = await makePaymentRequest({ page: firstPage, context });
 
-      // Resume session
-      const resumeLink = `/${context.team!.slug!}/${context.flow!
-        .slug!}/preview?analytics=false&sessionId=${sessionId}`;
-      const secondPage = await browserContext.newPage();
-      await secondPage.goto(resumeLink);
-      expect(
-        await secondPage.getByRole("heading", {
-          name: "Resume your application",
-        })
-      ).toBeVisible();
-      await secondPage.getByLabel("Email address").fill(context.user.email);
-      await secondPage.getByTestId("continue-button").click();
+    // Resume session
+    const resumeLink = `/${context.team!.slug!}/${context.flow!
+      .slug!}/preview?analytics=false&sessionId=${sessionId}`;
+    const secondPage = await browserContext.newPage();
+    await secondPage.goto(resumeLink);
+    expect(
+      await secondPage.getByRole("heading", {
+        name: "Resume your application",
+      })
+    ).toBeVisible();
+    await secondPage.getByLabel("Email address").fill(context.user.email);
+    await secondPage.getByTestId("continue-button").click();
 
-      expect(
-        await secondPage.getByRole("heading", {
-          name: "Your application is locked",
-        })
-      ).toBeVisible();
-      expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
-    }
-  );
+    expect(
+      await secondPage.getByRole("heading", {
+        name: "Your application is locked",
+      })
+    ).toBeVisible();
+    expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
+  });
 
-  test(
-    "reconciliation does not apply to sessions with open payment requests",
-    async ({ page: firstPage, context: browserContext }) => {
-      const sessionId = await makePaymentRequest({ page: firstPage, context });
+  test("reconciliation does not apply to sessions with open payment requests", async ({
+    page: firstPage,
+    context: browserContext,
+  }) => {
+    const sessionId = await makePaymentRequest({ page: firstPage, context });
 
-      // Make change to flow, publish it
-      await modifyFlow({ context, modifiedFlow: modifiedInviteToPayFlow });
+    // Make change to flow, publish it
+    await modifyFlow({ context, modifiedFlow: modifiedInviteToPayFlow });
 
-      // Navigate to resume session link
-      const resumeLink = `/${context.team!.slug!}/${context.flow!
-        .slug!}/preview?analytics=false&sessionId=${sessionId}`;
-      const secondPage = await browserContext.newPage();
-      await secondPage.goto(resumeLink);
-      expect(
-        await secondPage.getByRole("heading", { name: "Resume your application" })
-      ).toBeVisible();
-      await secondPage.getByLabel("Email address").fill(context.user.email);
-      await secondPage.getByTestId("continue-button").click();
+    // Navigate to resume session link
+    const resumeLink = `/${context.team!.slug!}/${context.flow!
+      .slug!}/preview?analytics=false&sessionId=${sessionId}`;
+    const secondPage = await browserContext.newPage();
+    await secondPage.goto(resumeLink);
+    expect(
+      await secondPage.getByRole("heading", { name: "Resume your application" })
+    ).toBeVisible();
+    await secondPage.getByLabel("Email address").fill(context.user.email);
+    await secondPage.getByTestId("continue-button").click();
 
-      // Reconciliation ignored
-      const reconciliationText = await secondPage.getByText(
-        "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue."
-      );
-      expect(reconciliationText).not.toBeVisible();
+    // Reconciliation ignored
+    const reconciliationText = await secondPage.getByText(
+      "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue."
+    );
+    expect(reconciliationText).not.toBeVisible();
 
-      // Locked application message displayed
-      expect(
-        await secondPage.getByRole("heading", {
-          name: "Your application is locked",
-        })
-      ).toBeVisible();
-      expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
-    }
-  );
+    // Locked application message displayed
+    expect(
+      await secondPage.getByRole("heading", {
+        name: "Your application is locked",
+      })
+    ).toBeVisible();
+    expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
+  });
 });


### PR DESCRIPTION

## What does this PR do?
 - Returns an error from the API when trying to validate a session which is locked
 - Returns the associated `payment_request` record for a session
 - Displays a warning page, with payment link, for the applicant / agent
 - Card created on Green Trello to cross check copy - https://trello.com/b/AfZjkFq0/planx-services-delivery

<img width="1394" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/9832bf09-b19d-4fd7-9615-09c8d70a11a1">