### PR TITLE
fix: tweak data sync to fix sharedb errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     profiles: ["seed"]
     working_dir: "/app"
     entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}
-    command: ["reset_flows", "include_published_flows"]
+    command: ["include_published_flows"]
     restart: "no"
     depends_on:
       hasura-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - "./scripts/seed-database:/app"
     profiles: ["seed"]
     working_dir: "/app"
-    entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}
+    entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS} "reset_flows" "include_published_flows"
     restart: "no"
     depends_on:
       hasura-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     profiles: ["seed"]
     working_dir: "/app"
     entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}
-    command: "reset_flows" "include_published_flows"
+    command: ["reset_flows", "include_published_flows"]
     restart: "no"
     depends_on:
       hasura-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,8 @@ services:
       - "./scripts/seed-database:/app"
     profiles: ["seed"]
     working_dir: "/app"
-    entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS} "reset_flows" "include_published_flows"
+    entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}
+    command: "reset_flows" "include_published_flows"
     restart: "no"
     depends_on:
       hasura-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,8 +101,8 @@ services:
       - "./scripts/seed-database:/app"
     profiles: ["seed"]
     working_dir: "/app"
-    entrypoint: ./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}
-    command: ["include_published_flows"]
+    entrypoint: "./container.sh postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE} ${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}"
+    command: "no_reset include_published_flows"
     restart: "no"
     depends_on:
       hasura-proxy:

--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -36,6 +36,9 @@ SELECT
 FROM sync_flows
 ON CONFLICT (id) DO NOTHING;
 
+-- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
+UPDATE flows SET version = 1;
+
 -- insert an operation for each flow (to make sharedb happy)
 INSERT INTO operations (flow_id, data, version)
 SELECT


### PR DESCRIPTION
two fixes for bugs I encountered on #1721:
- `flows` & `operations` need aligned versions (flows are copied with their original version from prod, but operations are inserted fresh at v1, so flows needs to be manually updated) or else sharedb will error and flows will fail to load in the editor
- docker images (aka pizzas) should `"include_published_flows"` (previously only staging sync was using this flag) 
  - still not sure i understand a scenario where we'd ever _not_ want this behavior on sync, is it more clear to handle `published_flows` same as other tables rather than uniquely?
  - i think there was a tricky reason we needed the last _two_ published_flows (save & return reconciliation maybe?) as originally written by gunar, rather than the last _one_ as updated recently - this is one to still keep an eye out for in testing?