### PR TITLE
Fix: Limit ITP to one Pay node

### DIFF
--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -280,37 +280,6 @@ describe("invite to pay validation on diff", () => {
       });
   });
 
-  it("does not update if invite to pay is enabled, but there is no Pay component", async () => {
-    const invalidFlow = {
-      ...flowWithInviteToPay,
-      Pay: undefined,
-      _root: {
-        edges: flowWithInviteToPay._root.edges!.filter((id) => id !== "Pay"),
-      },
-    };
-
-    queryMock.mockQuery({
-      name: "GetFlowData",
-      matchOnVariables: false,
-      data: {
-        flows_by_pk: {
-          data: invalidFlow,
-        },
-      },
-    });
-
-    await supertest(app)
-      .post("/flows/1/diff")
-      .set(authHeader())
-      .expect(200)
-      .then((res) => {
-        expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual(
-          "When using Invite to Pay, your flow must have a Pay"
-        );
-      });
-  });
-
   it("does not update if invite to pay is enabled, but there is more than one Pay component", async () => {
     const invalidFlow = {
       ...flowWithInviteToPay,

--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -280,6 +280,68 @@ describe("invite to pay validation on diff", () => {
       });
   });
 
+  it("does not update if invite to pay is enabled, but there is no Pay component", async () => {
+    const invalidFlow = {
+      ...flowWithInviteToPay,
+      Pay: undefined,
+      _root: {
+        edges: flowWithInviteToPay._root.edges!.filter((id) => id !== "Pay"),
+      },
+    };
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: false,
+      data: {
+        flows_by_pk: {
+          data: invalidFlow,
+        },
+      },
+    });
+
+    await supertest(app)
+      .post("/flows/1/diff")
+      .set(authHeader())
+      .expect(200)
+      .then((res) => {
+        expect(res.body.message).toEqual("Cannot publish an invalid flow");
+        expect(res.body.description).toEqual(
+          "When using Invite to Pay, your flow must have a Pay"
+        );
+      });
+  });
+
+  it("does not update if invite to pay is enabled, but there is more than one Pay component", async () => {
+    const invalidFlow = {
+      ...flowWithInviteToPay,
+      PayTwo: { ...flowWithInviteToPay.Pay },
+      _root: {
+        edges: [...flowWithInviteToPay._root.edges!, "PayTwo"],
+      },
+    };
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: false,
+      data: {
+        flows_by_pk: {
+          data: invalidFlow,
+        },
+      },
+    });
+
+    await supertest(app)
+      .post("/flows/1/diff")
+      .set(authHeader())
+      .expect(200)
+      .then((res) => {
+        expect(res.body.message).toEqual("Cannot publish an invalid flow");
+        expect(res.body.description).toEqual(
+          "When using Invite to Pay, your flow must have exactly ONE Pay"
+        );
+      });
+  });
+
   it("does not update if invite to pay is enabled, but there is not a Checklist that sets `proposal.projectType`", async () => {
     const {
       Checklist,

--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -59,7 +59,7 @@ describe("publish", () => {
   it("updates published flow and returns altered nodes if there have been changes", async () => {
     const alteredFlow = {
       ...mockFlowData,
-      "ResultNode": {
+      ResultNode: {
         data: {
           flagSet: "Planning permission",
           overrides: {
@@ -71,7 +71,7 @@ describe("publish", () => {
         type: 3,
       },
     };
-  
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,
@@ -81,7 +81,7 @@ describe("publish", () => {
         },
       },
     });
-  
+
     queryMock.mockQuery({
       name: "PublishFlow",
       matchOnVariables: false,
@@ -91,7 +91,7 @@ describe("publish", () => {
         },
       },
     });
-  
+
     await supertest(app)
       .post("/flows/1/publish")
       .set(authHeader())
@@ -121,15 +121,15 @@ describe("sections validation on diff", () => {
   it("does not update if there are sections in an external portal", async () => {
     const alteredFlow = {
       ...mockFlowData,
-      "externalPortalNodeId": {
+      externalPortalNodeId: {
         edges: ["newSectionNodeId"],
         type: 310,
       },
-      "newSectionNodeId": {
+      newSectionNodeId: {
         type: 360,
       },
     };
-  
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,
@@ -139,7 +139,7 @@ describe("sections validation on diff", () => {
         },
       },
     });
-  
+
     await supertest(app)
       .post("/flows/1/diff")
       .set(authHeader())
@@ -148,22 +148,23 @@ describe("sections validation on diff", () => {
         expect(res.body).toEqual({
           alteredNodes: null,
           message: "Cannot publish an invalid flow",
-          description: "Found Sections in one or more External Portals, but Sections are only allowed in main flow",
+          description:
+            "Found Sections in one or more External Portals, but Sections are only allowed in main flow",
         });
       });
   });
-  
+
   it("does not update if there are sections, but there is not a section in the first position", async () => {
     const flowWithSections: Flow["data"] = {
       _root: {
-        edges: ["questionNode", "sectionNode"]
+        edges: ["questionNode", "sectionNode"],
       },
       questionNode: {},
       sectionNode: {
         type: 360,
       },
     };
-  
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,
@@ -173,7 +174,7 @@ describe("sections validation on diff", () => {
         },
       },
     });
-  
+
     await supertest(app)
       .post("/flows/1/diff")
       .set(authHeader())
@@ -182,17 +183,20 @@ describe("sections validation on diff", () => {
         expect(res.body).toEqual({
           alteredNodes: null,
           message: "Cannot publish an invalid flow",
-          description: "When using Sections, your flow must start with a Section"
+          description:
+            "When using Sections, your flow must start with a Section",
         });
       });
   });
 });
 
 describe("invite to pay validation on diff", () => {
-  it("does not update if invite to pay is enabled, but there is not a Send component", async () => {  
+  it("does not update if invite to pay is enabled, but there is not a Send component", async () => {
     const { Send, ...invalidatedFlow } = flowWithInviteToPay;
-    invalidatedFlow["_root"].edges?.splice(invalidatedFlow["_root"].edges?.indexOf("Send"));
-    
+    invalidatedFlow["_root"].edges?.splice(
+      invalidatedFlow["_root"].edges?.indexOf("Send")
+    );
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,
@@ -202,26 +206,28 @@ describe("invite to pay validation on diff", () => {
         },
       },
     });
-  
+
     await supertest(app)
       .post("/flows/1/diff")
       .set(authHeader())
       .expect(200)
       .then((res) => {
         expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual("When using Invite to Pay, your flow must have a Send");
+        expect(res.body.description).toEqual(
+          "When using Invite to Pay, your flow must have a Send"
+        );
       });
   });
 
   it("does not update if invite to pay is enabled, but there is more than one Send component", async () => {
     const alteredFlow = {
       ...flowWithInviteToPay,
-      "secondSend": {
+      secondSend: {
         type: 650,
         data: {
-          destinations: ["bops", "email"]
-        }
-      }
+          destinations: ["bops", "email"],
+        },
+      },
     };
 
     queryMock.mockQuery({
@@ -240,14 +246,18 @@ describe("invite to pay validation on diff", () => {
       .expect(200)
       .then((res) => {
         expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual("When using Invite to Pay, your flow must have exactly ONE Send. It can select many destinations");
+        expect(res.body.description).toEqual(
+          "When using Invite to Pay, your flow must have exactly ONE Send. It can select many destinations"
+        );
       });
   });
-  
+
   it("does not update if invite to pay is enabled, but there is not a FindProperty (`_address`) component", async () => {
     const { FindProperty, ...invalidatedFlow } = flowWithInviteToPay;
-    invalidatedFlow["_root"].edges?.splice(invalidatedFlow["_root"].edges?.indexOf("FindProperty"));
-    
+    invalidatedFlow["_root"].edges?.splice(
+      invalidatedFlow["_root"].edges?.indexOf("FindProperty")
+    );
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,
@@ -257,21 +267,30 @@ describe("invite to pay validation on diff", () => {
         },
       },
     });
-  
+
     await supertest(app)
       .post("/flows/1/diff")
       .set(authHeader())
       .expect(200)
       .then((res) => {
         expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual("When using Invite to Pay, your flow must have a FindProperty");
+        expect(res.body.description).toEqual(
+          "When using Invite to Pay, your flow must have a FindProperty"
+        );
       });
   });
-  
+
   it("does not update if invite to pay is enabled, but there is not a Checklist that sets `proposal.projectType`", async () => {
-    const { Checklist, ChecklistOptionOne, ChecklistOptionTwo, ...invalidatedFlow } = flowWithInviteToPay;
-    invalidatedFlow["_root"].edges?.splice(invalidatedFlow["_root"].edges?.indexOf("Checklist"));
-    
+    const {
+      Checklist,
+      ChecklistOptionOne,
+      ChecklistOptionTwo,
+      ...invalidatedFlow
+    } = flowWithInviteToPay;
+    invalidatedFlow["_root"].edges?.splice(
+      invalidatedFlow["_root"].edges?.indexOf("Checklist")
+    );
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,
@@ -281,14 +300,16 @@ describe("invite to pay validation on diff", () => {
         },
       },
     });
-  
+
     await supertest(app)
       .post("/flows/1/diff")
       .set(authHeader())
       .expect(200)
       .then((res) => {
         expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual("When using Invite to Pay, your flow must have a Checklist that sets the passport variable `proposal.projectType`");
+        expect(res.body.description).toEqual(
+          "When using Invite to Pay, your flow must have a Checklist that sets the passport variable `proposal.projectType`"
+        );
       });
   });
 });
@@ -306,16 +327,16 @@ const mockFlowData: Flow["data"] = {
       "ConfirmationNode",
     ],
   },
-  "SectionOne": {
+  SectionOne: {
     type: 360,
     data: {
       title: "Section 1",
     },
   },
-  "FindPropertyNode": {
+  FindPropertyNode: {
     type: 9,
   },
-  "ResultNode": {
+  ResultNode: {
     data: {
       flagSet: "Planning permission",
       overrides: {
@@ -326,7 +347,7 @@ const mockFlowData: Flow["data"] = {
     },
     type: 3,
   },
-  "AnswerOne": {
+  AnswerOne: {
     data: {
       text: "?",
     },

--- a/api.planx.uk/editor/publish.ts
+++ b/api.planx.uk/editor/publish.ts
@@ -181,6 +181,14 @@ const validateInviteToPay = (flow: Record<string, any>): ValidationResponse => {
       };
     }
 
+    if (numberOfComponentType(flow, ComponentType.Pay) > 1) {
+      return {
+        isValid: false,
+        message: "Cannot publish an invalid flow",
+        description: "When using Invite to Pay, your flow must have exactly ONE Pay",
+      };
+    }
+
     if (numberOfComponentType(flow, ComponentType.Send) > 1) {
       return {
         isValid: false,

--- a/api.planx.uk/editor/publish.ts
+++ b/api.planx.uk/editor/publish.ts
@@ -192,14 +192,8 @@ const validateInviteToPay = (flow: Record<string, any>): ValidationResponse => {
     isValid: false,
     message: "Cannot publish an invalid flow",
   };
-  if (inviteToPayEnabled(flow)) {
-    if (!hasComponentType(flow, ComponentType.Pay)) {
-      return {
-        ...invalidResponseTemplate,
-        description: "When using Invite to Pay, your flow must have a Pay",
-      };
-    }
 
+  if (inviteToPayEnabled(flow)) {
     if (numberOfComponentType(flow, ComponentType.Pay) > 1) {
       return {
         ...invalidResponseTemplate,
@@ -253,7 +247,10 @@ const inviteToPayEnabled = (flow: Record<string, any>): boolean => {
   const payNodeStatuses = Object.entries(flow)
     .filter(([_nodeId, nodeData]) => nodeData?.type === ComponentType.Pay)
     ?.map(([_nodeId, nodeData]) => nodeData?.data?.allowInviteToPay);
-  return payNodeStatuses.every((status) => status === true);
+  return (
+    payNodeStatuses.length > 0 &&
+    payNodeStatuses.every((status) => status === true)
+  );
 };
 
 const hasComponentType = (

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#c847345",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#main",
     "@opensystemslab/planx-document-templates": "github:theopensystemslab/planx-document-templates#baf18b8",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#8d3c2bf",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#c847345",
     "@opensystemslab/planx-document-templates": "github:theopensystemslab/planx-document-templates#baf18b8",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@airbrake/node': ^2.1.8
   '@babel/core': ^7.21.4
   '@babel/preset-typescript': ^7.21.4
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#c847345
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#main
   '@opensystemslab/planx-document-templates': github:theopensystemslab/planx-document-templates#baf18b8
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -79,7 +79,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.8
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/c847345
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/c0dee57a031238887eaeb6a3e8f1ce4ad019899d
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/baf18b8
   '@types/isomorphic-fetch': 0.0.36
   adm-zip: 0.5.10
@@ -7571,8 +7571,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/c847345:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c847345}
+  github.com/theopensystemslab/planx-core/c0dee57a031238887eaeb6a3e8f1ce4ad019899d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c0dee57a031238887eaeb6a3e8f1ce4ad019899d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@airbrake/node': ^2.1.8
   '@babel/core': ^7.21.4
   '@babel/preset-typescript': ^7.21.4
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#8d3c2bf
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#c847345
   '@opensystemslab/planx-document-templates': github:theopensystemslab/planx-document-templates#baf18b8
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -79,7 +79,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.8
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/8d3c2bf
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/c847345
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/baf18b8
   '@types/isomorphic-fetch': 0.0.36
   adm-zip: 0.5.10
@@ -98,7 +98,7 @@ dependencies:
   form-data: 4.0.0
   graphql: 16.6.0
   graphql-request: 4.3.0_graphql@16.6.0
-  graphql-voyager: 1.0.2_ldugk2z6rczrboweosjqqkvcxa
+  graphql-voyager: 1.0.2_oiha6uk5baqtsd2u7tyoqua3te
   helmet: 5.1.1
   http-proxy-middleware: 2.0.6_@types+express@4.17.17
   isomorphic-fetch: 3.0.0
@@ -671,7 +671,7 @@ packages:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
     dev: false
 
-  /@emotion/react/11.10.5_duavcg6prxxl5begav3y2fyxcu:
+  /@emotion/react/11.10.5_@babel+core@7.21.4:
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -690,11 +690,10 @@ packages:
       '@emotion/babel-plugin': 11.10.6
       '@emotion/cache': 11.10.7
       '@emotion/serialize': 1.1.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0
       '@emotion/utils': 1.2.0
       '@emotion/weak-memoize': 0.3.0
       hoist-non-react-statics: 3.3.2
-      react: 18.2.0
     dev: false
 
   /@emotion/react/11.10.6_react@18.2.0:
@@ -733,7 +732,7 @@ packages:
     resolution: {integrity: sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==}
     dev: false
 
-  /@emotion/styled/11.10.5_topaxx52cuxnde6ktj7zz2t36u:
+  /@emotion/styled/11.10.5_akceqhtkqit3xsjqyga7qlq7yy:
     resolution: {integrity: sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -752,11 +751,10 @@ packages:
       '@babel/runtime': 7.21.0
       '@emotion/babel-plugin': 11.10.6
       '@emotion/is-prop-valid': 1.2.0
-      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
+      '@emotion/react': 11.10.5_@babel+core@7.21.4
       '@emotion/serialize': 1.1.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0
       '@emotion/utils': 1.2.0
-      react: 18.2.0
     dev: false
 
   /@emotion/styled/11.10.6_3og6jmu6wvzuytygvdoxepq3x4:
@@ -783,6 +781,15 @@ packages:
 
   /@emotion/unitless/0.8.0:
     resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
+    dev: false
+
+  /@emotion/use-insertion-effect-with-fallbacks/1.0.0:
+    resolution: {integrity: sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==}
+    peerDependencies:
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
     dev: false
 
   /@emotion/use-insertion-effect-with-fallbacks/1.0.0_react@18.2.0:
@@ -1216,7 +1223,7 @@ packages:
       '@lit-labs/ssr-dom-shim': 1.1.0
     dev: false
 
-  /@mui/base/5.0.0-alpha.112_biqbaboplfbrettd7655fr4n2y:
+  /@mui/base/5.0.0-alpha.112:
     resolution: {integrity: sha512-KPwb1iYPXsV/P8uu0SNQrj7v7YU6wdN4Eccc2lZQyRDW+f6PJYjHBuFUTYKc408B98Jvs1XbC/z5MN45a2DWrQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1234,12 +1241,10 @@ packages:
       '@babel/runtime': 7.21.0
       '@emotion/is-prop-valid': 1.2.0
       '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0_react@18.2.0
+      '@mui/utils': 5.12.0
       '@popperjs/core': 2.11.7
       clsx: 1.2.1
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
     dev: false
 
@@ -1274,7 +1279,7 @@ packages:
     resolution: {integrity: sha512-1hoFIdlLI0sG+mkJgm70FjgIVpfLcE1vxPtNolg1tLFXrvbXGUYp9NHy3d6c41nDkg2OajuVS+Mn6A8UirFuMw==}
     dev: false
 
-  /@mui/icons-material/5.11.0_24thufdhhc6uudyuozyjrubopi:
+  /@mui/icons-material/5.11.0_@mui+material@5.11.2:
     resolution: {integrity: sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1288,11 +1293,10 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@mui/material': 5.11.2_5rzy53przelm5jchjmb5vr6dxy
-      react: 18.2.0
+      '@mui/material': 5.11.2_z6zezfurr26maxy6gvsa52xlim
     dev: false
 
-  /@mui/lab/5.0.0-alpha.114_je6wcyxzzodpuivmp54wfrprbm:
+  /@mui/lab/5.0.0-alpha.114_jq36szbwhuuho2c54hfkimln3q:
     resolution: {integrity: sha512-tChDoLaJ3qcYk37GIwBL1KrCiW0gpmEY//D5z5nHWnO/mzx3axjRJZpBOBeGEvhuoO/Y3QzMz4rhTvqbGNkW0w==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1315,21 +1319,19 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
-      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
-      '@mui/base': 5.0.0-alpha.112_biqbaboplfbrettd7655fr4n2y
-      '@mui/material': 5.11.2_5rzy53przelm5jchjmb5vr6dxy
-      '@mui/system': 5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm
+      '@emotion/react': 11.10.5_@babel+core@7.21.4
+      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
+      '@mui/base': 5.0.0-alpha.112
+      '@mui/material': 5.11.2_z6zezfurr26maxy6gvsa52xlim
+      '@mui/system': 5.12.0_z6zezfurr26maxy6gvsa52xlim
       '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0_react@18.2.0
+      '@mui/utils': 5.12.0
       clsx: 1.2.1
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
     dev: false
 
-  /@mui/material/5.11.2_5rzy53przelm5jchjmb5vr6dxy:
+  /@mui/material/5.11.2_z6zezfurr26maxy6gvsa52xlim:
     resolution: {integrity: sha512-PeraRDsghnDLzejorfe9ps1syxlB8UrGs+UKwg9GGlndv5Tghm+9nwuibrP2TCDC14mlryF+u2WlAOYaPPMwGA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1351,21 +1353,19 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
-      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
-      '@mui/base': 5.0.0-alpha.112_biqbaboplfbrettd7655fr4n2y
+      '@emotion/react': 11.10.5_@babel+core@7.21.4
+      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
+      '@mui/base': 5.0.0-alpha.112
       '@mui/core-downloads-tracker': 5.12.0
-      '@mui/system': 5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm
+      '@mui/system': 5.12.0_z6zezfurr26maxy6gvsa52xlim
       '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0_react@18.2.0
+      '@mui/utils': 5.12.0
       '@types/react-transition-group': 4.4.5
       clsx: 1.2.1
       csstype: 3.1.2
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
-      react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
+      react-transition-group: 4.4.5
     dev: false
 
   /@mui/material/5.11.9_fbxtuirhogpez7m7qjkm3itwca:
@@ -1407,6 +1407,23 @@ packages:
       react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
     dev: false
 
+  /@mui/private-theming/5.12.0:
+    resolution: {integrity: sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@mui/utils': 5.12.0
+      prop-types: 15.8.1
+    dev: false
+
   /@mui/private-theming/5.12.0_react@18.2.0:
     resolution: {integrity: sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==}
     engines: {node: '>=12.0.0'}
@@ -1421,30 +1438,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@mui/utils': 5.12.0_react@18.2.0
-      prop-types: 15.8.1
-      react: 18.2.0
-    dev: false
-
-  /@mui/styled-engine/5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm:
-    resolution: {integrity: sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      react:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@emotion/cache': 11.10.7
-      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
-      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
-      csstype: 3.1.2
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
@@ -1473,35 +1466,27 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@mui/system/5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm:
-    resolution: {integrity: sha512-Zi+WHuiJfK1ya+9+oeJQ1rLIBdY8CGDYT5oVlQg/6kIuyiCaE6SnN9PVzxBxfY77wHuOPwz4kxcPe9srdZc12Q==}
+  /@mui/styled-engine/5.12.0_z6zezfurr26maxy6gvsa52xlim:
+    resolution: {integrity: sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@emotion/react': ^11.5.0
+      '@emotion/react': ^11.4.1
       '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
       '@emotion/styled':
         optional: true
-      '@types/react':
-        optional: true
       react:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
-      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
-      '@mui/private-theming': 5.12.0_react@18.2.0
-      '@mui/styled-engine': 5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm
-      '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0_react@18.2.0
-      clsx: 1.2.1
+      '@emotion/cache': 11.10.7
+      '@emotion/react': 11.10.5_@babel+core@7.21.4
+      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
       csstype: 3.1.2
       prop-types: 15.8.1
-      react: 18.2.0
     dev: false
 
   /@mui/system/5.12.0_xqp3pgpqjlfxxa3zxu4zoc4fba:
@@ -1535,6 +1520,36 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@mui/system/5.12.0_z6zezfurr26maxy6gvsa52xlim:
+    resolution: {integrity: sha512-Zi+WHuiJfK1ya+9+oeJQ1rLIBdY8CGDYT5oVlQg/6kIuyiCaE6SnN9PVzxBxfY77wHuOPwz4kxcPe9srdZc12Q==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/react': 11.10.5_@babel+core@7.21.4
+      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
+      '@mui/private-theming': 5.12.0
+      '@mui/styled-engine': 5.12.0_z6zezfurr26maxy6gvsa52xlim
+      '@mui/types': 7.2.4
+      '@mui/utils': 5.12.0
+      clsx: 1.2.1
+      csstype: 3.1.2
+      prop-types: 15.8.1
+    dev: false
+
   /@mui/types/7.2.4:
     resolution: {integrity: sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==}
     peerDependencies:
@@ -1542,6 +1557,22 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+    dev: false
+
+  /@mui/utils/5.12.0:
+    resolution: {integrity: sha512-RmQwgzF72p7Yr4+AAUO6j1v2uzt6wr7SWXn68KBsnfVpdOHyclCzH2lr/Xu6YOw9su4JRtdAIYfJFXsS6Cjkmw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@types/prop-types': 15.7.5
+      '@types/react-is': 17.0.3
+      prop-types: 15.8.1
+      react-is: 18.2.0
     dev: false
 
   /@mui/utils/5.12.0_react@18.2.0:
@@ -4186,7 +4217,7 @@ packages:
       - encoding
     dev: false
 
-  /graphql-voyager/1.0.2_ldugk2z6rczrboweosjqqkvcxa:
+  /graphql-voyager/1.0.2_oiha6uk5baqtsd2u7tyoqua3te:
     resolution: {integrity: sha512-PYvW7pKbQcIlun37hZ6sWE4bneECM6wDNAkdyW0rpZ3oVA/2INthORIiWd+ol4jSzZLD/fYYo8a6SYLc5btnKQ==}
     peerDependencies:
       graphql: '>=16.5.0'
@@ -4198,16 +4229,14 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
-      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
-      '@mui/icons-material': 5.11.0_24thufdhhc6uudyuozyjrubopi
-      '@mui/lab': 5.0.0-alpha.114_je6wcyxzzodpuivmp54wfrprbm
-      '@mui/material': 5.11.2_5rzy53przelm5jchjmb5vr6dxy
+      '@emotion/react': 11.10.5_@babel+core@7.21.4
+      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
+      '@mui/icons-material': 5.11.0_@mui+material@5.11.2
+      '@mui/lab': 5.0.0-alpha.114_jq36szbwhuuho2c54hfkimln3q
+      '@mui/material': 5.11.2_z6zezfurr26maxy6gvsa52xlim
       commonmark: 0.30.0
       graphql: 16.6.0
       lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
       svg-pan-zoom: 3.6.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -6350,6 +6379,23 @@ packages:
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
+  /react-transition-group/4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+    dev: false
+
   /react-transition-group/4.4.5_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -7525,8 +7571,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/8d3c2bf:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8d3c2bf}
+  github.com/theopensystemslab/planx-core/c847345:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c847345}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^16, pnpm: ^7.8.0}


### PR DESCRIPTION
Invite to Pay validation is timing-out and/or running out of memory and a patch for simple validation is currently in place (https://github.com/theopensystemslab/planx-core/pull/36)

This PR applies a different workaround which limits flow that use the ITP feature to only define one Pay node in that flow (corresponding planx-core update here: https://github.com/theopensystemslab/planx-core/pull/38).

Like the Send node restriction, this limit is temporary until we can efficiently traverse the flow graph to find the next node of the matching type.