### PR TITLE
feat: Shared file upload UI components

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -1,17 +1,14 @@
-import FileIcon from "@mui/icons-material/AttachFile";
-import DeleteIcon from "@mui/icons-material/Close";
 import CloudUpload from "@mui/icons-material/CloudUpload";
 import Box from "@mui/material/Box";
 import ButtonBase from "@mui/material/ButtonBase";
-import IconButton from "@mui/material/IconButton";
 import makeStyles from "@mui/styles/makeStyles";
 import { visuallyHidden } from "@mui/utils";
 import { uploadPrivateFile } from "api/upload";
 import classNames from "classnames";
-import ImagePreview from "components/ImagePreview";
 import { nanoid } from "nanoid";
 import React, { useEffect, useState } from "react";
 import { FileWithPath, useDropzone } from "react-dropzone";
+import { UploadedFileCard } from "ui/UploadedFileCard";
 
 import handleRejectedUpload from "../../shared/handleRejectedUpload";
 
@@ -54,62 +51,9 @@ const useStyles = makeStyles((theme) => ({
       transform: "scale(1)",
     },
   },
-  file: {
-    position: "relative",
-    height: theme.spacing(14),
-    backgroundColor: theme.palette.background.paper,
-    border: `1px solid ${theme.palette.background.paper}`,
-    display: "flex",
-    alignItems: "center",
-    padding: theme.spacing(1.5),
-    marginBottom: theme.spacing(2),
-    "& > *": {
-      zIndex: 1,
-    },
-  },
-  deleteIcon: {
-    position: "absolute",
-    top: theme.spacing(1),
-    right: theme.spacing(1),
-  },
-  filePreview: {
-    height: theme.spacing(14),
-    width: theme.spacing(14),
-    marginLeft: -theme.spacing(1.5),
-    marginRight: theme.spacing(1.5),
-    opacity: 0.5,
-    position: "relative",
-    overflow: "hidden",
-    "& img": {
-      position: "absolute",
-      width: "100%",
-      left: "50%",
-      top: "50%",
-      transform: "translate(-50%, -50%)",
-    },
-    "& svg": {
-      position: "absolute",
-      left: "50%",
-      top: "50%",
-      transform: "translate(-50%, -50%)",
-      width: theme.spacing(5),
-      height: theme.spacing(5),
-    },
-  },
-  progress: {
-    position: "absolute",
-    height: "100%",
-    left: 0,
-    top: 0,
-    backgroundColor: theme.palette.background.default,
-    zIndex: 0,
-  },
   underlinedLink: {
     textDecoration: "underline",
     color: theme.palette.primary.main,
-  },
-  fileSize: {
-    whiteSpace: "nowrap",
   },
 }));
 
@@ -120,6 +64,7 @@ export interface FileUpload<T extends File = any> {
   id: string;
   url?: string;
 }
+
 interface Props {
   setFile: (file?: FileUpload) => void;
   initialFile?: FileUpload;
@@ -170,51 +115,13 @@ export default function FileUpload(props: Props) {
   return (
     <>
       {slot && (
-        <Box className={classes.file}>
-          <IconButton
-            size="small"
-            className={classes.deleteIcon}
-            aria-label={`Delete ${slot?.file.path}`}
-            title={`Delete ${slot?.file.path}`}
-            onClick={() => {
-              setSlot(undefined);
-              setFileUploadStatus(() => `${slot?.file.path} was deleted`);
-            }}
-          >
-            <DeleteIcon />
-          </IconButton>
-          <Box
-            className={classes.progress}
-            width={`${Math.min(Math.ceil(slot?.progress * 100), 100)}%`}
-            role="progressbar"
-            aria-valuenow={slot?.progress * 100 || 0}
-          />
-          <Box className={classes.filePreview}>
-            {slot?.file instanceof File &&
-            slot?.file?.type?.includes("image") ? (
-              <ImagePreview file={slot?.file} />
-            ) : (
-              <FileIcon />
-            )}
-          </Box>
-          <Box flexGrow={1}>
-            <Box
-              fontSize="caption.fontSize"
-              fontWeight={700}
-              color="text.secondary"
-            >
-              File
-            </Box>
-            {slot?.file.path}
-          </Box>
-          <Box
-            color="text.secondary"
-            alignSelf="flex-end"
-            className={classes.fileSize}
-          >
-            {formatBytes(slot?.file.size)}
-          </Box>
-        </Box>
+        <UploadedFileCard
+          {...slot}
+          onClick={() => {
+            setSlot(undefined);
+            setFileUploadStatus(() => `${slot?.file.path} was deleted`);
+          }}
+        />
       )}
       {fileUploadStatus && (
         <p role="status" style={visuallyHidden}>
@@ -247,16 +154,5 @@ export default function FileUpload(props: Props) {
         </Box>
       </ButtonBase>
     </>
-  );
-}
-
-function formatBytes(a: any, b = 2) {
-  if (0 === a) return "0 Bytes";
-  const c = 0 > b ? 0 : b,
-    d = Math.floor(Math.log(a) / Math.log(1024));
-  return (
-    parseFloat((a / Math.pow(1024, d)).toFixed(c)) +
-    " " +
-    ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d]
   );
 }

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -1,3 +1,4 @@
+import { FileUploadSlot } from "@planx/components/FileUpload/Public";
 import { uploadPrivateFile } from "api/upload";
 import { nanoid } from "nanoid";
 import React, { useEffect, useState } from "react";
@@ -7,21 +8,15 @@ import { UploadedFileCard } from "ui/UploadedFileCard";
 
 import handleRejectedUpload from "../../shared/handleRejectedUpload";
 
-export interface FileUpload<T extends File = any> {
-  file: T;
-  status: "success" | "error" | "uploading";
-  progress: number;
-  id: string;
-  url?: string;
-}
-
 interface Props {
-  setFile: (file?: FileUpload) => void;
-  initialFile?: FileUpload;
+  setFile: (file?: FileUploadSlot) => void;
+  initialFile?: FileUploadSlot;
 }
 
 export default function FileUpload(props: Props) {
-  const [slot, setSlot] = useState<FileUpload | undefined>(props.initialFile);
+  const [slot, setSlot] = useState<FileUploadSlot | undefined>(
+    props.initialFile
+  );
   const [fileUploadStatus, setFileUploadStatus] = useState<string>();
   const MAX_UPLOAD_SIZE_MB = 30;
 
@@ -40,16 +35,22 @@ export default function FileUpload(props: Props) {
       // XXX: This is a non-blocking promise chain
       uploadPrivateFile(file, {
         onProgress: (progress) => {
-          setSlot((_file: any) => ({ ..._file, progress }));
+          setSlot((_file) =>
+            _file?.file === file ? { ..._file, progress } : _file
+          );
         },
       })
-        .then((url) => {
-          setSlot((_file: any) => ({ ..._file, url, status: "success" }));
+        .then((url: string) => {
+          setSlot((_file) =>
+            _file?.file === file ? { ..._file, url, status: "success" } : _file
+          );
           setFileUploadStatus(() => `File ${file.path} was uploaded`);
         })
         .catch((error) => {
           console.error(error);
-          setSlot((_file: any) => ({ ..._file, status: "error" }));
+          setSlot((_file) =>
+            _file?.file === file ? { ..._file, status: "error" } : _file
+          );
         });
       setSlot({
         file,

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Upload.tsx
@@ -1,61 +1,11 @@
-import CloudUpload from "@mui/icons-material/CloudUpload";
-import Box from "@mui/material/Box";
-import ButtonBase from "@mui/material/ButtonBase";
-import makeStyles from "@mui/styles/makeStyles";
-import { visuallyHidden } from "@mui/utils";
 import { uploadPrivateFile } from "api/upload";
-import classNames from "classnames";
 import { nanoid } from "nanoid";
 import React, { useEffect, useState } from "react";
 import { FileWithPath, useDropzone } from "react-dropzone";
+import { Dropzone } from "ui/Dropzone";
 import { UploadedFileCard } from "ui/UploadedFileCard";
 
 import handleRejectedUpload from "../../shared/handleRejectedUpload";
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: theme.spacing(14),
-    backgroundColor: theme.palette.background.paper,
-    display: "flex",
-    alignItems: "center",
-    padding: theme.spacing(1.5),
-    position: "relative",
-    width: "100%",
-    fontSize: "medium",
-    zIndex: 10,
-    "&::before": {
-      content: "''",
-      position: "absolute",
-      left: -theme.spacing(0.75),
-      top: -theme.spacing(0.75),
-      width: `calc(100% + ${theme.spacing(1.5)})`,
-      height: `calc(100% + ${theme.spacing(1.5)})`,
-      display: "block",
-      border: `2px dashed ${theme.palette.secondary.light}`,
-      opacity: 0,
-      transform: "scale(0.8)",
-      zIndex: -1,
-      transformOrigin: "center center",
-      backgroundColor: theme.palette.background.paper,
-      transition: [
-        theme.transitions.create(["opacity", "transform"], {
-          duration: "0.2s",
-        }),
-      ],
-    },
-  },
-  dragActive: {
-    backgroundColor: theme.palette.background.default,
-    "&::before": {
-      opacity: 1,
-      transform: "scale(1)",
-    },
-  },
-  underlinedLink: {
-    textDecoration: "underline",
-    color: theme.palette.primary.main,
-  },
-}));
 
 export interface FileUpload<T extends File = any> {
   file: T;
@@ -78,7 +28,6 @@ export default function FileUpload(props: Props) {
   useEffect(() => {
     props.setFile(slot);
   }, [props.setFile, slot]);
-  const classes = useStyles();
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
       "image/jpeg": [".jpg", ".jpeg"],
@@ -123,36 +72,12 @@ export default function FileUpload(props: Props) {
           }}
         />
       )}
-      {fileUploadStatus && (
-        <p role="status" style={visuallyHidden}>
-          {fileUploadStatus}
-        </p>
-      )}
-      <ButtonBase
-        className={classNames(classes.root, isDragActive && classes.dragActive)}
-        {...getRootProps()}
-      >
-        <input data-testid="upload-boundary-input" {...getInputProps()} />
-        <Box pl={3} pr={4} color="text.secondary">
-          <CloudUpload />
-        </Box>
-        <Box flexGrow={1}>
-          <Box>
-            {isDragActive ? (
-              "Drop the files here"
-            ) : (
-              <>
-                Drag files here or{" "}
-                <span className={classes.underlinedLink}>choose a file</span>
-              </>
-            )}
-          </Box>
-          <Box color="text.secondary">pdf, jpg or png</Box>
-        </Box>
-        <Box color="text.secondary" alignSelf="flex-end">
-          max size 30MB
-        </Box>
-      </ButtonBase>
+      <Dropzone
+        getRootProps={getRootProps}
+        getInputProps={getInputProps}
+        isDragActive={isDragActive}
+        fileUploadStatus={fileUploadStatus}
+      />
     </>
   );
 }

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
+import { FileUploadSlot } from "@planx/components/FileUpload/Public";
 import Card from "@planx/components/shared/Preview/Card";
 import {
   MapContainer,
@@ -14,10 +15,10 @@ import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
 
 import { DrawBoundary, PASSPORT_UPLOAD_KEY } from "../model";
-import Upload, { FileUpload } from "./Upload";
+import Upload from "./Upload";
 
 export type Props = PublicProps<DrawBoundary>;
-export type SelectedFile = FileUpload;
+export type SelectedFile = FileUploadSlot;
 
 export default function Component(props: Props) {
   const isMounted = useRef(false);

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -1,18 +1,13 @@
-import CloudUpload from "@mui/icons-material/CloudUpload";
-import Box from "@mui/material/Box";
-import ButtonBase from "@mui/material/ButtonBase";
-import makeStyles from "@mui/styles/makeStyles";
-import { visuallyHidden } from "@mui/utils";
 import { MoreInformation } from "@planx/components/shared";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { uploadPrivateFile } from "api/upload";
-import classNames from "classnames";
 import { nanoid } from "nanoid";
 import { Store } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useRef, useState } from "react";
 import { FileWithPath, useDropzone } from "react-dropzone";
+import { Dropzone } from "ui/Dropzone";
 import ErrorWrapper from "ui/ErrorWrapper";
 import { UploadedFileCard } from "ui/UploadedFileCard";
 import { array } from "yup";
@@ -28,51 +23,6 @@ interface Props extends MoreInformation {
   handleSubmit: handleSubmit;
   previouslySubmittedData?: Store.userData;
 }
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    height: theme.spacing(14),
-    backgroundColor: theme.palette.background.paper,
-    display: "flex",
-    alignItems: "center",
-    padding: theme.spacing(1.5),
-    position: "relative",
-    width: "100%",
-    fontSize: "medium",
-    zIndex: 10,
-    "&::before": {
-      content: "''",
-      position: "absolute",
-      left: -theme.spacing(0.75),
-      top: -theme.spacing(0.75),
-      width: `calc(100% + ${theme.spacing(1.5)})`,
-      height: `calc(100% + ${theme.spacing(1.5)})`,
-      display: "block",
-      border: `2px dashed ${theme.palette.secondary.light}`,
-      opacity: 0,
-      transform: "scale(0.8)",
-      zIndex: -1,
-      transformOrigin: "center center",
-      backgroundColor: theme.palette.background.paper,
-      transition: [
-        theme.transitions.create(["opacity", "transform"], {
-          duration: "0.2s",
-        }),
-      ],
-    },
-  },
-  dragActive: {
-    backgroundColor: theme.palette.background.default,
-    "&::before": {
-      opacity: 1,
-      transform: "scale(1)",
-    },
-  },
-  underlinedLink: {
-    textDecoration: "underline",
-    color: theme.palette.primary.main,
-  },
-}));
 
 const slotsSchema = array()
   .required()
@@ -156,7 +106,7 @@ const FileUpload: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
       />
       <ErrorWrapper error={validationError} id={props.id}>
-        <Dropzone
+        <Upload
           slots={slots}
           setSlots={setSlots}
           fileUploadStatus={fileUploadStatus}
@@ -167,9 +117,8 @@ const FileUpload: React.FC<Props> = (props) => {
   );
 };
 
-function Dropzone(props: any) {
+function Upload(props: any) {
   const { slots, setSlots, fileUploadStatus, setFileUploadStatus } = props;
-  const classes = useStyles();
   const MAX_UPLOAD_SIZE_MB = 30;
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -239,6 +188,7 @@ function Dropzone(props: any) {
         return (
           <UploadedFileCard
             {...slot}
+            key={slot.id}
             index={index}
             onClick={() => {
               setSlots(
@@ -251,36 +201,12 @@ function Dropzone(props: any) {
           />
         );
       })}
-      {fileUploadStatus && (
-        <p role="status" style={visuallyHidden}>
-          {fileUploadStatus}
-        </p>
-      )}
-      <ButtonBase
-        className={classNames(classes.root, isDragActive && classes.dragActive)}
-        {...getRootProps({ role: "button" })}
-      >
-        <input {...getInputProps()} />
-        <Box pl={3} pr={4} color="text.secondary">
-          <CloudUpload />
-        </Box>
-        <Box flexGrow={1}>
-          <Box>
-            {isDragActive ? (
-              "Drop the files here"
-            ) : (
-              <>
-                Drag files here or{" "}
-                <span className={classes.underlinedLink}>choose a file</span>
-              </>
-            )}
-          </Box>
-          <Box color="text.secondary">pdf, jpg or png</Box>
-        </Box>
-        <Box color="text.secondary" alignSelf="flex-end">
-          max size {MAX_UPLOAD_SIZE_MB}MB
-        </Box>
-      </ButtonBase>
+      <Dropzone
+        getRootProps={getRootProps}
+        getInputProps={getInputProps}
+        isDragActive={isDragActive}
+        fileUploadStatus={fileUploadStatus}
+      />
     </>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -1,9 +1,6 @@
-import FileIcon from "@mui/icons-material/AttachFile";
-import DeleteIcon from "@mui/icons-material/Close";
 import CloudUpload from "@mui/icons-material/CloudUpload";
 import Box from "@mui/material/Box";
 import ButtonBase from "@mui/material/ButtonBase";
-import IconButton from "@mui/material/IconButton";
 import makeStyles from "@mui/styles/makeStyles";
 import { visuallyHidden } from "@mui/utils";
 import { MoreInformation } from "@planx/components/shared";
@@ -11,14 +8,13 @@ import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { uploadPrivateFile } from "api/upload";
 import classNames from "classnames";
-import ImagePreview from "components/ImagePreview";
 import { nanoid } from "nanoid";
 import { Store } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useRef, useState } from "react";
 import { FileWithPath, useDropzone } from "react-dropzone";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import ErrorWrapper from "ui/ErrorWrapper";
+import { UploadedFileCard } from "ui/UploadedFileCard";
 import { array } from "yup";
 
 import handleRejectedUpload from "../shared/handleRejectedUpload";
@@ -72,62 +68,9 @@ const useStyles = makeStyles((theme) => ({
       transform: "scale(1)",
     },
   },
-  file: {
-    position: "relative",
-    height: theme.spacing(14),
-    backgroundColor: theme.palette.background.paper,
-    border: `1px solid ${theme.palette.background.paper}`,
-    display: "flex",
-    alignItems: "center",
-    padding: theme.spacing(1.5),
-    marginBottom: theme.spacing(2),
-    "& > *": {
-      zIndex: 1,
-    },
-  },
-  deleteIcon: {
-    position: "absolute",
-    top: theme.spacing(1),
-    right: theme.spacing(1),
-  },
-  filePreview: {
-    height: theme.spacing(14),
-    width: theme.spacing(14),
-    marginLeft: -theme.spacing(1.5),
-    marginRight: theme.spacing(1.5),
-    opacity: 0.5,
-    position: "relative",
-    overflow: "hidden",
-    "& img": {
-      position: "absolute",
-      width: "100%",
-      left: "50%",
-      top: "50%",
-      transform: "translate(-50%, -50%)",
-    },
-    "& svg": {
-      position: "absolute",
-      left: "50%",
-      top: "50%",
-      transform: "translate(-50%, -50%)",
-      width: theme.spacing(5),
-      height: theme.spacing(5),
-    },
-  },
-  progress: {
-    position: "absolute",
-    height: "100%",
-    left: 0,
-    top: 0,
-    backgroundColor: theme.palette.background.default,
-    zIndex: 0,
-  },
   underlinedLink: {
     textDecoration: "underline",
     color: theme.palette.primary.main,
-  },
-  fileSize: {
-    whiteSpace: "nowrap",
   },
 }));
 
@@ -292,54 +235,20 @@ function Dropzone(props: any) {
 
   return (
     <>
-      {slots.map(({ id, file, status, progress, url }: any, index: number) => {
+      {slots.map((slot: any, index: number) => {
         return (
-          <Box key={id} className={classes.file}>
-            <IconButton
-              size="small"
-              className={classes.deleteIcon}
-              aria-label={`Delete ${file.path}`}
-              title={`Delete ${file.path}`}
-              onClick={() => {
-                setSlots((slots: any) =>
-                  slots.filter((slot: any) => slot.file !== file)
-                );
-                setFileUploadStatus(() => `${file.path} was deleted`);
-              }}
-            >
-              <DeleteIcon />
-            </IconButton>
-            <Box
-              className={classes.progress}
-              width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
-              role="progressbar"
-              aria-valuenow={progress * 100 || 0}
-            />
-            <Box className={classes.filePreview}>
-              {file instanceof File && file?.type?.includes("image") ? (
-                <ImagePreview file={file} url={url} />
-              ) : (
-                <FileIcon />
-              )}
-            </Box>
-            <Box flexGrow={1}>
-              <Box
-                fontSize="body2.fontSize"
-                fontWeight={FONT_WEIGHT_SEMI_BOLD}
-                color="text.secondary"
-              >
-                File {index + 1}
-              </Box>
-              {file.path}
-            </Box>
-            <Box
-              color="text.secondary"
-              alignSelf="flex-end"
-              className={classes.fileSize}
-            >
-              {formatBytes(file.size)}
-            </Box>
-          </Box>
+          <UploadedFileCard
+            {...slot}
+            index={index}
+            onClick={() => {
+              setSlots(
+                slots.filter(
+                  (currentSlot: any) => currentSlot.file !== slot.file
+                )
+              );
+              setFileUploadStatus(() => `${slot.file.path} was deleted`);
+            }}
+          />
         );
       })}
       {fileUploadStatus && (
@@ -373,17 +282,6 @@ function Dropzone(props: any) {
         </Box>
       </ButtonBase>
     </>
-  );
-}
-
-function formatBytes(a: any, b = 2) {
-  if (0 === a) return "0 Bytes";
-  const c = 0 > b ? 0 : b,
-    d = Math.floor(Math.log(a) / Math.log(1024));
-  return (
-    parseFloat((a / Math.pow(1024, d)).toFixed(c)) +
-    " " +
-    ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d]
   );
 }
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -98,7 +98,7 @@ const DesignSettings: React.FC = () => {
               <Typography variant="h5">Logo</Typography>
             </InputRowLabel>
             <InputRowItem width={50}>
-              <PublicFileUploadButton></PublicFileUploadButton>
+              <PublicFileUploadButton />
             </InputRowItem>
             <Box color="text.secondary" pl={2} alignSelf="center">
               .png or .svg

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -5,13 +5,13 @@ import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import React from "react";
 import ColorPicker from "ui/ColorPicker";
-import FileUpload from "ui/FileUpload";
 import Input, { Props as InputProps } from "ui/Input";
 import InputGroup from "ui/InputGroup";
 import InputRow from "ui/InputRow";
 import InputRowItem from "ui/InputRowItem";
 import InputRowLabel from "ui/InputRowLabel";
 import OptionButton from "ui/OptionButton";
+import PublicFileUploadButton from "ui/PublicFileUploadButton";
 
 const TextInput: React.FC<{
   title: string;
@@ -98,7 +98,7 @@ const DesignSettings: React.FC = () => {
               <Typography variant="h5">Logo</Typography>
             </InputRowLabel>
             <InputRowItem width={50}>
-              <FileUpload></FileUpload>
+              <PublicFileUploadButton></PublicFileUploadButton>
             </InputRowItem>
             <Box color="text.secondary" pl={2} alignSelf="center">
               .png or .svg

--- a/editor.planx.uk/src/ui/Dropzone.tsx
+++ b/editor.planx.uk/src/ui/Dropzone.tsx
@@ -5,12 +5,13 @@ import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import { visuallyHidden } from "@mui/utils";
 import React from "react";
+import type { DropzoneState } from "react-dropzone";
 
 interface Props {
   isDragActive: boolean;
-  getRootProps: any;
-  getInputProps: any;
-  fileUploadStatus: any;
+  getRootProps: DropzoneState["getRootProps"];
+  getInputProps: DropzoneState["getInputProps"];
+  fileUploadStatus?: string;
 }
 
 interface RootProps extends ButtonBaseProps {
@@ -59,7 +60,7 @@ export const Dropzone: React.FC<Props> = ({
   getInputProps,
   fileUploadStatus,
 }) => (
-  <Root isDragActive={isDragActive} {...getRootProps()}>
+  <Root isDragActive={isDragActive} {...getRootProps({ role: "button" })}>
     {fileUploadStatus && (
       <p role="status" style={visuallyHidden}>
         {fileUploadStatus}

--- a/editor.planx.uk/src/ui/Dropzone.tsx
+++ b/editor.planx.uk/src/ui/Dropzone.tsx
@@ -1,0 +1,88 @@
+import CloudUpload from "@mui/icons-material/CloudUpload";
+import Box from "@mui/material/Box";
+import ButtonBase, { ButtonBaseProps } from "@mui/material/ButtonBase";
+import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
+import { visuallyHidden } from "@mui/utils";
+import React from "react";
+
+interface Props {
+  isDragActive: boolean;
+  getRootProps: any;
+  getInputProps: any;
+  fileUploadStatus: any;
+}
+
+interface RootProps extends ButtonBaseProps {
+  isDragActive: boolean;
+}
+
+const Root = styled(ButtonBase, {
+  shouldForwardProp: (prop) => prop !== "isDragActive",
+})<RootProps>(({ theme, isDragActive }) => ({
+  height: theme.spacing(14),
+  backgroundColor: isDragActive
+    ? theme.palette.background.default
+    : theme.palette.background.paper,
+  display: "flex",
+  alignItems: "center",
+  padding: theme.spacing(1.5),
+  position: "relative",
+  width: "100%",
+  fontSize: "medium",
+  zIndex: 10,
+  "&::before": {
+    content: "''",
+    position: "absolute",
+    left: -theme.spacing(0.75),
+    top: -theme.spacing(0.75),
+    width: `calc(100% + ${theme.spacing(1.5)})`,
+    height: `calc(100% + ${theme.spacing(1.5)})`,
+    display: "block",
+    border: `2px dashed ${theme.palette.secondary.light}`,
+    opacity: isDragActive ? 1 : 0,
+    transform: isDragActive ? "scale(1)" : "scale(0.8)",
+    zIndex: -1,
+    transformOrigin: "center center",
+    backgroundColor: theme.palette.background.paper,
+    transition: [
+      theme.transitions.create(["opacity", "transform"], {
+        duration: "0.2s",
+      }),
+    ],
+  },
+}));
+
+export const Dropzone: React.FC<Props> = ({
+  isDragActive,
+  getRootProps,
+  getInputProps,
+  fileUploadStatus,
+}) => (
+  <Root isDragActive={isDragActive} {...getRootProps()}>
+    {fileUploadStatus && (
+      <p role="status" style={visuallyHidden}>
+        {fileUploadStatus}
+      </p>
+    )}
+    <input data-testid="upload-boundary-input" {...getInputProps()} />
+    <Box pl={3} pr={4} color="text.secondary">
+      <CloudUpload />
+    </Box>
+    <Box flexGrow={1}>
+      <Box>
+        {isDragActive ? (
+          "Drop the files here"
+        ) : (
+          <>
+            Drag files here or <Link>choose a file</Link>
+          </>
+        )}
+      </Box>
+      <Box color="text.secondary">pdf, jpg or png</Box>
+    </Box>
+    <Box color="text.secondary" alignSelf="flex-end">
+      max size 30MB
+    </Box>
+  </Root>
+);

--- a/editor.planx.uk/src/ui/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/ImgInput.tsx
@@ -6,7 +6,7 @@ import Tooltip from "@mui/material/Tooltip";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useMemo, useState } from "react";
 
-import FileUpload from "./FileUpload";
+import PublicFileUploadButton from "./PublicFileUploadButton";
 
 const useClasses = makeStyles((theme) => ({
   imageUploadContainer: {
@@ -79,7 +79,7 @@ export default function ImgInput({
   ) : (
     <Tooltip title="Drop file here">
       <div className={classes.imageUploadContainer}>
-        <FileUpload
+        <PublicFileUploadButton
           onChange={(newUrl) => {
             setAnchorEl(null);
             onChange && onChange(newUrl);

--- a/editor.planx.uk/src/ui/PublicFileUploadButton.tsx
+++ b/editor.planx.uk/src/ui/PublicFileUploadButton.tsx
@@ -25,7 +25,7 @@ const useClasses = makeStyles((theme) => ({
   },
 }));
 
-export default function FileUpload(props: Props): FCReturn {
+export default function PublicFileUploadButton(props: Props): FCReturn {
   const { onChange } = props;
 
   const [status, setStatus] = useState<

--- a/editor.planx.uk/src/ui/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/ui/UploadedFileCard.tsx
@@ -3,22 +3,14 @@ import DeleteIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
+import { FileUploadSlot } from "@planx/components/FileUpload/Public";
 import ImagePreview from "components/ImagePreview";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-interface FileSlot {
-  path: string;
-  size: number;
-} // is this File?
-
-interface Props {
-  id: string;
-  file: FileSlot; // TODO: Tighten this up
-  progress: number;
-  url?: string;
+interface Props extends FileUploadSlot {
   index?: number;
-  onClick: any;
+  onClick: () => void;
 }
 
 const Root = styled(Box)(({ theme }) => ({
@@ -123,7 +115,7 @@ export const UploadedFileCard: React.FC<Props> = ({
   </Root>
 );
 
-function formatBytes(a: any, b = 2) {
+function formatBytes(a: number, b = 2) {
   if (0 === a) return "0 Bytes";
   const c = 0 > b ? 0 : b,
     d = Math.floor(Math.log(a) / Math.log(1024));

--- a/editor.planx.uk/src/ui/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/ui/UploadedFileCard.tsx
@@ -1,0 +1,136 @@
+import FileIcon from "@mui/icons-material/AttachFile";
+import DeleteIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import ImagePreview from "components/ImagePreview";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+interface FileSlot {
+  path: string;
+  size: number;
+} // is this File?
+
+interface Props {
+  id: string;
+  file: FileSlot; // TODO: Tighten this up
+  progress: number;
+  url?: string;
+  index?: number;
+  onClick: any;
+}
+
+const Root = styled(Box)(({ theme }) => ({
+  position: "relative",
+  height: theme.spacing(14),
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.background.paper}`,
+  display: "flex",
+  alignItems: "center",
+  padding: theme.spacing(1.5),
+  marginBottom: theme.spacing(2),
+  "& > *": {
+    zIndex: 1,
+  },
+}));
+
+const FilePreview = styled(Box)(({ theme }) => ({
+  height: theme.spacing(14),
+  width: theme.spacing(14),
+  marginLeft: -theme.spacing(1.5),
+  marginRight: theme.spacing(1.5),
+  opacity: 0.5,
+  position: "relative",
+  overflow: "hidden",
+  "& img": {
+    position: "absolute",
+    width: "100%",
+    left: "50%",
+    top: "50%",
+    transform: "translate(-50%, -50%)",
+  },
+  "& svg": {
+    position: "absolute",
+    left: "50%",
+    top: "50%",
+    transform: "translate(-50%, -50%)",
+    width: theme.spacing(5),
+    height: theme.spacing(5),
+  },
+}));
+
+const DeleteIconButton = styled(IconButton)(({ theme }) => ({
+  position: "absolute",
+  top: theme.spacing(1),
+  right: theme.spacing(1),
+}));
+
+const ProgressBar = styled(Box)(({ theme }) => ({
+  position: "absolute",
+  height: "100%",
+  left: 0,
+  top: 0,
+  backgroundColor: theme.palette.background.default,
+  zIndex: 0,
+}));
+
+const FileSize = styled(Box)(({ theme }) => ({
+  whiteSpace: "nowrap",
+  color: theme.palette.text.secondary,
+  alignSelf: "flex-end",
+}));
+
+export const UploadedFileCard: React.FC<Props> = ({
+  id,
+  file,
+  progress,
+  url,
+  index,
+  onClick,
+}) => (
+  <Root key={id}>
+    <DeleteIconButton
+      size="small"
+      aria-label={`Delete ${file.path}`}
+      title={`Delete ${file.path}`}
+      onClick={onClick}
+    >
+      <DeleteIcon />
+    </DeleteIconButton>
+    <ProgressBar
+      width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
+      role="progressbar"
+      aria-valuenow={progress * 100 || 0}
+    />
+    <FilePreview>
+      {file instanceof File && file?.type?.includes("image") ? (
+        <ImagePreview file={file} url={url} />
+      ) : (
+        <FileIcon />
+      )}
+    </FilePreview>
+    <Box flexGrow={1}>
+      <Box
+        fontSize="body2.fontSize"
+        fontWeight={FONT_WEIGHT_SEMI_BOLD}
+        color="text.secondary"
+      >
+        File {index !== undefined && index + 1}
+      </Box>
+      {file.path}
+    </Box>
+    <FileSize>{formatBytes(file.size)}</FileSize>
+  </Root>
+);
+
+function formatBytes(a: any, b = 2) {
+  if (0 === a) return "0 Bytes";
+  const c = 0 > b ? 0 : b,
+    d = Math.floor(Math.log(a) / Math.log(1024));
+  return (
+    parseFloat((a / Math.pow(1024, d)).toFixed(c)) +
+    " " +
+    ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d]
+  );
+}

--- a/editor.planx.uk/src/ui/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/ui/UploadedFileCard.tsx
@@ -82,14 +82,13 @@ const FileSize = styled(Box)(({ theme }) => ({
 }));
 
 export const UploadedFileCard: React.FC<Props> = ({
-  id,
   file,
   progress,
   url,
   index,
   onClick,
 }) => (
-  <Root key={id}>
+  <Root>
     <DeleteIconButton
       size="small"
       aria-label={`Delete ${file.path}`}


### PR DESCRIPTION
A first stab at rationalising some of the duplicated file upload code.

I've focused here on just the `Dropzone` and `FileUploadCard` UI components - there's a lot of duplicated logic left controlling uploads and slots. I'm going to branch off this PR and give that a go as well as I don't think it's too far off - working on a new branch means I can timebox it a bit easier and reviewing should be simpler also.