### PR TITLE
fix: `validateDOMNesting()` warning on Pay component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -69,17 +69,15 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
             >
               {props.instructionsTitle || "How to pay"}
             </Typography>
-            <Typography variant="body2">
-              <ReactMarkdownOrHtml
-                source={
-                  props.instructionsDescription ||
-                  `<p>You can pay for your application by using GOV.UK Pay.</p>\
-                   <p>Your application will be sent after you have paid the fee. \
-                   Wait until you see an application sent message before closing your browser.</p>`
-                }
-                openLinksOnNewTab
-              />
-            </Typography>
+            <ReactMarkdownOrHtml
+              source={
+                props.instructionsDescription ||
+                `<p>You can pay for your application by using GOV.UK Pay.</p>\
+                  <p>Your application will be sent after you have paid the fee. \
+                  Wait until you see an application sent message before closing your browser.</p>`
+              }
+              openLinksOnNewTab
+            />
             <Button
               variant="contained"
               color="primary"


### PR DESCRIPTION
Been meaning to get around to the bottom of this one for a while!

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/b62e9c56-dd8f-436a-99cc-ebc62702688e)
