### PR TITLE
fix: Add padding to `PreviewBrowser`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
     overflow: "auto",
     flex: 1,
     background: "#fff",
-    paddingTop: theme.spacing(3),
+    padding: theme.spacing(3),
   },
   refreshButton: {
     color: "inherit",


### PR DESCRIPTION
I think this is a regression introduced in https://github.com/theopensystemslab/planx-new/pull/1648 that I missed on review

| Before | After |
|--------|--------|
| ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/236bba07-a83f-4a7d-8f23-374c3a410af6) | ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/e28446a6-2202-49c8-8268-a48d0aad7b58) |