### PR TITLE
feat: show global and per-file help text in MultipleFileUpload component

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -3,10 +3,19 @@ import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import React, { useState } from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
+import MoreInfoIcon from "ui/icons/MoreInfo";
+import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
+import { emptyContent } from "ui/RichTextInput";
 
 import { FileUploadSlot } from "../FileUpload/Public";
+import { MoreInformation } from "../shared";
 import Card from "../shared/Preview/Card";
-import QuestionHeader from "../shared/Preview/QuestionHeader";
+import MoreInfo from "../shared/Preview/MoreInfo";
+import MoreInfoSection from "../shared/Preview/MoreInfoSection";
+import QuestionHeader, {
+  Image,
+  StyledIconButton,
+} from "../shared/Preview/QuestionHeader";
 import { Dropzone } from "../shared/PrivateFileUpload/Dropzone";
 import { FileStatus } from "../shared/PrivateFileUpload/FileStatus";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
@@ -24,7 +33,14 @@ function Component(props: Props) {
 
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
-      <QuestionHeader title={props.title} description={props.description} />
+      <QuestionHeader
+        title={props.title}
+        description={props.description}
+        info={props.info}
+        policyRef={props.policyRef}
+        howMeasured={props.howMeasured}
+        definitionImg={props.definitionImg}
+      />
       <Box>
         <FileStatus status={fileUploadStatus} />
         <Box sx={{ display: "flex", mb: 4, gap: 2 }}>
@@ -40,7 +56,10 @@ function Component(props: Props) {
               Required files
             </Typography>
             {props.fileTypes.map((fileType) => (
-              <p key={fileType.key}>{fileType.key}</p>
+              <InteractiveFileListItem
+                name={fileType.key}
+                moreInformation={fileType.moreInformation}
+              />
             ))}
           </Box>
         </Box>
@@ -63,3 +82,59 @@ function Component(props: Props) {
     </Card>
   );
 }
+
+interface FileListItemProps {
+  name: string;
+  moreInformation?: MoreInformation;
+}
+
+const InteractiveFileListItem = (props: FileListItemProps) => {
+  const [open, setOpen] = React.useState(false);
+
+  const { info, policyRef, howMeasured, definitionImg } =
+    props.moreInformation || {};
+
+  const handleHelpClick = () => {
+    setOpen(true);
+  };
+
+  return (
+    <Box
+      key={props.name}
+      style={{ display: "flex", justifyContent: "space-between" }}
+    >
+      <p>{props.name}</p>
+      {!!(info || policyRef || howMeasured) && (
+        <StyledIconButton
+          title={`More information`}
+          aria-label={`See more information about "${props.name}"`}
+          onClick={handleHelpClick}
+          aria-haspopup="dialog"
+          size="large"
+        >
+          <MoreInfoIcon />
+        </StyledIconButton>
+      )}
+      <MoreInfo open={open} handleClose={() => setOpen(false)}>
+        {info && info !== emptyContent ? (
+          <MoreInfoSection title="Why does it matter?">
+            <ReactMarkdownOrHtml source={info} openLinksOnNewTab />
+          </MoreInfoSection>
+        ) : undefined}
+        {policyRef && policyRef !== emptyContent ? (
+          <MoreInfoSection title="Source">
+            <ReactMarkdownOrHtml source={policyRef} openLinksOnNewTab />
+          </MoreInfoSection>
+        ) : undefined}
+        {howMeasured && howMeasured !== emptyContent ? (
+          <MoreInfoSection title="How is it defined?">
+            <>
+              {definitionImg && <Image src={definitionImg} alt="definition" />}
+              <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab />
+            </>
+          </MoreInfoSection>
+        ) : undefined}
+      </MoreInfo>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -34,14 +34,7 @@ function Component(props: Props) {
 
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
-      <QuestionHeader
-        title={props.title}
-        description={props.description}
-        info={props.info}
-        policyRef={props.policyRef}
-        howMeasured={props.howMeasured}
-        definitionImg={props.definitionImg}
-      />
+<QuestionHeader {...props}/>
       <Box>
         <FileStatus status={fileUploadStatus} />
         <Box sx={{ display: "flex", mb: 4, gap: 2 }}>

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import React, { useState } from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
 import MoreInfoIcon from "ui/icons/MoreInfo";
@@ -90,12 +91,14 @@ interface FileListItemProps {
 
 const InteractiveFileListItem = (props: FileListItemProps) => {
   const [open, setOpen] = React.useState(false);
-
+  const { trackHelpClick } = useAnalyticsTracking();
   const { info, policyRef, howMeasured, definitionImg } =
     props.moreInformation || {};
 
   const handleHelpClick = () => {
     setOpen(true);
+    // TODO: track granularity of file name in analytics, currently only knows help was clicked for this overall component type/node id
+    trackHelpClick(); // This returns a promise but we don't need to await for it
   };
 
   return (

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -28,13 +28,13 @@ const Description = styled(Box)(({ theme }) => ({
   },
 }));
 
-const StyledIconButton = styled(IconButton)(() => ({
+export const StyledIconButton = styled(IconButton)(() => ({
   "&:hover": {
     backgroundColor: "transparent",
   },
 }));
 
-const Image = styled("img")(() => ({
+export const Image = styled("img")(() => ({
   maxWidth: "100%",
 }));
 


### PR DESCRIPTION
Conditionally renders the more information icon & sidebar for both the overall component and individual files which have help text defined in the editor.
![Screenshot from 2023-06-06 13-17-33](https://github.com/theopensystemslab/planx-new/assets/5132349/ff713359-d4f5-4b90-bbc8-5c05ab3f84ea)
