### PR TITLE
feat: adds basic validation and back/change behavior to MultipleFileUpload

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -1,8 +1,10 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
+import ErrorWrapper from "ui/ErrorWrapper";
+import { array } from "yup";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import Card from "../shared/Preview/Card";
@@ -10,31 +12,98 @@ import QuestionHeader from "../shared/Preview/QuestionHeader";
 import { Dropzone } from "../shared/PrivateFileUpload/Dropzone";
 import { FileStatus } from "../shared/PrivateFileUpload/FileStatus";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
+import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import { MultipleFileUpload } from "./model";
 
 type Props = PublicProps<MultipleFileUpload>;
 
 export default Component;
 
+const slotsSchema = array()
+  .required()
+  .test({
+    name: "nonUploading",
+    message: "Upload at least one file",
+    test: (slots?: Array<FileUploadSlot>) => {
+      return Boolean(
+        slots &&
+          slots.length > 0 &&
+          !slots.some((slot) => slot.status === "uploading")
+      );
+    },
+  });
+
 function Component(props: Props) {
-  const [slots, setSlots] = useState<FileUploadSlot[]>([]);
+  const recoveredSlots = getPreviouslySubmittedData(props)?.map(
+    (slot: FileUploadSlot) => slot.cachedSlot
+  );
+  const [slots, setSlots] = useState<FileUploadSlot[]>(recoveredSlots ?? []);
   const [fileUploadStatus, setFileUploadStatus] = useState<string | undefined>(
     undefined
   );
+  const [validationError, setValidationError] = useState<string | undefined>();
+
+  const handleSubmit = () => {
+    slotsSchema
+      .validate(slots)
+      .then(() => {
+        props.handleSubmit?.(
+          makeData(
+            props,
+            slots.map((slot) => ({
+              url: slot.url,
+              filename: slot.file.path,
+              cachedSlot: {
+                ...slot,
+                file: {
+                  path: slot.file.path,
+                  type: slot.file.type,
+                  size: slot.file.size,
+                },
+              },
+            }))
+          )
+        );
+      })
+      .catch((err) => {
+        setValidationError(err.message);
+      });
+  };
+
+  /**
+   * Declare a ref to hold a mutable copy the up-to-date validation error.
+   * The intention is to prevent frequent unnecessary update loops that clears the
+   * validation error state if it is already empty.
+   */
+  const validationErrorRef = useRef(validationError);
+  useEffect(() => {
+    validationErrorRef.current = validationError;
+  }, [validationError]);
+
+  useEffect(() => {
+    if (validationErrorRef.current) {
+      setValidationError(undefined);
+    }
+  }, [slots]);
 
   return (
-    <Card handleSubmit={props.handleSubmit} isValid>
+    <Card
+      handleSubmit={handleSubmit}
+      isValid={slots.every((slot) => slot.url && slot.status === "success")}
+    >
       <QuestionHeader title={props.title} description={props.description} />
       <Box>
         <FileStatus status={fileUploadStatus} />
         <Box sx={{ display: "flex", mb: 4, gap: 2 }}>
-          <Box sx={{ flex: "50%" }}>
-            <Dropzone
-              slots={slots}
-              setSlots={setSlots}
-              setFileUploadStatus={setFileUploadStatus}
-            />
-          </Box>
+          <ErrorWrapper error={validationError} id={props.id}>
+            <Box sx={{ flex: "50%" }}>
+              <Dropzone
+                slots={slots}
+                setSlots={setSlots}
+                setFileUploadStatus={setFileUploadStatus}
+              />
+            </Box>
+          </ErrorWrapper>
           <Box sx={{ flex: "50%" }}>
             <Typography fontWeight={FONT_WEIGHT_BOLD}>
               Required files


### PR DESCRIPTION
Two changes here for some foundational functionality we can keep building on:
1. Adds a basic error wrapper around the file dropzone if you try to continue before uploading anything - and introduces a basic yup validation schema we can add "real" rules to next
![Screenshot from 2023-06-06 16-19-41](https://github.com/theopensystemslab/planx-new/assets/5132349/a6835792-9722-4b83-b778-d43870a9dbe6)

2. Retains previously uploaded files when navigating fowards / back (& on "change" from Review page in future)
![Screenshot from 2023-06-06 16-20-04](https://github.com/theopensystemslab/planx-new/assets/5132349/d115e5c3-6274-4841-a535-7be5cced1d20)
