### PR TITLE
chore: Bump up API timeout

### DIFF
--- a/api.planx.uk/send/bops.ts
+++ b/api.planx.uk/send/bops.ts
@@ -14,6 +14,8 @@ interface SendToBOPSRequest {
 }
 
 const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
+  req.setTimeout(120 * 1000); // Temporary bump to address submission timeouts
+
   // `/bops/:localAuthority` is only called via Hasura's scheduled event webhook now, so body is wrapped in a "payload" key
   const { payload }: SendToBOPSRequest = req.body;
   if (!payload) {

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -21,6 +21,8 @@ import { _admin as $admin } from "../client";
 import { PlanXExportData } from "@opensystemslab/planx-document-templates/types/types";
 
 const sendToEmail = async(req: Request, res: Response, next: NextFunction) => {
+  req.setTimeout(120 * 1000); // Temporary bump to address submission timeouts
+
   // `/email-submission/:localAuthority` is only called via Hasura's scheduled event webhook, so body is wrapped in a "payload" key
   const { payload } = req.body;
   if (!payload?.sessionId) {

--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -65,6 +65,8 @@ interface SendToUniformPayload {
  *   finally, insert a record into uniform_applications for future auditing
  */
 const sendToUniform = async (req: Request, res: Response, next: NextFunction) => {
+  req.setTimeout(120 * 1000); // Temporary bump to address submission timeouts
+  
   const uniformClient = getUniformClient(req.params.localAuthority);
   
   if (!uniformClient) {

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -644,8 +644,9 @@ app.use(errorHandler);
 
 const server = new Server(app);
 
-server.keepAliveTimeout = 30000; // 30s
+server.keepAliveTimeout = (30000); // 30s
 server.headersTimeout = 35000; // 35s
+server.setTimeout(60 * 1000); // 60s
 
 export default server;
 

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -260,6 +260,7 @@ export = async () => {
     external: true,
     vpc,
     subnets: networking.requireOutput("publicSubnetIds"),
+    idleTimeout: 120,
   });
   // XXX: If you change the port, you'll have to make the security group accept incoming connections on the new port
   const API_PORT = 80;


### PR DESCRIPTION
An attempt at an immediate fix for recent submission timeouts. This value is set to 60s by default, bumping it to 120s may give us a bit of breathing space to get to the root of the problem.

It's likely that fetching and processing the entire flow on the API is taking longer than it did on the frontend where we already had the flow upfront.