### PR TITLE
feat: Create `FileList` from passport and parsed `FileType` rules

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
@@ -174,6 +174,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
         <InputRow>
           <Input
             required
+            name="fn"
             value={props.value.rule.fn}
             onChange={(e) =>
               props.onChange(
@@ -184,7 +185,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
                 })
               )
             }
-            placeholder="Date field"
+            placeholder="Data field"
           />
           <Operator>Equals</Operator>
           <Input

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
@@ -52,9 +52,7 @@ Operator.defaultProps = {
 
 function MultipleFileUploadComponent(props: Props) {
   const formik = useFormik<MultipleFileUpload>({
-    initialValues: {
-      ...parseContent(props.node?.data),
-    },
+    initialValues: parseContent(props.node?.data),
     validationSchema: multipleFileUploadSchema,
     validateOnBlur: true,
     validateOnChange: false,

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
@@ -52,7 +52,9 @@ Operator.defaultProps = {
 
 function MultipleFileUploadComponent(props: Props) {
   const formik = useFormik<MultipleFileUpload>({
-    initialValues: parseContent(props.node?.data),
+    initialValues: {
+      ...parseContent(props.node?.data),
+    },
     validationSchema: multipleFileUploadSchema,
     validateOnBlur: true,
     validateOnChange: false,
@@ -172,7 +174,6 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
         <InputRow>
           <Input
             required
-            name="fn"
             value={props.value.rule.fn}
             onChange={(e) =>
               props.onChange(

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -3,6 +3,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
 import ErrorWrapper from "ui/ErrorWrapper";
@@ -24,11 +25,9 @@ import { Dropzone } from "../shared/PrivateFileUpload/Dropzone";
 import { FileStatus } from "../shared/PrivateFileUpload/FileStatus";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
-import { MultipleFileUpload } from "./model";
+import { createFileList, FileList, MultipleFileUpload } from "./model";
 
 type Props = PublicProps<MultipleFileUpload>;
-
-export default Component;
 
 const DropzoneContainer = styled(Box)(({ theme }) => ({
   display: "grid",
@@ -106,6 +105,18 @@ function Component(props: Props) {
       setValidationError(undefined);
     }
   }, [slots]);
+  
+  const [fileList, setFileList] = useState<FileList>({
+    required: [],
+    recommended: [],
+    optional: [],
+  });
+
+  useEffect(() => {
+    const passport = useStore.getState().computePassport();
+    const fileList = createFileList({ passport, fileTypes: props.fileTypes });
+    setFileList(fileList);
+  }, []);
 
   return (
     <Card
@@ -114,6 +125,7 @@ function Component(props: Props) {
     >
       <QuestionHeader {...props} />
         <DropzoneContainer>
+          <FileStatus status={fileUploadStatus} />
           <ErrorWrapper error={validationError} id={props.id}>
           <Dropzone
             slots={slots}
@@ -125,7 +137,7 @@ function Component(props: Props) {
             <Typography fontWeight={FONT_WEIGHT_BOLD}>
               Required files
             </Typography>
-            {props.fileTypes.map((fileType) => (
+            {fileList.required.map((fileType) => (
               <InteractiveFileListItem
                 name={fileType.key}
                 moreInformation={fileType.moreInformation}
@@ -214,3 +226,5 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
     </Box>
   );
 };
+
+export default Component;


### PR DESCRIPTION
# What does this PR do?
 - Build a `FileList` object based on the current passport and the `FileType` rules built by the Editor
 - This structure can (hopefully) do the job of driving the logic for the public facing component

## Comments
 - Not totally sold on a few names here - `FileList` feels pretty vague and generic - thoughts welcome!