### PR TITLE
fix(style): `InputRow` length

### DIFF
--- a/editor.planx.uk/src/ui/InputRow.tsx
+++ b/editor.planx.uk/src/ui/InputRow.tsx
@@ -18,7 +18,6 @@ const useClasses = makeStyles((theme) => ({
       },
       "&:last-child": {
         marginRight: 0,
-        flexShrink: 0,
       },
     },
   },


### PR DESCRIPTION
Visual regression introduced here - https://github.com/theopensystemslab/planx-new/pull/1616/files#diff-13dc74286f2a3643ed730d3b71dbc8ec7fb23a019be0f6c68976c38d9fcc1a6a

I've checked the very few places where `InputRow` is used in the public interface and I can't see a negative effect of dropping this.