### PR TITLE
feat: add a modal for tagging files in MultipleFileUpload

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Modal.tsx
@@ -1,0 +1,62 @@
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+import { FileUploadSlot } from "../FileUpload/Public";
+import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
+
+const TagsPerFileContainer = styled(Box)(({ theme }) => ({
+  marginBottom: theme.spacing(4),
+}));
+
+interface FileTaggingModalProps {
+  uploadedFiles: FileUploadSlot[];
+  setShowModal: (value: React.SetStateAction<boolean>) => void;
+}
+
+export const FileTaggingModal = (props: FileTaggingModalProps) => {
+  return (
+    <Dialog
+      open
+      onClose={() => props.setShowModal(false)}
+      data-testid="file-tagging-dialog"
+      maxWidth="xl"
+      PaperProps={{
+        sx: {
+          borderRadius: 0,
+          borderTop: (theme) => `10px solid ${theme.palette.primary.main}`,
+        },
+      }}
+    >
+      <DialogContent>
+        {props.uploadedFiles.map((slot) => (
+          <TagsPerFileContainer>
+            <UploadedFileCard {...slot} key={slot.id} />
+            <span>What does this file show?</span>
+          </TagsPerFileContainer>
+        ))}
+      </DialogContent>
+      <DialogActions style={{ display: "flex", justifyContent: "flex-start" }}>
+        <Link
+          component="button"
+          onClick={() => props.setShowModal(false)}
+          sx={{ paddingLeft: 2 }}
+        >
+          <Typography variant="body2">Done</Typography>
+        </Link>
+        <Link
+          component="button"
+          onClick={() => props.setShowModal(false)}
+          sx={{ paddingLeft: 2 }}
+        >
+          <Typography variant="body2">Cancel</Typography>
+        </Link>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -253,7 +253,7 @@ const FileTaggingModal = (props: FileTaggingModalProps) => {
       PaperProps={{
         sx: {
           borderRadius: 0,
-          borderTop: `10px solid ${DEFAULT_PRIMARY_COLOR}`,
+          borderTop: (theme) => `10px solid ${theme.palette.primary.main}`,
         },
       }}
     >

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -1,15 +1,11 @@
 import Box from "@mui/material/Box";
-import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
-import { DEFAULT_PRIMARY_COLOR, FONT_WEIGHT_BOLD } from "theme";
+import { FONT_WEIGHT_BOLD } from "theme";
 import ErrorWrapper from "ui/ErrorWrapper";
 import MoreInfoIcon from "ui/icons/MoreInfo";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
@@ -29,6 +25,7 @@ import { Dropzone } from "../shared/PrivateFileUpload/Dropzone";
 import { FileStatus } from "../shared/PrivateFileUpload/FileStatus";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
+import { FileTaggingModal } from "./Modal";
 import { createFileList, FileList, MultipleFileUpload } from "./model";
 
 type Props = PublicProps<MultipleFileUpload>;
@@ -231,57 +228,6 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
         ) : undefined}
       </MoreInfo>
     </Box>
-  );
-};
-
-const TagsPerFileContainer = styled(Box)(({ theme }) => ({
-  marginBottom: theme.spacing(4),
-}));
-
-interface FileTaggingModalProps {
-  uploadedFiles: FileUploadSlot[];
-  setShowModal: (value: React.SetStateAction<boolean>) => void;
-}
-
-const FileTaggingModal = (props: FileTaggingModalProps) => {
-  return (
-    <Dialog
-      open
-      onClose={() => props.setShowModal(false)}
-      data-testid="file-tagging-dialog"
-      maxWidth="xl"
-      PaperProps={{
-        sx: {
-          borderRadius: 0,
-          borderTop: (theme) => `10px solid ${theme.palette.primary.main}`,
-        },
-      }}
-    >
-      <DialogContent>
-        {props.uploadedFiles.map((slot) => (
-          <TagsPerFileContainer>
-            <UploadedFileCard {...slot} key={slot.id} />
-            <span>What does this file show?</span>
-          </TagsPerFileContainer>
-        ))}
-      </DialogContent>
-      <DialogActions style={{ display: "flex", justifyContent: "flex-start" }}>
-        <Link
-          component="button"
-          onClick={() => props.setShowModal(false)}
-          sx={{ paddingLeft: 2 }}
-        >
-          <Typography variant="body2">Done</Typography>
-        </Link>
-        <Link
-          component="button"
-          onClick={() => props.setShowModal(false)}
-          sx={{ paddingLeft: 2 }}
-        >
-          <Typography variant="body2">Cancel</Typography>
-        </Link>
-      </DialogActions>
-    </Dialog>
   );
 };
 

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -11,7 +11,7 @@ import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface Props extends FileUploadSlot {
-  removeFile: () => void;
+  removeFile?: () => void;
   onChange?: () => void;
   tags?: string[];
 }
@@ -121,14 +121,16 @@ export const UploadedFileCard: React.FC<Props> = ({
           <Typography variant="body2">{file.path}</Typography>
           <FileSize>{formatBytes(file.size)}</FileSize>
         </Box>
-        <IconButton
-          size="small"
-          aria-label={`Delete ${file.path}`}
-          title={`Delete ${file.path}`}
-          onClick={removeFile}
-        >
-          <DeleteIcon />
-        </IconButton>
+        {removeFile && (
+          <IconButton
+            size="small"
+            aria-label={`Delete ${file.path}`}
+            title={`Delete ${file.path}`}
+            onClick={removeFile}
+          >
+            <DeleteIcon />
+          </IconButton>
+        )}
       </Box>
     </FileCard>
     {tags && (

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -13,7 +13,7 @@ import { hasFeatureFlag } from "lib/featureFlags";
 
 const GOVUK_YELLOW = "#FFDD00";
 
-const DEFAULT_PRIMARY_COLOR = "#000661";
+export const DEFAULT_PRIMARY_COLOR = "#000661";
 const TEXT_COLOR_PRIMARY = "#0B0C0C";
 const TEXT_COLOR_SECONDARY = "#505A5F";
 const BG_COLOR_DEFAULT = "#FFFFFF";


### PR DESCRIPTION
Has been feeling good to have small, incremental PRs for MultipleFileUpload to avoid big rebases as we work in parallel, so opening this "starter Dialog" for review now 

What it does so far:
- Opens on clicking "Change" from any uploaded file card, closes on clicking action dialog buttons or outside dialog
- Renders each uploaded file in the dialog
- Very basic initial styling to match Figma like square corners and top border
![Screenshot from 2023-06-07 14-34-41](https://github.com/theopensystemslab/planx-new/assets/5132349/5db41927-1bbe-4c37-b0a9-63cafea82f7e)

What it still needs to do: 
- Also open when a file is dropped in the dropzone
  - What about on file deletion or validation errors? Quickly realised this was trickier than hooking into existing `useEffect` hook that listens for changes to `slots`, so just started with straightforward option to open on "Change" for now
- Render a dropdown with grouped checklists of `fileTypes`
  - MUI docs https://mui.com/material-ui/react-select/#checkmarks && https://mui.com/material-ui/react-select/#grouping
- Show the selected `fileTypes` as "chips" in the Dialog select
  - MUI docs https://mui.com/material-ui/react-select/#chip
- `handleSubmit` or similar on "Done"