### PR TITLE
fix: Use passport from state for `SummaryListsBySections`

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -36,15 +36,23 @@ const ReconciliationPage: React.FC<Props> = ({
   buttonText,
   onButtonClick,
 }) => {
-  const [flow, hasSections, sectionNodes, currentCard, changeAnswer, record] =
-    useStore((state) => [
-      state.flow,
-      state.hasSections,
-      state.sectionNodes,
-      state.currentCard(),
-      state.changeAnswer,
-      state.record,
-    ]);
+  const [
+    flow,
+    hasSections,
+    sectionNodes,
+    currentCard,
+    changeAnswer,
+    record,
+    passport,
+  ] = useStore((state) => [
+    state.flow,
+    state.hasSections,
+    state.sectionNodes,
+    state.currentCard(),
+    state.changeAnswer,
+    state.record,
+    state.computePassport(),
+  ]);
 
   const nextQuestion = () => {
     if (onButtonClick) {
@@ -109,7 +117,7 @@ const ReconciliationPage: React.FC<Props> = ({
           <SummaryListsBySections
             breadcrumbs={sortedBreadcrumbs}
             flow={flow}
-            passport={reconciliationResponse.reconciledSessionData.passport}
+            passport={passport}
             changeAnswer={changeAnswer}
             showChangeButton={false}
             sectionComponent="h3"


### PR DESCRIPTION
## What's the problem?
- As of https://github.com/theopensystemslab/planx-new/pull/1701 we no longer return the passport data as part of the response. This is done as the values were already set in state when `resumeSession() is called, and setting twice was leading to conflicts.
- The `SummaryListsBySections` component was relying on the `passport` returned by this response

## What's the solution?
 - Read `passport` from state, not the response
 - @builditben (as a follow on PR) to tidy up types of `ReconciliationResponse` on frontend and backend