### PR TITLE
fix: Make e2e tests pass first time round

### DIFF
--- a/e2e/src/helpers.ts
+++ b/e2e/src/helpers.ts
@@ -30,7 +30,7 @@ export function debugPageConsole(page: Page) {
 
 // used to detect `{ "setItem": ... }`, `{"getItem": ... }`
 // and "section state updated" debug messages on state transitions
-export function waitForDebugLog(page: Page) {
+export async function waitForDebugLog(page: Page) {
   return new Promise((resolve) => {
     page.on("console", (msg) => {
       if (msg.type() == "debug") {

--- a/e2e/src/invite-to-pay/agent.spec.ts
+++ b/e2e/src/invite-to-pay/agent.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
-import { setFeatureFlag, addSessionToContext, modifyFlow } from "../helpers";
+import {
+  setFeatureFlag,
+  addSessionToContext,
+  modifyFlow,
+} from "../helpers";
 import inviteToPayFlow from "../flows/invite-to-pay-flow";
 import {
   Context,
@@ -58,20 +62,21 @@ test.describe("Agent journey", async () => {
     const toggleInviteToPayButton = page.getByRole("button", {
       name: "Invite someone else to pay for this application",
     });
-    expect(toggleInviteToPayButton).toBeVisible();
+    await expect(toggleInviteToPayButton).toBeVisible();
     await toggleInviteToPayButton.click();
     const inviteToPayFormHeader = await page.getByText(
       "Invite someone else to pay for this application"
     );
-    expect(inviteToPayFormHeader).toBeVisible();
+    await expect(inviteToPayFormHeader).toBeVisible();
 
     await answerInviteToPayForm(page);
     await page.getByText("Send invitation to pay").click();
     await page.waitForLoadState("networkidle");
+
     const errorMessage = await page.getByText(
       "Error generating payment request, please try again"
     );
-    expect(errorMessage).not.toBeVisible();
+    await expect(errorMessage).not.toBeVisible();
 
     const paymentRequest = await getPaymentRequestBySessionId({
       sessionId,
@@ -81,7 +86,7 @@ test.describe("Agent journey", async () => {
     expect(paymentRequest).toMatchObject(mockPaymentRequest);
 
     const successMessage = await page.getByText("Payment invitation sent");
-    expect(successMessage).toBeVisible();
+    await expect(successMessage).toBeVisible();
   });
 
   test("agent cannot send a payment request after initialising a normal payment", async ({
@@ -99,7 +104,8 @@ test.describe("Agent journey", async () => {
     await page.getByLabel("email").fill(context.user.email);
     await page.getByText("Continue").click();
     await page.waitForLoadState("networkidle");
-    expect(toggleInviteToPayButton).toBeDisabled();
+
+    await expect(toggleInviteToPayButton).toBeDisabled();
   });
 
   test("agent cannot make changes after sending a payment request - session is locked", async ({
@@ -113,7 +119,7 @@ test.describe("Agent journey", async () => {
       .slug!}/preview?analytics=false&sessionId=${sessionId}`;
     const secondPage = await browserContext.newPage();
     await secondPage.goto(resumeLink);
-    expect(
+    await expect(
       await secondPage.getByRole("heading", {
         name: "Resume your application",
       })
@@ -121,12 +127,12 @@ test.describe("Agent journey", async () => {
     await secondPage.getByLabel("Email address").fill(context.user.email);
     await secondPage.getByTestId("continue-button").click();
 
-    expect(
+    await expect(
       await secondPage.getByRole("heading", {
         name: "Your application is locked",
       })
     ).toBeVisible();
-    expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
+    await expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
   });
 
   test("reconciliation does not apply to sessions with open payment requests", async ({
@@ -143,7 +149,7 @@ test.describe("Agent journey", async () => {
       .slug!}/preview?analytics=false&sessionId=${sessionId}`;
     const secondPage = await browserContext.newPage();
     await secondPage.goto(resumeLink);
-    expect(
+    await expect(
       await secondPage.getByRole("heading", { name: "Resume your application" })
     ).toBeVisible();
     await secondPage.getByLabel("Email address").fill(context.user.email);
@@ -153,14 +159,14 @@ test.describe("Agent journey", async () => {
     const reconciliationText = await secondPage.getByText(
       "This service has been updated since you last saved your application. We will ask you to answer any updated questions again when you continue."
     );
-    expect(reconciliationText).not.toBeVisible();
+    await expect(reconciliationText).not.toBeVisible();
 
     // Locked application message displayed
-    expect(
+    await expect(
       await secondPage.getByRole("heading", {
         name: "Your application is locked",
       })
     ).toBeVisible();
-    expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
+    await expect(secondPage.getByTestId("continue-button")).not.toBeVisible();
   });
 });

--- a/e2e/src/invite-to-pay/helpers.ts
+++ b/e2e/src/invite-to-pay/helpers.ts
@@ -7,7 +7,7 @@ import {
 } from "../helpers";
 import type { Page } from "@playwright/test";
 import { gql, GraphQLClient } from "graphql-request";
-import { fillInEmail } from "../helpers";
+import { fillInEmail  } from "../helpers";
 import { PaymentRequest } from "@opensystemslab/planx-core/dist/types";
 import { Context } from "../context";
 

--- a/e2e/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/src/invite-to-pay/nominee.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect, Page, APIRequestContext } from "@playwright/test";
 import { v4 as uuidV4 } from "uuid";
-import { setFeatureFlag, fillGovUkCardDetails, cards } from "../helpers";
+import {
+  setFeatureFlag,
+  fillGovUkCardDetails,
+  cards,
+} from "../helpers";
 import inviteToPayFlow from "../flows/invite-to-pay-flow";
 import {
   Context,
@@ -55,22 +59,22 @@ test.describe("Nominee journey", async () => {
     const { paymentRequest, sessionId } = await setupPaymentRequest(request);
     await navigateToPaymentRequestPage(paymentRequest, page);
 
-    expect(
+    await expect(
       await page.getByRole("heading", { name: "Pay for your application" })
     ).toBeVisible();
-    expect(
-      await page.locator("#main-content").getByText("Invite to pay test")
+    await expect(
+      page.locator("#main-content").getByText("Invite to pay test")
     ).toBeVisible();
-    expect(await page.getByText("123, Test Street, Testville")).toBeVisible();
+    await expect(page.getByText("123, Test Street, Testville")).toBeVisible();
 
     const formattedProjectType =
       "Alteration of internal walls and addition or alteration of a deck";
-    expect(await page.getByText(formattedProjectType)).toBeVisible();
+    await expect(page.getByText(formattedProjectType)).toBeVisible();
 
     const payButton = await page.getByRole("button", {
       name: "Pay using GOV.UK Pay",
     });
-    expect(payButton).toBeVisible();
+    await expect(payButton).toBeVisible();
 
     await payButton.click();
     await fillGovUkCardDetails({
@@ -83,7 +87,7 @@ test.describe("Nominee journey", async () => {
     // Wait for GovPay re-request to update paymentRequest status
     await page.waitForLoadState("networkidle");
 
-    expect(await page.getByText("Payment received")).toBeVisible();
+    await expect(page.getByText("Payment received")).toBeVisible();
     const updatedPaymentRequest = await getPaymentRequestBySessionId({
       sessionId,
       adminGQLClient,
@@ -97,7 +101,7 @@ test.describe("Nominee journey", async () => {
     await page.goto(invalidPaymentRequestURL);
     await page.waitForLoadState("networkidle");
 
-    expect(await page.getByText("Payment request not found")).toBeVisible();
+    await expect(page.getByText("Payment request not found")).toBeVisible();
   });
 
   test("navigating to a URL without a paymentRequestId", async ({ page }) => {
@@ -106,7 +110,7 @@ test.describe("Nominee journey", async () => {
     await page.goto(invalidPaymentRequestURL);
     await page.waitForLoadState("networkidle");
 
-    expect(await page.getByText("Payment request not found")).toBeVisible();
+    await expect(page.getByText("Payment request not found")).toBeVisible();
   });
 
   test("responding to a payment request which has been paid", async ({
@@ -117,7 +121,7 @@ test.describe("Nominee journey", async () => {
     await markPaymentRequestAsPaid(paymentRequest);
     await navigateToPaymentRequestPage(paymentRequest, page);
 
-    expect(await page.getByText("Payment request not found")).toBeVisible();
+    await expect(page.getByText("Payment request not found")).toBeVisible();
   });
 
   test("responding to a payment request which has expired", async ({
@@ -128,7 +132,7 @@ test.describe("Nominee journey", async () => {
     await markPaymentRequestAsExpired(paymentRequest);
     await navigateToPaymentRequestPage(paymentRequest, page);
 
-    expect(await page.getByText("Payment request not found")).toBeVisible();
+    await expect(page.getByText("Payment request not found")).toBeVisible();
   });
 });
 


### PR DESCRIPTION
Playwright test assertions can wait until the assertion is met (or a timeout) when `await`'ed: https://playwright.dev/docs/test-assertions

Adding `await` before each expectation fixes the issue of these e2e tests failing on the first run through.