### PR TITLE
fix: Correctly format conditions

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Editor.tsx
@@ -12,7 +12,7 @@ import {
   MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
-import { capitalize, merge } from "lodash";
+import { lowerCase, merge, upperFirst } from "lodash";
 import React from "react";
 import Input from "ui/Input";
 import InputRow from "ui/InputRow";
@@ -163,7 +163,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
         >
           {Object.entries(Condition).map(([key, value]) => (
             <MenuItem key={key} value={value}>
-              {capitalize(value)}
+              {upperFirst(lowerCase(value))}
             </MenuItem>
           ))}
         </SelectInput>


### PR DESCRIPTION
Something I missed in the previous review - I was using `lowerCase()` as a way of splitting the `Condition` enum between words with a space

Docs: https://lodash.com/docs/4.17.15#lowerCase

| Before | After |
|--------|--------|
| <img width="544" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/72933c12-58c0-41e8-9fed-9b227f1e9579"> | <img width="562" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/f161207c-40f7-4e57-bbf0-58b224ca3ff1"> |