### PR TITLE
fix: Header spacing

### DIFF
--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -6,13 +6,15 @@ import Typography from "@mui/material/Typography";
 import React, { useState } from "react";
 import AnalyticsChart from "ui/icons/AnalyticsChart";
 
+import { getHeaderPadding } from "./Header";
+
 const AnalyticsWarning = styled(Box)(({ theme }) => ({
   display: "flex",
   backgroundColor: "#FFFB00",
-  padding: theme.spacing(0.5, 2),
   color: "#070707",
   justifyContent: "space-between",
   alignItems: "center",
+  ...getHeaderPadding(theme),
 }));
 
 const AnalyticsDisabledBanner: React.FC = () => {

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { styled } from "@mui/material/styles";
 import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { deepmerge } from "@mui/utils";
 import { TYPES } from "@planx/components/types";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { clearLocalFlow } from "lib/local";
@@ -32,7 +33,7 @@ import {
   FONT_WEIGHT_SEMI_BOLD,
   LINE_HEIGHT_BASE,
 } from "theme";
-import { ApplicationPath, Team } from "types";
+import { ApplicationPath } from "types";
 import Reset from "ui/icons/Reset";
 
 import { useStore } from "../pages/FlowEditor/lib/store";
@@ -55,11 +56,7 @@ const StyledLink = styled(ReactNaviLink)(() => ({
   textDecoration: "none",
 })) as typeof Link;
 
-const StyledToolbar = styled(MuiToolbar)(({ theme }) => ({
-  minHeight: HEADER_HEIGHT,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "space-between",
+export const getHeaderPadding = (theme: Theme): React.CSSProperties => ({
   paddingLeft: theme.spacing(2),
   paddingRight: theme.spacing(2),
   [theme.breakpoints.up("md")]: {
@@ -70,6 +67,14 @@ const StyledToolbar = styled(MuiToolbar)(({ theme }) => ({
     paddingLeft: theme.spacing(4),
     paddingRight: theme.spacing(4),
   },
+});
+
+const StyledToolbar = styled(MuiToolbar)(({ theme }) => ({
+  height: HEADER_HEIGHT,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  ...getHeaderPadding(theme),
 }));
 
 const LeftBox = styled(Box)(() => ({
@@ -165,9 +170,13 @@ const ServiceTitleRoot = styled("span")(({ theme }) => ({
 const StyledNavBar = styled("nav")(({ theme }) => ({
   height: HEADER_HEIGHT,
   backgroundColor: theme.palette.primary.dark,
-  padding: theme.spacing(1.5),
-  paddingLeft: theme.spacing(4),
   fontSize: 16,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  ...getHeaderPadding(theme),
 }));
 
 const SectionName = styled(Typography)(() => ({
@@ -317,7 +326,7 @@ const PublicToolbar: React.FC<{
   return (
     <>
       <SkipLink href="#main-content">Skip to main content</SkipLink>
-      <StyledToolbar>
+      <StyledToolbar disableGutters>
         <LeftBox>
           {teamTheme?.logo ? (
             <TeamLogo />


### PR DESCRIPTION
Small visual regression in the sections header following font size updates. Also, a bit of a tidy up and standardisation of how header spacing is handled.

| Description | Before | After |
|--------|--------|--------|
| "Section 1 of X" not centre aligned vertically | ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/1b2168fa-759b-4b8a-a242-fd854095e4c8) | ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/303e16d4-bc7a-4515-909c-f946b0e4bde6) |
| Header smaller than section header | <img width="982" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/fb477d9a-e2d6-4757-9526-0884c6d770dd">_(Header 64px tall, section header 74px tall)_ | <img width="771" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/cf39ca88-337c-4351-8fc0-04d006eaefa4"> _Both headers 74px tall_ |

Header spacing - inconsistent across different header sections, particularly as breakpoints change

**Before**

https://github.com/theopensystemslab/planx-new/assets/20502206/79f3e4b9-5aba-41b2-b359-530300222866

**After**

https://github.com/theopensystemslab/planx-new/assets/20502206/61405d32-b0d8-467f-a601-54bdc53b427a 