### PR TITLE
fix: Result reasons shouldn't have hardcoded green band

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -99,7 +99,7 @@ const useClasses = makeStyles((theme: Theme) => ({
     left: "0",
     width: "10px",
     height: "100%",
-    backgroundColor: "#82E6A1",
+    backgroundColor: theme.palette.background.paper, // TODO match to flag color
     zIndex: "1",
   },
   accordionHeader: {


### PR DESCRIPTION
Fixes https://opensystemslab.slack.com/archives/C01E3AC0C03/p1686565382480159

Quickly updated to use `paper` color for all "Reasons". In the future, the band color should match the flag color if the question has an associated flag, or fallback to `paper` if it doesn't have an associated flag? Currently, the `ResultReason` doesn't have access to the flag info; it'll need to join to flow data on `id` in order to set the color. 
![Screenshot from 2023-06-12 12-38-41](https://github.com/theopensystemslab/planx-new/assets/5132349/f7317749-c341-45f0-ad52-f7679a1620f0)