### PR TITLE
feat: Automatically open tagging modal when file is uploaded

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.test.tsx
@@ -1,0 +1,204 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import axios from "axios";
+import React from "react";
+import { axe, setup } from "testUtils";
+
+import { mockFileTypes } from "./mocks";
+import MultipleFileUploadComponent from "./Public";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+window.URL.createObjectURL = jest.fn();
+
+describe("Basic state and setup", () => {
+  test("renders correctly", async () => {
+    setup(
+      <MultipleFileUploadComponent
+        title="Test title"
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
+      />
+    );
+
+    expect(screen.getAllByRole("heading")[0]).toHaveTextContent("Test title");
+
+    // Required file is listed
+    expect(screen.getByText("testKey")).toBeVisible();
+  });
+
+  it.skip("should not have any accessibility violations", async () => {
+    const { container } = setup(
+      <MultipleFileUploadComponent
+        title="Test title"
+        fileTypes={[mockFileTypes.AlwaysRequired]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe("Modal trigger", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test("Modal does not open on initial component render", async () => {
+    setup(
+      <MultipleFileUploadComponent
+        title="Test title"
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
+      />
+    );
+
+    const fileTaggingModal = within(document.body).queryByTestId(
+      "file-tagging-dialog"
+    );
+
+    expect(fileTaggingModal).not.toBeInTheDocument();
+  });
+
+  test("Modal opens when a single file is uploaded", async () => {
+    const { user } = setup(
+      <MultipleFileUploadComponent
+        title="Test title"
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
+      />
+    );
+    const mockedPost = mockedAxios.post.mockResolvedValue({
+      data: {
+        file_type: "image/png",
+        fileUrl: "https://api.editor.planx.dev/file/private/gws7l5d1/test.jpg",
+      },
+    });
+
+    const file = new File(["test"], "test.png", { type: "image/png" });
+    const input = screen.getByTestId("upload-input");
+    await user.upload(input, file);
+    expect(mockedPost).toHaveBeenCalled();
+
+    const fileTaggingModal = await within(document.body).findByTestId(
+      "file-tagging-dialog"
+    );
+    expect(fileTaggingModal).toBeVisible();
+
+    expect(await within(fileTaggingModal).findByText("test.png")).toBeVisible();
+  });
+
+  test("Modal opens when multiple files are uploaded", async () => {
+    const { user } = setup(
+      <MultipleFileUploadComponent
+        title="Test title"
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
+      />
+    );
+
+    const mockedPost = mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          file_type: "image/png",
+          fileUrl:
+            "https://api.editor.planx.dev/file/private/gws7l5d1/test1.jpg",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          file_type: "image/png",
+          fileUrl:
+            "https://api.editor.planx.dev/file/private/gws7l5d1/test2.jpg",
+        },
+      });
+
+    const file1 = new File(["test1"], "test1.png", { type: "image/png" });
+    const file2 = new File(["test2"], "test2.png", { type: "image/png" });
+    const input = screen.getByTestId("upload-input");
+    await user.upload(input, [file1, file2]);
+    expect(mockedPost).toHaveBeenCalledTimes(2);
+
+    const fileTaggingModal = await within(document.body).findByTestId(
+      "file-tagging-dialog"
+    );
+    expect(
+      await within(fileTaggingModal).findByText("test1.png")
+    ).toBeVisible();
+    expect(
+      await within(fileTaggingModal).findByText("test2.png")
+    ).toBeVisible();
+  });
+
+  test("Modal does not open when a file is deleted", async () => {
+    const { user } = setup(
+      <MultipleFileUploadComponent
+        title="Test title"
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
+      />
+    );
+
+    // Upload two files
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          file_type: "image/png",
+          fileUrl:
+            "https://api.editor.planx.dev/file/private/gws7l5d1/test1.jpg",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          file_type: "image/png",
+          fileUrl:
+            "https://api.editor.planx.dev/file/private/gws7l5d1/test2.jpg",
+        },
+      });
+
+    const file1 = new File(["test1"], "test1.png", { type: "image/png" });
+    const file2 = new File(["test2"], "test2.png", { type: "image/png" });
+    const input = screen.getByTestId("upload-input");
+    await user.upload(input, [file1, file2]);
+
+    const fileTaggingModal = await within(document.body).findByTestId(
+      "file-tagging-dialog"
+    );
+
+    // Close modal
+    const closeModalButton = await within(fileTaggingModal).findByText(
+      "Cancel"
+    );
+    expect(closeModalButton).toBeVisible();
+    user.click(closeModalButton);
+    await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
+
+    // Uploaded files displayed as cards
+    expect(screen.getByText("test1.png")).toBeVisible();
+    expect(screen.getByText("test2.png")).toBeVisible();
+
+    // Delete the second file
+    user.click(screen.getByLabelText("Delete test2.png"));
+
+    // Card removed from screen
+    await waitFor(() =>
+      expect(screen.queryByText("test2.png")).not.toBeInTheDocument()
+    );
+
+    // Modal not open
+    expect(fileTaggingModal).not.toBeVisible();
+  });
+});

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.test.tsx
@@ -30,11 +30,17 @@ describe("Basic state and setup", () => {
     expect(screen.getByText("testKey")).toBeVisible();
   });
 
-  it.skip("should not have any accessibility violations", async () => {
+  it("should not have any accessibility violations", async () => {
     const { container } = setup(
       <MultipleFileUploadComponent
         title="Test title"
-        fileTypes={[mockFileTypes.AlwaysRequired]}
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
       />
     );
     const results = await axe(container);

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -143,24 +143,22 @@ function Component(props: Props) {
         <List disablePadding sx={{ width: "100%" }}>
           {(Object.keys(fileList) as Array<keyof typeof fileList>)
             .filter((fileListCategory) => fileList[fileListCategory].length > 0)
-            .map((fileListCategory) => (
-              <Box key={`wrapper-${fileListCategory}-files`}>
-                <ListSubheader
-                  key={`subheader-${fileListCategory}-files`}
-                  disableGutters
-                >
-                  {`${capitalize(fileListCategory)} files`}
-                </ListSubheader>
-                {fileList[fileListCategory].map((fileType) => (
-                  <ListItem key={fileType.name} disablePadding>
-                    <InteractiveFileListItem
-                      name={fileType.name}
-                      moreInformation={fileType.moreInformation}
-                    />
-                  </ListItem>
-                ))}
-              </Box>
-            ))}
+            .flatMap((fileListCategory) => [
+              <ListSubheader
+                key={`subheader-${fileListCategory}-files`}
+                disableGutters
+              >
+                {`${capitalize(fileListCategory)} files`}
+              </ListSubheader>,
+              fileList[fileListCategory].map((fileType) => (
+                <ListItem key={fileType.name} disablePadding>
+                  <InteractiveFileListItem
+                    name={fileType.name}
+                    moreInformation={fileType.moreInformation}
+                  />
+                </ListItem>
+              ))
+            ])}
         </List>
       </DropzoneContainer>
       {Boolean(slots.length) && (

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -9,6 +9,7 @@ import capitalize from "lodash/capitalize";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
+import { usePrevious } from "react-use";
 import { FONT_WEIGHT_BOLD } from "theme";
 import ErrorWrapper from "ui/ErrorWrapper";
 import MoreInfoIcon from "ui/icons/MoreInfo";
@@ -72,6 +73,13 @@ function Component(props: Props) {
   }, [props.previouslySubmittedData, fileList]);
 
   const [slots, setSlots] = useState<FileUploadSlot[]>([]);
+
+  // Track number of slots, and open modal when this increases
+  const previousSlotCount = usePrevious(slots.length);
+  useEffect(() => {
+    if (previousSlotCount === undefined) return;
+    if (slots.length > previousSlotCount) setShowModal(true);
+  }, [slots.length]);
 
   const [fileUploadStatus, setFileUploadStatus] = useState<string | undefined>(
     undefined

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -132,7 +132,7 @@ export const Dropzone: React.FC<Props> = ({
 
   return (
     <Root isDragActive={isDragActive} {...getRootProps({ role: "button" })}>
-      <input data-testid="upload-boundary-input" {...getInputProps()} />
+      <input data-testid="upload-input" {...getInputProps()} />
       <Box pl={2} pr={3} color="text.secondary">
         <CloudUpload />
       </Box>


### PR DESCRIPTION
## What does this PR do?
Adds the following behaviour to the `MultipleFileUpload` public component - 
 - `FileTaggingModal` does not open on component mount
 - `FileTaggingModal` opens when a single file is uploaded
 - `FileTaggingModal` opens when multiple files are uploaded
 - `FileTaggingModal` is not opened when files are deleted

Also a quick a11y fix, and some basic tests for the above cases.