### PR TITLE
feat: Page container / layout restructure

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -1,8 +1,10 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import { styled } from "@mui/material/styles";
 import type { Checklist, Group } from "@planx/components/Checklist/model";
 import ImageButton from "@planx/components/shared/Buttons/ImageButton";
 import Card from "@planx/components/shared/Preview/Card";
+import { fullWidthContent } from "@planx/components/shared/Preview/MapContainer";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { useFormik } from "formik";
 import React, { useState } from "react";
@@ -43,6 +45,15 @@ function getFlatOptions({
   }
   return [];
 }
+
+const FullWidthContainer = styled(Box)(({ theme }) => ({
+  ...fullWidthContent(theme),
+}));
+
+const FormWrapper = styled(Box)(({ theme }) => ({
+  width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
+}));
 
 const ChecklistComponent: React.FC<Props> = ({
   allRequired,
@@ -136,77 +147,90 @@ const ChecklistComponent: React.FC<Props> = ({
         howMeasured={howMeasured}
         img={img}
       />
-
-      <ErrorWrapper error={formik.errors.checked} id={id}>
-        <Grid container spacing={layout === ChecklistLayout.Images ? 2 : 0}>
-          {options ? (
-            options.map((option: any) =>
-              layout === ChecklistLayout.Basic ? (
-                <Grid item xs={12} key={option.data.text}>
-                  <ChecklistItem
-                    onChange={changeCheckbox(option.id)}
-                    label={option.data.text}
-                    id={option.id}
-                    checked={formik.values.checked.includes(option.id)}
-                  />
-                </Grid>
-              ) : (
-                <Grid item xs={12} sm={6} key={option.data.text}>
-                  <ImageButton
-                    title={option.data.text}
-                    id={option.id}
-                    img={option.data.img}
-                    selected={formik.values.checked.includes(option.id)}
-                    onClick={changeCheckbox(option.id)}
-                    checkbox
-                  />
-                </Grid>
+      <FullWidthContainer>
+        <ErrorWrapper error={formik.errors.checked} id={id}>
+          <Grid container spacing={layout === ChecklistLayout.Images ? 2 : 0}>
+            {options ? (
+              options.map((option: any) =>
+                layout === ChecklistLayout.Basic ? (
+                  <FormWrapper>
+                    <Grid item xs={12} key={option.data.text}>
+                      <ChecklistItem
+                        onChange={changeCheckbox(option.id)}
+                        label={option.data.text}
+                        id={option.id}
+                        checked={formik.values.checked.includes(option.id)}
+                      />
+                    </Grid>
+                  </FormWrapper>
+                ) : (
+                  <Grid
+                    item
+                    xs={12}
+                    sm={6}
+                    contentWrap={4}
+                    key={option.data.text}
+                  >
+                    <ImageButton
+                      title={option.data.text}
+                      id={option.id}
+                      img={option.data.img}
+                      selected={formik.values.checked.includes(option.id)}
+                      onClick={changeCheckbox(option.id)}
+                      checkbox
+                    />
+                  </Grid>
+                )
               )
-            )
-          ) : groupedOptions ? (
-            <Grid item xs={12}>
-              <ExpandableList>
-                {groupedOptions.map((group, index) => {
-                  const isExpanded = expandedGroups.includes(index);
-                  return (
-                    <ExpandableListItem
-                      key={index}
-                      expanded={isExpanded}
-                      onToggle={() => {
-                        setExpandedGroups((previous) =>
-                          toggleInArray(index, previous)
-                        );
-                      }}
-                      headingId={`group-${index}-heading`}
-                      groupId={`group-${index}-content`}
-                      title={group.title}
-                    >
-                      <Box
-                        py={2}
-                        aria-labelledby={`group-${index}-heading`}
-                        id={`group-${index}-content`}
-                        data-testid={`group-${index}${
-                          isExpanded ? "-expanded" : ""
-                        }`}
-                      >
-                        {group.children.map((option: any) => (
-                          <ChecklistItem
-                            onChange={changeCheckbox(option.id)}
-                            key={option.data.text}
-                            label={option.data.text}
-                            id={option.id}
-                            checked={formik.values.checked.includes(option.id)}
-                          />
-                        ))}
-                      </Box>
-                    </ExpandableListItem>
-                  );
-                })}
-              </ExpandableList>
-            </Grid>
-          ) : null}
-        </Grid>
-      </ErrorWrapper>
+            ) : groupedOptions ? (
+              <FormWrapper>
+                <Grid item xs={12}>
+                  <ExpandableList>
+                    {groupedOptions.map((group, index) => {
+                      const isExpanded = expandedGroups.includes(index);
+                      return (
+                        <ExpandableListItem
+                          key={index}
+                          expanded={isExpanded}
+                          onToggle={() => {
+                            setExpandedGroups((previous) =>
+                              toggleInArray(index, previous)
+                            );
+                          }}
+                          headingId={`group-${index}-heading`}
+                          groupId={`group-${index}-content`}
+                          title={group.title}
+                        >
+                          <Box
+                            py={2}
+                            aria-labelledby={`group-${index}-heading`}
+                            id={`group-${index}-content`}
+                            data-testid={`group-${index}${
+                              isExpanded ? "-expanded" : ""
+                            }`}
+                          >
+                            {group.children.map((option: any) => (
+                              <ChecklistItem
+                                onChange={changeCheckbox(option.id)}
+                                key={option.data.text}
+                                label={option.data.text}
+                                id={option.id}
+                                checked={formik.values.checked.includes(
+                                  option.id
+                                )}
+                              />
+                            ))}
+                          </Box>
+                        </ExpandableListItem>
+                      );
+                    })}
+                  </ExpandableList>
+                </Grid>
+              </FormWrapper>
+            ) : null}
+          </Grid>
+        </ErrorWrapper>
+      </FullWidthContainer>
     </Card>
   );
 

--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -11,6 +11,7 @@ import React, { useState } from "react";
 import ChecklistItem from "ui/ChecklistItem";
 import ErrorWrapper from "ui/ErrorWrapper";
 import { ExpandableList, ExpandableListItem } from "ui/ExpandableList";
+import FormWrapper from "ui/FormWrapper";
 import { array, object } from "yup";
 
 import { Option } from "../shared";
@@ -48,11 +49,6 @@ function getFlatOptions({
 
 const FullWidthContainer = styled(Box)(({ theme }) => ({
   ...fullWidthContent(theme),
-}));
-
-const FormWrapper = styled(Box)(({ theme }) => ({
-  width: theme.breakpoints.values.formWrap,
-  maxWidth: "100%",
 }));
 
 const ChecklistComponent: React.FC<Props> = ({

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -60,7 +60,7 @@ export default function ConfirmationComponent(props: Props) {
       >
         {props.description && (
           <Box mt={4}>
-            <Typography>{props.description}</Typography>
+            <Typography maxWidth="formWrap">{props.description}</Typography>
           </Box>
         )}
       </Banner>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -5,6 +5,7 @@ import ListItem from "@mui/material/ListItem";
 import ListSubheader from "@mui/material/ListSubheader";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { fullWidthContent } from "@planx/components/shared/Preview/MapContainer";
 import { PublicProps } from "@planx/components/ui";
 import capitalize from "lodash/capitalize";
 import {
@@ -44,6 +45,10 @@ import {
 import { fileListSchema, slotsSchema } from "./schema";
 
 type Props = PublicProps<FileUploadAndLabel>;
+
+const FullWidthContainer = styled(Box)(({ theme }) => ({
+  ...fullWidthContent(theme),
+}));
 
 const DropzoneContainer = styled(Box)(({ theme }) => ({
   display: "grid",
@@ -128,92 +133,94 @@ function Component(props: Props) {
       isValid={slots.every((slot) => slot.url && slot.status === "success")}
     >
       <QuestionHeader {...props} />
-      <DropzoneContainer>
-        <FileStatus status={fileUploadStatus} />
-        <ErrorWrapper error={dropzoneError} id={`${props.id}-dropzone`}>
-          <Dropzone
-            slots={slots}
-            setSlots={setSlots}
-            setFileUploadStatus={setFileUploadStatus}
-          />
-        </ErrorWrapper>
-        <List
-          disablePadding
-          sx={{
-            width: "100%",
-            marginTop: { md: "-1em" },
-          }}
-        >
-          {(Object.keys(fileList) as Array<keyof typeof fileList>)
-            .filter((fileListCategory) => fileList[fileListCategory].length > 0)
-            .flatMap((fileListCategory) => [
-              <ListSubheader
-                key={`subheader-${fileListCategory}-files`}
-                disableGutters
-                disableSticky
-                sx={{
-                  background: "transparent",
-                  color: "unset",
-                  padding: "1.5em 0 1em",
-                }}
-              >
-                <Typography variant="h3" component="h2">
-                  {`${capitalize(fileListCategory)} files`}
-                </Typography>
-              </ListSubheader>,
-              fileList[fileListCategory].map((fileType) => (
-                <ListItem key={fileType.name} disablePadding>
-                  <InteractiveFileListItem
-                    name={fileType.name}
-                    fn={fileType.fn}
-                    completed={Boolean(fileType.slots?.length)}
-                    moreInformation={fileType.moreInformation}
-                  />
-                </ListItem>
-              )),
-            ])}
-        </List>
-      </DropzoneContainer>
-      <ErrorWrapper error={fileListError} id={`${props.id}-fileList`}>
-        <Box>
-          {Boolean(slots.length) && (
-            <Typography variant="h3" mb={2}>
-              Your uploaded files
-            </Typography>
-          )}
-          {showModal && (
-            <FileTaggingModal
-              uploadedFiles={slots}
-              fileList={fileList}
-              setFileList={setFileList}
-              setShowModal={setShowModal}
+      <FullWidthContainer>
+        <DropzoneContainer>
+          <FileStatus status={fileUploadStatus} />
+          <ErrorWrapper error={dropzoneError} id={`${props.id}-dropzone`}>
+            <Dropzone
+              slots={slots}
+              setSlots={setSlots}
+              setFileUploadStatus={setFileUploadStatus}
             />
-          )}
-          {slots.map((slot) => {
-            return (
-              <UploadedFileCard
-                {...slot}
-                key={slot.id}
-                tags={getTagsForSlot(slot.id, fileList)}
-                onChange={onUploadedFileCardChange}
-                removeFile={() => {
-                  setSlots(
-                    slots.filter(
-                      (currentSlot) => currentSlot.file !== slot.file
-                    )
-                  );
-                  setFileUploadStatus(`${slot.file.path} was deleted`);
-                  removeSlots(
-                    getTagsForSlot(slot.id, fileList),
-                    slot,
-                    fileList
-                  );
-                }}
+          </ErrorWrapper>
+          <List
+            disablePadding
+            sx={{
+              width: "100%",
+              marginTop: { md: "-1em" },
+            }}
+          >
+            {(Object.keys(fileList) as Array<keyof typeof fileList>)
+              .filter((fileListCategory) => fileList[fileListCategory].length > 0)
+              .flatMap((fileListCategory) => [
+                <ListSubheader
+                  key={`subheader-${fileListCategory}-files`}
+                  disableGutters
+                  disableSticky
+                  sx={{
+                    background: "transparent",
+                    color: "unset",
+                    padding: "1.5em 0 1em",
+                  }}
+                >
+                  <Typography variant="h3" component="h2">
+                    {`${capitalize(fileListCategory)} files`}
+                  </Typography>
+                </ListSubheader>,
+                fileList[fileListCategory].map((fileType) => (
+                  <ListItem key={fileType.name} disablePadding>
+                    <InteractiveFileListItem
+                      name={fileType.name}
+                      fn={fileType.fn}
+                      completed={Boolean(fileType.slots?.length)}
+                      moreInformation={fileType.moreInformation}
+                    />
+                  </ListItem>
+                )),
+              ])}
+          </List>
+        </DropzoneContainer>
+        <ErrorWrapper error={fileListError} id={`${props.id}-fileList`}>
+          <Box>
+            {Boolean(slots.length) && (
+              <Typography variant="h3" mb={2}>
+                Your uploaded files
+              </Typography>
+            )}
+            {showModal && (
+              <FileTaggingModal
+                uploadedFiles={slots}
+                fileList={fileList}
+                setFileList={setFileList}
+                setShowModal={setShowModal}
               />
-            );
-          })}
-        </Box>
-      </ErrorWrapper>
+            )}
+            {slots.map((slot) => {
+              return (
+                <UploadedFileCard
+                  {...slot}
+                  key={slot.id}
+                  tags={getTagsForSlot(slot.id, fileList)}
+                  onChange={onUploadedFileCardChange}
+                  removeFile={() => {
+                    setSlots(
+                      slots.filter(
+                        (currentSlot) => currentSlot.file !== slot.file
+                      )
+                    );
+                    setFileUploadStatus(`${slot.file.path} was deleted`);
+                    removeSlots(
+                      getTagsForSlot(slot.id, fileList),
+                      slot,
+                      fileList
+                    );
+                  }}
+                />
+              );
+            })}
+          </Box>
+        </ErrorWrapper>
+      </FullWidthContainer>
     </Card>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -10,6 +10,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { ApplicationPath } from "types";
 import Banner from "ui/Banner";
+import FormWrapper from "ui/FormWrapper";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 import { formattedPriceWithCurrencySymbol } from "../model";
@@ -53,11 +54,6 @@ const ErrorSummary = styled(Box)(({ theme }) => ({
   marginTop: theme.spacing(1),
   padding: theme.spacing(3),
   border: `5px solid ${theme.palette.error.main}`,
-}));
-
-const FormWrapper = styled(Box)(({ theme }) => ({
-  width: theme.breakpoints.values.formWrap,
-  maxWidth: "100%",
 }));
 
 const PayBody: React.FC<PayBodyProps> = (props) => {

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -55,6 +55,11 @@ const ErrorSummary = styled(Box)(({ theme }) => ({
   border: `5px solid ${theme.palette.error.main}`,
 }));
 
+const FormWrapper = styled(Box)(({ theme }) => ({
+  width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
+}));
+
 const PayBody: React.FC<PayBodyProps> = (props) => {
   const path = useStore((state) => state.path);
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
@@ -147,7 +152,7 @@ export default function Confirm(props: Props) {
   return (
     <Box textAlign="left" width="100%">
       <>
-        <Container maxWidth="md">
+        <Container maxWidth="contentWrap">
           <Typography variant="h2" component="h1" align="left" pb={3}>
             {page === "Pay" ? props.title : props.secondaryPageTitle}
           </Typography>
@@ -159,7 +164,7 @@ export default function Confirm(props: Props) {
               text: theme.palette.text.primary,
             }}
           >
-            <Container maxWidth="md">
+            <FormWrapper>
               <Typography
                 variant="h3"
                 gutterBottom
@@ -183,7 +188,7 @@ export default function Confirm(props: Props) {
                   openLinksOnNewTab
                 />
               </Typography>
-            </Container>
+            </FormWrapper>
           </Banner>
         )}
         {page === "Pay" ? (

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -80,9 +80,10 @@ export interface PresentationalProps {
 
 const MapContainer = styled(Box)(({ theme }) => ({
   padding: theme.spacing(1, 0),
+  maxWidth: "none",
   "& my-map": {
     width: "100%",
-    height: "50vh",
+    height: "60vh",
   },
 }));
 

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -19,6 +19,7 @@ import { useFormik } from "formik";
 import { Store } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
 import React from "react";
+import FormWrapper from "ui/FormWrapper";
 
 export interface IQuestion {
   id?: string;
@@ -45,11 +46,6 @@ export enum QuestionLayout {
   Images,
   Descriptions,
 }
-
-const FormWrapper = styled(Box)(({ theme }) => ({
-  width: theme.breakpoints.values.formWrap,
-  maxWidth: "100%",
-}));
 
 const Question: React.FC<IQuestion> = (props) => {
   const theme = useTheme();

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -1,13 +1,16 @@
+import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
 import FormLabel from "@mui/material/FormLabel";
 import Grid from "@mui/material/Grid";
 import RadioGroup from "@mui/material/RadioGroup";
+import { styled } from "@mui/material/styles";
 import { useTheme } from "@mui/styles";
 import { visuallyHidden } from "@mui/utils";
 import { DESCRIPTION_TEXT } from "@planx/components/shared/constants";
 import Card from "@planx/components/shared/Preview/Card";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
+import { fullWidthContent } from "@planx/components/shared/Preview/MapContainer";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
 import DescriptionRadio from "@planx/components/shared/Radio/DescriptionRadio";
@@ -42,6 +45,11 @@ export enum QuestionLayout {
   Images,
   Descriptions,
 }
+
+const FormWrapper = styled(Box)(({ theme }) => ({
+  width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
+}));
 
 const Question: React.FC<IQuestion> = (props) => {
   const theme = useTheme();
@@ -90,7 +98,9 @@ const Question: React.FC<IQuestion> = (props) => {
         definitionImg={props.definitionImg}
         img={props.img}
       />
-      <FormControl sx={{ ...contentFlowSpacing(theme), width: "100%" }}>
+      <FormControl
+        sx={{ ...contentFlowSpacing(theme), ...fullWidthContent(theme) }}
+      >
         <FormHelperText style={visuallyHidden}>
           {props.description ? DESCRIPTION_TEXT : ""}
         </FormHelperText>
@@ -122,13 +132,15 @@ const Question: React.FC<IQuestion> = (props) => {
               switch (layout) {
                 case QuestionLayout.Basic:
                   return (
-                    <Grid item xs={12} ml={1} key={response.id}>
-                      <BasicRadio
-                        {...buttonProps}
-                        {...response}
-                        data-testid="basic-radio"
-                      />
-                    </Grid>
+                    <FormWrapper>
+                      <Grid item xs={12} ml={1} key={response.id}>
+                        <BasicRadio
+                          {...buttonProps}
+                          {...response}
+                          data-testid="basic-radio"
+                        />
+                      </Grid>
+                    </FormWrapper>
                   );
                 case QuestionLayout.Descriptions:
                   return (
@@ -136,6 +148,7 @@ const Question: React.FC<IQuestion> = (props) => {
                       item
                       xs={12}
                       sm={6}
+                      contentWrap={4}
                       key={response.id}
                       data-testid="description-radio"
                     >
@@ -144,7 +157,7 @@ const Question: React.FC<IQuestion> = (props) => {
                   );
                 case QuestionLayout.Images:
                   return (
-                    <Grid item xs={12} sm={6} key={response.id}>
+                    <Grid item xs={12} sm={6} contentWrap={4} key={response.id}>
                       <ImageRadio {...buttonProps} {...response} />
                     </Grid>
                   );

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultSummary.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultSummary.tsx
@@ -5,7 +5,13 @@ import Banner from "ui/Banner";
 const ResultSummary = ({ heading, description, color }: any) => (
   <Banner heading={heading} color={color}>
     {description && (
-      <Typography variant="body1" align="left" gutterBottom mt={2}>
+      <Typography
+        variant="body1"
+        align="left"
+        gutterBottom
+        mt={2}
+        maxWidth="formWrap"
+      >
         {description}
       </Typography>
     )}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -23,6 +23,8 @@ export const contentFlowSpacing = (theme: Theme): React.CSSProperties => ({
 });
 
 const InnerContainer = styled(Box)(({ theme }) => ({
+  width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
   "& > * + *": {
     ...contentFlowSpacing(theme),
   },

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -23,10 +23,12 @@ export const contentFlowSpacing = (theme: Theme): React.CSSProperties => ({
 });
 
 const InnerContainer = styled(Box)(({ theme }) => ({
-  width: theme.breakpoints.values.formWrap,
   maxWidth: "100%",
   "& > * + *": {
     ...contentFlowSpacing(theme),
+  },
+  "& > *": {
+    maxWidth: theme.breakpoints.values.formWrap,
   },
 }));
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -52,7 +52,7 @@ const Card: React.FC<Props> = ({
       mountOnEnter={true}
       unmountOnExit={true}
     >
-      <Container maxWidth="md">
+      <Container maxWidth="contentWrap">
         <InnerContainer
           bgcolor="background.default"
           py={{ xs: 2, md: 4 }}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -12,14 +12,21 @@ interface MapContainerProps {
  * and maintains a consistent right margin
  */
 const dynamicMapSizeStyle = (theme: Theme): Record<string, any> => {
-  const mainContainerWidth = `${theme.breakpoints.values.md}px`;
-  const mainContainerMargin = `((100vw - ${mainContainerWidth}) / 2)`;
-  const mapMarginRight = "150px";
+  const mainContainerWidth = `${theme.breakpoints.values.contentWrap}px`;
+  const pageGutter = "60px";
 
   const style = {
+    width: "100%",
+    height: "70vh",
     [theme.breakpoints.up("md")]: {
-      height: "70vh",
-      width: `calc(${mainContainerMargin} + ${mainContainerWidth} - ${mapMarginRight})`,
+      width: `calc(100vw - ${pageGutter})`,
+    },
+    [theme.breakpoints.up("contentWrap")]: {
+      width: `calc(${mainContainerWidth} - ${pageGutter})`,
+      height: "80vh",
+    },
+    [theme.breakpoints.up("lg")]: {
+      width: `${mainContainerWidth}`,
     },
   };
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -7,6 +7,19 @@ interface MapContainerProps {
   size?: "large";
 }
 
+export const fullWidthContent = (theme: Theme): React.CSSProperties => ({
+  width: "100%",
+  [theme.breakpoints.up("md")]: {
+    width: `calc(100vw - 60px)`,
+  },
+  [theme.breakpoints.up("contentWrap")]: {
+    width: `calc(${theme.breakpoints.values.contentWrap}px - 60px)`,
+  },
+  [theme.breakpoints.up("lg")]: {
+    width: `${theme.breakpoints.values.contentWrap}px`,
+  },
+});
+
 /**
  * Generate a style which increases the map size as the window grows
  * and maintains a consistent right margin

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -15,9 +15,6 @@ export const fullWidthContent = (theme: Theme): React.CSSProperties => ({
   [theme.breakpoints.up("contentWrap")]: {
     width: `calc(${theme.breakpoints.values.contentWrap}px - 60px)`,
   },
-  [theme.breakpoints.up("lg")]: {
-    width: `${theme.breakpoints.values.contentWrap}px`,
-  },
 });
 
 /**
@@ -25,22 +22,9 @@ export const fullWidthContent = (theme: Theme): React.CSSProperties => ({
  * and maintains a consistent right margin
  */
 const dynamicMapSizeStyle = (theme: Theme): Record<string, any> => {
-  const mainContainerWidth = `${theme.breakpoints.values.contentWrap}px`;
-  const pageGutter = "60px";
-
   const style = {
-    width: "100%",
+    ...fullWidthContent(theme),
     height: "70vh",
-    [theme.breakpoints.up("md")]: {
-      width: `calc(100vw - ${pageGutter})`,
-    },
-    [theme.breakpoints.up("contentWrap")]: {
-      width: `calc(${mainContainerWidth} - ${pageGutter})`,
-      height: "80vh",
-    },
-    [theme.breakpoints.up("lg")]: {
-      width: `${mainContainerWidth}`,
-    },
   };
 
   return style;

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -9,12 +9,7 @@ interface MapContainerProps {
 
 export const fullWidthContent = (theme: Theme): React.CSSProperties => ({
   width: "100%",
-  [theme.breakpoints.up("md")]: {
-    width: `calc(100vw - 60px)`,
-  },
-  [theme.breakpoints.up("contentWrap")]: {
-    width: `calc(${theme.breakpoints.values.contentWrap}px - 60px)`,
-  },
+  maxWidth: "none",
 });
 
 /**
@@ -34,6 +29,7 @@ export const MapContainer = styled(Box)<MapContainerProps>(
   ({ theme, environment, size }) => ({
     padding: theme.spacing(1, 0, 6, 0),
     width: "100%",
+    maxWidth: "none",
     height: "50vh",
     // Only increase map size in Preview & Unpublished routes
     ...(size === "large" &&

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -56,7 +56,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
   };
 
   return (
-    <Box mb={1}>
+    <Box mb={1} maxWidth="formWrap">
       <Grid container justifyContent="space-between" wrap="nowrap">
         <Grid item>
           {title && (

--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -1,12 +1,11 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React, { useState } from "react";
 import AnalyticsChart from "ui/icons/AnalyticsChart";
-
-import { getHeaderPadding } from "./Header";
 
 const AnalyticsWarning = styled(Box)(({ theme }) => ({
   display: "flex",
@@ -14,7 +13,7 @@ const AnalyticsWarning = styled(Box)(({ theme }) => ({
   color: "#070707",
   justifyContent: "space-between",
   alignItems: "center",
-  ...getHeaderPadding(theme),
+  padding: "0.2em 0",
 }));
 
 const AnalyticsDisabledBanner: React.FC = () => {
@@ -33,17 +32,30 @@ const AnalyticsDisabledBanner: React.FC = () => {
     <>
       {isAnalyticsDisabled() && showAnalyticsWarning && (
         <AnalyticsWarning>
-          <Box display="flex" alignItems="center">
-            <AnalyticsChart />
-            <Typography variant="body2" ml={1}>
-              <strong>Analytics off</strong> This is a preview link for testing.
-              No usage data is being recorded.{"  "}
-              <Link href={enableAnalytics()} color="inherit" mr={1}>
-                Go to normal link
-              </Link>
-            </Typography>
-          </Box>
-          <Button onClick={() => setShowAnalyticsWarning(false)}>Hide</Button>
+          <Container
+            maxWidth="xl"
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <AnalyticsChart />
+              <Typography variant="body2" ml={1}>
+                <strong>Analytics off</strong> This is a preview link for
+                testing. No usage data is being recorded.{"  "}
+                <Link href={enableAnalytics()} color="inherit" mr={1}>
+                  Go to normal link
+                </Link>
+              </Typography>
+            </Box>
+            <Button onClick={() => setShowAnalyticsWarning(false)}>Hide</Button>
+          </Container>
         </AnalyticsWarning>
       )}
     </>

--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -33,7 +33,7 @@ const AnalyticsDisabledBanner: React.FC = () => {
       {isAnalyticsDisabled() && showAnalyticsWarning && (
         <AnalyticsWarning>
           <Container
-            maxWidth="xl"
+            maxWidth={false}
             sx={{
               display: "flex",
               alignItems: "center",

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -129,7 +129,7 @@ export default function Footer(props: Props) {
 
   return (
     <Root>
-      <Container maxWidth="xl">
+      <Container maxWidth={false}>
         <ButtonGroup py={0.5}>
           {items
             ?.filter((item) => item.title)

--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { FeedbackFish } from "@feedback-fish/react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -15,12 +16,9 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 const Root = styled("footer")(({ theme }) => ({
   color: theme.palette.common.white,
   backgroundColor: theme.palette.common.black,
-  padding: theme.spacing(2, 2),
+  padding: theme.spacing(2, 0),
   [theme.breakpoints.up("md")]: {
-    padding: theme.spacing(3, 3),
-  },
-  [theme.breakpoints.up("lg")]: {
-    padding: theme.spacing(3, 4),
+    padding: theme.spacing(3, 0),
   },
 }));
 
@@ -131,28 +129,30 @@ export default function Footer(props: Props) {
 
   return (
     <Root>
-      <ButtonGroup py={0.5}>
-        {items
-          ?.filter((item) => item.title)
-          .map((item) => (
-            <FooterItem {...item} key={item.title} />
-          ))}
-        {feedbackFishId && (
-          <>
-            {feedbackPrivacyNoteVisible && (
-              <FeedbackPrivacyNote onClose={handleFeedbackPrivacyNoteClose} />
-            )}
-            <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
-              <Link color="inherit" component="button">
-                <Typography variant="body2" textAlign="left">
-                  Feedback
-                </Typography>
-              </Link>
-            </FeedbackFish>
-          </>
-        )}
-      </ButtonGroup>
-      <Box py={2}>{children}</Box>
+      <Container maxWidth="xl">
+        <ButtonGroup py={0.5}>
+          {items
+            ?.filter((item) => item.title)
+            .map((item) => (
+              <FooterItem {...item} key={item.title} />
+            ))}
+          {feedbackFishId && (
+            <>
+              {feedbackPrivacyNoteVisible && (
+                <FeedbackPrivacyNote onClose={handleFeedbackPrivacyNoteClose} />
+              )}
+              <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
+                <Link color="inherit" component="button">
+                  <Typography variant="body2" textAlign="left">
+                    Feedback
+                  </Typography>
+                </Link>
+              </FeedbackFish>
+            </>
+          )}
+        </ButtonGroup>
+        <Box py={2}>{children}</Box>
+      </Container>
     </Root>
   );
 }

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -264,7 +264,7 @@ const NavBar: React.FC = () => {
       {isVisible && (
         <StyledNavBar data-testid="navigation-bar">
           <Container
-            maxWidth="xl"
+            maxWidth={false}
             sx={{
               display: "flex",
               flexDirection: "column",
@@ -321,7 +321,7 @@ const PublicToolbar: React.FC<{
     <>
       <SkipLink href="#main-content">Skip to main content</SkipLink>
       <StyledToolbar disableGutters>
-        <Container maxWidth="xl">
+        <Container maxWidth={false}>
           <InnerContainer>
             <LeftBox>
               {teamTheme?.logo ? (
@@ -347,7 +347,7 @@ const PublicToolbar: React.FC<{
         </Container>
       </StyledToolbar>
       {!showCentredServiceTitle && (
-        <Container maxWidth="xl">
+        <Container maxWidth={false}>
           <ServiceTitle />
         </Container>
       )}
@@ -395,7 +395,7 @@ const EditorToolbar: React.FC<{
   return (
     <>
       <StyledToolbar disableGutters>
-        <Container maxWidth="xl">
+        <Container maxWidth={false}>
           <InnerContainer>
             <LeftBox>
               <Breadcrumbs handleClick={handleClick}></Breadcrumbs>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -4,6 +4,7 @@ import AppBar from "@mui/material/AppBar";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import ButtonBase from "@mui/material/ButtonBase";
+import Container from "@mui/material/Container";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import MenuItem from "@mui/material/MenuItem";
@@ -57,25 +58,14 @@ const StyledLink = styled(ReactNaviLink)(() => ({
   textDecoration: "none",
 })) as typeof Link;
 
-export const getHeaderPadding = (theme: Theme): React.CSSProperties => ({
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(2),
-  [theme.breakpoints.up("md")]: {
-    paddingLeft: theme.spacing(3),
-    paddingRight: theme.spacing(3),
-  },
-  [theme.breakpoints.up("lg")]: {
-    paddingLeft: theme.spacing(4),
-    paddingRight: theme.spacing(4),
-  },
-});
-
 const StyledToolbar = styled(MuiToolbar)(({ theme }) => ({
   height: HEADER_HEIGHT,
+}));
+
+const InnerContainer = styled(Box)(() => ({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
-  ...getHeaderPadding(theme),
 }));
 
 const LeftBox = styled(Box)(() => ({
@@ -160,24 +150,17 @@ const ServiceTitleRoot = styled("span")(({ theme }) => ({
   flexShrink: 1,
   lineHeight: LINE_HEIGHT_BASE,
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(2),
   paddingBottom: theme.spacing(1.5),
   [theme.breakpoints.up("md")]: {
     paddingBottom: 0,
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
   },
 }));
 
 const StyledNavBar = styled("nav")(({ theme }) => ({
-  height: HEADER_HEIGHT,
   backgroundColor: theme.palette.primary.dark,
   fontSize: 16,
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(2),
-  ...getHeaderPadding(theme),
 }));
 
 const SectionName = styled(Typography)(() => ({
@@ -280,8 +263,18 @@ const NavBar: React.FC = () => {
     <>
       {isVisible && (
         <StyledNavBar data-testid="navigation-bar">
-          <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
-          <SectionName>{capitalize(title)}</SectionName>
+          <Container
+            maxWidth="xl"
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              minHeight: HEADER_HEIGHT,
+            }}
+          >
+            <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
+            <SectionName>{capitalize(title)}</SectionName>
+          </Container>
         </StyledNavBar>
       )}
     </>
@@ -328,28 +321,36 @@ const PublicToolbar: React.FC<{
     <>
       <SkipLink href="#main-content">Skip to main content</SkipLink>
       <StyledToolbar disableGutters>
-        <LeftBox>
-          {teamTheme?.logo ? (
-            <TeamLogo />
-          ) : (
-            <Breadcrumbs handleClick={navigate} />
-          )}
-        </LeftBox>
-        {showCentredServiceTitle && <ServiceTitle />}
-        <RightBox>
-          {showResetButton && (
-            <IconButton
-              color="secondary"
-              onClick={handleRestart}
-              aria-label="Restart Application"
-              size="large"
-            >
-              <Reset color="secondary" />
-            </IconButton>
-          )}
-        </RightBox>
+        <Container maxWidth="xl">
+          <InnerContainer>
+            <LeftBox>
+              {teamTheme?.logo ? (
+                <TeamLogo />
+              ) : (
+                <Breadcrumbs handleClick={navigate} />
+              )}
+            </LeftBox>
+            {showCentredServiceTitle && <ServiceTitle />}
+            <RightBox>
+              {showResetButton && (
+                <IconButton
+                  color="secondary"
+                  onClick={handleRestart}
+                  aria-label="Restart Application"
+                  size="large"
+                >
+                  <Reset color="secondary" />
+                </IconButton>
+              )}
+            </RightBox>
+          </InnerContainer>
+        </Container>
       </StyledToolbar>
-      {!showCentredServiceTitle && <ServiceTitle />}
+      {!showCentredServiceTitle && (
+        <Container maxWidth="xl">
+          <ServiceTitle />
+        </Container>
+      )}
       <NavBar />
       <AnalyticsDisabledBanner />
       <TestEnvironmentBanner />

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -88,7 +88,7 @@ const ProfileSection = styled(MuiToolbar)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  marginRight: theme.spacing(2),
+  marginRight: theme.spacing(1),
 }));
 
 const StyledPopover = styled(Popover)(() => ({
@@ -394,38 +394,42 @@ const EditorToolbar: React.FC<{
 
   return (
     <>
-      <StyledToolbar>
-        <LeftBox>
-          <Breadcrumbs handleClick={handleClick}></Breadcrumbs>
-        </LeftBox>
-        <RightBox>
-          {route.data.username && (
-            <ProfileSection>
-              {route.data.flow && (
-                <IconButton
-                  color="inherit"
-                  onClick={togglePreview}
-                  aria-label="Toggle Preview"
-                  size="large"
-                >
-                  <MenuOpenIcon />
-                </IconButton>
+      <StyledToolbar disableGutters>
+        <Container maxWidth="xl">
+          <InnerContainer>
+            <LeftBox>
+              <Breadcrumbs handleClick={handleClick}></Breadcrumbs>
+            </LeftBox>
+            <RightBox>
+              {route.data.username && (
+                <ProfileSection disableGutters>
+                  {route.data.flow && (
+                    <IconButton
+                      color="inherit"
+                      onClick={togglePreview}
+                      aria-label="Toggle Preview"
+                      size="large"
+                    >
+                      <MenuOpenIcon />
+                    </IconButton>
+                  )}
+                  <Box mr={1}>
+                    <Avatar>{route.data.username[0]}</Avatar>
+                  </Box>
+                  <IconButton
+                    edge="end"
+                    color="inherit"
+                    aria-label="Toggle Menu"
+                    onClick={handleMenuToggle}
+                    size="large"
+                  >
+                    <KeyboardArrowDown />
+                  </IconButton>
+                </ProfileSection>
               )}
-              <Box mr={1}>
-                <Avatar>{route.data.username[0]}</Avatar>
-              </Box>
-              <IconButton
-                edge="end"
-                color="inherit"
-                aria-label="Toggle Menu"
-                onClick={handleMenuToggle}
-                size="large"
-              >
-                <KeyboardArrowDown />
-              </IconButton>
-            </ProfileSection>
-          )}
-        </RightBox>
+            </RightBox>
+          </InnerContainer>
+        </Container>
       </StyledToolbar>
       <StyledPopover
         open={open}

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -2,27 +2,26 @@ import { Span } from "@airbrake/browser/dist/metrics";
 import { FeedbackFish } from "@feedback-fish/react";
 import Box from "@mui/material/Box";
 import ButtonBase from "@mui/material/ButtonBase";
+import Container from "@mui/material/Container";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { getFeedbackMetadata } from "lib/feedback";
 import React, { useEffect, useState } from "react";
 
-const Root = styled(ButtonBase)(({ theme }) => ({
+const Root = styled(Box)(({ theme }) => ({
   width: "100%",
   border: `solid ${theme.palette.grey[400]}`,
   borderWidth: "1px 0",
-  backgroundColor: "white",
+  backgroundColor: "#FFFFFF",
+}));
+
+const Inner = styled(ButtonBase)(({ theme }) => ({
+  width: "100%",
   display: "flex",
   justifyContent: "start",
   alignItems: "start",
-  padding: theme.spacing(1, 2),
-  [theme.breakpoints.up("md")]: {
-    padding: theme.spacing(1, 3),
-  },
-  [theme.breakpoints.up("lg")]: {
-    padding: theme.spacing(1, 4),
-  },
+  padding: theme.spacing(1, 0),
 }));
 
 const BetaFlag = styled(Box)(({ theme }) => ({
@@ -52,33 +51,37 @@ export default function PhaseBanner(): FCReturn {
 
   return (
     <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
-      <Root aria-label="This is a new service. Click here to provide feedback.">
-        <BetaFlag
-          bgcolor="primary.main"
-          color="white"
-          display="flex"
-          alignItems="flex-start"
-          flexBasis={0}
-          px={1}
-          mr={1}
-          py={0.5}
-          fontSize={14}
-          textAlign="center"
-          whiteSpace="nowrap"
-          fontWeight={600}
-        >
-          PUBLIC BETA
-        </BetaFlag>
-        <Typography
-          variant="body2"
-          fontSize={14}
-          color="textPrimary"
-          textAlign="left"
-          mt="0.25em"
-        >
-          This is a new service. Your <Link>feedback</Link> will help us improve
-          it.
-        </Typography>
+      <Root>
+        <Container maxWidth="xl">
+          <Inner aria-label="This is a new service. Click here to provide feedback.">
+            <BetaFlag
+              bgcolor="primary.main"
+              color="white"
+              display="flex"
+              alignItems="flex-start"
+              flexBasis={0}
+              px={1}
+              mr={1}
+              py={0.5}
+              fontSize={14}
+              textAlign="center"
+              whiteSpace="nowrap"
+              fontWeight={600}
+            >
+              PUBLIC BETA
+            </BetaFlag>
+            <Typography
+              variant="body2"
+              fontSize={14}
+              color="textPrimary"
+              textAlign="left"
+              mt="0.25em"
+            >
+              This is a new service. Your <Link>feedback</Link> will help us
+              improve it.
+            </Typography>
+          </Inner>
+        </Container>
       </Root>
     </FeedbackFish>
   );

--- a/editor.planx.uk/src/components/PhaseBanner.tsx
+++ b/editor.planx.uk/src/components/PhaseBanner.tsx
@@ -52,7 +52,7 @@ export default function PhaseBanner(): FCReturn {
   return (
     <FeedbackFish projectId={feedbackFishId} metadata={metadata}>
       <Root>
-        <Container maxWidth="xl">
+        <Container maxWidth={false}>
           <Inner aria-label="This is a new service. Click here to provide feedback.">
             <BetaFlag
               bgcolor="primary.main"

--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -1,11 +1,10 @@
 import ReportIcon from "@mui/icons-material/Report";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React, { useState } from "react";
-
-import { getHeaderPadding } from "./Header";
 
 const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
   display: "flex",
@@ -13,7 +12,7 @@ const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
   color: theme.palette.text.primary,
   justifyContent: "space-between",
   alignItems: "center",
-  ...getHeaderPadding(theme),
+  padding: "0.2em 0",
 }));
 
 const TestEnvironmentBanner: React.FC = () => {
@@ -25,14 +24,23 @@ const TestEnvironmentBanner: React.FC = () => {
     <>
       {isTestEnvironment() && showWarning && (
         <TestEnvironmentWarning>
-          <Box display="flex" alignItems="center">
-            <ReportIcon color="error" />
-            <Typography variant="body2" ml={1}>
-              This is a <strong>testing environment</strong> for new features.
-              Do not use it to make permanent content changes.
-            </Typography>
-          </Box>
-          <Button onClick={() => setShowWarning(false)}>Hide</Button>
+          <Container
+            maxWidth="xl"
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Box display="flex" alignItems="center">
+              <ReportIcon color="error" />
+              <Typography variant="body2" ml={1}>
+                This is a <strong>testing environment</strong> for new features.
+                Do not use it to make permanent content changes.
+              </Typography>
+            </Box>
+            <Button onClick={() => setShowWarning(false)}>Hide</Button>
+          </Container>
         </TestEnvironmentWarning>
       )}
     </>

--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -25,7 +25,7 @@ const TestEnvironmentBanner: React.FC = () => {
       {isTestEnvironment() && showWarning && (
         <TestEnvironmentWarning>
           <Container
-            maxWidth="xl"
+            maxWidth={false}
             sx={{
               display: "flex",
               alignItems: "center",

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -28,7 +28,6 @@ const PreviewContainer = styled(Box)(({ theme }) => ({
   overflow: "auto",
   flex: 1,
   background: "#fff",
-  padding: theme.spacing(3),
 }));
 
 const Header = styled("header")(() => ({

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -6,6 +6,7 @@ import Link from "@mui/material/Link";
 import { lighten, styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { PaymentRequest } from "@opensystemslab/planx-core/types";
+import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import { getExpiryDateForPaymentRequest } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -13,6 +14,15 @@ import Banner from "ui/Banner";
 
 const List = styled("ul")(({ theme }) => ({
   fontSize: theme.typography.body2.fontSize,
+}));
+
+const FormWrapper = styled(Box)(({ theme }) => ({
+  width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
+  padding: theme.spacing(2, 0, 4),
+  "& > *": {
+    ...contentFlowSpacing(theme),
+  },
 }));
 
 const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
@@ -31,59 +41,61 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
           text: "black",
         }}
       >
-        <Typography pt={2} variant="body2">
+        <Typography pt={2} variant="body2" maxWidth="formWrap">
           A payment invitation has been sent to your nominee. You will receive
           an email to confirm when the payment has been completed.
         </Typography>
       </Banner>
-      <Container maxWidth="md" sx={{ py: 4 }}>
-        <Typography variant="h2" pb={2}>
-          You will be contacted
-        </Typography>
-        <List>
-          <li>if your nominee fails to make payment by {expiryDate}</li>
-          <li>
-            if there is anything missing from the information you have provided
-            so far
-          </li>
-          <li>if any additional information is required</li>
-          <li>to arrange a site visit, if required</li>
-          <li>to inform you whether a certificate has been granted or not</li>
-        </List>
-        <Divider sx={{ pt: 2 }} />
-        <Typography variant="h2" pt={4} pb={2}>
-          Contact us
-        </Typography>
-        <List>
-          <li>
-            if you have any questions about your application or this service
-          </li>
-        </List>
-        <Box pt={2}>
-          <Typography variant="body2" sx={{ margin: 0 }}>
-            <b>Telephone</b> {team.notifyPersonalisation?.helpPhone}
+      <Container maxWidth="contentWrap">
+        <FormWrapper>
+          <Typography variant="h2">
+            You will be contacted
           </Typography>
-          <Typography variant="body2" sx={{ margin: 0 }}>
-            {team.notifyPersonalisation?.helpOpeningHours}
+          <List>
+            <li>if your nominee fails to make payment by {expiryDate}</li>
+            <li>
+              if there is anything missing from the information you have provided
+              so far
+            </li>
+            <li>if any additional information is required</li>
+            <li>to arrange a site visit, if required</li>
+            <li>to inform you whether a certificate has been granted or not</li>
+          </List>
+          <Divider />
+          <Typography variant="h2">
+            Contact us
           </Typography>
-        </Box>
-        <Box pt={2}>
-          <Typography variant="body2" sx={{ margin: 0 }}>
-            <b>Email</b>{" "}
-            <Link href={`mailto:${team.notifyPersonalisation?.helpEmail}`}>
-              {team.notifyPersonalisation?.helpEmail}
-            </Link>
-          </Typography>
-          <Typography variant="body2" sx={{ margin: 0 }}>
-            We aim to respond within 2 working days.
-          </Typography>
-          <Divider sx={{ pt: 4 }} />
-          <Box sx={{ pt: 4 }}>
-            <Link href="../preview" variant="body2">
-              Start a new application
-            </Link>
+          <List>
+            <li>
+              if you have any questions about your application or this service
+            </li>
+          </List>
+          <Box>
+            <Typography variant="body2">
+              <strong>Telephone</strong> {team.notifyPersonalisation?.helpPhone}
+            </Typography>
+            <Typography variant="body2">
+              {team.notifyPersonalisation?.helpOpeningHours}
+            </Typography>
           </Box>
-        </Box>
+          <Box>
+            <Typography variant="body2">
+              <strong>Email</strong>{" "}
+              <Link href={`mailto:${team.notifyPersonalisation?.helpEmail}`}>
+                {team.notifyPersonalisation?.helpEmail}
+              </Link>
+            </Typography>
+            <Typography variant="body2">
+              We aim to respond within 2 working days.
+            </Typography>
+            <Divider />
+            <Box>
+              <Link href="../preview" variant="body2">
+                Start a new application
+              </Link>
+            </Box>
+          </Box>
+        </FormWrapper>
       </Container>
     </>
   );

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -16,9 +16,7 @@ const List = styled("ul")(({ theme }) => ({
   fontSize: theme.typography.body2.fontSize,
 }));
 
-const FormWrapper = styled(Box)(({ theme }) => ({
-  width: theme.breakpoints.values.formWrap,
-  maxWidth: "100%",
+const FormInner = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2, 0, 4),
   "& > *": {
     ...contentFlowSpacing(theme),
@@ -47,7 +45,7 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
         </Typography>
       </Banner>
       <Container maxWidth="contentWrap">
-        <FormWrapper>
+        <FormInner maxWidth="formWrap">
           <Typography variant="h2" mt={2}>
             You will be contacted
           </Typography>
@@ -95,7 +93,7 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
               Start a new application
             </Link>
           </Box>
-        </FormWrapper>
+        </FormInner>
       </Container>
     </>
   );

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -48,21 +48,21 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
       </Banner>
       <Container maxWidth="contentWrap">
         <FormWrapper>
-          <Typography variant="h2">
+          <Typography variant="h2" mt={2}>
             You will be contacted
           </Typography>
           <List>
             <li>if your nominee fails to make payment by {expiryDate}</li>
             <li>
-              if there is anything missing from the information you have provided
-              so far
+              if there is anything missing from the information you have
+              provided so far
             </li>
             <li>if any additional information is required</li>
             <li>to arrange a site visit, if required</li>
             <li>to inform you whether a certificate has been granted or not</li>
           </List>
-          <Divider />
-          <Typography variant="h2">
+          <Divider sx={{ mt: 4 }} />
+          <Typography variant="h2" mt={4}>
             Contact us
           </Typography>
           <List>
@@ -88,12 +88,12 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
             <Typography variant="body2">
               We aim to respond within 2 working days.
             </Typography>
-            <Divider />
-            <Box>
-              <Link href="../preview" variant="body2">
-                Start a new application
-              </Link>
-            </Box>
+          </Box>
+          <Divider sx={{ mt: 4 }} />
+          <Box>
+            <Link href="../preview" variant="body2">
+              Start a new application
+            </Link>
           </Box>
         </FormWrapper>
       </Container>

--- a/editor.planx.uk/src/pages/Pay/MakePayment.tsx
+++ b/editor.planx.uk/src/pages/Pay/MakePayment.tsx
@@ -158,13 +158,13 @@ export default function MakePayment({
           text: "black",
         }}
       >
-        <Typography pt={2} variant="body2">
+        <Typography pt={2} variant="body2" maxWidth="formWrap">
           Thanks for making your payment. We'll send you a confirmation email.
         </Typography>
       </Banner>
     ) : (
-      <Container maxWidth="md">
-        <Typography maxWidth="md" variant="h1" pt={5} gutterBottom>
+      <Container maxWidth="contentWrap">
+        <Typography maxWidth="formWrap" variant="h1" pt={5} gutterBottom>
           Pay for your application
         </Typography>
       </Container>
@@ -220,7 +220,7 @@ export default function MakePayment({
     }
 
     return (
-      <Container maxWidth="md" sx={{ pb: 0 }}>
+      <Container maxWidth="contentWrap" sx={{ pb: 0 }}>
         <DescriptionList data={data} />
       </Container>
     );

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -164,7 +164,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   return (
     <Box width="100%" role="main" pt={1}>
-      <Container maxWidth="xl">
+      <Container maxWidth={false}>
         <ButtonBase
           className={classnames(classes.backButton, {
             [classes.hidden]: !showBackButton,

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -1,6 +1,7 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Box from "@mui/material/Box";
 import ButtonBase from "@mui/material/ButtonBase";
+import Container from "@mui/material/Container";
 import makeStyles from "@mui/styles/makeStyles";
 import classnames from "classnames";
 import { getLocalFlow, setLocalFlow } from "lib/local";
@@ -17,7 +18,6 @@ import Node, { handleSubmit } from "./Node";
 
 const useClasses = makeStyles((theme) => ({
   backButton: {
-    marginLeft: theme.spacing(2),
     marginBottom: theme.spacing(1),
     visibility: "visible",
     pointerEvents: "auto",
@@ -164,15 +164,17 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   return (
     <Box width="100%" role="main" pt={1}>
-      <ButtonBase
-        className={classnames(classes.backButton, {
-          [classes.hidden]: !showBackButton,
-        })}
-        onClick={() => goBack()}
-      >
-        <ArrowBackIcon fontSize="small"></ArrowBackIcon>
-        Back
-      </ButtonBase>
+      <Container maxWidth="xl">
+        <ButtonBase
+          className={classnames(classes.backButton, {
+            [classes.hidden]: !showBackButton,
+          })}
+          onClick={() => goBack()}
+        >
+          <ArrowBackIcon fontSize="small"></ArrowBackIcon>
+          Back
+        </ButtonBase>
+      </Container>
 
       {node && (
         <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -34,6 +34,7 @@ declare module "@mui/material/styles" {
     md: true;
     lg: true;
     xl: true;
+    formWrap: true;
     contentWrap: true;
   }
 }
@@ -169,6 +170,7 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
         md: 768, // Used with Container as general max-width
         lg: 1280,
         xl: 1920,
+        formWrap: 690,
         contentWrap: 1020,
       },
     },

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -27,18 +27,6 @@ export const FONT_WEIGHT_BOLD = "700";
 export const LINE_HEIGHT_BASE = "1.33";
 const SPACING_TIGHT = "-0.02em";
 
-declare module "@mui/material/styles" {
-  interface BreakpointOverrides {
-    xs: true;
-    sm: true;
-    md: true;
-    lg: true;
-    xl: true;
-    formWrap: true;
-    contentWrap: true;
-  }
-}
-
 const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   primary: {
     main: DEFAULT_PRIMARY_COLOR,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -204,6 +204,9 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
             backgroundColor: BG_COLOR_DEFAULT,
             lineHeight: LINE_HEIGHT_BASE,
           },
+          hr: {
+            marginLeft: 0,
+          },
         },
       },
       MuiButtonBase: {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -167,11 +167,11 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
       values: {
         xs: 0,
         sm: 500,
-        md: 768, // Used with Container as general max-width
+        md: 768,
         lg: 1280,
         xl: 1920,
-        formWrap: 690,
-        contentWrap: 1020,
+        formWrap: 690, // Max width for form content
+        contentWrap: 1020, // Max width for page
       },
     },
     transitions: {
@@ -180,6 +180,18 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
       },
     },
     components: {
+      MuiContainer: {
+        styleOverrides: {
+          root: {
+            "@media (min-width: 500px)": {
+              padding: "0 20px",
+            },
+            "@media (min-width: 768px)": {
+              padding: "0 30px",
+            },
+          },
+        },
+      },
       MuiCssBaseline: {
         styleOverrides: {
           strong: {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -27,6 +27,17 @@ export const FONT_WEIGHT_BOLD = "700";
 export const LINE_HEIGHT_BASE = "1.33";
 const SPACING_TIGHT = "-0.02em";
 
+declare module "@mui/material/styles" {
+  interface BreakpointOverrides {
+    xs: true;
+    sm: true;
+    md: true;
+    lg: true;
+    xl: true;
+    contentWrap: true;
+  }
+}
+
 const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   primary: {
     main: DEFAULT_PRIMARY_COLOR,
@@ -158,6 +169,7 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
         md: 768, // Used with Container as general max-width
         lg: 1280,
         xl: 1920,
+        contentWrap: 1020,
       },
     },
     transitions: {

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -5,3 +5,16 @@ declare module "@mui/material/Chip" {
     uploadedFileTag: true;
   }
 }
+
+// Add our custom breakpoints
+declare module "@mui/material/styles" {
+  interface BreakpointOverrides {
+    xs: true;
+    sm: true;
+    md: true;
+    lg: true;
+    xl: true;
+    formWrap: true;
+    contentWrap: true;
+  }
+}

--- a/editor.planx.uk/src/ui/Banner.tsx
+++ b/editor.planx.uk/src/ui/Banner.tsx
@@ -40,7 +40,7 @@ function Banner(props: BannerProps) {
       color={props.color && props.color.text}
     >
       <Container
-        maxWidth="md"
+        maxWidth="contentWrap"
         sx={{ display: "flex", flexDirection: "column", gap: 2 }}
       >
         {props.Icon && (

--- a/editor.planx.uk/src/ui/FormWrapper.tsx
+++ b/editor.planx.uk/src/ui/FormWrapper.tsx
@@ -1,0 +1,18 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import React from "react";
+
+export interface Props {
+  children: JSX.Element[] | JSX.Element;
+}
+
+const Root = styled(Box)(({ theme }) => ({
+  width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
+}));
+
+function FormWrapper(props: Props) {
+  return <Root>{props.children || null}</Root>;
+}
+
+export default FormWrapper;


### PR DESCRIPTION
PR aims to simplify and unify the container system.

- Adds two new media queries, `contentWrap` for page-level containers and `formWrap` to use as a max-width for form content.
- Adds MUI `<Container>` to all page level items to unify padding and max-widths.
- Sets global padding for `<Container>` at theme level.
- Removes `getHeaderPadding` property as this is inherited from containers.
- Uses wildcard selector (`& > *`) to apply max-width to form items in `Card.ts`, and targeted styles to set the following to full-width: Upload and label, maps, radio and checkbox with description and/or images.
- Adds targeted max-widths to invite-to-pay hardcoded content.