### PR TITLE
fix: ITP PO feedback

### DIFF
--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -62,7 +62,7 @@ test.describe("Agent journey", async () => {
     await expect(inviteToPayFormHeader).toBeVisible();
 
     await answerInviteToPayForm(page);
-    await page.getByText("Send invitation to pay").click();
+    await page.getByRole("button", { name: "Send invitation to pay" }).click();
     await page.waitForLoadState("networkidle");
 
     const errorMessage = await page.getByText(
@@ -174,7 +174,7 @@ test.describe("Agent journey", async () => {
     // Make payment request in tab 1
     await tab1.getByTestId("invite-page-link").click();
     await answerInviteToPayForm(tab1);
-    await tab1.getByText("Send invitation to pay").click();
+    await tab1.getByRole("button", { name: "Send invitation to pay" }).click();
     await tab1.waitForResponse(
       (resp) => resp.url().includes("/v1/graphql") && resp.status() === 200
     );
@@ -210,7 +210,7 @@ test.describe("Agent journey", async () => {
     // Attempt to generate payment request in tab 2...
     await tab2.getByTestId("invite-page-link").click();
     await answerInviteToPayForm(tab2);
-    await tab2.getByText("Send invitation to pay").click();
+    await tab2.getByRole("button", { name: "Send invitation to pay" }).click();
 
     // ...and fail to do so
     const errorMessage = tab2.getByText(

--- a/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
@@ -94,7 +94,7 @@ export async function makePaymentRequest({
   });
   await toggleInviteToPayButton.click();
   await answerInviteToPayForm(page);
-  await page.getByText("Send invitation to pay").click();
+  await page.getByRole("button", { name: "Send invitation to pay" }).click();
   await page.waitForLoadState("networkidle");
 
   return sessionId;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -236,8 +236,8 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
         <WarningContainer>
           <ErrorOutline />
           <Typography variant="body2" ml={2} fontWeight="bold">
-            Selecting "continue" locks your application and you'll no longer be
-            able to make changes.
+            Selecting "Send invitation to pay" locks your application and you'll
+            no longer be able to make changes.
           </Typography>
         </WarningContainer>
         {error ? (

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -474,7 +474,7 @@ interface ToolbarProps {
 
 const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
   const route = useCurrentRoute();
-  const path = route.url.pathname.split("/").slice(-1)[0];
+  const path = route.url.pathname.split("/").slice(-1)[0] || undefined;
   const [flowSlug, previewEnvironment] = useStore((state) => [
     state.flowSlug,
     state.previewEnvironment,
@@ -489,6 +489,7 @@ const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
     case flowSlug: // Custom domains
     case "preview":
     case "unpublished":
+    case "pay":
       return <PublicToolbar />;
     default:
       return <PublicToolbar showResetButton={false} />;

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -55,10 +55,6 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
         </Typography>
         <List>
           <li>
-            if you do not receive an email confirming that we have received your
-            application within 24 hours or the next working day
-          </li>
-          <li>
             if you have any questions about your application or this service
           </li>
         </List>


### PR DESCRIPTION
**Changes made following feedback** (Link: https://trello.com/c/2n0EJ3wA/1635-invite-to-pay-epic) -
 - Removed text saying we’ll contact in 24hrs
 - Guarded against double payments (https://github.com/theopensystemslab/planx-new/pull/1773)
 - Changes warning text about “Continue” button
 - Show "Restart application" button on `/pay` pages
- Requested services delivery / content team look at question of copy on the payment confirmation page https://trello.com/c/31xGMIcV/1268-write-copy-for-payment-confirmation-page-invite-to-pay-journeys

**Next steps...**
 - Once merged (and https://github.com/theopensystemslab/planx-new/pull/1721 rebased) I'll request POs test again, in particular the double payment issues
 - If all ok, we can merge the above PR 🎉 
 - There are a few very minor green trello cards regarding copy on a few pages - if we get responses soon, that's great, but this probably doesn't need to hold us up?