### PR TITLE
fix: Support multiple slots per `userFile`

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -93,7 +93,7 @@ function Component(props: Props) {
     // The first slot is mapped to a single required file
 
     // const fileListWithTaggedFile = {...fileList}
-    // fileListWithTaggedFile.required[0].slot = slots[0]
+    // fileListWithTaggedFile.required[0].slots = [ slots[0], slots[1] ]
     // setFileList(fileListWithTaggedFile);
 
     Promise.all([
@@ -157,7 +157,7 @@ function Component(props: Props) {
                     moreInformation={fileType.moreInformation}
                   />
                 </ListItem>
-              ))
+              )),
             ])}
         </List>
       </DropzoneContainer>

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/mocks.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/mocks.ts
@@ -80,15 +80,17 @@ export const mockFileList = {
       rule: {
         condition: "AlwaysRequired",
       },
-      slot: {
-        file: {
-          path: "PXL_20230511_093922923.jpg",
+      slots: [
+        {
+          file: {
+            path: "PXL_20230511_093922923.jpg",
+          },
+          status: "success",
+          progress: 1,
+          id: "EFGI1yU8s5s_cSBxnnYau",
+          url: "http://localhost:7002/file/private/jjpmkz8g/PXL_20230511_093922923.jpg",
         },
-        status: "success",
-        progress: 1,
-        id: "EFGI1yU8s5s_cSBxnnYau",
-        url: "http://localhost:7002/file/private/jjpmkz8g/PXL_20230511_093922923.jpg",
-      },
+      ],
     },
   ],
   recommended: [
@@ -98,15 +100,17 @@ export const mockFileList = {
       rule: {
         condition: "AlwaysRecommended",
       },
-      slot: {
-        file: {
-          path: "PXL_20230507_150205350~2.jpg",
+      slots: [
+        {
+          file: {
+            path: "PXL_20230507_150205350~2.jpg",
+          },
+          status: "success",
+          progress: 1,
+          id: "ZrGNE4siV36zvA7u1QZQD",
+          url: "http://localhost:7002/file/private/82wo7bev/PXL_20230507_150205350~2.jpg",
         },
-        status: "success",
-        progress: 1,
-        id: "ZrGNE4siV36zvA7u1QZQD",
-        url: "http://localhost:7002/file/private/82wo7bev/PXL_20230507_150205350~2.jpg",
-      },
+      ],
     },
   ],
   optional: [
@@ -116,15 +120,17 @@ export const mockFileList = {
       rule: {
         condition: "NotRequired",
       },
-      slot: {
-        file: {
-          path: "PXL_20230511_093922923.jpg",
+      slots: [
+        {
+          file: {
+            path: "PXL_20230511_093922923.jpg",
+          },
+          status: "success",
+          progress: 1,
+          id: "6bZBneLnY-L6qiqOblu8t",
+          url: "http://localhost:7002/file/private/truap5az/PXL_20230511_093922923.jpg",
         },
-        status: "success",
-        progress: 1,
-        id: "6bZBneLnY-L6qiqOblu8t",
-        url: "http://localhost:7002/file/private/truap5az/PXL_20230511_093922923.jpg",
-      },
+      ],
     },
   ],
 } as FileList;

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/mocks.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/mocks.ts
@@ -134,3 +134,46 @@ export const mockFileList = {
     },
   ],
 } as FileList;
+
+export const mockFileListMultiple = {
+  required: [
+    {
+      fn: "fileFn",
+      name: "firstFileType",
+      rule: {
+        condition: "AlwaysRequired",
+      },
+      slots: [
+        {
+          file: {
+            path: "first.jpg",
+          },
+          status: "success",
+          progress: 1,
+          id: "001",
+          url: "http://localhost:7002/file/private/jjpmkz8g/first.jpg",
+        },
+        {
+          file: {
+            path: "second.jpg",
+          },
+          status: "success",
+          progress: 1,
+          id: "002",
+          url: "http://localhost:7002/file/private/jjpmkz8g/second.jpg",
+        },
+        {
+          file: {
+            path: "third.jpg",
+          },
+          status: "success",
+          progress: 1,
+          id: "003",
+          url: "http://localhost:7002/file/private/jjpmkz8g/third.jpg",
+        },
+      ],
+    },
+  ],
+  recommended: [],
+  optional: [],
+} as unknown as FileList;

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.test.ts
@@ -1,7 +1,7 @@
 import { Store } from "pages/FlowEditor/lib/store";
 import { FileWithPath } from "react-dropzone";
 
-import { mockFileList, mockFileTypes } from "./mocks";
+import { mockFileList, mockFileListMultiple, mockFileTypes } from "./mocks";
 import {
   Condition,
   createFileList,
@@ -323,6 +323,15 @@ describe("generatePayload function", () => {
     expect(result.data).toHaveProperty("requiredFileFn");
     expect(result.data).toHaveProperty("recommendedFileFn");
     expect(result.data).not.toHaveProperty("optionalFileFn");
+  });
+
+  it("maps multiple different user uploaded files, tagged as the same fileType, to a single passport key", () => {
+    const result = generatePayload(mockFileListMultiple);
+    expect(result.data).toHaveProperty("fileFn");
+    expect(result.data?.fileFn).toHaveLength(3);
+    expect(result.data?.fileFn?.[0].filename).toEqual("first.jpg");
+    expect(result.data?.fileFn?.[1].filename).toEqual("second.jpg");
+    expect(result.data?.fileFn?.[2].filename).toEqual("third.jpg");
   });
 });
 

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.test.ts
@@ -297,13 +297,15 @@ describe("generatePayload function", () => {
     expect(result.data).toHaveProperty("optionalFileFn");
 
     // Value in passport matches expected shape
-    expect(result.data?.requiredFileFn).toMatchObject({
-      url: "http://localhost:7002/file/private/jjpmkz8g/PXL_20230511_093922923.jpg",
-      filename: "PXL_20230511_093922923.jpg",
-      rule: {
-        condition: Condition.AlwaysRequired,
+    expect(result.data?.requiredFileFn).toMatchObject([
+      {
+        url: "http://localhost:7002/file/private/jjpmkz8g/PXL_20230511_093922923.jpg",
+        filename: "PXL_20230511_093922923.jpg",
+        rule: {
+          condition: Condition.AlwaysRequired,
+        },
       },
-    });
+    ]);
   });
 
   it("ignores files without a slot", () => {
@@ -312,7 +314,7 @@ describe("generatePayload function", () => {
       optional: [
         {
           ...mockFileList.recommended[0],
-          slot: undefined,
+          slots: undefined,
         },
       ],
     } as FileList;
@@ -326,7 +328,7 @@ describe("generatePayload function", () => {
 
 describe("getRecoveredSlots function", () => {
   it("recovers a previously uploaded file from the passport", () => {
-    const mockCachedSlot: NonNullable<UserFile["slot"]>["cachedSlot"] = {
+    const mockCachedSlot: NonNullable<UserFile["slots"]>[0]["cachedSlot"] = {
       id: "abc123",
       file: {
         path: "filePath.png",

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.ts
@@ -88,7 +88,7 @@ export const checkIfConditionalRule = (condition: Condition) =>
   [Condition.RecommendedIf, Condition.RequiredIf].includes(condition);
 
 export interface UserFile extends FileType {
-  slot?: FileUploadSlot;
+  slots?: FileUploadSlot[];
 }
 
 export interface FileList {
@@ -166,29 +166,30 @@ const isRuleMet = (
   );
 };
 
-interface UserFileWithSlot extends UserFile {
-  slot: NonNullable<UserFile["slot"]>;
+interface UserFileWithSlots extends UserFile {
+  slots: NonNullable<UserFile["slots"]>;
 }
 
-const formatUserFile = (userFile: UserFileWithSlot) => ({
-  rule: userFile.rule,
-  url: userFile.slot.url,
-  filename: userFile.slot.file.path,
-  cachedSlot: {
-    ...userFile.slot,
-    file: {
-      path: userFile.slot.file.path,
-      type: userFile.slot.file.type,
-      size: userFile.slot.file.size,
+const formatUserFile = (userFile: UserFileWithSlots) =>
+  userFile.slots.map((slot) => ({
+    rule: userFile.rule,
+    url: slot.url,
+    filename: slot.file.path,
+    cachedSlot: {
+      ...slot,
+      file: {
+        path: slot.file.path,
+        type: slot.file.type,
+        size: slot.file.size,
+      },
     },
-  },
-});
+  }));
 
 /**
  * Type guard to coerce UserFile -> UserFileWithSlot
  */
-const hasSlot = (userFile: UserFile): userFile is UserFileWithSlot =>
-  Boolean(userFile?.slot);
+const hasSlots = (userFile: UserFile): userFile is UserFileWithSlots =>
+  Boolean(userFile?.slots);
 
 /**
  * Generate payload for MultipleFileUpload breadcrumb
@@ -201,7 +202,7 @@ export const generatePayload = (fileList: FileList): Store.userData => {
     ...fileList.required,
     ...fileList.recommended,
     ...fileList.optional,
-  ].filter(hasSlot);
+  ].filter(hasSlots);
 
   uploadedFiles.forEach((userFile) => {
     newPassportData[userFile.fn] = formatUserFile(userFile);

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/schema.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/schema.ts
@@ -73,7 +73,7 @@ export const fileListSchema = object({
     message: "Please upload and tag all required files",
     test: (userFile?: UserFile[]) => {
       const isEverySlotFilled = Boolean(
-        userFile?.every((userFile) => userFile?.slot)
+        userFile?.every((userFile) => userFile?.slots)
       );
       return isEverySlotFilled;
     },


### PR DESCRIPTION
## What does this PR do?
- Changes the `UserFile` type to support have `FileUploadSlot[]` instead of just a single `FileUploadSlot`
- This matches our current file upload data structure, and should work with submissions as-is 🤞 