### PR TITLE
UPDATE: styling for notice component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -58,8 +58,8 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     alignItems: "center",
   },
   icon: {
-    width: 30,
-    height: 30,
+    width: 34,
+    height: 34,
   },
   title: {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
@@ -72,6 +72,9 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     "& a": {
       color: (props) =>
         getContrastTextColor(props.color, theme.palette.primary.main),
+    },
+    "& p:last-of-type": {
+      marginBottom: 0,
     },
   },
 }));

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -26,29 +26,45 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     display: "flex",
     alignItems: "flex-start",
     justifyContent: "space-between",
+    padding: theme.spacing(2),
     backgroundColor: (props) => props.color,
     color: (props) =>
-      mostReadable(props.color, ["#fff", "#000"])?.toHexString(),
+      mostReadable(props.color, [
+        "#fff",
+        `${theme.palette.text.primary}`,
+      ])?.toHexString(),
     "&:before": {
       content: "' '",
       position: "absolute",
       top: 0,
       left: 0,
-      width: 10,
-      bottom: 0,
-      backgroundColor: (props) =>
-        mostReadable(props.color, ["#fff", "#000"])?.toHexString(),
+      width: "100%",
+      height: "100%",
+      color: (props) =>
+        mostReadable(props.color, [
+          "#fff",
+          `${theme.palette.text.primary}`,
+        ])?.toHexString(),
       opacity: 0.3,
+      border: "2px solid currentColor",
+      pointerEvents: "none",
     },
-    padding: theme.spacing(2),
-    paddingLeft: `calc(${theme.spacing(2)} + 10px)`,
   },
   content: {
     flex: 1,
   },
+  titleWrap: {
+    display: "flex",
+    alignItems: "center",
+  },
+  icon: {
+    width: 30,
+    height: 30,
+  },
   title: {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
     margin: 0,
+    paddingLeft: theme.spacing(1),
   },
   description: {
     fontWeight: 400,
@@ -61,7 +77,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
 }));
 
 const NoticeComponent: React.FC<Props> = (props) => {
-  const styles = useStyles({ color: props.color || "#EFEFEF" });
+  const styles = useStyles({ color: props.color || "#F9F8F8" });
   const handleSubmit = !props.resetButton
     ? () => props.handleSubmit?.()
     : undefined;
@@ -75,15 +91,17 @@ const NoticeComponent: React.FC<Props> = (props) => {
         />
         <div className={styles.container}>
           <div className={styles.content}>
-            <Typography component="h3" variant="h4" className={styles.title}>
-              {props.title}
-            </Typography>
+            <div className={styles.titleWrap}>
+              <ErrorOutline className={styles.icon} />
+              <Typography component="h3" variant="h4" className={styles.title}>
+                {props.title}
+              </Typography>
+            </div>
             <ReactMarkdownOrHtml
               className={styles.description}
               source={props.description}
             />
           </div>
-          <ErrorOutline />
         </div>
         {props.resetButton && (
           <Button


### PR DESCRIPTION
PR updates notice component to match Figma designs.

Update prevents a visual conflict between help text icon in upper right of title.

Before (above) and updated (below):
![image](https://github.com/theopensystemslab/planx-new/assets/51156018/5d3a31ce-9958-4868-be04-d628de14f60c)
