### PR TITLE
chore: enable Camden to query planning constraints from digital land

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -54,6 +54,7 @@ function Component(props: Props) {
     "opensystemslab",
     "buckinghamshire",
     "canterbury",
+    "camden",
     "doncaster",
     "lambeth",
     "medway",


### PR DESCRIPTION
Data is still WIP, no granular Article 4 info yet (hence no API file changes)