### PR TITLE
FIX: editor settings panel min-height

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -89,6 +89,7 @@ const useStyles = makeStyles(() => ({
     top: HEADER_HEIGHT,
     left: 0,
     right: 0,
+    minHeight: `calc(100% - ${HEADER_HEIGHT}px)`,
   },
   tabs: {
     backgroundColor: "#ddd",


### PR DESCRIPTION
PR add min-height so that editor settings panel spans full height of page.

Before:
<img width="1728" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/93d3ed56-2e84-46fc-970d-560686761fcf">

After:
<img width="1728" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/5350f6d0-4e3b-4030-889e-ee10bde14aa9">