### PR TITLE
fix: Missing margin on `FileUpload`

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import { MoreInformation } from "@planx/components/shared";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
@@ -110,7 +111,9 @@ const FileUpload: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
       />
       <ErrorWrapper error={validationError} id={props.id}>
-        <PrivateFileUpload slots={slots} setSlots={setSlots} />
+        <Box mb={2}>
+          <PrivateFileUpload slots={slots} setSlots={setSlots} />
+        </Box>
       </ErrorWrapper>
     </Card>
   );


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/06cd284b-1310-4731-b30e-be8dce9d1d17) | ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/5f01491a-487e-4489-a9fb-97480eb07ff7) | 

A more robust solution for all components here may be having the wrapping `Card` component managing this spacing and using `margin-trim` (docs: https://developer.mozilla.org/en-US/docs/Web/CSS/margin-trim) to ensure nothing gets doubled up?