### PR TITLE
fix: MFU "Back" behaviour

### DIFF
--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -98,7 +98,7 @@ function Component(props: Props) {
   const handleSubmit = () => {
     Promise.all([
       slotsSchema.validate(slots),
-      fileListSchema.validate(fileList),
+      fileListSchema.validate(fileList, { context: { slots } }),
     ])
       .then(() => {
         const payload = generatePayload(fileList);

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -7,12 +7,10 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import capitalize from "lodash/capitalize";
-import merge from "lodash/merge";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
 import { usePrevious } from "react-use";
-import { FONT_WEIGHT_BOLD } from "theme";
 import ErrorWrapper from "ui/ErrorWrapper";
 import MoreInfoIcon from "ui/icons/MoreInfo";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
@@ -35,7 +33,7 @@ import {
   createFileList,
   FileList,
   generatePayload,
-  getRecoveredSlots,
+  getRecoveredData,
   getTagsForSlot,
   MultipleFileUpload,
   removeSlots,
@@ -65,16 +63,16 @@ function Component(props: Props) {
     const passport = useStore.getState().computePassport();
     const fileList = createFileList({ passport, fileTypes: props.fileTypes });
     setFileList(fileList);
-  }, []);
 
-  useEffect(() => {
-    // TODO: Re-map slots to userfiles also?
-    const recoveredSlots: FileUploadSlot[] = getRecoveredSlots(
-      props.previouslySubmittedData,
-      fileList
-    );
-    setSlots(recoveredSlots);
-  }, [props.previouslySubmittedData, fileList]);
+    if (props.previouslySubmittedData) {
+      const recoverredData = getRecoveredData(
+        props.previouslySubmittedData,
+        fileList
+      );
+      setSlots(recoverredData.slots);
+      setFileList(recoverredData.fileList);
+    }
+  }, []);
 
   const [slots, setSlots] = useState<FileUploadSlot[]>([]);
 
@@ -93,13 +91,6 @@ function Component(props: Props) {
   const [showModal, setShowModal] = useState<boolean>(false);
 
   const handleSubmit = () => {
-    // This is a temp cheat to bypass tagging
-    // The first slot is mapped to a single required file
-
-    // const fileListWithTaggedFile = {...fileList}
-    // fileListWithTaggedFile.required[0].slots = [ slots[0], slots[1] ]
-    // setFileList(fileListWithTaggedFile);
-
     Promise.all([
       slotsSchema.validate(slots),
       fileListSchema.validate(fileList),

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/Public.tsx
@@ -71,6 +71,7 @@ function Component(props: Props) {
       );
       setSlots(recoverredData.slots);
       setFileList(recoverredData.fileList);
+      setIsUserReturningToNode(true);
     }
   }, []);
 
@@ -80,6 +81,8 @@ function Component(props: Props) {
   const previousSlotCount = usePrevious(slots.length);
   useEffect(() => {
     if (previousSlotCount === undefined) return;
+    // Only stop modal opening on initial return to node
+    if (isUserReturningToNode) return setIsUserReturningToNode(false);
     if (slots.length > previousSlotCount) setShowModal(true);
   }, [slots.length]);
 
@@ -89,6 +92,8 @@ function Component(props: Props) {
 
   const [validationError, setValidationError] = useState<string | undefined>();
   const [showModal, setShowModal] = useState<boolean>(false);
+  const [isUserReturningToNode, setIsUserReturningToNode] =
+    useState<boolean>(false);
 
   const handleSubmit = () => {
     Promise.all([

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/model.test.ts
@@ -17,7 +17,7 @@ import {
   FileList,
   FileType,
   generatePayload,
-  getRecoveredSlots,
+  getRecoveredData,
   getTagsForSlot,
   Operator,
   removeSlots,
@@ -347,8 +347,8 @@ describe("generatePayload function", () => {
   });
 });
 
-describe("getRecoveredSlots function", () => {
-  it("recovers a previously uploaded file from the passport", () => {
+describe("getRecoveredData function", () => {
+  it("recovers a single slot from the passport", () => {
     const mockCachedSlot: NonNullable<UserFile["slots"]>[0]["cachedSlot"] = {
       id: "abc123",
       file: {
@@ -361,15 +361,20 @@ describe("getRecoveredSlots function", () => {
     // Mock breadcrumb data with FileType.fn -> UserFile mapped
     const previouslySubmittedData: Store.userData = {
       data: {
-        requiredFileFn: {
-          cachedSlot: mockCachedSlot,
-        },
+        requiredFileFn: [
+          {
+            cachedSlot: mockCachedSlot,
+          },
+        ],
       },
     };
 
-    const result = getRecoveredSlots(previouslySubmittedData, mockFileList);
+    const { slots: result } = getRecoveredData(
+      previouslySubmittedData,
+      mockFileList
+    );
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject(mockCachedSlot);
+    expect(result?.[0]).toMatchObject(mockCachedSlot);
   });
 });
 

--- a/editor.planx.uk/src/@planx/components/MultipleFileUpload/schema.ts
+++ b/editor.planx.uk/src/@planx/components/MultipleFileUpload/schema.ts
@@ -1,11 +1,13 @@
-import { array, mixed, object, SchemaOf, string } from "yup";
+import { array, mixed, object, SchemaOf, string, TestContext } from "yup";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import { MoreInformation } from "../shared";
 import {
   checkIfConditionalRule,
   Condition,
+  FileList,
   FileType,
+  getTagsForSlot,
   MultipleFileUpload,
   Operator,
   Rule,
@@ -67,6 +69,10 @@ export const slotsSchema = array()
     },
   });
 
+interface FileListSchemaTextContext extends TestContext {
+  slots: FileUploadSlot[];
+}
+
 export const fileListSchema = object({
   required: array().test({
     name: "allRequiredFilesUploaded",
@@ -80,4 +86,17 @@ export const fileListSchema = object({
       return isEverySlotFilled;
     },
   }),
+}).test({
+  name: "allFilesTagged",
+  message: "Please tag all files",
+  test: (fileList, { options: { context } }) => {
+    if (!context) throw new Error("Missing context for fileListSchema");
+    const { slots } = context as FileListSchemaTextContext;
+    const isEveryFileTagged = Boolean(
+      slots?.every(
+        (slot) => getTagsForSlot(slot.id, fileList as FileList).length
+      )
+    );
+    return isEveryFileTagged;
+  },
 });


### PR DESCRIPTION
## What does this PR do?
- Allows an applicant to navigate "back" to an MFU component and retain their state
  - This was a regression I missed when changing from a single `userFile.slot` to `userFiles.slots` in https://github.com/theopensystemslab/planx-new/pull/1784
- Fixes a few schema validation issues to enforce the following - 
  - All user uploaded files must be tagged
  - All required fileTypes must have associates slots (also fixed here - https://github.com/theopensystemslab/planx-new/pull/1801#discussion_r1233842550)