### PR TITLE
FIX: content flow margins

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Fade from "@mui/material/Fade";
-import { styled, useTheme } from "@mui/material/styles";
+import { styled, Theme, useTheme } from "@mui/material/styles";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ApplicationPath } from "types";
@@ -15,9 +15,16 @@ interface Props {
   handleSubmit?: (data?: any) => void;
 }
 
+export const contentFlowSpacing = (theme: Theme): React.CSSProperties => ({
+  marginTop: theme.spacing(2),
+  [theme.breakpoints.up("md")]: {
+    marginTop: theme.spacing(2.5),
+  },
+});
+
 const InnerContainer = styled(Box)(({ theme }) => ({
   "& > * + *": {
-    marginTop: theme.spacing(2.5),
+    ...contentFlowSpacing(theme),
   },
 }));
 
@@ -64,6 +71,7 @@ const Card: React.FC<Props> = ({
               disabled={!isValid}
               onClick={async () => await handleSubmit()}
               data-testid="continue-button"
+              sx={{ ...contentFlowSpacing(theme) }}
             >
               Continue
             </Button>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
@@ -1,8 +1,18 @@
+import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ApplicationPath } from "types";
+
+import { contentFlowSpacing } from "./Card";
+
+const InnerContainer = styled(Box)(({ theme }) => ({
+  "& p": {
+    ...contentFlowSpacing(theme),
+  },
+}));
 
 const SaveResumeButton: React.FC = () => {
   const saveToEmail = useStore((state) => state.saveToEmail);
@@ -14,7 +24,7 @@ const SaveResumeButton: React.FC = () => {
     });
 
   return (
-    <>
+    <InnerContainer>
       <Typography variant="body1">or</Typography>
       <Link component="button" onClick={onClick}>
         <Typography variant="body1" textAlign="left">
@@ -23,7 +33,7 @@ const SaveResumeButton: React.FC = () => {
             : "Resume an application you have already started"}
         </Typography>
       </Link>
-    </>
+    </InnerContainer>
   );
 };
 


### PR DESCRIPTION
PR fixes a visual regression that was causing elements to not inherit the `margin-top` added with a wildcard selector.

The regression appears to have been caused by the move to `styled` as a method, which has changed the specificity of styles in the CSS output. Any elements that bring default styling (in this case `margin: 0` for `<button>` and `<p>`) are overriding the selector used on the container with these styles.

To fix this I have created the margin as a global property that can be applied to elements (`<button>`, `<p>` etc) that carry their own default styling.