### PR TITLE
fix: throw an error if attempting to clone external portals

### DIFF
--- a/editor.planx.uk/src/@planx/graph/__tests__/clone.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/clone.test.ts
@@ -118,4 +118,16 @@ describe("error handling", () => {
       })
     ).toThrow("cannot clone sections");
   });
+
+  test("cannot clone external portals", () => {
+    expect(() =>
+      clone("externalPortalNodeId", { toParent: "a" })({
+        _root: {
+          edges: ["a", "externalPortalNodeId"],
+        },
+        a: {},
+        externalPortalNodeId: { type: 310 },
+      })
+    ).toThrow("cannot clone external portals");
+  });
 });

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -40,6 +40,9 @@ const isSomething = (x: any): boolean =>
 const isSectionNodeType = (id: string, graph: Graph): boolean =>
   graph[id]?.type === TYPES.Section;
 
+const isExternalPortalNodeType = (id: string, graph: Graph): boolean =>
+  graph[id]?.type === TYPES.ExternalPortal;
+
 const sanitize = (x: any) => {
   if ((x && typeof x === "string") || x instanceof String) {
     return trim(x.replace(/[\u200B-\u200D\uFEFF↵]/g, ""));
@@ -222,6 +225,8 @@ export const clone =
         throw new Error("cannot clone to same parent");
       else if (isSectionNodeType(id, graph))
         throw new Error("cannot clone sections");
+      else if (isExternalPortalNodeType(id, graph))
+        throw new Error("cannot clone external portals");
 
       const toParentNode = draft[toParent];
 


### PR DESCRIPTION
will throw during live editing, _not_ on publish - therefore won't flag any pre-existing cloned external portals - but is a proactive guard against the bug raised by George & Alastair here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1687273389151209