### PR TITLE
UPDATE: file upload styles

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -180,7 +180,14 @@ const SelectMultiple = (props: SelectMultipleProps) => {
         sx={{
           border: (theme) => `1px solid ${theme.palette.secondary.main}`,
           background: (theme) => theme.palette.background.paper,
-          minHeight: "50px",
+          "& > div": {
+            minHeight: "50px",
+            paddingTop: (theme) => theme.spacing(1),
+            paddingBottom: (theme) => theme.spacing(1),
+          },
+          "& > div:focus": {
+            background: (theme) => theme.palette.action.focus,
+          },
         }}
         renderValue={(selected) => (
           <Box
@@ -198,6 +205,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
                 label={value}
                 variant="uploadedFileTag"
                 size="small"
+                sx={{ pointerEvents: "none" }}
               />
             ))}
           </Box>
@@ -224,6 +232,8 @@ const SelectMultiple = (props: SelectMultipleProps) => {
                     key={`menuitem-${fileType.name}-${uploadedFile.id}`}
                     value={fileType.name}
                     data-testid="select-menuitem"
+                    disableRipple
+                    disableTouchRipple
                   >
                     <Checkbox
                       key={`checkbox-${fileType.name}-${uploadedFile.id}`}

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -22,6 +22,12 @@ interface RootProps extends ButtonBaseProps {
   isDragActive: boolean;
 }
 
+const FauxLink = styled(Box)(({ theme }) => ({
+  color: theme.palette.primary.main,
+  textDecoration: "underline",
+  whiteSpace: "nowrap",
+}));
+
 const Root = styled(ButtonBase, {
   shouldForwardProp: (prop) => prop !== "isDragActive",
 })<RootProps>(({ theme, isDragActive }) => ({
@@ -144,7 +150,7 @@ export const Dropzone: React.FC<Props> = ({
           ) : (
             <>
               Drop {maxFiles === 1 ? "file" : "files"} here or{" "}
-              <Link sx={{ whiteSpace: "nowrap" }}>choose a file</Link> to upload
+              <FauxLink component="span">choose a file</FauxLink> to upload
             </>
           )}
         </Box>

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -68,7 +68,7 @@ const ProgressBar = styled(Box)(({ theme }) => ({
   zIndex: 0,
 }));
 
-const FileSize = styled(Box)(({ theme }) => ({
+const FileSize = styled(Typography)(({ theme }) => ({
   whiteSpace: "nowrap",
   color: theme.palette.text.secondary,
   alignSelf: "flex-end",
@@ -112,7 +112,7 @@ export const UploadedFileCard: React.FC<Props> = ({
           <Typography variant="body1" pb="0.25em">
             {file.path}
           </Typography>
-          <FileSize>{formatBytes(file.size)}</FileSize>
+          <FileSize variant="body2">{formatBytes(file.size)}</FileSize>
         </Box>
         {removeFile && (
           <IconButton


### PR DESCRIPTION
PR addresses a few styling snags for Upload and Label.

- Removes min-height from multi-select wrapper and adds to child clickable div with padding, this addresses an issue where the clickable area was shorter in height than the parent select input. To target this I've had to use the direct child selector (& > div) as the element is injected into the DOM with JavaScript.
- Adds global yellow focus style to multi-select.
- Adds `pointer-events: none` to chips within the multi-select component so they don't block interaction.
- Removes the empty link in the dropzone as this was flagged as an accessibility violation, converted to a span with 'faux' link styling. Interaction is maintained as parent dropzone represents a button.
- Small type update for file size label to `body2`.