### PR TITLE
fix: remove single `designated` variable from GIS API response

### DIFF
--- a/api.planx.uk/gis/digitalLand.ts
+++ b/api.planx.uk/gis/digitalLand.ts
@@ -2,7 +2,7 @@ import type { Constraint, GISResponse, Metadata } from "@opensystemslab/planx-co
 import { gql } from "graphql-request";
 import fetch from "isomorphic-fetch";
 import { adminGraphQLClient as adminClient } from "../hasura";
-import { addDesignatedVariable, omitGeometry } from "./helpers";
+import { omitGeometry } from "./helpers";
 import { baseSchema } from "./local_authorities/metadata/base";
 
 export interface LocalAuthorityMetadata {
@@ -130,9 +130,6 @@ async function go(localAuthority: string, geom: string, extras: Record<string, s
   });
 
   // --- DESIGNATED LAND ---
-  // add top-level 'designated' variable based on granular query results
-  formattedResult = addDesignatedVariable(formattedResult);
-
   // set granular `designated.nationalPark.broads` based on entity id (eventually extract to helper method if other cases like this)
   const broads = "designated.nationalPark.broads";
   if (

--- a/api.planx.uk/gis/digitalLand.ts
+++ b/api.planx.uk/gis/digitalLand.ts
@@ -89,7 +89,7 @@ async function go(localAuthority: string, geom: string, extras: Record<string, s
 
   // --- INTERSECTIONS ---
   // check for & add any 'positive' constraints to the formattedResult
-  let formattedResult: Record<string, Constraint> = {};
+  const formattedResult: Record<string, Constraint> = {};
   if (res && res.count > 0 && res.entities) {
     res.entities.forEach((entity: { dataset: any; }) => {
       // get the planx variable that corresponds to this entity's 'dataset', should never be null because our initial request is filtered on 'dataset'
@@ -207,7 +207,7 @@ async function go(localAuthority: string, geom: string, extras: Record<string, s
       .then((response: { json: () => any; }) => response.json())
       .catch((error: any) => console.log(error))
   )).then((responses) => {
-    responses.forEach((response) => {
+    responses.forEach((response: any) => {
       // get the planx variable that corresponds to this 'dataset', should never be null because we only requested known datasets
       const key = Object.keys(baseSchema).find((key) => baseSchema[key]["digital-land-datasets"]?.includes(response.dataset));
       if (key) metadata[key] = response;

--- a/api.planx.uk/gis/helpers.js
+++ b/api.planx.uk/gis/helpers.js
@@ -120,44 +120,6 @@ const getManualConstraints = (metadata) => {
   return manualConstraints;
 };
 
-// Adds "designated" variable to response object, so we can auto-answer less granular questions like "are you on designated land"
-const addDesignatedVariable = (responseObject) => {
-  const resObjWithDesignated = {
-    ...responseObject,
-    designated: { value: false },
-  };
-
-  const subVariables = [
-    "conservationArea",
-    "AONB",
-    "nationalPark",
-    "WHS",
-    "SPA",
-  ];
-
-  // If any of the subvariables are true, then set "designated" to true
-  subVariables.forEach((s) => {
-    if (resObjWithDesignated[`designated.${s}`]?.value) {
-      resObjWithDesignated["designated"] = { value: true };
-    }
-  });
-
-  // Ensure that our response includes all the expected subVariables before returning "designated"
-  //   so we don't incorrectly auto-answer any questions for individual layer queries that may have failed
-  let subVariablesFound = 0;
-  Object.keys(responseObject).forEach((key) => {
-    if (key.startsWith(`designated.`)) {
-      subVariablesFound++;
-    }
-  });
-
-  if (subVariablesFound < subVariables.length) {
-    return responseObject;
-  } else {
-    return resObjWithDesignated;
-  }
-};
-
 // Squash multiple layers into a single result
 const squashResultLayers = (originalOb, layers, layerName) => {
   const ob = { ...originalOb };
@@ -222,7 +184,6 @@ export {
   getQueryableConstraints,
   getFalseConstraints,
   getManualConstraints,
-  addDesignatedVariable,
   squashResultLayers,
   rollupResultLayers,
   getA4Subvariables,

--- a/api.planx.uk/gis/local_authorities/braintree.js
+++ b/api.planx.uk/gis/local_authorities/braintree.js
@@ -5,7 +5,6 @@ import {
   makeEsriUrl,
   setEsriGeometryType,
   setEsriGeometry,
-  addDesignatedVariable,
   squashResultLayers,
   rollupResultLayers,
 } from "../helpers.js";
@@ -134,10 +133,7 @@ async function go(x, y, siteBoundary, extras) {
     "listed"
   );
 
-  // Add summary "designated" key to response
-  const obWithDesignated = addDesignatedVariable(obWithSingleListed);
-
-  return obWithDesignated;
+  return obWithSingleListed;
 }
 
 async function locationSearch(x, y, siteBoundary, extras) {

--- a/api.planx.uk/gis/local_authorities/scotland.js
+++ b/api.planx.uk/gis/local_authorities/scotland.js
@@ -5,7 +5,6 @@ import {
   makeEsriUrl,
   setEsriGeometryType,
   setEsriGeometry,
-  addDesignatedVariable,
   rollupResultLayers,
 } from "../helpers.js";
 import { planningConstraints } from "./metadata/scotland";

--- a/api.planx.uk/gis/local_authorities/scotland.js
+++ b/api.planx.uk/gis/local_authorities/scotland.js
@@ -112,10 +112,7 @@ async function go(x, y, siteBoundary, extras) {
     "designated.nationalPark",
   );
 
-  // Add summary "designated" key to response
-  const obWithDesignated = addDesignatedVariable(obWithOneNationalPark);
-
-  return obWithDesignated;
+  return obWithOneNationalPark;
 }
 
 async function locationSearch(x, y, siteBoundary, extras) {


### PR DESCRIPTION
Found this while debugging some multiple file upload logic: `computePassport()` was overriding this and already handling the granularity logic (eg auto-answer "Is it on designated land?" if any one of the `designated.X` constraints is set) on the frontend. 

No reason to explicitly return this via the API anymore - which will then also let us enforce a stricter type since this variable uniquely only had a `value` property. Will make type changes in a followup PR. 