### PR TITLE
FIX: radio alignment on zoom

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -106,7 +106,7 @@ const Question: React.FC<IQuestion> = (props) => {
         >
           <Grid
             container
-            spacing={layout === QuestionLayout.Basic ? 1 : 2}
+            spacing={layout === QuestionLayout.Basic ? 0 : 2}
             alignItems="stretch"
           >
             {!props.text?.startsWith("Sorry") &&

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -315,12 +315,13 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
               // Styles for radio icon dot
               content: "''",
               position: "absolute",
-              top: "11px",
-              left: "11px",
+              top: "50%",
+              left: "50%",
               width: 0,
               height: 0,
+              transform: "translate(-50%, -50%)",
               color: TEXT_COLOR_PRIMARY,
-              border: "11px solid currentcolor",
+              border: "10px solid currentcolor",
               borderRadius: "50%",
               background: "currentcolor",
               // Hide by default, show if checked


### PR DESCRIPTION
PR updates radio styling to prevent mis-alignment at different zoom levels.

- Adjust dot to be an even number in diameter (20px), matching even size of border (40px).
- Use top and left position of 50% to force top-left of dot to centre of element, then translate -50% in both axis to ensure dot sits at centre, rather than rely on pixel spacing to align.

The combination of the above should ensure the dot is central at all zoom levels.

Before (at 75% zoom):
<img width="511" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/8285006d-9b18-435d-b0e3-9526cac3a278">

After (at 75% zoom):
<img width="511" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/06906ac6-85d3-4cbf-b84b-69ad20674576">
