### PR TITLE
feat: Remove 'Cancel' button from Upload and label modal

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -78,14 +78,6 @@ export const FileTaggingModal = (props: FileTaggingModalProps) => {
         >
           Done
         </Button>
-        <Button
-          variant="contained"
-          color="secondary"
-          onClick={() => props.setShowModal(false)}
-          sx={{ paddingLeft: 2 }}
-        >
-          Cancel
-        </Button>
       </DialogActions>
     </Dialog>
   );
@@ -147,7 +139,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
       sx={{ display: "flex", flexDirection: "column" }}
     >
       <InputLabel
-        id={`select-mutliple-file-tags-label-${uploadedFile.id}`}
+        id={`select-multiple-file-tags-label-${uploadedFile.id}`}
         sx={{
           top: "16%",
           textDecoration: "underline",


### PR DESCRIPTION
Currently, this button doesn't behave as expected - is doesn't undo any actions done in the modal as these all happen on the select's `onChange` event.

There's a good design / UX question here about if a user would want this "Cancel" option, but removing it for now seems a good option as it's slightly misleading.