### PR TITLE
feat: add a warning banner to non-production environments

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -39,6 +39,7 @@ import Reset from "ui/icons/Reset";
 import { useStore } from "../pages/FlowEditor/lib/store";
 import { rootFlowPath } from "../routes/utils";
 import AnalyticsDisabledBanner from "./AnalyticsDisabledBanner";
+import TestEnvironmentBanner from "./TestEnvironmentBanner";
 
 export const HEADER_HEIGHT = 74;
 
@@ -351,6 +352,7 @@ const PublicToolbar: React.FC<{
       {!showCentredServiceTitle && <ServiceTitle />}
       <NavBar />
       <AnalyticsDisabledBanner />
+      <TestEnvironmentBanner />
     </>
   );
 };

--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -1,0 +1,42 @@
+import ReportIcon from "@mui/icons-material/Report";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React, { useState } from "react";
+
+import { getHeaderPadding } from "./Header";
+
+const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
+  display: "flex",
+  backgroundColor: theme.palette.background.paper,
+  color: theme.palette.text.primary,
+  justifyContent: "space-between",
+  alignItems: "center",
+  ...getHeaderPadding(theme),
+}));
+
+const TestEnvironmentBanner: React.FC = () => {
+  const [showWarning, setShowWarning] = useState(true);
+
+  const isTestEnvironment = () => !window.location.href.includes(".uk");
+
+  return (
+    <>
+      {isTestEnvironment() && showWarning && (
+        <TestEnvironmentWarning>
+          <Box display="flex" alignItems="center">
+            <ReportIcon color="error" />
+            <Typography variant="body2" ml={1}>
+              This is a <strong>testing environment</strong> for new features.
+              Do not use it to make permanent content changes.
+            </Typography>
+          </Box>
+          <Button onClick={() => setShowWarning(false)}>Hide</Button>
+        </TestEnvironmentWarning>
+      )}
+    </>
+  );
+};
+
+export default TestEnvironmentBanner;

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client";
 import { TYPES } from "@planx/components/types";
 import ErrorFallback from "components/ErrorFallback";
+import TestEnvironmentBanner from "components/TestEnvironmentBanner";
 import natsort from "natsort";
 import {
   compose,
@@ -209,6 +210,7 @@ const routes = compose(
     return (
       <>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <TestEnvironmentBanner />
           <FlowEditor key={flow} flow={flow} breadcrumbs={breadcrumbs} />
         </ErrorBoundary>
         <View />


### PR DESCRIPTION
New councils are onboarding to the Editor and we want to avoid hiccups around creating content on staging https://opensystemslab.slack.com/archives/C5Q59R3HB/p1687518232056569

This banner will display on the following pages: 
![Screenshot from 2023-06-23 13-54-58](https://github.com/theopensystemslab/planx-new/assets/5132349/32709332-3499-46c2-a9d7-2bb56074faba)
![Screenshot from 2023-06-23 13-48-44](https://github.com/theopensystemslab/planx-new/assets/5132349/55fc4bca-67ff-4ae1-a05f-ed38f07fd1db)
![Screenshot from 2023-06-23 13-55-10](https://github.com/theopensystemslab/planx-new/assets/5132349/9582412d-fa25-4729-8036-c61b684cab54)