### PR TITLE
fix: Different ITP routing for custom domains

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -11,6 +11,7 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { useNavigation } from "react-navi";
+import { isPreviewOnlyDomain } from "routes/utils";
 import useSWRMutation from "swr/mutation";
 import { ApplicationPath, PaymentStatus } from "types";
 import ErrorWrapper from "ui/ErrorWrapper";
@@ -120,11 +121,11 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
       redirectToConfirmationPage(paymentRequest.id);
   };
 
-  // TODO: This fails in the editor
-  // TODO: Test on prod custom domains
   const redirectToConfirmationPage = (paymentRequestId: string) => {
     const params = new URLSearchParams({ paymentRequestId }).toString();
-    const inviteToPayURL = `./pay/invite?${params}`;
+    const inviteToPayURL = isPreviewOnlyDomain
+      ? `/pay/invite?${params}`
+      : `./pay/invite?${params}`;
     navigation.navigate(inviteToPayURL);
   };
 


### PR DESCRIPTION
## What is the problem?
ITP routing is not working on custom domains. When I invite somebody else to pay, the request is successful, but I'm not routed to the correct confirmation page.

## What's the solution?
Custom domains do not have the `/preview` suffix on routes - this fix accounts for this by changing the route used based on `isPreviewOnlyDomain`.