### PR TITLE
fix(itp): Handle routing for custom domains

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -9,8 +9,8 @@ import { WarningContainer } from "@planx/components/shared/Preview/WarningContai
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
-import { useNavigation } from "react-navi";
+import React, { useEffect } from "react";
+import { useCurrentRoute, useNavigation } from "react-navi";
 import { isPreviewOnlyDomain } from "routes/utils";
 import useSWRMutation from "swr/mutation";
 import { ApplicationPath, PaymentStatus } from "types";
@@ -86,6 +86,14 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   const [sessionId, path] = useStore((state) => [state.sessionId, state.path]);
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
   const navigation = useNavigation();
+  const {
+    data: { mountpath },
+  } = useCurrentRoute();
+
+  // Scroll to top when loading component
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const postRequest = async (
     url: string,
@@ -124,7 +132,7 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   const redirectToConfirmationPage = (paymentRequestId: string) => {
     const params = new URLSearchParams({ paymentRequestId }).toString();
     const inviteToPayURL = isPreviewOnlyDomain
-      ? `/pay/invite?${params}`
+      ? `${mountpath}/pay/invite?${params}`
       : `./pay/invite?${params}`;
     navigation.navigate(inviteToPayURL);
   };

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import { FullStore, vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
+import * as ReactNavi from "react-navi";
 import { axe, setup } from "testUtils";
 import { ApplicationPath, PaymentStatus } from "types";
 
@@ -11,6 +12,10 @@ import Pay from "./Pay";
 const { getState, setState } = vanillaStore;
 
 let initialState: FullStore;
+
+jest
+  .spyOn(ReactNavi, "useCurrentRoute")
+  .mockImplementation(() => ({ data: { mountpath: "mountpath" } } as any));
 
 const resumeButtonText = "Resume an application you have already started";
 const saveButtonText = "Save and return to this application later";


### PR DESCRIPTION
Tested by adding `localhost` to the list of preview only domains, and setting it as domain for Bucks locally as well - getting the expected results now for both domain types.