### PR TITLE
fix(ci): Update `andstor/file-existence-action` to use `fail` option

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
@@ -65,7 +65,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
@@ -99,7 +99,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,7 +71,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
@@ -112,7 +112,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
@@ -148,7 +148,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true

--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./scripts/pull-secrets.sh
       - name: Check if .env files exist
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true


### PR DESCRIPTION
![image](https://github.com/theopensystemslab/planx-new/assets/20502206/0f3719be-7df5-4424-ba03-58da0e7785c8)

Something I clearly missed in https://github.com/theopensystemslab/planx-new/pull/1326 - the `fail` option was only introduced in v2.

I don't think this will resolve current CI issues but it's something I hit along the way and needed to be fixed 👍 
