### PR TITLE
fix(ci): Run `apt-get update` before all other commands

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -314,6 +314,8 @@ jobs:
           password: ${{ steps.create.outputs.default_password }}
           command_timeout: 20m
           script: |
+            apt-get update -y
+
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
             cd planx-new
             git fetch origin "pull/${{ env.PULLREQUEST_ID }}/head" && git checkout FETCH_HEAD
@@ -341,6 +343,8 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD }}
           command_timeout: 10m
           script: |
+            apt-get update -y
+
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
             cd planx-new
             git add . && git stash

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -6,8 +6,6 @@ cd "$(dirname $0)/../.."
 
 echo "root:$SSH_PASSWORD" | chpasswd
 
-apt-get update -y
-
 # check if swap space is available - see link for more on updating swap:
 # https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-22-04
 swapon --show
@@ -18,7 +16,6 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --de
 echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update -y
 apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 
 # set env for this shell


### PR DESCRIPTION
This addresses recent CI failures on a number of PRs. See error message thrown by GitHub actions below - 

```
out: Fetched 44.8 MB in 9s (5,227 kB/s)
err: E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cups/libcups2_2.4.1op1-1ubuntu4.2_amd64.deb  404  Not Found [IP: 91.189.91.38 80]
err: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
err: ./scripts/pull-secrets.sh: line 5: aws: command not found
err: ./scripts/pull-secrets.sh: line 6: aws: command not found
err: ./scripts/pull-secrets.sh: line 7: aws: command not found
out: Complete: Secrets from S3 copied to local machine
err: cat: .env: No such file or directory
```

This PR ran without issue, and did not need to be rebuilt etc to succeed.