### PR TITLE
fix: Add back second `apt-get update`

### DIFF
--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -16,6 +16,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --de
 echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update -y
 apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 
 # set env for this shell


### PR DESCRIPTION
https://github.com/theopensystemslab/planx-new/pull/1864/files#diff-5ea9e337803948274b694e82fe6c895196b548a3299642155678ebb149f2fe15L21

Now hitting the following CI issues, possibly resolved by adding back this second `apt-get` removed in #1864 

Errors seen on rebase PR here - https://github.com/theopensystemslab/planx-new/actions/runs/5398583470/jobs/9805904969


```
out: Preparing to unpack .../apt-transport-https_2.4.9_all.deb ...
out: Unpacking apt-transport-https (2.4.9) ...
out: Setting up apt-transport-https (2.4.9) ...
out: Running kernel seems to be up-to-date.
out: No services need to be restarted.
out: No containers need to be restarted.
out: No user sessions are running outdated binaries.
out: No VM guests are running outdated hypervisor (qemu) binaries on this host.
out: Reading package lists...
out: Building dependency tree...
out: Reading state information...
out: Package docker-ce is not available, but is referred to by another package.
out: This may mean that the package is missing, has been obsoleted, or
out: is only available from another source
err: E: Package 'docker-ce' has no installation candidate
err: E: Unable to locate package docker-ce-cli
err: E: Unable to locate package containerd.io
err: E: Couldn't find any package by glob 'containerd.io'
err: E: Couldn't find any package by regex 'containerd.io'
err: E: Unable to locate package docker-compose-plugin
2023/06/28 09:02:59 Process exited with status 100
```