### PR TITLE
fix: Don't pass `tagType` prop to DOM

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
@@ -15,7 +15,7 @@ const BG_ACTIVE = "#E5F1EB";
 const BG_NOTICE = "#F3F2F1";
 
 const Root = styled(MuiButtonBase, {
-  shouldForwardProp: (prop) => prop !== "type",
+  shouldForwardProp: (prop) => prop !== "tagType",
 })<ButtonBaseProps & Props>(({ theme, tagType }) => ({
   fontSize: theme.typography.body2.fontSize,
   fontWeight: FONT_WEIGHT_SEMI_BOLD,


### PR DESCRIPTION
Fix of a typo from https://github.com/theopensystemslab/planx-new/pull/1837 which was throwing an error in the console.