### PR TITLE
fix: Add `secrets.GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -383,6 +383,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: vultr
           message: |
             ## Pizza


### PR DESCRIPTION
Previous run on XXX succeed once required secrets added to Dependabot secrets in repo settings. However, it failed when posting the comment to the PR - see screenshot.

There's a chance this won't work and we'll need to explicitly set this value to a PAT in dependabot secrets but I'm keen to give this a go first.

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/d4c53433-1166-4b9e-85b9-e30831a3c8f5)
