### PR TITLE
chore: Ignore Hasura `cli-migrations-v3` versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,9 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - "theopensystemslab/planx"
+    ignore:
+      - dependency-name: "hasura/graphql-engine"
+        versions: ["x.cli-migrations-v3"]
 
   - package-ecosystem: "docker"
     directory: "/hasura.planx.uk/proxy"


### PR DESCRIPTION
Really unsure of the syntax here but worth a try...!

At some point we probably do want to migrate to the v3 version, but it's fine to park it for now 

Docs: https://hasura.io/docs/latest/migrations-metadata-seeds/legacy-configs/upgrade-v3/