### PR TITLE
fix: Handle radio group state

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
@@ -96,17 +96,15 @@ describe("Question component", () => {
 
       expect(screen.getByRole("heading")).toHaveTextContent("Best food");
 
-      let celeryRadio: HTMLElement | undefined;
-      if (QuestionLayout[type] === "Basic") {
-        celeryRadio = screen.getByRole("radio", { name: "Celery" });
-      } else if (QuestionLayout[type] === "Descriptions") {
-        celeryRadio = screen.getByRole("radio", {
-          name: "Celery This is celery",
-        });
-      } else if (QuestionLayout[type] === "Images") {
-        celeryRadio = screen.getByRole("radio", { name: "Celery Celery" });
-      }
+      const celeryRadio = screen.getByRole("radio", { name: /Celery/ });
+      const pizzaRadio = screen.getByRole("radio", { name: /Pizza/ });
+
+      // State is preserved...
       expect(celeryRadio).toBeChecked();
+
+      // ...and can be updated
+      await user.click(pizzaRadio);
+      expect(pizzaRadio).toBeChecked();
 
       const continueButton = screen.getByTestId("continue-button");
       expect(continueButton).toBeEnabled();

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -103,7 +103,7 @@ const Question: React.FC<IQuestion> = (props) => {
         <RadioGroup
           aria-labelledby={`radio-buttons-group-label-${props.id}`}
           name={`radio-buttons-group-${props.id}`}
-          value={previousResponseId}
+          value={formik.values.selected.id}
         >
           <Grid
             container


### PR DESCRIPTION
This fixes a visual regression when taking the following actions - 
 - Answer a question
 - Go back
 - Attempt to change answer

This journey results in the correct, new, answer being selected but there's no visual feedback for the user (the radio button remains unchecked).

This was something missed as part of #1844 - `previousResponseId` is static and calculated on initial of the component, whilst `formik.values.selected.id` is dynamic and updates as users interact with the radio group.