### PR TITLE
Revert "chore: Ignore Hasura `cli-migrations-v3` versions"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,6 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - "theopensystemslab/planx"
-    ignore:
-      - dependency-name: "hasura/graphql-engine"
-        versions: ["x.cli-migrations-v3"]
 
   - package-ecosystem: "docker"
     directory: "/hasura.planx.uk/proxy"


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#1877

This is leading to other PRs failing - reverting for now to take a closer look.