### PR TITLE
fix: Incorrect MUI classes syntax

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -111,7 +111,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
   "&.Mui-expanded": {
     margin: "0",
   },
-  [`& .${classes.removeTopBorder}`]: {
+  [`&.${classes.removeTopBorder}`]: {
     "&:before": {
       display: "none",
     },

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -30,7 +30,7 @@ const Root = styled(Drawer, {
     marginRight: "-100%",
   },
 
-  [`& .${classes.drawerPaper}`]: {
+  [`&.${classes.drawerPaper}`]: {
     width: drawerWidth,
     backgroundColor: theme.palette.background.default,
     border: 0,

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -14,7 +14,6 @@ const PREFIX = "Input";
 
 const classes = {
   multiline: `${PREFIX}-multiline`,
-  adornedEnd: `${PREFIX}-adornedEnd`,
   focused: `${PREFIX}-focused`,
 };
 
@@ -63,17 +62,14 @@ const StyledInputBase = styled(InputBase, {
     width: "100%",
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
   }),
-  [`& .${classes.multiline}`]: {
+  [`&.${classes.multiline}`]: {
     height: "auto",
     "& textarea": {
       padding: theme.spacing(1.5, 0),
       lineHeight: 1.6,
     },
   },
-  [`& .${classes.adornedEnd}`]: {
-    paddingRight: 2,
-  },
-  [`& .${classes.focused}`]: {
+  [`&.${classes.focused}`]: {
     ...(bordered && borderedFocusStyle),
   },
 }));

--- a/editor.planx.uk/src/ui/SelectInput.tsx
+++ b/editor.planx.uk/src/ui/SelectInput.tsx
@@ -25,7 +25,7 @@ const Root = styled(Select)(({ theme }) => ({
   padding: theme.spacing(0, 1.5),
   height: 50,
   backgroundColor: "#fff",
-  [`& .${classes.rootSelect}`]: {
+  [`&.${classes.rootSelect}`]: {
     paddingRight: theme.spacing(6),
     boxSizing: "border-box",
     backgroundColor: "#fff",
@@ -34,11 +34,11 @@ const Root = styled(Select)(({ theme }) => ({
     alignItems: "center",
     justifyContent: "flex-start",
   },
-  [`& .${classes.icon}`]: {
+  [`&.${classes.icon}`]: {
     right: theme.spacing(1),
     color: "rgba(0,0,0,0.25)",
   },
-  [`& .${classes.menuPaper}`]: {
+  [`&.${classes.menuPaper}`]: {
     border: `2px solid ${theme.palette.primary.light}`,
     borderTop: 0,
     marginTop: -2,
@@ -59,7 +59,7 @@ const Root = styled(Select)(({ theme }) => ({
       height: "auto",
     },
   },
-  [`& .${classes.inputSelect}`]: {
+  [`&.${classes.inputSelect}`]: {
     backgroundColor: "transparent",
     fontSize: "1rem",
     "&:focus": {


### PR DESCRIPTION
Fixes https://trello.com/c/Edty1cU8/2502-text-in-text-input-showing-outside-of-box

It appears that under certain conditions (possibly when the parent is not a styled component?) the syntax for applying classes cannot have a space. `$ .classname` is invalid but `$.classname` is. 