### PR TITLE
chore: Keep Hasura CloudWatch logs for 30 days

### DIFF
--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
 import * as tldjs from "tldjs";
@@ -61,6 +62,10 @@ export const createHasuraService = async ({
     cluster,
     subnets: networking.requireOutput("publicSubnetIds"),
     taskDefinitionArgs: {
+      logGroup: new aws.cloudwatch.LogGroup("hasura", {
+        namePrefix: "hasura",
+        retentionInDays: 30,
+      }),
       containers: {
         hasuraProxy: {
           image: repo.buildAndPushImage("../../hasura.planx.uk/proxy"),


### PR DESCRIPTION
Currently, these are just retained for 1 day and not 30 like all other services which can make resolving issues a little tricky!

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/dd93808b-efd2-48f6-ba26-245fef2c066d)
