### PR TITLE
fix: paper drawer width

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -31,13 +31,11 @@ const Root = styled(Drawer, {
   },
 
   [`& .${classes.drawerPaper}`]: {
-    width: drawerWidth,
+    width: "100%",
+    maxWidth: drawerWidth,
     backgroundColor: theme.palette.background.default,
     border: 0,
     boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
-    [theme.breakpoints.only("xs")]: {
-      width: "100%",
-    },
     padding: theme.spacing(1),
   },
 }));

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -30,7 +30,7 @@ const Root = styled(Drawer, {
     marginRight: "-100%",
   },
 
-  [`&.${classes.drawerPaper}`]: {
+  [`& .${classes.drawerPaper}`]: {
     width: drawerWidth,
     backgroundColor: theme.palette.background.default,
     border: 0,


### PR DESCRIPTION
Over the weekend I noticed the width on the help drawer dialog had stopped applying, and tracked it down to a regression introduced in https://github.com/theopensystemslab/planx-new/pull/1890

This PR reverts that and adds a `max-width` to simplify and prevent overlap at smaller viewports.