### PR TITLE
chore: Add `payment_status.amount` column 

### DIFF
--- a/api.planx.uk/inviteToPay/paymentRequest.ts
+++ b/api.planx.uk/inviteToPay/paymentRequest.ts
@@ -6,7 +6,7 @@ import {
   postPaymentNotificationToSlack,
   fetchPaymentViaProxyWithCallback,
 } from "../pay";
-import type { GovUKPayment } from "../types";
+import { GovUKPayment } from "@opensystemslab/planx-core/types";
 
 // middleware used by routes:
 //  * /payment-request/:paymentRequest/pay

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#20ad600",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#ff11779",
     "@opensystemslab/planx-document-templates": "github:theopensystemslab/planx-document-templates#baf18b8",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",

--- a/api.planx.uk/pay/pay.ts
+++ b/api.planx.uk/pay/pay.ts
@@ -4,10 +4,10 @@ import { responseInterceptor } from "http-proxy-middleware";
 import SlackNotify from "slack-notify";
 import { logPaymentStatus } from "../send/helpers";
 import { usePayProxy } from "./proxy";
-import type { GovUKPayment } from "../types";
 import { addGovPayPaymentIdToPaymentRequest } from "../inviteToPay";
 import { $admin } from "../client";
 import { ServerError } from "../errors";
+import { GovUKPayment } from "@opensystemslab/planx-core/types";
 
 assert(process.env.SLACK_WEBHOOK_URL);
 

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@airbrake/node': ^2.1.8
   '@babel/core': ^7.21.4
   '@babel/preset-typescript': ^7.21.4
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#20ad600
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#ff11779
   '@opensystemslab/planx-document-templates': github:theopensystemslab/planx-document-templates#baf18b8
   '@types/adm-zip': ^0.5.0
   '@types/body-parser': ^1.19.2
@@ -81,7 +81,7 @@ specifiers:
 
 dependencies:
   '@airbrake/node': 2.1.8
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/20ad600
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/ff11779
   '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/baf18b8
   '@types/isomorphic-fetch': 0.0.36
   adm-zip: 0.5.10
@@ -100,7 +100,7 @@ dependencies:
   form-data: 4.0.0
   graphql: 16.6.0
   graphql-request: 4.3.0_graphql@16.6.0
-  graphql-voyager: 1.0.2_oiha6uk5baqtsd2u7tyoqua3te
+  graphql-voyager: 1.0.2_ldugk2z6rczrboweosjqqkvcxa
   helmet: 5.1.1
   http-proxy-middleware: 2.0.6_@types+express@4.17.17
   isomorphic-fetch: 3.0.0
@@ -675,7 +675,7 @@ packages:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
     dev: false
 
-  /@emotion/react/11.10.5_@babel+core@7.21.4:
+  /@emotion/react/11.10.5_duavcg6prxxl5begav3y2fyxcu:
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -694,10 +694,11 @@ packages:
       '@emotion/babel-plugin': 11.10.6
       '@emotion/cache': 11.10.7
       '@emotion/serialize': 1.1.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
       '@emotion/utils': 1.2.0
       '@emotion/weak-memoize': 0.3.0
       hoist-non-react-statics: 3.3.2
+      react: 18.2.0
     dev: false
 
   /@emotion/react/11.10.6_react@18.2.0:
@@ -736,7 +737,7 @@ packages:
     resolution: {integrity: sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==}
     dev: false
 
-  /@emotion/styled/11.10.5_akceqhtkqit3xsjqyga7qlq7yy:
+  /@emotion/styled/11.10.5_topaxx52cuxnde6ktj7zz2t36u:
     resolution: {integrity: sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -755,10 +756,11 @@ packages:
       '@babel/runtime': 7.21.0
       '@emotion/babel-plugin': 11.10.6
       '@emotion/is-prop-valid': 1.2.0
-      '@emotion/react': 11.10.5_@babel+core@7.21.4
+      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
       '@emotion/serialize': 1.1.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
       '@emotion/utils': 1.2.0
+      react: 18.2.0
     dev: false
 
   /@emotion/styled/11.10.6_3og6jmu6wvzuytygvdoxepq3x4:
@@ -785,15 +787,6 @@ packages:
 
   /@emotion/unitless/0.8.0:
     resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
-    dev: false
-
-  /@emotion/use-insertion-effect-with-fallbacks/1.0.0:
-    resolution: {integrity: sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==}
-    peerDependencies:
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
     dev: false
 
   /@emotion/use-insertion-effect-with-fallbacks/1.0.0_react@18.2.0:
@@ -1227,7 +1220,7 @@ packages:
       '@lit-labs/ssr-dom-shim': 1.1.0
     dev: false
 
-  /@mui/base/5.0.0-alpha.112:
+  /@mui/base/5.0.0-alpha.112_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-KPwb1iYPXsV/P8uu0SNQrj7v7YU6wdN4Eccc2lZQyRDW+f6PJYjHBuFUTYKc408B98Jvs1XbC/z5MN45a2DWrQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1245,10 +1238,12 @@ packages:
       '@babel/runtime': 7.21.0
       '@emotion/is-prop-valid': 1.2.0
       '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0
+      '@mui/utils': 5.12.0_react@18.2.0
       '@popperjs/core': 2.11.7
       clsx: 1.2.1
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
     dev: false
 
@@ -1283,7 +1278,7 @@ packages:
     resolution: {integrity: sha512-1hoFIdlLI0sG+mkJgm70FjgIVpfLcE1vxPtNolg1tLFXrvbXGUYp9NHy3d6c41nDkg2OajuVS+Mn6A8UirFuMw==}
     dev: false
 
-  /@mui/icons-material/5.11.0_@mui+material@5.11.2:
+  /@mui/icons-material/5.11.0_24thufdhhc6uudyuozyjrubopi:
     resolution: {integrity: sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1297,10 +1292,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@mui/material': 5.11.2_z6zezfurr26maxy6gvsa52xlim
+      '@mui/material': 5.11.2_5rzy53przelm5jchjmb5vr6dxy
+      react: 18.2.0
     dev: false
 
-  /@mui/lab/5.0.0-alpha.114_jq36szbwhuuho2c54hfkimln3q:
+  /@mui/lab/5.0.0-alpha.114_je6wcyxzzodpuivmp54wfrprbm:
     resolution: {integrity: sha512-tChDoLaJ3qcYk37GIwBL1KrCiW0gpmEY//D5z5nHWnO/mzx3axjRJZpBOBeGEvhuoO/Y3QzMz4rhTvqbGNkW0w==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1323,19 +1319,21 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.10.5_@babel+core@7.21.4
-      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
-      '@mui/base': 5.0.0-alpha.112
-      '@mui/material': 5.11.2_z6zezfurr26maxy6gvsa52xlim
-      '@mui/system': 5.12.0_z6zezfurr26maxy6gvsa52xlim
+      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
+      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
+      '@mui/base': 5.0.0-alpha.112_biqbaboplfbrettd7655fr4n2y
+      '@mui/material': 5.11.2_5rzy53przelm5jchjmb5vr6dxy
+      '@mui/system': 5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm
       '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0
+      '@mui/utils': 5.12.0_react@18.2.0
       clsx: 1.2.1
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
     dev: false
 
-  /@mui/material/5.11.2_z6zezfurr26maxy6gvsa52xlim:
+  /@mui/material/5.11.2_5rzy53przelm5jchjmb5vr6dxy:
     resolution: {integrity: sha512-PeraRDsghnDLzejorfe9ps1syxlB8UrGs+UKwg9GGlndv5Tghm+9nwuibrP2TCDC14mlryF+u2WlAOYaPPMwGA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1357,19 +1355,21 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/react': 11.10.5_@babel+core@7.21.4
-      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
-      '@mui/base': 5.0.0-alpha.112
+      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
+      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
+      '@mui/base': 5.0.0-alpha.112_biqbaboplfbrettd7655fr4n2y
       '@mui/core-downloads-tracker': 5.12.0
-      '@mui/system': 5.12.0_z6zezfurr26maxy6gvsa52xlim
+      '@mui/system': 5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm
       '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0
+      '@mui/utils': 5.12.0_react@18.2.0
       '@types/react-transition-group': 4.4.5
       clsx: 1.2.1
       csstype: 3.1.2
       prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       react-is: 18.2.0
-      react-transition-group: 4.4.5
+      react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
     dev: false
 
   /@mui/material/5.11.9_fbxtuirhogpez7m7qjkm3itwca:
@@ -1411,23 +1411,6 @@ packages:
       react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
     dev: false
 
-  /@mui/private-theming/5.12.0:
-    resolution: {integrity: sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@mui/utils': 5.12.0
-      prop-types: 15.8.1
-    dev: false
-
   /@mui/private-theming/5.12.0_react@18.2.0:
     resolution: {integrity: sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==}
     engines: {node: '>=12.0.0'}
@@ -1442,6 +1425,30 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@mui/utils': 5.12.0_react@18.2.0
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/styled-engine/5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm:
+    resolution: {integrity: sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/cache': 11.10.7
+      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
+      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
+      csstype: 3.1.2
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
@@ -1470,27 +1477,35 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@mui/styled-engine/5.12.0_z6zezfurr26maxy6gvsa52xlim:
-    resolution: {integrity: sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==}
+  /@mui/system/5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm:
+    resolution: {integrity: sha512-Zi+WHuiJfK1ya+9+oeJQ1rLIBdY8CGDYT5oVlQg/6kIuyiCaE6SnN9PVzxBxfY77wHuOPwz4kxcPe9srdZc12Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
       '@emotion/styled':
         optional: true
+      '@types/react':
+        optional: true
       react:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@emotion/cache': 11.10.7
-      '@emotion/react': 11.10.5_@babel+core@7.21.4
-      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
+      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
+      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
+      '@mui/private-theming': 5.12.0_react@18.2.0
+      '@mui/styled-engine': 5.12.0_dovxhg2tvkkxkdnqyoum6wzcxm
+      '@mui/types': 7.2.4
+      '@mui/utils': 5.12.0_react@18.2.0
+      clsx: 1.2.1
       csstype: 3.1.2
       prop-types: 15.8.1
+      react: 18.2.0
     dev: false
 
   /@mui/system/5.12.0_xqp3pgpqjlfxxa3zxu4zoc4fba:
@@ -1524,36 +1539,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@mui/system/5.12.0_z6zezfurr26maxy6gvsa52xlim:
-    resolution: {integrity: sha512-Zi+WHuiJfK1ya+9+oeJQ1rLIBdY8CGDYT5oVlQg/6kIuyiCaE6SnN9PVzxBxfY77wHuOPwz4kxcPe9srdZc12Q==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@emotion/react': 11.10.5_@babel+core@7.21.4
-      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
-      '@mui/private-theming': 5.12.0
-      '@mui/styled-engine': 5.12.0_z6zezfurr26maxy6gvsa52xlim
-      '@mui/types': 7.2.4
-      '@mui/utils': 5.12.0
-      clsx: 1.2.1
-      csstype: 3.1.2
-      prop-types: 15.8.1
-    dev: false
-
   /@mui/types/7.2.4:
     resolution: {integrity: sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==}
     peerDependencies:
@@ -1561,22 +1546,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-    dev: false
-
-  /@mui/utils/5.12.0:
-    resolution: {integrity: sha512-RmQwgzF72p7Yr4+AAUO6j1v2uzt6wr7SWXn68KBsnfVpdOHyclCzH2lr/Xu6YOw9su4JRtdAIYfJFXsS6Cjkmw==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@types/prop-types': 15.7.5
-      '@types/react-is': 17.0.3
-      prop-types: 15.8.1
-      react-is: 18.2.0
     dev: false
 
   /@mui/utils/5.12.0_react@18.2.0:
@@ -4228,7 +4197,7 @@ packages:
       - encoding
     dev: false
 
-  /graphql-voyager/1.0.2_oiha6uk5baqtsd2u7tyoqua3te:
+  /graphql-voyager/1.0.2_ldugk2z6rczrboweosjqqkvcxa:
     resolution: {integrity: sha512-PYvW7pKbQcIlun37hZ6sWE4bneECM6wDNAkdyW0rpZ3oVA/2INthORIiWd+ol4jSzZLD/fYYo8a6SYLc5btnKQ==}
     peerDependencies:
       graphql: '>=16.5.0'
@@ -4240,14 +4209,16 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@emotion/react': 11.10.5_@babel+core@7.21.4
-      '@emotion/styled': 11.10.5_akceqhtkqit3xsjqyga7qlq7yy
-      '@mui/icons-material': 5.11.0_@mui+material@5.11.2
-      '@mui/lab': 5.0.0-alpha.114_jq36szbwhuuho2c54hfkimln3q
-      '@mui/material': 5.11.2_z6zezfurr26maxy6gvsa52xlim
+      '@emotion/react': 11.10.5_duavcg6prxxl5begav3y2fyxcu
+      '@emotion/styled': 11.10.5_topaxx52cuxnde6ktj7zz2t36u
+      '@mui/icons-material': 5.11.0_24thufdhhc6uudyuozyjrubopi
+      '@mui/lab': 5.0.0-alpha.114_je6wcyxzzodpuivmp54wfrprbm
+      '@mui/material': 5.11.2_5rzy53przelm5jchjmb5vr6dxy
       commonmark: 0.30.0
       graphql: 16.6.0
       lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       svg-pan-zoom: 3.6.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -6394,23 +6365,6 @@ packages:
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
-  /react-transition-group/4.4.5:
-    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
-    peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-    dev: false
-
   /react-transition-group/4.4.5_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -7585,8 +7539,8 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/20ad600:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/20ad600}
+  github.com/theopensystemslab/planx-core/ff11779:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ff11779}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     engines: {node: ^18}

--- a/api.planx.uk/send/helpers.ts
+++ b/api.planx.uk/send/helpers.ts
@@ -64,6 +64,7 @@ export async function logPaymentStatus({
   flowId: string | undefined;
   teamSlug: string;
   govUkResponse: {
+    amount: number;
     payment_id: string;
     state: {
       status: string;
@@ -85,6 +86,7 @@ export async function logPaymentStatus({
         teamSlug,
         paymentId: govUkResponse.payment_id,
         status: govUkResponse.state?.status || "unknown",
+        amount: govUkResponse.amount,
       });
     } catch (e) {
       reportError({
@@ -119,14 +121,16 @@ async function insertPaymentStatus({
   paymentId,
   teamSlug,
   status,
+  amount,
 }: {
   flowId: string;
   sessionId: string;
   paymentId: string;
   teamSlug: string;
   status: string;
+  amount: number;
 }): Promise<void> {
-  const response = await adminGraphQLClient.request(
+  const _response = await adminGraphQLClient.request(
     gql`
       mutation InsertPaymentStatus(
         $flowId: uuid!
@@ -134,6 +138,7 @@ async function insertPaymentStatus({
         $paymentId: String!
         $teamSlug: String!
         $status: payment_status_enum_enum
+        $amount: Int!
       ) {
         insert_payment_status(
           objects: {
@@ -142,6 +147,7 @@ async function insertPaymentStatus({
             payment_id: $paymentId
             team_slug: $teamSlug
             status: $status
+            amount: $amount
           }
         ) {
           affected_rows
@@ -154,6 +160,7 @@ async function insertPaymentStatus({
       teamSlug,
       paymentId,
       status,
+      amount,
     }
   );
 }

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -1,4 +1,5 @@
 import { PaymentRequest } from "@opensystemslab/planx-core/dist/types";
+import { GovUKPayment } from "@opensystemslab/planx-core/types";
 
 export interface Node {
   id?: string;
@@ -145,44 +146,3 @@ export type NotifyConfig =
   | EmailSubmissionNotifyConfig
   | InviteToPayNotifyConfig
   | AgentAndPayeeSubmissionNotifyConfig;
-
-// https://docs.payments.service.gov.uk/making_payments/#receiving-the-api-response
-export interface GovUKPayment {
-  amount: number;
-  reference?: string;
-  state: {
-    // https://docs.payments.service.gov.uk/api_reference/#payment-status-meanings
-    status:
-      | "created"
-      | "started"
-      | "submitted"
-      | "capturable"
-      | "success"
-      | "failed"
-      | "cancelled"
-      | "error";
-    finished: boolean;
-    message?: string;
-  };
-  payment_id: string;
-  payment_provider: string;
-  created_date?: string;
-  _links?: {
-    self: {
-      href: string;
-      method: string;
-    };
-    next_url?: {
-      href: string;
-      method: string;
-    };
-    next_url_post: {
-      type: string;
-      params: {
-        chargeTokenId: string;
-      };
-      href: string;
-      method: string;
-    };
-  };
-}

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.1.2",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#fb8178b",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#ff11779",
     "axios": "^1.4.0",
     "dotenv": "^16.1.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@cucumber/cucumber': ^9.1.2
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#fb8178b
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#ff11779
   '@types/node': '18'
   axios: ^1.4.0
   dotenv: ^16.1.1
@@ -13,7 +13,7 @@ specifiers:
 
 dependencies:
   '@cucumber/cucumber': 9.1.2
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/fb8178b
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/ff11779
   axios: 1.4.0
   dotenv: 16.1.1
   dotenv-expand: 10.0.0
@@ -1998,15 +1998,15 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/fb8178b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fb8178b}
+  github.com/theopensystemslab/planx-core/ff11779:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ff11779}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
-    engines: {node: ^16, pnpm: ^7.8.0}
+    engines: {node: ^18}
     prepare: true
     requiresBuild: true
     dependencies:
-      '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca
+      '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/28e0705
       fast-xml-parser: 4.2.2
       graphql: 16.6.0
       graphql-request: 5.2.0_graphql@16.6.0
@@ -2028,11 +2028,11 @@ packages:
       - rollup
     dev: false
 
-  github.com/theopensystemslab/planx-document-templates/debaeca:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/debaeca}
+  github.com/theopensystemslab/planx-document-templates/28e0705:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/28e0705}
     name: '@opensystemslab/planx-document-templates'
     version: 1.0.0
-    engines: {node: ^16, pnpm: ^7.8.0}
+    engines: {node: ^18}
     prepare: true
     requiresBuild: true
     dependencies:

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#fb8178b",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#ff11779",
     "axios": "^1.3.6",
     "dotenv": "^16.0.3",
     "eslint": "^8.42.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#fb8178b
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#ff11779
   '@playwright/test': ^1.28.1
   '@types/dotenv': ^8.2.0
   '@types/node': ^18.16.0
@@ -17,7 +17,7 @@ specifiers:
   uuid: ^9.0.0
 
 dependencies:
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/fb8178b
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/ff11779
   axios: 1.4.0
   dotenv: 16.0.3
   eslint: 8.42.0
@@ -2258,15 +2258,15 @@ packages:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/fb8178b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fb8178b}
+  github.com/theopensystemslab/planx-core/ff11779:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ff11779}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
-    engines: {node: ^16, pnpm: ^7.8.0}
+    engines: {node: ^18}
     prepare: true
     requiresBuild: true
     dependencies:
-      '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca
+      '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/28e0705
       fast-xml-parser: 4.2.2
       graphql: 16.6.0
       graphql-request: 5.2.0_graphql@16.6.0
@@ -2288,11 +2288,11 @@ packages:
       - rollup
     dev: false
 
-  github.com/theopensystemslab/planx-document-templates/debaeca:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/debaeca}
+  github.com/theopensystemslab/planx-document-templates/28e0705:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/28e0705}
     name: '@opensystemslab/planx-document-templates'
     version: 1.0.0
-    engines: {node: ^16, pnpm: ^7.8.0}
+    engines: {node: ^18}
     prepare: true
     requiresBuild: true
     dependencies:

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/styles": "^5.13.7",
     "@mui/utils": "^5.13.7",
     "@opensystemslab/map": "^0.7.4",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#main",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#ff11779",
     "@opensystemslab/planx-document-templates": "github:theopensystemslab/planx-document-templates#baf18b8",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -28,7 +28,7 @@ specifiers:
   '@mui/styles': ^5.13.7
   '@mui/utils': ^5.13.7
   '@opensystemslab/map': ^0.7.4
-  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#main
+  '@opensystemslab/planx-core': github:theopensystemslab/planx-core#ff11779
   '@opensystemslab/planx-document-templates': github:theopensystemslab/planx-document-templates#baf18b8
   '@react-theming/storybook-addon': ^1.1.10
   '@storybook/addon-actions': ^7.0.25
@@ -173,8 +173,8 @@ dependencies:
   '@mui/styles': 5.13.7_i73ekzlbntu7jol6ph2fvy4mga
   '@mui/utils': 5.13.7_react@18.2.0
   '@opensystemslab/map': 0.7.4
-  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/0544d99ffd040eb2a70326e9bfa52ba1ba06c780_@types+react@18.2.14
-  '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/baf18b8_@types+react@18.2.14
+  '@opensystemslab/planx-core': github.com/theopensystemslab/planx-core/ff11779_yjgyzgwxdwfto4564aykofm2eq
+  '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/baf18b8_yjgyzgwxdwfto4564aykofm2eq
   '@tiptap/core': 2.0.3_@tiptap+pm@2.0.3
   '@tiptap/extension-bold': 2.0.3_@tiptap+core@2.0.3
   '@tiptap/extension-bubble-menu': 2.0.3_7qxxgdyo6i4mk7xrbxa2xtsga4
@@ -293,7 +293,7 @@ devDependencies:
   esbuild: 0.14.54
   esbuild-jest: 0.5.0_esbuild@0.14.54
   eslint: 8.43.0
-  eslint-plugin-jest: 27.2.2_2jcgcerbs6bi4debdtwega5q6u
+  eslint-plugin-jest: 27.2.2_3eycl6g4frzq3g5vh3g6oze5ee
   eslint-plugin-jsx-a11y: 6.7.1_eslint@8.43.0
   eslint-plugin-simple-import-sort: 7.0.0_eslint@8.43.0
   eslint-plugin-testing-library: 5.11.0_2jcgcerbs6bi4debdtwega5q6u
@@ -4793,7 +4793,7 @@ packages:
       '@rollup/pluginutils': 3.1.0_rollup@2.61.1
       rollup: 2.61.1
 
-  /@rollup/plugin-commonjs/23.0.7:
+  /@rollup/plugin-commonjs/23.0.7_rollup@2.61.1:
     resolution: {integrity: sha512-hsSD5Qzyuat/swzrExGG5l7EuIlPhwTsT7KwKbSCQzIcJWjRxiimi/0tyMYY2bByitNb3i1p+6JWEDGa0NvT0Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4802,12 +4802,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2
+      '@rollup/pluginutils': 5.0.2_rollup@2.61.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
+      rollup: 2.61.1
     dev: false
 
   /@rollup/plugin-node-resolve/11.2.1_rollup@2.61.1:
@@ -4844,7 +4845,7 @@ packages:
       picomatch: 2.3.1
       rollup: 2.61.1
 
-  /@rollup/pluginutils/5.0.2:
+  /@rollup/pluginutils/5.0.2_rollup@2.61.1:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4856,6 +4857,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 2.61.1
     dev: false
 
   /@rushstack/eslint-patch/1.1.0:
@@ -10282,7 +10284,7 @@ packages:
       - supports-color
       - typescript
 
-  /eslint-plugin-jest/27.2.2_2jcgcerbs6bi4debdtwega5q6u:
+  /eslint-plugin-jest/27.2.2_3eycl6g4frzq3g5vh3g6oze5ee:
     resolution: {integrity: sha512-euzbp06F934Z7UDl5ZUaRPLAc9MKjh0rMPERrHT7UhlCEwgb25kBj37TvMgWeHZVkR5I9CayswrpoaqZU1RImw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -10297,6 +10299,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.58.0_2jcgcerbs6bi4debdtwega5q6u
       eslint: 8.43.0
+      jest: 27.4.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19639,16 +19642,16 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  github.com/theopensystemslab/planx-core/0544d99ffd040eb2a70326e9bfa52ba1ba06c780_@types+react@18.2.14:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0544d99ffd040eb2a70326e9bfa52ba1ba06c780}
-    id: github.com/theopensystemslab/planx-core/0544d99ffd040eb2a70326e9bfa52ba1ba06c780
+  github.com/theopensystemslab/planx-core/ff11779_yjgyzgwxdwfto4564aykofm2eq:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ff11779}
+    id: github.com/theopensystemslab/planx-core/ff11779
     name: '@opensystemslab/planx-core'
     version: 1.0.0
-    engines: {node: ^16, pnpm: ^7.8.0}
+    engines: {node: ^18}
     prepare: true
     requiresBuild: true
     dependencies:
-      '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/debaeca_@types+react@18.2.14
+      '@opensystemslab/planx-document-templates': github.com/theopensystemslab/planx-document-templates/28e0705_yjgyzgwxdwfto4564aykofm2eq
       fast-xml-parser: 4.2.2
       graphql: 16.7.1
       graphql-request: 5.2.0_graphql@16.7.1
@@ -19670,7 +19673,31 @@ packages:
       - rollup
     dev: false
 
-  github.com/theopensystemslab/planx-document-templates/baf18b8_@types+react@18.2.14:
+  github.com/theopensystemslab/planx-document-templates/28e0705_yjgyzgwxdwfto4564aykofm2eq:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/28e0705}
+    id: github.com/theopensystemslab/planx-document-templates/28e0705
+    name: '@opensystemslab/planx-document-templates'
+    version: 1.0.0
+    engines: {node: ^18}
+    prepare: true
+    requiresBuild: true
+    dependencies:
+      '@emotion/react': 11.11.1_i73ekzlbntu7jol6ph2fvy4mga
+      '@emotion/styled': 11.11.0_rowjtfdjat7gur3v4vqpuckrf4
+      '@lit-labs/ssr': 2.3.0
+      '@mui/material': 5.11.9_t72as5nkc72wvuzlfm5pknb3h4
+      '@rollup/plugin-commonjs': 23.0.7_rollup@2.61.1
+      docx: 7.8.2
+      lodash.groupby: 4.6.0
+      lodash.startcase: 4.4.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - rollup
+    dev: false
+
+  github.com/theopensystemslab/planx-document-templates/baf18b8_yjgyzgwxdwfto4564aykofm2eq:
     resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/baf18b8}
     id: github.com/theopensystemslab/planx-document-templates/baf18b8
     name: '@opensystemslab/planx-document-templates'
@@ -19683,31 +19710,7 @@ packages:
       '@emotion/styled': 11.11.0_rowjtfdjat7gur3v4vqpuckrf4
       '@lit-labs/ssr': 2.3.0
       '@mui/material': 5.11.9_t72as5nkc72wvuzlfm5pknb3h4
-      '@rollup/plugin-commonjs': 23.0.7
-      docx: 7.8.2
-      lodash.groupby: 4.6.0
-      lodash.startcase: 4.4.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - rollup
-    dev: false
-
-  github.com/theopensystemslab/planx-document-templates/debaeca_@types+react@18.2.14:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-document-templates/tar.gz/debaeca}
-    id: github.com/theopensystemslab/planx-document-templates/debaeca
-    name: '@opensystemslab/planx-document-templates'
-    version: 1.0.0
-    engines: {node: ^16, pnpm: ^7.8.0}
-    prepare: true
-    requiresBuild: true
-    dependencies:
-      '@emotion/react': 11.11.1_i73ekzlbntu7jol6ph2fvy4mga
-      '@emotion/styled': 11.11.0_rowjtfdjat7gur3v4vqpuckrf4
-      '@lit-labs/ssr': 2.3.0
-      '@mui/material': 5.11.9_t72as5nkc72wvuzlfm5pknb3h4
-      '@rollup/plugin-commonjs': 23.0.7
+      '@rollup/plugin-commonjs': 23.0.7_rollup@2.61.1
       docx: 7.8.2
       lodash.groupby: 4.6.0
       lodash.startcase: 4.4.0

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -3,11 +3,12 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { lighten, styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
 import SaveResumeButton from "@planx/components/shared/Preview/SaveResumeButton";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
-import { ApplicationPath, PaymentStatus } from "types";
+import { ApplicationPath } from "types";
 import Banner from "ui/Banner";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -2,7 +2,11 @@ import ErrorOutline from "@mui/icons-material/ErrorOutline";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import type { KeyPath, PaymentRequest } from "@opensystemslab/planx-core/types";
+import type {
+  KeyPath,
+  PaymentRequest,
+  PaymentStatus,
+} from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
 import SaveResumeButton from "@planx/components/shared/Preview/SaveResumeButton";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
@@ -13,7 +17,7 @@ import React, { useEffect } from "react";
 import { useCurrentRoute, useNavigation } from "react-navi";
 import { isPreviewOnlyDomain } from "routes/utils";
 import useSWRMutation from "swr/mutation";
-import { ApplicationPath, PaymentStatus } from "types";
+import { ApplicationPath } from "types";
 import ErrorWrapper from "ui/ErrorWrapper";
 import Input from "ui/Input";
 import InputLabel from "ui/InputLabel";

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -1,10 +1,11 @@
+import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import { screen } from "@testing-library/react";
 import { FullStore, vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import * as ReactNavi from "react-navi";
 import { axe, setup } from "testUtils";
-import { ApplicationPath, PaymentStatus } from "types";
+import { ApplicationPath } from "types";
 
 import Confirm, { Props } from "./Confirm";
 import Pay from "./Pay";

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -1,23 +1,20 @@
+import {
+  GOV_PAY_PASSPORT_KEY,
+  GovUKPayment,
+  PaymentStatus,
+} from "@opensystemslab/planx-core/types";
 import { logger } from "airbrake";
 import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { setLocalFlow } from "lib/local.new";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useReducer } from "react";
 import { useErrorHandler } from "react-error-boundary";
-import type { GovUKPayment, Session } from "types";
-import { PaymentStatus } from "types";
+import type { Session } from "types";
 
 import { makeData } from "../../shared/utils";
-import {
-  createPayload,
-  GOV_PAY_PASSPORT_KEY,
-  GOV_UK_PAY_URL,
-  Pay,
-  toDecimal,
-} from "../model";
+import { createPayload, GOV_UK_PAY_URL, Pay, toDecimal } from "../model";
 import Confirm from "./Confirm";
 
 export default Component;

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -80,8 +80,6 @@ const getReturnURL = (sessionId: string): string => {
 
 export const GOV_UK_PAY_URL = `${process.env.REACT_APP_API_URL}/pay`;
 
-export const GOV_PAY_PASSPORT_KEY = "application.fee.reference.govPay" as const;
-
 export const validationSchema = object({
   title: string().trim().required(),
   bannerTitle: string().trim().required(),

--- a/editor.planx.uk/src/@planx/components/Send/bops/index.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/index.ts
@@ -4,15 +4,18 @@
 // POST data payloads accepted by the BOPS API, see:
 // https://southwark.preview.bops.services/api-docs/index.html
 
+import {
+  GOV_PAY_PASSPORT_KEY,
+  GovUKPayment,
+} from "@opensystemslab/planx-core/types";
 import { logger } from "airbrake";
 import { isEmpty } from "lodash";
 import { flatFlags } from "pages/FlowEditor/data/flags";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { getResultData } from "pages/FlowEditor/lib/store/preview";
-import { GovUKPayment } from "types";
 
 import { Store } from "../../../../pages/FlowEditor/lib/store";
-import { GOV_PAY_PASSPORT_KEY, toPence } from "../../Pay/model";
+import { toPence } from "../../Pay/model";
 import { removeNilValues } from "../../shared/utils";
 import { TYPES } from "../../types";
 import { findGeoJSON } from "../helpers";

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -1,4 +1,5 @@
 import tinycolor from "@ctrl/tinycolor";
+import { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { TYPES } from "@planx/components/types";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { logger } from "airbrake";
@@ -14,7 +15,7 @@ import { v4 as uuidV4 } from "uuid";
 import type { StateCreator } from "zustand";
 
 import { DEFAULT_FLAG_CATEGORY, flatFlags } from "../../data/flags";
-import type { Flag, GovUKPayment, Node, Session } from "./../../../../types";
+import type { Flag, Node, Session } from "./../../../../types";
 import { ApplicationPath } from "./../../../../types";
 import type { Store } from ".";
 import { NavigationStore } from "./navigation";

--- a/editor.planx.uk/src/pages/Pay/MakePayment.tsx
+++ b/editor.planx.uk/src/pages/Pay/MakePayment.tsx
@@ -2,7 +2,11 @@ import Check from "@mui/icons-material/Check";
 import Container from "@mui/material/Container";
 import { lighten, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import type { PaymentRequest } from "@opensystemslab/planx-core/types";
+import {
+  type PaymentRequest,
+  GovUKPayment,
+  PaymentStatus,
+} from "@opensystemslab/planx-core/types";
 import axios from "axios";
 import { _public } from "client";
 import { format } from "date-fns";
@@ -20,7 +24,6 @@ import {
 import Confirm from "../../@planx/components/Pay/Public/Confirm";
 import { logger } from "../../airbrake";
 import DelayedLoadingIndicator from "../../components/DelayedLoadingIndicator";
-import { GovUKPayment, PaymentStatus } from "../../types";
 
 const States = {
   Init: {

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -1,3 +1,7 @@
+import {
+  GOV_PAY_PASSPORT_KEY,
+  GovUKPayment,
+} from "@opensystemslab/planx-core/types";
 import AddressInput from "@planx/components/AddressInput/Public";
 import Calculate from "@planx/components/Calculate/Public";
 import Checklist from "@planx/components/Checklist/Public";
@@ -12,7 +16,6 @@ import FindProperty from "@planx/components/FindProperty/Public";
 import NextSteps from "@planx/components/NextSteps/Public";
 import Notice from "@planx/components/Notice/Public";
 import NumberInput from "@planx/components/NumberInput/Public";
-import { GOV_PAY_PASSPORT_KEY } from "@planx/components/Pay/model";
 import Pay from "@planx/components/Pay/Public";
 import PlanningConstraints from "@planx/components/PlanningConstraints/Public";
 import PropertyInformation from "@planx/components/PropertyInformation/Public";
@@ -30,7 +33,6 @@ import { objectWithoutNullishValues } from "lib/objectHelpers";
 import { DEFAULT_FLAG_CATEGORY } from "pages/FlowEditor/data/flags";
 import mapAccum from "ramda/src/mapAccum";
 import React from "react";
-import type { GovUKPayment } from "types";
 
 import type { Store } from "../FlowEditor/lib/store";
 import { useStore } from "../FlowEditor/lib/store";

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -1,3 +1,4 @@
+import { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 
 import { Store } from "./pages/FlowEditor/lib/store/index";
@@ -85,49 +86,6 @@ export interface Node {
     info?: string;
     policyRef?: string;
   };
-}
-
-// https://docs.payments.service.gov.uk/making_payments/#receiving-the-api-response
-export interface GovUKPayment {
-  amount: number;
-  reference: string;
-  state: {
-    status: PaymentStatus;
-    finished: boolean;
-  };
-  payment_id: string;
-  created_date: string;
-  _links: {
-    self: {
-      href: string;
-      method: string;
-    };
-    next_url?: {
-      href: string;
-      method: string;
-    };
-    next_url_post: {
-      type: string;
-      params: {
-        chargeTokenId: string;
-      };
-      href: string;
-      method: string;
-    };
-  };
-}
-
-// https://docs.payments.service.gov.uk/api_reference/#status-and-finished
-export enum PaymentStatus {
-  created = "created",
-  started = "started",
-  submitted = "submitted",
-  capturable = "capturable",
-  success = "success",
-  failed = "failed",
-  cancelled = "cancelled",
-  error = "error",
-  unknown = "unknown", // used when response status is not valid
 }
 
 /**

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -222,6 +222,15 @@
           table:
             schema: public
             name: payment_requests
+    - name: payment_status
+      using:
+        manual_configuration:
+          remote_table:
+            schema: public
+            name: payment_status
+          insertion_order: null
+          column_mapping:
+            id: session_id
   insert_permissions:
     - role: public
       permission:
@@ -512,6 +521,16 @@
 - table:
     schema: public
     name: payment_status
+  object_relationships:
+    - name: lowcal_session
+      using:
+        manual_configuration:
+          remote_table:
+            schema: public
+            name: lowcal_sessions
+          insertion_order: null
+          column_mapping:
+            session_id: id
 - table:
     schema: public
     name: payment_status_enum

--- a/hasura.planx.uk/migrations/1688457221159_alter_table_public_payment_status_add_column_payment_amount/down.sql
+++ b/hasura.planx.uk/migrations/1688457221159_alter_table_public_payment_status_add_column_payment_amount/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."payment_status"."amount" is NULL;
+
+ALTER TABLE payment_status DROP COLUMN amount;

--- a/hasura.planx.uk/migrations/1688457221159_alter_table_public_payment_status_add_column_payment_amount/up.sql
+++ b/hasura.planx.uk/migrations/1688457221159_alter_table_public_payment_status_add_column_payment_amount/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."payment_status" add column "amount" integer
+ null;
+
+comment on column "public"."payment_status"."amount" is E'Value in pence of payment amount';


### PR DESCRIPTION
## What does this PR do?
 - Imports types from planx-core (relies on https://github.com/theopensystemslab/planx-core/pull/52)
 - Adds new `payment_status.amount` column
 - Adds relationship between `lowcal_sessions` and `payment_status` tables

---

Adding the relationship here allows us to query like this - 

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/d3d9e7c2-dd80-4440-bf52-91128c8d3325)

We could also make this a computed field on `lowcal_sessions` which may be simpler, but also less discoverable.

I think we'll just need to update this query once so this feels like the right approach but happy to re-evaluate if we end up repeating it.