### PR TITLE
fix: Banner icon sizing

### DIFF
--- a/editor.planx.uk/src/ui/Banner.tsx
+++ b/editor.planx.uk/src/ui/Banner.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import { styled } from "@mui/material/styles";
+import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
@@ -46,9 +46,9 @@ function Banner(props: BannerProps) {
         {props.Icon && (
           <props.Icon
             sx={{
-              marginBottom: 1,
-              height: 5,
-              width: 5,
+              marginBottom: (theme: Theme) => theme.spacing(1),
+              height: (theme: Theme) => theme.spacing(5),
+              width: (theme: Theme) => theme.spacing(5),
               border: "3px solid",
               borderRadius: "50%",
             }}


### PR DESCRIPTION
Fix of a visual regression introduced here - https://github.com/theopensystemslab/planx-new/pull/1862

<img width="583" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/d02b3d87-c8fe-4e53-b38a-19b0ff3f8e84">

I've been a bit sloppy and missed a few of these sorry whilst making the update to using `styled()` - I'm sorry about that and thanks @ianjon3s for tidying up behind me!

When using the `sx` prop, MUI should (and generally does) use the theme value for spacing, see example here directly from [MUI docs ](https://mui.com/system/getting-started/the-sx-prop/#spacing) - 

```jsx
<Box sx={{ margin: 2 }} />
// equivalent to margin: theme => theme.spacing(2)
```

The setup here of an `Icon` being passed in as a prop seems to be affecting this default behaviour. I've not found any open issues describing this on the MUI GitHub but will update if I can find an example.