### PR TITLE
chore: Use repo vars in GitHub actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,6 @@ env:
   FULL_DOMAIN: ${{ github.event.number }}.planx.pizza
   PULLREQUEST_ID: ${{ github.event.number }}
   EDITOR_DIRECTORY: editor.planx.uk
-  PNPM_VERSION: 7.8.0
-  NODE_VERSION: 18.16.1 # 18.16.1 = LTS
 
 permissions:
   pull-requests: write
@@ -80,10 +78,10 @@ jobs:
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
@@ -121,10 +119,10 @@ jobs:
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install dependencies
@@ -157,10 +155,10 @@ jobs:
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
@@ -186,11 +184,11 @@ jobs:
       - uses: pnpm/action-setup@v2.2.2
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
@@ -238,10 +236,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
@@ -438,11 +436,11 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: PNPM Install

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -10,8 +10,6 @@ concurrency: staging_environment
 
 env:
   DEPLOYMENT_ENVIRONMENT: staging
-  PNPM_VERSION: 7.8.0
-  NODE_VERSION: 18.16.1 # 18.16.1 = LTS
 
 jobs:
   build_react:
@@ -21,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
       # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
       - name: NPM cache
         uses: actions/cache@v3
@@ -47,7 +45,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: editor.planx.uk
       - run: pnpm build
@@ -75,14 +73,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
         working-directory: infrastructure/application
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -10,8 +10,6 @@ concurrency: production_environment
 
 env:
   DEPLOYMENT_ENVIRONMENT: production
-  PNPM_VERSION: 7.8.0
-  NODE_VERSION: 18.16.1 # 18.16.1 = LTS
 
 jobs:
   build_react:
@@ -21,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
       # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
       - name: NPM cache
         uses: actions/cache@v3
@@ -47,7 +45,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: editor.planx.uk
       - run: pnpm build
@@ -77,14 +75,14 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
         working-directory: infrastructure/application
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   EDITOR_DIRECTORY: editor.planx.uk
-  PNPM_VERSION: 7.8.0
-  NODE_VERSION: 18.16.1 # 18.16.1 = LTS
 
 jobs:
   integration_tests:
@@ -32,10 +30,10 @@ jobs:
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
@@ -71,10 +69,10 @@ jobs:
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install dependencies
@@ -105,10 +103,10 @@ jobs:
           fail: true
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
@@ -135,11 +133,11 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.2
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: ${{ vars.PNPM_VERSION }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: PNPM Install


### PR DESCRIPTION
Version numbers not updated, just where we get them from.

This is managed in https://github.com/theopensystemslab/planx-new/settings/variables/actions

It seems like a sensible option to simplify things a little, and make it a bit easier to reliably bump version numbers in future.

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/8dabbb5b-8396-4a15-9334-73a723069074)
