### PR TITLE
chore: Update font sizes to linear numbers

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -91,10 +91,10 @@ export default function ConfirmationComponent(props: Props) {
 
         {props.nextSteps && Boolean(props.nextSteps?.length) && (
           <Box pt={3}>
-            <Typography variant="h3" component="h2" mb={2}>
+            <Typography variant="h2" mb={2}>
               What happens next?
             </Typography>
-            <NumberedList items={props.nextSteps} heading="h3" />
+            <NumberedList items={props.nextSteps} heading="h2" />
           </Box>
         )}
 
@@ -110,7 +110,9 @@ export default function ConfirmationComponent(props: Props) {
         {props.contactInfo && (
           <>
             <Box py={1} color="primary.main">
-              <Typography variant="h3">Contact us</Typography>
+              <Typography variant="h2" component="h3">
+                Contact us
+              </Typography>
               <ReactMarkdownOrHtml source={props.contactInfo} />
             </Box>
           </>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -163,7 +163,7 @@ function Component(props: Props) {
                   padding: "1.5em 0 1em",
                 }}
               >
-                <Typography variant="h4" component="h2">
+                <Typography variant="h3" component="h2">
                   {`${capitalize(fileListCategory)} files`}
                 </Typography>
               </ListSubheader>,
@@ -181,7 +181,7 @@ function Component(props: Props) {
         </List>
       </DropzoneContainer>
       {Boolean(slots.length) && (
-        <Typography variant="h4" component="h3" mb={2}>
+        <Typography variant="h3" mb={2}>
           Your uploaded files
         </Typography>
       )}

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -87,9 +87,7 @@ const NoticeComponent: React.FC<Props> = (props) => {
           <Content>
             <TitleWrap>
               <ErrorOutline sx={{ width: 34, height: 34 }} />
-              <Title component="h3" variant="h4">
-                {props.title}
-              </Title>
+              <Title variant="h3">{props.title}</Title>
             </TitleWrap>
             <Box mt={2}>
               <ReactMarkdownOrHtml

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -64,7 +64,7 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
         <Card>
           <PayText>
             <Typography
-              variant="h3"
+              variant="h2"
               component={props.hideFeeBanner ? "h2" : "h3"}
             >
               {props.instructionsTitle || "How to pay"}
@@ -107,7 +107,7 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
       ) : (
         <Card handleSubmit={props.onConfirm} isValid>
           <ErrorSummary role="status" data-testid="error-summary">
-            <Typography variant="h5" component="h3" gutterBottom>
+            <Typography variant="h4" component="h3" gutterBottom>
               {props.error}
             </Typography>
             <Typography variant="body2">
@@ -147,7 +147,7 @@ export default function Confirm(props: Props) {
     <Box textAlign="left" width="100%">
       <>
         <Container maxWidth="md">
-          <Typography variant="h3" component="h1" align="left" pb={3}>
+          <Typography variant="h2" component="h1" align="left" pb={3}>
             {page === "Pay" ? props.title : props.secondaryPageTitle}
           </Typography>
         </Container>
@@ -160,7 +160,7 @@ export default function Confirm(props: Props) {
           >
             <Container maxWidth="md">
               <Typography
-                variant="h4"
+                variant="h3"
                 gutterBottom
                 className="marginBottom"
                 component="h2"

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -154,9 +154,7 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   ) : (
     <Card>
       <StyledForm onSubmit={formik.handleSubmit}>
-        <Typography variant="h3" component="h2">
-          {nomineeTitle}
-        </Typography>
+        <Typography variant="h2">{nomineeTitle}</Typography>
         {nomineeDescription && (
           <Typography variant="body2">
             <ReactMarkdownOrHtml
@@ -209,7 +207,7 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
             }}
           />
         </InputLabel>
-        <Typography variant="h3" component="h2" pt={2}>
+        <Typography variant="h2" pt={2}>
           {yourDetailsTitle}
         </Typography>
         {yourDetailsDescription && (

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -163,7 +163,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
         <Collapse in={showConstraintData}>
           <Box py={1.5} px={2}>
             <>
-              <Typography variant="h4" component="h4" gutterBottom>
+              <Typography variant="h3" component="h4" gutterBottom>
                 {`This property ${props?.content}`}
               </Typography>
               {Boolean(props.data?.length) && (

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -255,7 +255,7 @@ export function PlanningConstraintsContent(
       )}
       {positiveConstraints.length > 0 && (
         <>
-          <Typography variant="h4" component="h2" gutterBottom>
+          <Typography variant="h3" component="h2" gutterBottom>
             These are the planning constraints we think apply to this property
           </Typography>
           <ConstraintsList data={positiveConstraints} metadata={metadata} />
@@ -275,7 +275,7 @@ export function PlanningConstraintsContent(
       )}
       {positiveConstraints.length === 0 && negativeConstraints.length > 0 && (
         <>
-          <Typography variant="h4" component="h2">
+          <Typography variant="h3" component="h2">
             It looks like there are no constraints on this property
           </Typography>
           <Typography variant="body2">
@@ -319,7 +319,7 @@ interface ConstraintsFetchErrorProps {
 
 const ConstraintsFetchError = (props: ConstraintsFetchErrorProps) => (
   <ErrorSummaryContainer role="status" data-testid="error-summary-no-info">
-    <Typography variant="h5" component="h2" gutterBottom>
+    <Typography variant="h4" component="h2" gutterBottom>
       No information available
     </Typography>
     {props.error &&
@@ -353,7 +353,7 @@ const ConstraintsGraphError = (props: ConstraintsGraphErrorProps) => (
       role="status"
       data-testid="error-summary-invalid-graph"
     >
-      <Typography variant="h5" component="h2" gutterBottom>
+      <Typography variant="h4" component="h2" gutterBottom>
         Invalid graph
       </Typography>
       <Typography variant="body2">

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -52,7 +52,7 @@ function Component(props: PublicProps<PropertyInformation>) {
         role="status"
         data-testid="error-summary-invalid-graph"
       >
-        <Typography variant="h5" component="h2" gutterBottom>
+        <Typography variant="h4" component="h2" gutterBottom>
           Invalid graph
         </Typography>
         <Typography variant="body2">

--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -97,7 +97,7 @@ const ResultComponent: React.FC<Result> = (props) => {
       <ModalSection>
         <ModalSectionContent title="Result" Icon={ICONS[TYPES.Result]}>
           <InputRow>
-            <Typography variant="h6">
+            <Typography variant="h5" component="h6">
               <label htmlFor="result-flagSet">Flag set</label>
             </Typography>
             <select
@@ -116,7 +116,9 @@ const ResultComponent: React.FC<Result> = (props) => {
           </InputRow>
 
           <Box mt={2}>
-            <Typography variant="h6">Flag Text Overrides (optional)</Typography>
+            <Typography variant="h5" component="h6">
+              Flag Text Overrides (optional)
+            </Typography>
             <Typography variant="body2">
               The overrides you set here will change what is displayed to the
               user upon arriving at this result. If you provide no overrides,

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -131,7 +131,7 @@ const Result: React.FC<Props> = ({
         isValid
       >
         <Box mt={4} mb={3}>
-          <Typography variant="h3" component="h2" gutterBottom>
+          <Typography variant="h2" gutterBottom>
             {reasonsTitle}
           </Typography>
         </Box>
@@ -164,7 +164,7 @@ const Result: React.FC<Props> = ({
             <Box ml={1}>
               <Box display="flex" alignItems="center">
                 <DisclaimerHeading
-                  variant="h6"
+                  variant="h5"
                   component="h3"
                   color="text.primary"
                 >

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -43,7 +43,7 @@ export default function Component(props: Props) {
     <Card isValid handleSubmit={props.handleSubmit}>
       <QuestionHeader title={flowName} />
       <Box>
-        <Typography variant="h4" component="h2" pb="0.15em">
+        <Typography variant="h3" component="h2" pb="0.15em">
           Application incomplete.
         </Typography>
         <Typography variant="subtitle2" component="h3">

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfoSection.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfoSection.tsx
@@ -23,7 +23,7 @@ const MoreInfoSection: React.FC<IMoreInfoSection> = ({ title, children }) => {
   return (
     <Root className="MoreInfoSection-root" pb={3}>
       {title && (
-        <Typography mb={4} variant="h3" component="h2">
+        <Typography mb={4} variant="h2">
           {title}
         </Typography>
       )}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -62,7 +62,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           {title && (
             <Box mr={1} pt={0.5}>
               <Typography
-                variant="h3"
+                variant="h2"
                 role="heading"
                 aria-level={1}
                 component="h1"

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -160,7 +160,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
                 <Box sx={{ display: "flex", justifyContent: "space-between" }}>
                   <Typography
                     component={props.sectionComponent || "h2"}
-                    variant="h5"
+                    variant="h4"
                   >
                     {props.flow[`${Object.keys(sections[i])[0]}`]?.data?.title}
                   </Typography>

--- a/editor.planx.uk/src/components/ErrorFallback.tsx
+++ b/editor.planx.uk/src/components/ErrorFallback.tsx
@@ -11,7 +11,7 @@ function ErrorFallback(props: { error: Error }) {
   return (
     <Card>
       <ErrorSummaryContainer role="alert">
-        <Typography variant="h5" component="h1" gutterBottom>
+        <Typography variant="h4" component="h1" gutterBottom>
           Something went wrong
         </Typography>
         <Typography>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -362,7 +362,7 @@ const ServiceTitle: React.FC = () => {
 
   return (
     <ServiceTitleRoot data-testid="service-title">
-      <Typography component="span" variant="h5">
+      <Typography component="span" variant="h4">
         {flowName}
       </Typography>
     </ServiceTitleRoot>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -14,7 +14,7 @@ const DataManagerSettings = () => {
   return (
     <form onSubmit={formik.handleSubmit}>
       <Box pb={3}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h2" component="h3" gutterBottom>
           <strong>Data Manager</strong>
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -30,7 +30,9 @@ const TextInput: React.FC<{
     <Box mb={2} width="100%">
       <Box my={2} display="flex" alignItems="center">
         <Switch {...switchProps} color="primary" />
-        <Typography variant="h5">{title}</Typography>
+        <Typography variant="h4" component="h5">
+          {title}
+        </Typography>
       </Box>
       <Box mb={2}>
         {description && <Typography variant="body2">{description}</Typography>}
@@ -62,7 +64,7 @@ const DesignSettings: React.FC = () => {
   return (
     <form onSubmit={formik.handleSubmit}>
       <Box pb={3} borderBottom={1}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h2" component="h3" gutterBottom>
           <strong>Design</strong>
         </Typography>
         <Typography variant="body1">
@@ -83,7 +85,9 @@ const DesignSettings: React.FC = () => {
         <InputGroup>
           <InputRow>
             <InputRowLabel>
-              <Typography variant="h5">Background</Typography>
+              <Typography variant="h4" component="h5">
+                Background
+              </Typography>
             </InputRowLabel>
             <InputRowItem width="70%">
               <ColorPicker
@@ -95,7 +99,9 @@ const DesignSettings: React.FC = () => {
           </InputRow>
           <InputRow>
             <InputRowLabel>
-              <Typography variant="h5">Logo</Typography>
+              <Typography variant="h4" component="h5">
+                Logo
+              </Typography>
             </InputRowLabel>
             <InputRowItem width={50}>
               <PublicFileUploadButton />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -90,7 +90,7 @@ const ServiceFlags: React.FC<IServiceFlags> = ({ flagSets }) => {
   return (
     <form onSubmit={formik.handleSubmit}>
       <Box pb={3} borderBottom={1}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h2" component="h3" gutterBottom>
           <strong>Service flags</strong>
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -32,7 +32,9 @@ const TextInput: React.FC<{
     <Box mb={2} width="100%">
       <Box my={2} display="flex" alignItems="center">
         <Switch {...switchProps} color="primary" />
-        <Typography variant="h5">{title}</Typography>
+        <Typography variant="h4" component="h5">
+          {title}
+        </Typography>
       </Box>
       <Box mb={2}>
         {description && <Typography variant="body2">{description}</Typography>}
@@ -97,7 +99,7 @@ const ServiceSettings: React.FC = () => {
   return (
     <form onSubmit={formik.handleSubmit}>
       <Box py={3} borderBottom={1}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h2" component="h3" gutterBottom>
           <strong>Elements</strong>
         </Typography>
         <Typography variant="body1">
@@ -126,7 +128,7 @@ const ServiceSettings: React.FC = () => {
         />
       </Box>
       <Box pt={2}>
-        <Typography variant="h4">
+        <Typography variant="h3" component="h4">
           <strong>Footer Links</strong>
         </Typography>
         <InputGroup>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -50,7 +50,9 @@ const TeamMember = ({ name, email, userRole }: any) => {
           <StyledAvatar>{name[0]}</StyledAvatar>
         </Grid>
         <StyledGrid item>
-          <Typography variant="h5">{name}</Typography>
+          <Typography variant="h4" component="h5">
+            {name}
+          </Typography>
           <Box fontSize="h5.fontSize">{email}</Box>
         </StyledGrid>
         <Grid item>
@@ -85,7 +87,7 @@ const Team: React.FC = () => {
   return (
     <form onSubmit={formik.handleSubmit}>
       <Box pb={3} borderBottom={1}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h2" component="h3" gutterBottom>
           <strong>Team</strong>
         </Typography>
         <Typography variant="body1">
@@ -141,7 +143,7 @@ const Team: React.FC = () => {
         </Grid>
       </Box>
       <Box py={3}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant="h2" component="h3" gutterBottom>
           <strong>Sharing</strong>
         </Typography>
         <Typography variant="body1" gutterBottom>

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -49,7 +49,7 @@ function Component() {
         <Typography variant="h1">Global Settings</Typography>
         <Box mb={2}>
           <Box py={3} borderBottom={1}>
-            <Typography variant="h3" gutterBottom>
+            <Typography variant="h2" component="h3" gutterBottom>
               <strong>Footer Elements</strong>
             </Typography>
             <Typography variant="body1">

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -37,7 +37,7 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
         </Typography>
       </Banner>
       <Container maxWidth="md" sx={{ py: 4 }}>
-        <Typography variant="h3" component="h2" pb={2}>
+        <Typography variant="h2" pb={2}>
           You will be contacted
         </Typography>
         <List>
@@ -51,7 +51,7 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
           <li>to inform you whether a certificate has been granted or not</li>
         </List>
         <Divider sx={{ pt: 2 }} />
-        <Typography variant="h3" component="h2" pt={4} pb={2}>
+        <Typography variant="h2" pt={4} pb={2}>
           Contact us
         </Typography>
         <List>

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -87,7 +87,7 @@ const ReconciliationPage: React.FC<Props> = ({
             </Typography>
           </Box>
         )}
-        <Typography variant="h3" component="h2">
+        <Typography variant="h2">
           Review your {hasSections ? "progress" : "answers"} so far
         </Typography>
         {hasSections ? (

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -325,7 +325,7 @@ const Team: React.FC<{ id: number; slug: string }> = ({ id, slug }) => {
     <Root>
       <Dashboard>
         <Box pl={2} pb={2}>
-          <Typography variant="h3" component="h1" gutterBottom>
+          <Typography variant="h2" component="h1" gutterBottom>
             My services
           </Typography>
         </Box>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -38,14 +38,14 @@ const Teams: React.FC<Props> = ({ teams }) => {
     <Root>
       <Dashboard>
         <Box pl={2} pb={2}>
-          <Typography variant="h3" component="h1" gutterBottom>
+          <Typography variant="h2" component="h1" gutterBottom>
             Select a team
           </Typography>
         </Box>
         {teams.map(({ name, slug }) => (
           <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
             <Box mb={2.5} px={2.5} py={3} mx={2} component={Card}>
-              <Typography variant="h5" component="h2">
+              <Typography variant="h4" component="h2">
                 {name}
               </Typography>
             </Box>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -111,17 +111,21 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
         letterSpacing: SPACING_TIGHT,
         fontWeight: FONT_WEIGHT_BOLD,
       },
-      h3: {
+      h2: {
         fontSize: "2.25rem",
         letterSpacing: SPACING_TIGHT,
         fontWeight: FONT_WEIGHT_BOLD,
       },
-      h4: {
+      h3: {
         fontSize: "1.5rem",
         fontWeight: FONT_WEIGHT_SEMI_BOLD,
       },
-      h5: {
+      h4: {
         fontSize: "1.188rem",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+      },
+      h5: {
+        fontSize: "1rem",
         fontWeight: FONT_WEIGHT_SEMI_BOLD,
       },
       h6: {

--- a/editor.planx.uk/src/ui/ExpandableList.tsx
+++ b/editor.planx.uk/src/ui/ExpandableList.tsx
@@ -49,7 +49,7 @@ export function ExpandableListItem(props: {
         disableRipple
         onClick={handleToggle}
       >
-        <Typography variant="h5" component="h2" id={props.headingId}>
+        <Typography variant="h4" component="h2" id={props.headingId}>
           {props.title}
         </Typography>
         <Caret

--- a/editor.planx.uk/src/ui/NumberedList.tsx
+++ b/editor.planx.uk/src/ui/NumberedList.tsx
@@ -128,7 +128,7 @@ function ListItem(props: Item & { index: number; heading?: HeadingLevel }) {
       >
         <Box>
           <Typography
-            variant="h4"
+            variant="h3"
             component={props.heading || "h5"}
             id={`group-${props.index}-heading`}
             align="left"

--- a/editor.planx.uk/src/ui/Palette.stories.tsx
+++ b/editor.planx.uk/src/ui/Palette.stories.tsx
@@ -51,7 +51,9 @@ const ColorGrid: React.FC<{ option: PaletteOption }> = (props) => {
 
   return (
     <>
-      <Typography variant="h5">{props.option}</Typography>
+      <Typography variant="h4" component="h5">
+        {props.option}
+      </Typography>
       <Grid container spacing={1}>
         {colors.map((color, i) => {
           return (


### PR DESCRIPTION
PR updates heading tags to be sequential throughout the app.

Currently the theme and component files contain no `<h2>`, meaning that styles go straight from `<h1>` to `<h3>`.

PR bumps all styles from h3–6 up to h2–5, specifying or removing `component="x"` wherever necessary to maintain sequential headings in the DOM.