### PR TITLE
feat: Basic validation in 'Upload and label' modal

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -17,6 +17,7 @@ import capitalize from "lodash/capitalize";
 import merge from "lodash/merge";
 import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
+import ErrorWrapper from "ui/ErrorWrapper";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
@@ -27,6 +28,7 @@ import {
   removeSlots,
   resetAllSlots,
 } from "./model";
+import { fileListSchema, slotsSchema } from "./schema";
 
 interface FileTaggingModalProps {
   uploadedFiles: FileUploadSlot[];
@@ -35,11 +37,29 @@ interface FileTaggingModalProps {
   setShowModal: (value: React.SetStateAction<boolean>) => void;
 }
 
-export const FileTaggingModal = (props: FileTaggingModalProps) => {
+export const FileTaggingModal = ({
+  uploadedFiles,
+  fileList,
+  setFileList,
+  setShowModal,
+}: FileTaggingModalProps) => {
+  const [error, setError] = useState<string | undefined>();
+
+  const closeModal = () => setShowModal(false);
+
+  const handleSubmit = () => {
+    Promise.all([
+      slotsSchema.validate(uploadedFiles),
+      fileListSchema.validate(fileList, { context: { slots: uploadedFiles } }),
+    ])
+      .then(closeModal)
+      .catch((err) => setError(err.message));
+  };
+
   return (
     <Dialog
       open
-      onClose={() => props.setShowModal(false)}
+      onClose={closeModal}
       data-testid="file-tagging-dialog"
       maxWidth="xl"
       PaperProps={{
@@ -53,13 +73,13 @@ export const FileTaggingModal = (props: FileTaggingModalProps) => {
       }}
     >
       <DialogContent>
-        {props.uploadedFiles.map((slot) => (
+        {uploadedFiles.map((slot) => (
           <Box sx={{ mb: 4 }} key={`tags-per-file-container-${slot.id}`}>
             <UploadedFileCard {...slot} key={slot.id} />
             <SelectMultiple
               uploadedFile={slot}
-              fileList={props.fileList}
-              setFileList={props.setFileList}
+              fileList={fileList}
+              setFileList={setFileList}
             />
           </Box>
         ))}
@@ -71,13 +91,17 @@ export const FileTaggingModal = (props: FileTaggingModalProps) => {
           padding: 2,
         }}
       >
-        <Button
-          variant="contained"
-          onClick={() => props.setShowModal(false)}
-          sx={{ paddingLeft: 2 }}
-        >
-          Done
-        </Button>
+        <ErrorWrapper error={error}>
+          <Box>
+            <Button
+              variant="contained"
+              onClick={handleSubmit}
+              sx={{ paddingLeft: 2 }}
+            >
+              Done
+            </Button>
+          </Box>
+        </ErrorWrapper>
       </DialogActions>
     </Dialog>
   );

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -198,9 +198,7 @@ describe("Modal trigger", () => {
     );
 
     // Close modal
-    const closeModalButton = await within(fileTaggingModal).findByText("Done");
-    expect(closeModalButton).toBeVisible();
-    user.click(closeModalButton);
+    await user.keyboard("{Esc}");
     await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
 
     // Uploaded files displayed as cards
@@ -256,12 +254,20 @@ describe("Adding tags and syncing state", () => {
     const selects = await within(document.body).findAllByTestId("select");
     expect(selects).toHaveLength(1);
 
+    const submitModalButton = await within(fileTaggingModal).findByText("Done");
+    expect(submitModalButton).toBeVisible();
+
+    // Attempt to close without tagging files
+    user.click(submitModalButton);
+    const errorText = await within(fileTaggingModal).findByText(
+      "Please tag all files"
+    );
+    expect(errorText).toBeVisible();
+
     // Apply multiple tags to this file
     fireEvent.change(selects[0], { target: { value: "Roof plan" } });
 
-    // Close modal
-    const submitModalButton = await within(fileTaggingModal).findByText("Done");
-    expect(submitModalButton).toBeVisible();
+    // Close modal successfully
     user.click(submitModalButton);
     await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
 
@@ -322,9 +328,7 @@ describe("Adding tags and syncing state", () => {
     fireEvent.change(selects[0], { target: { value: "Utility bill" } });
 
     // Close modal
-    const submitModalButton = await within(fileTaggingModal).findByText("Done");
-    expect(submitModalButton).toBeVisible();
-    user.click(submitModalButton);
+    await user.keyboard("{Esc}");
     await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
 
     // Uploaded file displayed as card with chip tags

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -136,13 +136,11 @@ function Component(props: Props) {
       <QuestionHeader {...props} />
       <DropzoneContainer>
         <FileStatus status={fileUploadStatus} />
-        <ErrorWrapper error={validationError} id={props.id}>
-          <Dropzone
-            slots={slots}
-            setSlots={setSlots}
-            setFileUploadStatus={setFileUploadStatus}
-          />
-        </ErrorWrapper>
+        <Dropzone
+          slots={slots}
+          setSlots={setSlots}
+          setFileUploadStatus={setFileUploadStatus}
+        />
         <List
           disablePadding
           sx={{
@@ -180,36 +178,46 @@ function Component(props: Props) {
             ])}
         </List>
       </DropzoneContainer>
-      {Boolean(slots.length) && (
-        <Typography variant="h3" mb={2}>
-          Your uploaded files
-        </Typography>
-      )}
-      {showModal && (
-        <FileTaggingModal
-          uploadedFiles={slots}
-          fileList={fileList}
-          setFileList={setFileList}
-          setShowModal={setShowModal}
-        />
-      )}
-      {slots.map((slot) => {
-        return (
-          <UploadedFileCard
-            {...slot}
-            key={slot.id}
-            tags={getTagsForSlot(slot.id, fileList)}
-            onChange={() => setShowModal(true)}
-            removeFile={() => {
-              setSlots(
-                slots.filter((currentSlot) => currentSlot.file !== slot.file)
-              );
-              setFileUploadStatus(`${slot.file.path} was deleted`);
-              removeSlots(getTagsForSlot(slot.id, fileList), slot, fileList);
-            }}
-          />
-        );
-      })}
+      <ErrorWrapper error={validationError} id={props.id}>
+        <Box>
+          {Boolean(slots.length) && (
+            <Typography variant="h3" mb={2}>
+              Your uploaded files
+            </Typography>
+          )}
+          {showModal && (
+            <FileTaggingModal
+              uploadedFiles={slots}
+              fileList={fileList}
+              setFileList={setFileList}
+              setShowModal={setShowModal}
+            />
+          )}
+          {slots.map((slot) => {
+            return (
+              <UploadedFileCard
+                {...slot}
+                key={slot.id}
+                tags={getTagsForSlot(slot.id, fileList)}
+                onChange={() => setShowModal(true)}
+                removeFile={() => {
+                  setSlots(
+                    slots.filter(
+                      (currentSlot) => currentSlot.file !== slot.file
+                    )
+                  );
+                  setFileUploadStatus(`${slot.file.path} was deleted`);
+                  removeSlots(
+                    getTagsForSlot(slot.id, fileList),
+                    slot,
+                    fileList
+                  );
+                }}
+              />
+            );
+          })}
+        </Box>
+      </ErrorWrapper>
     </Card>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -12,7 +12,7 @@ import {
   useAnalyticsTracking,
 } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
 import ErrorWrapper from "ui/ErrorWrapper";
 import MoreInfoIcon from "ui/icons/MoreInfo";
@@ -86,6 +86,8 @@ function Component(props: Props) {
     if (previousSlotCount === undefined) return;
     // Only stop modal opening on initial return to node
     if (isUserReturningToNode) return setIsUserReturningToNode(false);
+    if (slots.length && dropzoneError) setDropzoneError(undefined);
+    if (!slots.length && fileListError) setFileListError(undefined);
     if (slots.length > previousSlotCount) setShowModal(true);
   }, [slots.length]);
 
@@ -93,7 +95,8 @@ function Component(props: Props) {
     undefined
   );
 
-  const [validationError, setValidationError] = useState<string | undefined>();
+  const [dropzoneError, setDropzoneError] = useState<string | undefined>();
+  const [fileListError, setFileListError] = useState<string | undefined>();
   const [showModal, setShowModal] = useState<boolean>(false);
   const [isUserReturningToNode, setIsUserReturningToNode] =
     useState<boolean>(false);
@@ -107,26 +110,17 @@ function Component(props: Props) {
         const payload = generatePayload(fileList);
         props.handleSubmit?.(payload);
       })
-      .catch((err) => {
-        setValidationError(err.message);
-      });
+      .catch((err) =>
+        err?.type === "min"
+          ? setDropzoneError(err?.message)
+          : setFileListError(err?.message)
+      );
   };
 
-  /**
-   * Declare a ref to hold a mutable copy the up-to-date validation error.
-   * The intention is to prevent frequent unnecessary update loops that clears the
-   * validation error state if it is already empty.
-   */
-  const validationErrorRef = useRef(validationError);
-  useEffect(() => {
-    validationErrorRef.current = validationError;
-  }, [validationError]);
-
-  useEffect(() => {
-    if (validationErrorRef.current) {
-      setValidationError(undefined);
-    }
-  }, [slots]);
+  const onUploadedFileCardChange = () => {
+    setFileListError(undefined);
+    setShowModal(true);
+  };
 
   return (
     <Card
@@ -136,11 +130,13 @@ function Component(props: Props) {
       <QuestionHeader {...props} />
       <DropzoneContainer>
         <FileStatus status={fileUploadStatus} />
-        <Dropzone
-          slots={slots}
-          setSlots={setSlots}
-          setFileUploadStatus={setFileUploadStatus}
-        />
+        <ErrorWrapper error={dropzoneError} id={`${props.id}-dropzone`}>
+          <Dropzone
+            slots={slots}
+            setSlots={setSlots}
+            setFileUploadStatus={setFileUploadStatus}
+          />
+        </ErrorWrapper>
         <List
           disablePadding
           sx={{
@@ -178,7 +174,7 @@ function Component(props: Props) {
             ])}
         </List>
       </DropzoneContainer>
-      <ErrorWrapper error={validationError} id={props.id}>
+      <ErrorWrapper error={fileListError} id={`${props.id}-fileList`}>
         <Box>
           {Boolean(slots.length) && (
             <Typography variant="h3" mb={2}>
@@ -199,7 +195,7 @@ function Component(props: Props) {
                 {...slot}
                 key={slot.id}
                 tags={getTagsForSlot(slot.id, fileList)}
-                onChange={() => setShowModal(true)}
+                onChange={onUploadedFileCardChange}
                 removeFile={() => {
                   setSlots(
                     slots.filter(


### PR DESCRIPTION
https://github.com/theopensystemslab/planx-new/assets/20502206/23b7d2d1-4164-43e7-b40f-e15bab3d1d20

 - Add additional validating of `FileList` on "Done"
 - Still allow users to exit modal with errors (click away or `Esc`) for a11y - validation will catch any issues on "Continue"
 - As with the current component, validation of for the entire state and not "per file" so the warning is at a global level
 - `ErrorWrapper` is moved to a more prominent location on the main component