### PR TITLE
chore: Temporarily turn off dependabot for IaC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,53 +127,53 @@ updates:
       - "theopensystemslab/planx"
   
   # Infrastructure
-  - package-ecosystem: "npm"
-    directory: "/infrastructure/application"
-    schedule:
-      interval: "daily"
-    labels:
-      - "infra/application"
-    open-pull-requests-limit: 1
-    commit-message:
-      prefix: "[skip pizza] "
-    reviewers:
-      - "theopensystemslab/planx"
+  # - package-ecosystem: "npm"
+  #   directory: "/infrastructure/application"
+  #   schedule:
+  #     interval: "daily"
+  #   labels:
+  #     - "infra/application"
+  #   open-pull-requests-limit: 1
+  #   commit-message:
+  #     prefix: "[skip pizza] "
+  #   reviewers:
+  #     - "theopensystemslab/planx"
 
-  - package-ecosystem: "npm"
-    directory: "/infrastructure/certificates"
-    schedule:
-      interval: "daily"
-    labels:
-      - "infra/certificates"
-    open-pull-requests-limit: 1
-    commit-message:
-      prefix: "[skip pizza] "
-    reviewers:
-      - "theopensystemslab/planx"
+  # - package-ecosystem: "npm"
+  #   directory: "/infrastructure/certificates"
+  #   schedule:
+  #     interval: "daily"
+  #   labels:
+  #     - "infra/certificates"
+  #   open-pull-requests-limit: 1
+  #   commit-message:
+  #     prefix: "[skip pizza] "
+  #   reviewers:
+  #     - "theopensystemslab/planx"
 
-  - package-ecosystem: "npm"
-    directory: "/infrastructure/data"
-    schedule:
-      interval: "daily"
-    labels:
-      - "infra/data"
-    open-pull-requests-limit: 1
-    commit-message:
-      prefix: "[skip pizza] "
-    reviewers:
-      - "theopensystemslab/planx"
+  # - package-ecosystem: "npm"
+  #   directory: "/infrastructure/data"
+  #   schedule:
+  #     interval: "daily"
+  #   labels:
+  #     - "infra/data"
+  #   open-pull-requests-limit: 1
+  #   commit-message:
+  #     prefix: "[skip pizza] "
+  #   reviewers:
+  #     - "theopensystemslab/planx"
 
-  - package-ecosystem: "npm"
-    directory: "/infrastructure/networking"
-    schedule:
-      interval: "daily"
-    labels:
-      - "infra/networking"
-    open-pull-requests-limit: 1
-    commit-message:
-      prefix: "[skip pizza] "
-    reviewers:
-      - "theopensystemslab/planx"
+  # - package-ecosystem: "npm"
+  #   directory: "/infrastructure/networking"
+  #   schedule:
+  #     interval: "daily"
+  #   labels:
+  #     - "infra/networking"
+  #   open-pull-requests-limit: 1
+  #   commit-message:
+  #     prefix: "[skip pizza] "
+  #   reviewers:
+  #     - "theopensystemslab/planx"
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
### Why I think we should do this...
 - IaC code has numerous dependencies major versions behind
 - Updating and testing these is difficult as it can only be done on staging / production
 - Testing here will be slow and could hold up CI pipelines whilst we work issues out

 
### I think a better approach here would be - 
 - Close open dependabot infra PRs
 - Document and use Sandbox environment (https://trello.com/c/H3mGuTjL/2497-document-and-turn-off-aws-sandbox-environment)
 - Update dependencies as it's own task, test on Sandbox (https://trello.com/c/U2Lmt4oK/2280-upgrade-infrastructure-dependencies)
 - Once looking good, merge to staging
 - Turn dependabot back on