### PR TITLE
chore: TS annotations for Storybook v7

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/AddressInput.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/AddressInput.stories.tsx
@@ -5,27 +5,32 @@ import React from "react";
 import Wrapper from "../fixtures/Wrapper";
 import Editor from "./Editor";
 import Public from "./Public";
+import AddressInputComponent from "./Public";
 
-export default {
+const meta = {
   title: "PlanX Components/AddressInput",
   component: Public,
-} as Meta;
+} satisfies Meta<typeof AddressInputComponent>;
 
-export const EmptyForm: StoryObj = {
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const EmptyForm = {
   args: {
     title: "Enter your address",
     description: "It might be where you live",
   },
-};
+} satisfies Story;
 
-export const EmptyFormWithHelpText: StoryObj = {
+export const EmptyFormWithHelpText = {
   args: {
     ...EmptyForm.args,
     howMeasured: "This is an example definition.",
   },
-};
+} satisfies Story;
 
-export const FilledForm: StoryObj = {
+export const FilledForm = {
   ...EmptyForm,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -48,7 +53,7 @@ export const FilledForm: StoryObj = {
     const submitButton = canvas.getByRole("button");
     await userEvent.click(submitButton);
   },
-};
+} satisfies Story;
 
 export const WithEditor = () => {
   return <Wrapper Editor={Editor} Public={Public} />;

--- a/editor.planx.uk/src/@planx/components/AddressInput/AddressInput.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/AddressInput.stories.tsx
@@ -5,12 +5,11 @@ import React from "react";
 import Wrapper from "../fixtures/Wrapper";
 import Editor from "./Editor";
 import Public from "./Public";
-import AddressInputComponent from "./Public";
 
 const meta = {
   title: "PlanX Components/AddressInput",
   component: Public,
-} satisfies Meta<typeof AddressInputComponent>;
+} satisfies Meta<typeof Public>;
 
 type Story = StoryObj<typeof meta>;
 


### PR DESCRIPTION
Follow up from conversation here - https://github.com/theopensystemslab/planx-new/pull/1910#discussion_r1254053772

I did a bit of reading up on Storybook v7 and TypeScript integration and this pattern looks like it works. We end up inheriting the expected props without everything being optional or having `| undefined` appended to its types. Docs / blog post here - https://storybook.js.org/blog/improved-type-safety-in-storybook-7/

Might be worth pulling this branch down @jessicamcinchak and just double checking that this works as expected.

If so I'm happy to go through and update v7 stories, or it can be picked up on your branch - whatever works 🙂 