### PR TITLE
feat: Next steps component build

### DIFF
--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -61,6 +61,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
         <Input
           required
           name="url"
+          type="url"
           value={props.value.url}
           onChange={(ev: ChangeEvent<HTMLInputElement>) => {
             props.onChange({

--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -1,3 +1,6 @@
+import Box from "@mui/material/Box";
+import type { NextSteps, Step } from "@planx/components/NextSteps/model";
+import { parseNextSteps } from "@planx/components/NextSteps/model";
 import { TYPES } from "@planx/components/types";
 import {
   EditorProps,
@@ -6,51 +9,113 @@ import {
   MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
-import React from "react";
+import React, { ChangeEvent } from "react";
 import Input from "ui/Input";
 import InputRow from "ui/InputRow";
+import ListManager, {
+  EditorProps as ListManagerEditorProps,
+} from "ui/ListManager";
 import ModalSection from "ui/ModalSection";
 import ModalSectionContent from "ui/ModalSectionContent";
 import RichTextInput from "ui/RichTextInput";
 
-import { NextSteps, parseContent } from "./model";
-
 type Props = EditorProps<TYPES.NextSteps, NextSteps>;
 
-export default NextSteps;
+const newStep = (): Step => ({
+  title: "",
+  description: "",
+  url: "",
+});
 
-function NextSteps(props: Props) {
+const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
+  return (
+    <Box sx={{ flex: 1 }}>
+      <InputRow>
+        <Input
+          required
+          name="title"
+          value={props.value.title}
+          onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+            props.onChange({
+              ...props.value,
+              title: ev.target.value,
+            });
+          }}
+          placeholder="Title"
+        />
+      </InputRow>
+      <InputRow>
+        <Input
+          name="description"
+          value={props.value.description}
+          onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+            props.onChange({
+              ...props.value,
+              description: ev.target.value,
+            });
+          }}
+          placeholder="Description"
+        />
+      </InputRow>
+      <InputRow>
+        <Input
+          required
+          name="url"
+          value={props.value.url}
+          onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+            props.onChange({
+              ...props.value,
+              url: ev.target.value,
+            });
+          }}
+          placeholder="url"
+        />
+      </InputRow>
+    </Box>
+  );
+};
+
+const NextStepsComponent: React.FC<Props> = (props) => {
   const formik = useFormik({
-    initialValues: parseContent(props.node?.data),
+    initialValues: parseNextSteps(props.node?.data),
     onSubmit: (newValues) => {
-      props.handleSubmit?.({
-        type: TYPES.NextSteps,
-        data: newValues,
-      });
+      if (props.handleSubmit) {
+        props.handleSubmit({ type: TYPES.NextSteps, data: newValues });
+      }
     },
+    validate: () => {},
   });
-
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Next steps" Icon={ICONS[TYPES.NextSteps]}>
-          <InputRow>
-            <Input
-              format="large"
-              name="title"
-              placeholder={formik.values.title}
-              value={formik.values.title}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <RichTextInput
-              name="description"
-              placeholder="Description"
-              value={formik.values.description}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
+        <ModalSectionContent title="Next Steps" Icon={ICONS[TYPES.NextSteps]}>
+          <Box mb="1rem">
+            <InputRow>
+              <Input
+                name="title"
+                value={formik.values.title}
+                onChange={formik.handleChange}
+                placeholder="Main Title"
+                format="large"
+              />
+            </InputRow>
+            <InputRow>
+              <RichTextInput
+                name="description"
+                value={formik.values.description}
+                onChange={formik.handleChange}
+                placeholder="Main Description"
+              />
+            </InputRow>
+          </Box>
+          <ListManager
+            values={formik.values.steps}
+            onChange={(steps: Array<Step>) => {
+              formik.setFieldValue("steps", steps);
+            }}
+            Editor={TaskEditor}
+            newValue={newStep}
+          />
         </ModalSectionContent>
       </ModalSection>
       <MoreInformation
@@ -62,9 +127,11 @@ function NextSteps(props: Props) {
       />
       <InternalNotes
         name="notes"
-        value={formik.values.notes}
         onChange={formik.handleChange}
+        value={formik.values.notes}
       />
     </form>
   );
-}
+};
+
+export default NextStepsComponent;

--- a/editor.planx.uk/src/@planx/components/NextSteps/NextSteps.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/NextSteps.stories.tsx
@@ -1,0 +1,43 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import Wrapper from "../fixtures/Wrapper";
+import Editor from "./Editor";
+import type { Props as PublicProps } from "./Public";
+import Public from "./Public";
+
+const metadata: Meta = {
+  title: "PlanX Components/NextSteps",
+  component: Public,
+  argTypes: {
+    handleSubmit: { control: { disable: true }, action: false },
+  },
+};
+
+export const Frontend: StoryObj<PublicProps> = {
+  args: {
+    title: "What would you like to do next?",
+    description: "The decision is yours.",
+    steps: [
+      {
+        title: "First option",
+        description: "Get advice before submitting continuing your project.",
+        url: "https://www.planx.uk",
+      },
+      {
+        title: "Second option",
+        description: "Find out how to submit an application.",
+        url: "https://www.planx.uk",
+      },
+      {
+        title: "Third option",
+        description: "Your progress will be automatically saved.",
+        url: "https://www.planx.uk",
+      },
+    ],
+  },
+};
+
+export const WithEditor = () => <Wrapper Editor={Editor} Public={Public} />;
+
+export default metadata;

--- a/editor.planx.uk/src/@planx/components/NextSteps/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Public.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { axe, setup } from "testUtils";
+
+import NextStepsComponent from "./Public";
+
+it("should not have any accessibility violations", async () => {
+  const { container } = setup(
+    <NextStepsComponent
+      title="title"
+      description="description"
+      steps={[
+        { title: "option 1", description: "", url: "" },
+        { title: "option 2", description: "", url: "" },
+      ]}
+    />,
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
@@ -1,5 +1,3 @@
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import React from "react";
 import NextStepsList from "ui/NextStepsList";

--- a/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
@@ -20,7 +20,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
         howMeasured={props.howMeasured}
       />
-      <NextStepsList items={props.steps} heading={"h2"} />
+      <NextStepsList items={props.steps} />
     </Card>
   );
 };

--- a/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
@@ -2,24 +2,27 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import React from "react";
+import NextStepsList from "ui/NextStepsList";
 
 import Card from "../shared/Preview/Card";
 import QuestionHeader from "../shared/Preview/QuestionHeader";
 import { NextSteps } from "./model";
 
-type Props = PublicProps<NextSteps>;
+export type Props = PublicProps<NextSteps>;
 
-export default Component;
-
-function Component(props: Props) {
+const NextStepsComponent: React.FC<Props> = (props) => {
   return (
-    <Card handleSubmit={props.handleSubmit} isValid>
-      <QuestionHeader {...props} />
-      <Box>
-        <Typography variant="h2" style={{ color: "orangered" }}>
-          UNDER DEVELOPMENT
-        </Typography>
-      </Box>
+    <Card>
+      <QuestionHeader
+        title={props.title}
+        description={props.description}
+        info={props.info}
+        policyRef={props.policyRef}
+        howMeasured={props.howMeasured}
+      />
+      <NextStepsList items={props.steps} heading={"h2"} />
     </Card>
   );
-}
+};
+
+export default NextStepsComponent;

--- a/editor.planx.uk/src/@planx/components/NextSteps/model.ts
+++ b/editor.planx.uk/src/@planx/components/NextSteps/model.ts
@@ -3,15 +3,21 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 export interface NextSteps extends MoreInformation {
   title: string;
   description: string;
-  fn: string;
+  steps: Array<Step>;
 }
 
-export const parseContent = (
-  data: Record<string, any> | undefined,
+export interface Step {
+  title: string;
+  description: string;
+  url: string;
+}
+
+export const parseNextSteps = (
+  data: Record<string, any> | undefined
 ): NextSteps => ({
+  steps: /* remove once migrated */ data?.taskList?.steps || data?.steps || [],
   title: data?.title || DEFAULT_TITLE,
   description: data?.description || "",
-  fn: data?.fn || "",
   ...parseMoreInformation(data),
 });
 

--- a/editor.planx.uk/src/@planx/components/NextSteps/model.ts
+++ b/editor.planx.uk/src/@planx/components/NextSteps/model.ts
@@ -13,9 +13,9 @@ export interface Step {
 }
 
 export const parseNextSteps = (
-  data: Record<string, any> | undefined
+  data: Record<string, any> | undefined,
 ): NextSteps => ({
-  steps: /* remove once migrated */ data?.taskList?.steps || data?.steps || [],
+  steps: data?.steps || [],
   title: data?.title || DEFAULT_TITLE,
   description: data?.description || "",
   ...parseMoreInformation(data),

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -1,6 +1,7 @@
+import EastIcon from "@mui/icons-material/East";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
-import { styled } from "@mui/material/styles";
+import { darken, styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
@@ -12,35 +13,82 @@ const List = styled("ol")(({ theme }) => ({
 
 const Step = styled("li")(({ theme }) => ({
   position: "relative",
+  display: "flex",
+  borderBottom: `1px solid ${theme.palette.secondary.main}`,
 }));
 
-type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+const Inner = styled(Link)(({ theme }) => ({
+  width: "100%",
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: theme.spacing(2, 0),
+  textDecoration: "none",
+  borderBottom: `1px solid theme.palette.text.secondary`,
+  // Manually set hover and focus behaviours as we are doing something outside of the usual button style
+  "&:hover > span": {
+    backgroundColor: theme.palette.primary.dark,
+  },
+  "&:hover h2": {
+    textDecorationThickness: "3px",
+  },
+  "&:focus > span": {
+    backgroundColor: theme.palette.text.primary,
+  },
+  "&:focus h2": {
+    textDecoration: "none",
+  },
+}));
+
+const Description = styled(Typography)(() => ({}));
+
+const ArrowButton = styled("span")(({ theme }) => ({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.common.white,
+  width: "50px",
+  height: "50px",
+  flexShrink: "0",
+}));
+
 interface Item {
   title: string;
   description: string;
   url: string;
 }
 
-function ListItem(props: Item & { index: number; heading?: HeadingLevel }) {
+function ListItem(props: Item) {
   return (
     <Step>
-      <Link href={props.url}>
-        <Box>
-          <Typography variant="h3" component={props.heading || "h5"}>
+      <Inner href={props.url}>
+        <Box pr={2}>
+          <Typography
+            variant="h3"
+            component="h2"
+            mb={0.75}
+            sx={{ textDecoration: "underline", textDecorationThickness: "1px" }}
+          >
             {props.title}
           </Typography>
+          <Description variant="body2" color="text.secondary">
+            {props.description}
+          </Description>
         </Box>
-        <Typography variant="body2">{props.description}</Typography>
-      </Link>
+        <ArrowButton>
+          <EastIcon />
+        </ArrowButton>
+      </Inner>
     </Step>
   );
 }
 
-function NextStepsList(props: { items: Item[]; heading?: HeadingLevel }) {
+function NextStepsList(props: { items: Item[] }) {
   return (
     <List>
       {props.items?.map((item, i) => (
-        <ListItem {...item} key={i} index={i} heading={props.heading} />
+        <ListItem {...item} key={i} />
       ))}
     </List>
   );

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -1,0 +1,49 @@
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+const List = styled("ol")(({ theme }) => ({
+  listStyle: "none",
+  margin: theme.spacing(3, 0, 0, 0),
+  padding: 0,
+}));
+
+const Step = styled("li")(({ theme }) => ({
+  position: "relative",
+}));
+
+type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+interface Item {
+  title: string;
+  description: string;
+  url: string;
+}
+
+function ListItem(props: Item & { index: number; heading?: HeadingLevel }) {
+  return (
+    <Step>
+      <Link href={props.url}>
+        <Box>
+          <Typography variant="h3" component={props.heading || "h5"}>
+            {props.title}
+          </Typography>
+        </Box>
+        <Typography variant="body2">{props.description}</Typography>
+      </Link>
+    </Step>
+  );
+}
+
+function NextStepsList(props: { items: Item[]; heading?: HeadingLevel }) {
+  return (
+    <List>
+      {props.items?.map((item, i) => (
+        <ListItem {...item} key={i} index={i} heading={props.heading} />
+      ))}
+    </List>
+  );
+}
+
+export default NextStepsList;

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -1,11 +1,11 @@
 import EastIcon from "@mui/icons-material/East";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
-import { darken, styled } from "@mui/material/styles";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-const List = styled("ol")(({ theme }) => ({
+const List = styled("ul")(({ theme }) => ({
   listStyle: "none",
   margin: theme.spacing(3, 0, 0, 0),
   padding: 0,

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -57,7 +57,7 @@ const ArrowButton = styled("span")(({ theme }) => ({
 function ListItem(props: Step) {
   return (
     <Step>
-      <Inner href={props.url}>
+      <Inner href={props.url} target="_blank" rel="noopener">
         <Box pr={2}>
           <Typography
             variant="h3"

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import type { Step } from "@planx/components/NextSteps/model";
 import React from "react";
 
 const List = styled("ul")(({ theme }) => ({
@@ -53,13 +54,7 @@ const ArrowButton = styled("span")(({ theme }) => ({
   flexShrink: "0",
 }));
 
-interface Item {
-  title: string;
-  description: string;
-  url: string;
-}
-
-function ListItem(props: Item) {
+function ListItem(props: Step) {
   return (
     <Step>
       <Inner href={props.url}>
@@ -84,13 +79,9 @@ function ListItem(props: Item) {
   );
 }
 
-function NextStepsList(props: { items: Item[] }) {
+function NextStepsList(props: { items: Step[] }) {
   return (
-    <List>
-      {props.items?.map((item, i) => (
-        <ListItem {...item} key={i} />
-      ))}
-    </List>
+    <List>{props.items?.map((item, i) => <ListItem {...item} key={i} />)}</List>
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
PR adds a new component named Next Steps.

I've constructed this using examples from other components. 

Bits I'm not sure on so far:
- The component does not have a continue button and I've tried to set this up accordingly, using the Confirmation component as an example.
- ~~The URL field is currently a text field, I'm expecting this should have a `type="url"` property added with validation, but wasn't sure how to bring this in.~~ update: added `type="url"`
- Model.ts has the commented text `/* remove once migrated */`, which was copied over from another file, does this need addressing? https://github.com/theopensystemslab/planx-new/pull/1957/files#diff-99e03f9ab40b152de3dbfa281c5ae664df487266dee9594485d388d0b4ae221cR18

Working example:
https://1957.planx.pizza/lambeth/next-steps-component/preview

Storybook example:
https://storybook.1957.planx.pizza/?path=/docs/planx-components-nextsteps--docs