### PR TITLE
fix: Handle arrays when updating node data

### DIFF
--- a/editor.planx.uk/src/@planx/graph/__tests__/update.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/update.test.ts
@@ -405,3 +405,178 @@ describe("error handling", () => {
     ).toThrow("id not found");
   });
 });
+
+describe("complex example with node data", () => {
+  describe("node with array", () => {
+    test("updating a non-array field", () => {
+      const dataFromFormik = {
+        title: "Upload and label",
+        description: "",
+        fn: "",
+        fileTypes: [
+          {
+            name: "11",
+            fn: "22",
+            rule: {
+              condition: "AlwaysRequired",
+            },
+          },
+        ],
+        hideDropZone: true,
+      };
+
+      const [graph, ops] = update(
+        "a",
+        dataFromFormik
+      )({
+        a: {
+          type: 145,
+          data: {
+            title: "Upload and label",
+            fileTypes: [
+              {
+                name: "11",
+                fn: "22",
+                rule: {
+                  condition: "AlwaysRequired",
+                },
+              },
+            ],
+            hideDropZone: false,
+          },
+        },
+      });
+
+      expect(graph).toEqual({
+        a: {
+          type: 145,
+          data: {
+            title: "Upload and label",
+            fileTypes: [
+              {
+                name: "11",
+                fn: "22",
+                rule: {
+                  condition: "AlwaysRequired",
+                },
+              },
+            ],
+            hideDropZone: true,
+          },
+        },
+      });
+
+      expect(ops).toEqual([
+        {
+          od: false,
+          oi: true,
+          p: ["a", "data", "hideDropZone"],
+        },
+      ]);
+    });
+
+    test("updating an array field", () => {
+      const dataFromFormik = {
+        title: "Upload and label",
+        description: "",
+        fn: "",
+        fileTypes: [
+          {
+            name: "11",
+            fn: "22",
+            rule: {
+              condition: "AlwaysRequired",
+            },
+          },
+          {
+            name: "33",
+            fn: "44",
+            rule: {
+              condition: "AlwaysRequired",
+            },
+          },
+        ],
+        hideDropZone: true,
+      };
+
+      const [graph, ops] = update(
+        "a",
+        dataFromFormik
+      )({
+        a: {
+          type: 145,
+          data: {
+            title: "Upload and label",
+            fileTypes: [
+              {
+                name: "11",
+                fn: "22",
+                rule: {
+                  condition: "AlwaysRequired",
+                },
+              },
+            ],
+            hideDropZone: true,
+          },
+        },
+      });
+
+      expect(graph).toEqual({
+        a: {
+          type: 145,
+          data: {
+            title: "Upload and label",
+            fileTypes: [
+              {
+                name: "11",
+                fn: "22",
+                rule: {
+                  condition: "AlwaysRequired",
+                },
+              },
+              {
+                name: "33",
+                fn: "44",
+                rule: {
+                  condition: "AlwaysRequired",
+                },
+              },
+            ],
+            hideDropZone: true,
+          },
+        },
+      });
+
+      expect(ops).toEqual([
+        {
+          od: [
+            {
+              name: "11",
+              fn: "22",
+              rule: {
+                condition: "AlwaysRequired",
+              },
+            },
+          ],
+          oi: [
+            {
+              name: "11",
+              fn: "22",
+              rule: {
+                condition: "AlwaysRequired",
+              },
+            },
+            {
+              name: "33",
+              fn: "44",
+              rule: {
+                condition: "AlwaysRequired",
+              },
+            },
+          ],
+          p: ["a", "data", "fileTypes"],
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
New PR cherry-picked from https://github.com/theopensystemslab/planx-new/pull/1952 to avoid rebase headaches! 🍒 

## What does this PR do?
- Fixes a bug in `_update()` where updates in an array in `node.data` is not handled correctly
- This bug results in arrays incorrectly getting a `remove` patch / operation when another property of the node is updated. See video below for demonstration of this on the `TaskList` component - 


https://github.com/theopensystemslab/planx-new/assets/20502206/05a1841a-14f0-4925-ad48-3ffc5fb9040c


## How are node updates handled?
Helpful model to have in mind here - I wasn't super familiar with this aspect of the codebase.

```mermaid
sequenceDiagram
    participant Editor
    participant Immer
    participant convert as convertPatchesToOps()
    participant ShareDB Client
    participant ShareDB Service
    participant Postgres

    Editor->>Immer: Add /remove / update node
    Immer->>convert: Produces patches
    convert->>ShareDB Client: Produces operations
    ShareDB Client->>ShareDB Service: Websockets API
    ShareDB Service->>Postgres: INSERT operations
    ShareDB Service->>Postgres: UPDATE flow

```