### PR TITLE
fix: Notice "Back to start" should reset `saveToEmail` and `sessionId`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview.test.ts
@@ -579,6 +579,28 @@ describe("changeAnswer", () => {
   });
 });
 
+describe("resetPreview", () => {
+  test("should reset preview state correctly for a local storage session", async () => {
+    setState({
+      sessionId: "123",
+    });
+
+    resetPreview();
+    expect(getState().sessionId).toBe("");
+  });
+
+  test("should reset preview state correctly for a save & return session", async () => {
+    setState({
+      sessionId: "123",
+      saveToEmail: "test@council.gov.uk",
+    });
+
+    resetPreview();
+    expect(getState().sessionId).toBe("");
+    expect(getState().saveToEmail).toBe("");
+  });
+});
+
 const mockBreadcrumbs = {
   mBFPszBssY: {
     auto: false,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -1,5 +1,6 @@
 import { ROOT_NODE_KEY } from "@planx/graph";
 import { capitalize } from "lodash";
+import { removeSessionIdSearchParam } from "utils";
 import type { StateCreator } from "zustand";
 
 import type { Store } from ".";
@@ -74,7 +75,10 @@ export const sharedStore: StateCreator<
       _nodesPendingEdit: [],
       restore: false,
       changedNode: undefined,
+      saveToEmail: "",
     });
+
+    removeSessionIdSearchParam();
   },
 
   setFlow({ id, flow, flowSlug }) {

--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -7,6 +7,7 @@ import Card from "@planx/components/shared/Preview/Card";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import Banner from "ui/Banner";
+import { removeSessionIdSearchParam } from "utils";
 
 import { makeCsvData } from "../../@planx/components/Send/uniform";
 import FileDownload from "../../ui/FileDownload";
@@ -51,14 +52,6 @@ const StatusPage: React.FC<Props> = ({
 
   const theme = useTheme();
 
-  // Drop sessionId from URL to route to ApplicationPath.SaveAndReturn, not ApplicationPath.Resume
-  const startNewApplication = () => {
-    const currentURL = new URL(window.location.href);
-    currentURL.searchParams.delete("sessionId");
-    window.history.pushState({}, document.title, currentURL);
-    window.location.reload();
-  };
-
   return (
     <>
       <Box width="100%">
@@ -97,7 +90,7 @@ const StatusPage: React.FC<Props> = ({
             <Typography variant="body2">or</Typography>
             <Link
               component="button"
-              onClick={startNewApplication}
+              onClick={removeSessionIdSearchParam}
               sx={{ mt: 2.5 }}
             >
               <Typography variant="body2">Start new application</Typography>

--- a/editor.planx.uk/src/utils.ts
+++ b/editor.planx.uk/src/utils.ts
@@ -55,3 +55,10 @@ export function slugify(name: string): string {
 
 export const isLiveEnv = () =>
   ["production", "staging", "pizza"].includes(process.env.NODE_ENV || "");
+
+export const removeSessionIdSearchParam = () => {
+  const currentURL = new URL(window.location.href);
+  currentURL.searchParams.delete("sessionId");
+  window.history.pushState({}, document.title, currentURL);
+  window.location.reload();
+};


### PR DESCRIPTION
Bug spotted here with notes on how to re-create: https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1689144968660159

Changes:
- `resetPreview` store method clears `saveToEmail` in addition to `sessionId`
- `resetPreview` store method should remove the `sessionId` search param from the URL if it exists

Testing:
- it works on both save & return sessions when `saveToEmail` & `sessionId` search param are defined and with local storage when they're not