### PR TITLE
chore: update Storybook components [Design System / Atoms and Molecules]

### DIFF
--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.stories.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import AnalyticsDisabledBanner from "./AnalyticsDisabledBanner";
+
+const meta = {
+  title: "Design System/Molecules/AnalyticsDisabledBanner",
+  component: AnalyticsDisabledBanner,
+} satisfies Meta<typeof AnalyticsDisabledBanner>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+/** Add `&analytics=false` to the end this page's URL to display the banner */
+export const Basic = {
+  render: () => <AnalyticsDisabledBanner />,
+} satisfies Story;

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.stories.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import DelayedLoadingIndicator from "./DelayedLoadingIndicator";
+
+const meta = {
+  title: "Design System/Molecules/DelayedLoadingIndicator",
+  component: DelayedLoadingIndicator,
+} satisfies Meta<typeof DelayedLoadingIndicator>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    msDelayBeforeVisible: 5,
+    text: "Loading...",
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/components/ErrorFallback.stories.tsx
+++ b/editor.planx.uk/src/components/ErrorFallback.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import ErrorFallback from "./ErrorFallback";
+
+const meta = {
+  title: "Design System/Molecules/ErrorFallback",
+  component: ErrorFallback,
+} satisfies Meta<typeof ErrorFallback>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    error: {
+      name: "Storybook test",
+      message: "Failed to fetch data",
+    },
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/components/Footer.stories.tsx
+++ b/editor.planx.uk/src/components/Footer.stories.tsx
@@ -1,11 +1,20 @@
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
-import { StoryFn } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import Logo from "ui/images/OGLLogo.svg";
 
-import Footer, { Props } from "./Footer";
+import Footer from "./Footer";
+
+const meta = {
+  title: "Design System/Molecules/Footer",
+  component: Footer,
+} satisfies Meta<typeof Footer>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
 
 export const Basic = {
   args: {
@@ -35,9 +44,4 @@ export const Basic = {
       </Box>
     ),
   },
-};
-
-export default {
-  title: "Design System/Molecules/Footer",
-  component: Footer,
-};
+} satisfies Story;

--- a/editor.planx.uk/src/components/Header.stories.tsx
+++ b/editor.planx.uk/src/components/Header.stories.tsx
@@ -1,17 +1,17 @@
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import PhaseBanner from "./PhaseBanner";
+import Header from "./Header";
 
 const meta = {
-  title: "Design System/Molecules/PhaseBanner",
-  component: PhaseBanner,
-} satisfies Meta<typeof PhaseBanner>;
+  title: "Design System/Molecules/Header",
+  component: Header,
+} satisfies Meta<typeof Header>;
 
 type Story = StoryObj<typeof meta>;
 
 export default meta;
 
 export const Basic = {
-  render: () => <PhaseBanner />,
+  render: () => <Header />,
 } satisfies Story;

--- a/editor.planx.uk/src/components/TestEnvironmentBanner.stories.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import TestEnvironmentBanner from "./TestEnvironmentBanner";
+
+const meta = {
+  title: "Design System/Molecules/TestEnvironmentBanner",
+  component: TestEnvironmentBanner,
+} satisfies Meta<typeof TestEnvironmentBanner>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+/** Will not display if the page URL includes .uk */
+export const Basic = {
+  render: () => <TestEnvironmentBanner />,
+} satisfies Story;

--- a/editor.planx.uk/src/ui/Banner.stories.tsx
+++ b/editor.planx.uk/src/ui/Banner.stories.tsx
@@ -1,0 +1,30 @@
+import Check from "@mui/icons-material/Check";
+import Typography from "@mui/material/Typography";
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import Banner from "./Banner";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/Banner",
+  component: Banner,
+} satisfies Meta<typeof Banner>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    heading: "Application completed",
+    Icon: Check,
+    iconTitle: "Success",
+    color: {
+      background: "#ffdd00",
+      text: "#000",
+    },
+    children: (
+      <Typography variant="body1">This is an optional description.</Typography>
+    ),
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/Checkbox.stories.tsx
+++ b/editor.planx.uk/src/ui/Checkbox.stories.tsx
@@ -1,21 +1,19 @@
-import { Meta } from "@storybook/react";
-import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
 
-import type { Props } from "./Checkbox";
 import Checkbox from "./Checkbox";
 
-const metadata: Meta = {
+const meta = {
   title: "Design System/Atoms/Form Elements/Checkbox",
   component: Checkbox,
-  argTypes: {
-    color: { control: "color" },
-  },
-};
+} satisfies Meta<typeof Checkbox>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
 
 export const Basic = {
   args: {
+    id: "storybook-test-0",
     checked: false,
   },
-};
-
-export default metadata;
+} satisfies Story;

--- a/editor.planx.uk/src/ui/ChecklistItem.stories.tsx
+++ b/editor.planx.uk/src/ui/ChecklistItem.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import ChecklistItem from "./ChecklistItem";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/ChecklistItem",
+  component: ChecklistItem,
+} satisfies Meta<typeof ChecklistItem>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    id: "option-a",
+    label: "Option A",
+    checked: false,
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/CollapsibleInput.stories.tsx
+++ b/editor.planx.uk/src/ui/CollapsibleInput.stories.tsx
@@ -1,20 +1,30 @@
 import FeedbackInput from "@planx/components/shared/FeedbackInput";
-import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
 import CollapsibleInput, { Props } from "./CollapsibleInput";
 
-const metadata: Meta = {
-  title: "Design System/Molecules/CollapsibleInput",
+const meta = {
+  title: "Design System/Atoms/Form Elements/CollapsibleInput",
   component: CollapsibleInput,
-};
+} satisfies Meta<typeof CollapsibleInput>;
 
-export const Basic: StoryObj<Props> = {
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// TODO clarify use of args.children versus render here
+export const Basic = {
+  args: {
+    name: "Feedback",
+    value: "feedback",
+    children: <p>This is a child element.</p>,
+  },
   render: (_args: Props) => {
     const [text, setText] = useState("");
     return (
       <FeedbackInput
-        text="Is this result inaccurate? **tell us why**"
+        text="Is this result inaccurate? **Tell us why**"
         handleChange={(ev) => {
           setText(ev.target.value);
         }}
@@ -22,6 +32,4 @@ export const Basic: StoryObj<Props> = {
       />
     );
   },
-};
-
-export default metadata;
+} satisfies Story;

--- a/editor.planx.uk/src/ui/ColorPicker.stories.tsx
+++ b/editor.planx.uk/src/ui/ColorPicker.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import ColorPicker from "./ColorPicker";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/ColorPicker",
+  component: ColorPicker,
+} satisfies Meta<typeof ColorPicker>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    label: "Pick a color",
+    inline: false,
+    color: "#ffdd00",
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/DateInput.stories.tsx
+++ b/editor.planx.uk/src/ui/DateInput.stories.tsx
@@ -1,21 +1,34 @@
-import { Meta } from "@storybook/react";
-import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
 
 import DateInput from "./DateInput";
 
-const metadata: Meta = {
+const meta = {
   title: "Design System/Atoms/Form Elements/DateInput",
   component: DateInput,
   argTypes: {
     onChange: { action: true, control: { disable: true } },
   },
-};
+} satisfies Meta;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
 
 export const Basic = {
-  render: (args: { value: string }) => (
-    <DateInput {...args} bordered onChange={() => {}} />
-  ),
-  args: { value: "2020-20-02" },
-};
+  args: {
+    label: "When will the works start?",
+    value: "2025-01-01",
+    bordered: true,
+    id: "date-input-0",
+  },
+} satisfies Story;
 
-export default metadata;
+export const WithError = {
+  args: {
+    label: "",
+    value: "2025-13-13",
+    bordered: true,
+    id: "date-input-0",
+    error: "Enter a valid date",
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/DescriptionList.stories.tsx
+++ b/editor.planx.uk/src/ui/DescriptionList.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import { DescriptionList } from "./DescriptionList";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/DescriptionList",
+  component: DescriptionList,
+} satisfies Meta<typeof DescriptionList>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    data: [
+      {
+        term: "Application type",
+        details: "Apply for planning permission",
+      },
+      {
+        term: "Reference number",
+        details: "1ab2-3c4d-5e6f",
+      },
+      {
+        term: "Valid until",
+        details: "2025-01-01",
+      },
+    ],
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/ExpandableList.stories.tsx
+++ b/editor.planx.uk/src/ui/ExpandableList.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { ExpandableList, ExpandableListItem } from "./ExpandableList";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/ExpandableList",
+  component: ExpandableList,
+} satisfies Meta<typeof ExpandableList>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    children: ["Option A", "Option B", "Option C"].map((option) => (
+      <ExpandableListItem
+        key={option}
+        expanded={option === "Option B" ? true : false}
+        headingId={`group-${option}-heading`}
+        groupId={`group-${option}-content`}
+        title={option}
+      >
+        <p>This is a description of the option.</p>
+      </ExpandableListItem>
+    )),
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/ExternalPlanningSiteDialog.stories.tsx
+++ b/editor.planx.uk/src/ui/ExternalPlanningSiteDialog.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import ExternalPlanningSiteDialog, {
+  DialogPurpose,
+} from "./ExternalPlanningSiteDialog";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/ExternalPlanningSiteDialog",
+  component: ExternalPlanningSiteDialog,
+} satisfies Meta<typeof ExternalPlanningSiteDialog>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    purpose: DialogPurpose.MissingProjectType,
+    teamSettings: {
+      externalPlanningSite: {
+        name: "Council website",
+        url: "test.gov.uk",
+      },
+    },
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/FileDownload.stories.tsx
+++ b/editor.planx.uk/src/ui/FileDownload.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import FileDownload from "./FileDownload";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/FileDownload",
+  component: FileDownload,
+} satisfies Meta<typeof FileDownload>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    filename: "application.csv",
+    data: [
+      {
+        question: "What are you applying about?",
+        responses: "Works to trees",
+        metadata: { section_name: "About your project" },
+      },
+    ],
+    text: "Download your application (.csv)",
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/ImgInput.stories.tsx
+++ b/editor.planx.uk/src/ui/ImgInput.stories.tsx
@@ -1,33 +1,17 @@
-import Box from "@mui/material/Box";
-import { Meta } from "@storybook/react";
-import React, { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
 
 import ImgInput from "./ImgInput";
 
-const metadata: Meta = {
-  title: "Design System/Atoms/Form Elements/Image Upload",
+const meta = {
+  title: "Design System/Atoms/Form Elements/ImageInput",
   component: ImgInput,
-};
+} satisfies Meta<typeof ImgInput>;
 
-export const Basic = () => {
-  const [imageUrl, setImageUrl] = useState<string | undefined>();
+type Story = StoryObj<typeof meta>;
 
-  return (
-    <>
-      <ImgInput onChange={setImageUrl} />
-      {imageUrl && (
-        <Box
-          width="20rem"
-          m={1}
-          border="1px solid black"
-          display="flex"
-          justifyContent="center"
-        >
-          <img src={imageUrl} style={{ width: "100%" }} alt="example" />
-        </Box>
-      )}
-    </>
-  );
-};
+export default meta;
 
-export default metadata;
+export const Basic = {
+  render: () => <ImgInput />,
+} satisfies Story;

--- a/editor.planx.uk/src/ui/Input.stories.tsx
+++ b/editor.planx.uk/src/ui/Input.stories.tsx
@@ -1,30 +1,35 @@
-import { Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 
 import Input from "./Input";
 
-const metadata: Meta = {
+const meta = {
   title: "Design System/Atoms/Form Elements/Input",
   component: Input,
-};
+} satisfies Meta<typeof Input>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
 
 export const Basic = {
   args: {
-    bordered: false,
-  },
-};
-
-export const WithError = {
-  args: {
     bordered: true,
-    errorMessage: "WRONG YOU'RE SIMPLY WRONG",
+    multiline: false,
+    rows: 1,
   },
-};
+} satisfies Story;
 
 export const Multiline = {
   args: {
     bordered: true,
     multiline: true,
+    rows: 3,
   },
-};
+} satisfies Story;
 
-export default metadata;
+export const WithError = {
+  args: {
+    bordered: true,
+    errorMessage: "Enter a value",
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/InputField.stories.tsx
+++ b/editor.planx.uk/src/ui/InputField.stories.tsx
@@ -1,20 +1,22 @@
-import { Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import InputField from "ui/InputField";
 
-const metadata: Meta = {
+const meta = {
   title: "Design System/Atoms/Form Elements/InputField",
   component: InputField,
-};
+} satisfies Meta<typeof InputField>;
+
+type Story = StoryObj<typeof InputField>;
+
+export default meta;
 
 export const Basic = {
   args: {
-    name: "Text",
-    multiline: true,
-    placeholder: "Portal name",
-    rows: 2,
+    name: "name",
+    placeholder: "Enter your name",
+    multiline: false,
+    rows: 1,
     disabled: false,
     required: false,
   },
-};
-
-export default metadata;
+} satisfies Story;

--- a/editor.planx.uk/src/ui/OptionButton.stories.tsx
+++ b/editor.planx.uk/src/ui/OptionButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from "@storybook/react";
+import OptionButton from "ui/OptionButton";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/OptionButton",
+  component: OptionButton,
+} satisfies Meta<typeof OptionButton>;
+
+type Story = StoryObj<typeof OptionButton>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    selected: false,
+    backgroundColor: "#F9F8F8",
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/Palette.stories.tsx
+++ b/editor.planx.uk/src/ui/Palette.stories.tsx
@@ -17,18 +17,20 @@ const metadata: Meta = {
 const ColorSwatch: React.FC<{ color: string; title: string }> = (props) => (
   <Grid item>
     <Box
-      height={100}
-      width={100}
-      bgcolor={props.color}
-      border="1px solid black"
       display="flex"
-      alignItems="center"
-      justifyContent="center"
-      padding={1}
-      margin={0}
+      flexDirection="column"
       flexShrink={1}
+      alignItems="flex-start"
+      marginX={0}
+      marginY={1}
     >
       <Typography variant="caption">{props.title}</Typography>
+      <Box
+        height={100}
+        width={150}
+        bgcolor={props.color}
+        border="1px solid #eee"
+      ></Box>
     </Box>
   </Grid>
 );
@@ -54,7 +56,7 @@ const ColorGrid: React.FC<{ option: PaletteOption }> = (props) => {
       <Typography variant="h4" component="h5">
         {props.option}
       </Typography>
-      <Grid container spacing={1}>
+      <Grid container>
         {colors.map((color, i) => {
           return (
             !color.match(/opacity/i) && (

--- a/editor.planx.uk/src/ui/Radio.stories.tsx
+++ b/editor.planx.uk/src/ui/Radio.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from "@storybook/react";
+import Radio from "ui/Radio";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/Radio",
+  component: Radio,
+} satisfies Meta<typeof Radio>;
+
+type Story = StoryObj<typeof Radio>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    value: "option-a",
+    options: [
+      {
+        label: "Option A",
+        value: "option-a",
+      },
+      {
+        label: "Option B",
+        value: "option-b",
+      },
+    ],
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/RichTextInput.stories.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.stories.tsx
@@ -7,13 +7,15 @@ import React, { useState } from "react";
 
 import RichTextInput, { fromHtml, injectVariables } from "./RichTextInput";
 
-const metadata: Meta = {
+const meta = {
   title: "Design System/Atoms/Form Elements/RichTextInput",
   component: RichTextInput,
   parameters: {
     controls: { hideNoControlsWarning: true },
   },
-};
+} satisfies Meta<typeof RichTextInput>;
+
+export default meta;
 
 export const Basic = () => {
   const [value, setValue] = useState<string>(
@@ -75,5 +77,3 @@ export const Basic = () => {
     </Grid>
   );
 };
-
-export default metadata;

--- a/editor.planx.uk/src/ui/SelectInput.stories.tsx
+++ b/editor.planx.uk/src/ui/SelectInput.stories.tsx
@@ -1,0 +1,26 @@
+import MenuItem from "@mui/material/MenuItem";
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import SelectInput from "ui/SelectInput";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/SelectInput",
+  component: SelectInput,
+} satisfies Meta<typeof SelectInput>;
+
+type Story = StoryObj<typeof SelectInput>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    value: "admin",
+    children: (
+      <>
+        <MenuItem value="admin">Admin</MenuItem>
+        <MenuItem>Edit</MenuItem>
+        <MenuItem>Read</MenuItem>
+      </>
+    ),
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/ui/VisibilityToggle.stories.tsx
+++ b/editor.planx.uk/src/ui/VisibilityToggle.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from "@storybook/react";
+import VisibilityToggle from "ui/VisibilityToggle";
+
+const meta = {
+  title: "Design System/Atoms/Form Elements/VisibilityToggle",
+  component: VisibilityToggle,
+} satisfies Meta<typeof VisibilityToggle>;
+
+type Story = StoryObj<typeof VisibilityToggle>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    visible: true,
+  },
+} satisfies Story;


### PR DESCRIPTION
Filling in a lot of gaps here, but haven't really sweated what's best categorised as a "Molecule", an "Atom" or otherwise yet - I figure we can revisit that more comprehensively later once we have better component coverage.

My general approach here is:
- Update type annotations & naming in existing stories
- Add new stories for un-documented components
- "Form elements" typically just get a "Basic" story, maybe an additional "With Error" story if applicable