### PR TITLE
fix: HTML or markdown detection

### DIFF
--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -45,8 +45,7 @@ export default function ReactMarkdownOrHtml(props: {
   if (typeof props.source !== "string") {
     return null;
   }
-  const containsHTMLTags = new RegExp(/<([A-Za-z]*)\b[^>]*>/);
-  if (containsHTMLTags) {
+  if (props.source.includes("</") || props.source.includes("<img")) {
     const replaceTarget = props.openLinksOnNewTab
       ? props.source.replaceAll(`target="_self"`, `target="_blank" external`)
       : props.source;

--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -45,7 +45,7 @@ export default function ReactMarkdownOrHtml(props: {
   if (typeof props.source !== "string") {
     return null;
   }
-  if (props.source.includes("</") || props.source.includes("<img")) {
+  if (props.source.includes("</" || "<img")) {
     const replaceTarget = props.openLinksOnNewTab
       ? props.source.replaceAll(`target="_self"`, `target="_blank" external`)
       : props.source;


### PR DESCRIPTION
PR fixes a regression where markdown was been rendered as source code in the planning constraints component.

Not an ideal solution but could work as a patch for now.