### PR TITLE
feat(ci): CloudFlare proxy for Hasura console

### DIFF
--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -1,6 +1,6 @@
 ## BASE ##
 # 18.16.1 = LTS
-FROM --platform=linux/amd64 node:18.16.1-alpine as base
+FROM node:18.16.1-alpine as base
 
 RUN apk add --no-cache git # required for fetching git dependencies
 
@@ -19,7 +19,7 @@ RUN pnpm install --recursive --prefer-offline
 RUN pnpm build
 RUN pnpm prune --production
 
-FROM --platform=linux/amd64 node:18.16.1-alpine as production
+FROM node:18.16.1-alpine as production
 WORKDIR /api
 
 ## PRODUCTION ##

--- a/hasura.planx.uk/Dockerfile
+++ b/hasura.planx.uk/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 hasura/graphql-engine:v2.8.4.cli-migrations-v2
+FROM hasura/graphql-engine:v2.8.4.cli-migrations-v2
 WORKDIR /
 COPY metadata hasura-metadata
 COPY migrations hasura-migrations

--- a/hasura.planx.uk/proxy/Caddyfile
+++ b/hasura.planx.uk/proxy/Caddyfile
@@ -15,7 +15,7 @@
 	# Update response headers
 	header {
 		# Enable HSTS
-		# Strict-Transport-Security "max-age=15552000; includeSubDomains"
+		Strict-Transport-Security "max-age=15552000; includeSubDomains"
 
 		# Disable clients from sniffing the media type
 		X-Content-Type-Options nosniff

--- a/hasura.planx.uk/proxy/Caddyfile
+++ b/hasura.planx.uk/proxy/Caddyfile
@@ -14,16 +14,16 @@
 
 	# Update response headers
 	header {
-	  # Enable HSTS
-	  Strict-Transport-Security "max-age=15552000; includeSubDomains"
+		# Enable HSTS
+		# Strict-Transport-Security "max-age=15552000; includeSubDomains"
 
-	  # Disable clients from sniffing the media type
-	  X-Content-Type-Options nosniff
+		# Disable clients from sniffing the media type
+		X-Content-Type-Options nosniff
 
-	  # Clickjacking protection
-	  X-Frame-Options DENY
+		# Clickjacking protection
+		X-Frame-Options DENY
 
-	  # Do not leak server information
-	  -Server
+		# Do not leak server information
+		-Server
 	}
 }

--- a/hasura.planx.uk/proxy/Dockerfile
+++ b/hasura.planx.uk/proxy/Dockerfile
@@ -1,2 +1,2 @@
-FROM --platform=linux/amd64 caddy:2.6.4-alpine
+FROM caddy:2.6.4-alpine
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/infrastructure/application/package.json
+++ b/infrastructure/application/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "setup-sandbox-env": "REACT_APP_GOOGLE_OAUTH_OVERRIDE=https://api.editor.planx.dev REACT_APP_API_URL=https://api.planx.in REACT_APP_HASURA_URL=https://hasura.planx.in/v1/graphql REACT_APP_SHAREDB_URL=wss://sharedb.planx.in",
     "build-editor": "cd ../../editor.planx.uk && pnpm build",
-    "sandbox:up": "pnpm setup-sandbox-env pnpm build-editor && pulumi up --stack sandbox",
+    "sandbox:up": "pnpm setup-sandbox-env pnpm build-editor && DOCKER_DEFAULT_PLATFORM=linux/amd64 pulumi up --stack sandbox",
     "sandbox:down": "pulumi down --stack sandbox",
-    "sandbox:refresh": "pnpm setup-sandbox-env pnpm build-editor && pulumi up --refresh --stack sandbox"
+    "sandbox:refresh": "pnpm setup-sandbox-env pnpm build-editor && DOCKER_DEFAULT_PLATFORM=linux/amd64 pulumi up --refresh --stack sandbox"
   },
   "pnpm": {
     "overrides": {

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -37,17 +37,17 @@ export const createHasuraService = async ({
     },
   });
   // // Forward HTTP to HTTPS
-  // const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
-  //   protocol: "HTTP",
-  //   defaultAction: {
-  //     type: "redirect",
-  //     redirect: {
-  //       protocol: "HTTPS",
-  //       port: "443",
-  //       statusCode: "HTTP_301",
-  //     },
-  //   },
-  // });
+  const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
+    protocol: "HTTP",
+    defaultAction: {
+      type: "redirect",
+      redirect: {
+        protocol: "HTTPS",
+        port: "443",
+        statusCode: "HTTP_301",
+      },
+    },
+  });
   
   const hasuraListenerHttps = targetHasura.createListener("hasura-https", {
     protocol: "HTTPS",
@@ -129,6 +129,6 @@ export const createHasuraService = async ({
     zoneId: config.require("cloudflare-zone-id"),
     value: hasuraListenerHttps.endpoint.hostname,
     ttl: 1,
-    proxied: true,
+    proxied: false,
   });
 }

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -35,25 +35,8 @@ export const createHasuraService = async ({
     healthCheck: {
       path: "/healthz",
     },
-  });
-  // // Forward HTTP to HTTPS
-  const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
-    protocol: "HTTP",
-    defaultAction: {
-      type: "redirect",
-      redirect: {
-        protocol: "HTTPS",
-        port: "443",
-        statusCode: "HTTP_301",
-      },
-    },
-  });
-  
-  const hasuraListenerHttps = targetHasura.createListener("hasura-https", {
-    protocol: "HTTPS",
-    sslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
-    certificateArn: certificates.requireOutput("certificateArn"),
-  });
+  });  
+  const hasuraListenerHttp = targetHasura.createListener("hasura-http", { protocol: "HTTP" });
 
   // hasuraService is composed of two tightly coupled containers
   // hasuraProxy is publicly exposed (behind the load balancer) and reverse proxies requests to hasura
@@ -70,7 +53,7 @@ export const createHasuraService = async ({
         hasuraProxy: {
           image: repo.buildAndPushImage("../../hasura.planx.uk/proxy"),
           memory: 1024 /*MB*/,
-          portMappings: [hasuraListenerHttps],
+          portMappings: [hasuraListenerHttp],
           environment: [
             { name: "HASURA_PROXY_PORT", value: String(HASURA_PROXY_PORT) },
             { name: "HASURA_NETWORK_LOCATION", value: "localhost" },
@@ -127,8 +110,8 @@ export const createHasuraService = async ({
       : "hasura",
     type: "CNAME",
     zoneId: config.require("cloudflare-zone-id"),
-    value: hasuraListenerHttps.endpoint.hostname,
+    value: hasuraListenerHttp.endpoint.hostname,
     ttl: 1,
-    proxied: false,
+    proxied: true,
   });
 }

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -36,18 +36,18 @@ export const createHasuraService = async ({
       path: "/healthz",
     },
   });
-  // Forward HTTP to HTTPS
-  const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
-    protocol: "HTTP",
-    defaultAction: {
-      type: "redirect",
-      redirect: {
-        protocol: "HTTPS",
-        port: "443",
-        statusCode: "HTTP_301",
-      },
-    },
-  });
+  // // Forward HTTP to HTTPS
+  // const hasuraListenerHttp = targetHasura.createListener("hasura-http", {
+  //   protocol: "HTTP",
+  //   defaultAction: {
+  //     type: "redirect",
+  //     redirect: {
+  //       protocol: "HTTPS",
+  //       port: "443",
+  //       statusCode: "HTTP_301",
+  //     },
+  //   },
+  // });
   
   const hasuraListenerHttps = targetHasura.createListener("hasura-https", {
     protocol: "HTTPS",
@@ -129,6 +129,6 @@ export const createHasuraService = async ({
     zoneId: config.require("cloudflare-zone-id"),
     value: hasuraListenerHttps.endpoint.hostname,
     ttl: 1,
-    proxied: false,
+    proxied: true,
   });
 }

--- a/sharedb.planx.uk/Dockerfile
+++ b/sharedb.planx.uk/Dockerfile
@@ -1,5 +1,5 @@
 # 18.16.1 = LTS
-FROM --platform=linux/amd64 node:18.16.1-alpine as base
+FROM node:18.16.1-alpine as base
 
 WORKDIR /sharedb
 RUN npm install -g pnpm@8.6.6


### PR DESCRIPTION
## What does this PR do?
 - Remove HTTP -> HTTPS forwarding on AWS, and turn on CloudFlare proxying. See [docs here](https://developers.cloudflare.com/ssl/troubleshooting/too-many-redirects/#flexible-encryption-mode).

> If your domain’s encryption mode is set to [Flexible](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/flexible/), Cloudflare sends unencrypted requests to your origin server over HTTP.
>
> Redirect loops will occur if your origin server automatically redirects all HTTP requests to HTTPS.
>
> To solve this issue, either **remove HTTPS redirects from your origin server** or update your SSL/TLS Encryption Mode to be [Full](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full/) or higher (requires an SSL certificate configured at your origin server).

 - Fix docker builds on M1 Macs by replacing the `--platform` flag with injecting the `DOCKER_DEFAULT_PLATFORM` env var into the build command. This ensures that - 
   - Dev environment can be run multi-platform
   - Images built locally and deployed to AWS will always run on `linux/amd64`

### Next steps...
 - Merge to staging and test
 - Remove Caddy from our infrastructure as CloudFlare can handle all it's responsibilities and simplify things
 - Try to turn on CloudFlare proxying for the frontend

https://github.com/theopensystemslab/planx-new/assets/20502206/a978644b-af20-4dd3-ac0e-e665ea7cc3f4