### PR TITLE
feat: mobile styles update

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -4,7 +4,6 @@ import { styled } from "@mui/material/styles";
 import type { Checklist, Group } from "@planx/components/Checklist/model";
 import ImageButton from "@planx/components/shared/Buttons/ImageButton";
 import Card from "@planx/components/shared/Preview/Card";
-import { fullWidthContent } from "@planx/components/shared/Preview/MapContainer";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { useFormik } from "formik";
 import React, { useState } from "react";
@@ -12,6 +11,7 @@ import ChecklistItem from "ui/ChecklistItem";
 import ErrorWrapper from "ui/ErrorWrapper";
 import { ExpandableList, ExpandableListItem } from "ui/ExpandableList";
 import FormWrapper from "ui/FormWrapper";
+import FullWidthWrapper from "ui/FullWidthWrapper";
 import { array, object } from "yup";
 
 import { Option } from "../shared";
@@ -46,10 +46,6 @@ function getFlatOptions({
   }
   return [];
 }
-
-const FullWidthContainer = styled(Box)(({ theme }) => ({
-  ...fullWidthContent(theme),
-}));
 
 const ChecklistComponent: React.FC<Props> = ({
   allRequired,
@@ -143,7 +139,7 @@ const ChecklistComponent: React.FC<Props> = ({
         howMeasured={howMeasured}
         img={img}
       />
-      <FullWidthContainer>
+      <FullWidthWrapper>
         <ErrorWrapper error={formik.errors.checked} id={id}>
           <Grid container spacing={layout === ChecklistLayout.Images ? 2 : 0}>
             {options ? (
@@ -227,7 +223,7 @@ const ChecklistComponent: React.FC<Props> = ({
             ) : null}
           </Grid>
         </ErrorWrapper>
-      </FullWidthContainer>
+      </FullWidthWrapper>
     </Card>
   );
 

--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -198,7 +198,8 @@ const ChecklistComponent: React.FC<Props> = ({
                           title={group.title}
                         >
                           <Box
-                            py={2}
+                            pt={0.5}
+                            pb={2}
                             aria-labelledby={`group-${index}-heading`}
                             id={`group-${index}-content`}
                             data-testid={`group-${index}${

--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -3,7 +3,6 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import type { Content } from "@planx/components/Content/model";
 import Card from "@planx/components/shared/Preview/Card";
-import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { PublicProps } from "@planx/components/ui";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
@@ -26,11 +25,6 @@ const Content = styled(Box, {
 const ContentComponent: React.FC<Props> = (props) => {
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
-      <QuestionHeader
-        info={props.info}
-        policyRef={props.policyRef}
-        howMeasured={props.howMeasured}
-      />
       <Content {...props} data-testid="content">
         <ReactMarkdownOrHtml
           source={props.content}

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -116,25 +116,25 @@ export default function Component(props: Props) {
               resetControlImage="trash"
               osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
             />
-            <MapFooter>
-              <Typography variant="body2">
-                The site outline you have drawn is{" "}
-                <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
-              </Typography>
-              {!props.hideFileUpload && (
-                <Link
-                  component="button"
-                  onClick={() => setPage("upload")}
-                  disabled={Boolean(boundary)}
-                  data-testid="upload-file-button"
-                >
-                  <Typography variant="body2">
-                    Upload a location plan instead
-                  </Typography>
-                </Link>
-              )}
-            </MapFooter>
           </MapContainer>
+          <MapFooter>
+            <Typography variant="body1">
+              The site outline you have drawn is{" "}
+              <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
+            </Typography>
+            {!props.hideFileUpload && (
+              <Link
+                component="button"
+                onClick={() => setPage("upload")}
+                disabled={Boolean(boundary)}
+                data-testid="upload-file-button"
+              >
+                <Typography variant="body1">
+                  Upload a location plan instead
+                </Typography>
+              </Link>
+            )}
+          </MapFooter>
         </>
       );
     } else if (page === "upload") {

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -14,6 +14,7 @@ import type { PublicProps } from "@planx/components/ui";
 import type { Geometry } from "@turf/helpers";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { DrawBoundary, PASSPORT_UPLOAD_KEY } from "../model";
 
@@ -120,7 +121,13 @@ export default function Component(props: Props) {
           <MapFooter>
             <Typography variant="body1">
               The site outline you have drawn is{" "}
-              <strong>{area?.toLocaleString("en-GB") ?? 0} m²</strong>
+              <Typography
+                component="span"
+                noWrap
+                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+              >
+                {area?.toLocaleString("en-GB") ?? 0} m²
+              </Typography>
             </Typography>
             {!props.hideFileUpload && (
               <Link

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -15,6 +15,7 @@ import type { Geometry } from "@turf/helpers";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import FullWidthWrapper from "ui/FullWidthWrapper";
 
 import { DrawBoundary, PASSPORT_UPLOAD_KEY } from "../model";
 
@@ -88,60 +89,62 @@ export default function Component(props: Props) {
             howMeasured={props.howMeasured}
             definitionImg={props.definitionImg}
           />
-          <MapContainer environment={environment} size="large">
-            <p style={visuallyHidden}>
-              An interactive map centred on your address, with a red pointer to
-              draw your site outline. Click to place points and connect the
-              lines to make your site. Once you've closed the site shape, click
-              and drag the lines to modify it.
-            </p>
-            {!props.hideFileUpload && (
+          <FullWidthWrapper>
+            <MapContainer environment={environment} size="large">
               <p style={visuallyHidden}>
-                If you cannot draw, you can upload a location plan file using
-                the link below.
+                An interactive map centred on your address, with a red pointer
+                to draw your site outline. Click to place points and connect the
+                lines to make your site. Once you've closed the site shape,
+                click and drag the lines to modify it.
               </p>
-            )}
-            {/* @ts-ignore */}
-            <my-map
-              id="draw-boundary-map"
-              drawMode
-              drawPointer="crosshair"
-              drawGeojsonData={JSON.stringify(boundary)}
-              zoom={20}
-              maxZoom={23}
-              latitude={Number(passport?.data?._address?.latitude)}
-              longitude={Number(passport?.data?._address?.longitude)}
-              showMarker
-              markerLatitude={Number(passport?.data?._address?.latitude)}
-              markerLongitude={Number(passport?.data?._address?.longitude)}
-              resetControlImage="trash"
-              osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
-            />
-          </MapContainer>
-          <MapFooter>
-            <Typography variant="body1">
-              The site outline you have drawn is{" "}
-              <Typography
-                component="span"
-                noWrap
-                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
-              >
-                {area?.toLocaleString("en-GB") ?? 0} m²
-              </Typography>
-            </Typography>
-            {!props.hideFileUpload && (
-              <Link
-                component="button"
-                onClick={() => setPage("upload")}
-                disabled={Boolean(boundary)}
-                data-testid="upload-file-button"
-              >
-                <Typography variant="body1">
-                  Upload a location plan instead
+              {!props.hideFileUpload && (
+                <p style={visuallyHidden}>
+                  If you cannot draw, you can upload a location plan file using
+                  the link below.
+                </p>
+              )}
+              {/* @ts-ignore */}
+              <my-map
+                id="draw-boundary-map"
+                drawMode
+                drawPointer="crosshair"
+                drawGeojsonData={JSON.stringify(boundary)}
+                zoom={20}
+                maxZoom={23}
+                latitude={Number(passport?.data?._address?.latitude)}
+                longitude={Number(passport?.data?._address?.longitude)}
+                showMarker
+                markerLatitude={Number(passport?.data?._address?.latitude)}
+                markerLongitude={Number(passport?.data?._address?.longitude)}
+                resetControlImage="trash"
+                osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
+              />
+            </MapContainer>
+            <MapFooter>
+              <Typography variant="body1">
+                The site outline you have drawn is{" "}
+                <Typography
+                  component="span"
+                  noWrap
+                  sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+                >
+                  {area?.toLocaleString("en-GB") ?? 0} m²
                 </Typography>
-              </Link>
-            )}
-          </MapFooter>
+              </Typography>
+              {!props.hideFileUpload && (
+                <Link
+                  component="button"
+                  onClick={() => setPage("upload")}
+                  disabled={Boolean(boundary)}
+                  data-testid="upload-file-button"
+                >
+                  <Typography variant="body1">
+                    Upload a location plan instead
+                  </Typography>
+                </Link>
+              )}
+            </MapFooter>
+          </FullWidthWrapper>
         </>
       );
     } else if (page === "upload") {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -56,6 +56,7 @@ export const FileTaggingModal = ({
           borderRadius: 0,
           borderTop: (theme) => `20px solid ${theme.palette.primary.main}`,
           background: "#FFF",
+          margin: (theme) => theme.spacing(2),
         },
       }}
     >

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -5,7 +5,6 @@ import ListItem from "@mui/material/ListItem";
 import ListSubheader from "@mui/material/ListSubheader";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { fullWidthContent } from "@planx/components/shared/Preview/MapContainer";
 import { PublicProps } from "@planx/components/ui";
 import capitalize from "lodash/capitalize";
 import {
@@ -16,6 +15,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
 import ErrorWrapper from "ui/ErrorWrapper";
+import FullWidthWrapper from "ui/FullWidthWrapper";
 import MoreInfoIcon from "ui/icons/MoreInfo";
 import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 import { emptyContent } from "ui/RichTextInput";
@@ -45,10 +45,6 @@ import {
 import { fileListSchema, slotsSchema } from "./schema";
 
 type Props = PublicProps<FileUploadAndLabel>;
-
-const FullWidthContainer = styled(Box)(({ theme }) => ({
-  ...fullWidthContent(theme),
-}));
 
 const DropzoneContainer = styled(Box)(({ theme }) => ({
   display: "grid",
@@ -136,7 +132,7 @@ function Component(props: Props) {
         slots.every((slot) => slot.url && slot.status === "success")
       }
     >
-      <FullWidthContainer>
+      <FullWidthWrapper>
         <QuestionHeader {...props} />
         <DropzoneContainer>
           {!props.hideDropZone && (
@@ -230,7 +226,7 @@ function Component(props: Props) {
             })}
           </Box>
         </ErrorWrapper>
-      </FullWidthContainer>
+      </FullWidthWrapper>
     </Card>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -52,6 +52,7 @@ const FullWidthContainer = styled(Box)(({ theme }) => ({
 
 const DropzoneContainer = styled(Box)(({ theme }) => ({
   display: "grid",
+  marginTop: theme.spacing(2.5),
   marginBottom: theme.spacing(4),
   gap: theme.spacing(3),
   [theme.breakpoints.up("md")]: {

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -28,16 +28,16 @@ interface PickOSAddressProps {
 
 const AutocompleteWrapper = styled(Box)(({ theme }) => ({
   // Autocomplete style overrides
-  "--autocomplete__label__font-size": "18px",
-  "--autocomplete__input__padding": "6px 40px 7px 12px",
-  "--autocomplete__input__font-size": "1rem",
+  "--autocomplete__label__font-size": "1.1278rem;",
+  "--autocomplete__input__padding": "5px 35px 5px 15px",
+  "--autocomplete__input__font-size": "1em",
   "--autocomplete__input__height": "50px",
   "--autocomplete__dropdown-arrow-down__top": "16px",
   "--autocomplete__dropdown-arrow-down__z-index": "2",
   "--autocomplete__option__font-size": "1rem",
-  "--autocomplete__option__padding": "6px 12px 7px 12px",
+  "--autocomplete__option__padding": "7px 15px",
   "--autocomplete__menu__max-height": "336px",
-  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.grey[800]}`,
+  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.secondary.main}`,
   "--autocomplete__option__hover-border-color": theme.palette.primary.main,
   "--autocomplete__option__hover-background-color": theme.palette.primary.main,
   "--autocomplete__font-family": theme.typography.fontFamily,

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -175,7 +175,7 @@ function Component(props: Props) {
                   setAddress(undefined);
                 }}
               >
-                <Typography variant="body2">
+                <Typography variant="body1">
                   The site does not have an address
                 </Typography>
               </Link>

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -7,7 +7,6 @@ import { useTheme } from "@mui/styles";
 import { visuallyHidden } from "@mui/utils";
 import { DESCRIPTION_TEXT } from "@planx/components/shared/constants";
 import Card from "@planx/components/shared/Preview/Card";
-import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
 import DescriptionRadio from "@planx/components/shared/Radio/DescriptionRadio";
@@ -97,9 +96,7 @@ const Question: React.FC<IQuestion> = (props) => {
         img={props.img}
       />
       <FullWidthWrapper>
-        <FormControl
-          sx={{ ...contentFlowSpacing(theme), width: "100%" }}
-        >
+        <FormControl sx={{ width: "100%" }}>
           <FormHelperText style={visuallyHidden}>
             {props.description ? DESCRIPTION_TEXT : ""}
           </FormHelperText>
@@ -157,7 +154,13 @@ const Question: React.FC<IQuestion> = (props) => {
                     );
                   case QuestionLayout.Images:
                     return (
-                      <Grid item xs={12} sm={6} contentWrap={4} key={response.id}>
+                      <Grid
+                        item
+                        xs={12}
+                        sm={6}
+                        contentWrap={4}
+                        key={response.id}
+                      >
                         <ImageRadio {...buttonProps} {...response} />
                       </Grid>
                     );

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -8,7 +8,6 @@ import { visuallyHidden } from "@mui/utils";
 import { DESCRIPTION_TEXT } from "@planx/components/shared/constants";
 import Card from "@planx/components/shared/Preview/Card";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
-import { fullWidthContent } from "@planx/components/shared/Preview/MapContainer";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
 import DescriptionRadio from "@planx/components/shared/Radio/DescriptionRadio";
@@ -18,6 +17,7 @@ import { Store } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
 import React from "react";
 import FormWrapper from "ui/FormWrapper";
+import FullWidthWrapper from "ui/FullWidthWrapper";
 
 import type { Theme } from "../../../../theme";
 
@@ -96,75 +96,77 @@ const Question: React.FC<IQuestion> = (props) => {
         definitionImg={props.definitionImg}
         img={props.img}
       />
-      <FormControl
-        sx={{ ...contentFlowSpacing(theme), ...fullWidthContent(theme) }}
-      >
-        <FormHelperText style={visuallyHidden}>
-          {props.description ? DESCRIPTION_TEXT : ""}
-        </FormHelperText>
-        <FormLabel
-          style={visuallyHidden}
-          id={`radio-buttons-group-label-${props.id}`}
+      <FullWidthWrapper>
+        <FormControl
+          sx={{ ...contentFlowSpacing(theme), width: "100%" }}
         >
-          {props.text}
-        </FormLabel>
-        <RadioGroup
-          aria-labelledby={`radio-buttons-group-label-${props.id}`}
-          name={`radio-buttons-group-${props.id}`}
-          value={formik.values.selected.id}
-        >
-          <Grid
-            container
-            spacing={layout === QuestionLayout.Basic ? 0 : 2}
-            alignItems="stretch"
+          <FormHelperText style={visuallyHidden}>
+            {props.description ? DESCRIPTION_TEXT : ""}
+          </FormHelperText>
+          <FormLabel
+            style={visuallyHidden}
+            id={`radio-buttons-group-label-${props.id}`}
           >
-            {props.responses?.map((response) => {
-              const onChange = () => {
-                formik.setFieldValue("selected.id", response.id);
-                formik.setFieldValue("selected.a", response.responseKey);
-              };
-              const buttonProps = {
-                onChange,
-              };
+            {props.text}
+          </FormLabel>
+          <RadioGroup
+            aria-labelledby={`radio-buttons-group-label-${props.id}`}
+            name={`radio-buttons-group-${props.id}`}
+            value={formik.values.selected.id}
+          >
+            <Grid
+              container
+              spacing={layout === QuestionLayout.Basic ? 0 : 2}
+              alignItems="stretch"
+            >
+              {props.responses?.map((response) => {
+                const onChange = () => {
+                  formik.setFieldValue("selected.id", response.id);
+                  formik.setFieldValue("selected.a", response.responseKey);
+                };
+                const buttonProps = {
+                  onChange,
+                };
 
-              switch (layout) {
-                case QuestionLayout.Basic:
-                  return (
-                    <FormWrapper key={`wrapper-${response.id}`}>
-                      <Grid item xs={12} ml={1} key={`grid-${response.id}`}>
-                        <BasicRadio
-                          {...buttonProps}
-                          {...response}
-                          data-testid="basic-radio"
-                          key={`basic-radio-${response.id}`}
-                        />
+                switch (layout) {
+                  case QuestionLayout.Basic:
+                    return (
+                      <FormWrapper key={`wrapper-${response.id}`}>
+                        <Grid item xs={12} ml={1} key={`grid-${response.id}`}>
+                          <BasicRadio
+                            {...buttonProps}
+                            {...response}
+                            data-testid="basic-radio"
+                            key={`basic-radio-${response.id}`}
+                          />
+                        </Grid>
+                      </FormWrapper>
+                    );
+                  case QuestionLayout.Descriptions:
+                    return (
+                      <Grid
+                        item
+                        xs={12}
+                        sm={6}
+                        contentWrap={4}
+                        key={response.id}
+                        data-testid="description-radio"
+                      >
+                        <DescriptionRadio {...buttonProps} {...response} />
                       </Grid>
-                    </FormWrapper>
-                  );
-                case QuestionLayout.Descriptions:
-                  return (
-                    <Grid
-                      item
-                      xs={12}
-                      sm={6}
-                      contentWrap={4}
-                      key={response.id}
-                      data-testid="description-radio"
-                    >
-                      <DescriptionRadio {...buttonProps} {...response} />
-                    </Grid>
-                  );
-                case QuestionLayout.Images:
-                  return (
-                    <Grid item xs={12} sm={6} contentWrap={4} key={response.id}>
-                      <ImageRadio {...buttonProps} {...response} />
-                    </Grid>
-                  );
-              }
-            })}
-          </Grid>
-        </RadioGroup>
-      </FormControl>
+                    );
+                  case QuestionLayout.Images:
+                    return (
+                      <Grid item xs={12} sm={6} contentWrap={4} key={response.id}>
+                        <ImageRadio {...buttonProps} {...response} />
+                      </Grid>
+                    );
+                }
+              })}
+            </Grid>
+          </RadioGroup>
+        </FormControl>
+      </FullWidthWrapper>
     </Card>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -159,7 +159,7 @@ const ResultReason: React.FC<IResultReason> = ({
               width="100%"
             >
               <Typography
-                variant="body2"
+                variant="body1"
                 color="textPrimary"
                 id={`questionText-${id}`}
               >
@@ -188,7 +188,7 @@ const ResultReason: React.FC<IResultReason> = ({
           </ChangeLink>
         </Box>
         {hasMoreInfo && (
-          <AccordionDetails sx={{ p: 0 }}>
+          <AccordionDetails sx={{ py: 1, px: 0 }}>
             <MoreInfo>
               {question.data.info && (
                 <ReactMarkdownOrHtml

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -142,18 +142,20 @@ const Result: React.FC<Props> = ({
           <Responses responses={visibleResponses} allowChanges={allowChanges} />
 
           {hiddenResponses.length > 0 && (
-            <SimpleExpand
-              id="hidden-responses"
-              buttonText={{
-                open: "Show all responses",
-                closed: "Hide other responses",
-              }}
-            >
-              <Responses
-                responses={hiddenResponses}
-                allowChanges={allowChanges}
-              />
-            </SimpleExpand>
+            <Box py={2}>
+              <SimpleExpand
+                id="hidden-responses"
+                buttonText={{
+                  open: "Show all responses",
+                  closed: "Hide other responses",
+                }}
+              >
+                <Responses
+                  responses={hiddenResponses}
+                  allowChanges={allowChanges}
+                />
+              </SimpleExpand>
+            </Box>
           )}
         </Box>
         {disclaimer?.show && (

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -43,7 +43,7 @@ export default function Component(props: Props) {
     <Card isValid handleSubmit={props.handleSubmit}>
       <QuestionHeader title={flowName} />
       <Box>
-        <Typography variant="h3" component="h2" pb="0.15em">
+        <Typography variant="h3" component="h2" pb="0.25em">
           Application incomplete.
         </Typography>
         <Typography variant="subtitle2" component="h3">
@@ -168,8 +168,8 @@ const Grid = styled("dl")(({ theme }) => ({
   paddingBottom: theme.spacing(2),
   "& > *": {
     borderBottom: `1px solid ${theme.palette.secondary.main}`,
-    paddingBottom: theme.spacing(1.5),
-    paddingTop: theme.spacing(1.5),
+    paddingBottom: theme.spacing(1.25),
+    paddingTop: theme.spacing(1.25),
     verticalAlign: "top",
     margin: 0,
   },

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import { styled, Theme } from "@mui/material/styles";
+import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
 
 interface MapContainerProps {
@@ -35,7 +36,8 @@ export const MapContainer = styled(Box)<MapContainerProps>(
   }),
 );
 
-export const MapFooter = styled(Box)(() => ({
+export const MapFooter = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
+  ...contentFlowSpacing(theme),
 }));

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -27,7 +27,7 @@ const dynamicMapSizeStyle = (theme: Theme): Record<string, any> => {
 
 export const MapContainer = styled(Box)<MapContainerProps>(
   ({ theme, environment, size }) => ({
-    padding: theme.spacing(1, 0, 6, 0),
+    padding: theme.spacing(1, 0, 1, 0),
     width: "100%",
     maxWidth: "none",
     height: "50vh",
@@ -42,7 +42,7 @@ export const MapContainer = styled(Box)<MapContainerProps>(
 );
 
 export const MapFooter = styled(Box)(({ theme }) => ({
+  ...fullWidthContent(theme),
   display: "flex",
   justifyContent: "space-between",
-  paddingTop: theme.spacing(3),
 }));

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -7,18 +7,12 @@ interface MapContainerProps {
   size?: "large";
 }
 
-export const fullWidthContent = (theme: Theme): React.CSSProperties => ({
-  width: "100%",
-  maxWidth: "none",
-});
-
 /**
  * Generate a style which increases the map size as the window grows
  * and maintains a consistent right margin
  */
 const dynamicMapSizeStyle = (theme: Theme): Record<string, any> => {
   const style = {
-    ...fullWidthContent(theme),
     height: "70vh",
   };
 
@@ -41,8 +35,7 @@ export const MapContainer = styled(Box)<MapContainerProps>(
   }),
 );
 
-export const MapFooter = styled(Box)(({ theme }) => ({
-  ...fullWidthContent(theme),
+export const MapFooter = styled(Box)(() => ({
   display: "flex",
   justifyContent: "space-between",
 }));

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -145,14 +145,16 @@ export const Dropzone: React.FC<Props> = ({
       </Box>
       <Box sx={{ textAlign: "left" }}>
         <Box>
-          {isDragActive ? (
-            "Drop the files here"
-          ) : (
-            <>
-              Drop {maxFiles === 1 ? "file" : "files"} here or{" "}
-              <FauxLink component="span">choose a file</FauxLink> to upload
-            </>
-          )}
+          <Typography variant="body1">
+            {isDragActive ? (
+              "Drop the files here"
+            ) : (
+              <>
+                Drop {maxFiles === 1 ? "file" : "files"} here or{" "}
+                <FauxLink component="span">choose a file</FauxLink> to upload
+              </>
+            )}
+          </Typography>
         </Box>
         <Typography color="text.secondary" variant="body2">
           pdf, jpg, png

--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -54,7 +54,9 @@ const AnalyticsDisabledBanner: React.FC = () => {
                 </Link>
               </Typography>
             </Box>
-            <Button onClick={() => setShowAnalyticsWarning(false)}>Hide</Button>
+            <Button size="small" onClick={() => setShowAnalyticsWarning(false)}>
+              Hide
+            </Button>
           </Container>
         </AnalyticsWarning>
       )}

--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -39,7 +39,9 @@ const TestEnvironmentBanner: React.FC = () => {
                 Do not use it to make permanent content changes.
               </Typography>
             </Box>
-            <Button onClick={() => setShowWarning(false)}>Hide</Button>
+            <Button size="small" onClick={() => setShowWarning(false)}>
+              Hide
+            </Button>
           </Container>
         </TestEnvironmentWarning>
       )}

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -1,7 +1,7 @@
 import Warning from "@mui/icons-material/WarningOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import { useTheme } from "@mui/material/styles";
+import { lighten, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { SectionsOverviewList } from "@planx/components/Section/Public";
 import Card from "@planx/components/shared/Preview/Card";
@@ -67,8 +67,8 @@ const ReconciliationPage: React.FC<Props> = ({
         <Banner
           heading={bannerHeading}
           color={{
-            background: theme.palette.primary.main,
-            text: theme.palette.primary.contrastText,
+            background: lighten(theme.palette.info.main, 0.9),
+            text: theme.palette.text.primary,
           }}
         />
       </Box>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -279,6 +279,11 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
         defaultProps: {
           elevation: 0,
         },
+        styleOverrides: {
+          root: {
+            borderRadius: 0,
+          },
+        },
       },
       MuiLink: {
         styleOverrides: {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -229,7 +229,8 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
             borderRadius: 0,
             textTransform: "none",
             boxShadow: "inset 0 -2px 0 rgba(0,0,0,0.5)",
-            padding: "0.5em 1.1em",
+            padding: "0.7em 1.25em",
+            lineHeight: LINE_HEIGHT_BASE,
           },
           text: {
             color: "rgba(0,0,0,0.4)",
@@ -237,12 +238,16 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
               color: "rgba(0,0,0,1)",
             },
           },
+          sizeSmall: {
+            fontSize: "0.875em",
+            fontWeight: FONT_WEIGHT_SEMI_BOLD,
+          },
           sizeMedium: {
             fontSize: "1rem",
             fontWeight: FONT_WEIGHT_SEMI_BOLD,
           },
           sizeLarge: {
-            fontSize: "1.188rem",
+            fontSize: "1.05em",
             fontWeight: FONT_WEIGHT_SEMI_BOLD,
             width: "100%",
             "@media (min-width: 768px)": {
@@ -374,7 +379,7 @@ const generateTeamTheme = (
   primaryColor: string = DEFAULT_PRIMARY_COLOR,
 ): MUITheme => {
   const themeOptions = getThemeOptions(primaryColor);
-  const theme = responsiveFontSizes(createTheme(themeOptions));
+  const theme = responsiveFontSizes(createTheme(themeOptions), { factor: 3 });
   return theme;
 };
 

--- a/editor.planx.uk/src/ui/FullWidthWrapper.tsx
+++ b/editor.planx.uk/src/ui/FullWidthWrapper.tsx
@@ -1,0 +1,18 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import React from "react";
+
+export interface Props {
+  children: JSX.Element[] | JSX.Element;
+}
+
+const Root = styled(Box)(() => ({
+  width: "100%",
+  maxWidth: "none",
+}));
+
+function FullWidthWrapper(props: Props) {
+  return <Root>{props.children || null}</Root>;
+}
+
+export default FullWidthWrapper;

--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -9,8 +9,12 @@ import type { Theme } from "../theme";
 const useClasses = makeStyles((theme: Theme) => ({
   htmlRoot: {
     "& a": linkStyle(theme.palette.primary.main),
+    "& h1": theme.typography.h2,
     "& h2": theme.typography.h3,
-    "& h3": theme.typography.h5,
+    "& h3": theme.typography.h4,
+    "& h1, & h2, & h3": {
+      marginTop: 0,
+    },
     "& strong": {
       fontWeight: FONT_WEIGHT_SEMI_BOLD,
     },


### PR DESCRIPTION
### Summary

PR updates and fixes a number of mobile specific styles, following extensive mobile QA.

### Updates

- Updates default "factor" for responsive font resizing
- Adds small button size
- Adds missing `<Typography>` where needed
- Adjusts margins and padding of numerous components to unify layout
- Changes hierarchy of `<MapContainer>` and `<MapFooter>` to prevent overlap on smaller screens
- Adds a `nowrap` span to red line size indicator to keep units (m²) on same line as number

### Previews

Size comparison before (left) & after (right)

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/60ba3fff-9b6b-464e-801b-74a7c25bc2df)

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/f361e57f-7acc-452d-92cd-b79edd6564f5)
