### PR TITLE
fix: Stop sending E2E emails to enquiries inbox

### DIFF
--- a/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
@@ -11,6 +11,7 @@ import {
   mockPassport,
 } from "./mocks";
 import { $admin } from "../client";
+import { TEST_EMAIL } from "../../../ui-driven/src/helpers";
 
 export async function setUpMocks() {
   const serverMockFile = readFileSync(`${__dirname}/mocks/server-mocks.yaml`);
@@ -30,7 +31,7 @@ export async function createTeam() {
     slug: "E2E",
     logo: "https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/planx-testing.svg",
     primaryColor: "#444444",
-    submissionEmail: "simulate-delivered@notifications.service.gov.uk",
+    submissionEmail: TEST_EMAIL,
     homepage: "planx.uk",
   });
 }
@@ -39,7 +40,7 @@ export async function createUser() {
   return $admin.user.create({
     firstName: "Test",
     lastName: "Test",
-    email: "simulate-delivered@notifications.service.gov.uk",
+    email: TEST_EMAIL,
   });
 }
 
@@ -87,7 +88,7 @@ export async function buildPaymentRequestForSession(
     sessionId,
     applicantName: "Agent",
     payeeName: "Nominee",
-    payeeEmail: "simulate-delivered-2@notifications.service.gov.uk",
+    payeeEmail: TEST_EMAIL,
     sessionPreviewKeys: [["_address", "title"], ["proposal.projectType"]],
   });
 }

--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { log } from "./helpers";
+import { TEST_EMAIL, log } from "./helpers";
 import { sign } from "jsonwebtoken";
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { GraphQLClient, gql } from "graphql-request";
@@ -33,9 +33,7 @@ export const contextDefaults = {
   user: {
     firstName: "Test",
     lastName: "Test",
-    // Gov.uk Notify requests testing service use smoke test email addresses
-    // see https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing
-    email: "simulate-delivered@notifications.service.gov.uk",
+    email: TEST_EMAIL,
   },
   team: {
     name: "E2E Test Team",
@@ -43,7 +41,7 @@ export const contextDefaults = {
     logo: "https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/planx-testing.svg",
     primaryColor: "#444444",
     homepage: "planx.uk",
-    submissionEmail: "simulate-delivered@notifications.service.gov.uk",
+    submissionEmail: TEST_EMAIL,
   },
 };
 

--- a/e2e/tests/ui-driven/src/helpers.ts
+++ b/e2e/tests/ui-driven/src/helpers.ts
@@ -14,6 +14,10 @@ export const cards = {
   invalid_card_number: "4000000000000002",
 };
 
+// Gov.uk Notify requests testing service use smoke test email addresses
+// see https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing
+export const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk" as const;
+
 // utility functions
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -282,7 +286,7 @@ export async function fillGovUkCardDetails({
   await page.getByLabel("Postcode").fill("HP111BB");
   await page
     .getByLabel("Email")
-    .fill("simulate-delivered@notifications.service.gov.uk");
+    .fill(TEST_EMAIL);
   await page.locator("button#submit-card-details").click();
 }
 

--- a/e2e/tests/ui-driven/src/helpers.ts
+++ b/e2e/tests/ui-driven/src/helpers.ts
@@ -16,7 +16,8 @@ export const cards = {
 
 // Gov.uk Notify requests testing service use smoke test email addresses
 // see https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing
-export const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk" as const;
+export const TEST_EMAIL =
+  "simulate-delivered@notifications.service.gov.uk" as const;
 
 // utility functions
 
@@ -284,9 +285,7 @@ export async function fillGovUkCardDetails({
 
   await page.getByLabel("Town or city").fill("Test");
   await page.getByLabel("Postcode").fill("HP111BB");
-  await page
-    .getByLabel("Email")
-    .fill(TEST_EMAIL);
+  await page.getByLabel("Email").fill(TEST_EMAIL);
   await page.locator("button#submit-card-details").click();
 }
 

--- a/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
@@ -4,6 +4,7 @@ import {
   answerFindProperty,
   answerContactInput,
   addSessionToContext,
+  TEST_EMAIL,
 } from "../helpers";
 import type { Page } from "@playwright/test";
 import { gql, GraphQLClient } from "graphql-request";
@@ -35,7 +36,7 @@ export async function navigateToPayComponent(page: Page, context: Context) {
   await answerContactInput(page, {
     firstName: "agentFirst",
     lastName: "agentLast",
-    email: "testAgent@opensystemslab.com",
+    email: TEST_EMAIL,
     phoneNumber: "(0123) 456789",
   });
   await page.getByText("Continue").click();
@@ -43,7 +44,7 @@ export async function navigateToPayComponent(page: Page, context: Context) {
 
 export async function answerInviteToPayForm(page: Page) {
   await page.getByLabel("Full name").fill("Mr Nominee");
-  await page.getByLabel("Email").fill("testNominee@opensystemslab.com");
+  await page.getByLabel("Email").fill(TEST_EMAIL);
   await page.getByLabel("Your name").fill("Mr Agent (Agency Ltd)");
 }
 

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -8,7 +8,7 @@ import inviteToPayFlow from "../flows/invite-to-pay-flow";
 import { TEST_EMAIL } from "../helpers";
 
 export const mockPaymentRequest: Partial<PaymentRequest> = {
-  payeeEmail: "testNominee@opensystemslab.com",
+  payeeEmail: TEST_EMAIL,
   payeeName: "Mr Nominee",
   sessionPreviewData: {
     _address: {

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -5,6 +5,7 @@ import {
   SessionData,
 } from "@opensystemslab/planx-core/types";
 import inviteToPayFlow from "../flows/invite-to-pay-flow";
+import { TEST_EMAIL } from "../helpers";
 
 export const mockPaymentRequest: Partial<PaymentRequest> = {
   payeeEmail: "testNominee@opensystemslab.com",
@@ -138,6 +139,6 @@ export const modifiedInviteToPayFlow: FlowGraph = {
 export const mockPaymentRequestDetails = {
   applicantName: "Mr Nominee",
   payeeName: "Mrs Agent",
-  payeeEmail: "testAgent@opensystemslab.io",
+  payeeEmail: TEST_EMAIL,
   sessionPreviewKeys: [["_address", "title"], ["proposal.projectType"]],
 };


### PR DESCRIPTION
Told Mel earlier in the week I'd sort this...! 

An outstanding E2E test was sending emails to `testAgent@opensystemslab.io` which was then being forwarded to `enquiries@opensystemslab.io`.