### PR TITLE
[skip pizza] fix: hasura version for m1 mac

### DIFF
--- a/hasura.planx.uk/Dockerfile
+++ b/hasura.planx.uk/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 hasura/graphql-engine:v2.8.4.cli-migrations-v2
+FROM hasura/graphql-engine:v2.8.4.cli-migrations-v2
 WORKDIR /
 COPY metadata hasura-metadata
 COPY migrations hasura-migrations


### PR DESCRIPTION
FAO @DafyddLlyr , I needed to do this to get Docker spinning up on my Mac after an OS security update. 

To be discussed at the next dev call, whether or not this can be made as a global change.