### PR TITLE
feat: update disclaimer styling

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import FeedbackInput from "@planx/components/shared/FeedbackInput";
 import Card from "@planx/components/shared/Preview/Card";
 import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
+import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { useFormik } from "formik";
 import { submitFeedback } from "lib/feedback";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
@@ -39,32 +40,6 @@ interface Response {
 
 const DisclaimerContent = styled(Typography)(({ theme }) => ({
   marginTop: theme.spacing(1),
-  marginBottom: theme.spacing(1),
-}));
-
-const Disclaimer = styled(Box)(({ theme }) => ({
-  position: "relative",
-  width: "100%",
-  display: "flex",
-  alignItems: "flex-start",
-  justifyContent: "space-between",
-  padding: theme.spacing(2),
-  backgroundColor: "#EFEFEF",
-  color: theme.palette.text.primary,
-  "&:before": {
-    content: "' '",
-    position: "absolute",
-    top: 0,
-    left: 0,
-    width: "100%",
-    height: "100%",
-    opacity: 0.3,
-    border: "2px solid currentColor",
-    pointerEvents: "none",
-  },
-  "& p": {
-    marginBottom: 0,
-  },
 }));
 
 const TitleWrap = styled(Box)(() => ({
@@ -182,7 +157,7 @@ const Result: React.FC<Props> = ({
           )}
         </Box>
         {disclaimer?.show && (
-          <Disclaimer>
+          <WarningContainer>
             <Box sx={{ flex: 1 }}>
               <TitleWrap>
                 <ErrorOutline sx={{ width: 34, height: 34 }} />
@@ -194,15 +169,13 @@ const Result: React.FC<Props> = ({
                 </DisclaimerContent>
               </Box>
             </Box>
-          </Disclaimer>
+          </WarningContainer>
         )}
-        <Box mt="2">
-          <FeedbackInput
-            text="Is this information inaccurate? **Tell us why.**"
-            handleChange={formik.handleChange}
-            value={formik.values.feedback}
-          />
-        </Box>
+        <FeedbackInput
+          text="Is this information inaccurate? **Tell us why.**"
+          handleChange={formik.handleChange}
+          value={formik.values.feedback}
+        />
       </Card>
     </Box>
   );

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -1,7 +1,5 @@
-import Warning from "@mui/icons-material/WarningOutlined";
+import ErrorOutline from "@mui/icons-material/ErrorOutline";
 import Box from "@mui/material/Box";
-import Collapse from "@mui/material/Collapse";
-import Link from "@mui/material/Link";
 import { styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import FeedbackInput from "@planx/components/shared/FeedbackInput";
@@ -12,6 +10,7 @@ import { submitFeedback } from "lib/feedback";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useState } from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import type { Node, TextContent } from "types";
 
 import ResultReason from "./ResultReason";
@@ -43,8 +42,40 @@ const DisclaimerContent = styled(Typography)(({ theme }) => ({
   marginBottom: theme.spacing(1),
 }));
 
-const DisclaimerHeading = styled(Typography)(({ theme }) => ({
-  marginRight: theme.spacing(1),
+const Disclaimer = styled(Box)(({ theme }) => ({
+  position: "relative",
+  width: "100%",
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  padding: theme.spacing(2),
+  backgroundColor: "#EFEFEF",
+  color: theme.palette.text.primary,
+  "&:before": {
+    content: "' '",
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    opacity: 0.3,
+    border: "2px solid currentColor",
+    pointerEvents: "none",
+  },
+  "& p": {
+    marginBottom: 0,
+  },
+}));
+
+const TitleWrap = styled(Box)(() => ({
+  display: "flex",
+  alignItems: "center",
+}));
+
+const Title = styled(Typography)(({ theme }) => ({
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  margin: 0,
+  paddingLeft: theme.spacing(1),
 })) as typeof Typography;
 
 const Responses = ({
@@ -106,12 +137,9 @@ const Result: React.FC<Props> = ({
   const visibleResponses = responses.filter((r) => !r.hidden);
   const hiddenResponses = responses.filter((r) => r.hidden);
 
-  const [showDisclaimer, setShowDisclaimer] = useState(true);
   const [showSubmitButton, setShowSubmitButton] = useState<boolean>(
     Boolean(handleSubmit),
   );
-
-  const theme = useTheme();
 
   useEffect(() => {
     if (handleSubmit) return;
@@ -154,46 +182,27 @@ const Result: React.FC<Props> = ({
           )}
         </Box>
         {disclaimer?.show && (
-          <Box
-            bgcolor="background.paper"
-            p={1.25}
-            display="flex"
-            color={theme.palette.grey[600]}
-          >
-            <Warning titleAccess="Warning" color="primary" />
-            <Box ml={1}>
-              <Box display="flex" alignItems="center">
-                <DisclaimerHeading
-                  variant="h5"
-                  component="h3"
-                  color="text.primary"
-                >
-                  {disclaimer.heading}
-                </DisclaimerHeading>
-                <Link
-                  component="button"
-                  onClick={() =>
-                    setShowDisclaimer((showDisclaimer) => !showDisclaimer)
-                  }
-                >
-                  <Typography variant="body2">
-                    Read {showDisclaimer ? "less" : "more"}
-                  </Typography>
-                </Link>
-              </Box>
-              <Collapse in={showDisclaimer}>
+          <Disclaimer>
+            <Box sx={{ flex: 1 }}>
+              <TitleWrap>
+                <ErrorOutline sx={{ width: 34, height: 34 }} />
+                <Title variant="h3"> {disclaimer.heading}</Title>
+              </TitleWrap>
+              <Box mt={2}>
                 <DisclaimerContent variant="body2" color="text.primary">
                   {disclaimer.content}
                 </DisclaimerContent>
-              </Collapse>
+              </Box>
             </Box>
-          </Box>
+          </Disclaimer>
         )}
-        <FeedbackInput
-          text="Is this information inaccurate? **Tell us why.**"
-          handleChange={formik.handleChange}
-          value={formik.values.feedback}
-        />
+        <Box mt="2">
+          <FeedbackInput
+            text="Is this information inaccurate? **Tell us why.**"
+            handleChange={formik.handleChange}
+            value={formik.values.feedback}
+          />
+        </Box>
       </Card>
     </Box>
   );

--- a/editor.planx.uk/src/@planx/components/shared/Preview/WarningContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/WarningContainer.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 
 export const WarningContainer = styled(Box)(({ theme }) => ({
-  border: `solid 2px ${theme.palette.grey[400]}`,
+  border: `solid 2px ${theme.palette.secondary.main}`,
   backgroundColor: theme.palette.background.paper,
   padding: theme.spacing(2),
   marginTop: theme.spacing(2),


### PR DESCRIPTION
PR updates the disclaimer shown after a flow result to be inline with the notice styling.

I've also removed the "read more/less" toggle from this as it appears to be redundant, happy to reinstate if there is a valid use-case for this being here.

Previews of before (left) & after (right):

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/bee1cb17-6d68-4afd-8d9a-788d61ebf535)
