### PR TITLE
fix: don't validate that all required files are tagged yet when clicking modal "Done" 

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -28,7 +28,6 @@ import {
   removeSlots,
   resetAllSlots,
 } from "./model";
-import { fileListSchema, slotsSchema } from "./schema";
 
 interface FileTaggingModalProps {
   uploadedFiles: FileUploadSlot[];
@@ -46,15 +45,6 @@ export const FileTaggingModal = ({
   const [error, setError] = useState<string | undefined>();
 
   const closeModal = () => setShowModal(false);
-
-  const handleSubmit = () => {
-    Promise.all([
-      slotsSchema.validate(uploadedFiles),
-      fileListSchema.validate(fileList, { context: { slots: uploadedFiles } }),
-    ])
-      .then(closeModal)
-      .catch((err) => setError(err.message));
-  };
 
   return (
     <Dialog
@@ -95,7 +85,7 @@ export const FileTaggingModal = ({
           <Box>
             <Button
               variant="contained"
-              onClick={handleSubmit}
+              onClick={closeModal}
               sx={{ paddingLeft: 2 }}
             >
               Done

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -17,7 +17,6 @@ import capitalize from "lodash/capitalize";
 import merge from "lodash/merge";
 import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
-import ErrorWrapper from "ui/ErrorWrapper";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
@@ -42,8 +41,6 @@ export const FileTaggingModal = ({
   setFileList,
   setShowModal,
 }: FileTaggingModalProps) => {
-  const [error, setError] = useState<string | undefined>();
-
   const closeModal = () => setShowModal(false);
 
   return (
@@ -81,17 +78,15 @@ export const FileTaggingModal = ({
           padding: 2,
         }}
       >
-        <ErrorWrapper error={error}>
-          <Box>
-            <Button
-              variant="contained"
-              onClick={closeModal}
-              sx={{ paddingLeft: 2 }}
-            >
-              Done
-            </Button>
-          </Box>
-        </ErrorWrapper>
+        <Box>
+          <Button
+            variant="contained"
+            onClick={closeModal}
+            sx={{ paddingLeft: 2 }}
+          >
+            Done
+          </Button>
+        </Box>
       </DialogActions>
     </Dialog>
   );

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -462,44 +462,6 @@ describe("Error handling", () => {
     expect(dropzoneError).toBeVisible();
   });
 
-  test("An error is thrown in the modal if a user does not tag all files", async () => {
-    const { user } = setup(
-      <FileUploadAndLabelComponent
-        title="Test title"
-        fileTypes={[
-          mockFileTypes.AlwaysRequired,
-          mockFileTypes.AlwaysRecommended,
-          mockFileTypes.NotRequired,
-        ]}
-      />,
-    );
-
-    mockedAxios.post.mockResolvedValue({
-      data: {
-        file_type: "image/png",
-        fileUrl: "https://api.editor.planx.dev/file/private/gws7l5d1/test.jpg",
-      },
-    });
-
-    const file = new File(["test"], "test.jpg", { type: "image/jpg" });
-    const input = screen.getByTestId("upload-input");
-    await user.upload(input, file);
-
-    const fileTaggingModal = await within(document.body).findByTestId(
-      "file-tagging-dialog",
-    );
-    expect(fileTaggingModal).toBeVisible();
-    const submitModalButton = await within(fileTaggingModal).findByText("Done");
-
-    // Attempt to close without tagging files
-    await user.click(submitModalButton);
-    expect(true).toBeTruthy();
-    const modalError = await within(fileTaggingModal).findByText(
-      "Please tag all files",
-    );
-    expect(modalError).toBeVisible();
-  });
-
   test("An error is thrown in the main component if a user does not tag all files", async () => {
     const handleSubmit = jest.fn();
 


### PR DESCRIPTION
This came out of PO testing feedback: 

Previously:
- Upload one file, the tagging modal opens, select 1 or many "Required files" checkboxes
- Click “Done” in modal and throws error “All required files must be tagged”. 
  - Clicking away from Modal still closes it successfully, but as a user I don't understand this is an option
  - Clicking "Done" throws error that confuses me because I want to close it and upload my second file. I have to select incorrect checkboxes to proceed through "Done"
 
This wasn't noticeable if you drag many files into dropzone at same time and tag all at same time, or if you upload a single file that satisfies all requirements in one go. But if you're uploading one-by-one and focused on navigating with buttons, it's confusing! 
 
Now:
- Only validate on "Continue", simply close the modal on "Done" - basically reverting back to original behavior here https://github.com/theopensystemslab/planx-new/pull/1937