### PR TITLE
feat: general `admin/session/:sessionId/summary` endpoint for debugging

### DIFF
--- a/api.planx.uk/admin/session/summary.test.ts
+++ b/api.planx.uk/admin/session/summary.test.ts
@@ -1,0 +1,44 @@
+import supertest from "supertest";
+import app from "../../server";
+import { queryMock } from "../../tests/graphqlQueryMock";
+import { authHeader } from "../../tests/mockJWT";
+
+const endpoint = (strings: TemplateStringsArray) =>
+  `/admin/session/${strings[0]}/summary`;
+
+describe("Session summary admin endpoint", () => {
+  beforeEach(() => {
+    queryMock.mockQuery({
+      name: "GetSessionSummary",
+      variables: {
+        sessionId: "abc123",
+      },
+      data: {
+        lowcal_sessions_by_pk: {},
+      },
+    });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("requires a user to be logged in", async () => {
+    await supertest(app)
+      .get(endpoint`abc123`)
+      .expect(401)
+      .then((res) =>
+        expect(res.body).toEqual({
+          error: "No authorization token was found",
+        }),
+      );
+  });
+
+  it("returns JSON", async () => {
+    await supertest(app)
+      .get(endpoint`abc123`)
+      .set(authHeader())
+      .expect(200)
+      .then((res) => {
+        expect(res.text).toBe("{}");
+      });
+  });
+});

--- a/api.planx.uk/admin/session/summary.ts
+++ b/api.planx.uk/admin/session/summary.ts
@@ -62,7 +62,7 @@ const getSessionSummaryById = async (
 ): Promise<SessionSummary> => {
   const data = await adminClient.request(
     gql`
-      query GetSessionStatus($sessionId: uuid!) {
+      query GetSessionSummary($sessionId: uuid!) {
         lowcal_sessions_by_pk(id: $sessionId) {
           flow {
             id

--- a/api.planx.uk/admin/session/summary.ts
+++ b/api.planx.uk/admin/session/summary.ts
@@ -1,4 +1,8 @@
-import { GovUKPayment, PaymentRequest, Session } from "@opensystemslab/planx-core/types";
+import {
+  GovUKPayment,
+  PaymentRequest,
+  Session,
+} from "@opensystemslab/planx-core/types";
 import { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 
@@ -16,15 +20,16 @@ export async function getSessionSummary(
       res.send(data);
     } else {
       res.send({
-        message: `Cannot find data for this session; double-check your sessionId is correct`
-      })
+        message: `Cannot find data for this session; double-check your sessionId is correct`,
+      });
     }
   } catch (error) {
     return next({
-      message: "Failed to fetch session summary data: " + (error as Error).message,
+      message:
+        "Failed to fetch session summary data: " + (error as Error).message,
     });
   }
-};
+}
 
 interface SessionSummary {
   flow: {
@@ -32,7 +37,7 @@ interface SessionSummary {
     slug: Flow["slug"];
     team: {
       slug: Team["slug"];
-    }
+    };
     created_at: LowCalSession["created_at"];
     updated_at: LowCalSession["updated_at"];
     locked_at: LowCalSession["lockedAt"];
@@ -41,12 +46,20 @@ interface SessionSummary {
     email: LowCalSession["email"];
     passport: Passport["data"];
     breadcrumbs: Breadcrumb;
-    payments?: Pick<GovUKPayment, "created_date" | "payment_id" | "amount" | "state">[];
-    invitations_to_pay?: Pick<PaymentRequest, "createdAt" | "govPayPaymentId" | "paymentAmount" | "paidAt">[];
-  }
+    payments?: Pick<
+      GovUKPayment,
+      "created_date" | "payment_id" | "amount" | "state"
+    >[];
+    invitations_to_pay?: Pick<
+      PaymentRequest,
+      "createdAt" | "govPayPaymentId" | "paymentAmount" | "paidAt"
+    >[];
+  };
 }
 
-const getSessionSummaryById = async (sessionId: Session["id"]): Promise<SessionSummary> => {
+const getSessionSummaryById = async (
+  sessionId: Session["id"],
+): Promise<SessionSummary> => {
   const data = await adminClient.request(
     gql`
       query GetSessionStatus($sessionId: uuid!) {
@@ -66,23 +79,23 @@ const getSessionSummaryById = async (sessionId: Session["id"]): Promise<SessionS
           email
           passport: data(path: "passport.data")
           breadcrumbs: data(path: "breadcrumbs")
-          payments: payment_status(order_by: {created_at: desc}) {
-          	created_at
+          payments: payment_status(order_by: { created_at: desc }) {
+            created_at
             payment_id
             amount
             status
           }
-          invitations_to_pay: payment_requests(order_by: {created_at: desc}) {
+          invitations_to_pay: payment_requests(order_by: { created_at: desc }) {
             created_at
             govpay_payment_id
-      			payment_amount
+            payment_amount
             paid_at
           }
         }
       }
     `,
     {
-      sessionId
+      sessionId,
     },
   );
 

--- a/api.planx.uk/admin/session/summary.ts
+++ b/api.planx.uk/admin/session/summary.ts
@@ -1,0 +1,90 @@
+import { GovUKPayment, PaymentRequest, Session } from "@opensystemslab/planx-core/types";
+import { NextFunction, Request, Response } from "express";
+import { gql } from "graphql-request";
+
+import { adminGraphQLClient as adminClient } from "../../hasura";
+import { Breadcrumb, Flow, LowCalSession, Passport, Team } from "../../types";
+
+export async function getSessionSummary(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const data = await getSessionSummaryById(req.params.sessionId);
+    if (data) {
+      res.send(data);
+    } else {
+      res.send({
+        message: `Cannot find data for this session; double-check your sessionId is correct`
+      })
+    }
+  } catch (error) {
+    return next({
+      message: "Failed to fetch session summary data: " + (error as Error).message,
+    });
+  }
+};
+
+interface SessionSummary {
+  flow: {
+    id: Flow["id"];
+    slug: Flow["slug"];
+    team: {
+      slug: Team["slug"];
+    }
+    created_at: LowCalSession["created_at"];
+    updated_at: LowCalSession["updated_at"];
+    locked_at: LowCalSession["lockedAt"];
+    submitted_at: LowCalSession["submitted_at"];
+    sanitised_at: string;
+    email: LowCalSession["email"];
+    passport: Passport["data"];
+    breadcrumbs: Breadcrumb;
+    payments?: Pick<GovUKPayment, "created_date" | "payment_id" | "amount" | "state">[];
+    invitations_to_pay?: Pick<PaymentRequest, "createdAt" | "govPayPaymentId" | "paymentAmount" | "paidAt">[];
+  }
+}
+
+const getSessionSummaryById = async (sessionId: Session["id"]): Promise<SessionSummary> => {
+  const data = await adminClient.request(
+    gql`
+      query GetSessionStatus($sessionId: uuid!) {
+        lowcal_sessions_by_pk(id: $sessionId) {
+          flow {
+            id
+            slug
+            team {
+              slug
+            }
+          }
+          created_at
+          updated_at
+          submitted_at
+          locked_at
+          sanitised_at
+          email
+          passport: data(path: "passport.data")
+          breadcrumbs: data(path: "breadcrumbs")
+          payments: payment_status(order_by: {created_at: desc}) {
+          	created_at
+            payment_id
+            amount
+            status
+          }
+          invitations_to_pay: payment_requests(order_by: {created_at: desc}) {
+            created_at
+            govpay_payment_id
+      			payment_amount
+            paid_at
+          }
+        }
+      }
+    `,
+    {
+      sessionId
+    },
+  );
+
+  return data?.lowcal_sessions_by_pk;
+};

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -82,6 +82,7 @@ import { getCSVData, getRedactedCSVData } from "./admin/session/csv";
 import { getHTMLExport, getRedactedHTMLExport } from "./admin/session/html";
 import { generateZip } from "./admin/session/zip";
 import { createPaymentSendEvents } from "./inviteToPay/createPaymentSendEvents";
+import { getSessionSummary } from "./admin/session/summary";
 
 const router = express.Router();
 
@@ -428,11 +429,12 @@ app.use("/admin", useJWT);
 app.get("/admin/feedback", downloadFeedbackCSV);
 app.get("/admin/session/:sessionId/xml", getOneAppXML);
 app.get("/admin/session/:sessionId/bops", getBOPSPayload);
-app.get("/admin/session/:sessionId/csv", getCSVData);
+app.get("/admin/session/:sessionId/csv", getCSVData); // "?download=true" to download a file
 app.get("/admin/session/:sessionId/csv-redacted", getRedactedCSVData);
 app.get("/admin/session/:sessionId/html", getHTMLExport);
 app.get("/admin/session/:sessionId/html-redacted", getRedactedHTMLExport);
 app.get("/admin/session/:sessionId/zip", generateZip); // "?includeXML=true" to generate and include xml in the zip
+app.get("/admin/session/:sessionId/summary", getSessionSummary);
 
 // XXX: leaving this in temporarily as a testing endpoint to ensure it
 //      works correctly in staging and production


### PR DESCRIPTION
Was thinking about this yesterday when troubleshooting the recent LDC apps with George. This offers a quicker alternative than going directly into the Hasura console to check the `lowcal_sessions` table and is a link we could share with any Editor admin going forward rather than exporting/passing along CSVs or JSON files.

We can keep buildng on the format of this return response. 

Admin endpoints will be behind Cloudflare's Zero Trust soon for restricted access by email and WARP client connection. 