### PR TITLE
fix: heading styling in rich text

### DIFF
--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -11,10 +11,7 @@ const useClasses = makeStyles((theme: Theme) => ({
     "& a": linkStyle(theme.palette.primary.main),
     "& h1": theme.typography.h2,
     "& h2": theme.typography.h3,
-    "& h3": theme.typography.h4,
-    "& h1, & h2, & h3": {
-      marginTop: 0,
-    },
+    "& h3": theme.typography.h3,
     "& strong": {
       fontWeight: FONT_WEIGHT_SEMI_BOLD,
     },


### PR DESCRIPTION
PR fixes heading text sizing. Small headers shown below:

<img width="925" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/983c4a68-3fb5-4ecb-a6aa-dd6af9f2b5a3">
