### PR TITLE
fix: missing input label on feedback

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/FeedbackInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FeedbackInput.tsx
@@ -18,7 +18,7 @@ const StyledReactMarkdown = styled(ReactMarkdown)(() => ({
 }));
 
 const FeedbackInput: React.FC<Props> = ({ text, ...componentProps }: Props) => (
-  <CollapsibleInput {...componentProps} name="feedback">
+  <CollapsibleInput {...componentProps} name="feedback" ariaLabel={text}>
     <Typography variant="body1" color="inherit" component="div">
       <StyledReactMarkdown>{text}</StyledReactMarkdown>
     </Typography>

--- a/editor.planx.uk/src/ui/CollapsibleInput.stories.tsx
+++ b/editor.planx.uk/src/ui/CollapsibleInput.stories.tsx
@@ -19,6 +19,7 @@ export const Basic = {
     name: "Feedback",
     value: "feedback",
     children: <p>This is a child element.</p>,
+    ariaLabel: "Feedback",
   },
   render: (_args: Props) => {
     const [text, setText] = useState("");

--- a/editor.planx.uk/src/ui/CollapsibleInput.tsx
+++ b/editor.planx.uk/src/ui/CollapsibleInput.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import Link from "@mui/material/Link";
 import React, { useState } from "react";
@@ -9,6 +8,7 @@ export interface Props {
   handleChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   value: string;
   name: string;
+  ariaLabel: string;
 }
 
 const CollapsibleInput: React.FC<Props> = (props: Props) => {
@@ -16,23 +16,19 @@ const CollapsibleInput: React.FC<Props> = (props: Props) => {
 
   return (
     <>
-      <Link
-        component="button"
-        onClick={() => setExpanded((x) => !x)}
-        sx={{ marginBottom: 2 }}
-      >
+      <Link component="button" onClick={() => setExpanded((x) => !x)}>
         {props.children}
       </Link>
       <Collapse in={expanded}>
-        <Box py={0.5}>
-          <Input
-            multiline
-            bordered
-            value={props.value}
-            name={props.name}
-            onChange={props.handleChange}
-          />
-        </Box>
+        <Input
+          multiline
+          bordered
+          value={props.value}
+          name={props.name}
+          onChange={props.handleChange}
+          id={props.name}
+          inputProps={{ "aria-label": props.ariaLabel }}
+        />
       </Collapse>
     </>
   );


### PR DESCRIPTION
Accessibility fix: missing input label on collapsable feedback input.

PR adds an `aria-label` to the input, referencing the input button text.

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/b188c19c-7a2f-4504-80d7-e028acdc38cf)
