### PR TITLE
feat: improve usability of more info drawer

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -1,4 +1,5 @@
 import CloseIcon from "@mui/icons-material/Close";
+import Container from "@mui/material/Container";
 import Drawer, { DrawerProps } from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
@@ -36,20 +37,26 @@ const Root = styled(Drawer, {
     backgroundColor: theme.palette.background.default,
     border: 0,
     boxShadow: "-4px 0 0 rgba(0,0,0,0.1)",
-    padding: theme.spacing(1),
   },
 }));
 
-const DrawerContent = styled("div")(() => ({
-  padding: "0.5rem 1.75rem 1rem",
+const DrawerContent = styled("div")(({ theme }) => ({
+  padding: theme.spacing(2.5, 4, 6, 0),
   fontSize: "1rem",
   lineHeight: "1.5",
+  [theme.breakpoints.up("sm")]: {
+    padding: theme.spacing(6, 4, 6, 1),
+  },
 }));
 
-const CloseButton = styled("div")(() => ({
+const CloseButton = styled("div")(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   justifyContent: "flex-end",
+  position: "fixed",
+  top: theme.spacing(1),
+  right: theme.spacing(1),
+  color: theme.palette.text.primary,
 }));
 
 interface IMoreInfo {
@@ -78,13 +85,14 @@ const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
         title="Close panel"
         aria-label="Close panel"
         size="large"
+        color="inherit"
       >
         <CloseIcon />
       </IconButton>
     </CloseButton>
-    <div role="main">
+    <Container maxWidth={false} role="main">
       <DrawerContent>{children}</DrawerContent>
-    </div>
+    </Container>
   </Root>
 );
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfoSection.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfoSection.tsx
@@ -23,7 +23,7 @@ const MoreInfoSection: React.FC<IMoreInfoSection> = ({ title, children }) => {
   return (
     <Root className="MoreInfoSection-root" pb={3}>
       {title && (
-        <Typography mb={4} variant="h2">
+        <Typography mb="1em" variant="h3" component="h2">
           {title}
         </Typography>
       )}

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -118,7 +118,7 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
       },
       h3: {
         fontSize: "1.5rem",
-        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+        fontWeight: FONT_WEIGHT_BOLD,
       },
       h4: {
         fontSize: "1.188rem",


### PR DESCRIPTION
PR improves the usability of the 'more info' drawer.

Updates:

- Change position of close button to `fixed` so that it remains in place on scroll. This is especially needed for larger amounts of content on smaller screens, where there isn't the option to 'click outside' to close, and after reading content the user must scroll back to the top of the dialog to close.
- Increase contrast of close button.
- Bring `<Container>` into the dialog for more consistent and responsive gutters.
- Reduce heading font sizes so they form more readable content.
- Update `font-weight` of `<h3>`, this was missed when the numbers were incremented to make of use of the previously unused `<h2>` size.

Example to come once a pizza link is generated.