### PR TITLE
fix: Fix `pull-secrets.sh`

### DIFF
--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-if [ -z "${CI}"=true ]
+if [ "${CI}" ]
 then
     echo "Fetching secrets for CI"
     aws s3 cp s3://pizza-secrets/root.env ./../.env

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-if [ "${CI}" ]
+if [ -z "${CI}" ]
 then
     echo "Fetching secrets for CI"
     aws s3 cp s3://pizza-secrets/root.env ./../.env


### PR DESCRIPTION
Currently causing CI to fail. I did re-run all jobs on https://github.com/theopensystemslab/planx-new/pull/2005 after making this change and all jobs passed - GitHub actions must have been using a cache from a previous run.

This works locally for me, and if this PR succeeds it also works on CI.