### PR TITLE
fix: revert omission of `designated` variable in GIS response

### DIFF
--- a/api.planx.uk/gis/digitalLand.ts
+++ b/api.planx.uk/gis/digitalLand.ts
@@ -6,7 +6,7 @@ import type {
 import { gql } from "graphql-request";
 import fetch from "isomorphic-fetch";
 import { adminGraphQLClient as adminClient } from "../hasura";
-import { omitGeometry } from "./helpers";
+import { addDesignatedVariable, omitGeometry } from "./helpers";
 import { baseSchema } from "./local_authorities/metadata/base";
 
 export interface LocalAuthorityMetadata {
@@ -100,7 +100,7 @@ async function go(
 
   // --- INTERSECTIONS ---
   // check for & add any 'positive' constraints to the formattedResult
-  const formattedResult: Record<string, Constraint> = {};
+  let formattedResult: Record<string, Constraint> = {};
   if (res && res.count > 0 && res.entities) {
     res.entities.forEach((entity: { dataset: any }) => {
       // get the planx variable that corresponds to this entity's 'dataset', should never be null because our initial request is filtered on 'dataset'
@@ -142,6 +142,9 @@ async function go(
   });
 
   // --- DESIGNATED LAND ---
+  // add top-level 'designated' variable based on granular query results
+  formattedResult = addDesignatedVariable(formattedResult);
+
   // set granular `designated.nationalPark.broads` based on entity id (eventually extract to helper method if other cases like this)
   const broads = "designated.nationalPark.broads";
   if (

--- a/api.planx.uk/gis/helpers.js
+++ b/api.planx.uk/gis/helpers.js
@@ -16,11 +16,11 @@ const setEsriGeometry = (geometryType, x, y, radius, siteBoundary) => {
   return geometryType === "esriGeometryEnvelope"
     ? bufferPoint(x, y, radius)
     : JSON.stringify({
-      rings: siteBoundary,
-      spatialReference: {
-        wkid: 4326,
-      },
-    });
+        rings: siteBoundary,
+        spatialReference: {
+          wkid: 4326,
+        },
+      });
 };
 
 // Build up the URL used to query an ESRI feature

--- a/api.planx.uk/gis/helpers.js
+++ b/api.planx.uk/gis/helpers.js
@@ -16,11 +16,11 @@ const setEsriGeometry = (geometryType, x, y, radius, siteBoundary) => {
   return geometryType === "esriGeometryEnvelope"
     ? bufferPoint(x, y, radius)
     : JSON.stringify({
-        rings: siteBoundary,
-        spatialReference: {
-          wkid: 4326,
-        },
-      });
+      rings: siteBoundary,
+      spatialReference: {
+        wkid: 4326,
+      },
+    });
 };
 
 // Build up the URL used to query an ESRI feature
@@ -120,6 +120,44 @@ const getManualConstraints = (metadata) => {
   return manualConstraints;
 };
 
+// Adds "designated" variable to response object, so we can auto-answer less granular questions like "are you on designated land"
+const addDesignatedVariable = (responseObject) => {
+  const resObjWithDesignated = {
+    ...responseObject,
+    designated: { value: false },
+  };
+
+  const subVariables = [
+    "conservationArea",
+    "AONB",
+    "nationalPark",
+    "WHS",
+    "SPA",
+  ];
+
+  // If any of the subvariables are true, then set "designated" to true
+  subVariables.forEach((s) => {
+    if (resObjWithDesignated[`designated.${s}`]?.value) {
+      resObjWithDesignated["designated"] = { value: true };
+    }
+  });
+
+  // Ensure that our response includes all the expected subVariables before returning "designated"
+  //   so we don't incorrectly auto-answer any questions for individual layer queries that may have failed
+  let subVariablesFound = 0;
+  Object.keys(responseObject).forEach((key) => {
+    if (key.startsWith(`designated.`)) {
+      subVariablesFound++;
+    }
+  });
+
+  if (subVariablesFound < subVariables.length) {
+    return responseObject;
+  } else {
+    return resObjWithDesignated;
+  }
+};
+
 // Squash multiple layers into a single result
 const squashResultLayers = (originalOb, layers, layerName) => {
   const ob = { ...originalOb };
@@ -188,4 +226,5 @@ export {
   rollupResultLayers,
   getA4Subvariables,
   omitGeometry,
+  addDesignatedVariable,
 };

--- a/api.planx.uk/gis/local_authorities/braintree.js
+++ b/api.planx.uk/gis/local_authorities/braintree.js
@@ -7,6 +7,7 @@ import {
   setEsriGeometry,
   squashResultLayers,
   rollupResultLayers,
+  addDesignatedVariable,
 } from "../helpers.js";
 import { planningConstraints, A4_KEY } from "./metadata/braintree.js";
 
@@ -133,7 +134,10 @@ async function go(x, y, siteBoundary, extras) {
     "listed",
   );
 
-  return obWithSingleListed;
+  // Add summary "designated" key to response
+  const obWithDesignated = addDesignatedVariable(obWithSingleListed);
+
+  return obWithDesignated;
 }
 
 async function locationSearch(x, y, siteBoundary, extras) {

--- a/api.planx.uk/gis/local_authorities/scotland.js
+++ b/api.planx.uk/gis/local_authorities/scotland.js
@@ -6,6 +6,7 @@ import {
   setEsriGeometryType,
   setEsriGeometry,
   rollupResultLayers,
+  addDesignatedVariable,
 } from "../helpers.js";
 import { planningConstraints } from "./metadata/scotland";
 
@@ -114,7 +115,10 @@ async function go(x, y, siteBoundary, extras) {
     "designated.nationalPark",
   );
 
-  return obWithOneNationalPark;
+  // Add summary "designated" key to response
+  const obWithDesignated = addDesignatedVariable(obWithOneNationalPark);
+
+  return obWithDesignated;
 }
 
 async function locationSearch(x, y, siteBoundary, extras) {


### PR DESCRIPTION
manually reverts #1821 

for testing by August & George, see this thread: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1690462520855369

this was only working for sites that have at least one true constraint, not if all constraint values are part of `_nots` - which seems to break our passport granularity checks