### PR TITLE
fix: Fix `pull-secrets.sh` (again)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -326,7 +326,7 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
             export AWS_REGION=eu-west-2
 
-            ./scripts/pull-secrets.sh
+            CI=true ./scripts/pull-secrets.sh
 
             echo -e "\nROOT_DOMAIN=${{ env.FULL_DOMAIN }}\n" > .env.temp
             cat .env .env.temp .env.staging > .env.pizza
@@ -356,7 +356,7 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
             export AWS_REGION=eu-west-2
 
-            ./scripts/pull-secrets.sh
+            CI=true ./scripts/pull-secrets.sh
 
             echo -e "\nROOT_DOMAIN=${{ env.FULL_DOMAIN }}\n" > .env.temp
             cat .env .env.temp .env.staging > .env.pizza

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-if [ -z "${CI}" ]
+if [ "${CI}" ]
 then
     echo "Fetching secrets for CI"
     aws s3 cp s3://pizza-secrets/root.env ./../.env


### PR DESCRIPTION
The reasons I've been hitting issues here is because the `$CI` env var is set to `true` on GitHub actions, but not on Vultr which we ssh onto and then re-run the `pull-secrets.sh` script.