### PR TITLE
feat: Add payment_id computed field on sessions

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -602,6 +602,8 @@
           - has_user_saved
           - id
           - updated_at
+        computed_fields:
+          - payment_id
         filter:
           _and:
             - id:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -575,6 +575,13 @@
 - table:
     schema: public
     name: sessions
+  computed_fields:
+    - name: payment_id
+      definition:
+        function:
+          schema: public
+          name: sessions_payment
+      comment: A computed field to find the latest successful payment associated with a session
   insert_permissions:
     - role: public
       permission:

--- a/hasura.planx.uk/migrations/1690531868914_add_session_payment_computed_field/down.sql
+++ b/hasura.planx.uk/migrations/1690531868914_add_session_payment_computed_field/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION public.sessions_payment;

--- a/hasura.planx.uk/migrations/1690531868914_add_session_payment_computed_field/up.sql
+++ b/hasura.planx.uk/migrations/1690531868914_add_session_payment_computed_field/up.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION public.sessions_payment(
+  session_row sessions
+) RETURNS TEXT AS
+$$
+SELECT payment_id FROM payment_status
+  WHERE session_id = session_row.id AND status = 'success'
+  ORDER BY created_at DESC LIMIT 1
+$$ LANGUAGE sql STABLE;

--- a/hasura.planx.uk/tests/sessions.test.js
+++ b/hasura.planx.uk/tests/sessions.test.js
@@ -553,6 +553,7 @@ describe("sessions", () => {
               has_user_saved
               id
               updated_at
+              payment_id
             }
           }
         `,
@@ -560,7 +561,14 @@ describe("sessions", () => {
           headers
         );
         expect(res.data.sessions).toHaveLength(1);
-        expect(res.data.sessions[0].id).toEqual(alice1);
+        const session = res.data.sessions[0]
+        expect(session.id).toEqual(alice1);
+        expect(session).toHaveProperty(["created_at"]);
+        expect(session).toHaveProperty(["breadcrumbs"]);
+        expect(session).toHaveProperty(["has_user_saved"]);
+        expect(session).toHaveProperty(["id"]);
+        expect(session).toHaveProperty(["updated_at"]);
+        expect(session).toHaveProperty(["payment_id"]);
       });
 
       test("Anonymous users cannot select their own session", async () => {


### PR DESCRIPTION
Sessions should fetch a `payment_id` from a successful payment in the payment status table (discussed here: [doc/architecture/decisions/0006-remove-govukpayment-from-session-data.md](https://github.com/theopensystemslab/planx-new/blob/main/doc/architecture/decisions/0006-remove-govukpayment-from-session-data.md)).

This PR adds a computed field for the `sessions` table to fetch the id of the latest successful payment.

I believe this should work for invite-to-pay journeys too since the payment_status audit table is updated using the original lowcal_session id (an identical ID will be used for entries in the sessions table).