### PR TITLE
fix: notice component text colour

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.test.tsx
@@ -16,7 +16,7 @@ test("const { user } = setups correctly", async () => {
   expect(content()).toHaveTextContent("hello");
   expect(content()).toHaveStyle({
     background: "#fff",
-    color: "#000",
+    color: "#0B0C0C",
   });
 
   await user.click(screen.getByTestId("continue-button"));

--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -16,7 +16,10 @@ const Content = styled(Box, {
   padding: theme.spacing(2),
   backgroundColor: color,
   color:
-    mostReadable(color || "#fff", ["#fff", "#000"])?.toHexString() || "#000",
+    mostReadable(color || "#fff", [
+      "#fff",
+      theme.palette.text.primary,
+    ])?.toHexString() || theme.palette.text.primary,
   "& a": {
     color: getContrastTextColor(color || "#fff", theme.palette.primary.main),
   },

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -71,7 +71,7 @@ const NoticeComponent: React.FC<Props> = (props) => {
   const theme: Theme = useTheme();
   const textColor = getContrastTextColor(
     props.color,
-    theme.palette.primary.main,
+    theme.palette.text.primary,
   );
   const handleSubmit = !props.resetButton
     ? () => props.handleSubmit?.()


### PR DESCRIPTION
PR fixes a regression where the text of the notice component is outputting as the primary theme colour instead of a black/white contrast to the background.

Before:
<img width="858" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/7ff2cdde-3664-429b-953e-ee8cea1bbe53">


After:
<img width="858" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/ce7cc2c2-49ac-4abc-9e77-86bf735015d2">
