### PR TITLE
feat: tidy up resume pages

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
-import { lighten, styled, useTheme } from "@mui/material/styles";
+import { styled, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
@@ -156,7 +156,7 @@ export default function Confirm(props: Props) {
         {page === "Pay" && !props.hideFeeBanner && (
           <Banner
             color={{
-              background: lighten(theme.palette.info.main, 0.9),
+              background: theme.palette.info.light,
               text: theme.palette.text.primary,
             }}
           >

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -1,7 +1,7 @@
 import Warning from "@mui/icons-material/WarningOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import { lighten, useTheme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { SectionsOverviewList } from "@planx/components/Section/Public";
 import Card from "@planx/components/shared/Preview/Card";
@@ -67,7 +67,7 @@ const ReconciliationPage: React.FC<Props> = ({
         <Banner
           heading={bannerHeading}
           color={{
-            background: lighten(theme.palette.info.main, 0.9),
+            background: theme.palette.info.light,
             text: theme.palette.text.primary,
           }}
         />

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -149,6 +149,7 @@ export const InvalidSession: React.FC<{
       Reasons
     </Typography>
     <Typography variant="body1">
+      <br />
       This may be because your application has expired or there was a mistake in
       your email address.
       <br />

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -96,7 +96,7 @@ export const EmailError: React.FC<{ retry: () => void }> = ({ retry }) => {
       buttonText="Retry"
       onButtonClick={retry}
     >
-      <Typography variant="body2">
+      <Typography variant="body1">
         We are having trouble sending emails at the moment.
         <br />
         <br />
@@ -114,7 +114,7 @@ export const EmailSuccess: React.FC = () => {
       buttonText="Close Tab"
       onButtonClick={() => window.close()}
     >
-      <Typography variant="body2">
+      <Typography variant="body1">
         If you have any draft applications we have sent you an email that
         contains a link. Use this link to access your applications.
       </Typography>
@@ -145,10 +145,10 @@ export const InvalidSession: React.FC<{
     onButtonClick={retry}
     additionalOption="startNewApplication"
   >
-    <Typography variant="body2">
-      <b>Reasons</b>
-      <br />
-      <br />
+    <Typography variant="h3" component="h2">
+      Reasons
+    </Typography>
+    <Typography variant="body1">
       This may be because your application has expired or there was a mistake in
       your email address.
       <br />
@@ -165,7 +165,7 @@ export const LockedSession: React.FC<{
     bannerHeading="Sorry, you can't make changes to this application"
     additionalOption="startNewApplication"
   >
-    <Typography variant="body2">
+    <Typography variant="body1">
       This is because you've invited {paymentRequest?.payeeName} (
       <Link href={`mailto:${paymentRequest?.payeeEmail}`}>
         {paymentRequest?.payeeEmail}

--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -4,6 +4,7 @@ import Link from "@mui/material/Link";
 import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import Card from "@planx/components/shared/Preview/Card";
+import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import Banner from "ui/Banner";
@@ -58,8 +59,8 @@ const StatusPage: React.FC<Props> = ({
         <Banner
           heading={bannerHeading}
           color={{
-            background: theme.palette.primary.main,
-            text: theme.palette.primary.contrastText,
+            background: theme.palette.info.light,
+            text: theme.palette.text.primary,
           }}
         >
           {bannerText && (
@@ -87,13 +88,15 @@ const StatusPage: React.FC<Props> = ({
         )}
         {additionalOption === "startNewApplication" && (
           <>
-            <Typography variant="body2">or</Typography>
+            <Typography sx={contentFlowSpacing} variant="body1">
+              or
+            </Typography>
             <Link
               component="button"
               onClick={removeSessionIdSearchParam}
-              sx={{ mt: 2.5 }}
+              sx={contentFlowSpacing}
             >
-              <Typography variant="body2">Start new application</Typography>
+              <Typography variant="body1">Start new application</Typography>
             </Link>
           </>
         )}

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -55,6 +55,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   },
   info: {
     main: "#2196F3",
+    light: "#EBF4FD",
   },
 };
 


### PR DESCRIPTION
Watching Jess reveal the 'hard-to-reach' pages in this mornings demo, I realised that there were several pages that had missed out on the style update.

PR updates banner background colour, type sizes and spacing to tidy up the resume pages.

**Before:**
https://storybook.planx.uk/?path=/docs/design-system-pages-resume--docs

**After:**
https://storybook.2058.planx.pizza/?path=/docs/design-system-pages-resume--docs