### PR TITLE
feat: Basic `Section` stories

### DIFF
--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -18,55 +18,86 @@ export type Props = PublicProps<Section>;
 
 export default function Component(props: Props) {
   const [
-    flow,
-    flowName,
-    currentSectionIndex,
-    sectionCount,
-    sectionNodes,
-    currentCard,
-    changeAnswer,
     breadcrumbs,
     cachedBreadcrumbs,
+    changeAnswer,
+    currentCard,
+    currentSectionIndex,
+    flow,
+    flowName,
+    sectionCount,
+    sectionNodes,
   ] = useStore((state) => [
-    state.flow,
-    state.flowName,
-    state.currentSectionIndex,
-    state.sectionCount,
-    state.sectionNodes,
-    state.currentCard(),
-    state.changeAnswer,
     state.breadcrumbs,
     state.cachedBreadcrumbs,
+    state.changeAnswer,
+    state.currentCard(),
+    state.currentSectionIndex,
+    state.flow,
+    state.flowName,
+    state.sectionCount,
+    state.sectionNodes,
   ]);
 
   return (
-    <Card isValid handleSubmit={props.handleSubmit}>
-      <QuestionHeader title={flowName} />
-      <Box>
-        <Typography variant="h3" component="h2" pb="0.25em">
-          Application incomplete.
-        </Typography>
-        <Typography variant="subtitle2" component="h3">
-          {`You have completed ${
-            Object.keys(sectionNodes)[0] === currentCard?.id
-              ? 0
-              : currentSectionIndex
-          } of ${sectionCount} sections`}
-        </Typography>
-      </Box>
-      <SectionsOverviewList
-        flow={flow}
-        showChange={true}
-        changeAnswer={changeAnswer}
-        nextQuestion={() => props.handleSubmit && props.handleSubmit()}
-        sectionNodes={sectionNodes}
-        currentCard={currentCard}
-        breadcrumbs={breadcrumbs}
-        cachedBreadcrumbs={cachedBreadcrumbs}
-      />
-    </Card>
+    <Root
+      {...props}
+      breadcrumbs={breadcrumbs}
+      cachedBreadcrumbs={cachedBreadcrumbs}
+      changeAnswer={changeAnswer}
+      currentCard={currentCard}
+      currentSectionIndex={currentSectionIndex}
+      flow={flow}
+      flowName={flowName}
+      sectionCount={sectionCount}
+      sectionNodes={sectionNodes}
+    />
   );
 }
+
+interface RootProps
+  extends Omit<SectionsOverviewListProps, "showChange" | "nextQuestion">,
+    Props {
+  currentSectionIndex: number;
+  flowName: string;
+  sectionNodes: Record<string, SectionNode>;
+  currentCard: Store.node | null;
+  sectionCount: number;
+}
+
+// Stateless component to simplify testing of the "Section" component
+export const Root = ({
+  currentSectionIndex,
+  flowName,
+  handleSubmit,
+  sectionNodes,
+  currentCard,
+  sectionCount,
+  ...props
+}: RootProps) => (
+  <Card isValid handleSubmit={handleSubmit}>
+    <QuestionHeader title={flowName} />
+    <Box>
+      <Typography variant="h3" component="h2" pb="0.25em">
+        Application incomplete.
+      </Typography>
+      <Typography variant="subtitle2" component="h3">
+        {`You have completed ${
+          Object.keys(sectionNodes)[0] === currentCard?.id
+            ? 0
+            : currentSectionIndex
+        } of ${sectionCount} sections`}
+      </Typography>
+    </Box>
+    <SectionsOverviewList
+      {...props}
+      currentCard={currentCard}
+      sectionNodes={sectionNodes}
+      showChange={true}
+      nextQuestion={() => handleSubmit && handleSubmit()}
+    />
+  </Card>
+);
 
 type SectionsOverviewListProps = {
   flow: Store.flow;

--- a/editor.planx.uk/src/@planx/components/Section/Section.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Section.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React from "react";
+import { ComponentProps } from "react";
+import { SectionNode } from "types";
 
-import Wrapper from "../fixtures/Wrapper";
-import Editor from "./Editor";
-import Public from "./Public";
+import { TYPES } from "../types";
+import { Root as Public } from "./Public";
 
 const meta = {
   title: "PlanX Components/Section",
@@ -14,13 +14,73 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 
-// TODO needs internal state
+const sectionNodes: { [key: string]: SectionNode } = {
+  firstSection: {
+    data: {
+      title: "First section",
+    },
+    type: TYPES.Section,
+  },
+  secondSection: {
+    data: {
+      title: "Second section",
+    },
+    type: TYPES.Section,
+  },
+  thirdSection: {
+    data: {
+      title: "Third section",
+    },
+    type: TYPES.Section,
+  },
+};
+
+const defaultProps: ComponentProps<typeof Public> = {
+  currentSectionIndex: 0,
+  flowName: "Find out if you need planning permission",
+  sectionNodes,
+  currentCard: {
+    id: "abc123",
+  },
+  flow: {
+    _root: {
+      edges: ["firstSection", "secondSection", "thirdSection"],
+    },
+    ...sectionNodes,
+  },
+  changeAnswer: () => console.log("changeAnswer called"),
+  breadcrumbs: {},
+  title: "The property",
+  sectionCount: 3,
+};
+
 export const Basic = {
+  args: defaultProps,
+} satisfies Story;
+
+export const FirstSectionCompleted = {
   args: {
-    title: "The property",
+    ...defaultProps,
+    currentSectionIndex: 1,
+    breadcrumbs: {
+      firstSection: {
+        auto: false,
+      },
+    },
   },
 } satisfies Story;
 
-export const WithEditor = () => {
-  return <Wrapper Editor={Editor} Public={Public} />;
-};
+export const SecondSectionCompleted = {
+  args: {
+    ...defaultProps,
+    currentSectionIndex: 2,
+    breadcrumbs: {
+      firstSection: {
+        auto: false,
+      },
+      secondSection: {
+        auto: false,
+      },
+    },
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/@planx/components/Section/Section.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Section.stories.tsx
@@ -40,7 +40,7 @@ const defaultProps: ComponentProps<typeof Public> = {
   flowName: "Find out if you need planning permission",
   sectionNodes,
   currentCard: {
-    id: "abc123",
+    id: "firstQuestion",
   },
   flow: {
     _root: {
@@ -63,24 +63,19 @@ export const FirstSectionCompleted = {
     ...defaultProps,
     currentSectionIndex: 1,
     breadcrumbs: {
-      firstSection: {
-        auto: false,
-      },
+      firstSection: { auto: false },
     },
   },
 } satisfies Story;
 
-export const SecondSectionCompleted = {
+export const WithNewInformationNeeded = {
   args: {
     ...defaultProps,
-    currentSectionIndex: 2,
+    isReconciliation: true,
     breadcrumbs: {
-      firstSection: {
-        auto: false,
-      },
-      secondSection: {
-        auto: false,
-      },
+      firstSection: { auto: false },
+      secondSection: { auto: false },
     },
+    alteredSectionIds: ["firstSection"],
   },
 } satisfies Story;


### PR DESCRIPTION
I spent some time trying to resolve this using Zustand stores without much luck within the Storybook components. I think in order to get this to work we'd need to use a Provider approach, similar to what's outlined here - 

This would be a big refactor and I'm unsure of the real benefit for the effort involved.

I've gone for just a stateless wrapper component to simplify the visual testing of the "Section" component. 