### PR TITLE
feat(iac): Redirect ELB traffic to CloudFlare DNS

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -12,6 +12,7 @@ import * as url from "url";
 
 import { generateTeamSecrets } from "./utils/generateTeamSecrets";
 import { createHasuraService } from "./services/hasura";
+import { addRedirectToCloudFlareListenerRule } from "./utils/addListenerRule";
 
 const config = new pulumi.Config();
 
@@ -134,6 +135,13 @@ export = async () => {
   const metabaseListenerHttp = targetMetabase.createListener(
     "metabase-http", { protocol: "HTTP" }
   );
+
+  addRedirectToCloudFlareListenerRule({
+    serviceName: "metabase",
+    listener: metabaseListenerHttp,
+    domain: DOMAIN,
+  });
+  
   const metabaseService = new awsx.ecs.FargateService("metabase", {
     cluster,
     subnets: networking.requireOutput("publicSubnetIds"),
@@ -257,6 +265,13 @@ export = async () => {
   const apiListenerHttp = targetApi.createListener("api-http", {
     protocol: "HTTP",
   });
+
+  addRedirectToCloudFlareListenerRule({
+    serviceName: "api",
+    listener: apiListenerHttp,
+    domain: DOMAIN,
+  });
+
   const apiService = new awsx.ecs.FargateService("api", {
     cluster,
     subnets: networking.requireOutput("publicSubnetIds"),
@@ -403,6 +418,13 @@ export = async () => {
     },
   });
   const sharedbListenerHttp = targetSharedb.createListener("sharedb-http", { protocol: "HTTP" });
+
+  addRedirectToCloudFlareListenerRule({
+    serviceName: "sharedb",
+    listener: sharedbListenerHttp,
+    domain: DOMAIN,
+  });
+
   const sharedbService = new awsx.ecs.FargateService("sharedb", {
     cluster,
     subnets: networking.requireOutput("publicSubnetIds"),

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -7,6 +7,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as tldjs from "tldjs";
 
 import { CreateService } from './../types';
+import { addRedirectToCloudFlareListenerRule } from "../utils/addListenerRule";
 
 export const createHasuraService = async ({
   vpc,
@@ -37,6 +38,12 @@ export const createHasuraService = async ({
     },
   });  
   const hasuraListenerHttp = targetHasura.createListener("hasura-http", { protocol: "HTTP" });
+
+  addRedirectToCloudFlareListenerRule({
+    serviceName: "hasura",
+    listener: hasuraListenerHttp,
+    domain: DOMAIN,
+  });
 
   // hasuraService is composed of two tightly coupled containers
   // hasuraProxy is publicly exposed (behind the load balancer) and reverse proxies requests to hasura

--- a/infrastructure/application/utils/addListenerRule.ts
+++ b/infrastructure/application/utils/addListenerRule.ts
@@ -1,0 +1,28 @@
+import * as awsx from "@pulumi/awsx";
+
+/**
+ * Restrict access to ELB directly by redirecting all traffic via our DNS
+ * This ensures that CloudFlare proxies all requests
+ */
+export const addRedirectToCloudFlareListenerRule = async ({ serviceName, listener, domain }: {
+  serviceName: string;
+  listener: awsx.elasticloadbalancingv2.ApplicationListener;
+  domain: string;
+}) => {
+  listener.addListenerRule(`${serviceName}-redirectToCloudFlare`, {
+    actions: [{
+      type: "redirect",
+      redirect: {
+        host: `${serviceName}.${domain}`,
+        port: "443",
+        protocol: "HTTPS",
+        statusCode: "HTTP_301",
+      },
+    }],
+    conditions: [{
+      hostHeader: {
+        values: [`${serviceName}-*-*.eu-west-2.elb.amazonaws.com`],
+      }
+    }],
+  });
+};


### PR DESCRIPTION
The following URLs are no longer exposed and should redirect to `plan.in` domains which is proxied via CloudFlare - 

- http://sharedb-f3c94f4-2023684948.eu-west-2.elb.amazonaws.com →→→ https://sharedb.planx.in
- http://hasura-79e5fd6-2123067927.eu-west-2.elb.amazonaws.com →→→ https://hasura.planx.in
- http://metabase-ca18194-269509255.eu-west-2.elb.amazonaws.com →→→ https://metabase.planx.in
- http://api-b0a0d39-1647464175.eu-west-2.elb.amazonaws.com →→→ https://api.planx.in

You can confirm the redirect by...
 - checking the network activity for a 301 or 426 status
 - checking the new URL in the browser
 - checking the response headers (set in CloudFlare) for the `{ Daf-Test: "hello world" }` header as further proof we're proxying via CF! (I'll remove this once the PR is merged)