### PR TITLE
chore: Override protobufjs

### DIFF
--- a/infrastructure/certificates/package.json
+++ b/infrastructure/certificates/package.json
@@ -17,7 +17,7 @@
   },
   "pnpm": {
     "overrides": {
-      "protobufjs@>=6.10.0 <7.2.4": ">=7.2.4"
+      "protobufjs": ">=7.2.4"
     }
   }
 }

--- a/infrastructure/certificates/pnpm-lock.yaml
+++ b/infrastructure/certificates/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  protobufjs@>=6.10.0 <7.2.4: '>=7.2.4'
+  protobufjs: '>=7.2.4'
 
 dependencies:
   '@pulumi/aws':
@@ -34,8 +34,8 @@ devDependencies:
 
 packages:
 
-  /@grpc/grpc-js@1.8.21:
-    resolution: {integrity: sha512-KeyQeZpxeEBSqFVTi3q2K7PiPXmgBfECc4updA1ejCLjYmoAlvvM3ZMp5ztTDUCUQmoY3CpDxvchjO1+rFkoHg==}
+  /@grpc/grpc-js@1.9.0:
+    resolution: {integrity: sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==}
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.8
@@ -107,11 +107,11 @@ packages:
     requiresBuild: true
     dependencies:
       '@pulumi/pulumi': 3.0.0
-      aws-sdk: 2.1426.0
+      aws-sdk: 2.1432.0
       builtin-modules: 3.0.0
       mime: 2.6.0
       read-package-tree: 5.3.1
-      resolve: 1.22.2
+      resolve: 1.22.4
     dev: false
 
   /@pulumi/awsx@0.30.0(@pulumi/aws@4.0.0)(@pulumi/pulumi@3.0.0):
@@ -146,14 +146,14 @@ packages:
     resolution: {integrity: sha512-s9pwbdFrMU8vt4F5aIf8cpnDmHSM5Pn5V2Y7T7m0R14pfxTjCqt5ZAuEdKys0SgL+DxDp5L4Kz/53SXC6MFEEw==}
     engines: {node: '>=8.13.0 || >=10.10.0'}
     dependencies:
-      '@grpc/grpc-js': 1.8.21
+      '@grpc/grpc-js': 1.9.0
       '@logdna/tail-file': 2.2.0
       '@pulumi/query': 0.3.0
       google-protobuf: 3.21.2
       js-yaml: 3.14.1
       minimist: 1.2.8
       normalize-package-data: 2.5.0
-      protobufjs: 6.11.3
+      protobufjs: 7.2.4
       read-package-tree: 5.3.1
       require-from-string: 2.0.2
       semver: 6.3.1
@@ -245,8 +245,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /aws-sdk@2.1426.0:
-    resolution: {integrity: sha512-qq4ydcRzQW2IqjMdCz5FklORREEtkSCJ2tm9CUJ2PaUOaljxpdxq9UI64vXiyRD+GIp5vdkmVNoTRi2rCXh3rA==}
+  /aws-sdk@2.1432.0:
+    resolution: {integrity: sha512-bnPilJ0YkFOHGL2yYSnpd/oMnsDicGQKmE479vDn/AVcKhRswcg893DTqxrkkuuylEIcIIPPHBqX+IlwNv1zqw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       buffer: 4.9.2
@@ -615,8 +615,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+  /is-core-module@2.13.0:
+    resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
     dependencies:
       has: 1.0.3
     dev: false
@@ -761,7 +761,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.4
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: false
@@ -813,26 +813,6 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: false
-
-  /protobufjs@6.11.3:
-    resolution: {integrity: sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
-      '@types/node': 14.14.41
-      long: 4.0.0
     dev: false
 
   /protobufjs@7.2.4:
@@ -924,11 +904,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /resolve@1.22.2:
-    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
+  /resolve@1.22.4:
+    resolution: {integrity: sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.13.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: false


### PR DESCRIPTION
https://github.com/theopensystemslab/planx-new/security/dependabot/31 remained open following https://github.com/theopensystemslab/planx-new/pull/1235

When running `pnpm why protobufjs` in the `/infrastructure/certificates` layer we were still getting results for affected versions - the autogenerated version syntax from `pnpm audit --fix` didn't appear to be working as expected.

I've manually changed it to just override all versions, instead of using the autogenerated `@>=6.10.0 <7.2.4` syntax.