### PR TITLE
chore: Stringify Axios errors

### DIFF
--- a/api.planx.uk/hasura/metadata/index.ts
+++ b/api.planx.uk/hasura/metadata/index.ts
@@ -44,7 +44,7 @@ const postToMetadataAPI = async (
     );
   } catch (error) {
     const errorMessage = isAxiosError(error)
-      ? error.toJSON()
+      ? JSON.stringify(error.toJSON())
       : (error as Error).message;
     throw Error(`Failed to POST to Hasura Metadata API: ${errorMessage}`);
   }

--- a/api.planx.uk/hasura/schema/index.ts
+++ b/api.planx.uk/hasura/schema/index.ts
@@ -29,7 +29,7 @@ const postToSchemaAPI = async (
     );
   } catch (error) {
     const errorMessage = isAxiosError(error)
-      ? error.toJSON()
+      ? JSON.stringify(error.toJSON())
       : (error as Error).message;
     throw Error(`Failed to POST to Hasura Schema API: ${errorMessage}`);
   }


### PR DESCRIPTION
It's likely there's a better medium-term way of achieving this (`axiosError.cause.message` or `axiosError.response.data`) but right now I'd just like to see the entire object to try and work out what's going on.