### PR TITLE
chore: rotate `hasura-admin-secret` across all Pulumi/AWS environments

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -21,7 +21,7 @@ config:
   application:govuk-notify-api-key:
     secure: AAABADo05EPv/HWj7Rkf19nBeTcPJd4pEcRi2/uhyB3agraFODpLvNMx2bXfISf5pZ4HA41GYCE4f7OLcJN6hIV6ZMWUlEriPzvkoUAixbLlz1LIERiyk73R8E4F2bV65/9aFqi4l7caLS5c8iDJrE+JAvu2i7oS
   application:hasura-admin-secret:
-    secure: AAABAKtJJtogD8G+Tgr94r9ZnB0H1upTM2aN5qaZe+veQFezOQe0z0yYkxMREw5BIxOaQOBJRVvoD61+k9H4yA==
+    secure: AAABAEseHWNAzdsgRcvKSb6DnsSVO3gTdDl1CibAScJXTA3xrNj0XHLP2jxKvECj4nLLSoLIi4M=
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
   application:jwt-secret:

--- a/infrastructure/application/Pulumi.sandbox.yaml
+++ b/infrastructure/application/Pulumi.sandbox.yaml
@@ -15,6 +15,8 @@ config:
     secure: AAABAN6by1UpKop5de/dlYA003xrp1LMzLG60J2asKxioUMoUS0SsP7N+1KT53aKnux45aUZ6J+ryYpGge4+FkDhEZEC85Sw0+q/bMzKy1VER9BFIU6Qzxr/shdSVwzOW1ZZQNc/Q1cZjfY4umGbEiBipz1f
   application:hasura-admin-secret:
     secure: AAABAGxe3VrlLZWcmzAkh1Ng2amkOcn1cd4f7tDt7+bq2o1V3pJZfcRJZ1UiUjRfsbxIJbF/CoInGehJIWHfHQ==
+  application:hasura-admin-token:
+    secure: AAABAA5h/GxK9VwRUtVDv3K91yumfG5kAkCWf9xEm3zharGxnDOeaPXWbGbJsu9smJnSb8VbcKE=
   application:hasura-planx-api-key:
     secure: AAABAKVQcDltAw2qwW7xlZJ22Squvgir7cRker6goWiV194dWlaGtmwOPjC0HZXexoYfm8O4pFSSRCLQZhan/Ta1/vY=
   application:jwt-secret:

--- a/infrastructure/application/Pulumi.sandbox.yaml
+++ b/infrastructure/application/Pulumi.sandbox.yaml
@@ -14,9 +14,7 @@ config:
   application:govuk-notify-api-key:
     secure: AAABAN6by1UpKop5de/dlYA003xrp1LMzLG60J2asKxioUMoUS0SsP7N+1KT53aKnux45aUZ6J+ryYpGge4+FkDhEZEC85Sw0+q/bMzKy1VER9BFIU6Qzxr/shdSVwzOW1ZZQNc/Q1cZjfY4umGbEiBipz1f
   application:hasura-admin-secret:
-    secure: AAABAGxe3VrlLZWcmzAkh1Ng2amkOcn1cd4f7tDt7+bq2o1V3pJZfcRJZ1UiUjRfsbxIJbF/CoInGehJIWHfHQ==
-  application:hasura-admin-token:
-    secure: AAABAA5h/GxK9VwRUtVDv3K91yumfG5kAkCWf9xEm3zharGxnDOeaPXWbGbJsu9smJnSb8VbcKE=
+    secure: AAABABid66tza8SQBLcAwkQRw/+QjMNG6s9vWi8Nqq4tQwbCcwSdk1vBwPVU+9y6lfndX8kq+iY=
   application:hasura-planx-api-key:
     secure: AAABAKVQcDltAw2qwW7xlZJ22Squvgir7cRker6goWiV194dWlaGtmwOPjC0HZXexoYfm8O4pFSSRCLQZhan/Ta1/vY=
   application:jwt-secret:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -22,7 +22,7 @@ config:
   application:govuk-notify-api-key:
     secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
   application:hasura-admin-secret:
-    secure: AAABAGDAQe8KyGWt1sT/psdS282GOGBjHfI/KThzfcoixsDT0s/jBSnFGjwuTrAUvrDEc06hy5jhfO1rxnsLtQ==
+    secure: AAABABxsYkxVyb/OgzfNQgIqDN2jY1xttPzTplMqlcZFAXOtg3PCeZZFWqRgXeCYvXJcqQpd3Sg=
   application:hasura-planx-api-key:
     secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
   application:jwt-secret:


### PR DESCRIPTION
An offboarding step :white_check_mark: Hasura console access is restricted via zero trust now, but rotation ensures a dev couldn't connect to a GraphQL client directly.