### PR TITLE
chore: rotate `db-password` for Pulumi staging

### DIFF
--- a/infrastructure/data/Pulumi.staging.yaml
+++ b/infrastructure/data/Pulumi.staging.yaml
@@ -1,3 +1,3 @@
 config:
   data:db-password:
-    secure: AAABAITyXpt2+HqrVK8nO9AT0SLFZBx8XBHprCgUkaDMZjuV1y+EQkrh53de4WsLb6wtWTKvb56VNDUYtWUfuw==
+    secure: AAABAKzeQTH/rx0eZE5fMJLqhU0W7B19y7pw/dtyLe5ETjsZG6FQrYkf3/QpDWe+ZJlA51haXp0=


### PR DESCRIPTION
will need to be manually deployed as its part of the data layer. follow-up PRs for production & sandbox after confirming this works.