### PR TITLE
docs: Find and Replace Swagger docs

### DIFF
--- a/api.planx.uk/editor/findReplace.ts
+++ b/api.planx.uk/editor/findReplace.ts
@@ -49,6 +49,55 @@ const getMatches = (
   };
 };
 
+/**
+ * @swagger
+ * /flows/{flowId}/search:
+ *  post:
+ *    summary: Find and replace
+ *    description: Find and replace a data variable in a flow
+ *    tags:
+ *      - flows
+ *    parameters:
+ *      - in: path
+ *        name: flowId
+ *        type: string
+ *        required: true
+ *      - in: query
+ *        name: find
+ *        type: string
+ *        required: true
+ *      - in: query
+ *        name: replace
+ *        type: string
+ *        required: false
+ *    responses:
+ *      '200':
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  required: true
+ *                matches:
+ *                  type: object
+ *                  required: true
+ *                  additionalProperties: true
+ *                updatedFlow:
+ *                  type: object
+ *                  required: false
+ *                  additionalProperties: true
+ *                  properties:
+ *                    _root:
+ *                      type: object
+ *                      properties:
+ *                        edges:
+ *                          type: array
+ *                          items:
+ *                            type: string
+ */
 const findAndReplaceInFlow = async (
   req: Request,
   res: Response,

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -541,7 +541,55 @@ app.post("/flows/:flowId/move/:teamSlug", useJWT, moveFlow);
 
 app.post("/flows/:flowId/publish", useJWT, publishFlow);
 
-// use with query params `find` (required) and `replace` (optional)
+/**
+ * @swagger
+ * /flows/{flowId}/search:
+ *  post:
+ *    summary: Find and replace
+ *    description: Find and replace a data variable in a flow
+ *    tags:
+ *      - flows
+ *    parameters:
+ *      - in: path
+ *        name: flowId
+ *        type: string
+ *        required: true
+ *      - in: query
+ *        name: find
+ *        type: string
+ *        required: true
+ *      - in: query
+ *        name: replace
+ *        type: string
+ *        required: false
+ *    responses:
+ *      '200':
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  required: true
+ *                matches:
+ *                  type: object
+ *                  required: true
+ *                  additionalProperties: true
+ *                updatedFlow:
+ *                  type: object
+ *                  required: false
+ *                  additionalProperties: true
+ *                  properties:
+ *                    _root:
+ *                      type: object
+ *                      properties:
+ *                        edges:
+ *                          type: array
+ *                          items:
+ *                            type: string
+ */
 app.post("/flows/:flowId/search", useJWT, findAndReplaceInFlow);
 
 app.get("/flows/:flowId/copy-portal/:portalNodeId", useJWT, copyPortalAsFlow);


### PR DESCRIPTION
Relies on #2090 

Adds Swagger docs for find and replace endpoint. Hitting a few DX pain points with YAML in JSDocs annotation (spacing, no linting/types, text legibility etc). I'm going to take a look sometime next week at splitting out docs into their own YAML / JSON files that can just be referred to in modules before we go too far down the path with the `@swagger` notation 👍 