### PR TITLE
feat: Add `team.boundary` and `team.boundary_bbox` columns

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -677,15 +677,18 @@
     - role: public
       permission:
         columns:
+          - boundary
           - created_at
+          - domain
           - id
           - name
           - notify_personalisation
-          - domain
           - settings
           - slug
           - theme
           - updated_at
+        computed_fields:
+          - boundary_bbox
         filter: {}
 - table:
     schema: public

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -666,6 +666,13 @@
           table:
             schema: public
             name: team_members
+  computed_fields:
+    - name: boundary_bbox
+      definition:
+        function:
+          schema: public
+          name: boundary_bbox
+      comment: Bounding box of the team's full boundary
   select_permissions:
     - role: public
       permission:

--- a/hasura.planx.uk/migrations/1692010483148_add_team_boundary/down.sql
+++ b/hasura.planx.uk/migrations/1692010483148_add_team_boundary/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."teams"."boundary_geojson" is NULL;
+ALTER TABLE "public"."teams" DROP COLUMN "boundary_geojson"
+DROP FUNCTION IF EXISTS boundary_bbox;

--- a/hasura.planx.uk/migrations/1692010483148_add_team_boundary/up.sql
+++ b/hasura.planx.uk/migrations/1692010483148_add_team_boundary/up.sql
@@ -1,0 +1,44 @@
+-- Default to UK extent
+alter table "public"."teams" add column "boundary" jsonb
+not null default '{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+            [1.9134116, 49.528423],
+            [1.9134116, 61.331151],
+            [1.9134116, 61.331151],
+            [-10.76418, 61.331151],
+            [-10.76418, 49.528423]
+        ]]
+    }
+}';
+
+comment on column "public"."teams"."boundary" is E'GeoJSON boundary for team provided by planning.data.gov.uk. Simplified boundary_bbox should generally by used where possible. Defaults to UK extent.';
+
+-- Return a simplified bounding box instead of full GeoJSON
+CREATE OR REPLACE FUNCTION public.boundary_bbox(teams_row teams)
+RETURNS JSONB AS $$
+    SELECT
+        jsonb_build_object(
+            'type',
+            'Feature',
+            'geometry',
+            (
+                ST_AsGeoJSON(ST_ENVELOPE(ST_GeomFromGeoJSON(boundary.geom))) :: jsonb
+            ),
+            'properties',
+            boundary.properties
+        )
+    FROM
+        (
+            SELECT
+                boundary -> 'geometry' as geom,
+                boundary -> 'properties' as properties
+            FROM
+                teams
+            WHERE
+                teams.id = teams_row.id
+        ) as boundary
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
## What does this PR do?
 - Adds `team.boundary` column
 - Adds `team.boundary_bbox` column, which is a computed field derived from `team.boundary`

## What's the motivation from this?
As we want to move away from JSONB for team settings where possible, it made sense to make a start on this. By storing the boundary directly, we gain a few benefits - 
 - Less reliance on planning.data.gov.uk in terms of live services (a small, but non-zero, benefit)
 - The ability to just fetch the geometry we care about (e.g. a simplified envelope of the boundary)
 - Significant reduction in request size to get the boundary (Doncasters full GeoJSON is 89KB, bbox is 404B. As an extreme example Cornwall's full boundary on planning.data is 1.2MB 🤯 )

## Why store GeoJSON in the database?
- Generally, I'd prefer to store a `geometry` type for easier interactions with PostGIS. The `boundary_bbox` function is doing some unpacking and packing to call PostGIS functions.
- We're not really doing a whole load of geospatial work in PlanX, and the tradeoff would be making it harder to query via GraphQL / Hasura doesn't seem worth it. With this approach we can just query `team.boundary_bbox` and not worry about having to call a stored procedure to get this column in a format we can use.
- There would also be additional complexity of taking a planning.data.gov.uk GeoJSON -> storing as `geometry` on db -> returning as GeoJSON which seems unnecessary at this point.

## Next steps...
 - Onboarding script to populate `team.boundary` with GeoJSON instead of `team.settings.boundary` with a URL
- Use `team.boundary_bbox` for the `clipGeojsonData` property on the map webcomponent (https://github.com/theopensystemslab/map/pull/363)
- Remove `team.settings.boundary` and references to it (after PO testing)
- Manually update production boundaries (after PO testing)