### PR TITLE
Revert "chore: rotate `db-password` for Pulumi staging"

### DIFF
--- a/infrastructure/data/Pulumi.staging.yaml
+++ b/infrastructure/data/Pulumi.staging.yaml
@@ -1,3 +1,3 @@
 config:
   data:db-password:
-    secure: AAABAKzeQTH/rx0eZE5fMJLqhU0W7B19y7pw/dtyLe5ETjsZG6FQrYkf3/QpDWe+ZJlA51haXp0=
+    secure: AAABAITyXpt2+HqrVK8nO9AT0SLFZBx8XBHprCgUkaDMZjuV1y+EQkrh53de4WsLb6wtWTKvb56VNDUYtWUfuw==


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2089

CLI output when running `pulumi --up --stack staging --refresh` in `/infrastructure/data`

```
Previewing update (staging)

Updating (staging)

View in Browser (Ctrl+O): https://app.pulumi.com/planx/data/staging/updates/24

     Type                             Name                      Status           Info
     pulumi:pulumi:Stack              data-staging                               
 ~   ├─ pulumi:pulumi:StackReference  planx/networking/staging  refresh (1s)     
     ├─ aws:s3:Bucket                 user-data                                  [diff: ~corsRules,serverSideEncryptionConfiguration]
     └─ aws:rds:Instance              app                                        [diff: ~password]


Outputs:
    apiBucketId: **REDACTED**
    dbRootUrl  : **REDACTED**

Resources:
    3 unchanged

Duration: 9s
```

Despite seeming like this worked Friday afternoon when I ran it - it's actually picking up the diff, but showing "3 unchanged" after what looks like a successful run.

I'm reverting for now to move certificates forward but will look back through Slack and GitHub to work out what worked last time to try and understand what's happening here.