### PR TITLE
chore: Setup `.gitconfig`, use in CI tasks

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,7 @@
+# Required by GitHub actions in ~/.gitconfig where git submodules are used (e.g. planx-core)
+
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+
+[url "https://"]
+	insteadOf = git://

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,6 +77,8 @@ jobs:
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - uses: pnpm/action-setup@v2.4.0
         with:
           version: ${{ vars.PNPM_VERSION }}
@@ -118,6 +120,8 @@ jobs:
         with:
           files: ".env, .env.staging, api.planx.uk/.env.test, hasura.planx.uk/.env.test"
           fail: true
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - uses: pnpm/action-setup@v2.4.0
         with:
           version: ${{ vars.PNPM_VERSION }}
@@ -127,16 +131,10 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install dependencies
-        run: | 
-          git config --global url."https://github.com/".insteadOf git@github.com:
-          git config --global url."https://".insteadOf git://
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
         working-directory: api.planx.uk
       - name: Run API Tests
-        run: | 
-          git config --global url."https://github.com/".insteadOf git@github.com:
-          git config --global url."https://".insteadOf git://
-          pnpm install --frozen-lockfile && pnpm check && pnpm test
+        run: pnpm install --frozen-lockfile && pnpm check && pnpm test
         working-directory: api.planx.uk
 
   test_react:
@@ -168,6 +166,8 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
@@ -198,6 +198,8 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         if: steps.cache-react-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.EDITOR_DIRECTORY }}
@@ -450,6 +452,8 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
         working-directory: e2e


### PR DESCRIPTION
PNPM (and NPM) use SSH to fetch git submodules packages instead of HTTPS (despite the URL format), resulting in actions without sufficient permissions (dependabot) failing.

This should override that - it works on individual steps when tested.

Clearly this one is a good candidate for moving into a composite or reusable workflow when we get to that ticket..!