### PR TITLE
fix: Recurring call depth React error on Airbrake

### DIFF
--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -93,16 +93,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
         setGotFlow(true);
       });
     }
-    // Updating useContext (createAnalytics) within useEffect leads to recursive calls
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    // createAnalytics
-    id,
-    isStandalone,
-    isUsingLocalStorage,
-    resumeSession,
-    sessionId,
-  ]);
+  }, []);
 
   // Update session when a question is answered
   useEffect(() => {
@@ -119,16 +110,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     isUsingLocalStorage
       ? setLocalFlow(id, session)
       : NEW.setLocalFlow(sessionId, session);
-  }, [
-    gotFlow,
-    breadcrumbs,
-    passport,
-    sessionId,
-    id,
-    govUkPayment,
-    isUsingLocalStorage,
-    isStandalone,
-  ]);
+  }, [gotFlow, breadcrumbs, passport, sessionId, id, govUkPayment]);
 
   // scroll to top on any update to breadcrumbs
   useEffect(() => {


### PR DESCRIPTION
Partial roll back of https://github.com/theopensystemslab/planx-new/pull/2035/files

The following error has been recurring heavily since the above PR was deployed https://planx.airbrake.io/projects/329753/groups/3600981422569003052

I suspect this change is the most likely culprit - I've reverted the `useEffect()` dependency arrays to what they were originally. If this doesn't succeed I'll revert the entire PR next.