### PR TITLE
fix: Resolve non-persistent state in `FileUploadAndLabel`

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -75,7 +75,7 @@ export const parseContent = (
   title: data?.title || DEFAULT_TITLE,
   description: data?.description || "",
   fn: data?.fn || "",
-  fileTypes: data?.fileTypes || [newFileType()],
+  fileTypes: cloneDeep(data?.fileTypes) || [newFileType()],
   hideDropZone: data?.hideDropZone || false,
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/graph/__tests__/update.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/update.test.ts
@@ -475,7 +475,7 @@ describe("complex example with node data", () => {
       ]);
     });
 
-    test("updating an array field", () => {
+    test("adding an item to an array field", () => {
       const dataFromFormik = {
         title: "Upload and label",
         description: "",
@@ -572,6 +572,69 @@ describe("complex example with node data", () => {
               rule: {
                 condition: "AlwaysRequired",
               },
+            },
+          ],
+          p: ["a", "data", "fileTypes"],
+        },
+      ]);
+    });
+
+    test("updating an item within an array field", () => {
+      const dataFromFormik = {
+        title: "Upload and label",
+        description: "",
+        fn: "",
+        fileTypes: [
+          {
+            name: "newValue",
+          },
+        ],
+        hideDropZone: true,
+      };
+
+      const [graph, ops] = update(
+        "a",
+        dataFromFormik,
+      )({
+        a: {
+          type: 145,
+          data: {
+            title: "Upload and label",
+            fileTypes: [
+              {
+                name: "oldValue",
+              },
+            ],
+            hideDropZone: true,
+          },
+        },
+      });
+
+      expect(graph).toEqual({
+        a: {
+          type: 145,
+          data: {
+            title: "Upload and label",
+            fileTypes: [
+              {
+                name: "newValue",
+              },
+            ],
+            hideDropZone: true,
+          },
+        },
+      });
+
+      expect(ops).toEqual([
+        {
+          od: [
+            {
+              name: "oldValue",
+            },
+          ],
+          oi: [
+            {
+              name: "newValue",
             },
           ],
           p: ["a", "data", "fileTypes"],

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -408,12 +408,7 @@ const _update = (
 
       // eslint-disable-next-line no-prototype-builtins
       const isRemoved = !isSomething(v) && existingData.hasOwnProperty(k);
-      const isUpdatedArray =
-        Array.isArray(v) && !isEqual(v, (existingData as any)[k]);
-      const isUpdatedPrimitive =
-        typeof v !== "object" && v !== (existingData as any)[k];
-      const isUpdated =
-        isSomething(v) && (isUpdatedPrimitive || isUpdatedArray);
+      const isUpdated = isSomething(v) && !isEqual(v, (existingData as any)[k]);
 
       if (isRemoved) delete (existingData as any)[k];
       if (isUpdated) (existingData as any)[k] = v;


### PR DESCRIPTION
## Context
So this was an interesting / crazy one...

Before this fix - 
 - When I modified a `FileType` it would persist if I had just added it
 - Subsequent changes to the same `FileType` do not persist, but appear to do so as the local flow is updated

This actually matched behaviour George has described a few times (and maybe Emily?) and we've put it down to ShareDB I think.

## What was happening?
- The local flow was updating _immediately_ as soon as I modified my `FileType` in the modal, no need to "Confirm"
- When saving and exiting the modal, the ShareDB side of things should start to persist flow changes to the db (see https://github.com/theopensystemslab/planx-new/pull/1958 for context)
- However, as the local flow as _already_ up to date, there was no difference between old and existing data and no `ops` were generated 🤯 

## What was the cause?
A pass by value / pass by reference issue I believe. The `FileTypes[]` being passed into Formik wasn't a copy, but a reference to the flow (as it as deeply nested). This meant as your made individual changes in the modal, the local flow was instantaneously updating.

## What's the fix?
- Explicitly copy the data using `cloneDeep()`
- We probably want to watch out for this one elsewhere if we have more complex data types in the Editor Modal in future - it might be safer to explicitly use copies every time we use Formik / `parseContent()`


https://github.com/theopensystemslab/planx-new/assets/20502206/a739d9a5-cca4-4326-b733-2f056ed26a5d



