### PR TITLE
feat: Drop `team_members`, replace with `user_teams`

### DIFF
--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -195,22 +195,16 @@ const buildJWT = async (profile: Profile, done: VerifyCallback) => {
   );
 
   if (users.length === 1) {
-    const { id, is_admin = true } = users[0];
+    const { id } = users[0];
 
     const hasura = {
-      "x-hasura-allowed-roles": ["editor"],
-      "x-hasura-default-role": "editor",
+      "x-hasura-allowed-roles": ["admin"],
+      "x-hasura-default-role": "admin",
       "x-hasura-user-id": id.toString(),
     };
 
-    if (is_admin) {
-      hasura["x-hasura-allowed-roles"] = ["admin"];
-      hasura["x-hasura-default-role"] = "admin";
-    }
-
     const data = {
       sub: id.toString(),
-      // admin: is_admin,
       "https://hasura.io/jwt/claims": hasura,
     };
 
@@ -464,7 +458,6 @@ app.get("/me", useJWT, async function (req, res, next) {
             first_name
             last_name
             email
-            is_admin
             created_at
             updated_at
           }

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -646,13 +646,13 @@
           table:
             schema: public
             name: flows
-    - name: users
+    - name: members
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
             schema: public
-            name: user_teams
+            name: team_members
   select_permissions:
     - role: public
       permission:
@@ -693,7 +693,7 @@
         template_engine: Kriti
 - table:
     schema: public
-    name: user_teams
+    name: team_members
   object_relationships:
     - name: team
       using:
@@ -725,4 +725,4 @@
           column: user_id
           table:
             schema: public
-            name: user_teams
+            name: team_members

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -637,19 +637,6 @@
         check: null
 - table:
     schema: public
-    name: team_members
-  object_relationships:
-    - name: creator
-      using:
-        foreign_key_constraint_on: creator_id
-    - name: team
-      using:
-        foreign_key_constraint_on: team_id
-    - name: user
-      using:
-        foreign_key_constraint_on: user_id
-- table:
-    schema: public
     name: teams
   array_relationships:
     - name: flows
@@ -659,13 +646,6 @@
           table:
             schema: public
             name: flows
-    - name: members
-      using:
-        foreign_key_constraint_on:
-          column: team_id
-          table:
-            schema: public
-            name: team_members
   select_permissions:
     - role: public
       permission:
@@ -715,13 +695,6 @@
           table:
             schema: public
             name: flows
-    - name: created_team_members
-      using:
-        foreign_key_constraint_on:
-          column: creator_id
-          table:
-            schema: public
-            name: team_members
     - name: operations
       using:
         foreign_key_constraint_on:
@@ -729,10 +702,3 @@
           table:
             schema: public
             name: operations
-    - name: team_members
-      using:
-        foreign_key_constraint_on:
-          column: user_id
-          table:
-            schema: public
-            name: team_members

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -180,15 +180,15 @@
     - role: public
       permission:
         columns:
-          - id
-          - team_id
-          - slug
+          - created_at
           - creator_id
           - data
-          - version
-          - created_at
-          - updated_at
+          - id
           - settings
+          - slug
+          - team_id
+          - updated_at
+          - version
         computed_fields:
           - data_merged
         filter: {}
@@ -646,15 +646,22 @@
           table:
             schema: public
             name: flows
+    - name: users
+      using:
+        foreign_key_constraint_on:
+          column: team_id
+          table:
+            schema: public
+            name: user_teams
   select_permissions:
     - role: public
       permission:
         columns:
           - created_at
+          - domain
           - id
           - name
           - notify_personalisation
-          - domain
           - settings
           - slug
           - theme
@@ -686,6 +693,16 @@
         template_engine: Kriti
 - table:
     schema: public
+    name: user_teams
+  object_relationships:
+    - name: team
+      using:
+        foreign_key_constraint_on: team_id
+    - name: user
+      using:
+        foreign_key_constraint_on: user_id
+- table:
+    schema: public
     name: users
   array_relationships:
     - name: created_flows
@@ -702,3 +719,10 @@
           table:
             schema: public
             name: operations
+    - name: teams
+      using:
+        foreign_key_constraint_on:
+          column: user_id
+          table:
+            schema: public
+            name: user_teams

--- a/hasura.planx.uk/migrations/1692347940126_drop_table_public_team_members/down.sql
+++ b/hasura.planx.uk/migrations/1692347940126_drop_table_public_team_members/down.sql
@@ -1,3 +1,42 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- DROP table "public"."team_members";
+CREATE TABLE "public"."team_members"(
+  "team_id" integer NOT NULL,
+  "user_id" integer NOT NULL,
+  "creator_id" integer NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("team_id", "user_id")
+);
+
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"() 
+RETURNS TRIGGER AS $$ 
+DECLARE 
+  _new record;
+BEGIN 
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "set_public_team_members_updated_at" BEFORE
+UPDATE
+  ON "public"."team_members" FOR EACH ROW EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+
+COMMENT ON TRIGGER "set_public_team_members_updated_at" ON "public"."team_members" IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+
+alter table
+  "public"."team_members"
+add
+  constraint "team_members_user_id_fkey" foreign key ("user_id") references "public"."users" ("id") on update restrict on delete restrict;
+
+alter table
+  "public"."team_members"
+add
+  constraint "team_members_creator_id_fkey" foreign key ("creator_id") references "public"."users" ("id") on update restrict on delete restrict;
+
+alter table
+  "public"."team_members"
+add
+  constraint "team_members_team_id_fkey" foreign key ("team_id") references "public"."teams" ("id") on update restrict on delete restrict;
+
+comment on table "public"."team_members" is E'Assigns `users` to `teams`, currently no differences in access or permission levels though';

--- a/hasura.planx.uk/migrations/1692347940126_drop_table_public_team_members/down.sql
+++ b/hasura.planx.uk/migrations/1692347940126_drop_table_public_team_members/down.sql
@@ -1,0 +1,3 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- DROP table "public"."team_members";

--- a/hasura.planx.uk/migrations/1692347940126_drop_table_public_team_members/up.sql
+++ b/hasura.planx.uk/migrations/1692347940126_drop_table_public_team_members/up.sql
@@ -1,0 +1,1 @@
+DROP table "public"."team_members";

--- a/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/down.sql
+++ b/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."user_teams";

--- a/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/down.sql
+++ b/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/down.sql
@@ -1,1 +1,1 @@
-DROP TABLE "public"."user_teams";
+DROP TABLE "public"."team_members";

--- a/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/up.sql
+++ b/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/up.sql
@@ -1,0 +1,2 @@
+CREATE TABLE "public"."user_teams" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "user_id" integer NOT NULL, "team_id" integer NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON UPDATE cascade ON DELETE cascade, FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON UPDATE cascade ON DELETE cascade);COMMENT ON TABLE "public"."user_teams" IS E'Tracks relationship between users and teams';
+CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/up.sql
+++ b/hasura.planx.uk/migrations/1692350571424_create_table_public_user_teams/up.sql
@@ -1,2 +1,12 @@
-CREATE TABLE "public"."user_teams" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "user_id" integer NOT NULL, "team_id" integer NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON UPDATE cascade ON DELETE cascade, FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON UPDATE cascade ON DELETE cascade);COMMENT ON TABLE "public"."user_teams" IS E'Tracks relationship between users and teams';
+CREATE TABLE "public"."team_members" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "user_id" integer NOT NULL,
+  "team_id" integer NOT NULL,
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON UPDATE cascade ON DELETE cascade,
+  FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON UPDATE cascade ON DELETE cascade
+);
+
+COMMENT ON TABLE "public"."team_members" IS E'Tracks relationship between users and teams';
+
 CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/hasura.planx.uk/migrations/1692362284817_alter_table_public_users_drop_column_is_admin/down.sql
+++ b/hasura.planx.uk/migrations/1692362284817_alter_table_public_users_drop_column_is_admin/down.sql
@@ -1,0 +1,4 @@
+comment on column "public"."users"."is_admin" is E'Grants access to the Editor, currently requires a Google email for single sign-on';
+alter table "public"."users" alter column "is_admin" set default false;
+alter table "public"."users" alter column "is_admin" drop not null;
+alter table "public"."users" add column "is_admin" bool;

--- a/hasura.planx.uk/migrations/1692362284817_alter_table_public_users_drop_column_is_admin/up.sql
+++ b/hasura.planx.uk/migrations/1692362284817_alter_table_public_users_drop_column_is_admin/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" drop column "is_admin" cascade;

--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -1,6 +1,6 @@
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email, is_admin) VALUES (65, 'Ian', 'Jones', 'ian@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email) VALUES (65, 'Ian', 'Jones', 'ian@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
 SELECT setval('users_id_seq', max(id)) FROM users;
 SELECT setval('teams_id_seq', max(id)) FROM teams;

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -1,20 +1,18 @@
 const { introspectAs } = require("./utils");
 
-describe("teams and team_members", () => {
+describe("teams", () => {
   describe("public", () => {
     let i;
     beforeAll(async () => {
       i = await introspectAs("public");
     });
 
-    test("can query teams, but not their associated team members", () => {
+    test("can query teams", () => {
       expect(i.queries).toContain("teams");
-      expect(i.queries).not.toContain("team_members");
     });
 
-    test("cannot create, update, or delete teams or team members", () => {
+    test("cannot create, update, or delete teams", () => {
       expect(i).toHaveNoMutationsFor("teams");
-      expect(i).toHaveNoMutationsFor("team_members");
     });
   });
 
@@ -26,7 +24,6 @@ describe("teams and team_members", () => {
 
     test("can query teams and team members", () => {
       expect(i.queries).toContain("teams");
-      expect(i.queries).toContain("team_members");
     });
   });
 });

--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -15,15 +15,13 @@ INSERT INTO users (
   id,
   first_name,
   last_name,
-  email,
-  is_admin
+  email
 )
 SELECT
   id,
   first_name,
   last_name,
-  email,
-  is_admin
+  email
 FROM sync_users
 ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
## What does this PR do?
 - Drop the currently redundant `team_members` table
 - Drop the currently redundant `users.is_admin` column
 - Add a new `user_teams` (not totally sold on the name?) table which can be used to track the relationship between users and teams