### PR TITLE
fix: include `created_at` when syncing published flows

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -37,7 +37,7 @@ if [[ ${RESET} == "reset_flows" ]]; then
 fi
 
 if [[ ${INCLUDE_PUBLISHED_FLOWS} == "include_published_flows" ]]; then
-  psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
+  psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
   echo published_flows downloaded
 fi
 

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -3,23 +3,26 @@ CREATE TEMPORARY TABLE sync_published_flows (
   data jsonb,
   flow_id uuid,
   summary text,
-  publisher_id int
+  publisher_id int,
+  created_at timestamptz
 );
 
-\copy sync_published_flows (id, data, flow_id, summary, publisher_id) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
+\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
 
 INSERT INTO published_flows (
   id,
   data,
   flow_id,
   summary,
-  publisher_id
+  publisher_id,
+  created_at
 )
 SELECT
   id,
   data,
   flow_id,
   summary,
-  publisher_id
+  publisher_id,
+  created_at
 FROM sync_published_flows
 ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Bucks has been testing flows on .dev that send to email. The flows are all published, but folks were reporting issues of not being able to download the application files.

The bug was occurring because their staging `lowcal_session.created_at` was earlier than the `published_flow.created_at`, which was getting inserted as `now()` on each sync. 

We should be able to simply include the published flow's original date from production in the sync to fix.