### PR TITLE
chore: Setup `.gitconfig` on outstanding actions

### DIFF
--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -46,6 +46,8 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: editor.planx.uk
       - run: pnpm build

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -77,6 +77,8 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: api.planx.uk
@@ -111,6 +113,8 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
@@ -142,6 +146,8 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
         working-directory: e2e


### PR DESCRIPTION
This should fix this morning's regression test failure.

I've now double checked and the `.gitconfig` is being setup on each GitHub action before a `pnpm install` for any project which uses `planx-core`.

Bit on an awkward workaround, which we could mitigate in future by...
 - Reusable workflows
 - Publish `planx-core` to NPM