### PR TITLE
fix: adjust metadata text for classified roads

### DIFF
--- a/api.planx.uk/gis/classifiedRoads.ts
+++ b/api.planx.uk/gis/classifiedRoads.ts
@@ -113,6 +113,7 @@ export const classifiedRoadsSearch = async (
         [PASSPORT_FN]: {
           name: "Classified road",
           plural: "Classified roads",
+          text: "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road.",
         },
       },
     };
@@ -124,8 +125,11 @@ export const classifiedRoadsSearch = async (
           [PASSPORT_FN]: {
             fn: PASSPORT_FN,
             value: true,
-            text: `is on a Classified Road (${features[0].properties["RoadName1"]} - ${features[0].properties["RoadClassification"]})`,
-            data: features,
+            text: `is on a Classified Road`,
+            data: features.map((feature: any) => ({
+              name: `${feature.properties["RoadName1"]} - ${feature.properties["RoadClassification"]}`,
+              properties: feature.properties,
+            })),
             category: "General policy",
           } as RoadConstraint,
         },

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/classifiedRoadsNegativeResponseMock.ts
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/classifiedRoadsNegativeResponseMock.ts
@@ -7,6 +7,7 @@ export default {
     "road.classified": {
       name: "Classified road",
       plural: "Classified roads",
+      text: "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
     },
   },
   constraints: {

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/classifiedRoadsResponseMock.ts
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/classifiedRoadsResponseMock.ts
@@ -7,28 +7,17 @@ export default {
     "road.classified": {
       name: "Classified road",
       plural: "Classified roads",
+      text: "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
     },
   },
   constraints: {
     "road.classified": {
       fn: "road.classified",
       value: true,
-      text: "is on a Classified Road (Lambeth Palace Road - A Road)",
+      text: "is on a Classified Road",
       data: [
         {
-          type: "Feature",
-          geometry: {
-            type: "MultiLineString",
-            coordinates: [
-              [
-                [51.49981331, -0.11683771],
-                [51.49986254, -0.11686428],
-                [51.4999603, -0.11684774],
-                [51.50002833, -0.11683623],
-                [51.50005332, -0.11683201],
-              ],
-            ],
-          },
+          name: "Lambeth Palace Road - A Road",
           properties: {
             GmlID: "Highways_RoadLink.102656",
             OBJECTID: 102656,


### PR DESCRIPTION
Classified roads come from OS rather than Planning Data, so we maintain our own hardcoded metadata fields for consistency. This adds `text` that August wrote in response to user feedback identified here https://trello.com/c/3Q9x5JkL/1338-from-ur-constraints-page-extra-information

I've also moved the distinct road name & classification level into a bullet point for consistency with other constraints.

**After:**
![Screenshot from 2023-08-23 20-17-32](https://github.com/theopensystemslab/planx-new/assets/5132349/f68cc599-a7fd-47ec-963a-30a14648abc2)

**Before:**
![Screenshot from 2023-08-23 20-26-11](https://github.com/theopensystemslab/planx-new/assets/5132349/b906b639-27be-4aea-8b99-77993e3ce8e6)