### PR TITLE
fix: include new `teams.boundary` column in data sync

### DIFF
--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -9,7 +9,8 @@ CREATE TEMPORARY TABLE sync_teams (
   settings jsonb,
   notify_personalisation jsonb,
   domain text,
-  submission_email text
+  submission_email text,
+  boundary jsonb
 );
 
 \copy sync_teams FROM '/tmp/teams.csv' WITH (FORMAT csv, DELIMITER ';');
@@ -20,7 +21,8 @@ INSERT INTO teams (
   slug,
   theme,
   settings,
-  notify_personalisation
+  notify_personalisation,
+  boundary
 )
 SELECT
   id,
@@ -28,7 +30,8 @@ SELECT
   slug,
   theme,
   settings,
-  notify_personalisation
+  notify_personalisation,
+  boundary
 FROM sync_teams
 ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
Updated a bunch of boundaries on production, but realised staging is still using default UK extent value until this column is explicitly synced. 

To test: check that this pizza builds with updated values ! 