### PR TITLE
fix(api): Missing Husky dependency causing `pnpm dev` to fail 

### DIFF
--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -34,6 +34,5 @@ CMD ["npm", "start"]
 ## DEVELOPMENT ##
 FROM base as development
 ENV NODE_ENV development
-# reinstall pruned development dependencies
-RUN pnpm install --development
+RUN pnpm install
 CMD ["pnpm", "dev"]


### PR DESCRIPTION
Yesterday I did a `docker system prune -a` (the first since #2128) and subsequent builds have failed on the API due to Husky being missing as it's not a dev dependency.

This resolves the issue for me locally.

Details on the `--development` flag from [pnpm docs](https://pnpm.io/cli/install#--dev--d) - 
> Only devDependencies are installed and dependencies are removed insofar they were already installed, regardless of the NODE_ENV.

It looks like this flag is actually removing dependencies as opposed to just installing devDependencies. Possibly something that was missed on a pnpm upgrade? 