### PR TITLE
feat: `teamEditor` role

### DIFF
--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -29,7 +29,7 @@ const getAllowedRolesForUser = (user: User): Role[] => {
   const teamRoles = user.teams.map((teamRole) => teamRole.role);
   const allowedRoles: Role[] = [
     "public", // Allow public access
-    "teamAdmin", // Least privileged role for authenticated users - required for Editor access
+    "teamEditor", // Least privileged role for authenticated users - required for Editor access
     ...teamRoles, // User specific roles
   ];
   if (user.isPlatformAdmin) allowedRoles.push("platformAdmin");
@@ -45,5 +45,5 @@ const getAllowedRolesForUser = (user: User): Role[] => {
  * This is the role of least privilege for the user
  */
 const getDefaultRoleForUser = (user: User): Role => {
-  return user.isPlatformAdmin ? "platformAdmin" : "teamAdmin";
+  return user.isPlatformAdmin ? "platformAdmin" : "teamEditor";
 };

--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -1,34 +1,49 @@
 import { sign } from "jsonwebtoken";
-import { adminGraphQLClient as adminClient } from "../../hasura";
-import { gql } from "graphql-request";
+import { $admin } from "../../client";
+import { User, Role } from "@opensystemslab/planx-core/types";
 
-export const buildJWT = async (email: string | undefined) => {
-  const { users } = await adminClient.request(
-    gql`
-      query ($email: String!) {
-        users(where: { email: { _eq: $email } }, limit: 1) {
-          id
-        }
-      }
-    `,
-    { email },
-  );
-
-  if (!users.length) return;
-
-  const { id } = users[0];
-
-  const hasura = {
-    "x-hasura-allowed-roles": ["platformAdmin", "public"],
-    "x-hasura-default-role": "platformAdmin",
-    "x-hasura-user-id": id.toString(),
-  };
+export const buildJWT = async (email: string): Promise<string | undefined> => {
+  const user = await $admin.user.getByEmail(email);
+  if (!user) return;
 
   const data = {
-    sub: id.toString(),
-    "https://hasura.io/jwt/claims": hasura,
+    sub: user.id.toString(),
+    "https://hasura.io/jwt/claims": generateHasuraClaimsForUser(user),
   };
 
   const jwt = sign(data, process.env.JWT_SECRET!);
   return jwt;
+};
+
+const generateHasuraClaimsForUser = (user: User) => ({
+  "x-hasura-allowed-roles": getAllowedRolesForUser(user),
+  "x-hasura-default-role": getDefaultRoleForUser(user),
+  "x-hasura-user-id": user.id.toString(),
+});
+
+/**
+ * Get all possible roles for this user
+ * Requests made outside this scope will not be authorised by Hasura
+ */
+const getAllowedRolesForUser = (user: User): Role[] => {
+  const teamRoles = user.teams.map((teamRole) => teamRole.role);
+  const allowedRoles: Role[] = [
+    "public", // Allow public access
+    "teamAdmin", // Least privileged role for authenticated users - required for Editor access
+    ...teamRoles, // User specific roles
+  ];
+  if (user.isPlatformAdmin) allowedRoles.push("platformAdmin");
+
+  return [...new Set(allowedRoles)];
+};
+
+/**
+ * The default role is used for all requests
+ * Can be overwritten on a per-request basis in the client using the x-hasura-role header
+ * set to a role in the x-hasura-allowed-roles list
+ *
+ * This is the role of least privilege for the user
+ */
+const getDefaultRoleForUser = (user: User): Role => {
+  return user.isPlatformAdmin ? "platformAdmin" : "teamAdmin";
 };

--- a/api.planx.uk/modules/auth/strategy/google.ts
+++ b/api.planx.uk/modules/auth/strategy/google.ts
@@ -9,6 +9,8 @@ export const googleStrategy = new GoogleStrategy(
   },
   async function (_accessToken, _refreshToken, profile, done) {
     const { email } = profile._json;
+    if (!email) throw Error("Unable to authenticate without email");
+
     const jwt = await buildJWT(email);
 
     if (!jwt) {

--- a/api.planx.uk/modules/team/controller.ts
+++ b/api.planx.uk/modules/team/controller.ts
@@ -12,7 +12,7 @@ export const upsertMemberSchema = z.object({
   }),
   body: z.object({
     userId: z.number(),
-    role: z.enum(["teamAdmin", "teamViewer"]),
+    role: z.enum(["teamEditor", "teamViewer"]),
   }),
 });
 

--- a/api.planx.uk/modules/team/docs.yaml
+++ b/api.planx.uk/modules/team/docs.yaml
@@ -21,7 +21,7 @@ components:
           example: 123
         role:
           type: string
-          enum: ["teamViewer", "teamAdmin"]
+          enum: ["teamViewer", "teamEditor"]
 paths:
   /team/{teamId}/add-member:
     put:

--- a/api.planx.uk/modules/team/index.test.ts
+++ b/api.planx.uk/modules/team/index.test.ts
@@ -57,7 +57,7 @@ describe("Adding a user to a team", () => {
       });
   });
 
-  it("validates that role must one an accepted value", async () => {
+  it("validates that role must be an accepted value", async () => {
     await supertest(app)
       .put("/team/123/add-member")
       .set(authHeader())

--- a/api.planx.uk/modules/team/index.test.ts
+++ b/api.planx.uk/modules/team/index.test.ts
@@ -80,7 +80,7 @@ describe("Adding a user to a team", () => {
       .set(authHeader())
       .send({
         userId: 123,
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(500)
       .then((res) => {
@@ -98,7 +98,7 @@ describe("Adding a user to a team", () => {
       .set(authHeader())
       .send({
         userId: 123,
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(200)
       .then((res) => {
@@ -156,7 +156,7 @@ describe("Removing a user from a team", () => {
       .set(authHeader())
       .send({
         userId: 123,
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(200)
       .then((res) => {
@@ -173,7 +173,7 @@ describe("Changing a user's role", () => {
       .patch("/team/123/change-member-role")
       .send({
         userId: 123,
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(401);
   });
@@ -183,7 +183,7 @@ describe("Changing a user's role", () => {
       .patch("/team/123/change-member-role")
       .set(authHeader())
       .send({
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(400)
       .then((res) => {
@@ -229,7 +229,7 @@ describe("Changing a user's role", () => {
       .set(authHeader())
       .send({
         userId: 123,
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(500)
       .then((res) => {
@@ -247,7 +247,7 @@ describe("Changing a user's role", () => {
       .set(authHeader())
       .send({
         userId: 123,
-        role: "teamAdmin",
+        role: "teamEditor",
       })
       .expect(200)
       .then((res) => {

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4e3d09f",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1441.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f6fcac9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1441.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
-    version: github.com/theopensystemslab/planx-core/408e226
+    specifier: git+https://github.com/theopensystemslab/planx-core#4e3d09f
+    version: github.com/theopensystemslab/planx-core/4e3d09f
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8050,8 +8050,8 @@ packages:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/408e226:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
+  github.com/theopensystemslab/planx-core/4e3d09f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4e3d09f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f6fcac9
-    version: github.com/theopensystemslab/planx-core/dfaf533
+    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
+    version: github.com/theopensystemslab/planx-core/408e226
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8050,8 +8050,8 @@ packages:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dfaf533:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dfaf533}
+  github.com/theopensystemslab/planx-core/408e226:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/tests/mockJWT.js
+++ b/api.planx.uk/tests/mockJWT.js
@@ -4,8 +4,8 @@ function getJWT(userId) {
   const data = {
     sub: String(userId),
     "https://hasura.io/jwt/claims": {
-      "x-hasura-allowed-roles": ["admin"],
-      "x-hasura-default-role": "admin",
+      "x-hasura-allowed-roles": ["platformAdmin", "public"],
+      "x-hasura-default-role": "platformAdmin",
       "x-hasura-user-id": String(userId),
     },
   };

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f6fcac9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4e3d09f",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
-    version: github.com/theopensystemslab/planx-core/408e226
+    specifier: git+https://github.com/theopensystemslab/planx-core#4e3d09f
+    version: github.com/theopensystemslab/planx-core/4e3d09f
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -2498,8 +2498,8 @@ packages:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/408e226:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
+  github.com/theopensystemslab/planx-core/4e3d09f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4e3d09f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f6fcac9
-    version: github.com/theopensystemslab/planx-core/dfaf533
+    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
+    version: github.com/theopensystemslab/planx-core/408e226
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -2498,8 +2498,8 @@ packages:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dfaf533:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dfaf533}
+  github.com/theopensystemslab/planx-core/408e226:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4e3d09f",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.44.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f6fcac9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.44.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f6fcac9
-    version: github.com/theopensystemslab/planx-core/dfaf533
+    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
+    version: github.com/theopensystemslab/planx-core/408e226
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -2367,8 +2367,8 @@ packages:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dfaf533:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dfaf533}
+  github.com/theopensystemslab/planx-core/408e226:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
-    version: github.com/theopensystemslab/planx-core/408e226
+    specifier: git+https://github.com/theopensystemslab/planx-core#4e3d09f
+    version: github.com/theopensystemslab/planx-core/4e3d09f
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -2367,8 +2367,8 @@ packages:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/408e226:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
+  github.com/theopensystemslab/planx-core/4e3d09f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4e3d09f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -108,8 +108,8 @@ export function generateAuthenticationToken(userId) {
     {
       sub: `${userId}`,
       "https://hasura.io/jwt/claims": {
-        "x-hasura-allowed-roles": ["admin"],
-        "x-hasura-default-role": "admin",
+        "x-hasura-allowed-roles": ["platformAdmin", "public"],
+        "x-hasura-default-role": "platformAdmin",
         "x-hasura-user-id": `${userId}`,
       },
     },

--- a/e2e/tests/ui-driven/src/utils.ts
+++ b/e2e/tests/ui-driven/src/utils.ts
@@ -29,8 +29,8 @@ export const getJWT = (userId) => {
   const data = {
     sub: String(userId),
     "https://hasura.io/jwt/claims": {
-      "x-hasura-allowed-roles": ["admin"],
-      "x-hasura-default-role": "admin",
+      "x-hasura-allowed-roles": ["platformAdmin", "public"],
+      "x-hasura-default-role": "platformAdmin",
       "x-hasura-user-id": String(userId),
     },
   };

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.14.5",
     "@mui/utils": "^5.14.5",
     "@opensystemslab/map": "^0.7.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4e3d09f",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.6",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.14.5",
     "@mui/utils": "^5.14.5",
     "@opensystemslab/map": "^0.7.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f6fcac9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#408e226",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.6",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.5
     version: 0.7.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
-    version: github.com/theopensystemslab/planx-core/408e226(@types/react@18.2.20)
+    specifier: git+https://github.com/theopensystemslab/planx-core#4e3d09f
+    version: github.com/theopensystemslab/planx-core/4e3d09f(@types/react@18.2.20)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -20690,9 +20690,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/408e226(@types/react@18.2.20):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
-    id: github.com/theopensystemslab/planx-core/408e226
+  github.com/theopensystemslab/planx-core/4e3d09f(@types/react@18.2.20):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4e3d09f}
+    id: github.com/theopensystemslab/planx-core/4e3d09f
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.5
     version: 0.7.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f6fcac9
-    version: git/github.com+theopensystemslab/planx-core/f6fcac9(@types/react@18.2.20)
+    specifier: git+https://github.com/theopensystemslab/planx-core#408e226
+    version: github.com/theopensystemslab/planx-core/408e226(@types/react@18.2.20)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -20690,9 +20690,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  git/github.com+theopensystemslab/planx-core/f6fcac9(@types/react@18.2.20):
-    resolution: {commit: f6fcac9, repo: git@github.com:theopensystemslab/planx-core.git, type: git}
-    id: git@github.com+theopensystemslab/planx-core/f6fcac9
+  github.com/theopensystemslab/planx-core/408e226(@types/react@18.2.20):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/408e226}
+    id: github.com/theopensystemslab/planx-core/408e226
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -92,7 +92,7 @@ export const publicClient = new ApolloClient({
 
 /**
  * Explicitly connect to Hasura using the "public" role
- * Allows authenticated users with a different x-hasura-default-role (e.g. teamAdmin, platformAdmin) to access public resources
+ * Allows authenticated users with a different x-hasura-default-role (e.g. teamEditor, platformAdmin) to access public resources
  */
 export const publicContext: DefaultContext = {
   headers: {

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -91,7 +91,8 @@ export const publicClient = new ApolloClient({
 });
 
 /**
- * Connect to Hasura using the "public" role
+ * Explicitly connect to Hasura using the "public" role
+ * Allows authenticated users with a different x-hasura-default-role (e.g. teamAdmin, platformAdmin) to access public resources
  */
 export const publicContext: DefaultContext = {
   headers: {

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -1,6 +1,7 @@
 import {
   ApolloClient,
   createHttpLink,
+  DefaultContext,
   from,
   InMemoryCache,
 } from "@apollo/client";
@@ -88,3 +89,12 @@ export const publicClient = new ApolloClient({
   link: from([retryLink, errorLink, publicHttpLink]),
   cache: new InMemoryCache(),
 });
+
+/**
+ * Connect to Hasura using the "public" role
+ */
+export const publicContext: DefaultContext = {
+  headers: {
+    "x-hasura-role": "public"
+  }
+}

--- a/editor.planx.uk/src/lib/lowcalStorage.ts
+++ b/editor.planx.uk/src/lib/lowcalStorage.ts
@@ -1,4 +1,4 @@
-import { gql } from "@apollo/client";
+import { DefaultContext, gql } from "@apollo/client";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { Session } from "types";
 
@@ -20,7 +20,7 @@ class LowcalStorage {
         }
       `,
       variables: { id },
-      ...getPublicContext(id),
+      context: getSessionContext(id),
     });
 
     try {
@@ -49,7 +49,7 @@ class LowcalStorage {
         }
       `,
       variables: { id },
-      ...getPublicContext(id),
+      context: getSessionContext(id),
     });
   });
 
@@ -90,7 +90,7 @@ class LowcalStorage {
         email: useStore.getState().saveToEmail || "",
         flowId: useStore.getState().id,
       },
-      ...getPublicContext(id),
+      context: getSessionContext(id),
     });
   });
 }
@@ -130,15 +130,13 @@ export const stringifyWithRootKeysSortedAlphabetically = (
  * Generate context for GraphQL client Save & Return requests
  * Hasura "Public" role users need the sessionId and email for lowcal_sessions access
  */
-const getPublicContext = (sessionId: string) => ({
-  context: {
-    headers: {
-      "x-hasura-lowcal-session-id": sessionId,
-      "x-hasura-lowcal-email":
-        // email may be absent for non save and return journeys
-        useStore.getState().saveToEmail?.toLowerCase() || "",
-    },
-  },
+const getSessionContext = (sessionId: string): DefaultContext => ({
+  headers: {
+    "x-hasura-lowcal-session-id": sessionId,
+    "x-hasura-lowcal-email":
+      // email may be absent for non save and return journeys
+      useStore.getState().saveToEmail?.toLowerCase() || "",
+  }
 });
 
 /**

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -191,7 +191,7 @@
           - id
           - version
           - data
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         check:
           team:
@@ -200,7 +200,7 @@
                 - user_id:
                     _eq: x-hasura-user-id
                 - role:
-                    _eq: teamAdmin
+                    _eq: teamEditor
         columns:
           - creator_id
           - team_id
@@ -243,7 +243,7 @@
         computed_fields:
           - data_merged
         filter: {}
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - created_at
@@ -267,7 +267,7 @@
           - slug
         filter: {}
         check: null
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - data
@@ -280,10 +280,10 @@
                 - user_id:
                     _eq: x-hasura-user-id
                 - role:
-                    _eq: teamAdmin
+                    _eq: teamEditor
         check: null
   delete_permissions:
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         backend_only: false
         filter:
@@ -293,7 +293,7 @@
                 - user_id:
                     _eq: x-hasura-user-id
                 - role:
-                    _eq: teamAdmin
+                    _eq: teamEditor
 - table:
     schema: public
     name: global_settings
@@ -316,7 +316,7 @@
         columns:
           - footer_content
         filter: {}
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - footer_content
@@ -524,7 +524,7 @@
           - created_at
           - updated_at
           - flow_id
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         check: {}
         columns:
@@ -547,7 +547,7 @@
           - created_at
           - updated_at
         filter: {}
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - id
@@ -564,7 +564,7 @@
         columns: []
         filter: {}
         check: null
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns: []
         filter: {}
@@ -755,7 +755,7 @@
           - created_at
           - flow_id
           - data
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         check:
           flow:
@@ -765,7 +765,7 @@
                   - user_id:
                       _eq: x-hasura-user-id
                   - role:
-                      _eq: teamAdmin
+                      _eq: teamEditor
         columns:
           - id
           - publisher_id
@@ -794,7 +794,7 @@
           - publisher_id
           - summary
         filter: {}
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - created_at
@@ -951,7 +951,7 @@
         computed_fields:
           - boundary_bbox
         filter: {}
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - created_at
@@ -977,7 +977,7 @@
           - theme
         filter: {}
         check: null
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - domain
@@ -991,7 +991,7 @@
           members:
             _and:
               - role:
-                  _eq: teamAdmin
+                  _eq: teamEditor
               - user_id:
                   _eq: x-hasura-user-id
         check: null
@@ -1060,7 +1060,7 @@
           - updated_at
           - is_platform_admin
         filter: {}
-    - role: teamAdmin
+    - role: teamEditor
       permission:
         columns:
           - first_name

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -237,19 +237,32 @@
           - data
           - settings
           - slug
-        filter: {}
+        filter:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamAdmin
         check: null
+  delete_permissions:
+    - role: teamAdmin
+      permission:
+        backend_only: false
+        filter:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamAdmin
 - table:
     schema: public
     name: global_settings
   insert_permissions:
     - role: platformAdmin
-      permission:
-        check: {}
-        columns:
-          - id
-          - footer_content
-    - role: teamAdmin
       permission:
         check: {}
         columns:
@@ -275,13 +288,6 @@
         filter: {}
   update_permissions:
     - role: platformAdmin
-      permission:
-        columns:
-          - footer_content
-          - id
-        filter: {}
-        check: {}
-    - role: teamAdmin
       permission:
         columns:
           - footer_content
@@ -715,7 +721,15 @@
           - data
     - role: teamAdmin
       permission:
-        check: {}
+        check:
+          flow:
+            team:
+              members:
+                _and:
+                  - user_id:
+                      _eq: x-hasura-user-id
+                  - role:
+                      _eq: teamAdmin
         columns:
           - id
           - publisher_id
@@ -860,30 +874,17 @@
       permission:
         check: {}
         columns:
+          - boundary
+          - created_at
+          - domain
           - id
+          - name
           - notify_personalisation
           - settings
-          - theme
-          - domain
-          - name
           - slug
-          - created_at
-          - updated_at
           - submission_email
-    - role: teamAdmin
-      permission:
-        check: {}
-        columns:
-          - id
-          - notify_personalisation
-          - settings
           - theme
-          - domain
-          - name
-          - slug
-          - created_at
           - updated_at
-          - submission_email
   select_permissions:
     - role: platformAdmin
       permission:
@@ -950,7 +951,13 @@
           - slug
           - submission_email
           - theme
-        filter: {}
+        filter:
+          members:
+            _and:
+              - role:
+                  _eq: teamAdmin
+              - user_id:
+                  _eq: x-hasura-user-id
         check: null
 - table:
     schema: public
@@ -1007,17 +1014,6 @@
             name: team_members
   select_permissions:
     - role: platformAdmin
-      permission:
-        columns:
-          - id
-          - first_name
-          - last_name
-          - email
-          - created_at
-          - updated_at
-          - is_platform_admin
-        filter: {}
-    - role: teamAdmin
       permission:
         columns:
           - id

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -977,24 +977,6 @@
           - theme
         filter: {}
         check: null
-    - role: teamEditor
-      permission:
-        columns:
-          - domain
-          - name
-          - notify_personalisation
-          - settings
-          - slug
-          - submission_email
-          - theme
-        filter:
-          members:
-            _and:
-              - role:
-                  _eq: teamEditor
-              - user_id:
-                  _eq: x-hasura-user-id
-        check: null
 - table:
     schema: public
     name: uniform_applications

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -207,8 +207,31 @@
         computed_fields:
           - data_merged
         filter: {}
+    - role: teamAdmin
+      permission:
+        columns:
+          - created_at
+          - creator_id
+          - data
+          - id
+          - settings
+          - slug
+          - team_id
+          - updated_at
+          - version
+        computed_fields:
+          - data_merged
+        filter: {}
   update_permissions:
     - role: platformAdmin
+      permission:
+        columns:
+          - data
+          - settings
+          - slug
+        filter: {}
+        check: null
+    - role: teamAdmin
       permission:
         columns:
           - data
@@ -226,6 +249,12 @@
         columns:
           - id
           - footer_content
+    - role: teamAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - footer_content
   select_permissions:
     - role: platformAdmin
       permission:
@@ -238,8 +267,21 @@
         columns:
           - footer_content
         filter: {}
+    - role: teamAdmin
+      permission:
+        columns:
+          - footer_content
+          - id
+        filter: {}
   update_permissions:
     - role: platformAdmin
+      permission:
+        columns:
+          - footer_content
+          - id
+        filter: {}
+        check: {}
+    - role: teamAdmin
       permission:
         columns:
           - footer_content
@@ -440,6 +482,17 @@
           - created_at
           - updated_at
           - flow_id
+    - role: teamAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - actor_id
+          - version
+          - data
+          - created_at
+          - updated_at
+          - flow_id
   select_permissions:
     - role: platformAdmin
       permission:
@@ -452,8 +505,24 @@
           - created_at
           - updated_at
         filter: {}
+    - role: teamAdmin
+      permission:
+        columns:
+          - id
+          - flow_id
+          - version
+          - actor_id
+          - data
+          - created_at
+          - updated_at
+        filter: {}
   update_permissions:
     - role: platformAdmin
+      permission:
+        columns: []
+        filter: {}
+        check: null
+    - role: teamAdmin
       permission:
         columns: []
         filter: {}
@@ -644,6 +713,16 @@
           - created_at
           - flow_id
           - data
+    - role: teamAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - publisher_id
+          - summary
+          - created_at
+          - flow_id
+          - data
   select_permissions:
     - role: platformAdmin
       permission:
@@ -656,6 +735,16 @@
           - summary
         filter: {}
     - role: public
+      permission:
+        columns:
+          - created_at
+          - data
+          - flow_id
+          - id
+          - publisher_id
+          - summary
+        filter: {}
+    - role: teamAdmin
       permission:
         columns:
           - created_at
@@ -781,6 +870,20 @@
           - created_at
           - updated_at
           - submission_email
+    - role: teamAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - notify_personalisation
+          - settings
+          - theme
+          - domain
+          - name
+          - slug
+          - created_at
+          - updated_at
+          - submission_email
   select_permissions:
     - role: platformAdmin
       permission:
@@ -811,8 +914,33 @@
         computed_fields:
           - boundary_bbox
         filter: {}
+    - role: teamAdmin
+      permission:
+        columns:
+          - created_at
+          - domain
+          - id
+          - name
+          - notify_personalisation
+          - settings
+          - slug
+          - theme
+          - updated_at
+        filter: {}
   update_permissions:
     - role: platformAdmin
+      permission:
+        columns:
+          - domain
+          - name
+          - notify_personalisation
+          - settings
+          - slug
+          - submission_email
+          - theme
+        filter: {}
+        check: null
+    - role: teamAdmin
       permission:
         columns:
           - domain
@@ -879,6 +1007,17 @@
             name: team_members
   select_permissions:
     - role: platformAdmin
+      permission:
+        columns:
+          - id
+          - first_name
+          - last_name
+          - email
+          - created_at
+          - updated_at
+          - is_platform_admin
+        filter: {}
+    - role: teamAdmin
       permission:
         columns:
           - id

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -176,6 +176,42 @@
           schema: public
           name: compile_flow_portals
       comment: Flow data with portals merged in
+  insert_permissions:
+    - role: platformAdmin
+      permission:
+        check: {}
+        columns:
+          - creator_id
+          - team_id
+          - settings
+          - slug
+          - created_at
+          - updated_at
+          - copied_from
+          - id
+          - version
+          - data
+    - role: teamAdmin
+      permission:
+        check:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamAdmin
+        columns:
+          - creator_id
+          - team_id
+          - settings
+          - slug
+          - created_at
+          - updated_at
+          - copied_from
+          - id
+          - version
+          - data
   select_permissions:
     - role: platformAdmin
       permission:
@@ -1023,4 +1059,10 @@
           - created_at
           - updated_at
           - is_platform_admin
+        filter: {}
+    - role: teamAdmin
+      permission:
+        columns:
+          - first_name
+          - last_name
         filter: {}

--- a/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/down.sql
+++ b/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/down.sql
@@ -1,3 +1,0 @@
-INSERT INTO "public"."user_roles"("value") VALUES (E'teamAdmin');
-
-DELETE FROM "public"."user_roles" WHERE "value" = 'teamEditor';

--- a/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/down.sql
+++ b/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/down.sql
@@ -1,0 +1,3 @@
+INSERT INTO "public"."user_roles"("value") VALUES (E'teamAdmin');
+
+DELETE FROM "public"."user_roles" WHERE "value" = 'teamEditor';

--- a/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/up.sql
+++ b/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/up.sql
@@ -1,0 +1,3 @@
+INSERT INTO "public"."user_roles"("value") VALUES (E'teamEditor');
+
+DELETE FROM "public"."user_roles" WHERE "value" = 'teamAdmin'; 

--- a/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/up.sql
+++ b/hasura.planx.uk/migrations/1693512335183_insert_into_public_user_roles/up.sql
@@ -1,3 +1,0 @@
-INSERT INTO "public"."user_roles"("value") VALUES (E'teamEditor');
-
-DELETE FROM "public"."user_roles" WHERE "value" = 'teamAdmin'; 

--- a/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
+++ b/hasura.planx.uk/seeds/1595528762802_teams_and_users.sql
@@ -1,6 +1,6 @@
-INSERT INTO public.users (id, first_name, last_name, email) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
-INSERT INTO public.users (id, first_name, last_name, email) VALUES (65, 'Ian', 'Jones', 'ian@opensystemslab.io') ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_platform_admin) VALUES (2, 'Alastair', 'Parvin', 'alastair@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_platform_admin) VALUES (20, 'Jessica', 'McInchak', 'jessica@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_platform_admin) VALUES (33, 'Dafydd', 'Pearson', 'dafydd@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, first_name, last_name, email, is_platform_admin) VALUES (65, 'Ian', 'Jones', 'ian@opensystemslab.io', true) ON CONFLICT (id) DO NOTHING;
 SELECT setval('users_id_seq', max(id)) FROM users;
 SELECT setval('teams_id_seq', max(id)) FROM teams;

--- a/hasura.planx.uk/tests/analytics.test.js
+++ b/hasura.planx.uk/tests/analytics.test.js
@@ -54,4 +54,19 @@ describe("analytics and analytics_logs", () => {
       expect(i).toHaveNoMutationsFor("analytics_logs");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query analytics_logs", () => {
+      expect(i.queries).not.toContain("analytics_logs");
+    });
+
+    test("cannot create, update, or delete analytics_logs", () => {
+      expect(i).toHaveNoMutationsFor("analytics_logs");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/analytics.test.js
+++ b/hasura.planx.uk/tests/analytics.test.js
@@ -55,10 +55,10 @@ describe("analytics and analytics_logs", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query analytics_logs", () => {

--- a/hasura.planx.uk/tests/blpu_codes.test.js
+++ b/hasura.planx.uk/tests/blpu_codes.test.js
@@ -29,8 +29,22 @@ describe("blpu_codes", () => {
       expect(i.mutations).toContain("delete_blpu_codes");
     });
   });
-
   describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query blpu_codes", () => {
+      expect(i.queries).not.toContain("blpu_codes");
+    });
+
+    test("cannot create, update, or delete blpu_codes", () => {
+      expect(i).toHaveNoMutationsFor("blpu_codes");
+    });
+  });
+
+  describe("teamAdmin", () => {
     let i;
     beforeAll(async () => {
       i = await introspectAs("platformAdmin");

--- a/hasura.planx.uk/tests/blpu_codes.test.js
+++ b/hasura.planx.uk/tests/blpu_codes.test.js
@@ -44,7 +44,7 @@ describe("blpu_codes", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
       i = await introspectAs("platformAdmin");

--- a/hasura.planx.uk/tests/bops_applications.test.js
+++ b/hasura.planx.uk/tests/bops_applications.test.js
@@ -45,10 +45,10 @@ describe("bops_applications", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query bops_applications", () => {

--- a/hasura.planx.uk/tests/bops_applications.test.js
+++ b/hasura.planx.uk/tests/bops_applications.test.js
@@ -22,7 +22,7 @@ describe("bops_applications", () => {
       i = await introspectAs("admin");
     });
 
-    test("has full access to query and mutate bops appliations", () => {
+    test("has full access to query and mutate bops applications", () => {
       expect(i.queries).toContain("bops_applications");
       expect(i.mutations).toContain("insert_bops_applications");
       expect(i.mutations).toContain("update_bops_applications_by_pk");
@@ -36,12 +36,27 @@ describe("bops_applications", () => {
       i = await introspectAs("platformAdmin");
     });
 
-    test("cannot query bops_appliations", () => {
-      expect(i.queries).not.toContain("bops_appliations");
+    test("cannot query bops_applications", () => {
+      expect(i.queries).not.toContain("bops_applications");
     });
 
-    test("cannot create, update, or delete bops_appliations", () => {
-      expect(i).toHaveNoMutationsFor("bops_appliations");
+    test("cannot create, update, or delete bops_applications", () => {
+      expect(i).toHaveNoMutationsFor("bops_applications");
+    });
+  });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query bops_applications", () => {
+      expect(i.queries).not.toContain("bops_applications");
+    });
+
+    test("cannot create, update, or delete bops_applications", () => {
+      expect(i).toHaveNoMutationsFor("bops_applications");
     });
   });
 });

--- a/hasura.planx.uk/tests/email_applications.test.js
+++ b/hasura.planx.uk/tests/email_applications.test.js
@@ -46,10 +46,10 @@ describe("email_applications", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query email_applications", () => {

--- a/hasura.planx.uk/tests/email_applications.test.js
+++ b/hasura.planx.uk/tests/email_applications.test.js
@@ -45,4 +45,19 @@ describe("email_applications", () => {
       expect(i).toHaveNoMutationsFor("email_applications");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query email_applications", () => {
+      expect(i.queries).not.toContain("email_applications");
+    });
+
+    test("cannot create, update, or delete email_applications", () => {
+      expect(i).toHaveNoMutationsFor("email_applications");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -37,7 +37,6 @@ describe("flows and operations", () => {
       expect(i.mutations).toContain("delete_operations");
     });
   });
-
   describe("platformAdmin", () => {
     let i;
     beforeAll(async () => {
@@ -47,6 +46,44 @@ describe("flows and operations", () => {
     test("can query flows and their associated operations", () => {
       expect(i.queries).toContain("flows");
       expect(i.queries).toContain("operations");
+    });
+
+    test("can query published flows", () => {
+      expect(i.queries).toContain("published_flows");
+    });
+
+    test("can create published_flows", () => {
+      expect(i.mutations).toContain("insert_published_flows_one");
+      expect(i.mutations).toContain("insert_published_flows");
+    });
+
+    test("cannot update or delete published_flows", () => {
+      expect(i.mutations).not.toContain("delete_published_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_published_flows");
+      expect(i.mutations).not.toContain("update_published_flows_by_pk");
+      expect(i.mutations).not.toContain("update_published_flows");
+    });
+  });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query flows and their associated operations", () => {
+      expect(i.queries).toContain("flows");
+      expect(i.queries).toContain("operations");
+    });
+
+    test("can update flows", () => {
+      expect(i.mutations).toContain("update_flows_by_pk");
+      expect(i.mutations).toContain("update_flows");
+    });
+
+    test("can delete flows", () => {
+      expect(i.mutations).toContain("delete_flows_by_pk");
+      expect(i.mutations).toContain("delete_flows");
     });
 
     test("can query published flows", () => {

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -48,6 +48,16 @@ describe("flows and operations", () => {
       expect(i.queries).toContain("operations");
     });
 
+    test("can update flows", () => {
+      expect(i.mutations).toContain("update_flows_by_pk");
+      expect(i.mutations).toContain("update_flows");
+    });
+
+    test("can create flows", () => {
+      expect(i.mutations).toContain("insert_flows_one");
+      expect(i.mutations).toContain("insert_flows");
+    });
+
     test("can query published flows", () => {
       expect(i.queries).toContain("published_flows");
     });
@@ -79,6 +89,11 @@ describe("flows and operations", () => {
     test("can update flows", () => {
       expect(i.mutations).toContain("update_flows_by_pk");
       expect(i.mutations).toContain("update_flows");
+    });
+
+    test("can create flows", () => {
+      expect(i.mutations).toContain("insert_flows_one");
+      expect(i.mutations).toContain("insert_flows");
     });
 
     test("can delete flows", () => {

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -75,10 +75,10 @@ describe("flows and operations", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("can query flows and their associated operations", () => {

--- a/hasura.planx.uk/tests/global_settings.test.js
+++ b/hasura.planx.uk/tests/global_settings.test.js
@@ -49,10 +49,10 @@ describe("global_settings", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("can query global_settings view", () => {

--- a/hasura.planx.uk/tests/global_settings.test.js
+++ b/hasura.planx.uk/tests/global_settings.test.js
@@ -48,4 +48,19 @@ describe("global_settings", () => {
       expect(i.mutations).not.toContain("delete_global_settings");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query global_settings view", () => {
+      expect(i.queries).toContain("global_settings");
+    });
+
+    test("cannot create, update, or delete global_settings", () => {
+      expect(i).toHaveNoMutationsFor("global_settings");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -443,4 +443,19 @@ describe("lowcal_sessions", () => {
       expect(i).toHaveNoMutationsFor("lowcal_sessions");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query lowcal_sessions", () => {
+      expect(i.queries).not.toContain("lowcal_sessions");
+    });
+
+    test("cannot create, update, or delete lowcal_sessions", () => {
+      expect(i).toHaveNoMutationsFor("lowcal_sessions");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -444,10 +444,10 @@ describe("lowcal_sessions", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query lowcal_sessions", () => {

--- a/hasura.planx.uk/tests/package.json
+++ b/hasura.planx.uk/tests/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "test": "echo 'Running hasura tests…' && jest && echo 'Hasura tests passed.'",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "build-jwt": "DOTENV_CONFIG_PATH=../.env.test node -r dotenv/config scripts/buildJWT.js"
   },
   "dependencies": {
     "dotenv": "^16.3.1",

--- a/hasura.planx.uk/tests/payment_requests.test.js
+++ b/hasura.planx.uk/tests/payment_requests.test.js
@@ -112,6 +112,21 @@ describe("payment_requests", () => {
       expect(i).toHaveNoMutationsFor("payment_requests");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query payment_requests", () => {
+      expect(i.queries).not.toContain("payment_requests");
+    });
+
+    test("cannot create, update, or delete payment_requests", () => {
+      expect(i).toHaveNoMutationsFor("payment_requests");
+    });
+  });
 });
 
 const insertSessions = async (sessionIds) => {

--- a/hasura.planx.uk/tests/payment_requests.test.js
+++ b/hasura.planx.uk/tests/payment_requests.test.js
@@ -113,10 +113,10 @@ describe("payment_requests", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query payment_requests", () => {

--- a/hasura.planx.uk/tests/payment_status.test.js
+++ b/hasura.planx.uk/tests/payment_status.test.js
@@ -52,10 +52,10 @@ describe("payment_status", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query payment_status", () => {

--- a/hasura.planx.uk/tests/payment_status.test.js
+++ b/hasura.planx.uk/tests/payment_status.test.js
@@ -51,4 +51,19 @@ describe("payment_status", () => {
       expect(i).toHaveNoMutationsFor("payment_status");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query payment_status", () => {
+      expect(i.queries).not.toContain("payment_status");
+    });
+
+    test("cannot create, update, or delete payment_status", () => {
+      expect(i).toHaveNoMutationsFor("payment_status");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -45,10 +45,10 @@ describe("planning_constraints_requests", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query planning_constraints_requests", () => {

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -44,4 +44,19 @@ describe("planning_constraints_requests", () => {
       expect(i).toHaveNoMutationsFor("planning_constraints_requests");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query planning_constraints_requests", () => {
+      expect(i.queries).not.toContain("planning_constraints_requests");
+    });
+
+    test("cannot create, update, or delete planning_constraints_requests", () => {
+      expect(i).toHaveNoMutationsFor("planning_constraints_requests");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/scripts/buildJWT.js
+++ b/hasura.planx.uk/tests/scripts/buildJWT.js
@@ -5,7 +5,7 @@ const { buildJWTForRole } = require("../utils.js");
  *   Build a signed JWT for the provided role and userId. 
  *   Useful for testing permissions in the Hasura console at a finer-grained level than the introspection tests currently allow.
  * @usage pnpm build-jwt <ROLE> <USER_ID>
- * @example pnpm build-jwt teamAdmin 123
+ * @example pnpm build-jwt teamEditor 123
  * @returns A JWT which can be copy/pasted to the Hasura admin console as a the "authorization" header
  */
 const buildJWT = () => {

--- a/hasura.planx.uk/tests/scripts/buildJWT.js
+++ b/hasura.planx.uk/tests/scripts/buildJWT.js
@@ -1,0 +1,17 @@
+const { buildJWTForRole } = require("../utils.js");
+
+/**
+ * @description 
+ *   Build a signed JWT for the provided role and userId. 
+ *   Useful for testing permissions in the Hasura console at a finer-grained level than the introspection tests currently allow.
+ * @usage pnpm build-jwt <ROLE> <USER_ID>
+ * @example pnpm build-jwt teamAdmin 123
+ * @returns A JWT which can be copy/pasted to the Hasura admin console as a the "authorization" header
+ */
+const buildJWT = () => {
+  const [role, userId] = process.argv.slice(2);
+  const jwt = buildJWTForRole(role, userId);
+  console.log(`Bearer ${jwt}`)
+}
+
+buildJWT();

--- a/hasura.planx.uk/tests/sessions.test.js
+++ b/hasura.planx.uk/tests/sessions.test.js
@@ -611,10 +611,10 @@ describe("sessions", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query sessions", () => {

--- a/hasura.planx.uk/tests/sessions.test.js
+++ b/hasura.planx.uk/tests/sessions.test.js
@@ -610,5 +610,20 @@ describe("sessions", () => {
       expect(i).toHaveNoMutationsFor("sessions");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query sessions", () => {
+      expect(i.queries).not.toContain("sessions");
+    });
+
+    test("cannot create, update, or delete sessions", () => {
+      expect(i).toHaveNoMutationsFor("sessions");
+    });
+  });
   
 });

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -49,9 +49,9 @@ describe("teams", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("can query teams", () => {

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -48,4 +48,27 @@ describe("teams", () => {
       expect(i.mutations).not.toContain("delete_teams");
     });
   });
+
+  describe("teamAdmin", () => {
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query teams", () => {
+      expect(i.queries).toContain("teams");
+    });
+
+    test("can update teams", () => {
+      expect(i.mutations).toContain("update_teams");
+      expect(i.mutations).toContain("update_teams_by_pk");
+    });
+
+    test("cannot delete teams", async () => {
+      expect(i.mutations).not.toContain("delete_teams");
+    });
+
+    test("cannot insert teams", async () => {
+      expect(i.mutations).not.toContain("insert_teams");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -58,9 +58,9 @@ describe("teams", () => {
       expect(i.queries).toContain("teams");
     });
 
-    test("can update teams", () => {
-      expect(i.mutations).toContain("update_teams");
-      expect(i.mutations).toContain("update_teams_by_pk");
+    test("cannot update teams", () => {
+      expect(i.mutations).not.toContain("update_teams");
+      expect(i.mutations).not.toContain("update_teams_by_pk");
     });
 
     test("cannot delete teams", async () => {

--- a/hasura.planx.uk/tests/uniform_applications.test.js
+++ b/hasura.planx.uk/tests/uniform_applications.test.js
@@ -44,4 +44,19 @@ describe("uniform_applications", () => {
       expect(i).toHaveNoMutationsFor("uniform_applications");
     });
   });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query uniform_applications", () => {
+      expect(i.queries).not.toContain("uniform_applications");
+    });
+
+    test("cannot create, update, or delete uniform_applications", () => {
+      expect(i).toHaveNoMutationsFor("uniform_applications");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/uniform_applications.test.js
+++ b/hasura.planx.uk/tests/uniform_applications.test.js
@@ -45,10 +45,10 @@ describe("uniform_applications", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("cannot query uniform_applications", () => {

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -50,8 +50,8 @@ describe("users", () => {
       i = await introspectAs("teamAdmin");
     });
 
-    test("cannot query users", async () => {
-      expect(i.queries).not.toContain("users");
+    test("can query users", async () => {
+      expect(i.queries).toContain("users");
     });
 
     test("cannot create, update, or delete users", async () => {

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -29,7 +29,6 @@ describe("users", () => {
       expect(i.mutations).toContain("delete_users");
     });
   });
-
   describe("platformAdmin", () => {
     let i;
     beforeAll(async () => {
@@ -41,6 +40,21 @@ describe("users", () => {
     });
 
     test("cannot create, update, or delete users", () => {
+      expect(i).toHaveNoMutationsFor("users");
+    });
+  });
+
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query users", async () => {
+      expect(i.queries).not.toContain("users");
+    });
+
+    test("cannot create, update, or delete users", async () => {
       expect(i).toHaveNoMutationsFor("users");
     });
   });

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -44,10 +44,10 @@ describe("users", () => {
     });
   });
 
-  describe("teamAdmin", () => {
+  describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamAdmin");
+      i = await introspectAs("teamEditor");
     });
 
     test("can query users", async () => {

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -82,7 +82,7 @@ const introspectAs = async (role, userId = undefined) => {
     admin: gqlAdmin,
     public: gqlPublic,
     platformAdmin: gqlWithRole("platformAdmin", userId),
-    teamAdmin: gqlWithRole("teamAdmin", userId),
+    teamEditor: gqlWithRole("teamEditor", userId),
   }[role]
   const INTROSPECTION_QUERY = `
     query IntrospectionQuery {

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -83,6 +83,7 @@ const introspectAs = async (role, userId = undefined) => {
     admin: gqlAdmin,
     public: gqlPublic,
     platformAdmin: gqlWithRole("platformAdmin", userId),
+    teamAdmin: gqlWithRole("teamAdmin", userId),
   }[role]
   const INTROSPECTION_QUERY = `
     query IntrospectionQuery {

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -58,7 +58,6 @@ function buildJWTForRole(role, userId = 1) {
   const hasura = {
     "x-hasura-allowed-roles": [role],
     "x-hasura-default-role": role,
-    "x-hasura-role": role,
     "x-hasura-user-id": userId.toString(),
   };
 
@@ -118,4 +117,5 @@ module.exports = {
   gqlAdmin,
   gqlPublic,
   introspectAs,
+  buildJWTForRole,
 };


### PR DESCRIPTION
# What does this PR do?
- Adds the `teamEditor` role in Hasura, and associated introspection tests (more on this below)
- Builds a JWT token on login which represent the user's role
- Adds a helper script in `/hasura.planx.uk/tests` to generate a token
- A few necessary changes in the Editor to allow `platformAdmin` and `teamEditor` users to access public data

It's certainly a lot more than I wanted to put in one PR sorry, but things would be broken without joining up the dots a little here.

## What's going on with the tests?
I hit an issue with the introspection tests - if a user has access to a query/mutation, but it's execution is conditional (i.e. permission based) then an introspection test doesn't mean much. We'd need to execute a mutation or query to really test if a user has permission - and to do that we'd need to insert records to mutate, and insert users, teams, team member records etc... It gets heavy pretty fast and it's basically repeating a lot of boilerplate from `/e2e/tests/api-driven`.

I've still added (coarse-grained) introspection tests for the new role for new measure, but it's important to state clearly that these aren't actually testing the code we care most about (the permission checks defined in `tables.yaml`).

## How are we going to test this?
I'd probably vote we create test suites `/e2e/tests/api-driven` that properly test roles at a deeper level (actually trying to execute queries and mutations). These should be regression tests that run nightly as opposed to every PR.

I think given the repetitive nature of them (query X table as Y role, mutate X table as Y role) the Cucumber tests Ben has already set up are probably well suited to this task and will allow to to get a large number of meaningful tests with a relatively small amount of code. I'm super happy to pick this up the week I'm back.

I consider not covering these high importance code areas very far from ideal, but honestly it's actually super low risk - introspection tests cover the show stoppers (mutations which delete) and we're moving from god-mode so everything is an improvement!

## Next steps...
 - I've asked @Alastairparvin to assign users to teams in a CSV. When I get this back I'll update records on prod.
 - Every team member will be granted `teamEditor` status
 - Stop using `x-hasura-admin-secret` in the API and `planx-core`
 - Frontend implementation