### PR TITLE
chore: Change `user_role` enum from teamAdmin -> teamEditor

### DIFF
--- a/hasura.planx.uk/migrations/1693519114802_insert_into_public_user_roles/down.sql
+++ b/hasura.planx.uk/migrations/1693519114802_insert_into_public_user_roles/down.sql
@@ -1,0 +1,3 @@
+INSERT INTO "public"."user_roles"("value") VALUES (E'teamAdmin');
+
+DELETE FROM "public"."user_roles" WHERE "value" = 'teamEditor';

--- a/hasura.planx.uk/migrations/1693519114802_insert_into_public_user_roles/up.sql
+++ b/hasura.planx.uk/migrations/1693519114802_insert_into_public_user_roles/up.sql
@@ -1,0 +1,3 @@
+INSERT INTO "public"."user_roles"("value") VALUES (E'teamEditor');
+
+DELETE FROM "public"."user_roles" WHERE "value" = 'teamAdmin';


### PR DESCRIPTION
This will need to get merged to prod in order to assign user roles, and before #2182 