### PR TITLE
fix: Temporarily revert to admin role whilst setting up Public GraphQL client

### DIFF
--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -19,8 +19,8 @@ export const buildJWT = async (email: string | undefined) => {
   const { id } = users[0];
 
   const hasura = {
-    "x-hasura-allowed-roles": ["platformAdmin"],
-    "x-hasura-default-role": "platformAdmin",
+    "x-hasura-allowed-roles": ["admin"],
+    "x-hasura-default-role": "admin",
     "x-hasura-user-id": id.toString(),
   };
 


### PR DESCRIPTION
## What's going on?
A logged in user with the `platformAdmin` role is unable to access the same tables as the `public` role.

This comment explains in detail what the issue is - https://github.com/theopensystemslab/planx-new/pull/2182/commits/64a2d1141fc6da53a8206aa6bf1cf131f79d81d2#r1312254263

There's a commit queued on another PR which addresses this - https://github.com/theopensystemslab/planx-new/pull/2182/commits/64a2d1141fc6da53a8206aa6bf1cf131f79d81d2

I hadn't appreciated that this would be an issue yet but I'll queue up another discrete fix first which just addresses this issue. In the meantime, reverting to `admin` should work without any issues and leaves us in status-quo god mode.