### PR TITLE
feat: Sync `team_members`, fix sync script

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -18,7 +18,7 @@ mkdir -p /tmp
 # Create sync.sql file for all our comnands which will be executed in a single transaction
 touch '/tmp/sync.sql'
 
-tables=(flows users teams flow_document_templates)
+tables=(flows users teams flow_document_templates team_members)
 
 # run copy commands on remote  db
 for table in "${tables[@]}"; do

--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -3,3 +3,4 @@
 \include write/flows.sql
 \include write/flow_document_templates.sql
 \include write/published_flows.sql
+\include write/team_members.sql

--- a/scripts/seed-database/write/team_members.sql
+++ b/scripts/seed-database/write/team_members.sql
@@ -1,0 +1,15 @@
+CREATE TEMPORARY TABLE sync_team_members (
+  id uuid,
+  user_id integer,
+  team_id integer,
+  role text
+);
+
+\copy team_members FROM '/tmp/team_members.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  team_members (id, user_id, team_id, role)
+SELECT
+  id, user_id, team_id, role
+FROM
+  sync_team_members ON CONFLICT (id) DO NOTHING;

--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -5,7 +5,8 @@ CREATE TEMPORARY TABLE sync_users (
   last_name text,
   email text,
   created_at timestamptz,
-  updated_at timestamptz
+  updated_at timestamptz,
+  is_platform_admin boolean
 );
 
 \copy sync_users FROM '/tmp/users.csv'  WITH (FORMAT csv, DELIMITER ';');
@@ -14,13 +15,15 @@ INSERT INTO users (
   id,
   first_name,
   last_name,
-  email
+  email,
+  is_platform_admin
 )
 SELECT
   id,
   first_name,
   last_name,
-  email
+  email,
+  is_platform_admin
 FROM sync_users
 ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
This will be required for users to have permissions on Pizzas, and to keep staging up to date.

The `github_actions` user was granted the following - 

```sql
GRANT SELECT ON TABLE team_members TO github_actions;
```

The role isn't in code anywhere to the best of my knowledge which isn't ideal.

Also fixed the sync script (missing `is_platform_admin` column)