### PR TITLE
fix: Run development API following `pnpm add-data` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "stop": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services down",
     "recreate": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --quiet-pull --build --renew-anon-volumes --force-recreate",
     "destroy": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services down --remove-orphans -v",
-    "add-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.seed.yml run seed-database",
+    "add-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database",
     "clean-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.seed.yml run seed-database reset_all",
     "tests": "./scripts/start-containers-for-tests.sh",
     "analytics": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services --profile analytics  up -d --quiet-pull",


### PR DESCRIPTION
Lost a fair bit of time to this one...! 

Part of a wider issue already discussed with inconsistent Docker scripts which I'd like to get back to and sort.

Currently, running `pnpm add-data` does not pick up `docker-compose.local.yml` which is responsible for changing the target to "development". This means `pnpm add-data` currently runs a static version of the API from the `/dist` folder - no live reload of changes as you're working.

This change means that now running `pnpm add-data` will result in a the API refreshing and picking up changes as you work.

On a similar note - this issue is related https://github.com/docker/compose/issues/7262
 - Running `pnpm start` picks up the "development" target on the first instance
 - Re-running `pnpm start` does not pick up the "development" target as there isn't a rebuild - so you end up with a static API
 
 This could be fixed by using the `--build` flag (essentially the `pnpm recreate` script).
 
There's a few ways to fix this suggested in the thread, splitting out a dev and prod image seems an option. Overall though I'd just love to revisit this whole process before changing it further and see if there's scope for simplification - something to talk over in a dev call 👍 