### PR TITLE
fix: `cat` should use `>>` to append SQL commands for nightly staging sync

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -29,7 +29,7 @@ for table in "${tables[@]}"; do
 
   if [[ ${RESET} == "reset_all" ]]; then
     reset_cmd="TRUNCATE TABLE ${table} CASCADE;"
-    cat $reset_cmd > '/tmp/sync.sql'
+    cat $reset_cmd >> '/tmp/sync.sql'
   fi
 done
 
@@ -37,11 +37,11 @@ psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, da
 echo published_flows downloaded
 
 if [[ ${RESET} == "reset_flows" ]]; then
-  cat 'write/truncate_flows.sql' > '/tmp/sync.sql'
+  cat 'write/truncate_flows.sql' >> '/tmp/sync.sql'
 fi
 
 # Add main operations
-cat 'write/main.sql' > '/tmp/sync.sql'
+cat 'write/main.sql' >> '/tmp/sync.sql'
 
 echo "Beginning write transaction..."
 psql --quiet ${LOCAL_PG} -f '/tmp/sync.sql' --single-transaction -v ON_ERROR_STOP=on


### PR DESCRIPTION
Based on [Github Actions error message](https://github.com/theopensystemslab/planx-new/actions/runs/6067468978/job/16459159443), it seems like flows is failing to get truncated. 

I think this is because the `>` operator only _replaces_ when using cat (so we're only running main sql write commands), whereas we want `>>` to append.

This works for me locally, but going to merge directly to staging to see if it clears up the sync job which hasn't been totally predictable based on local/pizza testing.