### PR TITLE
fix: truncate `team_members` on staging sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "recreate": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --quiet-pull --build --renew-anon-volumes --force-recreate",
     "destroy": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services down --remove-orphans -v",
     "add-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database",
+    "test-sync": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database reset_flows",
     "clean-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.seed.yml run seed-database reset_all",
     "tests": "./scripts/start-containers-for-tests.sh",
     "analytics": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services --profile analytics  up -d --quiet-pull",

--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -38,6 +38,7 @@ echo published_flows downloaded
 
 if [[ ${RESET} == "reset_flows" ]]; then
   cat 'write/truncate_flows.sql' >> '/tmp/sync.sql'
+  cat 'write/truncate_team_members.sql' >> '/tmp/sync.sql'
 fi
 
 # Add main operations

--- a/scripts/seed-database/write/truncate_team_members.sql
+++ b/scripts/seed-database/write/truncate_team_members.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE team_members CASCADE;


### PR DESCRIPTION
Quick fix to most recent failure https://github.com/theopensystemslab/planx-new/actions/runs/6078545275/job/16489856129 
```sh
psql:write/team_members.sql:8: ERROR:  duplicate key value violates unique constraint "team_members_pkey"
DETAIL:  Key (id)=(ada5cbae-a4a2-4ab1-[98](https://github.com/theopensystemslab/planx-new/actions/runs/6078545275/job/16489856129#step:9:99)17-989689bf59b9) already exists.
CONTEXT:  COPY team_members, line 1
```

A quick truncation before copy does the trick but is a bit of a hack solution.

Going forward, I think we actually need to consider if `team_members.id` should be a sequenced integer, rather than random `uuid` - then adding a command like `SELECT setval('teams_members_id_seq', max(id)) FROM teams_members;` to end of insert rather than having to truncate (like how we do with users & teams!)