### PR TITLE
fix: `FileUploadAndLabel` modal should error if each file is not tagged, but not validate that all required files are uploaded yet

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -115,10 +115,18 @@ export const FileTaggingModal = ({
             <Button
               variant="contained"
               onClick={handleValidation}
-              sx={{ paddingLeft: 2 }}
               data-testid="modal-done-button"
             >
               Done
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              sx={{ ml: 1.5 }}
+              onClick={closeModal}
+              data-testid="modal-cancel-button"
+            >
+              Cancel
             </Button>
           </Box>
         </ErrorWrapper>
@@ -214,7 +222,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
           "aria-labelledby": `select-multiple-file-tags-label-${uploadedFile.id}`,
         }}
         sx={{
-          border: (theme) => `1px solid ${theme.palette.secondary.main}`,
+          border: (theme) => `1px solid ${theme.palette.border.main}`,
           background: (theme) => theme.palette.background.paper,
           "& > div": {
             minHeight: "50px",

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -46,7 +46,12 @@ export const FileTaggingModal = ({
 }: FileTaggingModalProps) => {
   const [error, setError] = useState<string | undefined>();
 
-  const closeModal = () => setShowModal(false);
+  const closeModal = (event: any, reason?: string) => {
+    if (reason && reason == "backdropClick") {
+      return;
+    }
+    setShowModal(false);
+  };
 
   const handleValidation = () => {
     fileLabelSchema
@@ -111,6 +116,7 @@ export const FileTaggingModal = ({
               variant="contained"
               onClick={handleValidation}
               sx={{ paddingLeft: 2 }}
+              data-testid="modal-done-button"
             >
               Done
             </Button>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -18,6 +18,7 @@ import capitalize from "lodash/capitalize";
 import merge from "lodash/merge";
 import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
+import ErrorWrapper from "ui/ErrorWrapper";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import { UploadedFileCard } from "../shared/PrivateFileUpload/UploadedFileCard";
@@ -28,6 +29,7 @@ import {
   removeSlots,
   resetAllSlots,
 } from "./model";
+import { fileLabelSchema } from "./schema";
 
 interface FileTaggingModalProps {
   uploadedFiles: FileUploadSlot[];
@@ -42,7 +44,16 @@ export const FileTaggingModal = ({
   setFileList,
   setShowModal,
 }: FileTaggingModalProps) => {
+  const [error, setError] = useState<string | undefined>();
+
   const closeModal = () => setShowModal(false);
+
+  const handleValidation = () => {
+    fileLabelSchema
+      .validate(fileList, { context: { slots: uploadedFiles } })
+      .then(closeModal)
+      .catch((err) => setError(err.message));
+  };
 
   return (
     <Dialog
@@ -94,15 +105,17 @@ export const FileTaggingModal = ({
           padding: 2,
         }}
       >
-        <Box>
-          <Button
-            variant="contained"
-            onClick={closeModal}
-            sx={{ paddingLeft: 2 }}
-          >
-            Done
-          </Button>
-        </Box>
+        <ErrorWrapper error={error}>
+          <Box>
+            <Button
+              variant="contained"
+              onClick={handleValidation}
+              sx={{ paddingLeft: 2 }}
+            >
+              Done
+            </Button>
+          </Box>
+        </ErrorWrapper>
       </DialogActions>
     </Dialog>
   );

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -448,7 +448,7 @@ describe("Adding tags and syncing state", () => {
     await user.click(screen.getByText("Continue"));
     expect(handleSubmit).toHaveBeenCalledTimes(0);
     const error = await within(document.body).findByText(
-      "Please upload and tag all required files",
+      "Please upload and label all required files",
     );
     expect(error).toBeVisible();
   });
@@ -543,7 +543,7 @@ describe("Error handling", () => {
     await user.click(submitModalButton);
     expect(true).toBeTruthy();
     const modalError = await within(fileTaggingModal).findByText(
-      "Please tag all files",
+      "Please label all files",
     );
     expect(modalError).toBeVisible();
   });
@@ -580,7 +580,7 @@ describe("Error handling", () => {
     // User cannot submit without uploading a file
     await user.click(screen.getByTestId("continue-button"));
     expect(handleSubmit).not.toHaveBeenCalled();
-    const fileListError = await screen.findByText("Please tag all files");
+    const fileListError = await screen.findByText("Please label all files");
     expect(fileListError).toBeVisible();
 
     // Re-open modal and tag file

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -510,6 +510,44 @@ describe("Error handling", () => {
     expect(dropzoneError).toBeVisible();
   });
 
+  test("An error is thrown in the modal if a user does not tag all files", async () => {
+    const { user } = setup(
+      <FileUploadAndLabelComponent
+        title="Test title"
+        fileTypes={[
+          mockFileTypes.AlwaysRequired,
+          mockFileTypes.AlwaysRecommended,
+          mockFileTypes.NotRequired,
+        ]}
+      />,
+    );
+
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        file_type: "image/png",
+        fileUrl: "https://api.editor.planx.dev/file/private/gws7l5d1/test.jpg",
+      },
+    });
+
+    const file = new File(["test"], "test.jpg", { type: "image/jpg" });
+    const input = screen.getByTestId("upload-input");
+    await user.upload(input, file);
+
+    const fileTaggingModal = await within(document.body).findByTestId(
+      "file-tagging-dialog",
+    );
+    expect(fileTaggingModal).toBeVisible();
+    const submitModalButton = await within(fileTaggingModal).findByText("Done");
+
+    // Attempt to close without tagging files
+    await user.click(submitModalButton);
+    expect(true).toBeTruthy();
+    const modalError = await within(fileTaggingModal).findByText(
+      "Please tag all files",
+    );
+    expect(modalError).toBeVisible();
+  });
+
   test("An error is thrown in the main component if a user does not tag all files", async () => {
     const handleSubmit = jest.fn();
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -269,7 +269,7 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
         justifyContent: "space-between",
         alignItems: "center",
         width: "100%",
-        borderBottom: (theme) => `1px solid ${theme.palette.secondary.main}`,
+        borderBottom: (theme) => `1px solid ${theme.palette.border.main}`,
         minHeight: "50px",
         padding: (theme) => theme.spacing(0.5, 0),
       }}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -42,7 +42,7 @@ import {
   getTagsForSlot,
   removeSlots,
 } from "./model";
-import { fileListSchema, slotsSchema } from "./schema";
+import { fileLabelSchema, fileListSchema, slotsSchema } from "./schema";
 
 type Props = PublicProps<FileUploadAndLabel>;
 
@@ -106,6 +106,7 @@ function Component(props: Props) {
   const validateAndSubmit = () => {
     Promise.all([
       slotsSchema.validate(slots, { context: { fileList } }),
+      fileLabelSchema.validate(fileList, { context: { slots } }),
       fileListSchema.validate(fileList, { context: { slots } }),
     ])
       .then(() => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
@@ -225,7 +225,7 @@ describe("fileLabelSchema", () => {
 
     await expect(() =>
       fileLabelSchema.validate(mockFileList, { context: { slots: mockSlots } }),
-    ).rejects.toThrow(/Please tag all files/);
+    ).rejects.toThrow(/Please label all files/);
   });
 
   it("allows fileLists where all files are tagged, but requirements are not satisfied yet", async () => {
@@ -258,7 +258,7 @@ describe("fileListSchema", () => {
 
     await expect(() =>
       fileListSchema.validate(mockFileList, { context: { slots: mockSlots } }),
-    ).rejects.toThrow(/Please upload and tag all required files/);
+    ).rejects.toThrow(/Please upload and label all required files/);
   });
 
   it("allows fileLists where all 'required' fileTypes have slots set", async () => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
@@ -2,6 +2,7 @@ import { FileUploadSlot } from "../FileUpload/Public";
 import { mockFileList, mockFileTypes, mockRules } from "./mocks";
 import { Condition, FileType, Operator } from "./model";
 import {
+  fileLabelSchema,
   fileListSchema,
   fileTypeSchema,
   fileUploadAndLabelSchema,
@@ -198,30 +199,16 @@ describe("slotSchema", () => {
   });
 });
 
-describe("fileListSchema", () => {
+describe("fileLabelSchema", () => {
   it("rejects if the proper context is not provided for validation", async () => {
     const mockFileList = {
       required: [],
       recommended: [],
       optional: [],
     };
-    await expect(() => fileListSchema.validate(mockFileList)).rejects.toThrow(
+    await expect(() => fileLabelSchema.validate(mockFileList)).rejects.toThrow(
       /Missing context for fileListSchema/,
     );
-  });
-
-  it("rejects if any 'required' fileTypes do not have slots set", async () => {
-    const mockSlots = [{ id: "123" }, { id: "456" }] as FileUploadSlot[];
-
-    const mockFileList = {
-      required: [{ ...mockFileTypes.AlwaysRequired, slots: undefined }],
-      recommended: [],
-      optional: [],
-    };
-
-    await expect(() =>
-      fileListSchema.validate(mockFileList, { context: { slots: mockSlots } }),
-    ).rejects.toThrow(/Please tag all files/);
   });
 
   it("rejects if any slots are untagged", async () => {
@@ -237,8 +224,41 @@ describe("fileListSchema", () => {
     };
 
     await expect(() =>
-      fileListSchema.validate(mockFileList, { context: { slots: mockSlots } }),
+      fileLabelSchema.validate(mockFileList, { context: { slots: mockSlots } }),
     ).rejects.toThrow(/Please tag all files/);
+  });
+
+  it("allows fileLists where all files are tagged, but requirements are not satisfied yet", async () => {
+    const mockSlots = [{ id: "123" }, { id: "456" }] as FileUploadSlot[];
+
+    const mockFileList = {
+      required: [{ ...mockFileTypes.AlwaysRequired, slots: undefined }],
+      recommended: [
+        { ...mockFileTypes.AlwaysRecommended, slots: [{ id: "123" }] },
+      ],
+      optional: [{ ...mockFileTypes.NotRequired, slots: [{ id: "456" }] }],
+    };
+
+    const result = await fileLabelSchema.isValid(mockFileList, {
+      context: { slots: mockSlots },
+    });
+    expect(result).toBe(true);
+  });
+});
+
+describe("fileListSchema", () => {
+  it("rejects if any 'required' fileTypes do not have slots set", async () => {
+    const mockSlots = [{ id: "123" }, { id: "456" }] as FileUploadSlot[];
+
+    const mockFileList = {
+      required: [{ ...mockFileTypes.AlwaysRequired, slots: undefined }],
+      recommended: [],
+      optional: [],
+    };
+
+    await expect(() =>
+      fileListSchema.validate(mockFileList, { context: { slots: mockSlots } }),
+    ).rejects.toThrow(/Please upload and tag all required files/);
   });
 
   it("allows fileLists where all 'required' fileTypes have slots set", async () => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -103,7 +103,7 @@ interface FileListSchemaTestContext extends TestContext {
 
 export const fileLabelSchema = object().test({
   name: "allFilesTagged",
-  message: "Please tag all files",
+  message: "Please label all files",
   test: (fileList, { options: { context } }) => {
     if (!context) throw new Error("Missing context for fileListSchema");
     const { slots } = context as FileListSchemaTestContext;
@@ -120,7 +120,7 @@ export const fileLabelSchema = object().test({
 export const fileListSchema = object({
   required: array().test({
     name: "allRequiredFilesUploaded",
-    message: "Please upload and tag all required files",
+    message: "Please upload and label all required files",
     test: (userFile?: UserFile[]) => {
       const isEverySlotFilled = Boolean(
         userFile?.every(

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -101,6 +101,22 @@ interface FileListSchemaTestContext extends TestContext {
   slots: FileUploadSlot[];
 }
 
+export const fileLabelSchema = object().test({
+  name: "allFilesTagged",
+  message: "Please tag all files",
+  test: (fileList, { options: { context } }) => {
+    if (!context) throw new Error("Missing context for fileListSchema");
+    const { slots } = context as FileListSchemaTestContext;
+    const isEveryFileTagged = Boolean(
+      slots?.every(
+        (slot) =>
+          getTagsForSlot(slot.id, fileList as unknown as FileList).length,
+      ),
+    );
+    return isEveryFileTagged;
+  },
+});
+
 export const fileListSchema = object({
   required: array().test({
     name: "allRequiredFilesUploaded",
@@ -114,17 +130,4 @@ export const fileListSchema = object({
       return isEverySlotFilled;
     },
   }),
-}).test({
-  name: "allFilesTagged",
-  message: "Please tag all files",
-  test: (fileList, { options: { context } }) => {
-    if (!context) throw new Error("Missing context for fileListSchema");
-    const { slots } = context as FileListSchemaTestContext;
-    const isEveryFileTagged = Boolean(
-      slots?.every(
-        (slot) => getTagsForSlot(slot.id, fileList as FileList).length,
-      ),
-    );
-    return isEveryFileTagged;
-  },
 });

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -37,7 +37,7 @@ const AutocompleteWrapper = styled(Box)(({ theme }) => ({
   "--autocomplete__option__font-size": "1rem",
   "--autocomplete__option__padding": "7px 15px",
   "--autocomplete__menu__max-height": "336px",
-  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.secondary.main}`,
+  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.border.main}`,
   "--autocomplete__option__hover-border-color": theme.palette.primary.main,
   "--autocomplete__option__hover-background-color": theme.palette.primary.main,
   "--autocomplete__font-family": theme.typography.fontFamily,

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -44,7 +44,7 @@ const StyledConstraint = styled(Box, {
     left: 0,
     width: "100%",
     height: "1px",
-    background: theme.palette.secondary.main,
+    background: theme.palette.border.main,
   },
 }));
 

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -204,7 +204,7 @@ const PropertyDetailsList = styled(Box)(({ theme }) => ({
   marginTop: theme.spacing(2),
   marginBottom: theme.spacing(2),
   "& > *": {
-    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+    borderBottom: `1px solid ${theme.palette.border.main}`,
     paddingBottom: theme.spacing(1.5),
     paddingTop: theme.spacing(1.5),
     verticalAlign: "top",

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -108,7 +108,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
     left: "0",
     width: "100%",
     height: "1px",
-    backgroundColor: theme.palette.secondary.main,
+    backgroundColor: theme.palette.border.main,
     zIndex: "2",
   },
   "&.Mui-expanded": {

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -198,7 +198,7 @@ const Grid = styled("dl")(({ theme }) => ({
   paddingTop: theme.spacing(3),
   paddingBottom: theme.spacing(2),
   "& > *": {
-    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+    borderBottom: `1px solid ${theme.palette.border.main}`,
     paddingBottom: theme.spacing(1.25),
     paddingTop: theme.spacing(1.25),
     verticalAlign: "top",

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -69,7 +69,7 @@ interface ImageLabelProps {
 
 const borderStyle = (theme: Theme, selected: boolean) =>
   `2px solid ${
-    selected ? theme.palette.primary.main : theme.palette.secondary.main
+    selected ? theme.palette.primary.main : theme.palette.border.main
   }`;
 
 const imageStyle = (theme: Theme): React.CSSProperties => ({

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -19,7 +19,7 @@ const Grid = styled("dl")(({ theme }) => ({
   marginTop: theme.spacing(4),
   marginBottom: theme.spacing(4),
   "& > *": {
-    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+    borderBottom: `1px solid ${theme.palette.border.main}`,
     paddingBottom: theme.spacing(2),
     paddingTop: theme.spacing(2),
     verticalAlign: "top",

--- a/editor.planx.uk/src/@planx/components/shared/Preview/WarningContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/WarningContainer.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 
 export const WarningContainer = styled(Box)(({ theme }) => ({
-  border: `solid 2px ${theme.palette.secondary.main}`,
+  border: `solid 2px ${theme.palette.border.main}`,
   backgroundColor: theme.palette.background.paper,
   padding: theme.spacing(2),
   marginTop: theme.spacing(2),

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -18,7 +18,7 @@ interface Props extends FileUploadSlot {
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  border: `1px solid ${theme.palette.secondary.main}`,
+  border: `1px solid ${theme.palette.border.main}`,
   marginBottom: theme.spacing(1),
   marginTop: theme.spacing(2),
 }));
@@ -76,7 +76,7 @@ const FileSize = styled(Typography)(({ theme }) => ({
 
 const TagRoot = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
-  borderTop: `1px solid ${theme.palette.secondary.main}`,
+  borderTop: `1px solid ${theme.palette.border.main}`,
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",

--- a/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio.tsx
@@ -23,7 +23,7 @@ const StyledFormLabel = styled(FormLabel, {
   border: "2px solid",
   borderColor: isSelected
     ? theme.palette.primary.main
-    : theme.palette.secondary.main,
+    : theme.palette.border.main,
   padding: theme.spacing(1.5),
   cursor: "pointer",
   display: "block",

--- a/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio.tsx
@@ -81,7 +81,7 @@ const StyledFormLabel = styled(FormLabel, {
   border: "2px solid",
   borderColor: isSelected
     ? theme.palette.primary.main
-    : theme.palette.secondary.main,
+    : theme.palette.border.main,
   padding: theme.spacing(1),
   cursor: "pointer",
   display: "block",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -37,7 +37,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     paper: "#F9F8F8",
   },
   secondary: {
-    main: "#B1B4B6",
+    main: "#F3F2F1",
   },
   text: {
     primary: TEXT_COLOR_PRIMARY,
@@ -56,6 +56,11 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   info: {
     main: "#2196F3",
     light: "#EBF4FD",
+  },
+  border: {
+    main: "#B1B4B6",
+    input: TEXT_COLOR_PRIMARY,
+    light: "#E0E0E0",
   },
 };
 

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -1,4 +1,6 @@
 import "@mui/material/Chip";
+// eslint-disable-next-line no-restricted-imports
+import "@mui/material/styles/createPalette";
 
 declare module "@mui/material/Chip" {
   interface ChipPropsVariantOverrides {
@@ -16,5 +18,16 @@ declare module "@mui/material/styles" {
     xl: true;
     formWrap: true;
     contentWrap: true;
+  }
+}
+
+// Append our custom colours to MUI palette
+declare module "@mui/material/styles/createPalette" {
+  interface Palette {
+    border: { main: string; input: string; light: string };
+  }
+
+  interface PaletteOptions {
+    border?: { main: string; input: string; light: string };
   }
 }

--- a/editor.planx.uk/src/ui/ExpandableList.tsx
+++ b/editor.planx.uk/src/ui/ExpandableList.tsx
@@ -39,7 +39,7 @@ export function ExpandableListItem(props: {
     <ListItem
       disablePadding
       sx={{
-        borderBottom: (theme) => `1px solid ${theme.palette.secondary.main}`,
+        borderBottom: (theme) => `1px solid ${theme.palette.border.main}`,
         display: "block",
       }}
     >

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -15,7 +15,7 @@ const List = styled("ul")(({ theme }) => ({
 const Step = styled("li")(({ theme }) => ({
   position: "relative",
   display: "flex",
-  borderBottom: `1px solid ${theme.palette.secondary.main}`,
+  borderBottom: `1px solid ${theme.palette.border.main}`,
 }));
 
 const Inner = styled(Link)(({ theme }) => ({

--- a/editor.planx.uk/src/ui/NumberedList.tsx
+++ b/editor.planx.uk/src/ui/NumberedList.tsx
@@ -25,7 +25,7 @@ const Panel = styled("li")(({ theme }) => ({
     position: "absolute",
     width: `calc(100% - ${STEP_SPACER})`,
     height: "1px",
-    background: theme.palette.secondary.main,
+    background: theme.palette.border.main,
     bottom: "0",
     left: STEP_SPACER,
   },


### PR DESCRIPTION
Splits up the validation checks for "each file should be tagged" & "all required files must be tagged" so that we can call _only_ the first check from the Modal when clicking "Done". This hopefully makes for any easier to understand user journey than this original feedback that we went back on forth on: https://github.com/theopensystemslab/planx-new/pull/1994

Other changes:
- Disables outside clicks to close the modal, ESC key still okay
- Changes all user-facing instances of "tag" to "label" in hardcoded error messages, etc

Behavior before: 
- Modal opens, you can click "Done" to close without tagging any files, no error
- Modal opens, you can click away to close without tagging any files, no error
- Modal opens, you can press ESC to close without tagging any files, no error
- You only see errors on "Continue" from main component

After: 
- Modal opens, you can click "Done" to close without tagging any files, you'll see error "Please tag all files" 
- Modal opens, you can click "Cancel" to close without tagging any files, you will not see a modal error
- Modal opens, you cannot click away to close whether or not you've tagged files yet
- Modal opens, you can press ESC to close without tagging any files, no error
- You continue to see errors on "Continue" from the main component
  - Order of error messages is: upload at least one file, all files need tags (for cases where modal is closed by "Cancel" or ESC), upload & tag all _required_ files

Testing: https://2209.planx.pizza/testing/test-upload-and-label/preview

Outstanding feedback / suggested followup PR:
- More robost click-handling for "Cancel" button: can it fully remove the actual uploaded files that triggered that modal session rather than just close? See feedback
- Address label persistance bug - this is re-creatable on staging too, so not introduced here - made a followup Trello ticket: https://trello.com/c/Kc3ifwND/2632-upload-label-labels-occassionally-disapear-in-the-modal-when-changed-multiple-times-in-a-row