### PR TITLE
fix: only allow the `FileUploadAndLabel` modal to be closed using buttons

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -47,8 +47,7 @@ export const FileTaggingModal = ({
   const [error, setError] = useState<string | undefined>();
 
   const closeModal = (event: any, reason?: string) => {
-    // Only allow the modal to be closed by clicking the action buttons
-    if (reason && ["backdropClick", "escapeKeyDown"].includes(reason)) {
+    if (reason && reason == "backdropClick") {
       return;
     }
     setShowModal(false);

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -46,7 +46,13 @@ export const FileTaggingModal = ({
 }: FileTaggingModalProps) => {
   const [error, setError] = useState<string | undefined>();
 
-  const closeModal = () => setShowModal(false);
+  const closeModal = (event: any, reason?: string) => {
+    // Only allow the modal to be closed by clicking the action buttons
+    if (reason && ["backdropClick", "escapeKeyDown"].includes(reason)) {
+      return;
+    }
+    setShowModal(false);
+  };
 
   const handleValidation = () => {
     fileLabelSchema
@@ -111,6 +117,7 @@ export const FileTaggingModal = ({
               variant="contained"
               onClick={handleValidation}
               sx={{ paddingLeft: 2 }}
+              data-testid="modal-done-button"
             >
               Done
             </Button>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -448,7 +448,7 @@ describe("Adding tags and syncing state", () => {
     await user.click(screen.getByText("Continue"));
     expect(handleSubmit).toHaveBeenCalledTimes(0);
     const error = await within(document.body).findByText(
-      "Please upload and tag all required files",
+      "Please upload and label all required files",
     );
     expect(error).toBeVisible();
   });
@@ -543,7 +543,7 @@ describe("Error handling", () => {
     await user.click(submitModalButton);
     expect(true).toBeTruthy();
     const modalError = await within(fileTaggingModal).findByText(
-      "Please tag all files",
+      "Please label all files",
     );
     expect(modalError).toBeVisible();
   });
@@ -580,7 +580,7 @@ describe("Error handling", () => {
     // User cannot submit without uploading a file
     await user.click(screen.getByTestId("continue-button"));
     expect(handleSubmit).not.toHaveBeenCalled();
-    const fileListError = await screen.findByText("Please tag all files");
+    const fileListError = await screen.findByText("Please label all files");
     expect(fileListError).toBeVisible();
 
     // Re-open modal and tag file

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
@@ -225,7 +225,7 @@ describe("fileLabelSchema", () => {
 
     await expect(() =>
       fileLabelSchema.validate(mockFileList, { context: { slots: mockSlots } }),
-    ).rejects.toThrow(/Please tag all files/);
+    ).rejects.toThrow(/Please label all files/);
   });
 
   it("allows fileLists where all files are tagged, but requirements are not satisfied yet", async () => {
@@ -258,7 +258,7 @@ describe("fileListSchema", () => {
 
     await expect(() =>
       fileListSchema.validate(mockFileList, { context: { slots: mockSlots } }),
-    ).rejects.toThrow(/Please upload and tag all required files/);
+    ).rejects.toThrow(/Please upload and label all required files/);
   });
 
   it("allows fileLists where all 'required' fileTypes have slots set", async () => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -103,7 +103,7 @@ interface FileListSchemaTestContext extends TestContext {
 
 export const fileLabelSchema = object().test({
   name: "allFilesTagged",
-  message: "Please tag all files",
+  message: "Please label all files",
   test: (fileList, { options: { context } }) => {
     if (!context) throw new Error("Missing context for fileListSchema");
     const { slots } = context as FileListSchemaTestContext;
@@ -120,7 +120,7 @@ export const fileLabelSchema = object().test({
 export const fileListSchema = object({
   required: array().test({
     name: "allRequiredFilesUploaded",
-    message: "Please upload and tag all required files",
+    message: "Please upload and label all required files",
     test: (userFile?: UserFile[]) => {
       const isEverySlotFilled = Boolean(
         userFile?.every(


### PR DESCRIPTION
Branched from / relies on #2209 

Based on Trello feedback [here](https://trello.com/c/IryaS9Yo/2582-investigate-if-we-can-make-users-label-file-before-returning-to-main-upload-and-label-component)

Disables closing the modal via clicking outside. Helpful docs [here](https://mui.com/api/dialog/) & [here](https://stackoverflow.com/questions/57329278/how-to-handle-outside-click-on-dialog-modal).

A number of our Public tests rely on checking modal visibility using ESC still.

I think the second suggestion for a Cancel button & deleting the actual uploaded file _slots_ from the modal will be quite tricky and require a big reshuffling of state - I'd vote that gets picked up separately & shouldn't hold up merging these incremental improvements! 