### PR TITLE
chore: Remove unused admin settings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import React from "react";
+import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 
 const DataManagerSettings = () => {
   const formik = useFormik({
@@ -13,13 +14,16 @@ const DataManagerSettings = () => {
   });
   return (
     <form onSubmit={formik.handleSubmit}>
-      <Box pb={3}>
+      <Box pb={3} borderBottom={1}>
         <Typography variant="h2" component="h3" gutterBottom>
           <strong>Data Manager</strong>
         </Typography>
         <Typography variant="body1">
           Manage the data that your service uses and makes available via its API
         </Typography>
+      </Box>
+      <Box py={4} borderBottom={1}>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
     </form>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -1,31 +1,23 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import { useFormik } from "formik";
 import React from "react";
 import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 
-const DataManagerSettings = () => {
-  const formik = useFormik({
-    initialValues: {},
-    onSubmit: (values) => {
-      alert(JSON.stringify(values, null, 2));
-    },
-    validate: () => {},
-  });
+const DataManagerSettings: React.FC = () => {
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <Box pb={3} borderBottom={1}>
+    <>
+      <Box>
         <Typography variant="h2" component="h3" gutterBottom>
-          <strong>Data Manager</strong>
+          Data Manager
         </Typography>
         <Typography variant="body1">
           Manage the data that your service uses and makes available via its API
         </Typography>
+        <Box py={5}>
+          <FeaturePlaceholder title="Feature in development" />
+        </Box>
       </Box>
-      <Box py={4} borderBottom={1}>
-        <FeaturePlaceholder title="Feature in development" />
-      </Box>
-    </form>
+    </>
   );
 };
 export default DataManagerSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -1,159 +1,23 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import Switch, { SwitchProps } from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
-import { useFormik } from "formik";
 import React from "react";
-import ColorPicker from "ui/ColorPicker";
-import Input, { Props as InputProps } from "ui/Input";
-import InputGroup from "ui/InputGroup";
-import InputRow from "ui/InputRow";
-import InputRowItem from "ui/InputRowItem";
-import InputRowLabel from "ui/InputRowLabel";
-import OptionButton from "ui/OptionButton";
-import PublicFileUploadButton from "ui/PublicFileUploadButton";
-
-export const TextInput: React.FC<{
-  title: string;
-  description?: string;
-  switchProps?: SwitchProps;
-  headingInputProps?: InputProps;
-  contentInputProps?: InputProps;
-}> = ({
-  title,
-  description,
-  switchProps,
-  headingInputProps,
-  contentInputProps,
-}) => {
-  return (
-    <Box mb={2} width="100%">
-      <Box my={2} display="flex" alignItems="center">
-        <Switch {...switchProps} color="primary" />
-        <Typography variant="h4" component="h5">
-          {title}
-        </Typography>
-      </Box>
-      <Box mb={2}>
-        {description && <Typography variant="body2">{description}</Typography>}
-      </Box>
-      <InputRow>
-        <InputRowItem>
-          <Input placeholder="Heading" format="bold" {...headingInputProps} />
-        </InputRowItem>
-      </InputRow>
-      <InputRow>
-        <InputRowItem>
-          <Input placeholder="Text" multiline rows={6} {...contentInputProps} />
-        </InputRowItem>
-      </InputRow>
-    </Box>
-  );
-};
+import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 
 const DesignSettings: React.FC = () => {
-  const formik = useFormik<{ phaseBannerColor: string; bgColor: string }>({
-    initialValues: {
-      phaseBannerColor: "#000",
-      bgColor: "#000",
-    },
-    onSubmit: () => {},
-    validate: () => {},
-  });
-
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <Box pb={3} borderBottom={1}>
+    <>
+      <Box>
         <Typography variant="h2" component="h3" gutterBottom>
-          <strong>Design</strong>
+          Design
         </Typography>
         <Typography variant="body1">
           How your service appears to public users
         </Typography>
+        <Box py={5}>
+          <FeaturePlaceholder title="Feature in development" />
+        </Box>
       </Box>
-      <Box py={3}>
-        <InputGroup>
-          <InputRow>
-            <InputRowItem width="50%">
-              <OptionButton selected>Fluid mode</OptionButton>
-            </InputRowItem>
-            <InputRowItem width="50%">
-              <OptionButton selected>Static mode</OptionButton>
-            </InputRowItem>
-          </InputRow>
-        </InputGroup>
-        <InputGroup>
-          <InputRow>
-            <InputRowLabel>
-              <Typography variant="h4" component="h5">
-                Background
-              </Typography>
-            </InputRowLabel>
-            <InputRowItem width="70%">
-              <ColorPicker
-                inline
-                color={formik.values.bgColor}
-                onChange={(color) => formik.setFieldValue("bgColor", color)}
-              />
-            </InputRowItem>
-          </InputRow>
-          <InputRow>
-            <InputRowLabel>
-              <Typography variant="h4" component="h5">
-                Logo
-              </Typography>
-            </InputRowLabel>
-            <InputRowItem width={50}>
-              <PublicFileUploadButton />
-            </InputRowItem>
-            <Box color="text.secondary" pl={2} alignSelf="center">
-              .png or .svg
-            </Box>
-          </InputRow>
-        </InputGroup>
-      </Box>
-      <Box py={3} borderBottom={1}>
-        <InputRow>
-          <InputRowItem>
-            <OptionButton selected>Progress bar</OptionButton>
-          </InputRowItem>
-          <InputRowItem>
-            <OptionButton selected>Use top level flows as steps</OptionButton>
-          </InputRowItem>
-        </InputRow>
-        <InputRow>
-          <InputRowItem>
-            <OptionButton selected>Phase banner</OptionButton>
-          </InputRowItem>
-        </InputRow>
-        <InputRow>
-          <InputRowItem>
-            <Input placeholder="Title" />
-          </InputRowItem>
-          <InputRowLabel>Colour</InputRowLabel>
-          <InputRowItem width={180}>
-            <ColorPicker
-              inline
-              color={formik.values.phaseBannerColor}
-              onChange={(color) =>
-                formik.setFieldValue("phaseBannerColor", color)
-              }
-            />
-          </InputRowItem>
-        </InputRow>
-        <InputRow>
-          <InputRowItem>
-            <Input placeholder="Text" />
-          </InputRowItem>
-        </InputRow>
-      </Box>
-
-      <Box py={2} justifyContent="flex-end" mb={4}>
-        <Button type="submit" variant="contained" color="primary">
-          Submit
-        </Button>
-      </Box>
-    </form>
+    </>
   );
 };
 export default DesignSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -6,17 +6,17 @@ import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 const ServiceFlags: React.FC = () => {
   return (
     <>
-      <Box pb={3} borderBottom={1}>
+      <Box>
         <Typography variant="h2" component="h3" gutterBottom>
-          <strong>Service flags</strong>
+          Service flags
         </Typography>
         <Typography variant="body1">
           Manage the flag sets that this service uses. Flags at the top of a set
           override flags below.
         </Typography>
-      </Box>
-      <Box py={4} borderBottom={1}>
-        <FeaturePlaceholder title="Feature in development" />
+        <Box py={5}>
+          <FeaturePlaceholder title="Feature in development" />
+        </Box>
       </Box>
     </>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -1,94 +1,11 @@
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useFormik } from "formik";
 import React from "react";
-import ColorPicker from "ui/ColorPicker";
-import Input from "ui/Input";
-import InputGroup from "ui/InputGroup";
-import InputRow from "ui/InputRow";
-import InputRowItem from "ui/InputRowItem";
-import InputRowLabel from "ui/InputRowLabel";
+import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 
-const Swatch = styled(Box)(({ theme }) => ({
-  width: 18,
-  height: 18,
-  display: "inline-block",
-  marginRight: theme.spacing(1),
-  verticalAlign: "middle",
-  marginTop: -3,
-}));
-
-export interface IServiceFlags {
-  flagSets: {
-    id?: number;
-    name: string;
-    dataField: string;
-    flags: {
-      title: string;
-      dataValue: string;
-      color: string;
-      new?: true;
-    }[];
-  }[];
-}
-
-const ServiceFlags: React.FC<IServiceFlags> = ({ flagSets }) => {
-  const formik = useFormik({
-    initialValues: {
-      flagSets,
-    },
-    onSubmit: (values) => {
-      alert(JSON.stringify(values, null, 2));
-    },
-    validate: () => {},
-  });
-  const deleteFlagSet = (index: number) => {
-    formik.setFieldValue(
-      "flagSets",
-      formik.values.flagSets.filter((flag, i) => {
-        return i !== index;
-      }),
-    );
-  };
-  const addFlagToFlagSet = (flagIndex: number) => {
-    formik.setFieldValue(`flagSets[${flagIndex}].flags`, [
-      ...formik.values.flagSets[flagIndex].flags,
-      {
-        title: "",
-        dataValue: "",
-        color: "",
-        new: true,
-      },
-    ]);
-  };
-  const addFlagSet = () => {
-    formik.setFieldValue("flagSets", [
-      ...formik.values.flagSets,
-      {
-        name: "",
-        dataField: "",
-        flags: [
-          {
-            title: "",
-            dataValue: "",
-            color: "",
-          },
-        ],
-      },
-    ]);
-  };
-  const deleteFlagFromFlagSet = (flagSetIndex: number, flagIndex: number) => {
-    formik.setFieldValue(
-      `flagSets[${flagSetIndex}].flags`,
-      formik.values.flagSets[flagSetIndex].flags.filter((flagSet, i) => {
-        return i !== flagIndex;
-      }),
-    );
-  };
+const ServiceFlags: React.FC = () => {
   return (
-    <form onSubmit={formik.handleSubmit}>
+    <>
       <Box pb={3} borderBottom={1}>
         <Typography variant="h2" component="h3" gutterBottom>
           <strong>Service flags</strong>
@@ -98,101 +15,10 @@ const ServiceFlags: React.FC<IServiceFlags> = ({ flagSets }) => {
           override flags below.
         </Typography>
       </Box>
-      <Box>
-        {formik.values.flagSets.map((flagSet, i) => {
-          return (
-            <Box py={3} width="100%" borderBottom={1} key={i}>
-              <Box pb={3}>
-                <InputGroup
-                  deletable={flagSet.id ? false : true}
-                  deleteInputGroup={() => deleteFlagSet(i)}
-                  key={i}
-                >
-                  <InputRow>
-                    <Input
-                      format="large"
-                      name={`flagSets[${i}].name`}
-                      value={flagSet.name}
-                      onChange={formik.handleChange}
-                      placeholder="Flag set"
-                    />
-                  </InputRow>
-                  <InputRow>
-                    <Input
-                      format="data"
-                      name={`flagSets[${i}].dataField`}
-                      value={flagSet.name}
-                      onChange={formik.handleChange}
-                      placeholder="data field"
-                    />
-                  </InputRow>
-                </InputGroup>
-              </Box>
-              {flagSet.flags.map((flag, j) => {
-                return (
-                  <Box pl={6.5} pb={2} key={j}>
-                    <InputGroup
-                      deletable={flag.new ? true : flagSet.id ? false : true}
-                      draggable={flagSet.id ? false : true}
-                      deleteInputGroup={() => deleteFlagFromFlagSet(i, j)}
-                      key={j}
-                    >
-                      <InputRow>
-                        <InputRowItem>
-                          <Input
-                            fullWidth
-                            name={`flagSets[${i}].flags[${j}].title`}
-                            value={flag.title}
-                            onChange={formik.handleChange}
-                            placeholder="Flag"
-                          />
-                        </InputRowItem>
-                        {flag.new || !flagSet.id ? (
-                          <InputRowItem width={180}>
-                            <ColorPicker
-                              inline
-                              color={flag.color}
-                              onChange={(color) =>
-                                formik.setFieldValue(
-                                  `flagSets[${i}].flags[${j}].color`,
-                                  color,
-                                )
-                              }
-                            />
-                          </InputRowItem>
-                        ) : (
-                          <InputRowLabel>
-                            <Swatch bgcolor={flag.color} />
-                            {flag.color}
-                          </InputRowLabel>
-                        )}
-                      </InputRow>
-                      <InputRow>
-                        <Input
-                          format="data"
-                          name={`flagSets[${i}].flags[${j}].dataValue`}
-                          value={flag.dataValue}
-                          placeholder="data value"
-                          onChange={formik.handleChange}
-                        />
-                      </InputRow>
-                    </InputGroup>
-                  </Box>
-                );
-              })}
-              <InputRow childRow>
-                <Box>
-                  <Button onClick={() => addFlagToFlagSet(i)}>add flag</Button>
-                </Box>
-              </InputRow>
-            </Box>
-          );
-        })}
+      <Box py={4} borderBottom={1}>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
-      <Button onClick={addFlagSet} size="large">
-        add flag set
-      </Button>
-    </form>
+    </>
   );
 };
 export default ServiceFlags;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -98,9 +98,9 @@ const ServiceSettings: React.FC = () => {
 
   return (
     <form onSubmit={formik.handleSubmit}>
-      <Box py={3} borderBottom={1}>
+      <Box pb={3} borderBottom={1}>
         <Typography variant="h2" component="h3" gutterBottom>
-          <strong>Elements</strong>
+          Elements
         </Typography>
         <Typography variant="body1">
           Manage the features that users will be able to see

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -1,57 +1,34 @@
 import Box from "@mui/material/Box";
-import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
-import { useFormik } from "formik";
 import React from "react";
 import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
-import InputGroup from "ui/InputGroup";
-import InputRow from "ui/InputRow";
-import InputRowItem from "ui/InputRowItem";
-import OptionButton from "ui/OptionButton";
-import SelectInput from "ui/SelectInput";
 
 const Team: React.FC = () => {
-  const formik = useFormik({
-    initialValues: {},
-    onSubmit: (values) => {
-      alert(JSON.stringify(values, null, 2));
-    },
-    validate: () => {},
-  });
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <Box pb={3} borderBottom={1}>
+    <>
+      <Box borderBottom={1}>
         <Typography variant="h2" component="h3" gutterBottom>
-          <strong>Team</strong>
+          Team
         </Typography>
         <Typography variant="body1">
           Manage who has permission to edit this service
         </Typography>
-      </Box>
-      <Box py={4} borderBottom={1}>
-        <FeaturePlaceholder title="Feature in development" />
-      </Box>
-      <Box py={3}>
-        <Typography variant="h2" component="h3" gutterBottom>
-          <strong>Sharing</strong>
-        </Typography>
-        <Typography variant="body1" gutterBottom>
-          Allow other teams on Plan✕ to find and use your service pattern
-        </Typography>
-        <Box pt={2}>
-          <InputGroup>
-            <InputRow>
-              <OptionButton selected>Share</OptionButton>
-              <InputRowItem width="60%">
-                <SelectInput>
-                  <MenuItem>Open Government Licence</MenuItem>
-                </SelectInput>
-              </InputRowItem>
-            </InputRow>
-          </InputGroup>
+        <Box py={5}>
+          <FeaturePlaceholder title="Feature in development" />
         </Box>
       </Box>
-    </form>
+      <Box pt={3}>
+        <Typography variant="h2" component="h3" gutterBottom>
+          Sharing
+        </Typography>
+        <Typography variant="body1">
+          Allow other teams on Plan✕ to find and use your service pattern
+        </Typography>
+        <Box py={5}>
+          <FeaturePlaceholder title="Feature in development" />
+        </Box>
+      </Box>
+    </>
   );
 };
 export default Team;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -1,80 +1,14 @@
-import Add from "@mui/icons-material/Add";
-import Close from "@mui/icons-material/Close";
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import Grid from "@mui/material/Grid";
-import IconButton from "@mui/material/IconButton";
-import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import React from "react";
-import Input from "ui/Input";
+import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 import InputGroup from "ui/InputGroup";
 import InputRow from "ui/InputRow";
 import InputRowItem from "ui/InputRowItem";
 import OptionButton from "ui/OptionButton";
 import SelectInput from "ui/SelectInput";
-
-const StyledAvatar = styled(Avatar)(({ theme }) => ({
-  width: theme.spacing(8),
-  height: theme.spacing(8),
-}));
-
-const StyledGrid = styled(Grid)(() => ({
-  flexGrow: 1,
-}));
-
-const StyledInputLabel = styled(InputLabel)(({ theme }) => ({
-  position: "absolute",
-  color: theme.palette.text.primary,
-  [theme.breakpoints.up("xs")]: {
-    fontSize: 12,
-  },
-  top: -18,
-}));
-
-const TeamMember = ({ name, email, userRole }: any) => {
-  const [role, setRole] = React.useState(userRole);
-  return (
-    <Box mb={1.5}>
-      <Grid
-        container
-        spacing={2}
-        justifyContent="flex-start"
-        alignItems="center"
-      >
-        <Grid item>
-          <StyledAvatar>{name[0]}</StyledAvatar>
-        </Grid>
-        <StyledGrid item>
-          <Typography variant="h4" component="h5">
-            {name}
-          </Typography>
-          <Box fontSize="h5.fontSize">{email}</Box>
-        </StyledGrid>
-        <Grid item>
-          <SelectInput
-            value={role}
-            onChange={(e) => setRole(e.target.value)}
-            fullWidth
-          >
-            <MenuItem value="admin">Admin</MenuItem>
-            <MenuItem value="edit">Edit</MenuItem>
-            <MenuItem value="view">View</MenuItem>
-          </SelectInput>
-        </Grid>
-        <Grid item>
-          <IconButton aria-label="Remove" size="large">
-            <Close />
-          </IconButton>
-        </Grid>
-      </Grid>
-    </Box>
-  );
-};
 
 const Team: React.FC = () => {
   const formik = useFormik({
@@ -95,52 +29,7 @@ const Team: React.FC = () => {
         </Typography>
       </Box>
       <Box py={4} borderBottom={1}>
-        <Box pb={3}>
-          <TeamMember
-            name="Alice Allenby"
-            email="alice.a@council.gov.uk"
-            userRole="admin"
-          />
-          <TeamMember
-            name="Remy Sharp"
-            email="alice.a@council.gov.uk"
-            userRole="edit"
-          />
-          <TeamMember
-            name="Travis Howard"
-            email="alice.a@council.gov.uk"
-            userRole="view"
-          />
-        </Box>
-        <Grid
-          container
-          spacing={2}
-          justifyContent="space-between"
-          alignItems="center"
-          wrap="nowrap"
-        >
-          <Grid item>
-            <StyledAvatar>
-              <Add />
-            </StyledAvatar>
-          </Grid>
-          <StyledGrid item>
-            <Box position="relative">
-              <StyledInputLabel>Invite new</StyledInputLabel>
-              <Input placeholder="enter new email address" fullWidth />
-            </Box>
-          </StyledGrid>
-          <Grid item>
-            <SelectInput value="admin">
-              <MenuItem value="admin">Admin</MenuItem>
-              <MenuItem>Edit</MenuItem>
-              <MenuItem>Read</MenuItem>
-            </SelectInput>
-          </Grid>
-          <Grid item>
-            <Button>Add</Button>
-          </Grid>
-        </Grid>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
       <Box py={3}>
         <Typography variant="h2" component="h3" gutterBottom>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -178,27 +178,7 @@ const NavTabs: React.FC<{ tab?: string }> = (props) => {
         <ServiceSettings />
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <ServiceFlags
-          flagSets={[
-            {
-              id: 1,
-              name: "Flag set by others",
-              dataField: "data field by others",
-              flags: [
-                {
-                  title: "Flag 1",
-                  dataValue: "data value",
-                  color: "#FF0000",
-                },
-                {
-                  title: "Flag 2",
-                  dataValue: "data value",
-                  color: "#579028",
-                },
-              ],
-            },
-          ]}
-        />
+        <ServiceFlags />
       </TabPanel>
       <TabPanel value={value} index={3}>
         <DesignSettings />

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -1,8 +1,5 @@
 import { gql } from "@apollo/client";
 import Add from "@mui/icons-material/Add";
-import CallSplitOutlined from "@mui/icons-material/CallSplitOutlined";
-import DeleteOutline from "@mui/icons-material/DeleteOutline";
-import FolderOutlined from "@mui/icons-material/FolderOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonBase from "@mui/material/ButtonBase";
@@ -11,10 +8,6 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemIcon from "@mui/material/ListItemIcon";
-import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import formatDistanceToNow from "date-fns/formatDistanceToNow";
@@ -149,29 +142,6 @@ function AddButton({
     </AddButtonRoot>
   );
 }
-
-const FooterLinks = () => (
-  <List>
-    <ListItem button disabled>
-      <ListItemIcon>
-        <CallSplitOutlined titleAccess="Flows" />
-      </ListItemIcon>
-      <ListItemText>Flows</ListItemText>
-    </ListItem>
-    <ListItem button disabled>
-      <ListItemIcon>
-        <FolderOutlined titleAccess="Archive" />
-      </ListItemIcon>
-      <ListItemText>Archive</ListItemText>
-    </ListItem>
-    <ListItem button disabled>
-      <ListItemIcon>
-        <DeleteOutline titleAccess="Trash" />
-      </ListItemIcon>
-      <ListItemText>Trash</ListItemText>
-    </ListItem>
-  </List>
-);
 
 interface FlowItemProps {
   flow: any;
@@ -360,7 +330,6 @@ const Team: React.FC<{ id: number; slug: string }> = ({ id, slug }) => {
             </AddButton>
           </DashboardList>
         )}
-        <FooterLinks />
       </Dashboard>
     </Root>
   );

--- a/editor.planx.uk/src/ui/FeaturePlaceholder.tsx
+++ b/editor.planx.uk/src/ui/FeaturePlaceholder.tsx
@@ -1,0 +1,34 @@
+import BuildIcon from "@mui/icons-material/Build";
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+interface Props {
+  title: string;
+}
+
+const Root = styled(Box)(({ theme }) => ({
+  display: "flex",
+  height: 50,
+  alignItems: "center",
+  background: "white",
+  padding: theme.spacing(4, 3),
+  border: "3px dashed black",
+  borderRadius: "200px",
+  justifyContent: "center",
+}));
+
+const TitleWrap = styled(Box)(() => ({
+  display: "flex",
+  alignItems: "center",
+}));
+
+export const FeaturePlaceholder: React.FC<Props> = ({ title }) => (
+  <Root>
+    <TitleWrap>
+      <BuildIcon sx={{ marginRight: "0.25em" }} />
+      <Typography variant="h4">{title}</Typography>
+    </TitleWrap>
+  </Root>
+);

--- a/editor.planx.uk/src/ui/FeaturePlaceholder.tsx
+++ b/editor.planx.uk/src/ui/FeaturePlaceholder.tsx
@@ -10,11 +10,11 @@ interface Props {
 
 const Root = styled(Box)(({ theme }) => ({
   display: "flex",
-  height: 50,
+  height: "auto",
   alignItems: "center",
-  background: "white",
-  padding: theme.spacing(4, 3),
-  border: "3px dashed black",
+  background: theme.palette.background.default,
+  padding: theme.spacing(3),
+  border: "3px dashed currentColor",
   borderRadius: "200px",
   justifyContent: "center",
 }));


### PR DESCRIPTION
PR addresses: https://trello.com/c/Bw9veG77/2558-remove-unused-settings-pages-in-planx

Summary of changes:
- Introduces a new UI element `FeaturePlaceholder`
- Uses this in place of admin settings that are currently non-functioning
- Removes Flows/Archive/Trash buttons from "My services" list