### PR TITLE
feat: set up border palette, add secondary button

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -123,6 +123,7 @@ export const FileTaggingModal = ({
               variant="contained"
               color="secondary"
               sx={{ ml: 1.5 }}
+              onClick={closeModal}
               data-testid="modal-cancel-button"
             >
               Cancel

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -115,10 +115,17 @@ export const FileTaggingModal = ({
             <Button
               variant="contained"
               onClick={handleValidation}
-              sx={{ paddingLeft: 2 }}
               data-testid="modal-done-button"
             >
               Done
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              sx={{ ml: 1.5 }}
+              data-testid="modal-cancel-button"
+            >
+              Cancel
             </Button>
           </Box>
         </ErrorWrapper>
@@ -214,7 +221,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
           "aria-labelledby": `select-multiple-file-tags-label-${uploadedFile.id}`,
         }}
         sx={{
-          border: (theme) => `1px solid ${theme.palette.secondary.main}`,
+          border: (theme) => `1px solid ${theme.palette.border.main}`,
           background: (theme) => theme.palette.background.paper,
           "& > div": {
             minHeight: "50px",

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -269,7 +269,7 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
         justifyContent: "space-between",
         alignItems: "center",
         width: "100%",
-        borderBottom: (theme) => `1px solid ${theme.palette.secondary.main}`,
+        borderBottom: (theme) => `1px solid ${theme.palette.border.main}`,
         minHeight: "50px",
         padding: (theme) => theme.spacing(0.5, 0),
       }}

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -37,7 +37,7 @@ const AutocompleteWrapper = styled(Box)(({ theme }) => ({
   "--autocomplete__option__font-size": "1rem",
   "--autocomplete__option__padding": "7px 15px",
   "--autocomplete__menu__max-height": "336px",
-  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.secondary.main}`,
+  "--autocomplete__option__border-bottom": `solid 1px ${theme.palette.border.main}`,
   "--autocomplete__option__hover-border-color": theme.palette.primary.main,
   "--autocomplete__option__hover-background-color": theme.palette.primary.main,
   "--autocomplete__font-family": theme.typography.fontFamily,

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -44,7 +44,7 @@ const StyledConstraint = styled(Box, {
     left: 0,
     width: "100%",
     height: "1px",
-    background: theme.palette.secondary.main,
+    background: theme.palette.border.main,
   },
 }));
 

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -204,7 +204,7 @@ const PropertyDetailsList = styled(Box)(({ theme }) => ({
   marginTop: theme.spacing(2),
   marginBottom: theme.spacing(2),
   "& > *": {
-    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+    borderBottom: `1px solid ${theme.palette.border.main}`,
     paddingBottom: theme.spacing(1.5),
     paddingTop: theme.spacing(1.5),
     verticalAlign: "top",

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -108,7 +108,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
     left: "0",
     width: "100%",
     height: "1px",
-    backgroundColor: theme.palette.secondary.main,
+    backgroundColor: theme.palette.border.main,
     zIndex: "2",
   },
   "&.Mui-expanded": {

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -198,7 +198,7 @@ const Grid = styled("dl")(({ theme }) => ({
   paddingTop: theme.spacing(3),
   paddingBottom: theme.spacing(2),
   "& > *": {
-    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+    borderBottom: `1px solid ${theme.palette.border.main}`,
     paddingBottom: theme.spacing(1.25),
     paddingTop: theme.spacing(1.25),
     verticalAlign: "top",

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -69,7 +69,7 @@ interface ImageLabelProps {
 
 const borderStyle = (theme: Theme, selected: boolean) =>
   `2px solid ${
-    selected ? theme.palette.primary.main : theme.palette.secondary.main
+    selected ? theme.palette.primary.main : theme.palette.border.main
   }`;
 
 const imageStyle = (theme: Theme): React.CSSProperties => ({

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -19,7 +19,7 @@ const Grid = styled("dl")(({ theme }) => ({
   marginTop: theme.spacing(4),
   marginBottom: theme.spacing(4),
   "& > *": {
-    borderBottom: `1px solid ${theme.palette.secondary.main}`,
+    borderBottom: `1px solid ${theme.palette.border.main}`,
     paddingBottom: theme.spacing(2),
     paddingTop: theme.spacing(2),
     verticalAlign: "top",

--- a/editor.planx.uk/src/@planx/components/shared/Preview/WarningContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/WarningContainer.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 
 export const WarningContainer = styled(Box)(({ theme }) => ({
-  border: `solid 2px ${theme.palette.secondary.main}`,
+  border: `solid 2px ${theme.palette.border.main}`,
   backgroundColor: theme.palette.background.paper,
   padding: theme.spacing(2),
   marginTop: theme.spacing(2),

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -18,7 +18,7 @@ interface Props extends FileUploadSlot {
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  border: `1px solid ${theme.palette.secondary.main}`,
+  border: `1px solid ${theme.palette.border.main}`,
   marginBottom: theme.spacing(1),
   marginTop: theme.spacing(2),
 }));
@@ -76,7 +76,7 @@ const FileSize = styled(Typography)(({ theme }) => ({
 
 const TagRoot = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
-  borderTop: `1px solid ${theme.palette.secondary.main}`,
+  borderTop: `1px solid ${theme.palette.border.main}`,
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",

--- a/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio.tsx
@@ -23,7 +23,7 @@ const StyledFormLabel = styled(FormLabel, {
   border: "2px solid",
   borderColor: isSelected
     ? theme.palette.primary.main
-    : theme.palette.secondary.main,
+    : theme.palette.border.main,
   padding: theme.spacing(1.5),
   cursor: "pointer",
   display: "block",

--- a/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio.tsx
@@ -81,7 +81,7 @@ const StyledFormLabel = styled(FormLabel, {
   border: "2px solid",
   borderColor: isSelected
     ? theme.palette.primary.main
-    : theme.palette.secondary.main,
+    : theme.palette.border.main,
   padding: theme.spacing(1),
   cursor: "pointer",
   display: "block",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -37,7 +37,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     paper: "#F9F8F8",
   },
   secondary: {
-    main: "#B1B4B6",
+    main: "#F3F2F1",
   },
   text: {
     primary: TEXT_COLOR_PRIMARY,
@@ -56,6 +56,11 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   info: {
     main: "#2196F3",
     light: "#EBF4FD",
+  },
+  border: {
+    main: "#B1B4B6",
+    input: TEXT_COLOR_PRIMARY,
+    light: "#E0E0E0",
   },
 };
 

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -1,4 +1,6 @@
 import "@mui/material/Chip";
+// eslint-disable-next-line no-restricted-imports
+import "@mui/material/styles/createPalette";
 
 declare module "@mui/material/Chip" {
   interface ChipPropsVariantOverrides {
@@ -16,5 +18,16 @@ declare module "@mui/material/styles" {
     xl: true;
     formWrap: true;
     contentWrap: true;
+  }
+}
+
+// Append our custom colours to MUI palette
+declare module "@mui/material/styles/createPalette" {
+  interface Palette {
+    border: { main: string; input: string; light: string };
+  }
+
+  interface PaletteOptions {
+    border?: { main: string; input: string; light: string };
   }
 }

--- a/editor.planx.uk/src/ui/ExpandableList.tsx
+++ b/editor.planx.uk/src/ui/ExpandableList.tsx
@@ -39,7 +39,7 @@ export function ExpandableListItem(props: {
     <ListItem
       disablePadding
       sx={{
-        borderBottom: (theme) => `1px solid ${theme.palette.secondary.main}`,
+        borderBottom: (theme) => `1px solid ${theme.palette.border.main}`,
         display: "block",
       }}
     >

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -15,7 +15,7 @@ const List = styled("ul")(({ theme }) => ({
 const Step = styled("li")(({ theme }) => ({
   position: "relative",
   display: "flex",
-  borderBottom: `1px solid ${theme.palette.secondary.main}`,
+  borderBottom: `1px solid ${theme.palette.border.main}`,
 }));
 
 const Inner = styled(Link)(({ theme }) => ({

--- a/editor.planx.uk/src/ui/NumberedList.tsx
+++ b/editor.planx.uk/src/ui/NumberedList.tsx
@@ -25,7 +25,7 @@ const Panel = styled("li")(({ theme }) => ({
     position: "absolute",
     width: `calc(100% - ${STEP_SPACER})`,
     height: "1px",
-    background: theme.palette.secondary.main,
+    background: theme.palette.border.main,
     bottom: "0",
     left: STEP_SPACER,
   },


### PR DESCRIPTION
@jessicamcinchak I've added this as a separate branch as it involves a lot of file changes.

The default secondary colour was being reused as a border style as MUI doesn't include specific entries for borders. I've added a custom border palette, which frees up the secondary colour to be used as intended.

I've also added the cancel button and styled with the secondary colour.