### PR TITLE
fix: include local authority name on submission errors

### DIFF
--- a/api.planx.uk/send/bops.ts
+++ b/api.planx.uk/send/bops.ts
@@ -142,7 +142,9 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
           );
         } else {
           // re-throw other errors
-          throw new Error(`Sending to BOPS failed (${localAuthority}):\n${error}`);
+          throw new Error(
+            `Sending to BOPS failed (${localAuthority}):\n${error}`,
+          );
         }
       });
     res.send(bopsResponse);

--- a/api.planx.uk/send/bops.ts
+++ b/api.planx.uk/send/bops.ts
@@ -134,7 +134,7 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
       .catch((error) => {
         if (error.response) {
           throw new Error(
-            `Sending to BOPS failed:\n${JSON.stringify(
+            `Sending to BOPS failed (${localAuthority}):\n${JSON.stringify(
               error.response.data,
               null,
               2,
@@ -142,7 +142,7 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
           );
         } else {
           // re-throw other errors
-          throw new Error(`Sending to BOPS failed:\n${error}`);
+          throw new Error(`Sending to BOPS failed (${localAuthority}):\n${error}`);
         }
       });
     res.send(bopsResponse);
@@ -150,7 +150,7 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
     next(
       new ServerError({
         status: 500,
-        message: "Sending to BOPS failed",
+        message: `Sending to BOPS failed (${localAuthority})`,
         cause: err,
       }),
     );

--- a/api.planx.uk/send/email.ts
+++ b/api.planx.uk/send/email.ts
@@ -75,7 +75,7 @@ export async function sendToEmail(
     if (response?.message !== "Success") {
       return next({
         status: 500,
-        message: `Failed to send "Submit" email: ${response?.message}`,
+        message: `Failed to send "Submit" email (${localAuthority}): ${response?.message}`,
       });
     }
     // Mark session as submitted so that reminder and expiry emails are not triggered

--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -159,7 +159,7 @@ export async function sendToUniform(
   } catch (error) {
     return next({
       error,
-      message: `Failed to send to Uniform. ${error}`,
+      message: `Failed to send to Uniform (${localAuthority}): ${error}`,
     });
   }
 }


### PR DESCRIPTION
More submission errors are popping up lately as folks are testing usually because their selected Send destination isn't configured or enabled in the environment they're testing in - eg https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1695054852938379

Airbrake doesn't capture the service URL in these cases (because the error is thrown via Hasura events?), so adding the local authority param direct to the message will make it a bit quicker to id bugs on live versus testing/staging-only integrations.