### PR TITLE
fix: Help text overlap in editor browser preview

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -57,6 +57,10 @@ const HelpButtonWrapper = styled(Box)(({ theme }) => ({
   [theme.breakpoints.up("lg")]: {
     width: "140px",
   },
+  "#embedded-browser &": {
+    width: "80px",
+    top: theme.spacing(13),
+  },
 }));
 
 export const HelpButton = styled(Button)(({ theme }) => ({
@@ -79,6 +83,9 @@ export const HelpButton = styled(Button)(({ theme }) => ({
     minHeight: "48px",
     fontSize: "1.375em",
     top: theme.spacing(1),
+  },
+  "#embedded-browser &": {
+    fontSize: "1em",
   },
 })) as typeof Button;
 
@@ -164,7 +171,6 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
             variant="contained"
             sx={{ width: "100%" }}
           >
-            
             Help
           </HelpButton>
         </HelpButtonWrapper>

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -126,7 +126,7 @@ const PreviewBrowser: React.FC<{
   });
 
   return (
-    <Box id="fake-browser">
+    <Box id="embedded-browser">
       <Header>
         <Box width="100%" display="flex">
           <input

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -34,7 +34,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   overflow: hidden;
 }
 
-#fake-browser {
+#embedded-browser {
   position: relative;
   top: 0;
   right: 0;


### PR DESCRIPTION
The sticky help text button causes an overlap in the editor browser preview, this PR adjust the spacing to make sure it doesn't overlap at any breakpoint.

Before (left) & after (right):

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/30f47d4d-448d-48fb-9b91-2f55d85ef574)
