### PR TITLE
feat: Improve upload + label select usability

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -39,8 +39,7 @@ interface FileTaggingModalProps {
   setShowModal: (value: React.SetStateAction<boolean>) => void;
 }
 
-
-const ListHeader = styled('li')(({ theme }) => ({
+const ListHeader = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
@@ -159,6 +158,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
   const initialTags = getTagsForSlot(uploadedFile.id, fileList);
   const [tags, setTags] = useState<string[]>(initialTags);
   const previousTags = usePrevious(tags);
+  const [open, setOpen] = React.useState(false);
 
   const handleChange = (event: SelectChangeEvent<typeof tags>) => {
     const {
@@ -168,6 +168,12 @@ const SelectMultiple = (props: SelectMultipleProps) => {
       // On autofill we get a stringified value.
       typeof value === "string" ? value.split(",") : value,
     );
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+  const handleOpen = () => {
+    setOpen(true);
   };
 
   const updateFileListWithTags = (
@@ -226,6 +232,9 @@ const SelectMultiple = (props: SelectMultipleProps) => {
         multiple
         value={tags}
         onChange={handleChange}
+        open={open}
+        onClose={handleClose}
+        onOpen={handleOpen}
         IconComponent={ArrowIcon}
         input={<Input key={`select-input-${uploadedFile.id}`} />}
         inputProps={{
@@ -279,14 +288,16 @@ const SelectMultiple = (props: SelectMultipleProps) => {
           },
         }}
       >
-        <ListHeader>
-          <Typography variant="h4">
-            Select all document types that apply
-          </Typography>
-          <Button variant="contained">
-            Done
-          </Button>
-        </ListHeader>
+        <ListSubheader disableGutters>
+          <ListHeader>
+            <Typography variant="h4">
+              Select all document types that apply
+            </Typography>
+            <Button variant="contained" onClick={handleClose}>
+              Done
+            </Button>
+          </ListHeader>
+        </ListSubheader>
         {(Object.keys(fileList) as Array<keyof typeof fileList>)
           .filter((fileListCategory) => fileList[fileListCategory].length > 0)
           .map((fileListCategory) => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -282,7 +282,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
       >
         <ListSubheader disableGutters>
           <ListHeader>
-            <Typography variant="h4" component="h3">
+            <Typography variant="h4" component="h3" pr={3}>
               Select all document types that apply
             </Typography>
             <Button variant="contained" onClick={handleClose}>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -13,6 +13,7 @@ import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
 import MenuItem from "@mui/material/MenuItem";
 import Select, { SelectChangeEvent, SelectProps } from "@mui/material/Select";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import merge from "lodash/merge";
@@ -37,6 +38,17 @@ interface FileTaggingModalProps {
   setFileList: (value: React.SetStateAction<FileList>) => void;
   setShowModal: (value: React.SetStateAction<boolean>) => void;
 }
+
+
+const ListHeader = styled('li')(({ theme }) => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: theme.spacing(1, 1.5),
+  background: theme.palette.grey[200],
+  // Offset default padding of MuiList
+  margin: "-8px 0 8px",
+}));
 
 export const FileTaggingModal = ({
   uploadedFiles,
@@ -267,6 +279,14 @@ const SelectMultiple = (props: SelectMultipleProps) => {
           },
         }}
       >
+        <ListHeader>
+          <Typography variant="h4">
+            Select all document types that apply
+          </Typography>
+          <Button variant="contained">
+            Done
+          </Button>
+        </ListHeader>
         {(Object.keys(fileList) as Array<keyof typeof fileList>)
           .filter((fileListCategory) => fileList[fileListCategory].length > 0)
           .map((fileListCategory) => {
@@ -274,7 +294,9 @@ const SelectMultiple = (props: SelectMultipleProps) => {
               <ListSubheader
                 key={`subheader-${fileListCategory}-${uploadedFile.id}`}
               >
-                {`${capitalize(fileListCategory)} files`}
+                <Typography py={1} variant="subtitle2">
+                  {`${capitalize(fileListCategory)} files`}
+                </Typography>
               </ListSubheader>,
               ...fileList[fileListCategory].map((fileType) => {
                 return [

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -91,16 +91,8 @@ export const FileTaggingModal = ({
     >
       <DialogContent>
         <Box sx={{ mt: 1, mb: 4 }}>
-          <Typography
-            variant="h3"
-            component="h2"
-            id="dialog-heading"
-            sx={{ mb: "0.15em" }}
-          >
+          <Typography variant="h3" component="h2" id="dialog-heading">
             What do these files show?
-          </Typography>
-          <Typography variant="subtitle2">
-            Select all document types that apply
           </Typography>
         </Box>
         {uploadedFiles.map((slot) => (

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -283,7 +283,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
         <ListSubheader disableGutters>
           <ListHeader>
             <Typography variant="h4" component="h3" pr={3}>
-              Select all document types that apply
+              Select all labels that apply
             </Typography>
             <Button variant="contained" onClick={handleClose} aria-label="Close list">
               Done

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -285,7 +285,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
             <Typography variant="h4" component="h3" pr={3}>
               Select all document types that apply
             </Typography>
-            <Button variant="contained" onClick={handleClose}>
+            <Button variant="contained" onClick={handleClose} aria-label="Close list">
               Done
             </Button>
           </ListHeader>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -304,6 +304,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
             return [
               <ListSubheader
                 key={`subheader-${fileListCategory}-${uploadedFile.id}`}
+                disableSticky
               >
                 <Typography py={1} variant="subtitle2">
                   {`${capitalize(fileListCategory)} files`}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -282,7 +282,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
       >
         <ListSubheader disableGutters>
           <ListHeader>
-            <Typography variant="h4">
+            <Typography variant="h4" component="h3">
               Select all document types that apply
             </Typography>
             <Button variant="contained" onClick={handleClose}>
@@ -298,7 +298,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
                 key={`subheader-${fileListCategory}-${uploadedFile.id}`}
                 disableSticky
               >
-                <Typography py={1} variant="subtitle2">
+                <Typography py={1} variant="subtitle2" component="h4">
                   {`${capitalize(fileListCategory)} files`}
                 </Typography>
               </ListSubheader>,


### PR DESCRIPTION
### Summary

- Adds a 'done' button to the header of the select dropdown list.
- Header is sticky so will be visible at all times for longer lists that overflow the viewport

PR satisfies: https://trello.com/c/XCE7KiSR/2645-add-okay-or-done-button-to-labels-component-for-upload-drawings-section

Demo:
https://2225.planx.pizza/planx/test-upload-label-select/preview
There are two upload and label components in the demo flow, the first with a short file list and the second with a longer list (to demonstrate the effectiveness of the list header). You will need to upload and label a file to reach the second component.