### PR TITLE
feat: Grant permissions on `team_members` table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1088,6 +1088,13 @@
     - role: teamEditor
       permission:
         columns:
+          - created_at
+          - email
           - first_name
+          - id
+          - is_platform_admin
           - last_name
-        filter: {}
+          - updated_at
+        filter:
+          id:
+            _eq: x-hasura-user-id

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -880,6 +880,49 @@
     - name: user
       using:
         foreign_key_constraint_on: user_id
+  insert_permissions:
+    - role: platformAdmin
+      permission:
+        check: {}
+        columns:
+          - team_id
+          - user_id
+          - role
+          - id
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - team_id
+          - user_id
+          - role
+          - id
+        filter: {}
+    - role: teamEditor
+      permission:
+        columns:
+          - team_id
+          - user_id
+          - role
+          - id
+        filter:
+          user_id:
+            _eq: x-hasura-user-id
+  update_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - team_id
+          - user_id
+          - role
+          - id
+        filter: {}
+        check: {}
+  delete_permissions:
+    - role: platformAdmin
+      permission:
+        backend_only: false
+        filter: {}
 - table:
     schema: public
     name: teams

--- a/hasura.planx.uk/tests/team_members.test.js
+++ b/hasura.planx.uk/tests/team_members.test.js
@@ -1,0 +1,62 @@
+const { introspectAs } = require("./utils");
+
+describe("team_members", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query teams", () => {
+      expect(i.queries).not.toContain("team_members");
+    });
+
+    test("cannot create, update, or delete team_members", () => {
+      expect(i).toHaveNoMutationsFor("team_members");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate team_members", () => {
+      expect(i.queries).toContain("team_members");
+      expect(i.mutations).toContain("insert_team_members");
+      expect(i.mutations).toContain("update_team_members_by_pk");
+      expect(i.mutations).toContain("delete_team_members");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("has full access to query and mutate team_members", () => {
+      expect(i.queries).toContain("team_members");
+      expect(i.mutations).toContain("insert_team_members");
+      expect(i.mutations).toContain("update_team_members_by_pk");
+      expect(i.mutations).toContain("delete_team_members");
+    });
+  });
+
+  describe("teamEditor", () => {
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+    
+    // Row-level permissions tested in e2e/tests/api-driven
+    // teamEditors can only query their own record
+    test("can query teams", () => {
+      expect(i.queries).toContain("team_members");
+    });
+
+    test("cannot create, update, or delete team_members", () => {
+      expect(i).toHaveNoMutationsFor("team_members");
+    });
+  });
+});

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -50,6 +50,8 @@ describe("users", () => {
       i = await introspectAs("teamEditor");
     });
 
+    // Row-level permissions tested in e2e/tests/api-driven
+    // teamEditors can only query their own record
     test("can query users", async () => {
       expect(i.queries).toContain("users");
     });


### PR DESCRIPTION
Permissions issue I hit when working on https://github.com/theopensystemslab/planx-new/pull/2224

- platformAdmins have full access to `team_members` table
- teamEditors can read their own record from the `team_members` table
- teamEditors can read their own record from the `users` table