### PR TITLE
feat: Create user endpoint, manage team members by email and teamSlugs

### DIFF
--- a/api.planx.uk/docs/index.ts
+++ b/api.planx.uk/docs/index.ts
@@ -96,7 +96,7 @@ const responses = {
         schema: {
           type: "object",
           properties: {
-            message: {
+            error: {
               type: "string",
               example: "Error!",
             },

--- a/api.planx.uk/modules/team/docs.yaml
+++ b/api.planx.uk/modules/team/docs.yaml
@@ -28,7 +28,7 @@ paths:
       summary: Add user to team, and assign them a role
       description: "Requires authentication via a Cloudflare WARP client
         \n\n
-        Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team){:target='_blank'}"
+        Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team)"
       tags: ["team"]
       parameters:
         - $ref: "#/components/parameters/teamSlug"
@@ -48,7 +48,7 @@ paths:
       summary: Change role of an existing team member
       description: "Requires authentication via a Cloudflare WARP client
         \n\n
-        Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team){:target='_blank'}"
+        Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team)"
       tags: ["team"]
       parameters:
         - $ref: "#/components/parameters/teamSlug"
@@ -68,7 +68,7 @@ paths:
       summary: Remover user from team
       description: "Requires authentication via a Cloudflare WARP client
         \n\n
-        Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team){:target='_blank'}"
+        Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team)"
       tags: ["team"]
       parameters:
         - $ref: "#/components/parameters/teamSlug"

--- a/api.planx.uk/modules/team/docs.yaml
+++ b/api.planx.uk/modules/team/docs.yaml
@@ -7,23 +7,23 @@ tags:
   description: Team and Team Member related requests
 components:
   parameters:
-    teamId:
+    teamSlug:
       in: path
-      name: teamId
-      type: integer
+      name: teamSlug
+      type: string
       required: true
   schemas:
     UpsertMember:
       type: object
       properties:
-        userId:
-          type: number
-          example: 123
+        userEmail:
+          type: email
+          example: einstein@princeton.edu
         role:
           type: string
           enum: ["teamViewer", "teamEditor"]
 paths:
-  /team/{teamId}/add-member:
+  /team/{teamSlug}/add-member:
     put:
       summary: Add user to team, and assign them a role
       description: "Requires authentication via a Cloudflare WARP client
@@ -31,7 +31,7 @@ paths:
         Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team){:target='_blank'}"
       tags: ["team"]
       parameters:
-        - $ref: "#/components/parameters/teamId"
+        - $ref: "#/components/parameters/teamSlug"
       requestBody:
         required: true
         content:
@@ -43,7 +43,7 @@ paths:
           $ref: "#/components/responses/SuccessMessage"
         "500":
           $ref: "#/components/responses/ErrorMessage"
-  /team/{teamId}/change-member-role:
+  /team/{teamSlug}/change-member-role:
     patch:
       summary: Change role of an existing team member
       description: "Requires authentication via a Cloudflare WARP client
@@ -51,7 +51,7 @@ paths:
         Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team){:target='_blank'}"
       tags: ["team"]
       parameters:
-        - $ref: "#/components/parameters/teamId"
+        - $ref: "#/components/parameters/teamSlug"
       requestBody:
         required: true
         content:
@@ -63,7 +63,7 @@ paths:
           $ref: "#/components/responses/SuccessMessage"
         "500":
           $ref: "#/components/responses/ErrorMessage"
-  /team/{teamId}/remove-member:
+  /team/{teamSlug}/remove-member:
     delete:
       summary: Remover user from team
       description: "Requires authentication via a Cloudflare WARP client
@@ -71,7 +71,7 @@ paths:
         Please login at [https://api.editor.planx.uk/team](https://api.editor.planx.uk/team){:target='_blank'}"
       tags: ["team"]
       parameters:
-        - $ref: "#/components/parameters/teamId"
+        - $ref: "#/components/parameters/teamSlug"
       requestBody:
         required: true
         content:
@@ -79,9 +79,9 @@ paths:
             schema:
               type: object
               properties:
-                userId:
-                  type: integer
-                  example: 123
+                userEmail:
+                  type: email
+                  example: einstein@princeton.edu
       responses:
         "200":
           $ref: "#/components/responses/SuccessMessage"

--- a/api.planx.uk/modules/team/routes.ts
+++ b/api.planx.uk/modules/team/routes.ts
@@ -7,17 +7,17 @@ const router = Router();
 
 router.use(AuthMiddleware.usePlatformAdminAuth);
 router.put(
-  "/:teamId/add-member",
+  "/:teamSlug/add-member",
   validate(Controller.upsertMemberSchema),
   Controller.addMember,
 );
 router.patch(
-  "/:teamId/change-member-role",
+  "/:teamSlug/change-member-role",
   validate(Controller.upsertMemberSchema),
   Controller.changeMemberRole,
 );
 router.delete(
-  "/:teamId/remove-member",
+  "/:teamSlug/remove-member",
   validate(Controller.removeMemberSchema),
   Controller.removeMember,
 );

--- a/api.planx.uk/modules/team/service.test.ts
+++ b/api.planx.uk/modules/team/service.test.ts
@@ -1,0 +1,108 @@
+import { getJWT } from "../../tests/mockJWT";
+import { userContext } from "../auth/middleware";
+
+import {
+  getUserAndTeam,
+  addMember,
+  removeMember,
+  changeMemberRole,
+} from "./service";
+
+const getStoreMock = jest.spyOn(userContext, "getStore");
+
+const mockTeam = { id: 123 };
+const mockUser = { id: 456 };
+
+const mockAddMember = jest.fn();
+const mockRemoveMember = jest.fn();
+const mockChangeMemberRole = jest.fn();
+const mockGetTeamBySlug = jest.fn().mockResolvedValue(mockTeam);
+const mockGetUserByEmail = jest.fn().mockResolvedValue(mockUser);
+
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    CoreDomainClient: jest.fn().mockImplementation(() => ({
+      team: {
+        getBySlug: () => mockGetTeamBySlug(),
+        addMember: () => mockAddMember(),
+        removeMember: () => mockRemoveMember(),
+        changeMemberRole: () => mockChangeMemberRole(),
+      },
+      user: {
+        getByEmail: () => mockGetUserByEmail(),
+      },
+    })),
+  };
+});
+
+describe("TeamService", () => {
+  beforeEach(() => {
+    getStoreMock.mockReturnValue({
+      user: {
+        sub: "123",
+        email: "test@opensystemslab.io",
+        jwt: getJWT({ role: "teamEditor" }),
+      },
+    });
+  });
+
+  describe("getUserAndTeam helper", () => {
+    it("handles invalid teamSlugs", async () => {
+      mockGetTeamBySlug.mockResolvedValueOnce(null);
+      await expect(() =>
+        getUserAndTeam({
+          userEmail: "newbie@council.gov",
+          teamSlug: "not-a-team",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("handles invalid emails", async () => {
+      mockGetUserByEmail.mockResolvedValueOnce(null);
+      await expect(() =>
+        getUserAndTeam({
+          userEmail: "invalid-email@council.gov",
+          teamSlug: "a-real-team",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("addMember", () => {
+    it("handles Hasura failures", async () => {
+      mockAddMember.mockResolvedValueOnce(false);
+      await expect(() =>
+        addMember({
+          userEmail: "newbie@council.gov",
+          role: "teamEditor",
+          teamSlug: "a-real-team",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("removeMember", () => {
+    it("handles Hasura failures", async () => {
+      mockRemoveMember.mockResolvedValueOnce(false);
+      await expect(() =>
+        removeMember({
+          userEmail: "newbie@council.gov",
+          teamSlug: "a-real-team",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("changeMemberRole", () => {
+    it("handles Hasura failures", async () => {
+      mockChangeMemberRole.mockResolvedValueOnce(false);
+      await expect(() =>
+        changeMemberRole({
+          userEmail: "newbie@council.gov",
+          role: "teamEditor",
+          teamSlug: "a-real-team",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/api.planx.uk/modules/team/service.ts
+++ b/api.planx.uk/modules/team/service.ts
@@ -1,0 +1,74 @@
+import { getClient } from "../../client";
+import { TeamRole } from "@opensystemslab/planx-core/types";
+
+interface UpsertMember {
+  userEmail: string;
+  teamSlug: string;
+  role: TeamRole;
+}
+
+interface RemoveUser {
+  userEmail: string;
+  teamSlug: string;
+}
+
+export const addMember = async ({
+  userEmail,
+  teamSlug,
+  role,
+}: UpsertMember) => {
+  const $client = getClient();
+  const { user, team } = await getUserAndTeam({ userEmail, teamSlug });
+
+  const isSuccess = await $client.team.addMember({
+    teamId: team.id,
+    userId: user.id,
+    role,
+  });
+  if (!isSuccess) throw Error(`Failed to assign ${userEmail} to ${teamSlug}`);
+};
+
+export const changeMemberRole = async ({
+  userEmail,
+  teamSlug,
+  role,
+}: UpsertMember) => {
+  const $client = getClient();
+  const { user, team } = await getUserAndTeam({ userEmail, teamSlug });
+
+  const isSuccess = await $client.team.changeMemberRole({
+    teamId: team.id,
+    userId: user.id,
+    role,
+  });
+  if (!isSuccess)
+    throw Error(`Failed to assign ${role} (${teamSlug}) to ${userEmail}`);
+};
+
+export const removeMember = async ({ userEmail, teamSlug }: RemoveUser) => {
+  const $client = getClient();
+  const { user, team } = await getUserAndTeam({ userEmail, teamSlug });
+  const isSuccess = await $client.team.removeMember({
+    teamId: team.id,
+    userId: user.id,
+  });
+  if (!isSuccess) throw Error(`Failed to remove ${userEmail} from ${teamSlug}`);
+};
+
+export const getUserAndTeam = async ({
+  userEmail,
+  teamSlug,
+}: {
+  userEmail: string;
+  teamSlug: string;
+}) => {
+  const $client = getClient();
+
+  const team = await $client.team.getBySlug(teamSlug);
+  if (!team) throw Error(`Unable to find team matching slug ${teamSlug}`);
+
+  const user = await $client.user.getByEmail(userEmail);
+  if (!user) throw Error(`Unable to find team matching email ${userEmail}`);
+
+  return { team, user };
+};

--- a/api.planx.uk/modules/user/controller.ts
+++ b/api.planx.uk/modules/user/controller.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { ValidatedRequestHandler } from "../../shared/middleware/validate";
+import { getClient } from "../../client";
+import { ServerError } from "../../errors";
+
+interface UserResponse {
+  message: string;
+}
+
+export const createUserSchema = z.object({
+  body: z.object({
+    firstName: z.string(),
+    lastName: z.string(),
+    email: z.string().email(),
+    isPlatformAdmin: z.boolean().optional().default(false),
+  }),
+});
+
+export type CreateUser = ValidatedRequestHandler<
+  typeof createUserSchema,
+  UserResponse
+>;
+
+export const createUser: CreateUser = async (req, res, next) => {
+  try {
+    const $client = getClient();
+    await $client.user.create(req.body);
+    return res.send({ message: "Successfully created user" });
+  } catch (error) {
+    return next(
+      new ServerError({ message: "Failed to create user", cause: error }),
+    );
+  }
+};

--- a/api.planx.uk/modules/user/docs.yaml
+++ b/api.planx.uk/modules/user/docs.yaml
@@ -41,4 +41,3 @@ paths:
           $ref: "#/components/responses/SuccessMessage"
         "500":
           $ref: "#/components/responses/ErrorMessage"
-

--- a/api.planx.uk/modules/user/docs.yaml
+++ b/api.planx.uk/modules/user/docs.yaml
@@ -25,7 +25,7 @@ components:
 paths:
   /user:
     put:
-      summary: Create a new user, and optionally assign them to teams
+      summary: Create a new user
       description: "Requires authentication via a Cloudflare WARP client
         \n\n
         Please login at [https://api.editor.planx.uk/user](https://api.editor.planx.uk/user)"

--- a/api.planx.uk/modules/user/docs.yaml
+++ b/api.planx.uk/modules/user/docs.yaml
@@ -1,0 +1,44 @@
+openapi: 3.1.0
+info:
+  title: Plan✕ API
+  version: 0.1.0
+tags:
+  name: user
+  description: User management
+components:
+  schemas:
+    CreateUserSchema:
+      type: object
+      properties:
+        firstName:
+          type: string
+          example: Bilbo
+        lastName:
+          type: string
+          example: Baggins
+        email:
+          type: email
+          example: bilbo@bagend.sh
+        isPlatformAdmin:
+          type: bool
+          example: false
+paths:
+  /user:
+    put:
+      summary: Create a new user, and optionally assign them to teams
+      description: "Requires authentication via a Cloudflare WARP client
+        \n\n
+        Please login at [https://api.editor.planx.uk/user](https://api.editor.planx.uk/user)"
+      tags: ["user"]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserSchema"
+      responses:
+        "200":
+          $ref: "#/components/responses/SuccessMessage"
+        "500":
+          $ref: "#/components/responses/ErrorMessage"
+

--- a/api.planx.uk/modules/user/index.test.ts
+++ b/api.planx.uk/modules/user/index.test.ts
@@ -1,0 +1,68 @@
+import supertest from "supertest";
+import app from "../../server";
+import { authHeader } from "../../tests/mockJWT";
+
+const mockCreateUser = jest.fn();
+
+const mockUser = {
+  firstName: "Bilbo",
+  lastName: "Baggins",
+  email: "bilbo@bagend.sh",
+  isPlatformAdmin: false,
+};
+
+jest.mock("@opensystemslab/planx-core", () => {
+  return {
+    CoreDomainClient: jest.fn().mockImplementation(() => ({
+      user: {
+        create: () => mockCreateUser(),
+      },
+    })),
+  };
+});
+
+const auth = authHeader({ role: "platformAdmin" });
+
+describe("Create user endpoint", () => {
+  it("requires authentication", async () => {
+    await supertest(app).put("/user").send(mockUser).expect(401);
+  });
+
+  it("requires the 'platformAdmin' role", async () => {
+    await supertest(app)
+      .put("/user")
+      .set(authHeader({ role: "teamEditor" }))
+      .send(mockUser)
+      .expect(403);
+  });
+
+  it("handles Hasura / DB errors", async () => {
+    mockCreateUser.mockRejectedValue(new Error("Something went wrong"));
+
+    await supertest(app)
+      .put("/user")
+      .set(auth)
+      .send(mockUser)
+      .expect(500)
+      .then((res) => {
+        expect(mockCreateUser).toHaveBeenCalled();
+        expect(res.body).toHaveProperty("error");
+        expect(res.body.error).toMatch(/Failed to create user/);
+      });
+  });
+
+  it("can successfully create a user", async () => {
+    mockCreateUser.mockResolvedValue(123);
+
+    await supertest(app)
+      .put("/user")
+      .set(auth)
+      .send(mockUser)
+      .expect(200)
+      .then((res) => {
+        expect(mockCreateUser).toHaveBeenCalled();
+        expect(res.body).toHaveProperty("message");
+        expect(res.body.message).toMatch(/Successfully created user/);
+      });
+  });
+});

--- a/api.planx.uk/modules/user/routes.ts
+++ b/api.planx.uk/modules/user/routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { usePlatformAdminAuth } from "../auth/middleware";
+import { validate } from "../../shared/middleware/validate";
+import { createUserSchema, createUser } from "./controller";
+
+const router = Router();
+
+router.use(usePlatformAdminAuth);
+router.put("/user", validate(createUserSchema), createUser);
+
+export default router;

--- a/api.planx.uk/modules/user/routes.ts
+++ b/api.planx.uk/modules/user/routes.ts
@@ -6,6 +6,6 @@ import { createUserSchema, createUser } from "./controller";
 const router = Router();
 
 router.use(usePlatformAdminAuth);
-router.put("/user", validate(createUserSchema), createUser);
+router.put("/", validate(createUserSchema), createUser);
 
 export default router;

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -195,7 +195,7 @@ app.use(urlencoded({ extended: true }));
 
 app.use(authRoutes);
 app.use(miscRoutes);
-app.use(userRoutes);
+app.use("/user", userRoutes);
 app.use("/team", teamRoutes);
 
 app.use("/gis", router);

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -80,6 +80,7 @@ import { googleStrategy } from "./modules/auth/strategy/google";
 import authRoutes from "./modules/auth/routes";
 import teamRoutes from "./modules/team/routes";
 import miscRoutes from "./modules/misc/routes";
+import userRoutes from "./modules/user/routes";
 import { useSwaggerDocs } from "./docs";
 import { Role } from "@opensystemslab/planx-core/types";
 
@@ -194,6 +195,7 @@ app.use(urlencoded({ extended: true }));
 
 app.use(authRoutes);
 app.use(miscRoutes);
+app.use(userRoutes);
 app.use("/team", teamRoutes);
 
 app.use("/gis", router);

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -977,6 +977,8 @@
           - slug
           - theme
           - updated_at
+        computed_fields:
+          - boundary_bbox
         filter: {}
     - role: public
       permission:
@@ -1006,6 +1008,8 @@
           - slug
           - theme
           - updated_at
+        computed_fields:
+          - boundary_bbox
         filter: {}
   update_permissions:
     - role: platformAdmin
@@ -1073,6 +1077,18 @@
           table:
             schema: public
             name: team_members
+  insert_permissions:
+    - role: platformAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - first_name
+          - last_name
+          - created_at
+          - updated_at
+          - is_platform_admin
+          - email
   select_permissions:
     - role: platformAdmin
       permission:

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -39,8 +39,14 @@ describe("users", () => {
       expect(i.queries).toContain("users");
     });
 
-    test("cannot create, update, or delete users", () => {
-      expect(i).toHaveNoMutationsFor("users");
+    test("can creates users", () => {
+      expect(i.mutations).toContain("insert_users");
+    });
+
+    test("cannot update or delete users", () => {
+      expect(i.mutations).not.toContain("update_users_by_pk");
+      expect(i.mutations).not.toContain("update_users");
+      expect(i.mutations).not.toContain("delete_users");
     });
   });
 


### PR DESCRIPTION
## What does this PR do?
- Adds a new create user endpoint to be used by Platform Admins
- Updates team endpoints to use user emails and team slugs
- Updates tests, standardises error handling in new modules
- Fixes a few missing permissions for the `platformAdmin` role

Depends on https://github.com/theopensystemslab/planx-core/pull/137