### PR TITLE
feat: all users can edit "Templates" team and `moveFlows` to teams they're allowed to edit

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -480,7 +480,7 @@ const EditorToolbar: React.FC<{
                 <Edit />
               </ListItemIcon>
               <ListItemText>
-                {user.isPlatformAdmin ? `All teams` : user.teams.map((team) => team.team.name).join(", ")}
+                {user.isPlatformAdmin ? `All teams` : user.teams.map((team) => team.team.name).concat(["Templates"]).join(", ")}
               </ListItemText>
             </MenuItem>
           )}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -23,6 +23,7 @@ import { FlowLayout } from "../../components/Flow";
 import { connectToDB, getConnection } from "./../sharedb";
 import type { Store } from ".";
 import type { SharedStore } from "./shared";
+import { UserStore } from "./user";
 
 let doc: any;
 
@@ -82,7 +83,7 @@ export interface EditorStore extends Store.Store {
 }
 
 export const editorStore: StateCreator<
-  SharedStore & EditorStore,
+  SharedStore & EditorStore & UserStore,
   [],
   [],
   EditorStore
@@ -333,6 +334,12 @@ export const editorStore: StateCreator<
   },
 
   moveFlow(flowId: string, teamSlug: string) {
+    const valid = get().canUserEditTeam(teamSlug);
+    if (!valid) {
+      alert(`You do not have permission to move this flow into ${teamSlug}, try again`);
+      return Promise.resolve();
+    }
+
     const token = getCookie("jwt");
 
     return axios

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -47,11 +47,9 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
 
   canUserEditTeam: (teamSlug) => {
     return (
-      get().teams.filter(
-        (team) =>
-          (team.role === "teamEditor" && team.team.slug === teamSlug) ||
-          get().isPlatformAdmin,
-      ).length > 0
+      get().isPlatformAdmin ||
+      teamSlug === "templates" ||
+      get().teams.filter((team) => team.role === "teamEditor" && team.team.slug === teamSlug).length > 0
     );
   },
 });


### PR DESCRIPTION
- I added a "Templates" team to production & staging, this change ensures any user will have `teamEditor` access to "Templates" by default when they're added independent of records in the `team_members` table (if this feels too liberal, very happy to re-think how we should do this!)
- `moveFlow` Editor store method now checks if the given user has permission to move the flow into the requested team. If they don't, it'll display and error and return early. The copy/move menu is only visible in teams you can edit already, so I don't think we need to do anything similar with other store methods besides `moveFlow` yet.

![Screenshot from 2023-09-27 09-46-52](https://github.com/theopensystemslab/planx-new/assets/5132349/71a3421c-df3f-4fc8-97af-d7c4800d69fc)

**Testing:** 
- (If you're a platformAdmin, toggle this off first in https://hasura.2239.planx.pizza/console/login)
- I see an "edit" icon next to `Templates` even though I do not have a `team_members` entry
- Inside "Templates", I can create a flow, copy it, and move it - I can successfully move to a team that I have edit access to, but see an error message when I try to move it to a team I can only view