### PR TITLE
feat: Add section descriptions

### DIFF
--- a/e2e/tests/ui-driven/src/helpers.ts
+++ b/e2e/tests/ui-driven/src/helpers.ts
@@ -252,8 +252,8 @@ export async function expectSections({
     status: string;
   }[];
 }) {
-  const pageSections = await page.locator("dl > dt");
-  const pageStatuses = await page.locator("dl > dd");
+  const pageSections = await page.locator("dl dt");
+  const pageStatuses = await page.locator("dl dd");
   await expect(pageSections).toContainText(sections.map((s) => s.title));
   await expect(pageStatuses).toContainText(sections.map((s) => s.status));
 }

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -44,7 +44,7 @@ function SectionComponent(props: Props) {
           </InputRow>
           <InputRow>
             <RichTextInput
-              placeholder="Description"
+              placeholder="Short section description"
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -6,6 +6,7 @@ import Input from "ui/Input";
 import InputRow from "ui/InputRow";
 import ModalSection from "ui/ModalSection";
 import ModalSectionContent from "ui/ModalSectionContent";
+import RichTextInput from "ui/RichTextInput";
 
 import { parseSection, Section } from "./model";
 
@@ -38,6 +39,14 @@ function SectionComponent(props: Props) {
               name="title"
               placeholder="Title"
               value={formik.values.title}
+              onChange={formik.handleChange}
+            />
+          </InputRow>
+          <InputRow>
+            <RichTextInput
+              placeholder="Description"
+              name="description"
+              value={formik.values.description}
               onChange={formik.handleChange}
             />
           </InputRow>

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -29,13 +29,13 @@ function SectionComponent(props: Props) {
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
         <ModalSectionContent
-          title="Section marker title"
+          title="Section marker"
           Icon={ICONS[TYPES.Section]}
         >
           <InputRow>
             <Input
               required
-              format="data"
+              format="large"
               name="title"
               placeholder="Title"
               value={formik.values.title}

--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -33,18 +33,21 @@ describe("SectionsOverviewList component", () => {
       type: 360,
       data: {
         title: "Section one",
+        description: "Description of section one",
       },
     },
     section2: {
       type: 360,
       data: {
         title: "Section two",
+        description: "Description of section two",
       },
     },
     section3: {
       type: 360,
       data: {
         title: "Section three",
+        description: "Description of section three",
       },
     },
   };

--- a/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.test.tsx
@@ -8,7 +8,7 @@ import Section, { SectionsOverviewList } from "./Public";
 describe("Section component", () => {
   it("renders correctly", () => {
     const handleSubmit = jest.fn();
-    setup(<Section title="Section one" handleSubmit={handleSubmit} />);
+    setup(<Section title="Section one" description="Description of section one" handleSubmit={handleSubmit} />);
 
     expect(screen.getByText("Application incomplete.")).toBeInTheDocument();
     expect(screen.getByText("Continue")).toBeInTheDocument();
@@ -19,7 +19,7 @@ describe("Section component", () => {
     const handleSubmit = jest.fn();
 
     const { container } = setup(
-      <Section title="Section one" handleSubmit={handleSubmit} />,
+      <Section title="Section one" description="Description of section one" handleSubmit={handleSubmit} />,
     );
 
     const results = await axe(container);

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -169,7 +169,6 @@ export function SectionsOverviewList({
     <DescriptionList>
       {Object.entries(sectionNodes).map(([sectionId, sectionNode]) => (
         <SectionRow key={sectionId}>
-          <SectionWrap>
             <SectionTitle>
               {showChange &&
               sectionStatuses[sectionId] === SectionStatus.Completed ? (
@@ -185,14 +184,11 @@ export function SectionsOverviewList({
               ) : (
                 <Typography variant="subtitle1" component="h4" color="inherit"><strong>{sectionNode.data.title}</strong></Typography>           
               )}
-            </SectionTitle>
-            <SectionDescription>
               <ReactMarkdownOrHtml
                 source={sectionNode.data.description}
                 openLinksOnNewTab
               />   
-            </SectionDescription>
-          </SectionWrap>
+            </SectionTitle>
           <SectionState> {getTag(sectionStatuses[sectionId])} </SectionState>
         </SectionRow>
       ))}
@@ -221,30 +217,16 @@ const SectionRow = styled(Box)(({ theme }) => ({
   borderBottom: `1px solid ${theme.palette.border.main}`,
   [theme.breakpoints.up("md")]: {
     flexDirection: "row",
-    flexWrap: "wrap",
-  },
-}));
-
-const SectionWrap = styled(Box)(({ theme }) => ({
-  [theme.breakpoints.up("md")]: {
-    flexShrink: 1,
-    flexBasis: `calc(100% - 230px)`,
   },
 }));
 
 const SectionTitle = styled("dt")(({ theme }) => ({
   margin: 0,
-  [theme.breakpoints.up("md")]: {
-    paddingTop: theme.spacing(0.33),
-  },
-}));
-
-const SectionDescription = styled("dd")(({ theme }) => ({
-  margin: 0,
   paddingBottom: theme.spacing(2),
   [theme.breakpoints.up("md")]: {
-    paddingBottom: 0,
-    flexBasis: "100%",
+    padding: theme.spacing(0.33, 1, 0, 0),
+    flexBasis: `calc(100% - 220px)`,
+    flexShrink: 1,
   },
 }));
 
@@ -252,8 +234,9 @@ const SectionState = styled("dd")(({ theme }) => ({
   margin: 0,
   [theme.breakpoints.up("md")]: {
     display: "flex",
+    flexBasis: "220px",
     flexShrink: 0,
-    flexBasis: "230px",
+    flexGrow: 1,
     justifyContent: "flex-end",
     alignItems: "flex-start",
   },

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -169,28 +169,30 @@ export function SectionsOverviewList({
     <DescriptionList>
       {Object.entries(sectionNodes).map(([sectionId, sectionNode]) => (
         <SectionRow key={sectionId}>
-          <SectionTitle>
-            {showChange &&
-            sectionStatuses[sectionId] === SectionStatus.Completed ? (
-              <Link
-                onClick={() => changeFirstAnswerInSection(sectionId)}
-                component="button"
-              >
-                <Typography variant="subtitle1" component="h4" color="primary" align="left">
-                  <span style={visuallyHidden}>{`Change `}</span>
-                  <strong>{sectionNode.data.title}</strong>
-                </Typography>
-              </Link>
-            ) : (
-              <Typography variant="subtitle1" component="h4" color="inherit"><strong>{sectionNode.data.title}</strong></Typography>           
-            )}
-          </SectionTitle>
-          <SectionDescription>
-            <ReactMarkdownOrHtml
-              source={sectionNode.data.description}
-              openLinksOnNewTab
-            />   
-          </SectionDescription>
+          <SectionWrap>
+            <SectionTitle>
+              {showChange &&
+              sectionStatuses[sectionId] === SectionStatus.Completed ? (
+                <Link
+                  onClick={() => changeFirstAnswerInSection(sectionId)}
+                  component="button"
+                >
+                  <Typography variant="subtitle1" component="h4" color="primary" align="left">
+                    <span style={visuallyHidden}>{`Change `}</span>
+                    <strong>{sectionNode.data.title}</strong>
+                  </Typography>
+                </Link>
+              ) : (
+                <Typography variant="subtitle1" component="h4" color="inherit"><strong>{sectionNode.data.title}</strong></Typography>           
+              )}
+            </SectionTitle>
+            <SectionDescription>
+              <ReactMarkdownOrHtml
+                source={sectionNode.data.description}
+                openLinksOnNewTab
+              />   
+            </SectionDescription>
+          </SectionWrap>
           <SectionState> {getTag(sectionStatuses[sectionId])} </SectionState>
         </SectionRow>
       ))}
@@ -216,45 +218,44 @@ const SectionRow = styled(Box)(({ theme }) => ({
   flexDirection: "column",
   width: "100%",
   padding: theme.spacing(2, 0),
-  margin: 0,
   borderBottom: `1px solid ${theme.palette.border.main}`,
-  [theme.breakpoints.up("sm")]: {
+  [theme.breakpoints.up("md")]: {
     flexDirection: "row",
     flexWrap: "wrap",
   },
 }));
 
-const SectionTitle = styled("dt")(({ theme }) => ({
-  order: 1,
-  margin: 0,
-  [theme.breakpoints.up("sm")]: {
-    order: 1,
+const SectionWrap = styled(Box)(({ theme }) => ({
+  [theme.breakpoints.up("md")]: {
     flexShrink: 1,
     flexBasis: `calc(100% - 260px)`,
+  },
+}));
+
+const SectionTitle = styled("dt")(({ theme }) => ({
+  margin: 0,
+  [theme.breakpoints.up("md")]: {
     paddingTop: theme.spacing(0.33),
   },
 }));
 
 const SectionDescription = styled("dd")(({ theme }) => ({
-  order: 2,
   margin: 0,
   paddingBottom: theme.spacing(2),
-  [theme.breakpoints.up("sm")]: {
+  [theme.breakpoints.up("md")]: {
     paddingBottom: 0,
-    order: 3,
     flexBasis: "100%",
   },
 }));
 
 const SectionState = styled("dd")(({ theme }) => ({
-  order: 3,
   margin: 0,
-  [theme.breakpoints.up("sm")]: {
-    order: 2,
+  [theme.breakpoints.up("md")]: {
     display: "flex",
     flexShrink: 0,
     flexBasis: "260px",
     justifyContent: "flex-end",
+    alignItems: "flex-start",
   },
   "& > button": {
     width: "auto",

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -8,6 +8,7 @@ import type { PublicProps } from "@planx/components/ui";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { SectionNode, SectionStatus } from "types";
+import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 import Card from "../shared/Preview/Card";
 import QuestionHeader from "../shared/Preview/QuestionHeader";
@@ -167,60 +168,91 @@ export function SectionsOverviewList({
   return (
     <DescriptionList>
       {Object.entries(sectionNodes).map(([sectionId, sectionNode]) => (
-        <React.Fragment key={sectionId}>
-          <dt>
+        <SectionRow key={sectionId}>
+          <SectionTitle>
             {showChange &&
             sectionStatuses[sectionId] === SectionStatus.Completed ? (
               <Link
                 onClick={() => changeFirstAnswerInSection(sectionId)}
                 component="button"
               >
-                <Typography variant="body1" align="left">
+                <Typography variant="subtitle1" color="primary" align="left">
                   <span style={visuallyHidden}>{`Change `}</span>
-                  {sectionNode.data.title}
+                  <strong>{sectionNode.data.title}</strong>
                 </Typography>
               </Link>
             ) : (
-              <Typography variant="body1">{sectionNode.data.title}</Typography>
+              <Typography variant="subtitle1" color="inherit"><strong>{sectionNode.data.title}</strong></Typography>           
             )}
-          </dt>
-          <dd> {getTag(sectionStatuses[sectionId])} </dd>
-        </React.Fragment>
+          </SectionTitle>
+          <SectionDescription>
+            <ReactMarkdownOrHtml
+              source={sectionNode.data.description}
+              openLinksOnNewTab
+            />   
+          </SectionDescription>
+          <SectionState> {getTag(sectionStatuses[sectionId])} </SectionState>
+        </SectionRow>
       ))}
     </DescriptionList>
   );
 }
 
-const Grid = styled("dl")(({ theme }) => ({
-  display: "grid",
-  gridTemplateColumns: "1fr 220px",
-  gridRowGap: "5px",
-  paddingTop: theme.spacing(3),
-  paddingBottom: theme.spacing(2),
-  "& > *": {
-    borderBottom: `1px solid ${theme.palette.border.main}`,
-    paddingBottom: theme.spacing(1.25),
-    paddingTop: theme.spacing(1.25),
-    verticalAlign: "top",
-    margin: 0,
-  },
-  "& ul": {
-    listStylePosition: "inside",
-    padding: 0,
-    margin: 0,
-  },
-  "& dt": {
-    // left column
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  "& dd:nth-of-type(1n)": {
-    // right column
-    textAlign: "right",
-    "& > button": {
-      width: "auto",
+const Table = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1, 0),
+  "& ul, & ol": {
+    padding: "0 0 0 1em",
+    "& p": {
+      marginTop: "0.5em",
     },
+    "&:last-of-type": {
+      marginBottom: 0,
+    },
+  },
+}));
+
+const SectionRow = styled(Box)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  padding: theme.spacing(2, 0),
+  borderBottom: `1px solid ${theme.palette.border.main}`,
+  [theme.breakpoints.up("sm")]: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+}));
+
+const SectionTitle = styled(Box)(({ theme }) => ({
+  order: 1,
+  [theme.breakpoints.up("sm")]: {
+    order: 1,
+    flexShrink: 1,
+    flexBasis: `calc(100% - 260px)`,
+    paddingTop: theme.spacing(0.25),
+  },
+}));
+
+const SectionDescription = styled(Box)(({ theme }) => ({
+  order: 2,
+  paddingBottom: theme.spacing(2),
+  [theme.breakpoints.up("sm")]: {
+    paddingBottom: 0,
+    order: 3,
+    flexBasis: "100%",
+  },
+}));
+
+const SectionState = styled(Box)(({ theme }) => ({
+  order: 3,
+  [theme.breakpoints.up("sm")]: {
+    order: 2,
+    flexShrink: 0,
+    flexBasis: "260px",
+    textAlign: "right",
+  },
+  "& > button": {
+    width: "auto",
   },
 }));
 
@@ -229,5 +261,5 @@ interface DescriptionListProps {
 }
 
 const DescriptionList: React.FC<DescriptionListProps> = ({ children }) => {
-  return <Grid>{children}</Grid>;
+  return <Table>{children}</Table>;
 };

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -228,7 +228,7 @@ const SectionRow = styled(Box)(({ theme }) => ({
 const SectionWrap = styled(Box)(({ theme }) => ({
   [theme.breakpoints.up("md")]: {
     flexShrink: 1,
-    flexBasis: `calc(100% - 260px)`,
+    flexBasis: `calc(100% - 230px)`,
   },
 }));
 
@@ -253,7 +253,7 @@ const SectionState = styled("dd")(({ theme }) => ({
   [theme.breakpoints.up("md")]: {
     display: "flex",
     flexShrink: 0,
-    flexBasis: "260px",
+    flexBasis: "230px",
     justifyContent: "flex-end",
     alignItems: "flex-start",
   },

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -176,13 +176,13 @@ export function SectionsOverviewList({
                 onClick={() => changeFirstAnswerInSection(sectionId)}
                 component="button"
               >
-                <Typography variant="subtitle1" color="primary" align="left">
+                <Typography variant="subtitle1" component="h4" color="primary" align="left">
                   <span style={visuallyHidden}>{`Change `}</span>
                   <strong>{sectionNode.data.title}</strong>
                 </Typography>
               </Link>
             ) : (
-              <Typography variant="subtitle1" color="inherit"><strong>{sectionNode.data.title}</strong></Typography>           
+              <Typography variant="subtitle1" component="h4" color="inherit"><strong>{sectionNode.data.title}</strong></Typography>           
             )}
           </SectionTitle>
           <SectionDescription>
@@ -198,7 +198,7 @@ export function SectionsOverviewList({
   );
 }
 
-const Table = styled(Box)(({ theme }) => ({
+const Table = styled("dl")(({ theme }) => ({
   padding: theme.spacing(1, 0),
   "& ul, & ol": {
     padding: "0 0 0 1em",
@@ -216,6 +216,7 @@ const SectionRow = styled(Box)(({ theme }) => ({
   flexDirection: "column",
   width: "100%",
   padding: theme.spacing(2, 0),
+  margin: 0,
   borderBottom: `1px solid ${theme.palette.border.main}`,
   [theme.breakpoints.up("sm")]: {
     flexDirection: "row",
@@ -223,18 +224,20 @@ const SectionRow = styled(Box)(({ theme }) => ({
   },
 }));
 
-const SectionTitle = styled(Box)(({ theme }) => ({
+const SectionTitle = styled("dt")(({ theme }) => ({
   order: 1,
+  margin: 0,
   [theme.breakpoints.up("sm")]: {
     order: 1,
     flexShrink: 1,
     flexBasis: `calc(100% - 260px)`,
-    paddingTop: theme.spacing(0.25),
+    paddingTop: theme.spacing(0.33),
   },
 }));
 
-const SectionDescription = styled(Box)(({ theme }) => ({
+const SectionDescription = styled("dd")(({ theme }) => ({
   order: 2,
+  margin: 0,
   paddingBottom: theme.spacing(2),
   [theme.breakpoints.up("sm")]: {
     paddingBottom: 0,
@@ -243,13 +246,15 @@ const SectionDescription = styled(Box)(({ theme }) => ({
   },
 }));
 
-const SectionState = styled(Box)(({ theme }) => ({
+const SectionState = styled("dd")(({ theme }) => ({
   order: 3,
+  margin: 0,
   [theme.breakpoints.up("sm")]: {
     order: 2,
+    display: "flex",
     flexShrink: 0,
     flexBasis: "260px",
-    textAlign: "right",
+    justifyContent: "flex-end",
   },
   "& > button": {
     width: "auto",

--- a/editor.planx.uk/src/@planx/components/Section/Section.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Section.stories.tsx
@@ -18,18 +18,21 @@ const sectionNodes: { [key: string]: SectionNode } = {
   firstSection: {
     data: {
       title: "First section",
+      description: "Description of first section",
     },
     type: TYPES.Section,
   },
   secondSection: {
     data: {
       title: "Second section",
+      description: "Description of second section",
     },
     type: TYPES.Section,
   },
   thirdSection: {
     data: {
       title: "Third section",
+      description: "Description of third section",
     },
     type: TYPES.Section,
   },
@@ -51,6 +54,7 @@ const defaultProps: ComponentProps<typeof Public> = {
   changeAnswer: () => console.log("changeAnswer called"),
   breadcrumbs: {},
   title: "The property",
+  description: "Short description of the property section",
   sectionCount: 3,
 };
 

--- a/editor.planx.uk/src/@planx/components/Section/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.test.ts
@@ -7,18 +7,21 @@ const flowSections: { [key: string]: SectionNode } = {
   firstSection: {
     data: {
       title: "First section",
+      description: "Description of first section",
     },
     type: TYPES.Section,
   },
   secondSection: {
     data: {
       title: "Second section",
+      description: "Description of second section",
     },
     type: TYPES.Section,
   },
   thirdSection: {
     data: {
       title: "Third section",
+      description: "Description of third section",
     },
     type: TYPES.Section,
   },

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -5,12 +5,14 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 
 export interface Section extends MoreInformation {
   title: string;
+  description?: string;
 }
 
 export const parseSection = (
   data: Record<string, any> | undefined,
 ): Section => ({
   title: data?.title || "",
+  description: data?.description,
   ...parseMoreInformation(data),
 });
 

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -131,5 +131,6 @@ export enum SectionStatus {
 export interface SectionNode extends Store.node {
   data: {
     title: string;
+    description?: string;
   };
 }


### PR DESCRIPTION
### Summary

- PR adds the option to add a rich-text description to sections
- `<dl>` structure is maintained, I've checked and nesting a `<div>` inside a `<dl>` is valid HTML [source](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element)
- Tests and storybook updated accordingly

Related to Trello card:
https://trello.com/c/SGy6v0Sm/2587-investigate-section-descriptions

Example:
https://2240.planx.pizza/lambeth/apply-for-prior-approval/preview