### PR TITLE
fix: Init user store across all routes

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -13,6 +13,7 @@ import jwtDecode from "jwt-decode";
 import { getCookie, setCookie } from "lib/cookie";
 import ErrorPage from "pages/ErrorPage";
 import { AnalyticsProvider } from "pages/FlowEditor/lib/analyticsProvider";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { Suspense, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { NotFoundBoundary, Router, useLoadingRoute, View } from "react-navi";
@@ -46,6 +47,7 @@ const hasJWT = (): boolean | void => {
           ],
         ) > 0
       ) {
+        useStore.getState().initUserStore(jwt);
         return true;
       }
     } catch (e) {}

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -1,7 +1,4 @@
-import { User } from "@opensystemslab/planx-core/types";
 import gql from "graphql-tag";
-import jwtDecode from "jwt-decode";
-import { getCookie } from "lib/cookie";
 import { compose, lazy, mount, route, withData, withView } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -21,38 +18,6 @@ const editorRoutes = compose(
 
   mount({
     "/": route(async () => {
-      const jwt = getCookie("jwt");
-      const email = jwt && (jwtDecode(jwt) as any)["email"];
-      const users = await client.query({
-        query: gql`
-          query GetUserByEmail($email: String!) {
-            users: users(where: { email: { _eq: $email } }) {
-              id
-              firstName: first_name
-              lastName: last_name
-              email
-              isPlatformAdmin: is_platform_admin
-              teams {
-                role
-                team {
-                  name
-                  slug
-                  id
-                }
-              }
-            }
-          }
-        `,
-        variables: { email },
-      });
-
-      if (users) {
-        const user: User = users.data.users[0];
-        useStore.getState().setUser(user);
-      } else {
-        throw new Error(`Failed to get user ${email}`);
-      }
-
       const { data } = await client.query({
         query: gql`
           query {


### PR DESCRIPTION
 - Init user store via router context
 - This means that we can refresh at any point / any page and the store will re-init