### PR TITLE
feat: Allow `platformAdmin` role to delete flows

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -283,6 +283,10 @@
                     _eq: teamEditor
         check: null
   delete_permissions:
+    - role: platformAdmin
+      permission:
+        backend_only: false
+        filter: {}
     - role: teamEditor
       permission:
         backend_only: false

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -58,6 +58,11 @@ describe("flows and operations", () => {
       expect(i.mutations).toContain("insert_flows");
     });
 
+    test("can delete flows", () => {
+      expect(i.mutations).toContain("delete_flows_by_pk");
+      expect(i.mutations).toContain("delete_flows");
+    });
+
     test("can query published flows", () => {
       expect(i.queries).toContain("published_flows");
     });


### PR DESCRIPTION
Raised by August [here on OSL Slack](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1695634674247739?thread_ts=1695633553.425559&cid=C5Q59R3HB)
