### PR TITLE
fix: Use `get()` instead of `this` in Zustand stores

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -54,7 +54,7 @@ export const teamStore: StateCreator<TeamStore, [], [], TeamStore> = (
     boundaryBBox: get().boundaryBBox,
   }),
 
-  async initTeamStore(teamSlugFromURLParams) {
+  initTeamStore: async (teamSlugFromURLParams) => {
     const slug = teamSlugFromURLParams || await getTeamFromDomain(window.location.hostname)
     const { data } = await client.query({
       query: gql`
@@ -86,7 +86,6 @@ export const teamStore: StateCreator<TeamStore, [], [], TeamStore> = (
     const team = data.teams[0];
 
     if (!team) throw new Error("Team not found");
-
-    this.setTeam(team);
+    get().setTeam(team);
   },
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -59,7 +59,7 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
     );
   },
 
-  async initUserStore(jwt: string) {
+  initUserStore: async (jwt: string) => {
     const email = (jwtDecode(jwt) as any)["email"];
     const users = await client.query({
       query: gql`
@@ -87,6 +87,6 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
     const user: User = users.data.users[0];
     if (!user) throw new Error(`Failed to get user ${email}`);
 
-    this.setUser(user);
+    get().setUser(user);
   },
 });

--- a/editor.planx.uk/src/routes/views/team.tsx
+++ b/editor.planx.uk/src/routes/views/team.tsx
@@ -13,7 +13,7 @@ export const teamView = async (req: NaviRequest) => {
     try {
       await initTeamStore(req.params.team);
     } catch (error) {
-      throw new NotFoundError("Team not found");
+      throw new NotFoundError(`Team not found: ${error}`);
     }
   }
   


### PR DESCRIPTION
Fixes bug currently live on staging which causes `/preview` and `/unpublished` routes to fail. E2E tests to follow which will cover this!