### PR TITLE
feat: add option to use "Pay without pay" and show error in cases of undefined fee

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -31,6 +31,7 @@ function Component(props: any) {
         `<p>You can pay for your application by using GOV.UK Pay.</p>\
          <p>Your application will be sent after you have paid the fee. \
          Wait until you see an application sent message before closing your browser.</p>`,
+      hidePay: props.node?.data?.hidePay || false,
       allowInviteToPay: props.node?.data?.allowInviteToPay ?? true,
       secondaryPageTitle:
         props.node?.data?.secondaryPageTitle ||
@@ -113,20 +114,30 @@ function Component(props: any) {
             />
           </InputRow>
         </ModalSectionContent>
-        <ModalSectionContent>
-          <InputRow>
-            <OptionButton
-              selected={formik.values.allowInviteToPay}
-              onClick={() => {
-                formik.setFieldValue(
-                  "allowInviteToPay",
-                  !formik.values.allowInviteToPay,
-                );
-              }}
-            >
-              Allow applicants to invite someone else to pay
-            </OptionButton>
-          </InputRow>
+        <OptionButton
+          selected={formik.values.hidePay}
+          onClick={() => {
+            formik.setFieldValue("hidePay", !formik.values.hidePay);
+          }}
+          style={{ width: "100%" }}
+        >
+          Hide the pay buttons and show fee for information only
+        </OptionButton>
+      </ModalSection>
+      <ModalSection>
+        <ModalSectionContent title="Invite to Pay" Icon={ICONS[TYPES.Pay]}>
+          <OptionButton
+            selected={formik.values.allowInviteToPay}
+            onClick={() => {
+              formik.setFieldValue(
+                "allowInviteToPay",
+                !formik.values.allowInviteToPay,
+              );
+            }}
+            style={{ width: "100%" }}
+          >
+            Allow applicants to invite someone else to pay
+          </OptionButton>
           {formik.values.allowInviteToPay ? (
             <>
               <Box>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -35,6 +35,7 @@ export interface Props {
   onConfirm: () => void;
   error?: string;
   hideFeeBanner?: boolean;
+  hidePay?: boolean;
 }
 
 interface PayBodyProps extends Props {
@@ -60,53 +61,9 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
   const path = useStore((state) => state.path);
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
 
-  return (
-    <>
-      {!props.error ? (
-        <Card>
-          <PayText>
-            <Typography
-              variant="h2"
-              component={props.hideFeeBanner ? "h2" : "h3"}
-            >
-              {props.instructionsTitle || "How to pay"}
-            </Typography>
-            <ReactMarkdownOrHtml
-              source={
-                props.instructionsDescription ||
-                `<p>You can pay for your application by using GOV.UK Pay.</p>\
-                  <p>Your application will be sent after you have paid the fee. \
-                  Wait until you see an application sent message before closing your browser.</p>`
-              }
-              openLinksOnNewTab
-            />
-            <Button
-              variant="contained"
-              color="primary"
-              size="large"
-              onClick={props.onConfirm}
-            >
-              {props.buttonTitle || "Pay now using GOV.UK Pay"}
-            </Button>
-            {props.showInviteToPay && (
-              <>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  style={{ borderBottom: `solid 2px lightgrey` }}
-                  size="large"
-                  onClick={props.changePage}
-                  disabled={Boolean(props?.paymentStatus)}
-                  data-testid="invite-page-link"
-                >
-                  {"Invite someone else to pay for this application"}
-                </Button>
-              </>
-            )}
-            {isSaveReturn && <SaveResumeButton />}
-          </PayText>
-        </Card>
-      ) : (
+  if (props.error) {
+    if (props.error.endsWith("local authority")) {
+      return (
         <Card handleSubmit={props.onConfirm} isValid>
           <ErrorSummary role="status" data-testid="error-summary">
             <Typography variant="h4" component="h3" gutterBottom>
@@ -118,8 +75,68 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
             </Typography>
           </ErrorSummary>
         </Card>
-      )}
-    </>
+      );
+    } else {
+      return (
+        <Card>
+          <ErrorSummary role="status" data-testid="error-summary">
+            <Typography variant="h4" component="h3" gutterBottom>
+              {props.error}
+            </Typography>
+            <Typography variant="body2">
+              This error has been logged and our team will see it soon. You can
+              safely close this tab and try resuming again soon by returning to
+              this URL.
+            </Typography>
+          </ErrorSummary>
+        </Card>
+      );
+    }
+  }
+
+  return (
+    <Card>
+      <PayText>
+        <Typography variant="h2" component={props.hideFeeBanner ? "h2" : "h3"}>
+          {props.instructionsTitle || "How to pay"}
+        </Typography>
+        <ReactMarkdownOrHtml
+          source={
+            props.instructionsDescription ||
+            `<p>You can pay for your application by using GOV.UK Pay.</p>\
+                  <p>Your application will be sent after you have paid the fee. \
+                  Wait until you see an application sent message before closing your browser.</p>`
+          }
+          openLinksOnNewTab
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          onClick={props.onConfirm}
+        >
+          {props.hidePay
+            ? "Continue"
+            : props.buttonTitle || "Pay now using GOV.UK Pay"}
+        </Button>
+        {!props.hidePay && props.showInviteToPay && (
+          <>
+            <Button
+              variant="contained"
+              color="secondary"
+              style={{ borderBottom: `solid 2px lightgrey` }}
+              size="large"
+              onClick={props.changePage}
+              disabled={Boolean(props?.paymentStatus)}
+              data-testid="invite-page-link"
+            >
+              {"Invite someone else to pay for this application"}
+            </Button>
+          </>
+        )}
+        {isSaveReturn && <SaveResumeButton />}
+      </PayText>
+    </Card>
   );
 };
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -15,6 +15,7 @@ import ReactMarkdownOrHtml from "ui/ReactMarkdownOrHtml";
 
 import { formattedPriceWithCurrencySymbol } from "../model";
 import InviteToPayForm, { InviteToPayFormProps } from "./InviteToPayForm";
+import { PAY_API_ERROR_UNSUPPORTED_TEAM } from "./Pay";
 
 export interface Props {
   title?: string;
@@ -62,7 +63,7 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
 
   if (props.error) {
-    if (props.error.endsWith("local authority")) {
+    if (props.error.startsWith(PAY_API_ERROR_UNSUPPORTED_TEAM)) {
       return (
         <Card handleSubmit={props.onConfirm} isValid>
           <ErrorSummary role="status" data-testid="error-summary">

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -194,7 +194,9 @@ export default function Confirm(props: Props) {
                 className="marginBottom"
                 component="span"
               >
-                {formattedPriceWithCurrencySymbol(props.fee)}
+                {isNaN(props.fee)
+                  ? "Unknown"
+                  : formattedPriceWithCurrencySymbol(props.fee)}
               </Typography>
               <Typography variant="subtitle1" component="span" color="inherit">
                 <ReactMarkdownOrHtml

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
@@ -56,3 +56,17 @@ export const WithInviteToPay = {
     yourDetailsLabel: "Your name or organisation name",
   },
 } satisfies Story;
+
+export const ForInformationOnly = {
+  args: {
+    title: "What you can expect to pay for your application",
+    bannerTitle: "The calculated fee is",
+    description:
+      "Based on your answers so far, this is the fee that we've calculated. The fee will cover the cost of processing your application.",
+    instructionsTitle: "How to pay",
+    instructionsDescription:
+      "Payments will be accepted for your future application via GOV.UK Pay. You will have the option to pay yourself or invite someone else to pay.",
+    fee: 103,
+    hidePay: true,
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -161,7 +161,8 @@ describe("Confirm component without inviteToPay", () => {
 
   it("displays an error and continue-with-testing button if Pay is not enabled for this team", async () => {
     const handleSubmit = jest.fn();
-    const errorMessage = "No pay token found for this local authority";
+    const errorMessage =
+      "GOV.UK Pay is not enabled for this local authority (testing)";
 
     const { user } = setup(
       <Confirm

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -89,7 +89,7 @@ describe("Confirm component without inviteToPay", () => {
 
   it("displays an error and continue-with-testing button if Pay is not enabled for this team", async () => {
     const handleSubmit = jest.fn();
-    const errorMessage = "No pay token found for this team!";
+    const errorMessage = "No pay token found for this local authority";
 
     const { user } = setup(
       <Confirm
@@ -291,5 +291,47 @@ describe("Confirm component with inviteToPay", () => {
     const { container } = setup(<Confirm {...inviteProps} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+});
+
+describe("Confirm component in information-only mode", () => {
+  beforeAll(() => (initialState = getState()));
+  afterEach(() => act(() => setState(initialState)));
+
+  it("renders correctly", () => {
+    setup(<Confirm {...defaultProps} hidePay={true} />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Pay for your application",
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "The fee is",
+    );
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+      "How to pay",
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Continue");
+    expect(screen.getByRole("button")).not.toHaveTextContent("Pay");
+  });
+
+  it("renders correctly when inviteToPay is also toggled on by an editor", () => {
+    setup(<Confirm {...defaultProps} hidePay={true} showInviteToPay={true} />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Pay for your application",
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "The fee is",
+    );
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+      "How to pay",
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Continue");
+    expect(screen.getByRole("button")).not.toHaveTextContent("Pay");
+    expect(screen.getByRole("button")).not.toHaveTextContent(
+      "Invite someone else to pay for this application",
+    );
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -298,8 +298,11 @@ describe("Confirm component in information-only mode", () => {
   beforeAll(() => (initialState = getState()));
   afterEach(() => act(() => setState(initialState)));
 
-  it("renders correctly", () => {
-    setup(<Confirm {...defaultProps} hidePay={true} />);
+  it("renders correctly", async () => {
+    const handleSubmit = jest.fn();
+    const { user } = setup(
+      <Confirm {...defaultProps} hidePay={true} onConfirm={handleSubmit} />,
+    );
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "Pay for your application",
@@ -313,10 +316,21 @@ describe("Confirm component in information-only mode", () => {
 
     expect(screen.getByRole("button")).toHaveTextContent("Continue");
     expect(screen.getByRole("button")).not.toHaveTextContent("Pay");
+
+    await user.click(screen.getByText("Continue"));
+    expect(handleSubmit).toHaveBeenCalled();
   });
 
-  it("renders correctly when inviteToPay is also toggled on by an editor", () => {
-    setup(<Confirm {...defaultProps} hidePay={true} showInviteToPay={true} />);
+  it("renders correctly when inviteToPay is also toggled on by an editor", async () => {
+    const handleSubmit = jest.fn();
+    const { user } = setup(
+      <Confirm
+        {...defaultProps}
+        hidePay={true}
+        showInviteToPay={true}
+        onConfirm={handleSubmit}
+      />,
+    );
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "Pay for your application",
@@ -333,5 +347,8 @@ describe("Confirm component in information-only mode", () => {
     expect(screen.getByRole("button")).not.toHaveTextContent(
       "Invite someone else to pay for this application",
     );
+
+    await user.click(screen.getByText("Continue"));
+    expect(handleSubmit).toHaveBeenCalled();
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -1,11 +1,12 @@
 import { PaymentStatus } from "@opensystemslab/planx-core/types";
+import { TYPES } from "@planx/components/types";
 import { screen } from "@testing-library/react";
-import { FullStore, vanillaStore } from "pages/FlowEditor/lib/store";
+import { FullStore, Store, vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import * as ReactNavi from "react-navi";
 import { axe, setup } from "testUtils";
-import { ApplicationPath } from "types";
+import { ApplicationPath, Breadcrumbs } from "types";
 
 import Confirm, { Props } from "./Confirm";
 import Pay from "./Pay";
@@ -21,21 +22,92 @@ jest
 const resumeButtonText = "Resume an application you have already started";
 const saveButtonText = "Save and return to this application later";
 
-it("renders correctly (is hidden) with <= £0 fee", () => {
-  const handleSubmit = jest.fn();
+const flowWithUndefinedFee: Store.flow = {
+  _root: {
+    edges: ["setValue", "pay"],
+  },
+  setValue: {
+    type: TYPES.SetValue,
+    edges: ["pay"],
+    data: {
+      fn: "application.fee.payable",
+      val: "0",
+    },
+  },
+  pay: {
+    type: TYPES.Pay,
+    data: {
+      fn: "application.fee.typo",
+    },
+  },
+};
 
-  // if no props.fn, then fee defaults to 0
-  setup(<Pay handleSubmit={handleSubmit} />);
+const flowWithZeroFee: Store.flow = {
+  _root: {
+    edges: ["setValue", "pay"],
+  },
+  setValue: {
+    type: TYPES.SetValue,
+    edges: ["pay"],
+    data: {
+      fn: "application.fee.payable",
+      val: "0",
+    },
+  },
+  pay: {
+    type: TYPES.Pay,
+    data: {
+      fn: "application.fee.payable",
+    },
+  },
+};
 
-  // handleSubmit is still called to set auto = true so Pay isn't seen in card sequence
-  expect(handleSubmit).toHaveBeenCalled();
-});
+// Mimic having passed setValue to reach Pay
+const breadcrumbs: Breadcrumbs = {
+  setValue: {
+    auto: true,
+    data: {
+      "application.fee.payable": ["0"],
+    },
+  },
+};
 
-it("should not have any accessibility violations", async () => {
-  const handleSubmit = jest.fn();
-  const { container } = setup(<Pay handleSubmit={handleSubmit} />);
-  const results = await axe(container);
-  expect(results).toHaveNoViolations();
+describe("Pay component when fee is undefined or £0", () => {
+  beforeEach(() => {
+    getState().resetPreview();
+  });
+
+  it("Shows an error if fee is undefined", () => {
+    const handleSubmit = jest.fn();
+
+    setState({ flow: flowWithUndefinedFee, breadcrumbs: breadcrumbs });
+    expect(getState().computePassport()).toEqual({
+      data: { "application.fee.payable": ["0"] },
+    });
+
+    setup(<Pay fn="application.fee.typo" handleSubmit={handleSubmit} />);
+
+    // handleSubmit has NOT been called (not skipped), Pay shows error instead
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("We are unable to calculate your fee right now"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Continue")).not.toBeInTheDocument();
+  });
+
+  it("Skips pay if fee = 0", () => {
+    const handleSubmit = jest.fn();
+
+    setState({ flow: flowWithZeroFee, breadcrumbs: breadcrumbs });
+    expect(getState().computePassport()).toEqual({
+      data: { "application.fee.payable": ["0"] },
+    });
+
+    setup(<Pay fn="application.fee.payable" handleSubmit={handleSubmit} />);
+
+    // handleSubmit is called to auto-answer Pay (aka "skip" in card sequence)
+    expect(handleSubmit).toHaveBeenCalled();
+  });
 });
 
 const defaultProps = {
@@ -116,12 +188,6 @@ describe("Confirm component without inviteToPay", () => {
     expect(handleSubmit).toHaveBeenCalled();
   });
 
-  it("should not have any accessibility violations", async () => {
-    const { container } = setup(<Confirm {...defaultProps} />);
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
-
   it("displays the Save/Resume option if the application path requires it", () => {
     act(() =>
       setState({
@@ -140,6 +206,12 @@ describe("Confirm component without inviteToPay", () => {
 
     expect(screen.queryByText(saveButtonText)).not.toBeInTheDocument();
     expect(screen.queryByText(resumeButtonText)).not.toBeInTheDocument();
+  });
+
+  it("should not have any accessibility violations", async () => {
+    const { container } = setup(<Confirm {...defaultProps} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });
 
@@ -350,5 +422,14 @@ describe("Confirm component in information-only mode", () => {
 
     await user.click(screen.getByText("Continue"));
     expect(handleSubmit).toHaveBeenCalled();
+  });
+
+  it("should not have any accessibility violations", async () => {
+    const handleSubmit = jest.fn();
+    const { container } = setup(
+      <Confirm {...defaultProps} hidePay={true} onConfirm={handleSubmit} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -43,6 +43,9 @@ enum Action {
   Success,
 }
 
+export const PAY_API_ERROR_UNSUPPORTED_TEAM =
+  "GOV.UK Pay is not enabled for this local authority";
+
 function Component(props: Props) {
   const [
     flowId,
@@ -242,7 +245,11 @@ function Component(props: Props) {
           window.location.replace(payment._links.next_url.href);
       })
       .catch((error) => {
-        if (error.response?.data?.error?.endsWith("local authority")) {
+        if (
+          error.response?.data?.error?.startsWith(
+            PAY_API_ERROR_UNSUPPORTED_TEAM,
+          )
+        ) {
           // Show a custom message if this team isn't set up to use Pay yet
           dispatch(Action.StartNewPaymentError);
         } else {

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -264,13 +264,13 @@ function Component(props: Props) {
           {...props}
           fee={fee}
           onConfirm={() => {
-            if (state.status === "init") {
+            if (props.hidePay || state.status === "unsupported_team") {
+              // Show "Continue" button to proceed
+              props.handleSubmit({ auto: false });
+            } else if (state.status === "init") {
               startNewPayment();
             } else if (state.status === "retry") {
               resumeExistingPayment();
-            } else if (state.status === "unsupported_team" || props.hidePay) {
-              // Show "Continue" button to proceed
-              props.handleSubmit({ auto: false });
             }
           }}
           buttonTitle={

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -34,6 +34,7 @@ type ComponentState =
   | { status: "undefined_fee" };
 
 enum Action {
+  NoFeeFound,
   NoPaymentFound,
   IncompletePaymentFound,
   IncompletePaymentConfirmed,
@@ -71,12 +72,10 @@ function Component(props: Props) {
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {
     switch (action) {
+      case Action.NoFeeFound:
+        return { status: "undefined_fee" };
       case Action.NoPaymentFound:
-        if (isNaN(fee)) {
-          return { status: "undefined_fee" };
-        } else {
-          return { status: "init" };
-        }
+        return { status: "init" };
       case Action.IncompletePaymentFound:
         return {
           status: "fetching_payment",
@@ -116,8 +115,9 @@ function Component(props: Props) {
 
     // If props.fn is undefined, display & log an error
     if (isNaN(fee)) {
-      dispatch(Action.NoPaymentFound);
+      dispatch(Action.NoFeeFound);
       logger.notify(`Unable to calculate fee for session ${sessionId}`);
+      return;
     }
 
     if (!govUkPayment) {

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -12,6 +12,7 @@ export interface Pay extends MoreInformation {
   fn?: string;
   instructionsTitle?: string;
   instructionsDescription?: string;
+  hidePay?: boolean;
   allowInviteToPay?: boolean;
   secondaryPageTitle?: string;
   nomineeTitle?: string;
@@ -87,6 +88,7 @@ export const validationSchema = object({
   fn: string().trim().required("Data field is required"),
   instructionsTitle: string().trim().required(),
   instructionsDescription: string().trim().required(),
+  hidePay: boolean(),
   allowInviteToPay: boolean(),
   nomineeTitle: string().trim().when("allowInviteToPay", {
     is: true,


### PR DESCRIPTION
**Changes:**
- Adds Editor option to "Hide the pay buttons and show fee for information only" (off by default)
  - Renders [like this in the public interface](https://storybook.2284.planx.pizza/?path=/story/planx-components-pay--for-information-only)
- Updates how `NaN` / `undefined` fees are handled
  - Current behavior: if the data field referenced by the Pay component (`props.fn`) is undefined when Pay is reached, then automatically skip the Pay component. This led to real applications being successfully submitted without paying because of a content error a few weeks ago.
  - New behavior: if `props.fn` is undefined when Pay is reached, display an error and do not let the applicant continue. An airbrake error including the `sessionId` is also thrown/should be picked up in Slack. 
  
**Testing:**
- Try the different paths in this flow and confirm you have expected behavior: https://2284.planx.pizza/lambeth/pay-without-pay-test/preview
- Confirm that teams that do not have GOV.UK Pay enabled still show the expected error: https://2284.planx.pizza/barking-and-dagenham/pay-test/preview (specifically with a "Continue" button that does not prevent you from proceeding with your test)

**Future scope / not addressed here:**
- The Pay component is still automatically skipped in cases where the fee = 0. My understanding is we don't want to "show" this case until we can properly design how to display "reasons" (eg resubmission or exemption or other calculation)
- Show a breakdown of how the fee was calculated ([currently on roadmap here](https://miro.com/app/board/uXjVPrebzwQ=/?moveToWidget=3458764558166771974&cot=14) :crystal_ball:) 