### PR TITLE
fix: Correctly parse and transform strings to date in `/webhook` APIs

### DIFF
--- a/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/schema.ts
@@ -4,7 +4,7 @@ import { ScheduledEventResponse } from "../../../../hasura/metadata";
 
 export const createSessionEventSchema = z.object({
   body: z.object({
-    createdAt: z.string().transform((val) => new Date(val)),
+    createdAt: z.string().pipe(z.coerce.date()),
     payload: z.object({
       sessionId: z.string(),
     }),

--- a/api.planx.uk/modules/webhooks/service/paymentRequestEvents/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/paymentRequestEvents/schema.ts
@@ -4,7 +4,7 @@ import { ScheduledEventResponse } from "../../../../hasura/metadata";
 
 export const createPaymentEventSchema = z.object({
   body: z.object({
-    createdAt: z.string().transform((val) => new Date(val)),
+    createdAt: z.string().pipe(z.coerce.date()),
     payload: z.object({
       paymentRequestId: z.string(),
     }),

--- a/api.planx.uk/shared/middleware/validate.ts
+++ b/api.planx.uk/shared/middleware/validate.ts
@@ -13,11 +13,18 @@ export const validate =
     next: NextFunction,
   ) => {
     try {
-      schema.parse({
+      const parsedReq = schema.parse({
         params: req.params,
         body: req.body,
         query: req.query,
       });
+
+      // Assign parsed values to the request object
+      // Required for schemas to transform or coerce raw requests
+      req.params = parsedReq.params;
+      req.body = parsedReq.body;
+      req.query = parsedReq.query;
+
       return next();
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Hit this issue when troubleshooting E2E test (this doesn't fix them yet! 😅)

The change introduced in https://github.com/theopensystemslab/planx-new/pull/2252 validates that incomming requests are valid (e.g. dates), and then hands over the request type to the `ValidatedRequestHandler` type.

What I missed is that we're never passing along the parsed request to the next middleware layer (but it does pass the type as mentioned above).

This means we end up with strings being passed into functions that expect `Date` objects. When running E2E tests a number of API requests fail as a result.