### PR TITLE
chore: Drop redundant API endpoints

### DIFF
--- a/api.planx.uk/server.test.js
+++ b/api.planx.uk/server.test.js
@@ -1,23 +1,6 @@
 import supertest from "supertest";
 
-import { queryMock } from "./tests/graphqlQueryMock";
 import app from "./server";
-
-it("mocks hasura", async () => {
-  queryMock.mockQuery({
-    name: "GetTeams",
-    data: {
-      teams: [{ id: 1 }],
-    },
-  });
-
-  await supertest(app)
-    .get("/hasura")
-    .expect(200)
-    .then((res) => {
-      expect(res.body).toEqual({ teams: [{ id: 1 }] });
-    });
-});
 
 describe("authentication", () => {
   test("Failed login endpoint", async () => {

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -190,21 +190,6 @@ app.use("/webhooks", webhookRoutes);
 
 app.use("/gis", router);
 
-app.get("/hasura", async function (_req, res, next) {
-  try {
-    const data = await adminClient.request(gql`
-      query GetTeams {
-        teams {
-          id
-        }
-      }
-    `);
-    res.json(data);
-  } catch (err) {
-    next(err);
-  }
-});
-
 app.get("/gis", (_req, _res, next) => {
   next({
     status: 400,
@@ -226,12 +211,6 @@ app.get("/admin/session/:sessionId/html", getHTMLExport);
 app.get("/admin/session/:sessionId/html-redacted", getRedactedHTMLExport);
 app.get("/admin/session/:sessionId/zip", generateZip);
 app.get("/admin/session/:sessionId/summary", getSessionSummary);
-
-// XXX: leaving this in temporarily as a testing endpoint to ensure it
-//      works correctly in staging and production
-app.get("/throw-error", () => {
-  throw new Error("custom error");
-});
 
 app.post("/flows/:flowId/copy", useTeamEditorAuth, copyFlow);
 
@@ -447,14 +426,6 @@ app.post("/validate-session", validateSession);
 app.post("/invite-to-pay/:sessionId", inviteToPay);
 
 app.use("/proxy/ordnance-survey", useOrdnanceSurveyProxy);
-
-app.get("/error", async (res, req, next) => {
-  try {
-    throw Error("This is a test error");
-  } catch (error) {
-    next(error);
-  }
-});
 
 const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {

--- a/api.planx.uk/tests/serverErrorHandler.test.js
+++ b/api.planx.uk/tests/serverErrorHandler.test.js
@@ -30,20 +30,6 @@ describe("bad requests", () => {
     await get("/pay/wrong/1").expect(400);
   });
 
-  test(`app.get("/hasura")`, async () => {
-    await get("/hasura").expect(500);
-  });
-
-  test(`app.get("/me")`, async () => {
-    await get("/me")
-      .expect(401)
-      .then((response) => {
-        expect(response.body).toEqual({
-          error: "No authorization token was found",
-        });
-      });
-  });
-
   test(`app.get("/gis")`, async () => {
     await get("/gis").expect(400);
   });
@@ -56,10 +42,6 @@ describe("bad requests", () => {
           error: "wrong is not a supported local authority",
         });
       });
-  });
-
-  test(`app.get("/throw-error")`, async () => {
-    await get("/throw-error").expect(500);
   });
 
   test(`app.post("/flows/:flowId/publish")`, async () => {


### PR DESCRIPTION
## What does this PR do?
 - Drops `/hasura`
   - E2E tests cover functionality, and `/me` can be used to the same effect to check API -> Hasura networking)
 - Drops `/error` and `/throw-error`