### PR TITLE
feat: Create new `api` role in Hasura

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -62,6 +62,52 @@
 - table:
     schema: public
     name: bops_applications
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - req_headers
+          - request
+          - response
+          - response_headers
+          - bops_id
+          - destination_url
+          - session_id
+          - created_at
+          - sanitised_at
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - req_headers
+          - request
+          - response
+          - response_headers
+          - bops_id
+          - destination_url
+          - session_id
+          - created_at
+          - sanitised_at
+        filter: {}
+  update_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - req_headers
+          - request
+          - response
+          - response_headers
+          - bops_id
+          - destination_url
+          - session_id
+          - created_at
+          - sanitised_at
+        filter: {}
+        check: {}
   event_triggers:
     - name: setup_bops_applications_notifications
       definition:
@@ -90,6 +136,46 @@
 - table:
     schema: public
     name: email_applications
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - request
+          - response
+          - recipient
+          - team_slug
+          - created_at
+          - sanitised_at
+          - session_id
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - request
+          - response
+          - recipient
+          - team_slug
+          - created_at
+          - sanitised_at
+          - session_id
+        filter: {}
+  update_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - request
+          - response
+          - recipient
+          - team_slug
+          - created_at
+          - sanitised_at
+          - session_id
+        filter: {}
+        check: {}
   event_triggers:
     - name: setup_email_applications_notifications
       definition:
@@ -119,6 +205,12 @@
       using:
         foreign_key_constraint_on: flow_id
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - document_template
+          - flow_id
+        filter: {}
     - role: public
       permission:
         columns:
@@ -177,6 +269,20 @@
           name: compile_flow_portals
       comment: Flow data with portals merged in
   insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - creator_id
+          - team_id
+          - settings
+          - slug
+          - created_at
+          - updated_at
+          - copied_from
+          - id
+          - version
+          - data
     - role: platformAdmin
       permission:
         check: {}
@@ -213,6 +319,22 @@
           - version
           - data
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - creator_id
+          - team_id
+          - settings
+          - slug
+          - created_at
+          - updated_at
+          - copied_from
+          - id
+          - version
+          - data
+        computed_fields:
+          - data_merged
+        filter: {}
     - role: platformAdmin
       permission:
         columns:
@@ -259,6 +381,21 @@
           - data_merged
         filter: {}
   update_permissions:
+    - role: api
+      permission:
+        columns:
+          - creator_id
+          - team_id
+          - settings
+          - slug
+          - created_at
+          - updated_at
+          - copied_from
+          - id
+          - version
+          - data
+        filter: {}
+        check: {}
     - role: platformAdmin
       permission:
         columns:
@@ -376,6 +513,21 @@
           - flow_id
           - id
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - data
+          - email
+          - created_at
+          - deleted_at
+          - locked_at
+          - submitted_at
+          - updated_at
+          - flow_id
+          - id
+          - has_user_saved
+          - sanitised_at
+        filter: {}
     - role: public
       permission:
         columns:
@@ -397,6 +549,22 @@
             - deleted_at:
                 _is_null: true
   update_permissions:
+    - role: api
+      permission:
+        columns:
+          - data
+          - email
+          - created_at
+          - deleted_at
+          - locked_at
+          - submitted_at
+          - updated_at
+          - flow_id
+          - id
+          - has_user_saved
+          - sanitised_at
+        filter: {}
+        check: {}
     - role: public
       permission:
         columns:
@@ -610,7 +778,36 @@
     - name: session
       using:
         foreign_key_constraint_on: session_id
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - session_preview_data
+          - applicant_name
+          - payee_email
+          - payee_name
+          - created_at
+          - paid_at
+          - id
+          - session_id
+          - govpay_payment_id
+          - payment_amount
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - session_preview_data
+          - applicant_name
+          - payee_email
+          - payee_name
+          - created_at
+          - paid_at
+          - id
+          - session_id
+          - govpay_payment_id
+          - payment_amount
+        filter: {}
     - role: public
       permission:
         columns:
@@ -624,6 +821,27 @@
         filter:
           id:
             _eq: x-hasura-payment-request-id
+  update_permissions:
+    - role: api
+      permission:
+        columns:
+          - session_preview_data
+          - applicant_name
+          - payee_email
+          - payee_name
+          - created_at
+          - paid_at
+          - id
+          - session_id
+          - govpay_payment_id
+          - payment_amount
+        filter: {}
+        check: {}
+  delete_permissions:
+    - role: api
+      permission:
+        backend_only: false
+        filter: {}
   event_triggers:
     - name: setup_payment_expiry_events
       definition:
@@ -751,6 +969,18 @@
           insertion_order: null
           column_mapping:
             session_id: id
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - payment_id
+          - status
+          - team_slug
+          - created_at
+          - flow_id
+          - session_id
+          - amount
 - table:
     schema: public
     name: payment_status_enum
@@ -758,6 +988,16 @@
 - table:
     schema: public
     name: planning_constraints_requests
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - response
+          - destination_url
+          - session_id
+          - created_at
 - table:
     schema: public
     name: project_types
@@ -779,6 +1019,16 @@
       using:
         foreign_key_constraint_on: publisher_id
   insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - publisher_id
+          - summary
+          - created_at
+          - flow_id
+          - data
     - role: platformAdmin
       permission:
         check: {}
@@ -808,6 +1058,16 @@
           - flow_id
           - data
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - publisher_id
+          - summary
+          - created_at
+          - flow_id
+          - data
+        filter: {}
     - role: platformAdmin
       permission:
         columns:
@@ -841,6 +1101,21 @@
 - table:
     schema: public
     name: reconciliation_requests
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - response
+          - message
+          - session_id
+          - created_at
+  delete_permissions:
+    - role: api
+      permission:
+        backend_only: false
+        filter: {}
 - table:
     schema: public
     name: sessions
@@ -999,6 +1274,23 @@
           - theme
           - updated_at
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - notify_personalisation
+          - settings
+          - theme
+          - domain
+          - name
+          - slug
+          - created_at
+          - updated_at
+          - boundary
+          - submission_email
+        computed_fields:
+          - boundary_bbox
+        filter: {}
     - role: platformAdmin
       permission:
         columns:
@@ -1061,6 +1353,49 @@
 - table:
     schema: public
     name: uniform_applications
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - response
+          - idox_submission_id
+          - created_at
+          - destination
+          - xml
+          - payload
+          - sanitised_at
+          - submission_reference
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - response
+          - idox_submission_id
+          - created_at
+          - destination
+          - xml
+          - payload
+          - sanitised_at
+          - submission_reference
+        filter: {}
+  update_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - response
+          - idox_submission_id
+          - created_at
+          - destination
+          - xml
+          - payload
+          - sanitised_at
+          - submission_reference
+        filter: {}
+        check: {}
   event_triggers:
     - name: setup_uniform_applications_notifications
       definition:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1199,6 +1199,14 @@
           - role
           - id
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - team_id
+          - user_id
+          - role
+          - id
+        filter: {}
     - role: platformAdmin
       permission:
         columns:
@@ -1459,6 +1467,17 @@
           - is_platform_admin
           - email
   select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - first_name
+          - last_name
+          - created_at
+          - updated_at
+          - is_platform_admin
+          - email
+        filter: {}
     - role: platformAdmin
       permission:
         columns:

--- a/hasura.planx.uk/tests/analytics.test.js
+++ b/hasura.planx.uk/tests/analytics.test.js
@@ -69,4 +69,26 @@ describe("analytics and analytics_logs", () => {
       expect(i).toHaveNoMutationsFor("analytics_logs");
     });
   });
+
+  describe("api", () => {
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query analytics", () => {
+      expect(i.queries).not.toContain("analytics");
+    });
+
+    test("cannot query analytics_logs", () => {
+      expect(i.queries).not.toContain("analytics_logs");
+    });
+
+    test("cannot create, update, or delete analytics", () => {
+      expect(i).toHaveNoMutationsFor("analytics");
+    });
+
+    test("cannot create, update, or delete analytics_logs", () => {
+      expect(i).toHaveNoMutationsFor("analytics_logs");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/blpu_codes.test.js
+++ b/hasura.planx.uk/tests/blpu_codes.test.js
@@ -47,7 +47,22 @@ describe("blpu_codes", () => {
   describe("teamEditor", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("platformAdmin");
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query blpu_codes", () => {
+      expect(i.queries).not.toContain("blpu_codes");
+    });
+
+    test("cannot create, update, or delete blpu_codes", () => {
+      expect(i).toHaveNoMutationsFor("blpu_codes");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
     });
 
     test("cannot query blpu_codes", () => {

--- a/hasura.planx.uk/tests/bops_applications.test.js
+++ b/hasura.planx.uk/tests/bops_applications.test.js
@@ -59,4 +59,21 @@ describe("bops_applications", () => {
       expect(i).toHaveNoMutationsFor("bops_applications");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query and mutate bops applications", () => {
+      expect(i.queries).toContain("bops_applications");
+      expect(i.mutations).toContain("insert_bops_applications");
+      expect(i.mutations).toContain("update_bops_applications_by_pk");
+    });
+
+    test("cannot delete bops applications", () => {
+      expect(i.mutations).not.toContain("delete_bops_applications");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/email_applications.test.js
+++ b/hasura.planx.uk/tests/email_applications.test.js
@@ -60,4 +60,22 @@ describe("email_applications", () => {
       expect(i).toHaveNoMutationsFor("email_applications");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("has full access to query and mutate email applications", () => {
+      expect(i.queries).toContain("email_applications");
+      expect(i.mutations).toContain("insert_email_applications");
+      expect(i.mutations).toContain("insert_email_applications_one");
+      expect(i.mutations).toContain("update_email_applications_by_pk");
+    });
+
+    test("cannot delete email applications", () => {
+      expect(i.mutations).not.toContain("delete_email_applications");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/flow_document_templates.test.js
+++ b/hasura.planx.uk/tests/flow_document_templates.test.js
@@ -1,0 +1,81 @@
+const { introspectAs } = require("./utils");
+
+describe("flow_document_templates", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    // TODO: Check this - seems unnecessary / incorrect?
+    test.skip("cannot query flow_document_templates", () => {
+      expect(i.queries).not.toContain("flow_document_templates");
+    });
+
+    test("cannot create, update, or delete flow_document_templates", () => {
+      expect(i).toHaveNoMutationsFor("flow_document_templates");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("can query flow_document_templates", () => {
+      expect(i.queries).toContain("flow_document_templates");
+    });
+
+    test("can create, update, or delete flow_document_templates", () => {
+      expect(i.mutations).toContain("insert_flow_document_templates");
+      expect(i.mutations).toContain("insert_flow_document_templates_one");
+      expect(i.mutations).toContain("update_flow_document_templates_by_pk");
+      expect(i.mutations).toContain("delete_flow_document_templates_by_pk");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query flow_document_templates", () => {
+      expect(i.queries).not.toContain("flow_document_templates");
+    });
+
+    test("cannot create, update, or delete flow_document_templates", () => {
+      expect(i).toHaveNoMutationsFor("flow_document_templates");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query flow_document_templates", () => {
+      expect(i.queries).not.toContain("flow_document_templates");
+    });
+
+    test("cannot create, update, or delete flow_document_templates", () => {
+      expect(i).toHaveNoMutationsFor("flow_document_templates");
+    });
+  });
+
+  describe("api", () => {
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query flow_document_templates", () => {
+      expect(i.queries).toContain("flow_document_templates");
+    });
+
+    test("cannot create, update, or delete flow_document_templates", () => {
+      expect(i).toHaveNoMutationsFor("flow_document_templates");
+    });
+  });
+});

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -140,4 +140,46 @@ describe("flows and operations", () => {
       expect(i.mutations).not.toContain("update_published_flows");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query flows", () => {
+      expect(i.queries).toContain("flows");
+    });
+
+    test("can create and update flows", () => {
+      expect(i.mutations).toContain("update_flows_by_pk");
+      expect(i.mutations).toContain("update_flows");
+    });
+
+    test("cannot delete flows", () => {
+      expect(i.mutations).not.toContain("delete_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_flows");
+    });
+
+    test("cannot query or mutate operations", () => {
+      expect(i.queries).not.toContain("operations");
+      expect(i).toHaveNoMutationsFor("operations");
+    });
+
+    test("can query published flows", () => {
+      expect(i.queries).toContain("published_flows");
+    });
+
+    test("can create published_flows", () => {
+      expect(i.mutations).toContain("insert_published_flows_one");
+      expect(i.mutations).toContain("insert_published_flows");
+    });
+
+    test("cannot update or delete published_flows", () => {
+      expect(i.mutations).not.toContain("delete_published_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_published_flows");
+      expect(i.mutations).not.toContain("update_published_flows_by_pk");
+      expect(i.mutations).not.toContain("update_published_flows");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/global_settings.test.js
+++ b/hasura.planx.uk/tests/global_settings.test.js
@@ -63,4 +63,19 @@ describe("global_settings", () => {
       expect(i).toHaveNoMutationsFor("global_settings");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query global_settings view", () => {
+      expect(i.queries).not.toContain("global_settings");
+    });
+
+    test("cannot create, update, or delete global_settings", () => {
+      expect(i).toHaveNoMutationsFor("global_settings");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -458,4 +458,26 @@ describe("lowcal_sessions", () => {
       expect(i).toHaveNoMutationsFor("lowcal_sessions");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot insert lowcal_sessions", () => {
+      expect(i.mutations).not.toContain("insert_lowcal_sessions");
+      expect(i.mutations).not.toContain("insert_lowcal_sessions_one");
+    });
+
+    test("can query and update local_sessions", () => {
+      expect(i.queries).toContain("lowcal_sessions");
+      expect(i.mutations).toContain("update_lowcal_sessions_by_pk");
+      expect(i.mutations).toContain("update_lowcal_sessions");
+    });
+
+    test("cannot delete lowcal_sessions", () => {
+      expect(i.mutations).not.toContain("delete_lowcal_sessions");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/payment_requests.test.js
+++ b/hasura.planx.uk/tests/payment_requests.test.js
@@ -127,6 +127,21 @@ describe("payment_requests", () => {
       expect(i).toHaveNoMutationsFor("payment_requests");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("has full access to query and mutate payment_requests", async () => {
+      expect(i.queries).toContain("payment_requests");
+      expect(i.mutations).toContain("insert_payment_requests");
+      expect(i.mutations).toContain("update_payment_requests");
+      expect(i.mutations).toContain("update_payment_requests_by_pk");
+      expect(i.mutations).toContain("delete_payment_requests");
+    });
+  });
 });
 
 const insertSessions = async (sessionIds) => {

--- a/hasura.planx.uk/tests/payment_status.test.js
+++ b/hasura.planx.uk/tests/payment_status.test.js
@@ -66,4 +66,24 @@ describe("payment_status", () => {
       expect(i).toHaveNoMutationsFor("payment_status");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query payment_status", () => {
+      expect(i.queries).not.toContain("payment_status");
+    })
+
+    test("can insert payment_status", () => {
+      expect(i.mutations).toContain("insert_payment_status");
+    });
+
+    test("cannot delete or update payment_status", () => {
+      expect(i.mutations).not.toContain("update_payment_status");
+      expect(i.mutations).not.toContain("delete_payment_status");
+    })
+  });
 });

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -59,4 +59,24 @@ describe("planning_constraints_requests", () => {
       expect(i).toHaveNoMutationsFor("planning_constraints_requests");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query planning_constraints_requests", () => {
+      expect(i.queries).not.toContain("planning_constraints_requests");
+    })
+
+    test("can insert planning_constraints_requests", () => {
+      expect(i.mutations).toContain("insert_planning_constraints_requests");
+    });
+
+    test("cannot update or delete planning_constriants_requests", () => {
+      expect(i.mutations).not.toContain("update_planning_constraints_requests_by_pk");
+      expect(i.mutations).not.toContain("delete_planning_constraints_requests");
+    })
+  });
 });

--- a/hasura.planx.uk/tests/reconciliation_requests.test.js
+++ b/hasura.planx.uk/tests/reconciliation_requests.test.js
@@ -1,0 +1,88 @@
+const { introspectAs } = require("./utils");
+
+describe("reconciliation_requests", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query reconciliation_requests", () => {
+      expect(i.queries).not.toContain("reconciliation_requests");
+    });
+
+    test("cannot create, update, or delete reconciliation_requests", () => {
+      expect(i).toHaveNoMutationsFor("reconciliation_requests");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("can query reconciliation_requests", () => {
+      expect(i.queries).toContain("reconciliation_requests");
+    });
+
+    test("can create, update, or delete reconciliation_requests", () => {
+      expect(i.mutations).toContain("insert_reconciliation_requests");
+      expect(i.mutations).toContain("insert_reconciliation_requests_one");
+      expect(i.mutations).toContain("update_reconciliation_requests_by_pk");
+      expect(i.mutations).toContain("delete_reconciliation_requests_by_pk");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query reconciliation_requests", () => {
+      expect(i.queries).not.toContain("reconciliation_requests");
+    });
+
+    test("cannot create, update, or delete reconciliation_requests", () => {
+      expect(i).toHaveNoMutationsFor("reconciliation_requests");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query reconciliation_requests", () => {
+      expect(i.queries).not.toContain("reconciliation_requests");
+    });
+
+    test("cannot create, update, or delete reconciliation_requests", () => {
+      expect(i).toHaveNoMutationsFor("reconciliation_requests");
+    });
+  });
+
+  describe("api", () => {
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query reconciliation_requests", () => {
+      expect(i.queries).not.toContain("reconciliation_requests");
+    });
+
+    test("cannot update reconciliation_requests", () => {
+      expect(i.mutations).not.toContain("update_reconciliation_requests");
+    });
+
+    test("can delete reconciliation_requests", () => {
+      expect(i.mutations).toContain("delete_reconciliation_requests");
+    });
+
+    test("can insert reconciliation requests", () => {
+      expect(i.mutations).toContain("insert_reconciliation_requests");
+    });
+  });
+});

--- a/hasura.planx.uk/tests/sessions.test.js
+++ b/hasura.planx.uk/tests/sessions.test.js
@@ -625,5 +625,22 @@ describe("sessions", () => {
       expect(i).toHaveNoMutationsFor("sessions");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query sessions", () => {
+      expect(i.queries).not.toContain("sessions");
+    });
+
+    test("cannot create, update, or delete sessions", () => {
+      expect(i.mutations).not.toContain("insert_sessions");
+      expect(i.mutations).not.toContain("update_sessions");
+      expect(i.mutations).not.toContain("delete_sessions");
+    });
+  });
   
 });

--- a/hasura.planx.uk/tests/team_members.test.js
+++ b/hasura.planx.uk/tests/team_members.test.js
@@ -59,4 +59,19 @@ describe("team_members", () => {
       expect(i).toHaveNoMutationsFor("team_members");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query teams members", () => {
+      expect(i.queries).not.toContain("team_members");
+    });
+
+    test("cannot create, update, or delete team_members", () => {
+      expect(i).toHaveNoMutationsFor("team_members");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/team_members.test.js
+++ b/hasura.planx.uk/tests/team_members.test.js
@@ -66,8 +66,8 @@ describe("team_members", () => {
       i = await introspectAs("api");
     });
 
-    test("cannot query teams members", () => {
-      expect(i.queries).not.toContain("team_members");
+    test("can query teams members", () => {
+      expect(i.queries).toContain("team_members");
     });
 
     test("cannot create, update, or delete team_members", () => {

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -71,4 +71,19 @@ describe("teams", () => {
       expect(i.mutations).not.toContain("insert_teams");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query teams", () => {
+      expect(i.queries).toContain("teams");
+    });
+
+    test("cannot create, update, or delete teams", () => {
+      expect(i).toHaveNoMutationsFor("teams");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/uniform_applications.test.js
+++ b/hasura.planx.uk/tests/uniform_applications.test.js
@@ -59,4 +59,21 @@ describe("uniform_applications", () => {
       expect(i).toHaveNoMutationsFor("uniform_applications");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("has full access to query and mutate uniform applications", () => {
+      expect(i.queries).toContain("uniform_applications");
+      expect(i.mutations).toContain("insert_uniform_applications");
+      expect(i.mutations).toContain("update_uniform_applications_by_pk");
+    });
+
+    test("cannot delete uniform applications", () => {
+      expect(i.mutations).not.toContain("delete_uniform_applications");
+    })
+  });
 });

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -73,8 +73,8 @@ describe("users", () => {
       i = await introspectAs("api");
     });
 
-    test("cannot query users", async () => {
-      expect(i.queries).not.toContain("users");
+    test("can query users", async () => {
+      expect(i.queries).toContain("users");
     });
 
     test("cannot create, update, or delete users", async () => {

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -66,4 +66,19 @@ describe("users", () => {
       expect(i).toHaveNoMutationsFor("users");
     });
   });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query users", async () => {
+      expect(i.queries).not.toContain("users");
+    });
+
+    test("cannot create, update, or delete users", async () => {
+      expect(i).toHaveNoMutationsFor("users");
+    });
+  });
 });

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -83,6 +83,7 @@ const introspectAs = async (role, userId = undefined) => {
     public: gqlPublic,
     platformAdmin: gqlWithRole("platformAdmin", userId),
     teamEditor: gqlWithRole("teamEditor", userId),
+    api: gqlWithRole("api"),
   }[role]
   const INTROSPECTION_QUERY = `
     query IntrospectionQuery {


### PR DESCRIPTION
## What does this PR do?
 - Adds a new `api` role in Hasura
 - Adds introspection test coverage for user role

## What's the motivation behind this?
I'm working towards https://trello.com/c/qSCoDRAO/2650-implement-editor-permissions-throughout-the-api which has two main aims - 
 - When a request to the API is initiated by a user, use their permission level throughout the call stack
 - When a request to the API is initiated by an internal service (e.g. Hasura), use appropriate permissions (not admin token with full "God mode")

The first step has been pretty well started in previous PRs. Adding an `api` role will allow us to scope service → API requests appropriately when a service has authenticated to the API (e.g. through the `useHasuraAuth()` middleware).

The permission set outlined here is based on queries currently made by the two admin GraphQL clients currently used in the API.

## Next steps...
- Drop `$admin` client from API
- Drop `adminGraphQLClient` from API
- Replace them with a role-scoped client. Either a user's role, or the new `api` role for service → API requests.
- Where a user-initiated request requires a "side effect" (such as adding an audit log), I think it would be appropriate to call the API-scoped client. An alternative could be using [backend only mutations](https://hasura.io/docs/latest/auth/authorization/permissions/backend-only/) but this feels like a more complex solution.

I'll likely split the above into a few PRs just to make them a bit more manageable.

## Nice to have?
Porting the introspection tests from JavaScript / Jest to Gherkin could be a really nice tidy up. I think it would be approx 10% of the number of lines of code that we currently have and be a lot easier to maintain and parse. This is not a very high priority tbh!
