### PR TITLE
fix: Left align 'Start new application' link

### DIFF
--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -96,7 +96,7 @@ const StatusPage: React.FC<Props> = ({
               onClick={removeSessionIdSearchParam}
               sx={contentFlowSpacing}
             >
-              <Typography variant="body1">Start new application</Typography>
+              <Typography variant="body1" align="left">Start new application</Typography>
             </Link>
           </>
         )}


### PR DESCRIPTION
Spotted this one today!

| Before | After |
|--------|--------|
| ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/0be9aaf5-6b99-407c-a78d-39d5da0a724d) | ![image](https://github.com/theopensystemslab/planx-new/assets/20502206/a36c3839-4a6f-44a0-b39b-21090a991a06) |


