### PR TITLE
feat: Drop `publicGraphQLClient` in favour of `$public` client

### DIFF
--- a/api.planx.uk/hasura/index.ts
+++ b/api.planx.uk/hasura/index.ts
@@ -9,9 +9,4 @@ const adminGraphQLClient = new GraphQLClient(process.env.HASURA_GRAPHQL_URL!, {
   },
 });
 
-/**
- * Connect to Hasura using the "Public" role
- */
-const publicGraphQLClient = new GraphQLClient(process.env.HASURA_GRAPHQL_URL!);
-
-export { adminGraphQLClient, publicGraphQLClient };
+export { adminGraphQLClient };

--- a/api.planx.uk/inviteToPay/sendPaymentEmail.test.ts
+++ b/api.planx.uk/inviteToPay/sendPaymentEmail.test.ts
@@ -6,16 +6,11 @@ import {
   validatePaymentRequestNotFoundQueryMock,
   validatePaymentRequestQueryMock,
 } from "../tests/mocks/inviteToPayMocks";
+import { CoreDomainClient } from "@opensystemslab/planx-core";
 
-jest.mock("@opensystemslab/planx-core", () => {
-  return {
-    CoreDomainClient: jest.fn().mockImplementation(() => ({
-      formatRawProjectTypes: jest
-        .fn()
-        .mockResolvedValue(["New office premises"]),
-    })),
-  };
-});
+jest
+  .spyOn(CoreDomainClient.prototype, "formatRawProjectTypes")
+  .mockResolvedValue("New office premises");
 
 const TEST_PAYMENT_REQUEST_ID = "09655c28-3f34-4619-9385-cd57312acc44";
 

--- a/api.planx.uk/notify/notify.ts
+++ b/api.planx.uk/notify/notify.ts
@@ -1,11 +1,7 @@
-import { GraphQLClient } from "graphql-request";
 import { NotifyClient } from "notifications-node-client";
-import {
-  adminGraphQLClient as adminClient,
-  publicGraphQLClient as publicClient,
-} from "../hasura";
 import { softDeleteSession } from "../saveAndReturn/utils";
 import { NotifyConfig } from "../types";
+import { $api, $public } from "../client";
 
 const notifyClient = new NotifyClient(process.env.GOVUK_NOTIFY_API_KEY);
 
@@ -84,7 +80,7 @@ const sendEmail = async (
   }
 };
 
-const getClientForTemplate = (template: Template): GraphQLClient =>
-  template in privateEmailTemplates ? adminClient : publicClient;
+const getClientForTemplate = (template: Template) =>
+  template in privateEmailTemplates ? $api.client : $public.client;
 
 export { sendEmail, getClientForTemplate };

--- a/api.planx.uk/notify/routeSendEmailRequest.test.ts
+++ b/api.planx.uk/notify/routeSendEmailRequest.test.ts
@@ -8,20 +8,15 @@ import {
   mockSoftDeleteLowcalSession,
   mockValidateSingleSessionRequest,
 } from "../tests/mocks/saveAndReturnMocks";
+import { CoreDomainClient } from "@opensystemslab/planx-core";
 
 // https://docs.notifications.service.gov.uk/node.html#email-addresses
 const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk";
 const SAVE_ENDPOINT = "/send-email/save";
 
-jest.mock("@opensystemslab/planx-core", () => {
-  return {
-    CoreDomainClient: jest.fn().mockImplementation(() => ({
-      formatRawProjectTypes: jest
-        .fn()
-        .mockResolvedValue(["New office premises"]),
-    })),
-  };
-});
+jest
+  .spyOn(CoreDomainClient.prototype, "formatRawProjectTypes")
+  .mockResolvedValue("New office premises");
 
 describe("Send Email endpoint", () => {
   beforeEach(() => {

--- a/api.planx.uk/notify/routeSendEmailRequest.test.ts
+++ b/api.planx.uk/notify/routeSendEmailRequest.test.ts
@@ -88,7 +88,7 @@ describe("Send Email endpoint", () => {
         name: "ValidateSingleSessionRequest",
         data: {
           flows_by_pk: mockFlow,
-          lowcal_sessions: [],
+          lowcalSessions: [],
         },
       });
 
@@ -253,7 +253,7 @@ describe("Setting up send email events", () => {
       name: "ValidateSingleSessionRequest",
       data: {
         flows_by_pk: mockFlow,
-        lowcal_sessions: [{ ...mockLowcalSession, has_user_saved: true }],
+        lowcalSessions: [{ ...mockLowcalSession, has_user_saved: true }],
       },
       matchOnVariables: false,
     });

--- a/api.planx.uk/saveAndReturn/utils.ts
+++ b/api.planx.uk/saveAndReturn/utils.ts
@@ -92,7 +92,10 @@ const validateSingleSessionRequest = async (
   try {
     const query = gql`
       query ValidateSingleSessionRequest($sessionId: uuid!) {
-        lowcal_sessions(where: { id: { _eq: $sessionId } }, limit: 1) {
+        lowcalSessions: lowcal_sessions(
+          where: { id: { _eq: $sessionId } }
+          limit: 1
+        ) {
           id
           data
           created_at
@@ -112,8 +115,8 @@ const validateSingleSessionRequest = async (
     const client = getClientForTemplate(template);
     const headers = getSaveAndReturnPublicHeaders(sessionId, email);
     const {
-      lowcal_sessions: [session],
-    } = await client.request<{ lowcal_sessions: LowCalSession[] }>(
+      lowcalSessions: [session],
+    } = await client.request<{ lowcalSessions: LowCalSession[] }>(
       query,
       { sessionId },
       headers,

--- a/api.planx.uk/saveAndReturn/utils.ts
+++ b/api.planx.uk/saveAndReturn/utils.ts
@@ -113,7 +113,11 @@ const validateSingleSessionRequest = async (
     const headers = getSaveAndReturnPublicHeaders(sessionId, email);
     const {
       lowcal_sessions: [session],
-    } = await client.request(query, { sessionId }, headers);
+    } = await client.request<{ lowcal_sessions: LowCalSession[] }>(
+      query,
+      { sessionId },
+      headers,
+    );
 
     if (!session) throw Error(`Unable to find session: ${sessionId}`);
 

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -144,7 +144,7 @@ export const mockValidateSingleSessionRequest = {
   name: "ValidateSingleSessionRequest",
   data: {
     flows_by_pk: mockFlow,
-    lowcal_sessions: [mockLowcalSession],
+    lowcalSessions: [mockLowcalSession],
   },
   variables: {
     sessionId: mockLowcalSession.id,

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -75,7 +75,7 @@ export interface LowCalSession {
   has_user_saved: boolean;
   flow: {
     slug: string;
-    team?: Team;
+    team: Team;
   };
   lockedAt?: string;
   paymentRequests?: Pick<PaymentRequest, "id" | "payeeEmail" | "payeeName">[];


### PR DESCRIPTION
## What does this PR do?
 - Replaces `publicGraphQLClient` in favour of `$public`
 - No functionality change, just a tidy up and simplification
 - Small permission change with `getClientForTemplate()` now conditionally using the `api` role instead of the `admin` role