### PR TITLE
feat: track notice reset click in analytics_log

### DIFF
--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -9,6 +9,7 @@ import Card from "@planx/components/shared/Preview/Card";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import { PublicProps } from "@planx/components/ui";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -75,6 +76,13 @@ const NoticeComponent: React.FC<Props> = (props) => {
     ? () => props.handleSubmit?.()
     : undefined;
 
+  const { trackNoticeResetClick } = useAnalyticsTracking();
+
+  const handleResetClick = () => {
+    trackNoticeResetClick({'hasClickedNoticeReset': true})
+    props.resetPreview && props.resetPreview()
+  }
+
   return (
     <Card handleSubmit={handleSubmit} isValid>
       <>
@@ -105,7 +113,7 @@ const NoticeComponent: React.FC<Props> = (props) => {
             variant="contained"
             size="large"
             type="submit"
-            onClick={props.resetPreview}
+            onClick={handleResetClick}
             sx={contentFlowSpacing}
           >
             Back to start

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -207,7 +207,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     if (shouldTrackAnalytics && lastAnalyticsLogId) {
       await publicClient.mutate({
         mutation: gql`
-          mutation UpdateNoticeResetEnabled(
+          mutation UpdateHasClickedNoticeReset(
             $id: bigint!,
             $metadata: jsonb = {}
           ) {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -183,7 +183,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     if (shouldTrackAnalytics && lastAnalyticsLogId) {
       await publicClient.mutate({
         mutation: gql`
-          mutation UpdateHasClickNextStepsLink(
+          mutation UpdateHasClickedNextStepsLink(
             $id: bigint!
             $metadata: jsonb = {}
           ) {


### PR DESCRIPTION
## What

- Add analytics_log data when a user click a `reset` button on a `Notice`. 
- Stores `{'hasClickedNoticeReset': true}` in the metadata column.
- As per: https://trello.com/c/G1bTFyVm/2564-track-notice-reset-status-in-node-metadata

## Why 

- Tracking how many users reach a dead end and start again in a flow could provide useful insight into potential content / product improvemnets

## Expected Behaviour

- A user see's a notice with the option to go `Back to start`, they select this button. 
- In the `analytics_log` the record for the Notice with the reset is updated to contain `{'hasClickedNoticeReset': true}`
- The `resetPreview` function still runs as intended and the user is returned to the start of the flow and their inputs are cleared. 

## Existing Bug?

- Currently on `main` when a user resets a flow the first node is loaded twice and two `analytics_log`s are generated. 
- This PR does not affect that behaviour.

## Screen recordings

(At the start no analytics log is shown because I filtered out the once associated with the initial load so that the first record would appear on refresh)

https://github.com/theopensystemslab/planx-new/assets/36415632/e1acd7e6-1636-4175-a0bc-1c5650da93af

https://github.com/theopensystemslab/planx-new/assets/36415632/4f7dfeef-9730-49ed-b904-05986c499a77

