### PR TITLE
feat: query & display Flood Risk Zones in PlanningConstraints

### DIFF
--- a/api.planx.uk/gis/digitalLand.ts
+++ b/api.planx.uk/gis/digitalLand.ts
@@ -169,6 +169,16 @@ async function go(
       formattedResult[broads] = { fn: broads, value: false };
   }
 
+  // FLOODING
+  if (formattedResult["flood"] && formattedResult["flood"].value) {
+    ["flood.zone.1", "flood.zone.2", "flood.zone.3"].forEach((zone) => 
+      formattedResult[zone] = {
+        fn: zone,
+        value: Boolean(formattedResult["flood"].data?.filter((entity) => entity["flood-risk-level"] === zone.split(".").pop()).length),
+      },
+    );
+  }
+
   // --- LISTED BUILDINGS ---
   // TODO add granular variables to reflect grade (eg `listed.grade1`), not reflected in content yet though
 

--- a/api.planx.uk/gis/digitalLand.ts
+++ b/api.planx.uk/gis/digitalLand.ts
@@ -171,11 +171,16 @@ async function go(
 
   // FLOODING
   if (formattedResult["flood"] && formattedResult["flood"].value) {
-    ["flood.zone.1", "flood.zone.2", "flood.zone.3"].forEach((zone) => 
-      formattedResult[zone] = {
-        fn: zone,
-        value: Boolean(formattedResult["flood"].data?.filter((entity) => entity["flood-risk-level"] === zone.split(".").pop()).length),
-      },
+    ["flood.zone.1", "flood.zone.2", "flood.zone.3"].forEach(
+      (zone) =>
+        (formattedResult[zone] = {
+          fn: zone,
+          value: Boolean(
+            formattedResult["flood"].data?.filter(
+              (entity) => entity["flood-risk-level"] === zone.split(".").pop(),
+            ).length,
+          ),
+        }),
     );
   }
 

--- a/api.planx.uk/gis/local_authorities/metadata/base.ts
+++ b/api.planx.uk/gis/local_authorities/metadata/base.ts
@@ -133,7 +133,7 @@ const baseSchema: PlanningConstraintsBaseSchema = {
     "digital-land-datasets": ["ancient-woodland"],
     category: "Ecology",
   },
-  "flood": {
+  flood: {
     active: true,
     neg: "is not in a Flood Risk Zone",
     pos: "is in a Flood Risk Zone",

--- a/api.planx.uk/gis/local_authorities/metadata/base.ts
+++ b/api.planx.uk/gis/local_authorities/metadata/base.ts
@@ -133,22 +133,11 @@ const baseSchema: PlanningConstraintsBaseSchema = {
     "digital-land-datasets": ["ancient-woodland"],
     category: "Ecology",
   },
-  "flood.zone1": {
-    active: false,
-    neg: "is not within a Flood Zone 1 (low risk)",
-    pos: "is within a Flood Zone 1 (low risk)",
-    category: "Flooding",
-  },
-  "flood.zone2": {
-    active: false,
-    neg: "is not within a Flood Zone 2 (medium risk)",
-    pos: "is within a Flood Zone 2 (medium risk)",
-    category: "Flooding",
-  },
-  "flood.zone3": {
-    active: false,
-    neg: "is not within a Flood Zone 3 (high risk)",
-    pos: "is within a Flood Zone 3 (high risk)",
+  "flood": {
+    active: true,
+    neg: "is not in a Flood Risk Zone",
+    pos: "is in a Flood Risk Zone",
+    "digital-land-datasets": ["flood-risk-zone"],
     category: "Flooding",
   },
   "defence.explosives": {

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -23,6 +23,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   "Heritage and conservation": "#EDDCD2",
   Ecology: "#E0EFCC",
   Trees: "#DBE7E4",
+  Flooding: "#ECECEC",
 };
 
 interface StyledConstraintProps extends BoxProps {


### PR DESCRIPTION
Changes:
- Adds values `flood`, `flood.zone.1`, `flood.zone.2` and `flood.zone.3` to the planning constraints check (only adds granular entries if `flood` is true, consistent with Article 4 granular variables)

I hit two quirks with Planning Data that I've raised with Matt L, and expect to be updated soon on their side. When it is, the dropdown will populate as expected, no extra code changes required (so no need to block initial merge I think!):
- Planning data hasn't populated the "text" for `flood-risk-zone` metadata (which is used to render the contextual paragraphs in the dropdown)
- Planning data hasn't populated the "name" for `flood-risk-zone` entities (which is used to render the bullet-pointed list in the dropdown)

Address in a flood zone for testing: 47, COBOURG ROAD, SOUTHWARK, SE5 0HU