### PR TITLE
chore: Convert `/download-schema` endpoint to `$public` client

### DIFF
--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -40,7 +40,6 @@ import {
 } from "./modules/auth/middleware";
 
 import airbrake from "./airbrake";
-import { adminGraphQLClient as adminClient } from "./hasura";
 import { sendEmailLimiter, apiLimiter } from "./rateLimit";
 import {
   privateDownloadController,
@@ -73,6 +72,7 @@ import webhookRoutes from "./modules/webhooks/routes";
 import analyticsRoutes from "./modules/analytics/routes";
 import { useSwaggerDocs } from "./docs";
 import { Role } from "@opensystemslab/planx-core/types";
+import { $public } from "./client";
 
 const router = express.Router();
 
@@ -279,13 +279,21 @@ app.get(
   copyPortalAsFlow,
 );
 
-// unauthenticated because accessing flow schema only, no user data
+interface FlowSchema {
+  node: string;
+  type: string;
+  text: string;
+  planx_variable: string;
+}
+
 app.get("/flows/:flowId/download-schema", async (req, res, next) => {
   try {
-    const schema = await adminClient.request(
+    const { flowSchema } = await $public.client.request<{
+      flowSchema: FlowSchema[];
+    }>(
       gql`
         query ($flow_id: String!) {
-          get_flow_schema(args: { published_flow_id: $flow_id }) {
+          flowSchema: get_flow_schema(args: { published_flow_id: $flow_id }) {
             node
             type
             text
@@ -296,7 +304,7 @@ app.get("/flows/:flowId/download-schema", async (req, res, next) => {
       { flow_id: req.params.flowId },
     );
 
-    if (schema.get_flow_schema.length < 1) {
+    if (!flowSchema.length) {
       next({
         status: 404,
         message:
@@ -304,7 +312,7 @@ app.get("/flows/:flowId/download-schema", async (req, res, next) => {
       });
     } else {
       // build a CSV and stream it
-      stringify(schema.get_flow_schema, { header: true }).pipe(res);
+      stringify(flowSchema, { header: true }).pipe(res);
 
       res.header("Content-type", "text/csv");
       res.attachment(`${req.params.flowId}.csv`);


### PR DESCRIPTION
There may be a few of these incoming - keeping them small and easy should it make it more readable and manageable. There's not much test coverage for some of these steps (and I'm not sure how valuable they would be?) so hopefully small PRs would mean they're a little more easily testable as we go along.