### PR TITLE
feat: track a user restarting their application via a new api route

### DIFF
--- a/api.planx.uk/modules/analytics/controller.ts
+++ b/api.planx.uk/modules/analytics/controller.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { trackAnalyticsLogExit } from "./service";
+import { trackAnalyticsLogExit, trackUserReset } from "./service";
 import { ValidatedRequestHandler } from "../../shared/middleware/validate";
 
 export const logAnalyticsSchema = z.object({
@@ -22,5 +22,11 @@ export const logUserExitController: LogAnalytics = async (req, res) => {
 export const logUserResumeController: LogAnalytics = async (req, res) => {
   const { analyticsLogId } = req.query;
   trackAnalyticsLogExit({ id: Number(analyticsLogId), isUserExit: false });
+  res.status(204).send();
+};
+
+export const logUserResetController: LogAnalytics = async (req, res) => {
+  const { analyticsLogId } = req.query;
+  trackUserReset({ id: Number(analyticsLogId), flow_direction: "reset" });
   res.status(204).send();
 };

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -4,6 +4,7 @@ import {
   logAnalyticsSchema,
   logUserExitController,
   logUserResumeController,
+  logUserResetController,
 } from "./controller";
 
 const router = Router();
@@ -17,6 +18,11 @@ router.post(
   "/log-user-resume",
   validate(logAnalyticsSchema),
   logUserResumeController,
+);
+router.post(
+  "/log-user-reset",
+  validate(logAnalyticsSchema),
+  logUserResetController,
 );
 
 export default router;

--- a/api.planx.uk/modules/analytics/service.ts
+++ b/api.planx.uk/modules/analytics/service.ts
@@ -55,3 +55,40 @@ export const trackAnalyticsLogExit = async ({
 
   return;
 };
+
+export const trackUserReset = async ({
+  id,
+  flow_direction,
+}: {
+  id: number;
+  flow_direction: string;
+}) => {
+  try {
+    await adminClient.request(
+      gql`
+        mutation UpdateAnalyticsLogUserReset(
+          $id: bigint!
+          $flow_direction: String
+        ) {
+          update_analytics_logs_by_pk(
+            pk_columns: { id: $id }
+            _set: { flow_direction: $flow_direction }
+          ) {
+            id
+          }
+        }
+      `,
+      {
+        id,
+        flow_direction: flow_direction,
+      },
+    );
+  } catch (e) {
+    // We need to catch this exception here otherwise the exception would become an unhandled rejection which brings down the whole node.js process
+    console.error(
+      "There's been an error while recording metrics for analytics but because this thread is non-blocking we didn't reject the request",
+      (e as Error).stack,
+    );
+  }
+  return;
+};

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -309,6 +309,7 @@ const PublicToolbar: React.FC<{
     state.id,
     state.teamTheme,
   ]);
+  const { trackUserResetConfirmation } = useAnalyticsTracking();
 
   // Center the service title on desktop layouts, or drop it to second line on mobile
   // ref https://design-system.service.gov.uk/styles/page-template/
@@ -322,6 +323,7 @@ const PublicToolbar: React.FC<{
         "Are you sure you want to restart? This will delete your previous answers",
       )
     ) {
+      trackUserResetConfirmation();
       if (path === ApplicationPath.SingleSession) {
         clearLocalFlow(id);
         window.location.reload();

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 
 import { Store, useStore } from "./store";
 
-export type AnalyticsType = "init" | "resume";
+export type AnalyticsType = "init" | "resume" | "reset"
 type AnalyticsLogDirection = AnalyticsType | "forwards" | "backwards";
 
 export type HelpClickMetadata = Record<string, string>;
@@ -18,11 +18,13 @@ const analyticsContext = createContext<{
   createAnalytics: (type: AnalyticsType) => Promise<void>;
   trackHelpClick: (metadata?: HelpClickMetadata) => Promise<void>;
   trackNextStepsLinkClick: (metadata?: SelectedUrlsMetadata) => Promise<void>;
+  trackUserResetConfirmation: () => Promise<void>;
   node: Store.node | null;
 }>({
   createAnalytics: () => Promise.resolve(),
   trackHelpClick: () => Promise.resolve(),
   trackNextStepsLinkClick: () => Promise.resolve(),
+  trackUserResetConfirmation: () => Promise.resolve(),
   node: null,
 });
 const { Provider } = analyticsContext;
@@ -104,6 +106,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         createAnalytics,
         trackHelpClick,
         trackNextStepsLinkClick,
+        trackUserResetConfirmation,
         node,
       }}
     >
@@ -199,6 +202,16 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }
 
+  async function trackUserResetConfirmation(){
+    if (lastAnalyticsLogId && shouldTrackAnalytics) {
+      send(
+        `${
+          process.env.REACT_APP_API_URL
+        }/analytics/log-user-reset?analyticsLogId=${lastAnalyticsLogId.toString()}`,
+      );
+    }
+  };
+  
   async function createAnalytics(type: AnalyticsType) {
     if (shouldTrackAnalytics) {
       const response = await publicClient.mutate({


### PR DESCRIPTION
## What

- Add a new analytics endpoint route to handle a updating the `"flow_direction"` of an application restart to a new type `"reset"`. 
- Hit the new endpoint when a user clicks "confirm" when restarting via the `Header` restart before the page reloads. 
- As per: https://trello.com/c/spEYlVk0/2566-track-which-node-users-are-on-when-they-click-to-restart-application-or-start-over

## Why

- We want to be able to log on which nodes users decide to restart their applications. 
- We already have a concept of `"flow_direction"` with `"reset"` being a descriptive name for the direction change being to the start of the application.  
- I was having issues with the mutation being called in the FE before the page reloaded. 
- Using Beacon guarantees we can update the `analytics_log` record.

## Screen Recording 

https://github.com/theopensystemslab/planx-new/assets/36415632/011362a0-a250-4a2b-b82c-bfb1898e6f1f

## Related PRs

- This might supersede https://github.com/theopensystemslab/planx-new/pull/2301 


