### PR TITLE
feat: track user resetting flow

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -315,6 +315,8 @@ const PublicToolbar: React.FC<{
   const showCentredServiceTitle = useMediaQuery((theme: Theme) =>
     theme.breakpoints.up("md"),
   );
+  
+  const { trackResetFlow } = useAnalyticsTracking();
 
   const handleRestart = async () => {
     if (
@@ -322,6 +324,7 @@ const PublicToolbar: React.FC<{
         "Are you sure you want to restart? This will delete your previous answers",
       )
     ) {
+      trackResetFlow();
       if (path === ApplicationPath.SingleSession) {
         clearLocalFlow(id);
         window.location.reload();

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -44,6 +44,7 @@
     - role: public
       permission:
         columns:
+          - flow_direction
           - has_clicked_help
           - metadata
         filter: {}


### PR DESCRIPTION
## What

- Add a new mutation to update the `flow_direction` of an `analytics_log` to a new type `reset`. 
- Call this mutation on confirming a reset when clicking the reset icon in the header.
- Call this mutation when a user clicks the "reset" of a `Notice` with a reset.
- As per: 
  - https://trello.com/c/spEYlVk0/2566-track-which-node-users-are-on-when-they-click-to-restart-application-or-start- 
  - https://trello.com/c/G1bTFyVm/2564-track-notice-reset-status-in-node-metadata

## Why
- `{flow_direction: "reset"}` will show when a user has decided to restart. 
- We can use this to infer data about user behaviour such as how often users are hitting dead ends or from which nodes they're deciding to restart. 

## Screen Recording

Shows:
- Change to `reset` when resetting via the header.
- No change on regular `Notice`  button press.
- Change on `reset` `Notice` button press.

https://github.com/theopensystemslab/planx-new/assets/36415632/bdf161fd-b052-41fd-9850-780d60a2c988

## Supersedes
- https://github.com/theopensystemslab/planx-new/pull/2306
- https://github.com/theopensystemslab/planx-new/pull/2301

## Note

- This still shows the bug that when restarting from a notice the first node re-renders unnecessarily. 


