### PR TITLE
fix: Add security header for `/webhooks` API routes

### DIFF
--- a/api.planx.uk/docs/index.ts
+++ b/api.planx.uk/docs/index.ts
@@ -8,6 +8,11 @@ const securitySchemes = {
     scheme: "bearer",
     bearerFormat: "JWT",
   },
+  hasuraAuth: {
+    type: "apiKey",
+    in: "header",
+    name: "Authorization",
+  },
 };
 
 const parameters = {

--- a/api.planx.uk/modules/webhooks/docs.yaml
+++ b/api.planx.uk/modules/webhooks/docs.yaml
@@ -191,6 +191,8 @@ paths:
   /webhooks/hasura/sendSlackNotification:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Send Slack notification
       description: Endpoint to trigger a Slack notification following a submission event
       parameters:
@@ -212,6 +214,8 @@ paths:
   /webhooks/hasura/create-payment-invitation-events:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Create payment invitation events
       description: Setup events which will trigger payment invitation emails to be generated
       requestBody:
@@ -227,6 +231,8 @@ paths:
   /webhooks/hasura/create-payment-reminder-events:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Create payment reminder events
       description: Setup events which will trigger payment reminder emails to be generated
       requestBody:
@@ -242,6 +248,8 @@ paths:
   /webhooks/hasura/create-payment-expiry-events:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Create payment expiry events
       description: Setup events which will trigger payment expiry emails to be generated
       requestBody:
@@ -257,6 +265,8 @@ paths:
   /webhooks/hasura/create-reminder-event:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Create session reminder event
       description: Setup events which will trigger session reminder emails to be generated
       requestBody:
@@ -272,6 +282,8 @@ paths:
   /webhooks/hasura/create-expiry-event:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Create session expiry event
       description: Setup events which will trigger session expiry email to be generated
       requestBody:
@@ -287,6 +299,8 @@ paths:
   /webhooks/hasura/sanitise-application-data:
     post:
       tags: ["webhooks"]
+      security:
+        - hasuraAuth: []
       summary: Sanitise application data
       description: Called by Hasura cron job "sanitise_application_data" on a nightly basis
       responses:


### PR DESCRIPTION
Restores `hasuraAuth` option to submission and webhook endpoints

<img width="1432" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/a892ad44-23f1-4e3b-9868-70590c86bb1a">
