### PR TITLE
fix: adjust BOPS & XML admin endpoints for debugging

### DIFF
--- a/api.planx.uk/admin/session/bops.ts
+++ b/api.planx.uk/admin/session/bops.ts
@@ -6,7 +6,7 @@ import { getClient } from "../../client";
  * /admin/session/{sessionId}/bops:
  *  get:
  *    summary: Generates a Back Office Planning System (BOPS) payload
- *    description: Generates a BOPS payload, relies on a submission record in `bops_applications`
+ *    description: Generates a BOPS payload
  *    tags:
  *      - admin
  *    parameters:

--- a/api.planx.uk/admin/session/bops.ts
+++ b/api.planx.uk/admin/session/bops.ts
@@ -1,5 +1,5 @@
-import { Request, Response, NextFunction } from "express";
-import { getClient } from "../../client";
+import { NextFunction, Request, Response } from "express";
+import { $api } from "../../client";
 
 /**
  * @swagger
@@ -20,10 +20,7 @@ export const getBOPSPayload = async (
   next: NextFunction,
 ) => {
   try {
-    const $client = getClient();
-    const { exportData } = await $client.export.bopsPayload(
-      req.params.sessionId,
-    );
+    const { exportData } = await $api.export.bopsPayload(req.params.sessionId);
     res.set("content-type", "application/json");
     return res.send(exportData);
   } catch (error) {

--- a/api.planx.uk/admin/session/oneAppXML.test.ts
+++ b/api.planx.uk/admin/session/oneAppXML.test.ts
@@ -1,40 +1,26 @@
 import supertest from "supertest";
 import app from "../../server";
-import { queryMock } from "../../tests/graphqlQueryMock";
 import { authHeader } from "../../tests/mockJWT";
 
 const endpoint = (strings: TemplateStringsArray) =>
   `/admin/session/${strings[0]}/xml`;
 
+const mockGenerateOneAppXML = jest
+  .fn()
+  .mockResolvedValue("<dummy:xml></dummy:xml>");
+
+jest.mock("../../client", () => {
+  return {
+    $api: {
+      generateOneAppXML: () => mockGenerateOneAppXML(),
+    },
+  };
+});
+
 describe("OneApp XML endpoint", () => {
-  beforeEach(() => {
-    queryMock.mockQuery({
-      name: "GetMostRecentUniformApplicationBySessionID",
-      variables: {
-        submission_reference: "abc123",
-      },
-      data: {
-        uniform_applications: [{ xml: "<dummy:xml></dummy:xml>" }],
-      },
-    });
-
-    queryMock.mockQuery({
-      name: "GetMostRecentUniformApplicationBySessionID",
-      variables: {
-        submission_reference: "xyz789",
-      },
-      data: {
-        uniform_applications: [],
-      },
-    });
-  });
-
-  afterEach(() => jest.clearAllMocks());
-  const auth = authHeader({ role: "platformAdmin" });
-
   it("requires a user to be logged in", async () => {
     await supertest(app)
-      .get(endpoint`abc123`)
+      .get(endpoint`123`)
       .expect(401)
       .then((res) =>
         expect(res.body).toEqual({
@@ -45,23 +31,15 @@ describe("OneApp XML endpoint", () => {
 
   it("requires a user to have the 'platformAdmin' role", async () => {
     await supertest(app)
-      .get(endpoint`abc123`)
+      .get(endpoint`123`)
       .set(authHeader({ role: "teamEditor" }))
       .expect(403);
   });
 
-  it("returns an error if sessionID is invalid", async () => {
-    await supertest(app)
-      .get(endpoint`xyz789`)
-      .set(auth)
-      .expect(500)
-      .then((res) => expect(res.body.error).toMatch(/Invalid sessionID/));
-  });
-
   it("returns XML", async () => {
     await supertest(app)
-      .get(endpoint`abc123`)
-      .set(auth)
+      .get(endpoint`123`)
+      .set(authHeader({ role: "platformAdmin" }))
       .expect(200)
       .expect("content-type", "text/xml; charset=utf-8")
       .then((res) => {

--- a/api.planx.uk/admin/session/oneAppXML.ts
+++ b/api.planx.uk/admin/session/oneAppXML.ts
@@ -1,13 +1,12 @@
-import { gql } from "graphql-request";
 import { Request, Response, NextFunction } from "express";
-import { adminGraphQLClient as client } from "../../hasura";
+import { getClient } from "../../client";
 
 /**
  * @swagger
  * /admin/session/{sessionId}/xml:
  *  get:
  *    summary: Generates a OneApp XML
- *    description: Generates a OneApp XML, relies on a submission record in `uniform_applications`
+ *    description: Generates a OneApp XML
  *    tags:
  *      - admin
  *    parameters:
@@ -21,39 +20,13 @@ export const getOneAppXML = async (
   next: NextFunction,
 ) => {
   try {
-    const xml = await fetchSessionXML(req.params.sessionId);
+    const $client = getClient();
+    const xml = await $client.generateOneAppXML(req.params.sessionId);
     res.set("content-type", "text/xml");
     return res.send(xml);
   } catch (error) {
     return next({
       message: "Failed to get OneApp XML: " + (error as Error).message,
     });
-  }
-};
-
-const fetchSessionXML = async (sessionId: string) => {
-  try {
-    const query = gql`
-      query GetMostRecentUniformApplicationBySessionID(
-        $submission_reference: String
-      ) {
-        uniform_applications(
-          where: { submission_reference: { _eq: $submission_reference } }
-          order_by: { created_at: desc }
-          limit: 1
-        ) {
-          xml
-        }
-      }
-    `;
-    const { uniform_applications } = await client.request(query, {
-      submission_reference: sessionId,
-    });
-
-    if (!uniform_applications?.length) throw Error("Invalid sessionID");
-
-    return uniform_applications[0].xml;
-  } catch (error) {
-    throw Error("Unable to fetch session XML: " + (error as Error).message);
   }
 };

--- a/api.planx.uk/admin/session/oneAppXML.ts
+++ b/api.planx.uk/admin/session/oneAppXML.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { getClient } from "../../client";
+import { $api } from "../../client";
 
 /**
  * @swagger
@@ -20,8 +20,7 @@ export const getOneAppXML = async (
   next: NextFunction,
 ) => {
   try {
-    const $client = getClient();
-    const xml = await $client.generateOneAppXML(req.params.sessionId);
+    const xml = await $api.generateOneAppXML(req.params.sessionId);
     res.set("content-type", "text/xml");
     return res.send(xml);
   } catch (error) {

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -528,6 +528,21 @@
           - has_user_saved
           - sanitised_at
         filter: {}
+    - role: platformAdmin
+      permission:
+        columns:
+          - data
+          - email
+          - created_at
+          - deleted_at
+          - locked_at
+          - submitted_at
+          - updated_at
+          - flow_id
+          - id
+          - has_user_saved
+          - sanitised_at
+        filter: {}
     - role: public
       permission:
         columns:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -528,21 +528,6 @@
           - has_user_saved
           - sanitised_at
         filter: {}
-    - role: platformAdmin
-      permission:
-        columns:
-          - data
-          - email
-          - created_at
-          - deleted_at
-          - locked_at
-          - submitted_at
-          - updated_at
-          - flow_id
-          - id
-          - has_user_saved
-          - sanitised_at
-        filter: {}
     - role: public
       permission:
         columns:


### PR DESCRIPTION
**Changes:**
- `/admin/xml` should query any `lowcal_sessions`, rather than rely on `uniform_applications` audit record
  - `/admin/bops` was already adjusted for this, make sure Swagger reflects that
- admin endpoints should use `$api` client, rather than granting session select access to `platformAdmin` 
  - (i've only made this change for xml & bops so far as we need these for immediate LDC debugging, will come back to adjust all admin endpoints in a follow-up PR once we confirm this is working as expected)

Test endpoints (this is a partial session, so OneApp shows errors as expected!):
- https://api.2309.planx.pizza/admin/session/cae52bd7-a4e5-4bfd-b25f-98913bb9d61f/bops
- https://api.2309.planx.pizza/admin/session/cae52bd7-a4e5-4bfd-b25f-98913bb9d61f/xml