### PR TITLE
chore: Bump API memory (and CPU)

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -285,7 +285,7 @@ export = async () => {
           context: "../../api.planx.uk",
           target: "production",
         }),
-        memory: 2048 /*MB*/,
+        memory: 4096 /*MB*/,
         portMappings: [apiListenerHttp],
         environment: [
           { name: "NODE_ENV", value: env },


### PR DESCRIPTION
## What's the problem?
Currently, the API is hitting 100% CPU on prod when handling submissions.

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/a7f5504e-7edb-4334-8c55-ccd9860f27be)

Even when submissions succeed, it causes the API to restart which means that subsequent calls to the API (e.g. to proxy image requests, or trigger Slack notifications) then fail.

## What's the solution
Doubling the memory also bumps the CPU size ([Fargate docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size)) 

If we can get this to prod and test (via `/admin` endpoints) I'd hope we can notice a difference on Fargate task.

## Next steps...
I'd like to take a look at (and profile) what I suspect the culprit is here (`computeBOPSParams()`) and see if there are any code changes we can make that don't purely rely on just upping memory / CPU. This should buy us some time though!