### PR TITLE
feat: add next_log_created_at to analytics_log to allow time tracking per card

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -1,5 +1,9 @@
 import { gql } from "@apollo/client";
-import { DEFAULT_FLAG_CATEGORY } from "@opensystemslab/planx-core/types";
+import {
+  DEFAULT_FLAG_CATEGORY,
+  Flag,
+  FlagSet,
+} from "@opensystemslab/planx-core/types";
 import { TYPES } from "@planx/components/types";
 import { publicClient } from "lib/graphql";
 import React, { createContext, useContext, useEffect, useState } from "react";
@@ -10,7 +14,16 @@ export type AnalyticsType = "init" | "resume";
 type AnalyticsLogDirection = AnalyticsType | "forwards" | "backwards";
 
 export type HelpClickMetadata = Record<string, string>;
-export type SelectedUrlsMetadata = Record<'selectedUrls', string[]>;
+export type SelectedUrlsMetadata = Record<"selectedUrls", string[]>;
+
+type NodeMetadata = {
+  flagset?: FlagSet;
+  displayText?: {
+    heading?: string;
+    description?: string;
+  };
+  flag?: Flag;
+};
 
 let lastAnalyticsLogId: number | undefined = undefined;
 
@@ -117,7 +130,31 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       node?.type === TYPES.Content
         ? getContentTitle(node)
         : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
+    // On component transition create the new analytics log
+    const result = await insertNewAnalyticsLog(
+      direction,
+      analyticsId,
+      metadata,
+      node_title,
+    );
+    const id = result?.data.insert_analytics_logs_one?.id;
+    const newLogCreatedAt = result?.data.insert_analytics_logs_one?.created_at;
 
+    // On successful create of a new log update the previous log with the next_log_created_at
+    // This allows us to estimate how long a user spend on a card
+    if (lastAnalyticsLogId && newLogCreatedAt) {
+      updateLastLogWithNextLogCreatedAt(lastAnalyticsLogId, newLogCreatedAt);
+    }
+
+    lastAnalyticsLogId = id;
+  }
+
+  async function insertNewAnalyticsLog(
+    direction: AnalyticsLogDirection,
+    analyticsId: number,
+    metadata: NodeMetadata,
+    node_title: string,
+  ) {
     const result = await publicClient.mutate({
       mutation: gql`
         mutation InsertNewAnalyticsLog(
@@ -138,6 +175,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
             }
           ) {
             id
+            created_at
           }
         }
       `,
@@ -149,8 +187,32 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         node_title: node_title,
       },
     });
-    const id = result?.data.insert_analytics_logs_one?.id;
-    lastAnalyticsLogId = id;
+    return result;
+  }
+
+  async function updateLastLogWithNextLogCreatedAt(
+    lastAnalyticsLogId: number,
+    newLogCreatedAt: Date,
+  ) {
+    await publicClient.mutate({
+      mutation: gql`
+        mutation UpdateNextLogCreatedAt(
+          $id: bigint!
+          $next_log_created_at: timestamptz
+        ) {
+          update_analytics_logs_by_pk(
+            pk_columns: { id: $id }
+            _set: { next_log_created_at: $next_log_created_at }
+          ) {
+            id
+          }
+        }
+      `,
+      variables: {
+        id: lastAnalyticsLogId,
+        next_log_created_at: newLogCreatedAt,
+      },
+    });
   }
 
   async function trackHelpClick(metadata?: HelpClickMetadata) {

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -38,6 +38,7 @@
       permission:
         columns:
           - analytics_id
+          - created_at
           - id
         filter: {}
   update_permissions:
@@ -46,6 +47,7 @@
         columns:
           - has_clicked_help
           - metadata
+          - next_log_created_at
         filter: {}
         check: null
 - table:

--- a/hasura.planx.uk/migrations/1697540635734_alter_table_public_analytics_logs_add_column_next_log_created_at/down.sql
+++ b/hasura.planx.uk/migrations/1697540635734_alter_table_public_analytics_logs_add_column_next_log_created_at/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."analytics_logs" drop column "next_log_created_at";

--- a/hasura.planx.uk/migrations/1697540635734_alter_table_public_analytics_logs_add_column_next_log_created_at/up.sql
+++ b/hasura.planx.uk/migrations/1697540635734_alter_table_public_analytics_logs_add_column_next_log_created_at/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."analytics_logs" add column "next_log_created_at" timestamp with time zone
+ null;


### PR DESCRIPTION
## What:

- Catch when a component is transitioned and a new `analytics_log` record is created. 
- Store the `created_at` of this against `newLogCreatedAt`
- Use the `lastAnalyticsLog` to mutate the last log with the new `newLogCreatedAt`stored against the new `next_log_created_at` column.

## Why:

- We want to be able to track how long users spend on each card
- When querying we can compare the difference between `created_at` and `next_log_created_at` to have a number for how long was take on the card in the context of a user in a session.
- Allow null to show that user's don't always proceed in the flow and might `"resume"` later kicking off a new session. 

## Rationale:

- [x] Is this a logical way to store this information
  - Shares the same format as existing data
  - Based on the system time which avoid conversion issues
  - I believe it will be easy to interrogate the data with SQL.
  - Also, nullable as sometimes there is no time spent on cards and there's not guarantee another log will be added in the session hence the field remains null. 
- [x] Is it actually representative of how long was spent on a card
  - Yes as it's scoped to a session
- [x] How do we handle auto answer questions which create instances of `analytics_logs` but aren't even shown to the user. 
  - I don't think we do need to handle this as card which effectively have no time on them can be filtered out of the query. 
  
  ## Screen Recording:
  
https://github.com/theopensystemslab/planx-new/assets/36415632/6decef34-b081-408c-8965-cc3a07d51337

