### PR TITLE
fix: Disable `grant_new_user_template_team_access` trigger on DB sync

### DIFF
--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -11,6 +11,11 @@ CREATE TEMPORARY TABLE sync_users (
 
 \copy sync_users FROM '/tmp/users.csv'  WITH (FORMAT csv, DELIMITER ';');
 
+-- Do not automatically generate team_member records for the templates team
+-- We manually truncate and replace the team_members table in another step
+ALTER TABLE
+  users DISABLE TRIGGER grant_new_user_template_team_access;
+
 INSERT INTO users (
   id,
   first_name,
@@ -26,5 +31,8 @@ SELECT
   is_platform_admin
 FROM sync_users
 ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE
+  users ENABLE TRIGGER grant_new_user_template_team_access;
 
 SELECT setval('users_id_seq', max(id)) FROM users;


### PR DESCRIPTION
The [nightly database sync](https://github.com/theopensystemslab/planx-new/actions/runs/6540664008) failed yesterday with the following error - 

```sh
psql:write/team_members.sql:8: ERROR:  duplicate key value violates unique constraint "team_members_user_id_team_id_key"
DETAIL:  Key (user_id, team_id)=(117, 29) already exists.
CONTEXT:  COPY team_members, line 174
Database sync failed!
```

I think what's happening here is a race condition between the trigger inserting record in `team_members` and the script inserting them. This could explain the flakiness we've seen on recent Pizzas with the sync sometimes working and sometimes failing.

I'd tested this locally a few times (including adding a new user to check the trigger is still active) and it seems to work as expected without a hitch.