### PR TITLE
chore: Update `planx-core`

### DIFF
--- a/api.planx.uk/inviteToPay/createPaymentSendEvents.ts
+++ b/api.planx.uk/inviteToPay/createPaymentSendEvents.ts
@@ -40,7 +40,7 @@ const createPaymentSendEvents = async (
     const now = new Date();
     const combinedResponse: CombinedResponse = {};
 
-    const session = await $api.getSessionById(payload.sessionId);
+    const session = await $api.session.find(payload.sessionId);
     if (!session) {
       return next({
         status: 400,

--- a/api.planx.uk/inviteToPay/inviteToPay.ts
+++ b/api.planx.uk/inviteToPay/inviteToPay.ts
@@ -39,7 +39,7 @@ export async function inviteToPay(
   }
 
   // lock session before creating a payment request
-  const locked = await $api.lockSession(sessionId);
+  const locked = await $api.session.lock(sessionId);
   if (locked === null) {
     return next(
       new ServerError({
@@ -63,7 +63,7 @@ export async function inviteToPay(
 
   let paymentRequest: PaymentRequest | undefined;
   try {
-    paymentRequest = await $api.createPaymentRequest({
+    paymentRequest = await $api.paymentRequest.create({
       sessionId,
       applicantName,
       payeeName,
@@ -72,7 +72,7 @@ export async function inviteToPay(
     });
   } catch (e: unknown) {
     // revert the session lock on failure
-    await $api.unlockSession(sessionId);
+    await $api.session.unlock(sessionId);
     return next(
       new ServerError({
         message:

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3a85966",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#280aaff",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#280aaff",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#c2d6f35",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#280aaff
-    version: github.com/theopensystemslab/planx-core/280aaff
+    specifier: git+https://github.com/theopensystemslab/planx-core#c2d6f35
+    version: github.com/theopensystemslab/planx-core/c2d6f35
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8152,8 +8152,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/280aaff:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/280aaff}
+  github.com/theopensystemslab/planx-core/c2d6f35:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c2d6f35}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3a85966
-    version: github.com/theopensystemslab/planx-core/3a85966
+    specifier: git+https://github.com/theopensystemslab/planx-core#280aaff
+    version: github.com/theopensystemslab/planx-core/280aaff
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8152,10 +8152,11 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/3a85966:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3a85966}
+  github.com/theopensystemslab/planx-core/280aaff:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/280aaff}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
+    prepare: true
     requiresBuild: true
     dependencies:
       '@emotion/react': 11.11.1(react@18.2.0)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3a85966",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fcb488",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fcb488",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#c2d6f35",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3a85966
-    version: github.com/theopensystemslab/planx-core/3a85966
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fcb488
+    version: github.com/theopensystemslab/planx-core/2fcb488
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -85,13 +85,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: false
-
-  /@babel/runtime@7.22.15:
-    resolution: {integrity: sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.0
     dev: false
 
   /@babel/runtime@7.22.6:
@@ -278,7 +271,7 @@ packages:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
       '@babel/helper-module-imports': 7.22.5
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.2
@@ -323,7 +316,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.2
@@ -358,7 +351,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/babel-plugin': 11.11.0
       '@emotion/is-prop-valid': 1.2.1
       '@emotion/react': 11.11.1(react@18.2.0)
@@ -744,10 +737,6 @@ packages:
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: false
 
-  /@types/prop-types@15.7.5:
-    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: false
-
   /@types/prop-types@15.7.8:
     resolution: {integrity: sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ==}
     dev: false
@@ -761,7 +750,7 @@ packages:
   /@types/react@18.2.18:
     resolution: {integrity: sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==}
     dependencies:
-      '@types/prop-types': 15.7.5
+      '@types/prop-types': 15.7.8
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
     dev: false
@@ -892,7 +881,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       cosmiconfig: 7.1.0
       resolve: 1.22.2
     dev: false
@@ -2726,8 +2715,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/3a85966:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3a85966}
+  github.com/theopensystemslab/planx-core/2fcb488:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fcb488}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fcb488
-    version: github.com/theopensystemslab/planx-core/2fcb488
+    specifier: git+https://github.com/theopensystemslab/planx-core#c2d6f35
+    version: github.com/theopensystemslab/planx-core/c2d6f35
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -2715,8 +2715,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fcb488:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fcb488}
+  github.com/theopensystemslab/planx-core/c2d6f35:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c2d6f35}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/src/permissions/helpers.ts
+++ b/e2e/tests/api-driven/src/permissions/helpers.ts
@@ -58,6 +58,8 @@ export const setup = async () => {
   return world;
 };
 
+export type GQLQueryResult = unknown[] | Record<"returning", unknown[]> | null;
+
 export const performGQLQuery = async ({
   world,
   action,
@@ -66,7 +68,7 @@ export const performGQLQuery = async ({
   const query = queries[table][action];
   const variables = buildVariables(query, world);
   const client = (await getClient(world.activeUserEmail)).client;
-  const { result } = await client.request<Record<"result", any>>(
+  const { result } = await client.request<Record<"result", GQLQueryResult>>(
     query,
     variables,
   );

--- a/e2e/tests/api-driven/src/permissions/steps.ts
+++ b/e2e/tests/api-driven/src/permissions/steps.ts
@@ -3,6 +3,7 @@ import { strict as assert } from "node:assert";
 import { getUser } from "../globalHelpers";
 import {
   Action,
+  GQLQueryResult,
   Table,
   addUserToTeam,
   cleanup,
@@ -28,7 +29,7 @@ export class CustomWorld extends World {
   activeUserEmail!: string;
 
   error?: Error = undefined;
-  result: unknown[] | Record<"returning", unknown[]> | null = null;
+  result: GQLQueryResult = null;
 }
 
 Before<CustomWorld>("@team-admin-permissions", async function () {

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fcb488",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#c2d6f35",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.44.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3a85966",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fcb488",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.44.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fcb488
-    version: github.com/theopensystemslab/planx-core/2fcb488
+    specifier: git+https://github.com/theopensystemslab/planx-core#c2d6f35
+    version: github.com/theopensystemslab/planx-core/c2d6f35
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -2491,8 +2491,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fcb488:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fcb488}
+  github.com/theopensystemslab/planx-core/c2d6f35:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c2d6f35}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3a85966
-    version: github.com/theopensystemslab/planx-core/3a85966
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fcb488
+    version: github.com/theopensystemslab/planx-core/2fcb488
   axios:
     specifier: ^1.4.0
     version: 1.4.0
@@ -87,13 +87,6 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/runtime@7.22.15:
-    resolution: {integrity: sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.0
-    dev: false
-
   /@babel/runtime@7.23.2:
     resolution: {integrity: sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==}
     engines: {node: '>=6.9.0'}
@@ -124,7 +117,7 @@ packages:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
       '@babel/helper-module-imports': 7.22.5
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.2
@@ -169,7 +162,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.2
@@ -204,7 +197,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/babel-plugin': 11.11.0
       '@emotion/is-prop-valid': 1.2.1
       '@emotion/react': 11.11.1(react@18.2.0)
@@ -575,10 +568,6 @@ packages:
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: false
 
-  /@types/prop-types@15.7.5:
-    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: false
-
   /@types/prop-types@15.7.8:
     resolution: {integrity: sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ==}
     dev: false
@@ -592,7 +581,7 @@ packages:
   /@types/react@18.2.20:
     resolution: {integrity: sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==}
     dependencies:
-      '@types/prop-types': 15.7.5
+      '@types/prop-types': 15.7.8
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
     dev: false
@@ -728,7 +717,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       cosmiconfig: 7.1.0
       resolve: 1.22.4
     dev: false
@@ -2502,8 +2491,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/3a85966:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3a85966}
+  github.com/theopensystemslab/planx-core/2fcb488:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fcb488}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -15,7 +15,7 @@ export interface Context {
   team: {
     id?: number;
     name: string;
-    slug?: string;
+    slug: string;
     logo: string;
     primaryColor: string;
     homepage: string;
@@ -50,13 +50,13 @@ export const contextDefaults: Context = {
 export async function setUpTestContext(
   initialContext: Context,
 ): Promise<Context> {
-  const core = getCoreDomainClient();
+  const $admin = getCoreDomainClient();
   const context: Context = { ...initialContext };
   if (context.user) {
-    context.user.id = await core.createUser(context.user);
+    context.user.id = await $admin.user.create(context.user);
   }
   if (context.team) {
-    context.team.id = await core.createTeam({
+    context.team.id = await $admin.team.create({
       slug: context.team.slug,
       name: context.team.name,
       logo: context.team.logo,
@@ -71,12 +71,12 @@ export async function setUpTestContext(
     context.team?.id &&
     context.user?.id
   ) {
-    context.flow.id = await core.createFlow({
+    context.flow.id = await $admin.flow.create({
       slug: context.flow.slug,
       teamId: context.team.id,
       data: context.flow!.data!,
     });
-    context.flow.publishedId = await core.publishFlow({
+    context.flow.publishedId = await $admin.flow.publish({
       flow: {
         id: context.flow.id,
         data: context.flow!.data!,

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.14.5",
     "@mui/utils": "^5.14.5",
     "@opensystemslab/map": "^0.7.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fcb488",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#c2d6f35",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.6",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.14.5",
     "@mui/utils": "^5.14.5",
     "@opensystemslab/map": "^0.7.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3a85966",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fcb488",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.6",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.5
     version: 0.7.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3a85966
-    version: github.com/theopensystemslab/planx-core/3a85966(@types/react@18.2.20)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fcb488
+    version: github.com/theopensystemslab/planx-core/2fcb488(@types/react@18.2.20)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -4002,7 +4002,7 @@ packages:
       '@emotion/core': ^10.0.28
       react: '>=16.3.0'
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/core': 10.3.1(react@18.2.0)
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/serialize': 0.11.16
@@ -5403,8 +5403,8 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
-      '@mui/utils': 5.14.11(@types/react@18.2.20)(react@18.2.0)
+      '@babel/runtime': 7.23.2
+      '@mui/utils': 5.14.13(@types/react@18.2.20)(react@18.2.0)
       '@types/react': 18.2.20
       prop-types: 15.8.1
       react: 18.2.0
@@ -5457,7 +5457,7 @@ packages:
       '@emotion/styled':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@18.2.20)(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.20)(react@18.2.0)
@@ -5611,8 +5611,8 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.15
-      '@types/prop-types': 15.7.5
+      '@babel/runtime': 7.23.2
+      '@types/prop-types': 15.7.8
       '@types/react': 18.2.20
       prop-types: 15.8.1
       react: 18.2.0
@@ -5934,13 +5934,13 @@ packages:
   /@remirror/core-constants@2.0.1:
     resolution: {integrity: sha512-ZR4aihtnnT9lMbhh5DEbsriJRlukRXmLZe7HmM+6ufJNNUDoazc75UX26xbgQlNUqgAqMcUdGFAnPc1JwgAdLQ==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
     dev: false
 
   /@remirror/core-helpers@2.0.3:
     resolution: {integrity: sha512-LqIPF4stGG69l9qu/FFicv9d9B+YaItzgDMC5A0CEvDQfKkGD3BfabLmfpnuWbsc06oKGdTduilgWcALLZoYLg==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@linaria/core': 4.2.9
       '@remirror/core-constants': 2.0.1
       '@remirror/types': 1.0.1
@@ -9240,7 +9240,7 @@ packages:
   /babel-plugin-macros@2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       cosmiconfig: 6.0.0
       resolve: 1.22.2
     dev: true
@@ -9249,7 +9249,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       cosmiconfig: 7.1.0
       resolve: 1.22.2
 
@@ -9759,7 +9759,7 @@ packages:
     engines: {node: '>=10.0.0'}
     requiresBuild: true
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@types/raf': 3.4.0
       core-js: 3.31.1
       raf: 3.4.1
@@ -10476,7 +10476,7 @@ packages:
   /css-vendor@2.0.8:
     resolution: {integrity: sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       is-in-browser: 1.1.3
 
   /css-what@3.4.2:
@@ -18409,7 +18409,7 @@ packages:
   /rtl-css-js@1.16.1:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
     dev: false
 
   /run-parallel@1.2.0:
@@ -20645,7 +20645,7 @@ packages:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.12.0)
       '@babel/core': 7.22.9
       '@babel/preset-env': 7.22.7(@babel/core@7.22.9)
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.2
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.22.9)(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.1)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
@@ -20999,11 +20999,12 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/3a85966(@types/react@18.2.20):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3a85966}
-    id: github.com/theopensystemslab/planx-core/3a85966
+  github.com/theopensystemslab/planx-core/2fcb488(@types/react@18.2.20):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fcb488}
+    id: github.com/theopensystemslab/planx-core/2fcb488
     name: '@opensystemslab/planx-core'
     version: 1.0.0
+    prepare: true
     requiresBuild: true
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.2.20)(react@18.2.0)

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.5
     version: 0.7.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fcb488
-    version: github.com/theopensystemslab/planx-core/2fcb488(@types/react@18.2.20)
+    specifier: git+https://github.com/theopensystemslab/planx-core#c2d6f35
+    version: github.com/theopensystemslab/planx-core/c2d6f35(@types/react@18.2.20)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -20999,9 +20999,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fcb488(@types/react@18.2.20):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fcb488}
-    id: github.com/theopensystemslab/planx-core/2fcb488
+  github.com/theopensystemslab/planx-core/c2d6f35(@types/react@18.2.20):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c2d6f35}
+    id: github.com/theopensystemslab/planx-core/c2d6f35
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
@@ -1,5 +1,4 @@
 import { PublicProps } from "@planx/components/ui";
-
 import React from "react";
 import NextStepsList from "ui/NextStepsList";
 
@@ -19,10 +18,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
         howMeasured={props.howMeasured}
       />
-      <NextStepsList
-        steps={props.steps}
-        handleSubmit={props.handleSubmit}
-      />
+      <NextStepsList steps={props.steps} handleSubmit={props.handleSubmit} />
     </Card>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -10,7 +10,7 @@ export type AnalyticsType = "init" | "resume";
 type AnalyticsLogDirection = AnalyticsType | "forwards" | "backwards";
 
 export type HelpClickMetadata = Record<string, string>;
-export type SelectedUrlsMetadata = Record<'selectedUrls', string[]>;
+export type SelectedUrlsMetadata = Record<"selectedUrls", string[]>;
 
 let lastAnalyticsLogId: number | undefined = undefined;
 

--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -96,7 +96,9 @@ const StatusPage: React.FC<Props> = ({
               onClick={removeSessionIdSearchParam}
               sx={contentFlowSpacing}
             >
-              <Typography variant="body1" align="left">Start new application</Typography>
+              <Typography variant="body1" align="left">
+                Start new application
+              </Typography>
             </Link>
           </>
         )}

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -80,7 +80,11 @@ function LinkStep(props: ListItemProps) {
       href={props.url}
       target="_blank"
       rel="noopener"
-      onClick={() => props.handleSelectingUrl && props.url && props.handleSelectingUrl(props.url)}
+      onClick={() =>
+        props.handleSelectingUrl &&
+        props.url &&
+        props.handleSelectingUrl(props.url)
+      }
     >
       <Step {...props} />
     </InnerLink>
@@ -119,19 +123,19 @@ const Step = ({ title, description, url }: ListItemProps) => (
 
 function NextStepsList(props: NextStepsListProps) {
   const [selectedUrls, setSelectedUrls] = useState<string[]>([]);
-  const { trackNextStepsLinkClick } = useAnalyticsTracking()
+  const { trackNextStepsLinkClick } = useAnalyticsTracking();
 
   const handleSelectingUrl = (newUrl: string) => {
-    setSelectedUrls(prevSelectedUrls => [...prevSelectedUrls, newUrl]);
-    trackNextStepsLinkClick({'selectedUrls': [...selectedUrls, newUrl]})
-  }
+    setSelectedUrls((prevSelectedUrls) => [...prevSelectedUrls, newUrl]);
+    trackNextStepsLinkClick({ selectedUrls: [...selectedUrls, newUrl] });
+  };
 
   return (
     <Root>
       {props.steps?.map((step, i) => (
         <StyledListItem key={i}>
           {step.url ? (
-            <LinkStep {...step} handleSelectingUrl={handleSelectingUrl}/>
+            <LinkStep {...step} handleSelectingUrl={handleSelectingUrl} />
           ) : (
             <ContinueStep {...step} handleSubmit={props.handleSubmit} />
           )}


### PR DESCRIPTION
This picks up the (long delayed!) changes made in [this PR ](https://github.com/theopensystemslab/planx-core/pull/79) which notably tidies up and namespaces more functionality (e.g. `$admin.createFlow()` → `$admin.flow.create()`).

There's also a few small type tidy picked up in E2E tests.

This PR relies on https://github.com/theopensystemslab/planx-core/pull/164 and should unblock https://github.com/theopensystemslab/planx-new/pull/2322