### PR TITLE
fix: Drop redundant (and error-throwing) `:first-child` selector

### DIFF
--- a/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Public.tsx
@@ -1,5 +1,4 @@
 import { PublicProps } from "@planx/components/ui";
-
 import React from "react";
 import NextStepsList from "ui/NextStepsList";
 
@@ -19,10 +18,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
         howMeasured={props.howMeasured}
       />
-      <NextStepsList
-        steps={props.steps}
-        handleSubmit={props.handleSubmit}
-      />
+      <NextStepsList steps={props.steps} handleSubmit={props.handleSubmit} />
     </Card>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -10,7 +10,7 @@ export type AnalyticsType = "init" | "resume";
 type AnalyticsLogDirection = AnalyticsType | "forwards" | "backwards";
 
 export type HelpClickMetadata = Record<string, string>;
-export type SelectedUrlsMetadata = Record<'selectedUrls', string[]>;
+export type SelectedUrlsMetadata = Record<"selectedUrls", string[]>;
 
 let lastAnalyticsLogId: number | undefined = undefined;
 

--- a/editor.planx.uk/src/pages/Preview/StatusPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/StatusPage.tsx
@@ -96,7 +96,9 @@ const StatusPage: React.FC<Props> = ({
               onClick={removeSessionIdSearchParam}
               sx={contentFlowSpacing}
             >
-              <Typography variant="body1" align="left">Start new application</Typography>
+              <Typography variant="body1" align="left">
+                Start new application
+              </Typography>
             </Link>
           </>
         )}

--- a/editor.planx.uk/src/ui/InputLabel.tsx
+++ b/editor.planx.uk/src/ui/InputLabel.tsx
@@ -6,9 +6,6 @@ import React, { ReactNode } from "react";
 const Root = styled("label")(() => ({
   display: "block",
   width: "100%",
-  "& > :not(:first-child)": {
-    width: "100%",
-  },
 }));
 
 export default function InputLabel(props: {

--- a/editor.planx.uk/src/ui/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/NextStepsList.tsx
@@ -80,7 +80,11 @@ function LinkStep(props: ListItemProps) {
       href={props.url}
       target="_blank"
       rel="noopener"
-      onClick={() => props.handleSelectingUrl && props.url && props.handleSelectingUrl(props.url)}
+      onClick={() =>
+        props.handleSelectingUrl &&
+        props.url &&
+        props.handleSelectingUrl(props.url)
+      }
     >
       <Step {...props} />
     </InnerLink>
@@ -119,19 +123,19 @@ const Step = ({ title, description, url }: ListItemProps) => (
 
 function NextStepsList(props: NextStepsListProps) {
   const [selectedUrls, setSelectedUrls] = useState<string[]>([]);
-  const { trackNextStepsLinkClick } = useAnalyticsTracking()
+  const { trackNextStepsLinkClick } = useAnalyticsTracking();
 
   const handleSelectingUrl = (newUrl: string) => {
-    setSelectedUrls(prevSelectedUrls => [...prevSelectedUrls, newUrl]);
-    trackNextStepsLinkClick({'selectedUrls': [...selectedUrls, newUrl]})
-  }
+    setSelectedUrls((prevSelectedUrls) => [...prevSelectedUrls, newUrl]);
+    trackNextStepsLinkClick({ selectedUrls: [...selectedUrls, newUrl] });
+  };
 
   return (
     <Root>
       {props.steps?.map((step, i) => (
         <StyledListItem key={i}>
           {step.url ? (
-            <LinkStep {...step} handleSelectingUrl={handleSelectingUrl}/>
+            <LinkStep {...step} handleSelectingUrl={handleSelectingUrl} />
           ) : (
             <ContinueStep {...step} handleSubmit={props.handleSubmit} />
           )}


### PR DESCRIPTION
<img width="635" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/ba3e5c59-daa9-40d7-8a6b-58946293d491">

A good play around with this shows it's not actually doing anything currently so can be safely removed.
