### PR TITLE
chore: Improve Uniform error logging

### DIFF
--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
 import { NextFunction, Request, Response } from "express";
 import { Buffer } from "node:buffer";
 import FormData from "form-data";
@@ -157,9 +157,12 @@ export async function sendToUniform(
       application: applicationAuditRecord,
     });
   } catch (error) {
+    const errorMessage = isAxiosError(error)
+      ? JSON.stringify(error.toJSON())
+      : (error as Error).message;
     return next({
       error,
-      message: `Failed to send to Uniform (${localAuthority}): ${error}`,
+      message: `Failed to send to Uniform (${localAuthority}): ${errorMessage}`,
     });
   }
 }
@@ -219,7 +222,13 @@ async function authenticate({
   const response = await axios.request<RawUniformAuthResponse>(authConfig);
 
   if (!response.data.access_token) {
-    throw Error("Failed to authenticate to Uniform");
+    throw Error("Failed to authenticate to Uniform - no access token returned");
+  }
+
+  if (!response.data["organisation-name"] || response.data["organisation-id"]) {
+    throw Error(
+      "Failed to authenticate to Uniform - no organisation details returned",
+    );
   }
 
   const uniformAuthResponse: UniformAuthResponse = {

--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
@@ -22,7 +22,7 @@
     body: >
       {
         "access_token": "TEST_TOKEN",
-        "organisataion-name": "MOCKED",
+        "organisation-name": "MOCKED",
         "organisation-id": "MOCKED"
       }
 


### PR DESCRIPTION
Currently testing submissions on staging and hitting issues with Uniform. The current message is getting logged which is not particularly insightful - 

`message: 'Failed to send to Uniform (chiltern): AxiosError: Request failed with status code 500'`

The issue I'm hitting is that their token endpoint is not returning `organisation-name` and `organisation-id` either Chiltern or Aylesbury Vale, which is required for the next step of the submission process.

Update: I've manually tested their production API and both `organisation-name` and `organisation-id` are returned so I'm confident we're good to put this additional error handling in place.