### PR TITLE
fix: Handle unique file list correctly

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.test.ts
@@ -164,6 +164,78 @@ describe("createFileList function", () => {
     expect(result).toEqual(expected);
   });
 
+  it("correctly handles unique file names", () => {
+    const fileTypes: FileType[] = [
+      {
+        fn: "files.documentA",
+        name: "Document A",
+        rule: {
+          fn: "documentA.required",
+          val: "true",
+          operator: Operator.Equals,
+          condition: Condition.RequiredIf,
+        },
+      },
+      {
+        fn: "files.documentB",
+        name: "Document B",
+        rule: {
+          fn: "documentB.recommended",
+          val: "true",
+          operator: Operator.Equals,
+          condition: Condition.RecommendedIf,
+        },
+      },
+      {
+        fn: "files.documentB",
+        name: "Document B",
+        rule: {
+          fn: "documentB.required",
+          val: "true",
+          operator: Operator.Equals,
+          condition: Condition.RequiredIf,
+        },
+      },
+    ];
+    const passport: Store.passport = {
+      data: {
+        "documentA.required": ["true"],
+        "documentB.recommended": ["true"],
+      },
+    };
+
+    const expected: FileList = {
+      required: [
+        {
+          fn: "files.documentA",
+          name: "Document A",
+          rule: {
+            fn: "documentA.required",
+            val: "true",
+            operator: Operator.Equals,
+            condition: Condition.RequiredIf,
+          },
+        },
+      ],
+      recommended: [
+        {
+          fn: "files.documentB",
+          name: "Document B",
+          rule: {
+            fn: "documentB.recommended",
+            val: "true",
+            operator: Operator.Equals,
+            condition: Condition.RecommendedIf,
+          },
+        },
+      ],
+      optional: [],
+    };
+    const result = createFileList({ passport, fileTypes });
+
+    expect(result).toEqual(expected);
+  });
+
   it("handles a complex list of FileTypes", () => {
     const fileTypes: FileType[] = [
       {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -125,8 +125,12 @@ export const createFileList = ({
   sortedFileTypes.forEach((fileType) => {
     const isUnique = !uniqueNames.includes(fileType.name);
     if (isUnique) {
-      uniqueNames.push(fileType.name);
-      populateFileList({ fileList, fileType, passport });
+      const isFileTypeAdded = populateFileList({
+        fileList,
+        fileType,
+        passport,
+      });
+      if (isFileTypeAdded) uniqueNames.push(fileType.name);
     }
   });
   return fileList;
@@ -139,6 +143,10 @@ const sortFileTypes = (fileTypes: FileType[]): FileType[] => {
   return sortedFileTypes;
 };
 
+/**
+ * Populate file list based on condition
+ * @returns true if file added, false if not
+ */
 const populateFileList = ({
   fileList,
   fileType,
@@ -147,27 +155,33 @@ const populateFileList = ({
   fileList: FileList;
   fileType: FileType;
   passport: Store.passport;
-}) => {
+}): boolean => {
   switch (fileType.rule.condition) {
     case Condition.AlwaysRequired:
       fileList.required.push(fileType);
-      break;
+      return true;
+
     case Condition.AlwaysRecommended:
       fileList.recommended.push(fileType);
-      break;
+      return true;
+
     case Condition.RequiredIf:
       if (isRuleMet(passport, fileType.rule)) {
         fileList.required.push(fileType);
+        return true;
       }
-      break;
+      return false;
+
     case Condition.RecommendedIf:
       if (isRuleMet(passport, fileType.rule)) {
         fileList.recommended.push(fileType);
+        return true;
       }
-      break;
+      return false;
+
     case Condition.NotRequired:
       fileList.optional.push(fileType);
-      break;
+      return true;
   }
 };
 


### PR DESCRIPTION
## What's the problem?
- When constructing a `FileList` for display to the user, we want this to only contain unique files (by name)
- We're experiencing a bug where a file is missing from the `FileList`
  - There are two `FileType`s with the same name
  - Only one of their conditions is met
  - Neither appear in the final list ❌ 
- Described in detail with example flow [here on OSL Slack](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1697646369616819)

## What's the cause?
- The unique list of file names we maintain does not check if the file has been added or not to the `FileList`

## What's the solution?
- Check if a file is added by the `populateFileList()` function
- Only count it as a unique file if added to our `FileList`

## Demo
Broken flow on prod - https://editor.planx.uk/testing/upload-and-label-recommended-test ❌ 
Fixed flow on pizza - https://2328.planx.pizza/testing/upload-and-label-recommended-test ✅  
