### PR TITLE
chore: Bump Vultr server size

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -308,7 +308,7 @@ jobs:
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
           os_id: 1743
-          plan: vc2-1c-1gb
+          plan: vc2-1c-2gb
           pullrequest_id: ${{ env.PULLREQUEST_ID }}
           region: lhr
           tag: pullrequest


### PR DESCRIPTION
This should resolve some issues seen recently with Vultr running out of JavaScript heap memory. This is certainly not intended as anything other than a temporary mitigation, but this PR should make for a better dev experience until we resolve it.

Vultr plans listed here under "response types" https://www.vultr.com/api/#tag/region/operation/list-available-plans-region

New working theory on the cause of the issue - TypeScript compilation on build (`tsc`). I'll look into this tomorrow - there's been a fair few changes in `planx-core` including including TS version and config. This article looks like a promising start to investigations....! 🔍 https://carlrannaberg.medium.com/overcoming-javascript-heap-out-of-memory-error-during-typescript-compilation-in-a-mui5-react-21396cc8a4e1