### PR TITLE
chore: Overwrite records on data-sync conflict

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -34,7 +34,7 @@ SELECT
   settings,
   copied_from
 FROM sync_flows
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -25,4 +25,4 @@ SELECT
   publisher_id,
   created_at
 FROM sync_published_flows
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE;

--- a/scripts/seed-database/write/team_members.sql
+++ b/scripts/seed-database/write/team_members.sql
@@ -12,4 +12,4 @@ INSERT INTO
 SELECT
   id, user_id, team_id, role
 FROM
-  sync_team_members ON CONFLICT (id) DO NOTHING;
+  sync_team_members ON CONFLICT (id) DO UPDATE;

--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -33,6 +33,6 @@ SELECT
   notify_personalisation,
   boundary
 FROM sync_teams
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE;
 
 SELECT setval('teams_id_seq', max(id)) FROM teams;

--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -30,7 +30,7 @@ SELECT
   email,
   is_platform_admin
 FROM sync_users
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE;
 
 ALTER TABLE
   users ENABLE TRIGGER grant_new_user_template_team_access;


### PR DESCRIPTION
See context on OSL Slack - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1696942132535689

Currently, we don't overwrite DB records on conflict - we skip them. This can lead to inconsistencies (as on the above thread), could potentially lead to permissions diverging between staging and prod, and also causes this new issue raised here where the prod boundary has not been copied across to staging - https://trello.com/c/hreL5mn4/2665-site-doesnt-have-address-showing-london-map-extract-on-bucks-service