### PR TITLE
fix: SQL `DO UPDATE` syntax for data sync script

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -1,4 +1,4 @@
--- insert flows skipping conflicts
+-- insert flows overwriting conflicts
 CREATE TEMPORARY TABLE sync_flows (
   id uuid,
   team_id int,
@@ -34,7 +34,15 @@ SELECT
   settings,
   copied_from
 FROM sync_flows
-ON CONFLICT (id) DO UPDATE;
+ON CONFLICT (id) DO UPDATE
+SET
+  team_id = EXCLUDED.team_id,
+  slug = EXCLUDED.slug,
+  creator_id = EXCLUDED.creator_id,
+  data = EXCLUDED.data,
+  version = EXCLUDED.version,
+  settings = EXCLUDED.settings,
+  copied_from = EXCLUDED.copied_from;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -1,3 +1,4 @@
+-- insert published_flows overwriting conflicts
 CREATE TEMPORARY TABLE sync_published_flows (
   id int,
   data jsonb,
@@ -25,4 +26,10 @@ SELECT
   publisher_id,
   created_at
 FROM sync_published_flows
-ON CONFLICT (id) DO UPDATE;
+ON CONFLICT (id) DO UPDATE
+SET
+  data = EXCLUDED.data,
+  flow_id = EXCLUDED.flow_id,
+  summary = EXCLUDED.summary,
+  publisher_id = EXCLUDED.publisher_id,
+  created_at = EXCLUDED.created_at;

--- a/scripts/seed-database/write/team_members.sql
+++ b/scripts/seed-database/write/team_members.sql
@@ -1,3 +1,4 @@
+-- insert team_members overwriting conflicts
 CREATE TEMPORARY TABLE sync_team_members (
   id uuid,
   user_id integer,
@@ -5,11 +6,15 @@ CREATE TEMPORARY TABLE sync_team_members (
   role text
 );
 
-\copy team_members FROM '/tmp/team_members.csv' WITH (FORMAT csv, DELIMITER ';');
+\copy sync_team_members FROM '/tmp/team_members.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
   team_members (id, user_id, team_id, role)
 SELECT
   id, user_id, team_id, role
 FROM
-  sync_team_members ON CONFLICT (id) DO UPDATE;
+  sync_team_members ON CONFLICT (id) DO UPDATE
+SET
+  user_id = EXCLUDED.user_id,
+  team_id = EXCLUDED.team_id,
+  role = EXCLUDED.role;

--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -1,4 +1,4 @@
--- insert teams skipping conflicts
+-- insert teams overwriting conflicts
 CREATE TEMPORARY TABLE sync_teams (
   id integer,
   name text,
@@ -33,6 +33,13 @@ SELECT
   notify_personalisation,
   boundary
 FROM sync_teams
-ON CONFLICT (id) DO UPDATE;
+ON CONFLICT (id) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  slug = EXCLUDED.slug,
+  theme = EXCLUDED.theme,
+  settings = EXCLUDED.settings,
+  notify_personalisation = EXCLUDED.notify_personalisation,
+  boundary = EXCLUDED.boundary;
 
 SELECT setval('teams_id_seq', max(id)) FROM teams;

--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -1,4 +1,4 @@
--- insert users skipping conflicts
+-- insert users overwriting conflicts
 CREATE TEMPORARY TABLE sync_users (
   id integer,
   first_name text,
@@ -30,7 +30,12 @@ SELECT
   email,
   is_platform_admin
 FROM sync_users
-ON CONFLICT (id) DO UPDATE;
+ON CONFLICT (id) DO UPDATE
+SET
+  first_name = EXCLUDED.first_name,
+  last_name = EXCLUDED.last_name,
+  email = EXCLUDED.email,
+  is_platform_admin = EXCLUDED.is_platform_admin;
 
 ALTER TABLE
   users ENABLE TRIGGER grant_new_user_template_team_access;


### PR DESCRIPTION
Fix for clumsy SQL in [previous PR](https://github.com/theopensystemslab/planx-new/pull/2332) which is causing the sync script to fail.

Tested multiple times locally and getting the expected results.