### PR TITLE
feat: first pass reordering uploaded files to show most recent first

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -95,7 +95,7 @@ function Component(props: Props) {
   useEffect(() => {
     if (previousSlotCount === undefined) return;
 
-    //  *** Show most recent upload at the top ***
+    // Show most recent upload at the top
     if (slots.length) setSlots(slots.reverse());
 
     // Only stop modal opening on initial return to node

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -94,6 +94,10 @@ function Component(props: Props) {
   const previousSlotCount = usePrevious(slots.length);
   useEffect(() => {
     if (previousSlotCount === undefined) return;
+
+    //  *** Show most recent upload at the top ***
+    if (slots.length) setSlots(slots.reverse());
+
     // Only stop modal opening on initial return to node
     if (isUserReturningToNode) return setIsUserReturningToNode(false);
     if (slots.length && dropzoneError) setDropzoneError(undefined);


### PR DESCRIPTION
## What

- Update the `FileUploadAndLabel` component to order the slots with the most recently uploaded at the top.
- This includes the main page and the labelling modal.
- As per: https://trello.com/c/YDoIk2tG/2663-upload-and-label-new-files-to-appear-at-top-of-modal

## Why

- In user testing it was found that users were not seeing their most recently uploaded files as they were not being clearly displayed as they were rendered at the bottom of the list.
- This caused issues for labelling and frustration for users. 

## How

- As per @jessicamcinchak's comment reversed the slot order in the `useEffect`
- Changing the order doesn't break the logic for uploading and labelling.

## Screenshots

The files uploaded and their labels as seen by the user:

<img width="1097" alt="Screenshot 2023-10-26 at 12 17 25" src="https://github.com/theopensystemslab/planx-new/assets/36415632/9951e65d-aece-4d70-a185-980a11510405">

Subsequent update to the data with the labels assigned as expected:

<img width="811" alt="Screenshot 2023-10-26 at 12 26 05" src="https://github.com/theopensystemslab/planx-new/assets/36415632/43ec9202-62e4-453d-9b6a-1226fd22edc5">


