### PR TITLE
fix: Failing regression E2E tests

### DIFF
--- a/api.planx.uk/send/uniform.ts
+++ b/api.planx.uk/send/uniform.ts
@@ -225,7 +225,10 @@ async function authenticate({
     throw Error("Failed to authenticate to Uniform - no access token returned");
   }
 
-  if (!response.data["organisation-name"] || response.data["organisation-id"]) {
+  if (
+    !response.data["organisation-name"] ||
+    !response.data["organisation-id"]
+  ) {
     throw Error(
       "Failed to authenticate to Uniform - no organisation details returned",
     );

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -20,7 +20,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "^1.39.0",
     "@types/node": "18.16.1",
     "eslint-plugin-playwright": "^0.12.0"
   }

--- a/e2e/tests/ui-driven/playwright.config.ts
+++ b/e2e/tests/ui-driven/playwright.config.ts
@@ -46,7 +46,7 @@ const config: PlaywrightTestConfig = {
   webServer: {
     command: `pnpm ui`,
     port: 3000,
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI,
   },
   /* Configure projects for major browsers */
   projects: [

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -38,8 +38,8 @@ dependencies:
 
 devDependencies:
   '@playwright/test':
-    specifier: ^1.35.1
-    version: 1.37.1
+    specifier: ^1.39.0
+    version: 1.39.0
   '@types/node':
     specifier: 18.16.1
     version: 18.16.1
@@ -515,15 +515,12 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@playwright/test@1.37.1:
-    resolution: {integrity: sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==}
+  /@playwright/test@1.39.0:
+    resolution: {integrity: sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      '@types/node': 18.16.1
-      playwright-core: 1.37.1
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright: 1.39.0
     dev: true
 
   /@popperjs/core@2.11.8:
@@ -1935,10 +1932,20 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /playwright-core@1.37.1:
-    resolution: {integrity: sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==}
+  /playwright-core@1.39.0:
+    resolution: {integrity: sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==}
     engines: {node: '>=16'}
     hasBin: true
+    dev: true
+
+  /playwright@1.39.0:
+    resolution: {integrity: sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.39.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /prelude-ls@1.2.1:

--- a/e2e/tests/ui-driven/src/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow.spec.ts
@@ -35,62 +35,6 @@ test.describe("Navigation", () => {
     await tearDownTestContext(context);
   });
 
-  test("Create a flow", async ({ browser }) => {
-    const page = await getTeamPage({
-      browser,
-      userId: context.user!.id!,
-      teamName: context.team.name,
-    });
-
-    page.on("dialog", (dialog) => dialog.accept(serviceProps.name));
-    await page.locator("button", { hasText: "Add a new service" }).click();
-
-    // update context to allow flow to be torn down
-    context.flow = { ...serviceProps };
-
-    await page.locator("li.hanger > a").click();
-    await page.getByRole("dialog").waitFor();
-
-    const questionText = "Is this a test?";
-    await page.getByPlaceholder("Text").fill(questionText);
-
-    await page.locator("button").filter({ hasText: "add new" }).click();
-    await page.getByPlaceholder("Option").fill("Yes");
-
-    await page.locator("button").filter({ hasText: "add new" }).click();
-    await page.getByPlaceholder("Option").nth(1).fill("No");
-
-    await page.locator("button").filter({ hasText: "Create question" }).click();
-    await expect(
-      page.locator("a").filter({ hasText: questionText }),
-    ).toBeVisible();
-
-    // Add a notice to the "Yes" path
-    const yesBranch = page.locator("#flow .card .options .option").nth(0);
-    await yesBranch.locator(".hanger > a").click();
-    await page.getByRole("dialog").waitFor();
-
-    await page.locator("select").selectOption({ label: "Notice" });
-    const yesBranchNoticeText = "Yes! this is a test";
-    await page.getByPlaceholder("Notice").fill(yesBranchNoticeText);
-    await page.locator("button").filter({ hasText: "Create notice" }).click();
-
-    // Add a notice to the "No" path
-    const noBranch = page.locator("#flow .card .options .option").nth(1);
-    await noBranch.locator(".hanger > a").click();
-    await page.getByRole("dialog").waitFor();
-
-    await page.locator("select").selectOption({ label: "Notice" });
-    const noBranchNoticeText = "Sorry, this is a test";
-    await page.getByPlaceholder("Notice").fill(noBranchNoticeText);
-    await page.locator("button").filter({ hasText: "Create notice" }).click();
-
-    const nodes = page.locator(".card");
-    await expect(nodes.getByText(questionText)).toBeVisible();
-    await expect(nodes.getByText(yesBranchNoticeText)).toBeVisible();
-    await expect(nodes.getByText(noBranchNoticeText)).toBeVisible();
-  });
-
   test("user data persists on page refresh @regression", async ({
     browser,
   }) => {
@@ -149,6 +93,62 @@ test.describe("Navigation", () => {
 
     await page.goBack();
     await expect(teamSlugInHeader).toBeHidden();
+  });
+
+  test("Create a flow", async ({ browser }) => {
+    const page = await getTeamPage({
+      browser,
+      userId: context.user!.id!,
+      teamName: context.team.name,
+    });
+
+    page.on("dialog", (dialog) => dialog.accept(serviceProps.name));
+    await page.locator("button", { hasText: "Add a new service" }).click();
+
+    // update context to allow flow to be torn down
+    context.flow = { ...serviceProps };
+
+    await page.locator("li.hanger > a").click();
+    await page.getByRole("dialog").waitFor();
+
+    const questionText = "Is this a test?";
+    await page.getByPlaceholder("Text").fill(questionText);
+
+    await page.locator("button").filter({ hasText: "add new" }).click();
+    await page.getByPlaceholder("Option").fill("Yes");
+
+    await page.locator("button").filter({ hasText: "add new" }).click();
+    await page.getByPlaceholder("Option").nth(1).fill("No");
+
+    await page.locator("button").filter({ hasText: "Create question" }).click();
+    await expect(
+      page.locator("a").filter({ hasText: questionText }),
+    ).toBeVisible();
+
+    // Add a notice to the "Yes" path
+    const yesBranch = page.locator("#flow .card .options .option").nth(0);
+    await yesBranch.locator(".hanger > a").click();
+    await page.getByRole("dialog").waitFor();
+
+    await page.locator("select").selectOption({ label: "Notice" });
+    const yesBranchNoticeText = "Yes! this is a test";
+    await page.getByPlaceholder("Notice").fill(yesBranchNoticeText);
+    await page.locator("button").filter({ hasText: "Create notice" }).click();
+
+    // Add a notice to the "No" path
+    const noBranch = page.locator("#flow .card .options .option").nth(1);
+    await noBranch.locator(".hanger > a").click();
+    await page.getByRole("dialog").waitFor();
+
+    await page.locator("select").selectOption({ label: "Notice" });
+    const noBranchNoticeText = "Sorry, this is a test";
+    await page.getByPlaceholder("Notice").fill(noBranchNoticeText);
+    await page.locator("button").filter({ hasText: "Create notice" }).click();
+
+    const nodes = page.locator(".card");
+    await expect(nodes.getByText(questionText)).toBeVisible();
+    await expect(nodes.getByText(yesBranchNoticeText)).toBeVisible();
+    await expect(nodes.getByText(noBranchNoticeText)).toBeVisible();
   });
 
   test("Preview a created flow", async ({ browser }: { browser: Browser }) => {

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -84,7 +84,7 @@
     "scroll-into-view-if-needed": "^2.2.31",
     "sharedb": "^3.3.1",
     "striptags": "^3.2.0",
-    "swr": "^2.2.0",
+    "swr": "^2.2.4",
     "tippy.js": "^6.3.7",
     "uuid": "^9.0.0",
     "wkt": "^0.1.1",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -256,8 +256,8 @@ dependencies:
     specifier: ^3.2.0
     version: 3.2.0
   swr:
-    specifier: ^2.2.0
-    version: 2.2.0(react@18.2.0)
+    specifier: ^2.2.4
+    version: 2.2.4(react@18.2.0)
   tippy.js:
     specifier: ^6.3.7
     version: 6.3.7
@@ -9892,6 +9892,10 @@ packages:
       string-width: 5.1.2
     dev: true
 
+  /client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
     dependencies:
@@ -19364,11 +19368,12 @@ packages:
       webpack: 5.88.1(@swc/core@1.3.71)(esbuild@0.14.54)
     dev: true
 
-  /swr@2.2.0(react@18.2.0):
-    resolution: {integrity: sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==}
+  /swr@2.2.4(react@18.2.0):
+    resolution: {integrity: sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
     dependencies:
+      client-only: 0.0.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -33,7 +33,7 @@ const DelayedLoadingIndicator: React.FC<{
     >
       <CircularProgress aria-label="Loading" />
       <Typography variant="body2" sx={{ ml: "1rem" }}>
-        {text ?? "Loading…"}
+        {text ?? "Loading..."}
       </Typography>
     </Root>
   ) : null;

--- a/editor.planx.uk/src/pages/Pay/MakePayment.tsx
+++ b/editor.planx.uk/src/pages/Pay/MakePayment.tsx
@@ -305,7 +305,6 @@ function computePaymentState(govUkPayment: GovUKPayment | null): PaymentState {
   ) {
     return PaymentState.Pending;
   }
-  // PaymentStatus.cancelled, PaymentStatus.error, PaymentStatus.failed,
   return PaymentState.Failed;
 }
 

--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -14,7 +14,7 @@ let cached: { flowSlug?: string; teamSlug?: string } = {
 };
 
 const routes = compose(
-  withView(teamView),
+  withView(async (req) => await teamView(req)),
 
   mount({
     "/": route(() => ({


### PR DESCRIPTION
## What's the problem?
E2E "Invite to Pay" tests have been failing for a while (and flaky prior to that). Here's a description and video of the bug which was leading to these failures -

- Visit any "Invite to Pay" URL (e.g. `/:team/:flow/pay` or `/:team/:flow/invite`)
- Page loads as expected ✅ 
- Refresh page
- Endless "Loading..." spinner, error thrown in console ❌ 
- Refresh again - issue persists
- Hard refresh - back to normal page load

Sometime you can hit the error immediately without first encountering the successful page load.

This bug was getting hit in Invite to Pay E2E tests where multiple tabs were being opened and refreshed to check the status of payment requests.

https://github.com/theopensystemslab/planx-new/assets/20502206/b193773e-6510-4936-bfc8-d4bfe2aa4e06


## What error is being thrown?

```
Uncaught (in promise) TypeError: ot is not a function
    at map.ts:20:47
    at Resolvable.ts:51:16
    at fi (main.f54878ac.js:1093:20469)
    at Object.next (main.f54878ac.js:1093:19696)
    at fi (main.f54878ac.js:1093:24012)
    at Object.next (main.f54878ac.js:1093:23809)
    at fi (main.f54878ac.js:1093:19899)
    at Object.next (main.f54878ac.js:1093:19696)
    at fi (main.f54878ac.js:1093:24012)
    at Object.next (main.f54878ac.js:1093:23809)
```

It's always some version of the above - please note that `ot` is a minified function name and can change from deploy to deploy. The stack trace however is consistent, and source maps show that it's an error being thrown by our routing library `react-navi`. The library is unfortunately deprecated and unmaintained, but having scoured their repo I'm pretty sure that the error matches this unresolved issue - https://github.com/frontarm/navi/issues/174. The error call stack and actual location in the code suggests this.

Try as I might, I can't trigger this bug when React is running locally - only once it's built.

I've also spent a lot of time trying to wrap various functions and components in try/catch blocks or `<ErrorBoundary>`s without success to programmatically narrow it down - there's something happening internally in react-navi that we're not being exposed to or isn't bubbling up correctly.

No network requests are being made prior to the error being thrown.

## What's the cause?
Something within the `route()` or `map()` functions for the `/pay` routes is throwing an error - usually the second time the page is loaded. This suggests caching (could be happening at a number of levels) and I spent a good while pursuing this line of thought as well - making sure all calls were not cached via Apollo or any other mechanism.

It eventually resorted to a tedious process of commenting out components and functions within the affected routes, rebuilding the React app, and running manual and E2E tests.

Narrowing down pointed to a pretty unlikely suspect - `useSWRMutation()`. If this was commented out, I couldn't replicate the issue - commented in it was consistently recreatable 🤯 

`useSWRMutation()` also has cache options - changing these seemed to have no effect.

I don't actually think that this is an issue with `useSWRMutation()` as such, but rather some sort of incompatibility issue with
`react-navi` that we're not quite able to see and pick up on.

## What's the fix?
Replace `useSWRMutation()` with `fetch()` and a few `setState()` hooks and all seems to work as expected. In the medium term I would be very interested in prioritising [replacing this library for something stable, maintained, and established](https://trello.com/c/js9dNpZg/1471-replace-the-code-dependency-react-navi-for-something-better). 

## How as this bug introduced?
This is a great question which I wish I had a better answer for. 

The first regression test failure related to this on `main` was on the [5th of October](https://github.com/theopensystemslab/planx-new/actions/runs/6415229898). Here's the [list of commits from the 4th](https://github.com/theopensystemslab/planx-new/commits?since=2023-10-04T00:00:00Z&until=2023-10-05T00:00:00Z) - nothing obvious here. I've also gone back through recent changes to permissions, routing, `teamStore` etc without much avail in finding the cause. Similarly `git bisect` wasn't super helpful - the bug is sort of flaky and I could find it further back than expected.

There was a successful regression test run on the [10th of October](https://github.com/theopensystemslab/planx-new/actions/runs/6465345751) which demonstrates this "flakiness" - sometimes they pass, sometimes they don't.

## So are regression tests passing now?
No 🥲 

All E2E tests pass locally, and all previously failing "Invite to pay" test are now passing - see [latest run here](https://github.com/theopensystemslab/planx-new/actions/runs/6637592882/job/18032220124) ✅ 

Now, two other tests are failing - I'm currently looking into this and hoping for a quick fix!

```
  2 failed
    [chromium] › create-flow.spec.ts:94:7 › Navigation › user data persists on page refresh @regression 
    [chromium] › create-flow.spec.ts:154:7 › Navigation › Preview a created flow ───────────────────
  32 passed (5.4m)
  ```