### PR TITLE
fix: `initUserStore() is not a function` bug

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -6,7 +6,6 @@ import Visibility from "@mui/icons-material/Visibility";
 import AppBar from "@mui/material/AppBar";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
-import ButtonBase from "@mui/material/ButtonBase";
 import Container from "@mui/material/Container";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
@@ -193,23 +192,28 @@ const TeamLogo: React.FC = () => {
   );
 };
 
-const Breadcrumbs: React.FC<{
-  handleClick?: (href: string) => void;
-}> = ({ handleClick }) => {
+const Breadcrumbs: React.FC = () => {
   const route = useCurrentRoute();
-  const team = useStore((state) => state.getTeam());
+  const [team, isStandalone] = useStore((state) => [
+    state.getTeam(),
+    state.previewEnvironment === "standalone",
+  ]);
 
   return (
     <BreadcrumbsRoot>
-      <ButtonBase
-        component="span"
-        color="#999"
-        onClick={() => handleClick && handleClick("/")}
+      <Link
+        style={{
+          color: "#fff",
+          textDecoration: "none",
+        }}
+        component={ReactNaviLink}
+        href={"/"}
+        prefetch={false}
+        {...(isStandalone && { target: "_blank" })}
       >
         Plan✕
-      </ButtonBase>
-
-      {team && (
+      </Link>
+      {team.slug && (
         <>
           {" / "}
           <Link
@@ -220,6 +224,7 @@ const Breadcrumbs: React.FC<{
             component={ReactNaviLink}
             href={`/${team.slug}`}
             prefetch={false}
+            {...(isStandalone && { target: "_blank" })}
           >
             {team.slug}
           </Link>
@@ -303,7 +308,6 @@ const NavBar: React.FC = () => {
 const PublicToolbar: React.FC<{
   showResetButton?: boolean;
 }> = ({ showResetButton = true }) => {
-  const { navigate } = useNavigation();
   const [path, id, teamTheme] = useStore((state) => [
     state.path,
     state.id,
@@ -346,11 +350,7 @@ const PublicToolbar: React.FC<{
         <Container maxWidth={false}>
           <InnerContainer>
             <LeftBox>
-              {teamTheme?.logo ? (
-                <TeamLogo />
-              ) : (
-                <Breadcrumbs handleClick={navigate} />
-              )}
+              {teamTheme?.logo ? <TeamLogo /> : <Breadcrumbs />}
             </LeftBox>
             {showCentredServiceTitle && <ServiceTitle />}
             <RightBox>
@@ -396,20 +396,14 @@ const EditorToolbar: React.FC<{
   headerRef: React.RefObject<HTMLElement>;
   route: Route;
 }> = ({ headerRef, route }) => {
+  const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
   const [togglePreview, user] = useStore((state) => [
     state.togglePreview,
     state.getUser(),
   ]);
 
-  const { navigate } = useNavigation();
-
   const handleClose = () => {
-    setOpen(false);
-  };
-
-  const handleClick = (href?: string) => {
-    if (href) navigate(href);
     setOpen(false);
   };
 
@@ -423,7 +417,7 @@ const EditorToolbar: React.FC<{
         <Container maxWidth={false}>
           <InnerContainer>
             <LeftBox>
-              <Breadcrumbs handleClick={handleClick}></Breadcrumbs>
+              <Breadcrumbs />
             </LeftBox>
             <RightBox>
               {user && (
@@ -502,7 +496,7 @@ const EditorToolbar: React.FC<{
             {route.data.flow && (
               <MenuItem
                 onClick={() =>
-                  handleClick([rootFlowPath(true), "settings"].join("/"))
+                  navigate([rootFlowPath(true), "settings"].join("/"))
                 }
               >
                 Settings

--- a/editor.planx.uk/src/routes/views/authenticated.tsx
+++ b/editor.planx.uk/src/routes/views/authenticated.tsx
@@ -16,6 +16,8 @@ export const authenticatedView = async () => {
 
   await useStore.getState().initUserStore(jwt);
 
+  useStore.getState().setPreviewEnvironment("editor");
+
   return (
     <AuthenticatedLayout>
       <View />


### PR DESCRIPTION
## What does this PR do?
 - Fixes `initUserStore() is not a function` error which Airbrake has been catching intermittently since the `UserStore` was introduced

## What's the bug?
The bug can be triggered by navigating from the `/preview` or `/unpublished` ("standalone") routes back into the Editor via the breadcrumb link in the header. Breadcrumbs only appear if a team does not have a logo, so this bug is probably only being triggered by those working on the Templates or Testing teams.

This is happening because the "standalone" pages of the application do not build a full Zustand store, only selected "slices" which does not contain the user store. See code below - 

https://github.com/theopensystemslab/planx-new/blob/caf3fb9d5b2ed398b372042ab5b5216842a862bc/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts#L65-L93

## How is this fixed?
This is handled when going from the Editor → Preview by opening a new tab (with new store, not including the UserStore).

When going back from Preview → Editor I'm doing the same - just opening in a new tab. This is probably a _slightly_ annoying workflow but the alternative is either - 
 - Always create a `UserStore` in the public context (unnecessary, and potentially a small risk)
 - Re-create a brand new store on navigation (overkill for a quick fix, but not inherently a bad idea).
 
 I've gone for the pragmatic option here...!