### PR TITLE
fix: Increase spacing above "Name the site" input

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -157,7 +157,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
           </Link>
         </MapFooter>
       </MapContainer>
-      <DescriptionInput data-testid="new-address-input">
+      <DescriptionInput data-testid="new-address-input" mt={2}>
         <InputLabel
           label={props.descriptionLabel || DEFAULT_NEW_ADDRESS_LABEL}
           htmlFor={`${props.id}-siteDescription`}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -13,13 +13,12 @@ export const MapContainer = styled(Box)<MapContainerProps>(
     padding: theme.spacing(1, 0, 1, 0),
     width: "100%",
     maxWidth: "none",
-    height: "50vh",
     "& my-map": {
       width: "100%",
-      height: "100%",
+      // Only increase map size in Preview & Unpublished routes
+      height:
+        size === "large" && environment === "standalone" ? "70vh" : "50vh",
     },
-    // Only increase map size in Preview & Unpublished routes
-    ...(size === "large" && environment === "standalone" && { height: "70vh" }),
   }),
 );
 


### PR DESCRIPTION
Quick fix for an outstanding issue I noticed when recently discussing this component.

The `MapContainer` currently does not encapsulate the `<MapFooter>` correctly as the `MyMap` element within it is styled to have `height: "100%"`. This means that any elements beneath it (such as the "Name the site" input) are not spaced correctly.

| | Before | After |
|--------|--------|--------|
|   **Spacing**   | <img width="1034" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/b2406ec8-24bf-43bd-8c99-160ffee281f5"> | <img width="1039" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/a425a540-58fe-45b2-858b-8ead6f4445d3"> |
|   **Map Container**   | <img width="942" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/170c9872-78d3-4754-bd1a-7cc26b803512"> | <img width="865" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/be67f571-b9f2-4b2c-b99c-830110d7aed8"> | 