### PR TITLE
chore: Bump API task CPU

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -285,6 +285,7 @@ export = async () => {
           context: "../../api.planx.uk",
           target: "production",
         }),
+        cpu: 1024,
         memory: 4096 /*MB*/,
         portMappings: [apiListenerHttp],
         environment: [


### PR DESCRIPTION
See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size

This should double the API vCPU from 0.5 → 1, which should help with Uniform submission issues.



<img width="719" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/fb4b25a6-1d7c-4225-8b80-1109d3c01add">