### PR TITLE
fix: React errors on content component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -12,7 +12,7 @@ export type Props = PublicProps<Content>;
 
 const Content = styled(Box, {
   shouldForwardProp: (prop) => prop !== "color",
-})<Props>(({ theme, color }) => ({
+})<{ color?: string }>(({ theme, color }) => ({
   padding: theme.spacing(2),
   backgroundColor: color,
   color:
@@ -28,7 +28,7 @@ const Content = styled(Box, {
 const ContentComponent: React.FC<Props> = (props) => {
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
-      <Content {...props} data-testid="content">
+      <Content color={props.color} data-testid="content">
         <ReactMarkdownOrHtml
           source={props.content}
           openLinksOnNewTab


### PR DESCRIPTION
Fixes React error seen when in dev mode on the "Content" component.

<img width="1435" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/83de5dcc-28a2-4473-a70c-5d3cb2d435a7">
