### PR TITLE
fix: Improve flakey E2E tests

### DIFF
--- a/e2e/tests/api-driven/src/globalHelpers.ts
+++ b/e2e/tests/api-driven/src/globalHelpers.ts
@@ -1,4 +1,4 @@
-import { TEST_EMAIL } from "../../ui-driven/src/helpers";
+import { TEST_EMAIL } from "../../ui-driven/src/globalHelpers";
 import { $admin } from "./client";
 
 export function createTeam(

--- a/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
@@ -12,7 +12,7 @@ import {
   mockPassport,
 } from "./mocks";
 import { $admin } from "../client";
-import { TEST_EMAIL } from "../../../ui-driven/src/helpers";
+import { TEST_EMAIL } from "../../../ui-driven/src/globalHelpers";
 import { createTeam, createUser } from "../globalHelpers";
 
 export async function setUpMocks() {

--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { log } from "./helpers";
+import { log } from "./globalHelpers";
 import { sign } from "jsonwebtoken";
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { GraphQLClient, gql } from "graphql-request";

--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -50,7 +50,10 @@ test.describe("Navigation", () => {
     const team = page.locator("h2", { hasText: context.team.name });
 
     let isRepeatedRequestMade = false;
-    page.on("request", (req) => (isRepeatedRequestMade = isGetUserRequest(req)));
+    page.on(
+      "request",
+      (req) => (isRepeatedRequestMade = isGetUserRequest(req)),
+    );
 
     Promise.all([
       await team.click(),

--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -10,7 +10,7 @@ import {
   clickContinue,
 } from "../globalHelpers";
 import type { Context } from "../context";
-import { getTeamPage, getUserRequest } from "./helpers";
+import { getTeamPage, isGetUserRequest } from "./helpers";
 
 test.describe("Navigation", () => {
   let context: Context = {
@@ -43,21 +43,21 @@ test.describe("Navigation", () => {
       userId: context.user!.id!,
     });
 
-    const initialRequest = page.waitForRequest(getUserRequest);
+    const initialRequest = page.waitForRequest(isGetUserRequest);
 
     Promise.all([await page.goto("/"), await initialRequest]);
 
     const team = page.locator("h2", { hasText: context.team.name });
 
     let isRepeatedRequestMade = false;
-    page.on("request", (req) => (isRepeatedRequestMade = getUserRequest(req)));
+    page.on("request", (req) => (isRepeatedRequestMade = isGetUserRequest(req)));
 
     Promise.all([
       await team.click(),
       expect(isRepeatedRequestMade).toBe(false),
     ]);
 
-    const reloadRequest = page.waitForRequest(getUserRequest);
+    const reloadRequest = page.waitForRequest(isGetUserRequest);
 
     Promise.all([await page.reload(), await reloadRequest]);
   });

--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -3,14 +3,14 @@ import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
-} from "./context";
+} from "../context";
 import {
-  getTeamPage,
   createAuthenticatedSession,
   answerQuestion,
   clickContinue,
-} from "./helpers";
-import type { Context } from "./context";
+} from "../globalHelpers";
+import type { Context } from "../context";
+import { getTeamPage, getUserRequest } from "./helpers";
 
 test.describe("Navigation", () => {
   let context: Context = {
@@ -43,32 +43,23 @@ test.describe("Navigation", () => {
       userId: context.user!.id!,
     });
 
-    let getUserRequestCount = 0;
-    page.on("request", (req) => {
-      const isHasuraRequest = req.url().includes("/graphql");
-      const isGetUserRequest =
-        isHasuraRequest && req.postData()?.toString().includes("GetUserById");
+    const initialRequest = page.waitForRequest(getUserRequest);
 
-      if (isGetUserRequest) getUserRequestCount++;
-    });
-
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
-
-    // Get user data on initial page load
-    expect(getUserRequestCount).toBe(1);
+    Promise.all([await page.goto("/"), await initialRequest]);
 
     const team = page.locator("h2", { hasText: context.team.name });
-    team.click();
-    await page.waitForLoadState("networkidle");
 
-    // User data not refetched on navigation to a new page
-    expect(getUserRequestCount).toBe(1);
+    let isRepeatedRequestMade = false;
+    page.on("request", (req) => (isRepeatedRequestMade = getUserRequest(req)));
 
-    // User data is refetched when page reloaded
-    await page.reload();
-    await page.waitForLoadState("networkidle");
-    expect(getUserRequestCount).toBe(2);
+    Promise.all([
+      await team.click(),
+      expect(isRepeatedRequestMade).toBe(false),
+    ]);
+
+    const reloadRequest = page.waitForRequest(getUserRequest);
+
+    Promise.all([await page.reload(), await reloadRequest]);
   });
 
   test("team data persists on page refresh @regression", async ({

--- a/e2e/tests/ui-driven/src/create-flow/helpers.ts
+++ b/e2e/tests/ui-driven/src/create-flow/helpers.ts
@@ -1,12 +1,10 @@
 import { Browser, Page, Request } from "@playwright/test";
 import { createAuthenticatedSession } from "../globalHelpers";
 
-export const getUserRequest = (req: Request) => {
+export const isGetUserRequest = (req: Request) => {
   const isHasuraRequest = req.url().includes("/graphql");
-  const isGetUserRequest = Boolean(
-    isHasuraRequest && req.postData()?.toString().includes("GetUserById"),
-  );
-  return isGetUserRequest;
+  const isGetUserOperation = req.postData()?.toString().includes("GetUserById");
+  return Boolean(isHasuraRequest && isGetUserOperation);
 };
 
 export async function getAdminPage({

--- a/e2e/tests/ui-driven/src/create-flow/helpers.ts
+++ b/e2e/tests/ui-driven/src/create-flow/helpers.ts
@@ -1,0 +1,39 @@
+import { Browser, Page, Request } from "@playwright/test";
+import { createAuthenticatedSession } from "../globalHelpers";
+
+export const getUserRequest = (req: Request) => {
+  const isHasuraRequest = req.url().includes("/graphql");
+  const isGetUserRequest = Boolean(
+    isHasuraRequest && req.postData()?.toString().includes("GetUserById"),
+  );
+  return isGetUserRequest;
+};
+
+export async function getAdminPage({
+  browser,
+  userId,
+}: {
+  browser: Browser;
+  userId: number;
+}): Promise<Page> {
+  const page = await createAuthenticatedSession({ browser, userId });
+  await page.goto("/");
+  await page.waitForResponse((response) => {
+    return response.url().includes("/graphql");
+  });
+  return page;
+}
+
+export async function getTeamPage({
+  browser,
+  userId,
+  teamName,
+}: {
+  browser: Browser;
+  userId: number;
+  teamName: string;
+}): Promise<Page> {
+  const page = await getAdminPage({ browser, userId });
+  await page.locator("h2", { hasText: teamName }).click();
+  return page;
+}

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -66,35 +66,6 @@ export async function createAuthenticatedSession({
   return page;
 }
 
-export async function getAdminPage({
-  browser,
-  userId,
-}: {
-  browser: Browser;
-  userId: number;
-}): Promise<Page> {
-  const page = await createAuthenticatedSession({ browser, userId });
-  await page.goto("/");
-  await page.waitForResponse((response) => {
-    return response.url().includes("/graphql");
-  });
-  return page;
-}
-
-export async function getTeamPage({
-  browser,
-  userId,
-  teamName,
-}: {
-  browser: Browser;
-  userId: number;
-  teamName: string;
-}): Promise<Page> {
-  const page = await getAdminPage({ browser, userId });
-  await page.locator("h2", { hasText: teamName }).click();
-  return page;
-}
-
 export async function saveSession({
   page,
   context,

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -15,9 +15,7 @@ import {
   navigateToPayComponent,
 } from "./helpers";
 import { mockPaymentRequest, modifiedInviteToPayFlow } from "./mocks";
-import { saveSession } from "../globalHelpers";
-import { returnToSession } from "../globalHelpers";
-import { clickContinue } from "../globalHelpers";
+import { saveSession, returnToSession, clickContinue } from "../globalHelpers";
 
 let context: Context = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page, BrowserContext } from "@playwright/test";
-import { addSessionToContext, modifyFlow } from "../helpers";
+import { addSessionToContext, modifyFlow } from "../globalHelpers";
 import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow";
 import {
   Context,
@@ -15,9 +15,9 @@ import {
   navigateToPayComponent,
 } from "./helpers";
 import { mockPaymentRequest, modifiedInviteToPayFlow } from "./mocks";
-import { saveSession } from "../helpers";
-import { returnToSession } from "../helpers";
-import { clickContinue } from "../helpers";
+import { saveSession } from "../globalHelpers";
+import { returnToSession } from "../globalHelpers";
+import { clickContinue } from "../globalHelpers";
 
 let context: Context = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
@@ -5,10 +5,10 @@ import {
   answerContactInput,
   addSessionToContext,
   TEST_EMAIL,
-} from "../helpers";
+} from "../globalHelpers";
 import type { Page } from "@playwright/test";
 import { gql, GraphQLClient } from "graphql-request";
-import { fillInEmail } from "../helpers";
+import { fillInEmail } from "../globalHelpers";
 import { PaymentRequest } from "@opensystemslab/planx-core/dist/types";
 import { Context } from "../context";
 

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -5,7 +5,7 @@ import {
   SessionData,
 } from "@opensystemslab/planx-core/types";
 import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow";
-import { TEST_EMAIL } from "../helpers";
+import { TEST_EMAIL } from "../globalHelpers";
 
 export const mockPaymentRequest: Partial<PaymentRequest> = {
   payeeEmail: TEST_EMAIL,

--- a/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page, APIRequestContext } from "@playwright/test";
 import { v4 as uuidV4 } from "uuid";
-import { fillGovUkCardDetails, cards } from "../helpers";
+import { fillGovUkCardDetails, cards } from "../globalHelpers";
 import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow";
 import {
   Context,

--- a/e2e/tests/ui-driven/src/login.spec.ts
+++ b/e2e/tests/ui-driven/src/login.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { createAuthenticatedSession } from "./helpers";
+import { createAuthenticatedSession } from "./globalHelpers";
 import {
   contextDefaults,
   setUpTestContext,

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -5,7 +5,7 @@ import {
   getSessionId,
   log,
   waitForPaymentResponse,
-} from "./helpers";
+} from "./globalHelpers";
 import type { Page } from "@playwright/test";
 import payFlow from "./mocks/flows/pay-flow.json";
 import { gql, GraphQLClient } from "graphql-request";

--- a/e2e/tests/ui-driven/src/save-and-return.spec.ts
+++ b/e2e/tests/ui-driven/src/save-and-return.spec.ts
@@ -16,7 +16,7 @@ import {
   returnToSession,
   saveSession,
   modifyFlow,
-} from "./helpers";
+} from "./globalHelpers";
 import type { Context } from "./context";
 
 test.describe("Save and return", () => {

--- a/e2e/tests/ui-driven/src/sections.spec.ts
+++ b/e2e/tests/ui-driven/src/sections.spec.ts
@@ -17,7 +17,7 @@ import {
   expectConfirmation,
   saveSession,
   returnToSession,
-} from "./helpers";
+} from "./globalHelpers";
 import { gql } from "graphql-request";
 import type { Context } from "./context";
 import type { FlowGraph } from "@opensystemslab/planx-core/types";


### PR DESCRIPTION
## What does this PR do?
 - Reduces / removes flakiness of `user data persists on page refresh @regression` E2E Playwright test
 - I've re-run this multiple times on CI (7-10 times?) without a failure so I've got a good degree of confidence it's better than the current implementation
 - This is achieved by wrapping actions in a `Promise.all()`

## Docs 
- https://github.com/microsoft/playwright/issues/5470
- https://www.workwithloop.com/blog/our-1-solution-to-playwright-flakiness-waitforresponse-waitforrequest-promises