### PR TITLE
fix: remove reset logic which cleared all slots

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -16,7 +16,6 @@ import Select, { SelectChangeEvent, SelectProps } from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
-import merge from "lodash/merge";
 import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
 import ErrorWrapper from "ui/ErrorWrapper";
@@ -171,19 +170,22 @@ const SelectMultiple = (props: SelectMultipleProps) => {
     previousTags: string[] | undefined,
     tags: string[],
   ) => {
-    let updatedFileList: FileList = merge(fileList);
     const updatedTags = tags.filter((tag) => !previousTags?.includes(tag));
     const removedTags = previousTags?.filter((tag) => !tags?.includes(tag));
 
     if (updatedTags.length > 0) {
-      updatedFileList = addOrAppendSlots(updatedTags, uploadedFile, fileList);
+      const updatedFileList = addOrAppendSlots(
+        updatedTags,
+        uploadedFile,
+        fileList,
+      );
+      setFileList(updatedFileList);
     }
 
     if (removedTags && removedTags.length > 0) {
-      updatedFileList = removeSlots(removedTags, uploadedFile, fileList);
+      const updatedFileList = removeSlots(removedTags, uploadedFile, fileList);
+      setFileList(updatedFileList);
     }
-
-    setFileList(updatedFileList);
   };
 
   useEffect(() => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -28,7 +28,6 @@ import {
   FileList,
   getTagsForSlot,
   removeSlots,
-  resetAllSlots,
 } from "./model";
 import { fileLabelSchema } from "./schema";
 
@@ -182,10 +181,6 @@ const SelectMultiple = (props: SelectMultipleProps) => {
 
     if (removedTags && removedTags.length > 0) {
       updatedFileList = removeSlots(removedTags, uploadedFile, fileList);
-    }
-
-    if (tags.length === 0 && previousTags) {
-      updatedFileList = resetAllSlots(fileList);
     }
 
     setFileList(updatedFileList);

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import { Store } from "pages/FlowEditor/lib/store";
@@ -331,7 +330,7 @@ export const addOrAppendSlots = (
   uploadedFile: FileUploadSlot,
   fileList: FileList,
 ): FileList => {
-  const updatedFileList: FileList = merge(fileList);
+  const updatedFileList: FileList = cloneDeep(fileList);
   const categories = Object.keys(updatedFileList) as Array<
     keyof typeof updatedFileList
   >;
@@ -368,7 +367,7 @@ export const removeSlots = (
   uploadedFile: FileUploadSlot,
   fileList: FileList,
 ): FileList => {
-  const updatedFileList: FileList = merge(fileList);
+  const updatedFileList: FileList = cloneDeep(fileList);
   const categories = Object.keys(updatedFileList) as Array<
     keyof typeof updatedFileList
   >;
@@ -396,7 +395,7 @@ export const removeSlots = (
 };
 
 export const resetAllSlots = (fileList: FileList): FileList => {
-  const updatedFileList: FileList = merge(fileList);
+  const updatedFileList: FileList = cloneDeep(fileList);
   const categories = Object.keys(updatedFileList) as Array<
     keyof typeof updatedFileList
   >;


### PR DESCRIPTION
## What

- Remove the `resetAllSlots` logic from `updateFileListWithTags`.
- Remove initial definition of `updatedFileList` from `updateFileListWithTags`.
- Refactor from `merge(fileList)` to `cloneDeep(fileList)`

## Why

- A bug was encountered where if a file had one tag which was then removed it would erroneously trigger the `resetAllSlots` which would wipe the tags applied to all files.
- As a tag can either be added or removed one at a time it was unclear what the use case for the reset was so it was removed to resolve the bug. 
- During debugging some opportunities for refactoring were found this included:
  - Moving from single argument `merge` to `cloneDeep` as `merge` was not a deep clone leading us to mutate state directly.
  - Removing the initial definition of `updatedFileList` from the `updateFileListWithTags` function as the initial value was never used. 

## Screen recordings 

Bug recording:

https://github.com/theopensystemslab/planx-new/pull/2209#issuecomment-1708237134

 Fix recording:

https://github.com/theopensystemslab/planx-new/assets/36415632/71aae0b5-bcad-427a-89d2-09ff01c4b5ab


 