### PR TITLE
feat: track a user hitting the "Save" application link

### DIFF
--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -76,10 +76,10 @@ const NoticeComponent: React.FC<Props> = (props) => {
     ? () => props.handleSubmit?.()
     : undefined;
 
-  const { trackResetFlow } = useAnalyticsTracking();
+  const { trackFlowDirectionChange } = useAnalyticsTracking();
 
   const handleNoticeResetClick = () => {
-    trackResetFlow();
+    trackFlowDirectionChange("reset");
     props.resetPreview && props.resetPreview();
   };
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ApplicationPath } from "types";
@@ -16,10 +17,18 @@ const InnerContainer = styled(Box)(({ theme }) => ({
 
 const SaveResumeButton: React.FC = () => {
   const saveToEmail = useStore((state) => state.saveToEmail);
-  const onClick = () =>
-    useStore.setState({
-      path: saveToEmail ? ApplicationPath.Save : ApplicationPath.Resume,
-    });
+  const { trackSaveFlow } = useAnalyticsTracking();
+
+  const handleClick = () => {
+    if (saveToEmail) {
+      trackSaveFlow();
+      useStore.setState({ path: ApplicationPath.Save });
+    } else {
+      useStore.setState({ path: ApplicationPath.Resume });
+    }
+  };
+
+  const onClick = () => handleClick();
 
   return (
     <InnerContainer>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SaveResumeButton.tsx
@@ -17,11 +17,11 @@ const InnerContainer = styled(Box)(({ theme }) => ({
 
 const SaveResumeButton: React.FC = () => {
   const saveToEmail = useStore((state) => state.saveToEmail);
-  const { trackSaveFlow } = useAnalyticsTracking();
+  const { trackFlowDirectionChange } = useAnalyticsTracking();
 
   const handleClick = () => {
     if (saveToEmail) {
-      trackSaveFlow();
+      trackFlowDirectionChange("save");
       useStore.setState({ path: ApplicationPath.Save });
     } else {
       useStore.setState({ path: ApplicationPath.Resume });

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -320,7 +320,7 @@ const PublicToolbar: React.FC<{
     theme.breakpoints.up("md"),
   );
 
-  const { trackResetFlow } = useAnalyticsTracking();
+  const { trackFlowDirectionChange } = useAnalyticsTracking();
 
   const handleRestart = async () => {
     if (
@@ -328,7 +328,7 @@ const PublicToolbar: React.FC<{
         "Are you sure you want to restart? This will delete your previous answers",
       )
     ) {
-      trackResetFlow();
+      trackFlowDirectionChange("reset");
       if (path === ApplicationPath.SingleSession) {
         clearLocalFlow(id);
         window.location.reload();


### PR DESCRIPTION
## What

- When a user decided to click the "Save" application link update the analytics_log for the node with a flow_direction of "save"

## Why

- This should allow us to analyse which nodes are most saved on etc.

## Refactor Opportunity

- This function is very similar to `trackResetFlow()`
- It might be worth adding a function which takes in a `flow_direction` and updates the `last_analytics_log` with that direction. 


```Typescript
  async function trackFlowDirectionChange (flowDirection: AnalyticsLogDirection) {
    if (shouldTrackAnalytics && lastAnalyticsLogId) {
      await publicClient.mutate({
        mutation: gql`
          mutation UpdateFlowDirection($id: bigint!, $flow_direction: String) {
            update_analytics_logs_by_pk(
              pk_columns: { id: $id }
              _set: { flow_direction: $flow_direction }
            ) {
              id
            }
          }
        `,
        variables: {
          id: lastAnalyticsLogId,
          flow_direction: flowDirection,
        },
      });
    }
  };
  ```
  
## Screen recording
  
https://github.com/theopensystemslab/planx-new/assets/36415632/63f93b5e-f65c-446c-8bb5-954a7d5f608f

