### PR TITLE
feat: track a user navigating backwards through flow by node id

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -6,6 +6,7 @@ import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import Caret from "ui/icons/Caret";
@@ -140,6 +141,13 @@ const ResultReason: React.FC<IResultReason> = ({
       : ""
   }`;
 
+  const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+
+  const handleChangeAnswer = (id: string) => {
+    trackBackwardsNavigationByNodeId(id, "change");
+    changeAnswer(id);
+  };
+
   return (
     <Root>
       <StyledAccordion
@@ -179,7 +187,7 @@ const ResultReason: React.FC<IResultReason> = ({
                   component="button"
                   onClick={(event) => {
                     event.stopPropagation();
-                    changeAnswer(id);
+                    handleChangeAnswer(id);
                   }}
                 >
                   Change

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -6,6 +6,7 @@ import { visuallyHidden } from "@mui/utils";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { TYPES } from "@planx/components/types";
 import format from "date-fns/format";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -203,8 +204,11 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
 // For applicable component types, display a list of their question & answers with a "change" link
 //  ref https://design-system.service.gov.uk/components/summary-list/
 function SummaryList(props: SummaryListProps) {
-  const handleClick = (nodeId: string) => {
-    props.changeAnswer(nodeId);
+  const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+
+  const handleChangeAnswer = (id: string) => {
+    trackBackwardsNavigationByNodeId(id, "change");
+    props.changeAnswer(id);
   };
 
   return (
@@ -222,7 +226,7 @@ function SummaryList(props: SummaryListProps) {
             <dd>
               {props.showChangeButton && (
                 <Link
-                  onClick={() => handleClick(nodeId)}
+                  onClick={() => handleChangeAnswer(nodeId)}
                   component="button"
                   fontSize="body2.fontSize"
                 >

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -312,10 +312,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     initiator: BackwardsNaviagtionInitiatorType,
   ) {
     const targetNodeMetadata = getTitleAndTypeFromFlow(nodeId);
-    console.log("Target node info: ", targetNodeMetadata);
     const metadata: Record<string, NodeMetadata> = {};
     metadata[`${initiator}`] = targetNodeMetadata;
-    console.log("Metadata payload:", metadata);
 
     if (shouldTrackAnalytics && lastAnalyticsLogId) {
       await publicClient.mutate({

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -74,7 +74,8 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.setPreviewEnvironment,
   ]);
   const isStandalone = previewEnvironment === "standalone";
-  const { createAnalytics, node } = useAnalyticsTracking();
+  const { createAnalytics, node, trackBackwardsNavigationByNodeId } =
+    useAnalyticsTracking();
   const [gotFlow, setGotFlow] = useState(false);
   const isUsingLocalStorage =
     useStore((state) => state.path) === ApplicationPath.SingleSession;
@@ -146,7 +147,10 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   const goBack = useCallback(() => {
     const previous = previousCard(node);
-    if (previous) record(previous);
+    if (previous) {
+      trackBackwardsNavigationByNodeId(previous, "back");
+      record(previous);
+    }
   }, [node?.id]);
 
   const showBackButton = useMemo(


### PR DESCRIPTION
## What

- Users can initiate moving backwards through the flow by node id via the `back` or `change` button.
- Track users initiating this and store the initiator i.e `back` or `change` and store target node metadata i.e. `title` and `type`.

## Why

- Currently we can't clearly infer when a user initiated moving backwards through a flow via the `back` or `change` button.
- Added some basic data of the target node being navigated back to gain insight on which question are challenging and which are often changed

## Screen Recording

https://github.com/theopensystemslab/planx-new/assets/36415632/4d32450a-6bc3-46f5-a2ab-bde0398c85fb


