### PR TITLE
chore: enable Barnet to query Planning Constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -58,7 +58,8 @@ function Component(props: Props) {
   // Configure which planx teams should query Digital Land (or continue to use custom GIS) and set URL params accordingly
   //   In future, Digital Land will theoretically support any UK address and this list won't be necessary, but data collection still limited to select councils!
   const digitalLandOrganisations: string[] = [
-    "opensystemslab",
+    "opensystemslab", // for UK-wide testing, subject to data availability
+    "barnet",
     "buckinghamshire",
     "canterbury",
     "camden",


### PR DESCRIPTION
A4s not published yet, so no associated API changes here yet. From https://opensystemslab.slack.com/archives/C5Q59R3HB/p1699018486114879

For postcode: EN5 5UU
![Screenshot from 2023-11-03 14-54-53](https://github.com/theopensystemslab/planx-new/assets/5132349/c79a41a0-5bd5-46ab-a357-a088c1744d92)
