### PR TITLE
fix: Correctly parse `amount` as number

### DIFF
--- a/api.planx.uk/inviteToPay/paymentRequest.ts
+++ b/api.planx.uk/inviteToPay/paymentRequest.ts
@@ -8,6 +8,14 @@ import {
 import { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { $api } from "../client";
 
+// https://docs.payments.service.gov.uk/api_reference/create_a_payment_reference/#json-body-parameters-for-39-create-a-payment-39
+interface GovPayCreatePayment {
+  amount: number;
+  reference: string;
+  description: string;
+  return_url: string;
+}
+
 interface GetPaymentRequestDetails {
   paymentRequest: {
     sessionId: string;
@@ -83,17 +91,30 @@ export async function buildPaymentPayload(
   if (!req.query.returnURL) {
     return next(
       new ServerError({
-        message: "missing required returnURL query param",
+        message: "Missing required returnURL query param",
         status: 400,
       }),
     );
   }
-  req.body = {
-    amount: req.params.paymentAmount,
-    reference: req.query.sessionId,
+
+  if (!req.query.sessionId) {
+    return next(
+      new ServerError({
+        message: "Missing required sessionId query param",
+        status: 400,
+      }),
+    );
+  }
+
+  const createPaymentBody: GovPayCreatePayment = {
+    amount: parseInt(req.params.paymentAmount),
+    reference: req.query.sessionId as string,
     description: "New application (nominated payee)",
-    return_url: req.query.returnURL,
+    return_url: req.query.returnURL as string,
   };
+
+  req.body = createPaymentBody;
+
   next();
 }
 


### PR DESCRIPTION
## What's the problem?
Regression tests are failing as an invalid body is being sent to GovPay to create a payment. The following error is returned from the GovPay sandbox API - 

```json
{
  "field": "amount",
  "code": "P0102",
  "description": "Invalid attribute value: amount. Must be a valid numeric format"
}
```

## What's causing this?
The bug was introduced [here](https://github.com/theopensystemslab/planx-new/blob/6e7b88f48d279b14a47021ad4cfbb21a171bf1ab/api.planx.uk/inviteToPay/paymentRequest.ts#L71) in this PR - https://github.com/theopensystemslab/planx-new/pull/2356.

`req.params` must be a string, so the amount was cast to as string but never back to a number.

This is only on staging currently so will not be affecting customers.

I did locally run E2E regression tests on this branch but must not have rebuilt the API after these changes were made.

## Next steps
This is fine and fixes the issue now, a few things I'd love to implement though would be - 
- GovPay types (maybe namespaced?)
- Convert pay to modules to introduce validation between middleware layers so we'd catch things like this.