### PR TITLE
fix: `Could not verify JWT` bug

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -6,8 +6,7 @@ import { $public, getClient } from "./client";
 
 // Get a flow's data (unflattened, without external portal nodes)
 const getFlowData = async (id: string): Promise<Flow> => {
-  const { client: $client } = getClient();
-  const { flow } = await $client.request<{ flow: Flow | null }>(
+  const { flow } = await $public.client.request<{ flow: Flow | null }>(
     gql`
       query GetFlowData($id: uuid!) {
         flow: flows_by_pk(id: $id) {


### PR DESCRIPTION
## What's the problem?
 - API errors thrown when hitting certain routes called via the frontend (e.g. `/diff`)
 - Errors suggest an issue with validation - `Could not verify JWT`
 - Likely caused by recent change to permissions (https://github.com/theopensystemslab/planx-new/pull/2356 & https://github.com/theopensystemslab/planx-new/pull/2375)

## What's the cause?
 - The middlewares `useRoleAuth` and `useLoginAuth` were only getting JWT's from `req.cookies`
 - However, auth headers were being used by the frontend to pass along the JWT to the API

## What's the solution?
- Update middlewares to get this data from the auth headers

## Why wasn't this caught in testing?
- API docs were reading `req.cookies` despite the additional Swagger authorisation
- E2E tests are adding a cookie to all requests using the helper method `createAuthenticatedSession()`