### PR TITLE
fix: Handle bug on first publish

### DIFF
--- a/api.planx.uk/editor/publish.test.ts
+++ b/api.planx.uk/editor/publish.test.ts
@@ -67,6 +67,20 @@ it("requires a user to have the 'teamEditor' role", async () => {
 });
 
 describe("publish", () => {
+  it("publishes for the first time", async () => {
+    queryMock.mockQuery({
+      name: "GetMostRecentPublishedFlow",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          publishedFlows: [],
+        },
+      },
+    });
+
+    await supertest(app).post("/flows/1/publish").set(auth).expect(200);
+  });
+
   it("does not update if there are no new changes", async () => {
     await supertest(app)
       .post("/flows/1/publish")

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -101,7 +101,7 @@ interface PublishedFlows {
 // Get the most recent version of a published flow's data (flattened, with external portal nodes)
 const getMostRecentPublishedFlow = async (
   id: string,
-): Promise<Flow["data"]> => {
+): Promise<Flow["data"] | undefined> => {
   const { flow } = await $public.client.request<PublishedFlows>(
     gql`
       query GetMostRecentPublishedFlow($id: uuid!) {
@@ -119,8 +119,6 @@ const getMostRecentPublishedFlow = async (
   );
 
   const mostRecent = flow?.publishedFlows?.[0]?.data;
-  if (!mostRecent) throw Error(`Published flow not found for flow ${id}`);
-
   return mostRecent;
 };
 

--- a/api.planx.uk/saveAndReturn/validateSession.ts
+++ b/api.planx.uk/saveAndReturn/validateSession.ts
@@ -138,6 +138,8 @@ async function reconcileSessionData({
   const alteredSectionIds = new Set<string>();
 
   const currentFlow = await getMostRecentPublishedFlow(sessionData.id);
+  if (!currentFlow)
+    throw Error(`Unable to find published flow for flow ${sessionData.id}`);
 
   // create ordered breadcrumbs to be able to look up section IDs later
   const orderedBreadcrumbs: OrderedBreadcrumbs = sortBreadcrumbs(


### PR DESCRIPTION
Over eager error handling excluded a use case where `mostRecent` should be falsy (on first publish)