### PR TITLE
fix: update audit table API permissions so unpublished routes can render PlanningConstraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -263,7 +263,7 @@ export function PlanningConstraintsContent(
           refreshConstraints={refreshConstraints}
         />
       )}
-      {positiveConstraints.length > 0 && (
+      {!showError && positiveConstraints.length > 0 && (
         <>
           <Typography variant="h3" component="h2" gutterBottom>
             These are the planning constraints we think apply to this property
@@ -283,31 +283,33 @@ export function PlanningConstraintsContent(
           <PlanningConditionsInfo />
         </>
       )}
-      {positiveConstraints.length === 0 && negativeConstraints.length > 0 && (
-        <>
-          <Typography variant="h3" component="h2">
-            It looks like there are no constraints on this property
-          </Typography>
-          <Typography variant="body2">
-            Based on the information you've given it looks like there are no
-            planning constraints on your property that might limit what you can
-            do.
-          </Typography>
-          <Typography variant="body2">
-            Continue with your application to tell us more about your project.
-          </Typography>
-          <SimpleExpand
-            id="negative-constraints-list"
-            buttonText={{
-              open: "Show the things we checked",
-              closed: "Hide constraints that don't apply",
-            }}
-          >
-            <ConstraintsList data={negativeConstraints} metadata={metadata} />
-          </SimpleExpand>
-          <PlanningConditionsInfo />
-        </>
-      )}
+      {!showError &&
+        positiveConstraints.length === 0 &&
+        negativeConstraints.length > 0 && (
+          <>
+            <Typography variant="h3" component="h2">
+              It looks like there are no constraints on this property
+            </Typography>
+            <Typography variant="body2">
+              Based on the information you've given it looks like there are no
+              planning constraints on your property that might limit what you
+              can do.
+            </Typography>
+            <Typography variant="body2">
+              Continue with your application to tell us more about your project.
+            </Typography>
+            <SimpleExpand
+              id="negative-constraints-list"
+              buttonText={{
+                open: "Show the things we checked",
+                closed: "Hide constraints that don't apply",
+              }}
+            >
+              <ConstraintsList data={negativeConstraints} metadata={metadata} />
+            </SimpleExpand>
+            <PlanningConditionsInfo />
+          </>
+        )}
     </Card>
   );
 }

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1003,6 +1003,16 @@
           - destination_url
           - session_id
           - created_at
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - response
+          - destination_url
+          - session_id
+          - created_at
+        filter: {}
 - table:
     schema: public
     name: project_types

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -67,7 +67,7 @@ describe("planning_constraints_requests", () => {
     });
 
     test("can query planning_constraints_requests", () => {
-      expect(i.queries).not.toContain("planning_constraints_requests");
+      expect(i.queries).toContain("planning_constraints_requests");
     })
 
     test("can insert planning_constraints_requests", () => {

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -66,7 +66,7 @@ describe("planning_constraints_requests", () => {
       i = await introspectAs("api");
     });
 
-    test("cannot query planning_constraints_requests", () => {
+    test("can query planning_constraints_requests", () => {
       expect(i.queries).not.toContain("planning_constraints_requests");
     })
 


### PR DESCRIPTION
August flagged this morning that on `/unpublished` routes, PlanningConstraints are failing to render correctly & throwing the following console error:
```json
{
 "extensions": {
    "path": "$.selectionSet.insert_planning_constraints_requests_one",
    "code": "validation-failed"
  },
  "message": "field "insert_planning_constraints_requests_one" not found in type: 'mutation_root'"
}
```

Before: https://editor.planx.uk/barnet/find-out-if-you-need-planning-permission/unpublished
After: https://2392.planx.pizza/barnet/find-out-if-you-need-planning-permission/unpublished

**Changes**:
- Update `planning_constraints_requests` table to grant the `api` role select permissions, consistent with other audit tables, as this is necessary for the `insert_` mutation to return the new record's `id`
- Adjust frontend conditional rendering so in cases of an error, that's all we ever display - never a mix of error plus successful roads response like happened in this edge case

This bug is only effecting `/unpublished` routes, not `/preview`, so no particular rush to deploy