### PR TITLE
refactor: update the pattern for settings the flowSettings in state

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -9,7 +9,6 @@ import { TeamStore } from "./team";
 
 export interface SettingsStore {
   flowSettings?: FlowSettings;
-  setFlowSettings: (flowSettings?: FlowSettings) => void;
   globalSettings?: GlobalSettings;
   setGlobalSettings: (globalSettings: GlobalSettings) => void;
   updateFlowSettings: (newSettings: FlowSettings) => Promise<number>;
@@ -23,8 +22,6 @@ export const settingsStore: StateCreator<
   SettingsStore
 > = (set, get) => ({
   flowSettings: undefined,
-
-  setFlowSettings: (flowSettings) => set({ flowSettings }),
 
   globalSettings: undefined,
 

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -185,7 +185,7 @@ const getFlowSettings = async (
           where: { slug: { _eq: $slug }, team: { slug: { _eq: $team_slug } } }
         ) {
           id
-          settings
+          flowSettings: settings
         }
       }
     `,
@@ -194,7 +194,7 @@ const getFlowSettings = async (
       team_slug: team,
     },
   });
-  return data.flows[0]?.settings;
+  return data.flows[0]?.flowSettings;
 };
 
 const routes = compose(
@@ -204,8 +204,11 @@ const routes = compose(
 
   withView(async (req) => {
     const [flow, ...breadcrumbs] = req.params.flow.split(",");
-    const settings: FlowSettings = await getFlowSettings(flow, req.params.team);
-    useStore.getState().setFlowSettings(settings);
+    const flowSettings: FlowSettings = await getFlowSettings(
+      flow,
+      req.params.team,
+    );
+    useStore.setState({ flowSettings });
 
     return (
       <>

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -209,6 +209,8 @@ const routes = compose(
       req.params.team,
     );
     useStore.setState({ flowSettings });
+    const state = useStore.getState()
+    console.log('Flow state:', state)
 
     return (
       <>

--- a/editor.planx.uk/src/routes/settings.tsx
+++ b/editor.planx.uk/src/routes/settings.tsx
@@ -27,7 +27,7 @@ const flowSettingsRoutes = compose(
               }
             ) {
               id
-              settings
+              flowSettings: settings
             }
           }
         `,
@@ -37,8 +37,8 @@ const flowSettingsRoutes = compose(
         },
       });
 
-      const settings: FlowSettings = data.flows[0].settings;
-      useStore.getState().setFlowSettings(settings);
+      const flowSettings: FlowSettings = data.flows[0].flowSettings;
+      useStore.setState({ flowSettings });
 
       return {
         title: makeTitle(

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -47,6 +47,8 @@ export const publishedView = async (req: NaviRequest) => {
   state.setGlobalSettings(data.globalSettings[0]);
   state.setTeam(flow.team);
 
+  console.log('Published state: ', state)
+
   return (
     <PublicLayout>
       <SaveAndReturnLayout>

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -31,18 +31,20 @@ export const publishedView = async (req: NaviRequest) => {
   const data = await fetchDataForPublishedView(flowSlug, teamSlug);
 
   const flow = data.flows[0];
+  const flowSettings = data.flows[0]?.flowSettings;
   if (!flow) throw new NotFoundError(req.originalUrl);
 
   const publishedFlow = flow.publishedFlows[0]?.data;
   const flowData = publishedFlow ? publishedFlow : await dataMerged(flow.id);
   setPath(flowData, req);
 
+  useStore.setState({ flowSettings });
+
   const state = useStore.getState();
   // XXX: necessary as long as not every flow is published; aim to remove dataMergedHotfix.ts in future
   // load pre-flattened published flow if exists, else load & flatten flow
   state.setFlow({ id: flow.id, flow: flowData, flowSlug });
   state.setGlobalSettings(data.globalSettings[0]);
-  state.setFlowSettings(flow.settings);
   state.setTeam(flow.team);
 
   return (
@@ -78,7 +80,7 @@ const fetchDataForPublishedView = async (
               notifyPersonalisation: notify_personalisation
               boundaryBBox: boundary_bbox
             }
-            settings
+            flowSettings: settings
             publishedFlows: published_flows(
               limit: 1
               order_by: { created_at: desc }

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -10,7 +10,7 @@ import { Flow, GlobalSettings } from "types";
 import { getTeamFromDomain } from "../utils";
 
 interface StandaloneViewData {
-  flows: Pick<Flow, "team" | "settings">[];
+  flows: Pick<Flow, "team" | "flowSettings">[];
   globalSettings: GlobalSettings[];
 }
 
@@ -25,14 +25,15 @@ const standaloneView = async (req: NaviRequest) => {
   const data = await fetchDataForStandaloneView(flowSlug, teamSlug);
 
   const {
-    flows: [{ team, settings: flowSettings }],
+    flows: [{ team, flowSettings }],
     globalSettings,
   } = data;
+
+  useStore.setState({ flowSettings });
 
   const state = useStore.getState();
   state.setFlowNameFromSlug(flowSlug);
   state.setGlobalSettings(globalSettings[0]);
-  state.setFlowSettings(flowSettings);
   state.setTeam(team);
 
   return (

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -36,6 +36,8 @@ const standaloneView = async (req: NaviRequest) => {
   state.setGlobalSettings(globalSettings[0]);
   state.setTeam(team);
 
+  console.log('Standalone state: ', state)
+
   return (
     <PublicLayout>
       <View />

--- a/editor.planx.uk/src/routes/views/unpublished.tsx
+++ b/editor.planx.uk/src/routes/views/unpublished.tsx
@@ -40,6 +40,8 @@ export const unpublishedView = async (req: NaviRequest) => {
   state.setGlobalSettings(data.globalSettings[0]);
   state.setTeam(flow.team);
 
+  console.log('Unpublished settings: ', state)
+
   return (
     <PublicLayout>
       <View />

--- a/editor.planx.uk/src/routes/views/unpublished.tsx
+++ b/editor.planx.uk/src/routes/views/unpublished.tsx
@@ -31,11 +31,13 @@ export const unpublishedView = async (req: NaviRequest) => {
 
   const flowData = await dataMerged(flow.id);
 
+  const flowSettings = flow.flowSettings;
+  useStore.setState({ flowSettings });
+
   const state = useStore.getState();
   state.setFlow({ id: flow.id, flow: flowData, flowSlug });
   state.setFlowNameFromSlug(flowSlug);
   state.setGlobalSettings(data.globalSettings[0]);
-  state.setFlowSettings(flow.settings);
   state.setTeam(flow.team);
 
   return (
@@ -69,7 +71,7 @@ const fetchDataForUnpublishedView = async (
               notifyPersonalisation: notify_personalisation
               boundaryBBox: boundary_bbox
             }
-            settings
+            flowSettings: settings
             slug
           }
 

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -13,7 +13,7 @@ export interface Flow {
   id: string;
   slug: string;
   team: Team;
-  settings?: FlowSettings;
+  flowSettings?: FlowSettings;
 }
 
 export interface Team {


### PR DESCRIPTION
## What 

- Rationalise the syntax for managing the `flowSettings` in state
- Remove unnecessary custom setter

## Why

- Improves readability/maintainability
