### PR TITLE
chore: enable Birmingham to query planning constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -60,6 +60,7 @@ function Component(props: Props) {
   const digitalLandOrganisations: string[] = [
     "opensystemslab", // for UK-wide testing, subject to data availability
     "barnet",
+    "birmingham",
     "buckinghamshire",
     "canterbury",
     "camden",


### PR DESCRIPTION
A4s not yet available https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geometry_curie=statistical-geography%3AE08000025&entry_date_day=&entry_date_month=&entry_date_year=