### PR TITLE
fix: account for new column `flows.analytics_link` in data sync script

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -9,7 +9,8 @@ CREATE TEMPORARY TABLE sync_flows (
   created_at timestamptz,
   updated_at timestamptz,
   settings jsonb,
-  copied_from uuid
+  copied_from uuid,
+  analytics_link text
 );
 
 \copy sync_flows FROM '/tmp/flows.csv' WITH (FORMAT csv, DELIMITER ';');
@@ -22,7 +23,8 @@ INSERT INTO flows (
   data,
   version,
   settings,
-  copied_from
+  copied_from,
+  null
 )
 SELECT
   id,
@@ -32,7 +34,8 @@ SELECT
   data,
   version,
   settings,
-  copied_from
+  copied_from,
+  analytics_link
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -42,7 +45,8 @@ SET
   data = EXCLUDED.data,
   version = EXCLUDED.version,
   settings = EXCLUDED.settings,
-  copied_from = EXCLUDED.copied_from;
+  copied_from = EXCLUDED.copied_from,
+  analytics_link = null;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;

--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -24,7 +24,7 @@ INSERT INTO flows (
   version,
   settings,
   copied_from,
-  null
+  null as analytics_link,
 )
 SELECT
   id,


### PR DESCRIPTION
A manual trigger of the data sync script failed here: https://github.com/theopensystemslab/planx-new/actions/runs/6849674665/job/18622337310#step:9:99

This is a bit of a tedious process:
- First we `select * from flows` in `scripts/seed_database/container.sh`
- Then, consequently, the specific list of columns in `scripts/seed_database/write/flows.sql` need to match `*`, even for columns like `analytics_link` where we don't want to sync the actual value across envs

I tested locally by running `pnpm test-sync` in the project root