### PR TITLE
fix: show warning and skip Send event creation if `DISABLE_SAVE_AND_RETURN` feature flag is enabled

### DIFF
--- a/editor.planx.uk/src/components/FeatureFlagBanner.tsx
+++ b/editor.planx.uk/src/components/FeatureFlagBanner.tsx
@@ -1,0 +1,54 @@
+import ReportIcon from "@mui/icons-material/Report";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { hasFeatureFlag } from "lib/featureFlags";
+import React, { useState } from "react";
+
+const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
+  display: "flex",
+  backgroundColor: theme.palette.background.paper,
+  color: theme.palette.text.primary,
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "0.2em 0",
+}));
+
+const FeatureFlagBanner: React.FC = () => {
+  const [showWarning, setShowWarning] = useState(true);
+
+  const isUsingFeatureFlag = () => hasFeatureFlag("DISABLE_SAVE_AND_RETURN");
+
+  return (
+    <>
+      {isUsingFeatureFlag() && showWarning && (
+        <TestEnvironmentWarning>
+          <Container
+            maxWidth={false}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Box display="flex" alignItems="center">
+              <ReportIcon color="error" />
+              <Typography variant="body2" ml={1}>
+                You have <strong>disabled save and return</strong> via feature
+                flag. This means you cannot save or submit your test
+                applications.
+              </Typography>
+            </Box>
+            <Button size="small" onClick={() => setShowWarning(false)}>
+              Hide
+            </Button>
+          </Container>
+        </TestEnvironmentWarning>
+      )}
+    </>
+  );
+};
+
+export default FeatureFlagBanner;

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -42,6 +42,7 @@ import Reset from "ui/icons/Reset";
 import { useStore } from "../pages/FlowEditor/lib/store";
 import { rootFlowPath } from "../routes/utils";
 import AnalyticsDisabledBanner from "./AnalyticsDisabledBanner";
+import FeatureFlagBanner from "./FeatureFlagBanner";
 import TestEnvironmentBanner from "./TestEnvironmentBanner";
 
 export const HEADER_HEIGHT = 74;
@@ -376,6 +377,7 @@ const PublicToolbar: React.FC<{
       <NavBar />
       <AnalyticsDisabledBanner />
       <TestEnvironmentBanner />
+      <FeatureFlagBanner />
     </>
   );
 };

--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -24,7 +24,7 @@ INSERT INTO flows (
   version,
   settings,
   copied_from,
-  null as analytics_link,
+  analytics_link
 )
 SELECT
   id,
@@ -35,7 +35,7 @@ SELECT
   version,
   settings,
   copied_from,
-  analytics_link
+  NULL
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -46,7 +46,7 @@ SET
   version = EXCLUDED.version,
   settings = EXCLUDED.settings,
   copied_from = EXCLUDED.copied_from,
-  analytics_link = null;
+  analytics_link = NULL;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;


### PR DESCRIPTION
Addresses this error: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1699868054247069

Testing:
- With no feature flags toggled, a published flow will create "Send" events as expected. There is no warning banner.
- With the `DISABLE_SAVE_AND_RETURN` feature flag toggled, you can still proceed through Send to the Confirmation page, but no events have been created in Hasura. The warning banner is also visible.