### PR TITLE
fix: bug with file requirements not changing on delete of file

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -240,11 +240,12 @@ function Component(props: Props) {
                       ),
                     );
                     setFileUploadStatus(`${slot.file.path} was deleted`);
-                    removeSlots(
+                    const updatedFileList = removeSlots(
                       getTagsForSlot(slot.id, fileList),
                       slot,
                       fileList,
                     );
+                    setFileList(updatedFileList);
                   }}
                 />
               );

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -1,4 +1,5 @@
 import cloneDeep from "lodash/cloneDeep";
+import merge from "lodash/merge";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import { Store } from "pages/FlowEditor/lib/store";
@@ -367,7 +368,7 @@ export const removeSlots = (
   uploadedFile: FileUploadSlot,
   fileList: FileList,
 ): FileList => {
-  const updatedFileList: FileList = cloneDeep(fileList);
+  const updatedFileList: FileList = merge(fileList);
   const categories = Object.keys(updatedFileList) as Array<
     keyof typeof updatedFileList
   >;

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import { Store } from "pages/FlowEditor/lib/store";
@@ -368,7 +367,7 @@ export const removeSlots = (
   uploadedFile: FileUploadSlot,
   fileList: FileList,
 ): FileList => {
-  const updatedFileList: FileList = merge(fileList);
+  const updatedFileList: FileList = cloneDeep(fileList);
   const categories = Object.keys(updatedFileList) as Array<
     keyof typeof updatedFileList
   >;


### PR DESCRIPTION
## What:

- Update the `removeFile` function to set the updated file list to state.

## Why:

- This was written when the state was being updated directly and was therefore broken when the fileList was deep cloned.

## Screen recording:

Bug:

https://github.com/theopensystemslab/planx-new/assets/36415632/1d8f28c8-accb-458e-94c8-361ff1b1f9d7

Post fix:

https://github.com/theopensystemslab/planx-new/assets/36415632/a5535588-7c6b-41b4-b3c9-8db7188068fc

