### PR TITLE
fix: `platformAdmin` and `teamEditor` roles need to be able to update `flows.team_id` for "move" functionality

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -418,6 +418,7 @@
           - data
           - settings
           - slug
+          - team_id
         filter: {}
         check: null
     - role: teamEditor
@@ -426,6 +427,7 @@
           - data
           - settings
           - slug
+          - team_id
         filter:
           team:
             members:


### PR DESCRIPTION
Reported here https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1699976778720039

Testing:
- As a platform admin you can "move" a flow to any team
- As a team editor you can "move" a flow to any team you have edit access to