### PR TITLE
fix: Point to `lowcal_sessions` table

### DIFF
--- a/api.planx.uk/saveAndReturn/resumeApplication.test.ts
+++ b/api.planx.uk/saveAndReturn/resumeApplication.test.ts
@@ -229,7 +229,7 @@ describe("Resume Application endpoint", () => {
 
     queryMock.mockQuery({
       name: "ValidateRequest",
-      data: { teams: null, sessions: null },
+      data: { teams: null, lowcalSessions: null },
       variables: body.payload,
     });
 
@@ -251,7 +251,7 @@ describe("Resume Application endpoint", () => {
     queryMock.mockQuery({
       name: "ValidateRequest",
       data: {
-        sessions: [mockLowcalSession],
+        lowcalSessions: [mockLowcalSession],
         teams: [mockTeam],
       },
       variables: body.payload,
@@ -271,7 +271,7 @@ describe("Resume Application endpoint", () => {
 
     queryMock.mockQuery({
       name: "ValidateRequest",
-      data: { teams: [mockTeam], sessions: [] },
+      data: { teams: [mockTeam], lowcalSessions: [] },
       variables: body.payload,
     });
 

--- a/api.planx.uk/saveAndReturn/resumeApplication.ts
+++ b/api.planx.uk/saveAndReturn/resumeApplication.ts
@@ -61,7 +61,7 @@ const validateRequest = async (
   try {
     const query = gql`
       query ValidateRequest($email: String, $teamSlug: String) {
-        sessions(
+        lowcalSessions: lowcal_sessions(
           where: {
             email: { _eq: $email }
             deleted_at: { _is_null: true }


### PR DESCRIPTION
This is a follow up to this comment - https://github.com/theopensystemslab/planx-new/pull/2356#discussion_r1381640332

Clearly I either didn't commit my change or I overwrote it on a merge somehow sorry.

We're currently pointing to the wrong table so "resume" requests will fail.