### PR TITLE
fix: Apply auth to public upload, not private

### DIFF
--- a/api.planx.uk/modules/file/routes.ts
+++ b/api.planx.uk/modules/file/routes.ts
@@ -17,6 +17,7 @@ const router = Router();
 router.post(
   "/public/upload",
   multer().single("file"),
+  useTeamEditorAuth,
   validate(uploadFileSchema),
   publicUploadController,
 );
@@ -24,7 +25,6 @@ router.post(
 router.post(
   "/private/upload",
   multer().single("file"),
-  useTeamEditorAuth,
   validate(uploadFileSchema),
   privateUploadController,
 );

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -178,7 +178,6 @@ app.use("/webhooks", webhookRoutes);
 app.use("/analytics", analyticsRoutes);
 app.use("/admin", adminRoutes);
 app.use(ordnanceSurveyRoutes);
-app.use(fileRoutes);
 app.use("/file", fileRoutes);
 
 app.use("/gis", router);


### PR DESCRIPTION
## What's the problem?
Reported here on ODP Slack - https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1700064607120349

Uploading files is not working from applicant facing flows.

## What's the solution?
The route guard `useTeamEditorAuth()` was incorrectly applied to the "public" and not the "private" - anybody can upload to private, only Editors can upload to public 🙃 

Maybe another sign that some E2E file upload tests may be a good idea to consider soon?