### PR TITLE
feat: enabled St Albans to query planning constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -70,6 +70,7 @@ function Component(props: Props) {
     "medway",
     "newcastle",
     "southwark",
+    "st-albans",
   ];
 
   const digitalLandParams: Record<string, string> = {


### PR DESCRIPTION
A4s not published yet, so frontend change only & no API metadata changes yet https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geometry_curie=statistical-geography%3AE07000240&entry_date_day=&entry_date_month=&entry_date_year=