### PR TITLE
chore: Improve email trigger error logging

### DIFF
--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -265,7 +265,7 @@ const setupEmailEventTriggers = async (sessionId: string) => {
     return hasUserSaved;
   } catch (error) {
     throw new Error(
-      `Error setting up email notifications for session ${sessionId}`,
+      `Error setting up email notifications for session ${sessionId}. Error: ${error}`,
     );
   }
 };


### PR DESCRIPTION
Trying to get a bit more insight into this error - https://planx.airbrake.io/projects/329753/groups/3673249731619951928?tab=overview

Payload and validation seem fine, can't locate the Hasura query log which indicates it never ran and it's maybe an import error somewhere with the client?

I'd like to get this across to prod, re-trigger action, then work on a fix...!