### PR TITLE
fix: Change `undefined` to `null` in `confirmationEmailSchema`

### DIFF
--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -72,7 +72,8 @@ const sendSingleApplicationEmail = async ({
       emailReplyToId: team.notifyPersonalisation.emailReplyToId,
     };
     const firstSave = !session.hasUserSaved;
-    if (firstSave) await setupEmailEventTriggers(sessionId);
+    if (firstSave && !session.submittedAt)
+      await setupEmailEventTriggers(sessionId);
     return await sendEmail(template, email, config);
   } catch (error) {
     throw Error((error as Error).message);
@@ -98,6 +99,7 @@ const validateSingleSessionRequest = async (
           id
           data
           created_at
+          submitted_at
           has_user_saved
           flow {
             slug
@@ -139,6 +141,7 @@ interface SessionDetails {
   projectType: string;
   id: string;
   expiryDate: string;
+  submittedAt: string | null;
 }
 
 /**
@@ -162,6 +165,7 @@ const getSessionDetails = async (
     id: session.id,
     expiryDate: calculateExpiryDate(session.created_at),
     hasUserSaved: session.has_user_saved,
+    submittedAt: session.submitted_at,
   };
 };
 

--- a/api.planx.uk/modules/sendEmail/index.test.ts
+++ b/api.planx.uk/modules/sendEmail/index.test.ts
@@ -186,6 +186,7 @@ describe("Send Email endpoint", () => {
             payload: {
               sessionId: "123",
               email: TEST_EMAIL,
+              lockedAt: null,
             },
           };
           await supertest(app)

--- a/api.planx.uk/modules/sendEmail/types.ts
+++ b/api.planx.uk/modules/sendEmail/types.ts
@@ -50,7 +50,7 @@ export const confirmationEmailSchema = z.object({
   body: z.object({
     payload: z.object({
       sessionId: z.string(),
-      lockedAt: z.string().optional(),
+      lockedAt: z.string().or(z.null()),
       email: z.string().email(),
     }),
   }),


### PR DESCRIPTION
## What does this PR do?
- Follow on and fix for https://github.com/theopensystemslab/planx-new/pull/2436 
- Don't trigger reminder emails if a session is already submitted. We have a guard on these emails to not send, but it's actually simpler if we just don't create events unnecessarily in the first place