### PR TITLE
feat: add `teams.reference_code` to store Planning Data organisation

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1324,17 +1324,18 @@
     - role: api
       permission:
         columns:
-          - id
-          - notify_personalisation
-          - settings
-          - theme
-          - domain
-          - name
-          - slug
-          - created_at
-          - updated_at
           - boundary
+          - created_at
+          - domain
+          - id
+          - name
+          - notify_personalisation
+          - reference_code
+          - settings
+          - slug
           - submission_email
+          - theme
+          - updated_at
         computed_fields:
           - boundary_bbox
         filter: {}
@@ -1346,6 +1347,7 @@
           - id
           - name
           - notify_personalisation
+          - reference_code
           - settings
           - slug
           - theme
@@ -1362,6 +1364,7 @@
           - id
           - name
           - notify_personalisation
+          - reference_code
           - settings
           - slug
           - theme
@@ -1377,6 +1380,7 @@
           - id
           - name
           - notify_personalisation
+          - reference_code
           - settings
           - slug
           - theme

--- a/hasura.planx.uk/migrations/1700221802780_alter_table_public_teams_add_column_reference_code/down.sql
+++ b/hasura.planx.uk/migrations/1700221802780_alter_table_public_teams_add_column_reference_code/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."teams" drop column "reference_code" cascade;

--- a/hasura.planx.uk/migrations/1700221802780_alter_table_public_teams_add_column_reference_code/up.sql
+++ b/hasura.planx.uk/migrations/1700221802780_alter_table_public_teams_add_column_reference_code/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."teams" add column "reference_code" text null;
+comment on column "public"."teams"."reference_code" is E'Organisation reference code sourced from planning.data.gov.uk/dataset/local-authority';


### PR DESCRIPTION
Followup from https://github.com/theopensystemslab/digital-planning-data-schemas/pull/71

Once merged to production, I'll populate for all existing council-teams based on https://files.planning.data.gov.uk/dataset/local-authority.json?limit=400