### PR TITLE
fix: repeated label removed from file on change click bug

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -147,7 +147,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
 
   const initialTags = getTagsForSlot(uploadedFile.id, fileList);
   const [tags, setTags] = useState<string[]>(initialTags);
-  const previousTags = usePrevious(tags);
+  const previousTags = usePrevious(tags) || initialTags;
   const [open, setOpen] = React.useState(false);
 
   const handleChange = (event: SelectChangeEvent<typeof tags>) => {


### PR DESCRIPTION
## What

- Update the modal component so that for each instance of the `SelectMultiple` component the `previousTags` are previous state or the `initialTags` on first render
-  Updates are checked but an update isn't applied as the previousTags = intialTags

## Why

- When the modal is rendered when there are two files it renders two `SelectMultiple` components and they were incorrectly updating the `fileList` as the `previousTags` variable was `undefined`
- Therefore the uploaded file was effectively being removed from the slots. 

## Screen recordings

Bug

https://github.com/theopensystemslab/planx-new/assets/36415632/4cc83831-dd36-4a14-b834-d02b920f5e92

Fix

https://github.com/theopensystemslab/planx-new/assets/36415632/f9fe4618-29d1-4eed-b9c5-06bc81dda470



