### PR TITLE
chore: Update Metabase to v0.47.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   metabase:
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.45.3
+    image: metabase/metabase:v0.47.8
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -160,7 +160,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.45.3",
+        image: "metabase/metabase:v0.47.8",
         portMappings: [metabaseListenerHttp],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
Seemed worthwhile to pick this up whilst we're making changes and we've not updated in 8 months or so.

v0.47 should also allow us to turn on JSONB support on a per-table basis which would be a great UI win.

⚠️ I'm always slightly nervous about updating Metabase - let's just double check that rolling this up to staging works as expected and we don't lose any data there before promoting to prod ⚠️ 