### PR TITLE
chore: Tidy up routes

### DIFF
--- a/api.planx.uk/modules/admin/routes.ts
+++ b/api.planx.uk/modules/admin/routes.ts
@@ -13,24 +13,24 @@ import { downloadFeedbackCSV } from "./controller";
 
 const router = Router();
 
-router.use(usePlatformAdminAuth);
+router.use("/admin/", usePlatformAdminAuth);
 router.get(
-  "/feedback",
+  "/admin/feedback",
   validate(downloadFeedbackCSVSchema),
   downloadFeedbackCSV,
 );
 
 // TODO: Split the routes below into controller and service components
-router.get("/session/:sessionId/xml", getOneAppXML);
-router.get("/session/:sessionId/bops", getBOPSPayload);
-router.get("/session/:sessionId/csv", getCSVData);
-router.get("/session/:sessionId/csv-redacted", getRedactedCSVData);
-router.get("/session/:sessionId/html", getHTMLExport);
-router.get("/session/:sessionId/html-redacted", getRedactedHTMLExport);
-router.get("/session/:sessionId/zip", generateZip);
-router.get("/session/:sessionId/summary", getSessionSummary);
+router.get("/admin/session/:sessionId/xml", getOneAppXML);
+router.get("/admin/session/:sessionId/bops", getBOPSPayload);
+router.get("/admin/session/:sessionId/csv", getCSVData);
+router.get("/admin/session/:sessionId/csv-redacted", getRedactedCSVData);
+router.get("/admin/session/:sessionId/html", getHTMLExport);
+router.get("/admin/session/:sessionId/html-redacted", getRedactedHTMLExport);
+router.get("/admin/session/:sessionId/zip", generateZip);
+router.get("/admin/session/:sessionId/summary", getSessionSummary);
 router.get(
-  "/session/:sessionId/digital-planning-application",
+  "/admin/session/:sessionId/digital-planning-application",
   getDigitalPlanningApplicationPayload,
 );
 

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -9,12 +9,12 @@ import {
 const router = Router();
 
 router.post(
-  "/log-user-exit",
+  "/analytics/log-user-exit",
   validate(logAnalyticsSchema),
   logUserExitController,
 );
 router.post(
-  "/log-user-resume",
+  "/analytics/log-user-resume",
   validate(logAnalyticsSchema),
   logUserResumeController,
 );

--- a/api.planx.uk/modules/file/routes.ts
+++ b/api.planx.uk/modules/file/routes.ts
@@ -15,7 +15,7 @@ import { validate } from "../../shared/middleware/validate";
 const router = Router();
 
 router.post(
-  "/public/upload",
+  "/file/public/upload",
   multer().single("file"),
   useTeamEditorAuth,
   validate(uploadFileSchema),
@@ -23,20 +23,20 @@ router.post(
 );
 
 router.post(
-  "/private/upload",
+  "/file/private/upload",
   multer().single("file"),
   validate(uploadFileSchema),
   privateUploadController,
 );
 
 router.get(
-  "/public/:fileKey/:fileName",
+  "/file/public/:fileKey/:fileName",
   validate(downloadFileSchema),
   publicDownloadController,
 );
 
 router.get(
-  "/private/:fileKey/:fileName",
+  "/file/private/:fileKey/:fileName",
   useFilePermission,
   validate(downloadFileSchema),
   privateDownloadController,

--- a/api.planx.uk/modules/flows/routes.ts
+++ b/api.planx.uk/modules/flows/routes.ts
@@ -24,49 +24,49 @@ import {
 const router = Router();
 
 router.post(
-  "/:flowId/copy",
+  "/flows/:flowId/copy",
   useTeamEditorAuth,
   validate(copyFlowSchema),
   copyFlowController,
 );
 
 router.post(
-  "/:flowId/search",
+  "/flows/:flowId/search",
   usePlatformAdminAuth,
   validate(findAndReplaceSchema),
   findAndReplaceController,
 );
 
 router.put(
-  "/:flowId/copy-portal/:portalNodeId",
+  "/flows/:flowId/copy-portal/:portalNodeId",
   usePlatformAdminAuth,
   validate(copyFlowAsPortalSchema),
   copyPortalAsFlowController,
 );
 
 router.post(
-  "/:flowId/move/:teamSlug",
+  "/flows/:flowId/move/:teamSlug",
   useTeamEditorAuth,
   validate(moveFlowSchema),
   moveFlowController,
 );
 
 router.post(
-  "/:flowId/publish",
+  "/flows/:flowId/publish",
   useTeamEditorAuth,
   validate(publishFlowSchema),
   publishFlowController,
 );
 
 router.post(
-  "/:flowId/diff",
+  "/flows/:flowId/diff",
   useTeamEditorAuth,
   validate(validateAndDiffSchema),
   validateAndDiffFlowController,
 );
 
 router.get(
-  "/:flowId/download-schema",
+  "/flows/:flowId/download-schema",
   validate(downloadFlowSchema),
   downloadFlowSchemaController,
 );

--- a/api.planx.uk/modules/team/routes.ts
+++ b/api.planx.uk/modules/team/routes.ts
@@ -5,19 +5,19 @@ import { validate } from "../../shared/middleware/validate";
 
 const router = Router();
 
-router.use(AuthMiddleware.usePlatformAdminAuth);
+router.use("/team/", AuthMiddleware.usePlatformAdminAuth);
 router.put(
-  "/:teamSlug/add-member",
+  "/team/:teamSlug/add-member",
   validate(Controller.upsertMemberSchema),
   Controller.addMember,
 );
 router.patch(
-  "/:teamSlug/change-member-role",
+  "/team/:teamSlug/change-member-role",
   validate(Controller.upsertMemberSchema),
   Controller.changeMemberRole,
 );
 router.delete(
-  "/:teamSlug/remove-member",
+  "/team/:teamSlug/remove-member",
   validate(Controller.removeMemberSchema),
   Controller.removeMember,
 );

--- a/api.planx.uk/modules/user/routes.ts
+++ b/api.planx.uk/modules/user/routes.ts
@@ -10,8 +10,8 @@ import {
 
 const router = Router();
 
-router.use(usePlatformAdminAuth);
-router.put("/", validate(createUserSchema), createUser);
-router.delete("/:email", validate(deleteUserSchema), deleteUser);
+router.use("/user", usePlatformAdminAuth);
+router.put("/user", validate(createUserSchema), createUser);
+router.delete("/user/:email", validate(deleteUserSchema), deleteUser);
 
 export default router;

--- a/api.planx.uk/modules/webhooks/routes.ts
+++ b/api.planx.uk/modules/webhooks/routes.ts
@@ -17,43 +17,46 @@ import { createSessionEventSchema } from "./service/lowcalSessionEvents/schema";
 
 const router = Router();
 
-router.use("/hasura", useHasuraAuth);
+router.use("/webhooks/hasura", useHasuraAuth);
 router.post(
-  "/hasura/create-payment-invitation-events",
+  "/webhooks/hasura/create-payment-invitation-events",
   validate(createPaymentEventSchema),
   createPaymentInvitationEventsController,
 );
 router.post(
-  "/hasura/create-payment-reminder-events",
+  "/webhooks/hasura/create-payment-reminder-events",
   validate(createPaymentEventSchema),
   createPaymentReminderEventsController,
 );
 router.post(
-  "/hasura/create-payment-expiry-events",
+  "/webhooks/hasura/create-payment-expiry-events",
   validate(createPaymentEventSchema),
   createPaymentExpiryEventsController,
 );
 router.post(
-  "/hasura/send-slack-notification",
+  "/webhooks/hasura/send-slack-notification",
   validate(sendSlackNotificationSchema),
   sendSlackNotificationController,
 );
 router.post(
-  "/hasura/create-reminder-event",
+  "/webhooks/hasura/create-reminder-event",
   validate(createSessionEventSchema),
   createSessionReminderEventController,
 );
 router.post(
-  "/hasura/create-expiry-event",
+  "/webhooks/hasura/create-expiry-event",
   validate(createSessionEventSchema),
   createSessionExpiryEventController,
 );
 router.post(
-  "/hasura/sanitise-application-data",
+  "/webhooks/hasura/sanitise-application-data",
   sanitiseApplicationDataController,
 );
 
 // TODO: Convert to the new API module structure
-router.post("/hasura/create-payment-send-events", createPaymentSendEvents);
+router.post(
+  "/webhooks/hasura/create-payment-send-events",
+  createPaymentSendEvents,
+);
 
 export default router;

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -110,21 +110,22 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use(urlencoded({ extended: true }));
 
+// Setup API routes
+app.use(adminRoutes);
+app.use(analyticsRoutes);
 app.use(authRoutes);
+app.use(fileRoutes);
+app.use(flowRoutes);
+app.use(gisRoutes);
 app.use(miscRoutes);
-app.use("/user", userRoutes);
-app.use("/team", teamRoutes);
-app.use("/webhooks", webhookRoutes);
-app.use("/analytics", analyticsRoutes);
-app.use("/admin", adminRoutes);
 app.use(ordnanceSurveyRoutes);
-app.use("/file", fileRoutes);
+app.use(payRoutes);
 app.use(saveAndReturnRoutes);
 app.use(sendEmailRoutes);
-app.use("/flows", flowRoutes);
-app.use(gisRoutes);
-app.use(payRoutes);
 app.use(sendRoutes);
+app.use(teamRoutes);
+app.use(userRoutes);
+app.use(webhookRoutes);
 
 const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {


### PR DESCRIPTION
## What does this PR do?
- Moves full route path to `router.ts` files and out of `server.ts`
- This means that the full route lives in one place instead of being split over two files