### PR TITLE
fix: `SummaryList` bug

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -113,21 +113,17 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
 
   const isValidComponent = ([nodeId, userData]: BreadcrumbEntry) => {
     const node = props.flow[nodeId];
-    const Component = node.type && presentationalComponents[node.type];
-
-    const isPresentationalComponent = Boolean(Component);
     const doesNodeExist = Boolean(props.flow[nodeId]);
+    if (!doesNodeExist) return false;
+
+    const Component = node.type && presentationalComponents[node.type];
+    const isPresentationalComponent = Boolean(Component);
     const isAutoAnswered = userData.auto;
     const isInfoOnlyMode =
       node.type === TYPES.FileUploadAndLabel &&
       props.flow[nodeId].data?.hideDropZone;
 
-    return (
-      doesNodeExist &&
-      !isAutoAnswered &&
-      isPresentationalComponent &&
-      !isInfoOnlyMode
-    );
+    return !isAutoAnswered && isPresentationalComponent && !isInfoOnlyMode;
   };
 
   const removeNonPresentationalNodes = (


### PR DESCRIPTION
Resolves https://planx.airbrake.io/projects/329753/groups/3674911676429344553?tab=overview and https://planx.airbrake.io/projects/329753/groups/3672018983332190585?tab=notice-detail

The session caught by the most recent exception had nodeIds in the breadcrumbs which are no longer in the flow which caused this issue. The session does have records in `reconciliation_requests` which show changes between answered questions and the newly published flow - hence the additional breadcrumbs.

I'm going to take a closer look at `removeAlteredAndAffectedBreadcrumb()` to try and work out why this breadcrumb wasn't dropped which is the ultimate cause of this issue.