### PR TITLE
fix: MUI tooltip warning on analytics button

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -173,9 +173,11 @@ const PreviewBrowser: React.FC<{
             </Tooltip>
           ) : (
             <Tooltip arrow title="Analytics page unavailable">
-              <Link component={"button"} disabled aria-disabled={true}>
-                <BarChart />
-              </Link>
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <BarChart />
+                </Link>
+              </Box>
             </Tooltip>
           )}
 


### PR DESCRIPTION
## Problem

<img width="644" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/4c7ffc88-3457-4e8f-ab6b-ebf8f5cf64a8">

## Solution
https://github.com/mui/material-ui/issues/8416