### PR TITLE
feat: add `hasPlanningData` property to `teams.settings`

### DIFF
--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -42,6 +42,7 @@ export interface TeamSettings {
   };
   supportEmail?: string;
   boundary?: string;
+  hasPlanningData?: boolean;
 }
 
 export interface NotifyPersonalisation {


### PR DESCRIPTION
As more councils are coming onboard, this change will let us skip [PRs for Trello tickets like this one](https://trello.com/c/JVlAfSp5/2701-hook-up-planning-data-constraints-for-st-albans) and instead just add the property `"hasPlanningData": true` to `teams.settings` in the prod Hasura console for this council. No changes to permissions or the staging data sync are necessary for this to work as expected.

We will **still** open PRs to add API GIS metadata when a council's granular Article 4 variables become available.

Also updated council onboarding step in README here: https://github.com/theopensystemslab/planx-team-onboarding/tree/main#after-running-this-script

Future scope: expose this property via the Team Settings page in the Editor or via admin endpoint in the short term (probably not worth it?)