### PR TITLE
chore: Drop p-memoize in favour of Apollo caching

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -59,7 +59,6 @@
     "nanoid-good": "^3.1.0",
     "natsort": "^2.0.3",
     "navi": "^0.15.0",
-    "p-memoize": "^7.1.1",
     "postcode": "^5.1.0",
     "prop-types": "^15.8.1",
     "ramda": "^0.28.0",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -177,9 +177,6 @@ dependencies:
   navi:
     specifier: ^0.15.0
     version: 0.15.0
-  p-memoize:
-    specifier: ^7.1.1
-    version: 7.1.1
   postcode:
     specifier: ^5.1.0
     version: 5.1.0
@@ -5263,8 +5260,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.2
       '@emotion/is-prop-valid': 1.2.1
-      '@mui/types': 7.2.7(@types/react@18.2.20)
-      '@mui/utils': 5.14.15(@types/react@18.2.20)(react@18.2.0)
+      '@mui/types': 7.2.8(@types/react@18.2.20)
+      '@mui/utils': 5.14.16(@types/react@18.2.20)(react@18.2.0)
       '@popperjs/core': 2.11.8
       '@types/react': 18.2.20
       clsx: 2.0.0
@@ -5439,7 +5436,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.2
-      '@mui/utils': 5.14.15(@types/react@18.2.20)(react@18.2.0)
+      '@mui/utils': 5.14.16(@types/react@18.2.20)(react@18.2.0)
       '@types/react': 18.2.20
       prop-types: 15.8.1
       react: 18.2.0
@@ -5571,8 +5568,8 @@ packages:
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.20)(react@18.2.0)
       '@mui/private-theming': 5.14.15(@types/react@18.2.20)(react@18.2.0)
       '@mui/styled-engine': 5.14.15(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/types': 7.2.7(@types/react@18.2.20)
-      '@mui/utils': 5.14.15(@types/react@18.2.20)(react@18.2.0)
+      '@mui/types': 7.2.8(@types/react@18.2.20)
+      '@mui/utils': 5.14.16(@types/react@18.2.20)(react@18.2.0)
       '@types/react': 18.2.20
       clsx: 2.0.0
       csstype: 3.1.2
@@ -5591,17 +5588,6 @@ packages:
       '@types/react': 18.2.20
     dev: false
 
-  /@mui/types@7.2.7(@types/react@18.2.20):
-    resolution: {integrity: sha512-sofpWmcBqOlTzRbr1cLQuUDKaUYVZTw8ENQrtL39TECRNENEzwgnNPh6WMfqMZlMvf1Aj9DLg74XPjnLr0izUQ==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 18.2.20
-    dev: false
-
   /@mui/types@7.2.8(@types/react@18.2.20):
     resolution: {integrity: sha512-9u0ji+xspl96WPqvrYJF/iO+1tQ1L5GTaDOeG3vCR893yy7VcWwRNiVMmPdPNpMDqx0WV1wtEW9OMwK9acWJzQ==}
     peerDependencies:
@@ -5611,24 +5597,6 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.2.20
-    dev: false
-
-  /@mui/utils@5.14.15(@types/react@18.2.20)(react@18.2.0):
-    resolution: {integrity: sha512-QBfHovAvTa0J1jXuYDaXGk+Yyp7+Fm8GSqx6nK2JbezGqzCFfirNdop/+bL9Flh/OQ/64PeXcW4HGDdOge+n3A==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.2
-      '@types/prop-types': 15.7.9
-      '@types/react': 18.2.20
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-is: 18.2.0
     dev: false
 
   /@mui/utils@5.14.16(@types/react@18.2.20)(react@18.2.0):
@@ -10352,7 +10320,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -15752,6 +15720,7 @@ packages:
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+    dev: true
 
   /min-document@2.19.0:
     resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
@@ -16339,14 +16308,6 @@ packages:
     dependencies:
       aggregate-error: 3.1.0
     dev: true
-
-  /p-memoize@7.1.1:
-    resolution: {integrity: sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==}
-    engines: {node: '>=14.16'}
-    dependencies:
-      mimic-fn: 4.0.0
-      type-fest: 3.12.0
-    dev: false
 
   /p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
@@ -20209,6 +20170,7 @@ packages:
   /type-fest@3.12.0:
     resolution: {integrity: sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==}
     engines: {node: '>=14.16'}
+    dev: true
 
   /type-fest@4.3.1:
     resolution: {integrity: sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==}

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -2,7 +2,6 @@ import { TYPES as NodeTypes } from "@planx/components/types";
 import gql from "graphql-tag";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { NaviRequest, NotFoundError } from "navi";
-import pMemoize from "p-memoize";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { ApplicationPath } from "types";
 
@@ -69,11 +68,12 @@ const QUERY_GET_TEAM_BY_DOMAIN = gql`
   query GetTeamByDomain($domain: String!) {
     teams(limit: 1, where: { domain: { _eq: $domain } }) {
       slug
+      id
     }
   }
 `;
 
-export const getTeamFromDomain = pMemoize(async (domain: string) => {
+export const getTeamFromDomain = async (domain: string) => {
   const {
     data: { teams },
   } = await publicClient.query({
@@ -84,7 +84,7 @@ export const getTeamFromDomain = pMemoize(async (domain: string) => {
   });
 
   return teams?.[0]?.slug;
-});
+};
 
 /**
  * Prevents accessing a different team than the one associated with the custom domain.


### PR DESCRIPTION
## What the problem?
- `NotFound` errors on routes in staging (not replicable yet on local dev)
- See OSL Slack for context - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1700476380638669

## What's the solution?
- I'm not totally confident that this is the cause but as the query isn't firing it makes sense to try this
- At minimum we rationalise how we do caching / memoization, drop our bundle size, and rule a variable out of the equation.