### PR TITLE
docs: Remove repeated `sessionId` param

### DIFF
--- a/api.planx.uk/modules/send/docs.yaml
+++ b/api.planx.uk/modules/send/docs.yaml
@@ -115,12 +115,6 @@ paths:
             type: string
             format: uuid
         - in: query
-          name: sessionId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - in: query
           name: email
           required: true
           schema:


### PR DESCRIPTION
`sessionId` is already a param in the path here - it's not required to be repeated again in the query.