### PR TITLE
test: Cover error handling cases in API tests (1/2)

### DIFF
--- a/api.planx.uk/client/index.test.ts
+++ b/api.planx.uk/client/index.test.ts
@@ -1,0 +1,23 @@
+import { CoreDomainClient } from "@opensystemslab/planx-core";
+import { getClient } from ".";
+import { userContext } from "../modules/auth/middleware";
+import { getJWT } from "../tests/mockJWT";
+
+test("getClient() throws an error if a store is not set", () => {
+  expect(() => getClient()).toThrow();
+});
+
+test("getClient() returns a client if store is set", () => {
+  const getStoreMock = jest.spyOn(userContext, "getStore");
+  getStoreMock.mockReturnValue({
+    user: {
+      sub: "123",
+      jwt: getJWT({ role: "teamEditor" }),
+    },
+  });
+
+  const client = getClient();
+
+  expect(client).toBeDefined();
+  expect(client).toBeInstanceOf(CoreDomainClient);
+});

--- a/api.planx.uk/helpers.test.ts
+++ b/api.planx.uk/helpers.test.ts
@@ -1,5 +1,10 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
-import { dataMerged, getFormattedEnvironment, isLiveEnv } from "./helpers";
+import {
+  dataMerged,
+  getFlowData,
+  getFormattedEnvironment,
+  isLiveEnv,
+} from "./helpers";
 import { queryMock } from "./tests/graphqlQueryMock";
 import { userContext } from "./modules/auth/middleware";
 import { getJWT } from "./tests/mockJWT";
@@ -167,6 +172,7 @@ describe("dataMerged() function", () => {
       },
     });
   });
+
   it("handles multiple external portal nodes", async () => {
     const result = await dataMerged("parent-id");
     const nodeTypes = Object.values(result).map((node) =>
@@ -178,5 +184,21 @@ describe("dataMerged() function", () => {
 
     // All external portals have been flattened / replaced
     expect(areAllPortalsFlattened).toBe(true);
+  });
+});
+
+describe("getFlowData() function", () => {
+  it("throws an error if a flow is not found", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      variables: {
+        id: "child-id",
+      },
+      data: {
+        flow: null,
+      },
+    });
+
+    await expect(getFlowData("child-id")).rejects.toThrow();
   });
 });

--- a/api.planx.uk/lib/hasura/metadata/index.test.ts
+++ b/api.planx.uk/lib/hasura/metadata/index.test.ts
@@ -1,7 +1,10 @@
 import { createScheduledEvent, RequiredScheduledEventArgs } from ".";
-import Axios from "axios";
+import Axios, { AxiosError } from "axios";
 
-jest.mock("axios");
+jest.mock("axios", () => ({
+  ...jest.requireActual("axios"),
+  post: jest.fn(),
+}));
 const mockAxios = Axios as jest.Mocked<typeof Axios>;
 
 const mockScheduledEvent: RequiredScheduledEventArgs = {
@@ -13,6 +16,11 @@ const mockScheduledEvent: RequiredScheduledEventArgs = {
 
 test("createScheduledEvent returns an error if request fails", async () => {
   mockAxios.post.mockRejectedValue(new Error());
+  await expect(createScheduledEvent(mockScheduledEvent)).rejects.toThrow();
+});
+
+test("createScheduledEvent returns an error if Axios errors", async () => {
+  mockAxios.post.mockRejectedValue(new AxiosError());
   await expect(createScheduledEvent(mockScheduledEvent)).rejects.toThrow();
 });
 

--- a/api.planx.uk/lib/hasura/metadata/index.ts
+++ b/api.planx.uk/lib/hasura/metadata/index.ts
@@ -54,8 +54,7 @@ const postToMetadataAPI = async (
       },
     );
   } catch (error) {
-    const isAxiosErrorBool = isAxiosError(error);
-    const errorMessage = isAxiosErrorBool
+    const errorMessage = isAxiosError(error)
       ? JSON.stringify(error.toJSON())
       : (error as Error).message;
     throw Error(`Failed to POST to Hasura Metadata API: ${errorMessage}`);

--- a/api.planx.uk/lib/hasura/metadata/index.ts
+++ b/api.planx.uk/lib/hasura/metadata/index.ts
@@ -54,7 +54,8 @@ const postToMetadataAPI = async (
       },
     );
   } catch (error) {
-    const errorMessage = isAxiosError(error)
+    const isAxiosErrorBool = isAxiosError(error);
+    const errorMessage = isAxiosErrorBool
       ? JSON.stringify(error.toJSON())
       : (error as Error).message;
     throw Error(`Failed to POST to Hasura Metadata API: ${errorMessage}`);

--- a/api.planx.uk/lib/hasura/schema/index.test.ts
+++ b/api.planx.uk/lib/hasura/schema/index.test.ts
@@ -1,13 +1,21 @@
 import { runSQL } from ".";
-import Axios from "axios";
+import Axios, { AxiosError } from "axios";
 
-jest.mock("axios");
+jest.mock("axios", () => ({
+  ...jest.requireActual("axios"),
+  post: jest.fn(),
+}));
 const mockAxios = Axios as jest.Mocked<typeof Axios>;
 
 const sql = "SELECT * FROM TEST";
 
 test("runSQL returns an error if request fails", async () => {
   mockAxios.post.mockRejectedValue(new Error());
+  await expect(runSQL(sql)).rejects.toThrow();
+});
+
+test("runSQL returns an error if Axios errors", async () => {
+  mockAxios.post.mockRejectedValue(new AxiosError());
   await expect(runSQL(sql)).rejects.toThrow();
 });
 

--- a/api.planx.uk/lib/notify/index.test.ts
+++ b/api.planx.uk/lib/notify/index.test.ts
@@ -1,0 +1,39 @@
+import { sendEmail } from ".";
+import { NotifyClient } from "notifications-node-client";
+import { NotifyConfig } from "../../types";
+
+jest.mock("notifications-node-client");
+
+const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk";
+const mockConfig: NotifyConfig = {
+  personalisation: {
+    teamName: "test",
+    emailReplyToId: "test",
+    helpEmail: "test",
+    helpOpeningHours: "test",
+    helpPhone: "test",
+  },
+};
+
+describe("sendEmail", () => {
+  it("throws an error if an invalid template is used", async () => {
+    // @ts-expect-error Argument of type "invalidTemplate" is not assignable to parameter
+    await expect(
+      sendEmail("invalidTemplate", "test@example.com", {}),
+    ).rejects.toThrow();
+  });
+
+  it("throw an error if an error is thrown within sendEmail()", async () => {
+    const mockNotifyClient = NotifyClient.mock.instances[0];
+    mockNotifyClient.sendEmail.mockRejectedValue(new Error());
+    await expect(sendEmail("save", TEST_EMAIL, mockConfig)).rejects.toThrow();
+  });
+
+  it("throw an error if the NotifyClient errors", async () => {
+    const mockNotifyClient = NotifyClient.mock.instances[0];
+    mockNotifyClient.sendEmail.mockRejectedValue({
+      response: { data: { errors: ["Invalid email"] } },
+    });
+    await expect(sendEmail("save", TEST_EMAIL, mockConfig)).rejects.toThrow();
+  });
+});

--- a/api.planx.uk/lib/notify/index.test.ts
+++ b/api.planx.uk/lib/notify/index.test.ts
@@ -17,8 +17,8 @@ const mockConfig: NotifyConfig = {
 
 describe("sendEmail", () => {
   it("throws an error if an invalid template is used", async () => {
-    // @ts-expect-error Argument of type "invalidTemplate" is not assignable to parameter
     await expect(
+      // @ts-expect-error Argument of type "invalidTemplate" is not assignable to parameter
       sendEmail("invalidTemplate", "test@example.com", {}),
     ).rejects.toThrow();
   });

--- a/api.planx.uk/lib/notify/index.ts
+++ b/api.planx.uk/lib/notify/index.ts
@@ -66,7 +66,7 @@ const sendEmail = async (
       expiryDate?: string;
     } = { message: "Success" };
     if (template === "expiry")
-      softDeleteSession(config.personalisation.sessionId!);
+      await softDeleteSession(config.personalisation.sessionId!);
     if (template === "save")
       returnValue.expiryDate = config.personalisation.expiryDate;
     return returnValue;

--- a/api.planx.uk/modules/admin/session/bops.test.ts
+++ b/api.planx.uk/modules/admin/session/bops.test.ts
@@ -37,6 +37,18 @@ describe("BOPS payload admin endpoint", () => {
       .expect(403);
   });
 
+  it("returns an error if the BOPS payload generation fails", async () => {
+    mockGenerateBOPSPayload.mockRejectedValueOnce("Error!");
+
+    await supertest(app)
+      .get(endpoint`123`)
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(500)
+      .then((res) => {
+        expect(res.body.error).toMatch(/Failed to get BOPS payload/);
+      });
+  });
+
   it("returns a JSON payload", async () => {
     await supertest(app)
       .get(endpoint`123`)

--- a/api.planx.uk/modules/admin/session/digitalPlanningData.test.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.test.ts
@@ -40,6 +40,22 @@ describe("Digital Planning Application payload admin endpoint", () => {
       .expect(403);
   });
 
+  it("returns an error if the XML generation fails", async () => {
+    mockGenerateDigitalPlanningApplicationPayload.mockRejectedValueOnce(
+      "Error!",
+    );
+
+    await supertest(app)
+      .get(endpoint`123`)
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(500)
+      .then((res) => {
+        expect(res.body.error).toMatch(
+          /Failed to make Digital Planning Application payload/,
+        );
+      });
+  });
+
   it("returns a valid JSON payload", async () => {
     await supertest(app)
       .get(endpoint`123`)

--- a/api.planx.uk/modules/admin/session/digitalPlanningData.test.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.test.ts
@@ -40,7 +40,7 @@ describe("Digital Planning Application payload admin endpoint", () => {
       .expect(403);
   });
 
-  it("returns an error if the XML generation fails", async () => {
+  it("returns an error if the Digital Planning payload generation fails", async () => {
     mockGenerateDigitalPlanningApplicationPayload.mockRejectedValueOnce(
       "Error!",
     );

--- a/api.planx.uk/modules/admin/session/oneAppXML.test.ts
+++ b/api.planx.uk/modules/admin/session/oneAppXML.test.ts
@@ -38,6 +38,18 @@ describe("OneApp XML endpoint", () => {
       .expect(403);
   });
 
+  it("returns an error if the XML generation fails", async () => {
+    mockGenerateOneAppXML.mockRejectedValueOnce("Error!");
+
+    await supertest(app)
+      .get(endpoint`123`)
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(500)
+      .then((res) => {
+        expect(res.body.error).toMatch(/Failed to get OneApp XML/);
+      });
+  });
+
   it("returns XML", async () => {
     await supertest(app)
       .get(endpoint`123`)

--- a/api.planx.uk/modules/admin/session/summary.test.ts
+++ b/api.planx.uk/modules/admin/session/summary.test.ts
@@ -39,6 +39,10 @@ describe("Session summary admin endpoint", () => {
       .expect(403);
   });
 
+  it.todo("returns an error if the service fails");
+
+  it.todo("returns an error if the session can't be found");
+
   it("returns JSON", async () => {
     await supertest(app)
       .get(endpoint`abc123`)

--- a/api.planx.uk/modules/admin/session/zip.test.ts
+++ b/api.planx.uk/modules/admin/session/zip.test.ts
@@ -40,4 +40,6 @@ describe("zip data admin endpoint", () => {
       .expect(200)
       .expect("content-type", "application/zip");
   });
+
+  it.todo("returns an error if the service fails");
 });

--- a/api.planx.uk/modules/flows/copyFlowAsPortal/service.ts
+++ b/api.planx.uk/modules/flows/copyFlowAsPortal/service.ts
@@ -7,7 +7,6 @@ import { Flow } from "../../../types";
 const copyPortalAsFlow = async (flowId: string, portalNodeId: string) => {
   // fetch the parent flow data
   const flow = await getFlowData(flowId);
-  if (!flow) throw Error("Unknown flowId");
 
   // confirm that the node id provided is a valid portal
   if (

--- a/api.planx.uk/modules/flows/findReplace/findReplace.test.ts
+++ b/api.planx.uk/modules/flows/findReplace/findReplace.test.ts
@@ -239,6 +239,31 @@ describe("string replacement", () => {
         });
       });
   });
+
+  it("returns an error thrown by the service", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          data: null,
+        },
+      },
+      graphqlErrors: [
+        {
+          message: "Something went wrong",
+        },
+      ],
+    });
+
+    await supertest(app)
+      .post("/flows/1/search?find=designated.monument&replace=monument")
+      .set(auth)
+      .expect(500)
+      .then((res) => {
+        expect(res.body.error).toMatch(/Failed to find and replace/);
+      });
+  });
 });
 
 describe("HTML replacement", () => {

--- a/api.planx.uk/modules/flows/findReplace/service.ts
+++ b/api.planx.uk/modules/flows/findReplace/service.ts
@@ -64,7 +64,6 @@ const findAndReplaceInFlow = async (
   replace?: string,
 ) => {
   const flow = await getFlowData(flowId);
-  if (!flow) throw Error("Unknown flowId");
 
   // Find
   if (!replace) {

--- a/api.planx.uk/modules/flows/publish/publish.test.ts
+++ b/api.planx.uk/modules/flows/publish/publish.test.ts
@@ -153,4 +153,17 @@ describe("publish", () => {
         });
       });
   });
+
+  it("throws an error if user details are missing", async () => {
+    const getStoreMock = jest.spyOn(userContext, "getStore");
+    getStoreMock.mockReturnValue(undefined);
+
+    await supertest(app)
+      .post("/flows/1/publish")
+      .set(auth)
+      .expect(500)
+      .then((res) => {
+        expect(res.body.error).toMatch(/User details missing from request/);
+      });
+  });
 });

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.test.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.test.ts
@@ -133,9 +133,14 @@ describe("Send email endpoint for invite to pay templates", () => {
   });
 
   describe("'Payment Expiry' templates", () => {
-    const _templates = ["payment-expiry", "payment-expiry-agent"];
-    it.todo(
-      "soft deletes the payment_request when a payment expiry email is sent",
-    );
+    const templates = ["payment-expiry", "payment-expiry-agent"];
+
+    for (const template of templates) {
+      describe(`${template} Template`, () => {
+        it.todo(
+          "soft deletes the payment_request when a payment expiry email is sent",
+        );
+      });
+    }
   });
 });

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -38,8 +38,6 @@ const sendSinglePaymentEmail = async ({
       paymentRequestId,
       template,
     );
-    if (!session || !paymentRequest)
-      throw Error(`Invalid payment request: ${paymentRequestId}`);
     const config = await getInviteToPayNotifyConfig(session, paymentRequest);
     const recipient = template.includes("-agent")
       ? session.email

--- a/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
@@ -1,5 +1,11 @@
-import { Team } from "../../../types";
-import { convertSlugToName, getResumeLink } from "./utils";
+import { queryMock } from "../../../tests/graphqlQueryMock";
+import { LowCalSession, LowCalSessionData, Team } from "../../../types";
+import {
+  convertSlugToName,
+  getResumeLink,
+  getSessionDetails,
+  setupEmailEventTriggers,
+} from "./utils";
 
 describe("convertSlugToName util function", () => {
   it("should return the correct value", () => {
@@ -39,5 +45,68 @@ describe("getResumeLink util function", () => {
     const testCase = getResumeLink(session, { slug: "team" } as Team, "flow");
     const expectedResult = "example.com/team/flow/preview?sessionId=123";
     expect(testCase).toEqual(expectedResult);
+  });
+});
+
+describe("getSessionDetails() util function", () => {
+  it("sets defaults for values not in the session", async () => {
+    const result = await getSessionDetails({
+      data: { id: "flowId", passport: { data: {} }, breadcrumbs: {} },
+      id: "abc123",
+      created_at: "2023-01-01",
+      submitted_at: "2023-02-02",
+      has_user_saved: true,
+    } as LowCalSession);
+
+    expect(result.address).toEqual("Address not submitted");
+    expect(result.projectType).toEqual("Project type not submitted");
+  });
+
+  it("defaults to address title if no single line address is present", async () => {
+    const sessionData: LowCalSessionData = {
+      id: "flowId",
+      passport: {
+        data: {
+          _address: {
+            title: "Address title",
+          },
+        },
+      },
+      breadcrumbs: {},
+    };
+
+    const result = await getSessionDetails({
+      data: sessionData,
+      id: "abc123",
+      created_at: "2023-01-01",
+      submitted_at: "2023-02-02",
+      has_user_saved: true,
+    } as LowCalSession);
+
+    expect(result.address).toEqual("Address title");
+  });
+});
+
+describe("setupEmailEventTriggers util function", () => {
+  it("handles GraphQL errors", async () => {
+    queryMock.mockQuery({
+      name: "SetupEmailNotifications",
+      data: {
+        session: {
+          id: "123",
+          hasUserSaved: true,
+        },
+      },
+      variables: {
+        sessionId: "123",
+      },
+      graphqlErrors: [
+        {
+          message: "Something went wrong",
+        },
+      ],
+    });
+
+    await expect(setupEmailEventTriggers("123")).rejects.toThrow();
   });
 });

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -147,7 +147,7 @@ interface SessionDetails {
 /**
  * Parse session details into an object which will be read by email template
  */
-const getSessionDetails = async (
+export const getSessionDetails = async (
   session: LowCalSession,
 ): Promise<SessionDetails> => {
   const passportProtectTypes =
@@ -248,7 +248,7 @@ interface SetupEmailNotifications {
 // Update lowcal_sessions.has_user_saved column to kick-off the setup_lowcal_expiry_events &
 // setup_lowcal_reminder_events event triggers in Hasura
 // Should only run once on initial save of a session
-const setupEmailEventTriggers = async (sessionId: string) => {
+export const setupEmailEventTriggers = async (sessionId: string) => {
   try {
     const mutation = gql`
       mutation SetupEmailNotifications($sessionId: uuid!) {

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
@@ -162,6 +162,15 @@ describe("Data sanitation operations", () => {
       expect(mockRunSQL).toHaveBeenCalled();
       expect(result).toEqual(mockIds);
     });
+
+    it("handles empty responses", async () => {
+      mockRunSQL.mockResolvedValue({
+        result: undefined,
+      });
+      const result = await deleteHasuraEventLogs();
+      expect(mockRunSQL).toHaveBeenCalled();
+      expect(result).toHaveLength(0);
+    });
   });
 
   describe("deleteApplicationFiles", () => {
@@ -187,6 +196,12 @@ describe("Data sanitation operations", () => {
       const fileCount = mockIds.length * filesPerMockSessionCount;
       expect(deletedFiles).toHaveLength(fileCount);
     });
+
+    it("handles missing sessions", async () => {
+      queryMock.mockQuery(mockGetExpiredSessionIdsQuery);
+      mockFindSession.mockResolvedValue(null);
+      await expect(deleteApplicationFiles()).rejects.toThrow();
+    });
   });
 
   describe("deleteHasuraScheduledEventsForSubmittedSessions", () => {
@@ -197,6 +212,15 @@ describe("Data sanitation operations", () => {
       const result = await deleteHasuraScheduledEventsForSubmittedSessions();
       expect(mockRunSQL).toHaveBeenCalled();
       expect(result).toEqual(mockIds);
+    });
+
+    it("handles empty responses", async () => {
+      mockRunSQL.mockResolvedValue({
+        result: undefined,
+      });
+      const result = await deleteHasuraScheduledEventsForSubmittedSessions();
+      expect(mockRunSQL).toHaveBeenCalled();
+      expect(result).toHaveLength(0);
     });
   });
 });

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -100,6 +100,31 @@ export const mockNotFoundSession = {
   },
 };
 
+export const mockLockedSession = {
+  name: "FindSession",
+  data: {
+    sessions: [
+      {
+        lockedAt: "2023-01-02-11.22.33.444444",
+      },
+    ],
+  },
+  variables: {
+    sessionId: "locked-id",
+    email: mockLowcalSession.email,
+  },
+};
+
+export const mockErrorSession = {
+  name: "FindSession",
+  data: {},
+  graphqlErrors: [
+    {
+      message: "Something went wrong",
+    },
+  ],
+};
+
 export const mockGetMostRecentPublishedFlow = (data: Flow["data"]) => ({
   name: "GetMostRecentPublishedFlow",
   data: {

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -174,6 +174,18 @@ export const mockValidateSingleSessionRequest = {
   variables: {
     sessionId: mockLowcalSession.id,
   },
+  matchOnVariables: true,
+};
+
+export const mockValidateSingleSessionRequestMissingSession = {
+  name: "ValidateSingleSessionRequest",
+  data: {
+    flows_by_pk: mockFlow,
+    lowcalSessions: [],
+  },
+  variables: {
+    sessionId: mockLowcalSession.id,
+  },
 };
 
 export const mockSoftDeleteLowcalSession = {
@@ -186,6 +198,7 @@ export const mockSoftDeleteLowcalSession = {
   variables: {
     sessionId: "123",
   },
+  matchOnVariables: true,
 };
 
 export const mockSetupEmailNotifications = {


### PR DESCRIPTION
## What does this PR do?
 - Tidies up a few uncovered branches with test cases following refactors for documentation and stronger enforcing of types
 - Most test cases just cover exception handling, but there's a few others thrown in
 - I see it as a helpful step before trying to take on https://trello.com/c/TfmJiwID/2686-fix-airbrake-error-logging-on-api
 - PR was growing in size so I'll pick up the rest next week - happy for this to be merged upon review


### API test coverage change in https://github.com/theopensystemslab/planx-new/pull/2466 & https://github.com/theopensystemslab/planx-new/pull/2482
| - | Before | After |
|--------|--------|--------|
| Statements | 79.32% | 80.41% | 
| Branches | 50.69% | 55.68% | 
| Functions | 67.88% | 67.88% | 
| Lines | 78.79% | 79.66% | 