### PR TITLE
fix: link math.js documentation in Calculate node modal

### DIFF
--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -1,4 +1,5 @@
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import { TYPES } from "@planx/components/types";
 import {
   EditorProps,
@@ -69,7 +70,11 @@ export default function Component(props: Props) {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Calculate" Icon={ICONS[TYPES.Calculate]} />
+        <ModalSectionContent title="Calculate" Icon={ICONS[TYPES.Calculate]}>
+          <Typography variant="body2">
+            This component does math! Write formulas using <a href="https://mathjs.org/index.html" target="_blank">Math.js</a>, omitting the <code>math.</code> prefix
+          </Typography>
+        </ModalSectionContent>
         <ModalSectionContent title="Output">
           <InputRow>
             <Input


### PR DESCRIPTION
Quick & simple for now - I'd love to take a pass at all components sometime in the future :art: 
![Screenshot from 2023-11-20 19-55-07](https://github.com/theopensystemslab/planx-new/assets/5132349/e95644f3-5369-4bc7-8fa6-6c2fe1c59f91)
