### PR TITLE
Revert "chore: Stream S3 files directly to zip"

### DIFF
--- a/api.planx.uk/modules/send/utils/exportZip.test.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.test.ts
@@ -7,6 +7,7 @@ jest.mock("fs", () => ({
   existsSync: () => true,
   unlinkSync: () => undefined,
   createWriteStream: () => undefined,
+  writeFileSync: () => undefined,
   rmSync: () => undefined,
 }));
 

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -197,7 +197,9 @@ export class ExportZip {
       throw new Error("file not found");
     }
     const filePath = path.join(this.tmpDir, name);
-    this.zip.addFile(filePath, body as Buffer);
+    fs.writeFileSync(filePath, body as Buffer);
+    this.zip.addLocalFile(filePath);
+    fs.unlinkSync(filePath);
   }
 
   toBuffer(): Buffer {


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2380 - building this pizza again to see if it introduced issue described here (**update: it did**): https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1700561792278499

Fixes issue where user-uploaded files appear not to be included in zip reported in #help-issues. On production, I can still see a `/tmp` folder &rarr; `{sessionId}_{s3FolderId}` folder &rarr; user uploaded files, but it sounds like for MS users the `/tmp` folder is being hidden altogether ! 

This one was a small tidy up without major performance impacts, so just going to revert & deploy fix for now & will add a Trello ticket to pick back up and solve properly :ok_hand: 