### PR TITLE
feat: Simple styling for editor console

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -49,7 +49,7 @@ const DebugConsole = () => {
     ],
   );
   return (
-    <Console>
+    <Console borderTop={2} borderColor="border.main" bgcolor="background.paper">
       <Typography variant="body2">
         <a
           href={`${process.env.REACT_APP_API_URL}/flows/${flowId}/download-schema`}


### PR DESCRIPTION
## What does this PR do?

Simple one — the debug console toggles in the editor browser preview with no difference in style from the browser background, meaning there is no visual boundary between the two.

PR adds a subtle border and background to create the delineation.

### Preview

Before:
<img width="499" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/ee92788f-b16c-4dd7-b6cd-0f088bfa6656">

After:
<img width="499" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/0d47d5ee-8e78-40ec-b6bc-dd9e44307919">
