### PR TITLE
fix: remove sessionId from URLs

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -16,6 +16,7 @@ import { ApplicationPath, SendEmailPayload } from "types";
 import Input from "ui/Input";
 import InputLabel from "ui/InputLabel";
 import InputRow from "ui/InputRow";
+import { removeSessionIdSearchParamWithoutReloading } from "utils";
 import { object, string } from "yup";
 
 import ReconciliationPage from "./ReconciliationPage";
@@ -215,7 +216,14 @@ const ResumePage: React.FC = () => {
     getInitialEmailValue(route.url.query.email),
   );
   const [paymentRequest, setPaymentRequest] = useState<MinPaymentRequest>();
-  const sessionId = useCurrentRoute().url.query.sessionId;
+
+  // Read the sessionId from the url to validate against
+  const sessionId = route.url.query.sessionId;
+
+  // As the sessionId has been extracted it can now be removed to avoid
+  // unnecessarily exposing it
+  removeSessionIdSearchParamWithoutReloading();
+
   const [reconciliationResponse, setReconciliationResponse] =
     useState<ReconciliationResponse>();
 

--- a/editor.planx.uk/src/pages/Preview/SaveAndReturn.test.tsx
+++ b/editor.planx.uk/src/pages/Preview/SaveAndReturn.test.tsx
@@ -1,5 +1,5 @@
 import Button from "@mui/material/Button";
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { FullStore, vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { axe, setup } from "testUtils";
@@ -65,31 +65,6 @@ describe("Save and Return component", () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-  });
-
-  it("stores the sessionId as part of the URL once an email has been submitted", async () => {
-    const children = <Button>Testing 123</Button>;
-    const { user } = setup(<SaveAndReturn children={children}></SaveAndReturn>);
-
-    const sessionId = getState().sessionId;
-    expect(sessionId).toBeDefined();
-
-    await user.type(screen.getByLabelText("Email address"), "test@test.com");
-    await user.type(
-      screen.getByLabelText("Confirm email address"),
-      "test@test.com",
-    );
-
-    expect(window.location.href).not.toContain("sessionId");
-    expect(window.location.href).not.toContain(sessionId);
-
-    await user.click(screen.getByTestId("continue-button"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Testing 123")).toBeInTheDocument();
-    });
-
-    expect(window.location.href).toContain(`sessionId=${sessionId}`);
   });
 });
 

--- a/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
+++ b/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
@@ -84,20 +84,10 @@ const SaveAndReturn: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const isEmailCaptured = Boolean(useStore((state) => state.saveToEmail));
-  const sessionId = useStore((state) => state.sessionId);
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
-
-  // Setting the URL search param "sessionId" will route the user to ApplicationPath.Resume
-  // Without this the user will need to click the magic link in their email after a refresh
-  const allowResumeOnBrowserRefresh = () => {
-    const url = new URL(window.location.href);
-    url.searchParams.set("sessionId", sessionId);
-    window.history.pushState({}, document.title, url);
-  };
 
   const handleSubmit = (email: string) => {
     useStore.setState({ saveToEmail: email });
-    allowResumeOnBrowserRefresh();
   };
 
   return (

--- a/editor.planx.uk/src/utils.ts
+++ b/editor.planx.uk/src/utils.ts
@@ -62,3 +62,9 @@ export const removeSessionIdSearchParam = () => {
   window.history.pushState({}, document.title, currentURL);
   window.location.reload();
 };
+
+export const removeSessionIdSearchParamWithoutReloading = () => {
+  const currentURL = new URL(window.location.href);
+  currentURL.searchParams.delete("sessionId");
+  window.history.replaceState({}, document.title, currentURL);
+};


### PR DESCRIPTION
## What: 

- On saving an application remove the feature which stored the sessionId in the url
- When a user clicks a link to resume a session, read the sessionId but then remove it from the params

## Why:

- Exposing the sessionId can have security implications



