### PR TITLE
fix: help text pointer overlap

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -47,6 +47,7 @@ const HelpButtonWrapper = styled(Box)(({ theme }) => ({
   width: HelpButtonMinWidth,
   top: "-4px",
   right: "-6px",
+  pointerEvents: "none",
   [theme.breakpoints.up("md")]: {
     width: "80px",
     top: 0,
@@ -72,6 +73,7 @@ export const HelpButton = styled(Button)(({ theme }) => ({
   boxShadow: "none",
   fontSize: "1.125em",
   filter: "drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.5))",
+  pointerEvents: "auto",
   [theme.breakpoints.up("lg")]: {
     minHeight: "48px",
     fontSize: "1.25em",


### PR DESCRIPTION
### What does this PR do?

The updated help text introduced a bug where the help text button container overlaps certain elements. This is caused by an absolute-positioned div that runs along the right-hand-side of the column.

By removing pointer-events from the column and reintroducing it on the button, no content is blocked.

Current example (bug present):
https://editor.planx.dev/testing/test-upload-and-label/preview?analytics=false

Fixed example:
https://2486.planx.pizza/testing/test-upload-and-label/preview?analytics=false