### PR TITLE
feat: track the answers to allow_list questions in analytics_logs

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -21,7 +21,7 @@ type AnalyticsLogDirection =
 
 const allowList = [
   "proposal.projectType",
-  "application.delcaration.connection",
+  "application.declaration.connection",
 ];
 
 export type HelpClickMetadata = Record<string, string>;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -189,6 +189,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
           $node_type: Int
           $node_title: String
           $user_agent: jsonb
+          $node_fn: String
         ) {
           insert_analytics_logs_one(
             object: {
@@ -198,6 +199,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
               metadata: $metadata
               node_type: $node_type
               node_title: $node_title
+              node_fn: $node_fn
             }
           ) {
             id
@@ -211,6 +213,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         metadata: metadata,
         node_type: node?.type,
         node_title: nodeTitle,
+        node_fn: node?.data?.fn || node?.data?.val,
       },
     });
     return result;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -454,7 +454,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   // Relies on being called at a point where the user has answered the Qs on the node.
   function getAllowListAnswers(nodeId: string) {
     const { data } = flow[nodeId];
-    const nodeFn = data?.fn || data?.val || null;
+    const nodeFn = data?.fn || data?.val;
     if (nodeFn && allowList.includes(nodeFn)) {
       const answerIds = breadcrumbs[nodeId]?.answers;
       const answerValues = answerIds?.map((answerId) => {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -80,7 +80,6 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     previewEnvironment,
     flowId,
     flow,
-    previousCard,
   ] = useStore((state) => [
     state.currentCard,
     state.breadcrumbs,
@@ -90,10 +89,11 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     state.previewEnvironment,
     state.id,
     state.flow,
-    state.previousCard,
   ]);
+
   const node = currentCard();
-  const previousNodeId = previousCard(node);
+  const [previousNodeId, setPreviousNodeId] = useState<any>();
+
   const isAnalyticsEnabled =
     new URL(window.location.href).searchParams.get("analytics") !== "false";
   const shouldTrackAnalytics =
@@ -138,6 +138,9 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       if (curLength < prevLength) track("backwards", analyticsId);
 
       setPreviousBreadcrumb(breadcrumbs);
+
+      // Track the id of the previous node for updating allow_list answers
+      setPreviousNodeId(node?.id);
     }
   }, [breadcrumbs]);
 
@@ -180,10 +183,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
 
     if (lastAnalyticsLogId && previousNodeId) {
-      await updateLastLogWithAllowListAnswers(
-        lastAnalyticsLogId,
-        previousNodeId,
-      );
+      updateLastLogWithAllowListAnswers(lastAnalyticsLogId, previousNodeId);
     }
 
     lastAnalyticsLogId = id;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -92,7 +92,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   ]);
 
   const node = currentCard();
-  const [previousNodeId, setPreviousNodeId] = useState<any>();
+  const [previousNodeId, setPreviousNodeId] = useState<string>();
 
   const isAnalyticsEnabled =
     new URL(window.location.href).searchParams.get("analytics") !== "false";
@@ -140,7 +140,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       setPreviousBreadcrumb(breadcrumbs);
 
       // Track the id of the previous node for updating allow_list answers
-      setPreviousNodeId(node?.id);
+      if (node?.id) setPreviousNodeId(node?.id);
     }
   }, [breadcrumbs]);
 
@@ -456,7 +456,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     const { data } = flow[nodeId];
     const nodeFn = data?.fn || data?.val || null;
     if (nodeFn && allowList.includes(nodeFn)) {
-      const answerIds = breadcrumbs[nodeId].answers;
+      const answerIds = breadcrumbs[nodeId]?.answers;
       const answerValues = answerIds?.map((answerId) => {
         return flow[answerId].data.val;
       });

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -57,6 +57,7 @@
     - role: public
       permission:
         columns:
+          - allow_list_answers
           - flow_direction
           - has_clicked_help
           - input_errors

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -51,6 +51,7 @@
           - analytics_id
           - created_at
           - id
+          - node_fn
           - user_exit
         filter: {}
   update_permissions:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -40,6 +40,7 @@
           - id
           - input_errors
           - metadata
+          - node_fn
           - node_title
           - node_type
           - user_exit

--- a/hasura.planx.uk/migrations/1700844043138_alter_table_public_analytics_logs_add_column_node_fn/down.sql
+++ b/hasura.planx.uk/migrations/1700844043138_alter_table_public_analytics_logs_add_column_node_fn/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."analytics_logs" drop column "node_fn";

--- a/hasura.planx.uk/migrations/1700844043138_alter_table_public_analytics_logs_add_column_node_fn/up.sql
+++ b/hasura.planx.uk/migrations/1700844043138_alter_table_public_analytics_logs_add_column_node_fn/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."analytics_logs" add column "node_fn" text
+ null;

--- a/hasura.planx.uk/migrations/1700845956731_alter_table_public_analytics_logs_add_column_allow_list_answers/down.sql
+++ b/hasura.planx.uk/migrations/1700845956731_alter_table_public_analytics_logs_add_column_allow_list_answers/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."analytics_logs" drop column "allow_list_answers";

--- a/hasura.planx.uk/migrations/1700845956731_alter_table_public_analytics_logs_add_column_allow_list_answers/up.sql
+++ b/hasura.planx.uk/migrations/1700845956731_alter_table_public_analytics_logs_add_column_allow_list_answers/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."analytics_logs" add column "allow_list_answers" jsonb
+ null default '[]'::jsonb;


### PR DESCRIPTION
## What:

- Passport variable tracking:
  - Begin tracking the `fn` or `val` of a `node` 
  - Store this data against a new column `node_fn` on the `analytics_logs`

- Answers to allow_list question tracking:
  - Defined a new array of questions which are part of the allow_list (i.e. useful for analytics but not sensitive and or PII)
  - On component transition check whether the `node` `fn` or `val` is in the allow list and if so update the log with the user's answer
  
## Why:

- Currently, node are generally identified in analytics by their `node_title` and `node_type`.
- This is useful information but there may be situations where it's usefully to additionally know their `fn` or `val` if they're assigned
- For example the `node_title` code change but we could easily continue to track via the passport variable which is unlikely to change
- Also, some questions in flowd could provide really useful insights to users but also not contain any PII or be invasive to track
- These questions are harmless to track and hence could be on the `allow_list` 

## Screen recoding

https://github.com/theopensystemslab/planx-new/assets/36415632/7994f4f7-0d14-49b5-8673-61d91adee213

## Note

- At the moment this only really works as a user goes forward in a flow. Do we need to track a user going backwards?
- There are analytics_logs records created going backwards so even if a user has completed an answer for `proposal.projectType` that wouldn't be stored on the analytics_log which was generated on hitting `Back`
- Would it make sense to track this when going backwards? 
