### PR TITLE
fix: get team from store, not route data, to display permissions icons in Editor

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -249,7 +249,7 @@ const Breadcrumbs: React.FC = () => {
       )}
       {route.data.flow && (
         <>
-          {useStore.getState().canUserEditTeam(route.data.team) ? (
+          {useStore.getState().canUserEditTeam(team.slug) ? (
             <Edit />
           ) : (
             <Visibility />
@@ -400,9 +400,10 @@ const EditorToolbar: React.FC<{
 }> = ({ headerRef, route }) => {
   const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
-  const [togglePreview, user] = useStore((state) => [
+  const [togglePreview, user, team] = useStore((state) => [
     state.togglePreview,
     state.getUser(),
+    state.getTeam(),
   ]);
 
   const handleClose = () => {
@@ -506,7 +507,7 @@ const EditorToolbar: React.FC<{
             )}
 
             {/* Only show global settings link from top-level admin view */}
-            {!route.data.flow && !route.data.team && (
+            {!route.data.flow && !team.slug && (
               <MenuItem onClick={() => navigate("/global-settings")}>
                 Global Settings
               </MenuItem>


### PR DESCRIPTION
Fixes bug reported here: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1701170825043769

Underlying permissions were correct, but edit-able teams were showing a view-only icon at the flow level. 

Steps to re-create issue:
- Login into editor as a non-platformAdmin
- At the teams-level, you see the correct icons
- Pick a team you can edit, you see the correct icons for the list of services
- At the graph view of an individual flow, you see the incorrect icon but have the correct permissions