### PR TITLE
feat: Editor styles and layout update

### DIFF
--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -73,7 +73,11 @@ export default function Component(props: Props) {
       <ModalSection>
         <ModalSectionContent title="Calculate" Icon={ICONS[TYPES.Calculate]}>
           <Typography variant="body2">
-            This component does math! Write formulas using <a href="https://mathjs.org/index.html" target="_blank">Math.js</a>, omitting the <code>math.</code> prefix
+            This component does math! Write formulas using{" "}
+            <a href="https://mathjs.org/index.html" target="_blank">
+              Math.js
+            </a>
+            , omitting the <code>math.</code> prefix
           </Typography>
         </ModalSectionContent>
         <ModalSectionContent title="Output">
@@ -82,6 +86,7 @@ export default function Component(props: Props) {
               required
               placeholder="output data field"
               name="output"
+              format="data"
               value={formik.values.output}
               onChange={formik.handleChange}
             />

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -146,7 +146,7 @@ const OptionEditor: React.FC<{
 
 const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
   return (
-    <ModalSectionContent title="Options">
+    <ModalSectionContent subtitle="Options">
       {formik.values.groupedOptions ? (
         <Box>
           {formik.values.groupedOptions.map(

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -18,7 +18,7 @@ export type Props = EditorProps<TYPES.Confirmation, Confirmation>;
 
 function StepEditor(props: ListManagerEditorProps<Step>) {
   return (
-    <Box>
+    <Box width="100%">
       <InputRow>
         <Input
           required

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
@@ -65,6 +65,7 @@ function DrawBoundaryComponent(props: Props) {
               <Input
                 name="dataFieldBoundary"
                 placeholder=""
+                format="data"
                 value={formik.values.dataFieldBoundary}
                 onChange={formik.handleChange}
               />
@@ -75,6 +76,7 @@ function DrawBoundaryComponent(props: Props) {
               <Input
                 name="dataFieldArea"
                 placeholder="property.boundary.area"
+                format="data"
                 value={formik.values.dataFieldArea}
                 onChange={formik.handleChange}
               />

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -150,6 +150,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
         <Input
           required
           name="fn"
+          format="data"
           value={props.value.fn}
           onChange={(e) =>
             props.onChange(merge(props.value, { fn: e.target.value }))

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -47,7 +47,7 @@ const InternalPortalForm: React.FC<{
   return (
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">
       <div>
-        <label htmlFor="flowId">Create new internal portal: </label>
+        <label htmlFor="portalFlowId">Create new internal portal: </label>
         <InputField
           name="text"
           onChange={formik.handleChange}
@@ -55,7 +55,7 @@ const InternalPortalForm: React.FC<{
           rows={2}
           value={formik.values.text}
           disabled={!!formik.values.flowId}
-          id="flowId"
+          id="portalFlowId"
           // required={!formik.values.flowId} (was ignored by @testing-library?)
         />
         {formik.errors.text && <FormError message={formik.errors.text} />}

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -47,7 +47,7 @@ const InternalPortalForm: React.FC<{
   return (
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">
       <div>
-        Create new internal portal:{" "}
+        <label htmlFor="flowId">Create new internal portal: </label>
         <InputField
           name="text"
           onChange={formik.handleChange}
@@ -55,6 +55,7 @@ const InternalPortalForm: React.FC<{
           rows={2}
           value={formik.values.text}
           disabled={!!formik.values.flowId}
+          id="flowId"
           // required={!formik.values.flowId} (was ignored by @testing-library?)
         />
         {formik.errors.text && <FormError message={formik.errors.text} />}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
@@ -53,6 +53,7 @@ function PlanningConstraintsComponent(props: Props) {
           <InputGroup label="Planning constraints data field">
             <InputRow>
               <Input
+                format="data"
                 name="fn"
                 placeholder={formik.values.fn}
                 value={formik.values.fn}

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -44,7 +44,7 @@ const OptionEditor: React.FC<{
       {props.value.id && (
         <input type="hidden" value={props.value.id} readOnly />
       )}
-      <InputRowItem width="50%">
+      <InputRowItem width="100%">
         <Input
           // required
           format="bold"
@@ -86,6 +86,7 @@ const OptionEditor: React.FC<{
             },
           });
         }}
+        sx={{ width: "160px", maxWidth: "160px" }}
       />
     </InputRow>
     <InputRow>
@@ -210,7 +211,7 @@ export const Question: React.FC<Props> = (props) => {
           </InputGroup>
         </ModalSectionContent>
 
-        <ModalSectionContent title="Options">
+        <ModalSectionContent subtitle="Options">
           <ListManager
             values={formik.values.options}
             onChange={(newOptions) => {

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -91,7 +91,6 @@ const OptionEditor: React.FC<{
     </InputRow>
     <InputRow>
       <Input
-        format="data"
         value={props.value.data.description || ""}
         placeholder="Description"
         onChange={(ev) => {

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,8 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["DISABLE_SAVE_AND_RETURN"] as const;
+const AVAILABLE_FEATURE_FLAGS = [
+  "DISABLE_SAVE_AND_RETURN",
+  "SHOW_TEAM_SETTINGS",
+] as const;
 
 type featureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import ColorPicker from "ui/ColorPicker";
 import EditorRow from "ui/EditorRow";
 import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
-import InputCaption from "ui/InputCaption";
+import InputDescription from "ui/InputDescription";
 import InputGroup from "ui/InputGroup";
 import InputLegend from "ui/InputLegend";
 import InputRow from "ui/InputRow";
@@ -45,13 +45,15 @@ const DesignSettings: React.FC = () => {
           <EditorRow background>
             <InputGroup flowSpacing>
               <InputLegend>Theme colour</InputLegend>
-              <InputCaption>
+              <InputDescription>
                 Set the theme colour. The theme colour should be a dark colour
                 that contrasts with white ("#ffffff").
-              </InputCaption>
-              <Link variant="body2" href="https://www.planx.uk">
-                See our guide for setting theme colours
-              </Link>
+              </InputDescription>
+              <InputDescription>
+                <Link href="https://www.planx.uk">
+                  See our guide for setting theme colours
+                </Link>
+              </InputDescription>
               <InputRow>
                 <InputRowItem>
                   <ColorPicker
@@ -66,14 +68,14 @@ const DesignSettings: React.FC = () => {
           <EditorRow background>
             <InputGroup flowSpacing>
               <InputLegend>Logo</InputLegend>
-              <InputCaption>
+              <InputDescription>
                 Set the logo to be used in the header of the service. The logo
                 should contrast with a dark background colour and have a
                 transparent background.
-              </InputCaption>
-              <Link variant="body2" href="https://www.planx.uk">
-                See our guide for logos
-              </Link>
+              </InputDescription>
+              <InputDescription>
+                <Link href="https://www.planx.uk">See our guide for logos</Link>
+              </InputDescription>
               <InputRow>
                 <InputRowLabel>Logo:</InputRowLabel>
                 <InputRowItem width={50}>
@@ -93,13 +95,15 @@ const DesignSettings: React.FC = () => {
           <EditorRow background>
             <InputGroup flowSpacing>
               <InputLegend>Favicon</InputLegend>
-              <InputCaption>
+              <InputDescription>
                 Set the favicon to be used in the browser tab. The favicon
                 should be 32x32px and in .ico or .png format.
-              </InputCaption>
-              <Link variant="body2" href="https://www.planx.uk">
-                See our guide for favicons
-              </Link>
+              </InputDescription>
+              <InputDescription>
+                <Link href="https://www.planx.uk">
+                  See our guide for favicons
+                </Link>
+              </InputDescription>
               <InputRow>
                 <InputRowLabel>Favicon:</InputRowLabel>
                 <InputRowItem width={50}>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -2,9 +2,11 @@ import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
+import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import ColorPicker from "ui/ColorPicker";
 import EditorRow from "ui/EditorRow";
+import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
 import InputCaption from "ui/InputCaption";
 import InputGroup from "ui/InputGroup";
 import InputLegend from "ui/InputLegend";
@@ -22,6 +24,8 @@ const DesignSettings: React.FC = () => {
     validate: () => {},
   });
 
+  const isUsingFeatureFlag = () => hasFeatureFlag("SHOW_TEAM_SETTINGS");
+
   return (
     <form onSubmit={formik.handleSubmit}>
       <EditorRow>
@@ -32,88 +36,93 @@ const DesignSettings: React.FC = () => {
           How your service appears to public users
         </Typography>
       </EditorRow>
-      <EditorRow background>
-        <InputGroup flowSpacing>
-          <InputLegend>Theme colour</InputLegend>
-          <InputCaption>
-            Set the theme colour. The theme colour should be a dark colour that
-            contrasts with white ("#ffffff").
-          </InputCaption>
-          <Link variant="body2" href="https://www.planx.uk">
-            See our guide for setting theme colours
-          </Link>
-          <InputRow>
-            <InputRowItem>
-              <ColorPicker
-                color={formik.values.bgColor}
-                onChange={(color) => formik.setFieldValue("bgColor", color)}
-                label="Theme colour"
-              />
-            </InputRowItem>
-          </InputRow>
-        </InputGroup>
-      </EditorRow>
-
-      <EditorRow background>
-        <InputGroup flowSpacing>
-          <InputLegend>Logo</InputLegend>
-          <InputCaption>
-            Set the logo to be used in the header of the service. The logo
-            should contrast with a dark background colour and have a transparent
-            background.
-          </InputCaption>
-          <Link variant="body2" href="https://www.planx.uk">
-            See our guide for logos
-          </Link>
-          <InputRow>
-            <InputRowLabel>Logo:</InputRowLabel>
-            <InputRowItem width={50}>
-              <PublicFileUploadButton />
-            </InputRowItem>
-            <Typography
-              color="text.secondary"
-              variant="body2"
-              pl={2}
-              alignSelf="center"
-            >
-              .png or .svg
-            </Typography>
-          </InputRow>
-        </InputGroup>
-      </EditorRow>
-
-      <EditorRow background>
-        <InputGroup flowSpacing>
-          <InputLegend>Favicon</InputLegend>
-          <InputCaption>
-            Set the favicon to be used in the browser tab. The favicon should be
-            32x32px and in .ico or .png format.
-          </InputCaption>
-          <Link variant="body2" href="https://www.planx.uk">
-            See our guide for favicons
-          </Link>
-          <InputRow>
-            <InputRowLabel>Favicon:</InputRowLabel>
-            <InputRowItem width={50}>
-              <PublicFileUploadButton />
-            </InputRowItem>
-            <Typography
-              color="text.secondary"
-              variant="body2"
-              pl={2}
-              alignSelf="center"
-            >
-              .ico or .png
-            </Typography>
-          </InputRow>
-        </InputGroup>
-      </EditorRow>
-
-      <EditorRow>
-        <Button type="submit" variant="contained" color="primary">
-          Update design settings
-        </Button>
-      </EditorRow>
+      {!isUsingFeatureFlag() ? (
+        <EditorRow>
+          <FeaturePlaceholder title="Feature in development" />{" "}
+        </EditorRow>
+      ) : (
+        <>
+          <EditorRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Theme colour</InputLegend>
+              <InputCaption>
+                Set the theme colour. The theme colour should be a dark colour
+                that contrasts with white ("#ffffff").
+              </InputCaption>
+              <Link variant="body2" href="https://www.planx.uk">
+                See our guide for setting theme colours
+              </Link>
+              <InputRow>
+                <InputRowItem>
+                  <ColorPicker
+                    color={formik.values.bgColor}
+                    onChange={(color) => formik.setFieldValue("bgColor", color)}
+                    label="Theme colour"
+                  />
+                </InputRowItem>
+              </InputRow>
+            </InputGroup>
+          </EditorRow>
+          <EditorRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Logo</InputLegend>
+              <InputCaption>
+                Set the logo to be used in the header of the service. The logo
+                should contrast with a dark background colour and have a
+                transparent background.
+              </InputCaption>
+              <Link variant="body2" href="https://www.planx.uk">
+                See our guide for logos
+              </Link>
+              <InputRow>
+                <InputRowLabel>Logo:</InputRowLabel>
+                <InputRowItem width={50}>
+                  <PublicFileUploadButton />
+                </InputRowItem>
+                <Typography
+                  color="text.secondary"
+                  variant="body2"
+                  pl={2}
+                  alignSelf="center"
+                >
+                  .png or .svg
+                </Typography>
+              </InputRow>
+            </InputGroup>
+          </EditorRow>
+          <EditorRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Favicon</InputLegend>
+              <InputCaption>
+                Set the favicon to be used in the browser tab. The favicon
+                should be 32x32px and in .ico or .png format.
+              </InputCaption>
+              <Link variant="body2" href="https://www.planx.uk">
+                See our guide for favicons
+              </Link>
+              <InputRow>
+                <InputRowLabel>Favicon:</InputRowLabel>
+                <InputRowItem width={50}>
+                  <PublicFileUploadButton />
+                </InputRowItem>
+                <Typography
+                  color="text.secondary"
+                  variant="body2"
+                  pl={2}
+                  alignSelf="center"
+                >
+                  .ico or .png
+                </Typography>
+              </InputRow>
+            </InputGroup>
+          </EditorRow>
+          <EditorRow>
+            <Button type="submit" variant="contained" color="primary">
+              Update design settings
+            </Button>
+          </EditorRow>
+        </>
+      )}
     </form>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -1,23 +1,119 @@
-import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
+import { useFormik } from "formik";
 import React from "react";
-import { FeaturePlaceholder } from "ui/FeaturePlaceholder";
+import ColorPicker from "ui/ColorPicker";
+import EditorRow from "ui/EditorRow";
+import InputCaption from "ui/InputCaption";
+import InputGroup from "ui/InputGroup";
+import InputLegend from "ui/InputLegend";
+import InputRow from "ui/InputRow";
+import InputRowItem from "ui/InputRowItem";
+import InputRowLabel from "ui/InputRowLabel";
+import PublicFileUploadButton from "ui/PublicFileUploadButton";
 
 const DesignSettings: React.FC = () => {
+  const formik = useFormik<{ bgColor: string }>({
+    initialValues: {
+      bgColor: "#000",
+    },
+    onSubmit: () => {},
+    validate: () => {},
+  });
+
   return (
-    <>
-      <Box>
+    <form onSubmit={formik.handleSubmit}>
+      <EditorRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Design
         </Typography>
         <Typography variant="body1">
           How your service appears to public users
         </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
-      </Box>
-    </>
+      </EditorRow>
+      <EditorRow>
+        <InputGroup flowSpacing>
+          <InputLegend>Theme colour</InputLegend>
+          <InputCaption>
+            Set the theme colour. The theme colour should be a dark colour that
+            contrasts with white ("#ffffff").
+          </InputCaption>
+          <Link variant="body2" href="https://www.planx.uk">
+            See our guide for setting theme colours
+          </Link>
+          <InputRow>
+            <InputRowItem>
+              <ColorPicker
+                color={formik.values.bgColor}
+                onChange={(color) => formik.setFieldValue("bgColor", color)}
+                label="Theme colour"
+              />
+            </InputRowItem>
+          </InputRow>
+        </InputGroup>
+      </EditorRow>
+
+      <EditorRow>
+        <InputGroup flowSpacing>
+          <InputLegend>Logo</InputLegend>
+          <InputCaption>
+            Set the logo to be used in the header of the service.
+          </InputCaption>
+          <Link variant="body2" href="https://www.planx.uk">
+            See our guide for logos
+          </Link>
+          <InputRow>
+            <InputRowLabel>Logo:</InputRowLabel>
+            <InputRowItem width={50}>
+              <PublicFileUploadButton />
+            </InputRowItem>
+            <Typography
+              color="text.secondary"
+              variant="body2"
+              pl={2}
+              alignSelf="center"
+            >
+              .png or .svg
+            </Typography>
+          </InputRow>
+        </InputGroup>
+      </EditorRow>
+
+      <EditorRow>
+        <InputGroup flowSpacing>
+          <InputLegend>Favicon</InputLegend>
+          <InputCaption>
+            Set the favicon to be used in the browser tab. The favicon should be
+            32x32px and in .ico or .png format.
+          </InputCaption>
+          <Link variant="body2" href="https://www.planx.uk">
+            See our guide for favicons
+          </Link>
+          <InputRow>
+            <InputRowLabel>Favicon:</InputRowLabel>
+            <InputRowItem width={50}>
+              <PublicFileUploadButton />
+            </InputRowItem>
+            <Typography
+              color="text.secondary"
+              variant="body2"
+              pl={2}
+              alignSelf="center"
+            >
+              .ico or .png
+            </Typography>
+          </InputRow>
+        </InputGroup>
+      </EditorRow>
+
+      <EditorRow>
+        <Button type="submit" variant="contained" color="primary">
+          Update design settings
+        </Button>
+      </EditorRow>
+    </form>
   );
 };
+
 export default DesignSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -32,7 +32,7 @@ const DesignSettings: React.FC = () => {
           How your service appears to public users
         </Typography>
       </EditorRow>
-      <EditorRow>
+      <EditorRow background>
         <InputGroup flowSpacing>
           <InputLegend>Theme colour</InputLegend>
           <InputCaption>
@@ -54,7 +54,7 @@ const DesignSettings: React.FC = () => {
         </InputGroup>
       </EditorRow>
 
-      <EditorRow>
+      <EditorRow background>
         <InputGroup flowSpacing>
           <InputLegend>Logo</InputLegend>
           <InputCaption>
@@ -80,7 +80,7 @@ const DesignSettings: React.FC = () => {
         </InputGroup>
       </EditorRow>
 
-      <EditorRow>
+      <EditorRow background>
         <InputGroup flowSpacing>
           <InputLegend>Favicon</InputLegend>
           <InputCaption>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -58,7 +58,9 @@ const DesignSettings: React.FC = () => {
         <InputGroup flowSpacing>
           <InputLegend>Logo</InputLegend>
           <InputCaption>
-            Set the logo to be used in the header of the service.
+            Set the logo to be used in the header of the service. The logo
+            should contrast with a dark background colour and have a transparent
+            background.
           </InputCaption>
           <Link variant="body2" href="https://www.planx.uk">
             See our guide for logos

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -4,8 +4,10 @@ import Switch, { SwitchProps } from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import React from "react";
+import EditorRow from "ui/EditorRow";
 import Input, { Props as InputProps } from "ui/Input";
 import InputGroup from "ui/InputGroup";
+import InputLegend from "ui/InputLegend";
 import InputRow from "ui/InputRow";
 import InputRowItem from "ui/InputRowItem";
 import RichTextInput from "ui/RichTextInput";
@@ -29,8 +31,8 @@ const TextInput: React.FC<{
   contentInputProps,
 }) => {
   return (
-    <Box mb={2} width="100%">
-      <Box my={2} display="flex" alignItems="center">
+    <Box width="100%">
+      <Box mb={2} display="flex" alignItems="center">
         <Switch {...switchProps} color="primary" />
         <Typography variant="h4" component="h5">
           {title}
@@ -98,15 +100,15 @@ const ServiceSettings: React.FC = () => {
 
   return (
     <form onSubmit={formik.handleSubmit}>
-      <Box pb={3} borderBottom={1}>
+      <EditorRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Elements
         </Typography>
         <Typography variant="body1">
           Manage the features that users will be able to see
         </Typography>
-      </Box>
-      <Box borderBottom={1} pb={3}>
+      </EditorRow>
+      <EditorRow background>
         <TextInput
           title="Legal Disclaimer"
           description="Displayed before a user submits their application"
@@ -126,61 +128,61 @@ const ServiceSettings: React.FC = () => {
             onChange: formik.handleChange,
           }}
         />
-      </Box>
-      <Box pt={2}>
-        <Typography variant="h3" component="h4">
-          <strong>Footer Links</strong>
-        </Typography>
-        <InputGroup>
-          <TextInput
-            title="Help Page"
-            richText
-            description="A place to communicate FAQs, useful tips, or contact information"
-            switchProps={{
-              name: "elements.help.show",
-              checked: formik.values.elements?.help?.show,
-              onChange: formik.handleChange,
-            }}
-            headingInputProps={{
-              name: "elements.help.heading",
-              value: formik.values.elements?.help?.heading,
-              onChange: formik.handleChange,
-            }}
-            contentInputProps={{
-              name: "elements.help.content",
-              value: formik.values.elements?.help?.content,
-              onChange: formik.handleChange,
-            }}
-          />
-
-          <TextInput
-            title="Privacy Page"
-            richText
-            description="Your privacy policy"
-            switchProps={{
-              name: "elements.privacy.show",
-              checked: formik.values.elements?.privacy?.show,
-              onChange: formik.handleChange,
-            }}
-            headingInputProps={{
-              name: "elements.privacy.heading",
-              value: formik.values.elements?.privacy?.heading,
-              onChange: formik.handleChange,
-            }}
-            contentInputProps={{
-              name: "elements.privacy.content",
-              value: formik.values.elements?.privacy?.content,
-              onChange: formik.handleChange,
-            }}
-          />
+      </EditorRow>
+      <EditorRow background>
+        <InputGroup flowSpacing>
+          <InputLegend>Footer Links</InputLegend>
+          <InputRow>
+            <TextInput
+              title="Help Page"
+              richText
+              description="A place to communicate FAQs, useful tips, or contact information"
+              switchProps={{
+                name: "elements.help.show",
+                checked: formik.values.elements?.help?.show,
+                onChange: formik.handleChange,
+              }}
+              headingInputProps={{
+                name: "elements.help.heading",
+                value: formik.values.elements?.help?.heading,
+                onChange: formik.handleChange,
+              }}
+              contentInputProps={{
+                name: "elements.help.content",
+                value: formik.values.elements?.help?.content,
+                onChange: formik.handleChange,
+              }}
+            />
+          </InputRow>
+          <InputRow>
+            <TextInput
+              title="Privacy Page"
+              richText
+              description="Your privacy policy"
+              switchProps={{
+                name: "elements.privacy.show",
+                checked: formik.values.elements?.privacy?.show,
+                onChange: formik.handleChange,
+              }}
+              headingInputProps={{
+                name: "elements.privacy.heading",
+                value: formik.values.elements?.privacy?.heading,
+                onChange: formik.handleChange,
+              }}
+              contentInputProps={{
+                name: "elements.privacy.content",
+                value: formik.values.elements?.privacy?.content,
+                onChange: formik.handleChange,
+              }}
+            />
+          </InputRow>
         </InputGroup>
-
-        <Box py={2} justifyContent="flex-end" mb={4}>
-          <Button type="submit" variant="contained" color="primary">
-            Save
-          </Button>
-        </Box>
-      </Box>
+      </EditorRow>
+      <EditorRow>
+        <Button type="submit" variant="contained" color="primary">
+          Update elements
+        </Button>
+      </EditorRow>
     </form>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -56,10 +56,11 @@ interface LinkTabProps {
   href?: string;
 }
 
-const StyledTab = styled(Tab)(() => ({
+const StyledTab = styled(Tab)(({ theme }) => ({
   position: "relative",
   zIndex: 1,
   textTransform: "none",
+  background: theme.palette.background.default,
 })) as typeof Tab;
 
 function LinkTab(props: LinkTabProps) {
@@ -84,16 +85,16 @@ const classes = {
   tabIndicator: `${PREFIX}-tabIndicator`,
 };
 
-const Root = styled(Box)(() => ({
+const Root = styled(Box)(({ theme }) => ({
   flexGrow: 1,
-  backgroundColor: "#f2f2f2",
+  backgroundColor: theme.palette.background.default,
   position: "absolute",
   top: HEADER_HEIGHT,
   left: 0,
   right: 0,
   minHeight: `calc(100% - ${HEADER_HEIGHT}px)`,
   [`& .${classes.tabs}`]: {
-    backgroundColor: "#ddd",
+    backgroundColor: theme.palette.border.main,
   },
   [`& .${classes.tabIndicator}`]: {
     height: "100%",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -36,7 +36,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Container maxWidth="sm" disableGutters>
+        <Container maxWidth="formWrap" disableGutters>
           <Box py={7}>{children}</Box>
         </Container>
       )}

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -21,15 +21,19 @@ import { useStore } from "../../lib/store";
 const StyledDialog = styled(Dialog)(({ theme }) => ({
   // Target all modal sections (the direct child is the backdrop, hence the double child selector)
   "& > * > *": {
-    backgroundColor: theme.palette.grey[100],
+    backgroundColor: theme.palette.background.paper,
   },
 }));
 
 const CloseButton = styled(IconButton)(({ theme }) => ({
-  float: "right",
-  margin: 0,
-  padding: 0,
+  margin: "0 0 0 auto",
+  padding: theme.spacing(1),
   color: theme.palette.grey[600],
+}));
+
+const TypeSelect = styled("select")(() => ({
+  fontSize: "1em",
+  padding: "0.25em",
 }));
 
 const NodeTypeSelect: React.FC<{
@@ -37,7 +41,7 @@ const NodeTypeSelect: React.FC<{
   onChange: (newValue: string) => void;
 }> = (props) => {
   return (
-    <select
+    <TypeSelect
       value={fromSlug(props.value)}
       onChange={(ev) => {
         props.onChange(ev.target.value);
@@ -85,7 +89,7 @@ const NodeTypeSelect: React.FC<{
       <optgroup label="Outputs">
         <option value={TYPES.Send}>Send</option>
       </optgroup>
-    </select>
+    </TypeSelect>
   );
 };
 
@@ -120,7 +124,14 @@ const FormModal: React.FC<{
       disableScrollLock
       onClose={handleClose}
     >
-      <DialogTitle>
+      <DialogTitle
+        sx={{
+          py: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
         {!handleDelete && (
           <NodeTypeSelect
             value={type}

--- a/editor.planx.uk/src/ui/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/ColorPicker.tsx
@@ -24,7 +24,6 @@ const Root = styled(Box, {
   display: "flex",
   alignItems: "center",
   ...(inline && {
-    height: 50,
     padding: theme.spacing(2, 0),
     "& .popover": {
       top: "calc(100% - 4px)",
@@ -32,15 +31,14 @@ const Root = styled(Box, {
   }),
 }));
 
-const Swatch = styled(Box)(() => ({
+const Swatch = styled(Box)(({ theme }) => ({
   background: "#fff",
   display: "inline-block",
   cursor: "pointer",
-  position: "absolute",
-  top: 0,
-  left: 0,
-  width: 18,
-  height: 18,
+  marginRight: theme.spacing(1),
+  width: 24,
+  height: 24,
+  border: `2px solid ${theme.palette.border.input}`,
 }));
 
 const Cover = styled(ButtonBase)(() => ({
@@ -64,11 +62,12 @@ const StyledButtonBase = styled(ButtonBase, {
   fontFamily: "inherit",
   fontSize: 15,
   position: "relative",
-  display: "block",
+  display: "flex",
+  alignItems: "center",
   textAlign: "left",
-  paddingLeft: theme.spacing(4),
-  paddingRight: theme.spacing(2),
+  padding: theme.spacing(1, 2),
   whiteSpace: "nowrap",
+  backgroundColor: theme.palette.common.white,
   ...(show && {
     color: theme.palette.primary.dark,
     "& .swatch": {
@@ -94,7 +93,7 @@ export default function ColorPicker(props: Props): FCReturn {
 
   return (
     <Root inline={props.inline}>
-      <Typography mr={2} variant="body2">
+      <Typography mr={2} variant="body2" component="label">
         {props.label || "Background colour"}:{" "}
       </Typography>
       <StyledButtonBase show={show} onClick={handleClick} disableRipple>

--- a/editor.planx.uk/src/ui/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/ColorPicker.tsx
@@ -65,9 +65,10 @@ const StyledButtonBase = styled(ButtonBase, {
   display: "flex",
   alignItems: "center",
   textAlign: "left",
-  padding: theme.spacing(1, 2),
+  padding: theme.spacing(1),
   whiteSpace: "nowrap",
   backgroundColor: theme.palette.common.white,
+  border: `1px solid ${theme.palette.border.light}`,
   ...(show && {
     color: theme.palette.primary.dark,
     "& .swatch": {

--- a/editor.planx.uk/src/ui/EditorRow.tsx
+++ b/editor.planx.uk/src/ui/EditorRow.tsx
@@ -1,0 +1,24 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
+import React, { ReactNode } from "react";
+
+const Root = styled(Box)(({ theme }) => ({
+  display: "block",
+  width: "100%",
+  padding: theme.spacing(3, 0),
+  "&:first-of-type": {
+    paddingTop: 0,
+  },
+  "& + &": {
+    borderTop: "1px solid",
+    borderColor: theme.palette.border.main,
+  },
+  "& > * + *": {
+    ...contentFlowSpacing(theme),
+  },
+}));
+
+export default function InputRow({ children }: { children: ReactNode }) {
+  return <Root>{children}</Root>;
+}

--- a/editor.planx.uk/src/ui/EditorRow.tsx
+++ b/editor.planx.uk/src/ui/EditorRow.tsx
@@ -1,24 +1,38 @@
-import Box from "@mui/material/Box";
+import Box, { BoxProps } from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import React, { ReactNode } from "react";
 
-const Root = styled(Box)(({ theme }) => ({
+interface RootProps extends BoxProps {
+  background?: boolean;
+}
+
+const Root = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "background",
+})<RootProps>(({ background, theme }) => ({
   display: "block",
   width: "100%",
-  padding: theme.spacing(3, 0),
+  padding: theme.spacing(2.5),
   "&:first-of-type": {
     paddingTop: 0,
-  },
-  "& + &": {
-    borderTop: "1px solid",
-    borderColor: theme.palette.border.main,
   },
   "& > * + *": {
     ...contentFlowSpacing(theme),
   },
+  ...(background && {
+    background: theme.palette.common.white,
+    marginTop: theme.spacing(2),
+    border: `1px solid #e5e9f2`,
+    filter: `drop-shadow(rgba(0, 0, 0, 0.1) 0px 1px 0px)`,
+  }),
 }));
 
-export default function InputRow({ children }: { children: ReactNode }) {
-  return <Root>{children}</Root>;
+export default function InputRow({
+  children,
+  background,
+}: {
+  children: ReactNode;
+  background?: boolean;
+}) {
+  return <Root background={background}>{children}</Root>;
 }

--- a/editor.planx.uk/src/ui/EditorRow.tsx
+++ b/editor.planx.uk/src/ui/EditorRow.tsx
@@ -12,7 +12,7 @@ const Root = styled(Box, {
 })<RootProps>(({ background, theme }) => ({
   display: "block",
   width: "100%",
-  padding: theme.spacing(2.5),
+  padding: theme.spacing(2.5, 0),
   "&:first-of-type": {
     paddingTop: 0,
   },
@@ -20,10 +20,10 @@ const Root = styled(Box, {
     ...contentFlowSpacing(theme),
   },
   ...(background && {
-    background: theme.palette.common.white,
+    background: theme.palette.background.paper,
     marginTop: theme.spacing(2),
-    border: `1px solid #e5e9f2`,
-    filter: `drop-shadow(rgba(0, 0, 0, 0.1) 0px 1px 0px)`,
+    padding: theme.spacing(2.5),
+    border: `1px solid ${theme.palette.border.light}`,
   }),
 }));
 

--- a/editor.planx.uk/src/ui/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/ImgInput.tsx
@@ -12,16 +12,17 @@ import PublicFileUploadButton from "./PublicFileUploadButton";
 
 const ImageUploadContainer = styled(Box)(() => ({
   height: 50,
-  width: 50,
   position: "relative",
+  flexGrow: 0,
+  display: "flex",
+  flexDirection: "row-reverse",
+  alignItems: "center",
 }));
 
 const StyledIconButton = styled(IconButton)(({ theme }) => ({
-  position: "absolute",
   backgroundColor: "rgba(0, 0, 0, 0.5)",
   color: theme.palette.common.white,
-  top: 0,
-  right: 0,
+  marginLeft: theme.spacing(0.5),
 }));
 
 /** Uploads an image and returns corresponding URL */

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -37,26 +37,36 @@ const StyledInputBase = styled(InputBase, {
   shouldForwardProp: (prop) =>
     !["format", "bordered"].includes(prop.toString()),
 })<StyledInputBase>(({ theme, format, bordered }) => ({
-  backgroundColor: "#fff",
+  backgroundColor: theme.palette.common.white,
   // Maintain 16px minimum input size to prevent zoom on iOS
   fontSize: "1rem",
   width: "100%",
   padding: theme.spacing(0, 1.5),
   height: 50,
+  border: `1px solid ${theme.palette.border.light}`,
   "& input": {
     fontWeight: "inherit",
+  },
+  "& ::placeholder": {
+    color: theme.palette.text.secondary,
+    opacity: "0.5",
+  },
+  "&:focus-within": {
+    border: `1px solid ${theme.palette.border.input}`,
+    boxShadow: `inset 0px 0px 0px 1px ${theme.palette.border.input}`,
+    outline: `3px solid ${theme.palette.action.focus}`,
   },
   ...(bordered && {
     border: `2px solid ${theme.palette.text.primary}`,
   }),
   ...(format === "data" && {
-    backgroundColor: "#fafafa",
+    backgroundColor: theme.palette.common.white,
   }),
   ...(format === "bold" && {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
   }),
   ...(format === "large" && {
-    backgroundColor: "#fff",
+    backgroundColor: theme.palette.common.white,
     height: 50,
     fontSize: 25,
     width: "100%",

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -60,7 +60,7 @@ const StyledInputBase = styled(InputBase, {
     border: `2px solid ${theme.palette.text.primary}`,
   }),
   ...(format === "data" && {
-    backgroundColor: theme.palette.common.white,
+    backgroundColor: theme.palette.background.paper,
   }),
   ...(format === "bold" && {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,

--- a/editor.planx.uk/src/ui/InputCaption.tsx
+++ b/editor.planx.uk/src/ui/InputCaption.tsx
@@ -1,0 +1,17 @@
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React, { ReactNode } from "react";
+
+const Caption = styled(Typography)(({ theme }) => ({
+  width: "100%",
+  textAlign: "left",
+  color: theme.palette.text.secondary,
+})) as typeof Typography;
+
+export default function InputCaption({ children }: { children: ReactNode }) {
+  return (
+    <Caption variant="body2" component="caption">
+      {children}
+    </Caption>
+  );
+}

--- a/editor.planx.uk/src/ui/InputDescription.tsx
+++ b/editor.planx.uk/src/ui/InputDescription.tsx
@@ -2,16 +2,16 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React, { ReactNode } from "react";
 
-const Caption = styled(Typography)(({ theme }) => ({
+const Description = styled(Typography)(({ theme }) => ({
   width: "100%",
   textAlign: "left",
   color: theme.palette.text.secondary,
 })) as typeof Typography;
 
-export default function InputCaption({ children }: { children: ReactNode }) {
-  return (
-    <Caption variant="body2" component="caption">
-      {children}
-    </Caption>
-  );
+export default function InputDescription({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <Description variant="body2">{children}</Description>;
 }

--- a/editor.planx.uk/src/ui/InputField.tsx
+++ b/editor.planx.uk/src/ui/InputField.tsx
@@ -12,7 +12,8 @@ const classes = {
 
 const Root = styled(InputBase)(({ theme }) => ({
   [`&.${classes.root}`]: {
-    backgroundColor: theme.palette.grey[100],
+    backgroundColor: theme.palette.common.white,
+    border: `1px solid ${theme.palette.border.light}`,
     transition: "background-color 0.2s ease-out",
     display: "block",
     width: "100%",

--- a/editor.planx.uk/src/ui/InputGroup.tsx
+++ b/editor.planx.uk/src/ui/InputGroup.tsx
@@ -3,6 +3,7 @@ import DragHandle from "@mui/icons-material/DragHandle";
 import Box, { BoxProps } from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
+import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import React, { PropsWithChildren, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 
@@ -13,12 +14,19 @@ interface Props {
   deleteInputGroup?: any;
   deletable?: boolean;
   draggable?: boolean;
+  flowSpacing?: boolean;
   id?: string;
   index?: number;
   handleMove?: (dragIndex: number, hoverIndex: number) => void;
 }
 
-const Root = styled("fieldset")(({ theme }) => ({
+interface RootProps extends BoxProps {
+  flowSpacing?: boolean;
+}
+
+const Root = styled("fieldset", {
+  shouldForwardProp: (prop) => prop !== "flowSpacing",
+})<RootProps>(({ flowSpacing, theme }) => ({
   border: 0,
   margin: 0,
   padding: 0,
@@ -28,6 +36,11 @@ const Root = styled("fieldset")(({ theme }) => ({
   "& .inputGroup + .inputGroup": {
     marginTop: 0,
   },
+  ...(flowSpacing && {
+    "& > div > * + *": {
+      ...contentFlowSpacing(theme),
+    },
+  }),
 }));
 
 const Label = styled("legend")(({ theme }) => ({
@@ -107,6 +120,7 @@ export default function InputGroup({
   id,
   index = 0,
   handleMove,
+  flowSpacing,
 }: Props): FCReturn {
   const [deleteHover, setDeleteHover] = React.useState(false);
 
@@ -169,7 +183,7 @@ export default function InputGroup({
   if (draggable) drag(drop(ref));
 
   return (
-    <Root ref={ref} className="inputGroup">
+    <Root ref={ref} className="inputGroup" flowSpacing={flowSpacing}>
       {label && <Label>{label}</Label>}
       <Content
         deletable={deletable}

--- a/editor.planx.uk/src/ui/InputGroup.tsx
+++ b/editor.planx.uk/src/ui/InputGroup.tsx
@@ -3,7 +3,6 @@ import DragHandle from "@mui/icons-material/DragHandle";
 import Box, { BoxProps } from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
-import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import React, { PropsWithChildren, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 
@@ -38,7 +37,7 @@ const Root = styled("fieldset", {
   },
   ...(flowSpacing && {
     "& > div > * + *": {
-      ...contentFlowSpacing(theme),
+      marginTop: theme.spacing(1.5),
     },
   }),
 }));

--- a/editor.planx.uk/src/ui/InputGroup.tsx
+++ b/editor.planx.uk/src/ui/InputGroup.tsx
@@ -3,6 +3,7 @@ import DragHandle from "@mui/icons-material/DragHandle";
 import Box, { BoxProps } from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import React, { PropsWithChildren, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 
@@ -42,10 +43,10 @@ const Root = styled("fieldset", {
   }),
 }));
 
-const Label = styled("legend")(({ theme }) => ({
-  fontSize: 15,
-  padding: theme.spacing(1.5, 0),
-}));
+const Label = styled(Typography)(({ theme }) => ({
+  display: "block",
+  padding: theme.spacing(0.75, 0),
+})) as typeof Typography;
 
 const Drag = styled(Box)(({ theme }) => ({
   position: "absolute",
@@ -183,7 +184,11 @@ export default function InputGroup({
 
   return (
     <Root ref={ref} className="inputGroup" flowSpacing={flowSpacing}>
-      {label && <Label>{label}</Label>}
+      {label && (
+        <Label variant="subtitle2" component="label">
+          {label}
+        </Label>
+      )}
       <Content
         deletable={deletable}
         draggable={draggable}

--- a/editor.planx.uk/src/ui/InputLegend.tsx
+++ b/editor.planx.uk/src/ui/InputLegend.tsx
@@ -1,0 +1,16 @@
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React, { ReactNode } from "react";
+
+const Legend = styled(Typography)(() => ({
+  display: "block",
+  width: "100%",
+})) as typeof Typography;
+
+export default function InputLegend({ children }: { children: ReactNode }) {
+  return (
+    <Legend variant="h3" component="legend">
+      {children}
+    </Legend>
+  );
+}

--- a/editor.planx.uk/src/ui/InputRow.tsx
+++ b/editor.planx.uk/src/ui/InputRow.tsx
@@ -8,12 +8,12 @@ const Root = styled(Box, {
   display: "flex",
   width: "100%",
   "&:not(:last-child)": {
-    marginBottom: 2,
+    marginBottom: 5,
   },
   "& > *": {
     flexGrow: 1,
     marginLeft: 1,
-    marginRight: 1,
+    marginRight: 5,
     "&:first-child": {
       marginLeft: 0,
     },

--- a/editor.planx.uk/src/ui/InputRowLabel.tsx
+++ b/editor.planx.uk/src/ui/InputRowLabel.tsx
@@ -1,8 +1,8 @@
-import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import React, { ReactNode } from "react";
 
-const Root = styled(Box)(({ theme }) => ({
+const Label = styled(Typography)(({ theme }) => ({
   flexShrink: 1,
   flexGrow: 0,
   paddingRight: theme.spacing(2),
@@ -10,8 +10,12 @@ const Root = styled(Box)(({ theme }) => ({
   "&:not(:first-child)": {
     paddingLeft: theme.spacing(2),
   },
-}));
+})) as typeof Typography;
 
 export default function InputRowLabel({ children }: { children: ReactNode }) {
-  return <Root>{children}</Root>;
+  return (
+    <Label variant="body2" component="label">
+      {children}
+    </Label>
+  );
 }

--- a/editor.planx.uk/src/ui/ModalSection.tsx
+++ b/editor.planx.uk/src/ui/ModalSection.tsx
@@ -3,9 +3,9 @@ import { styled } from "@mui/material/styles";
 import React, { PropsWithChildren } from "react";
 
 const Root = styled(Box)(({ theme }) => ({
-  paddingBottom: theme.spacing(3),
+  padding: theme.spacing(2, 0),
   "& + .modalSection": {
-    borderTop: "0.5px solid #bbb",
+    borderTop: `1px solid ${theme.palette.border.main}`,
   },
 }));
 

--- a/editor.planx.uk/src/ui/ModalSectionContent.tsx
+++ b/editor.planx.uk/src/ui/ModalSectionContent.tsx
@@ -1,11 +1,11 @@
-import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import React from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface Props {
   title?: string;
+  subtitle?: string;
   children?: JSX.Element[] | JSX.Element;
   author?: string;
   Icon?: any;
@@ -15,7 +15,7 @@ const SectionContentGrid = styled(Grid)(({ theme }) => ({
   position: "relative",
   paddingTop: theme.spacing(2),
   paddingBottom: theme.spacing(2),
-  wrap: "no-wrap",
+  flexWrap: "nowrap",
 }));
 
 const LeftGutter = styled(Grid)(({ theme }) => ({
@@ -28,12 +28,16 @@ const SectionContent = styled(Grid)(({ theme }) => ({
   paddingRight: theme.spacing(6),
 }));
 
-const Title = styled(Box)(({ theme }) => ({
-  opacity: 0.75,
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  fontSize: 18,
+const Title = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.primary,
   paddingBottom: theme.spacing(2),
-}));
+})) as typeof Typography;
+
+const Subtitle = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  paddingBottom: theme.spacing(2),
+  fontWeight: 600,
+})) as typeof Typography;
 
 const Author = styled("span")(({ theme }) => ({
   fontWeight: 400,
@@ -42,6 +46,7 @@ const Author = styled("span")(({ theme }) => ({
 
 export default function ModalSectionContent({
   title,
+  subtitle,
   children,
   author,
   Icon,
@@ -51,10 +56,16 @@ export default function ModalSectionContent({
       <LeftGutter item>{Icon && <Icon />}</LeftGutter>
       <SectionContent item>
         {title && (
-          <Title>
+          <Title variant="h3">
             {title}
             {author && <Author>by {author}</Author>}
           </Title>
+        )}
+        {subtitle && (
+          <Subtitle variant="subtitle1">
+            {subtitle}
+            {author && <Author>by {author}</Author>}
+          </Subtitle>
         )}
         {children}
       </SectionContent>

--- a/editor.planx.uk/src/ui/ModalSubtitle.tsx
+++ b/editor.planx.uk/src/ui/ModalSubtitle.tsx
@@ -2,7 +2,6 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface Props {
   title: string;
@@ -10,17 +9,15 @@ interface Props {
 
 const Root = styled(Box)(() => ({
   display: "flex",
-  height: 50,
   alignItems: "center",
 }));
 
-const StyledTypography = styled(Typography)(() => ({
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  opacity: 0.75,
+const StyledTypography = styled(Typography)(({ theme }) => ({
+  padding: theme.spacing(1.15, 0, 0.75),
 }));
 
 export const ModalSubtitle: React.FC<Props> = ({ title }) => (
   <Root sx={{ display: "flex" }}>
-    <StyledTypography variant="body2">{title}</StyledTypography>
+    <StyledTypography variant="subtitle2">{title}</StyledTypography>
   </Root>
 );

--- a/editor.planx.uk/src/ui/OptionButton.tsx
+++ b/editor.planx.uk/src/ui/OptionButton.tsx
@@ -12,8 +12,8 @@ const Root = styled(ButtonBase, {
     !["selected", "backgroundColor"].includes(prop.toString()),
 })<Props>(({ theme, selected, backgroundColor }) => ({
   height: 50,
-  paddingLeft: 50,
-  paddingRight: theme.spacing(3),
+  padding: theme.spacing(0, 3, 0, 5),
+  marginBottom: theme.spacing(0.5),
   fontSize: 15,
   position: "relative",
   fontFamily: "inherit",
@@ -21,18 +21,20 @@ const Root = styled(ButtonBase, {
   width: "auto",
   minWidth: 200,
   textAlign: "left",
+  border: `1px solid ${theme.palette.border.light}`,
+  backgroundColor: theme.palette.common.white,
   "&::before": {
     content: "''",
     position: "absolute",
-    height: 10,
-    width: 10,
-    left: 20,
-    top: 20,
+    height: 12,
+    width: 12,
+    left: 18,
+    top: 18,
     borderRadius: "50%",
-    backgroundColor: theme.palette.grey[500],
+    backgroundColor: theme.palette.grey[400],
     ...(selected && {
       color: "#fff",
-      backgroundColor: backgroundColor || theme.palette.success.light,
+      backgroundColor: backgroundColor || theme.palette.success.main,
     }),
   },
   ...(!selected && {
@@ -41,7 +43,7 @@ const Root = styled(ButtonBase, {
     },
   }),
   ...(selected && {
-    backgroundColor: theme.palette.grey[300],
+    backgroundColor: theme.palette.grey[200],
   }),
 }));
 

--- a/editor.planx.uk/src/ui/PublicFileUploadButton.tsx
+++ b/editor.planx.uk/src/ui/PublicFileUploadButton.tsx
@@ -26,8 +26,10 @@ const Root = styled(ButtonBase, {
   borderRadius: 0,
   height: 50,
   width: 50,
-  backgroundColor: "#fff",
-  color: theme.palette.primary.main,
+  flexGrow: 0,
+  backgroundColor: theme.palette.background.default,
+  color: theme.palette.primary.dark,
+  border: `1px solid ${theme.palette.border.light}`,
   ...(isDragActive && {
     border: `2px dashed ${theme.palette.primary.dark}`,
   }),

--- a/editor.planx.uk/src/ui/RichTextInput.css
+++ b/editor.planx.uk/src/ui/RichTextInput.css
@@ -1,7 +1,11 @@
 .ProseMirror {
-  padding: 15px;
+  padding: 12px 15px;
   background-color: #fff;
   min-height: 50px;
+  border: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .ProseMirror > * {
@@ -13,11 +17,18 @@
 }
 
 .ProseMirror p.is-editor-empty:first-child::before {
-  color: #adb5bd;
+  color: #505a5f;
+  opacity: 0.5;
   content: attr(data-placeholder);
   float: left;
   height: 0;
   pointer-events: none;
+}
+
+.ProseMirror.ProseMirror-focused {
+  border: 1px solid #000;
+  box-shadow: inset 0px 0px 0px 1px #000;
+  outline: 3px solid #ffdd00;
 }
 
 .passport {


### PR DESCRIPTION
# What does this PR do?

Two main areas of work addressed:

## 1. Adding admin setting design feature UI

UI has been added for the following (UI only, no working functionality at present).

1. Theme colour with colour picker
2. Logo with file upload
3. Favicon with file upload

Note: I've added example links to guides for each of these elements. I'll make sure these are in place on our PlanX Notion before the work goes live.

As part of this I have created the `EditorRow` UI component with optional background variant, to be used for each row of settings. 

As guided by @jessicamcinchak this sits behind the feature flag `window.featureFlags.toggle("SHOW_TEAM_SETTINGS")`

Preview:
https://2491.planx.pizza/buckinghamshire/find-out-if-you-need-planning-permission/settings/design

## 2. Updating general editor UI

Interwoven with and as an extension of the above, I've given the editor UI a going over with a focus on the following:

- Unifying input styles, sizes, backgrounds, borders, placeholder text
- Addressing issues with input layout, particularly layout shift when entering content
- Unifying focus styles (lots more potential quick-wins from an accessibility POV, but this is a good start)
- Unifying label and subtitle styles

Preview:
https://2491.planx.pizza/opensystemslab/permitteddevelopment,7GeYLgmnm9/nodes/i0uhcaViKg/nodes/CtyInx9nSU/edit