### PR TITLE
fix(docs): Auth on public, not private

### DIFF
--- a/api.planx.uk/modules/file/docs.yaml
+++ b/api.planx.uk/modules/file/docs.yaml
@@ -48,8 +48,6 @@ paths:
   /file/private/upload:
     post:
       tags: ["file"]
-      security:
-        - bearerAuth: []
       requestBody:
         content:
           multipart/form-data:
@@ -63,6 +61,8 @@ paths:
   /file/public/upload:
     post:
       tags: ["file"]
+      security:
+        - bearerAuth: []
       requestBody:
         content:
           multipart/form-data:


### PR DESCRIPTION
Noticed this when looking into https://opensystemslab.slack.com/archives/C01E3AC0C03/p1701187355822639

Follow on from https://github.com/theopensystemslab/planx-new/pull/2427