### PR TITLE
fix: remove zero padding for USRNs

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -74,7 +74,7 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
       if (selectedAddress) {
         props.setAddress({
           uprn: selectedAddress.UPRN.padStart(12, "0"),
-          usrn: selectedAddress.USRN.padStart(8, "0"),
+          usrn: selectedAddress.USRN, // padStart(8, "0") will break /roads API request
           blpu_code: selectedAddress.BLPU_STATE_CODE,
           latitude: selectedAddress.LAT,
           longitude: selectedAddress.LNG,


### PR DESCRIPTION
Per feedback from Birmingham about not picking up a classified road as expected - has been tested by council and working as expected now :heavy_check_mark: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1701099275002579

Notes: 
- Original UPRN padding comes from here, but it was a faulty assumption that USRN should be same: https://github.com/theopensystemslab/planx-new/pull/694
- ODP schema only defines a `maxLength` for USRN & UPRN, so this will still validate fine!