### PR TITLE
test(e2e): Access `sessionId` via store, not URL

### DIFF
--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -229,15 +229,6 @@ export async function expectSections({
   await expect(pageStatuses).toContainText(sections.map((s) => s.status));
 }
 
-export async function getSessionId(page: Page): Promise<string> {
-  // the session id is not available in the url so find it in a test utility component
-  const sessionId: string | null = await page
-    .getByTestId("sessionId")
-    .getAttribute("data-sessionid");
-  if (!sessionId) throw new Error("Session ID not found on page");
-  return sessionId!;
-}
-
 export async function fillGovUkCardDetails({
   page,
   cardNumber,
@@ -310,17 +301,16 @@ export async function setFeatureFlag(page: Page, featureFlag: string) {
   );
 }
 
-export async function getSessionIdFromURL(page: Page): Promise<string> {
-  const url = await new URL(page.url());
-  const sessionId = url.searchParams.get("sessionId");
-  if (!sessionId)
-    throw Error("Session ID missing from page. URL " + url.toString());
+export async function getSessionId(page: Page): Promise<string> {
+  // @ts-expect-error - Property api does not exist on type Window & typeof globalThis
+  const sessionId = page.evaluate(() => window.api.getState().sessionId);
+  if (!sessionId) throw Error("Session ID missing from window");
   return sessionId;
 }
 
 export async function addSessionToContext(page: Page, context: Context) {
-  const sessionId = await getSessionIdFromURL(page);
-  await context.sessionIds!.push(sessionId);
+  const sessionId = await getSessionId(page);
+  context.sessionIds!.push(sessionId);
   return sessionId;
 }
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -303,8 +303,6 @@ function Component(props: Props) {
       ) : (
         <DelayedLoadingIndicator text={state.displayText || state.status} />
       )}
-      {/* session id exposed for testing purposes */}
-      <span data-testid="sessionId" data-sessionid={sessionId}></span>
     </>
   );
 }


### PR DESCRIPTION
## What does this PR do?
 - Fixes regression tests which are failing as they expect to find `sessionId` via the URL (context: )
 - Instead, we can access this from our [`window.api`](https://github.com/theopensystemslab/planx-new/blob/cf1e311111541c4c41d649d0deebc972a089330d/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts#L106) methods, and Playwright's [`page.evalutate()`](https://playwright.dev/docs/evaluating) API
 - Prior discussion on this here - https://github.com/theopensystemslab/planx-new/pull/1485#discussion_r1117488853

E2E regression test suite passing locally and on CI ✅ https://github.com/theopensystemslab/planx-new/actions/runs/7023467552