### PR TITLE
feat: Add `team_integrations` table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1222,6 +1222,18 @@
         check: null
 - table:
     schema: public
+    name: team_integrations
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - team_id
+          - staging_bops_submission_url
+          - production_bops_submission_url
+        filter: {}
+- table:
+    schema: public
     name: team_members
   object_relationships:
     - name: team
@@ -1284,6 +1296,14 @@
 - table:
     schema: public
     name: teams
+  object_relationships:
+    - name: integrations
+      using:
+        foreign_key_constraint_on:
+          column: team_id
+          table:
+            schema: public
+            name: team_integrations
   array_relationships:
     - name: flows
       using:

--- a/hasura.planx.uk/migrations/1701282718987_create_table_public_team_integrations/down.sql
+++ b/hasura.planx.uk/migrations/1701282718987_create_table_public_team_integrations/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."team_integrations";

--- a/hasura.planx.uk/migrations/1701282718987_create_table_public_team_integrations/up.sql
+++ b/hasura.planx.uk/migrations/1701282718987_create_table_public_team_integrations/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "public"."team_integrations" (
+  "id" serial NOT NULL,
+  "team_id" integer NOT NULL,
+  "staging_bops_submission_url" text,
+  "production_bops_submission_url" text,
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON UPDATE restrict ON DELETE cascade,
+  UNIQUE ("team_id")
+);
+
+COMMENT ON TABLE "public"."team_integrations" IS E'Tracks URLs and API keys for integrations';

--- a/hasura.planx.uk/tests/team_integrations.test.js
+++ b/hasura.planx.uk/tests/team_integrations.test.js
@@ -1,0 +1,76 @@
+const { introspectAs } = require("./utils");
+
+describe("team_integrations", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query team_integrations", () => {
+      expect(i.queries).not.toContain("team_integrations");
+    });
+
+    test("cannot create, update, or delete team_integrations", () => {
+      expect(i).toHaveNoMutationsFor("team_integrations");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate team_integrations", () => {
+      expect(i.queries).toContain("team_integrations");
+      expect(i.mutations).toContain("insert_team_integrations");
+      expect(i.mutations).toContain("update_team_integrations_by_pk");
+      expect(i.mutations).toContain("delete_team_integrations");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query team_integrations", () => {
+      expect(i.queries).not.toContain("team_integrations");
+    });
+
+    test("cannot create, update, or delete team_integrations", () => {
+      expect(i).toHaveNoMutationsFor("team_integrations");
+    });
+  });
+
+  describe("teamEditor", () => {
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query team_integrations", () => {
+      expect(i.queries).not.toContain("team_integrations");
+    });
+
+    test("cannot create, update, or delete team_integrations", () => {
+      expect(i).toHaveNoMutationsFor("team_integrations");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query team_integrations", () => {
+      expect(i.queries).toContain("team_integrations");
+    });
+
+    test("cannot create, update, or delete team_integrations", () => {
+      expect(i).toHaveNoMutationsFor("team_integrations");
+    });
+  });
+});

--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -33,6 +33,11 @@ for table in "${tables[@]}"; do
   fi
 done
 
+# Copy subset of team_integrations columns
+# Do not copy production values
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url FROM team_integrations TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
+echo team_integrations downloaded
+
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
 echo published_flows downloaded
 

--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -4,3 +4,4 @@
 \include write/flow_document_templates.sql
 \include write/published_flows.sql
 \include write/team_members.sql
+\include write/team_integrations.sql

--- a/scripts/seed-database/write/team_integrations.sql
+++ b/scripts/seed-database/write/team_integrations.sql
@@ -1,0 +1,23 @@
+-- insert team_integrations overwriting conflicts
+CREATE TEMPORARY TABLE sync_team_integrations (
+  id serial,
+  team_id integer,
+  staging_bops_submission_url text
+);
+
+\ COPY sync_team_integrations
+FROM
+  '/tmp/team_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  team_integrations (id, team_id, staging_bops_submission_url)
+SELECT
+  id,
+  team_id,
+  staging_bops_submission_url
+FROM
+  sync_team_integrations ON CONFLICT (id) DO
+UPDATE
+SET
+  team_id = EXCLUDED.team_id,
+  staging_bops_submission_url = EXCLUDED.staging_bops_submission_url;


### PR DESCRIPTION
## What does this PR do?
- Adds a new `team_integrations` table
- Sets up sync script for this table

## Why do we need this?
As we need to add environment details for Medway it seems sensible to start tidying this up and dropping the numerous env vars we have holding these details.

In future we could also store encrypted API keys here.

### Why store `staging_*` and `production_* values in one table?` 
Doing this means we don't need to manage an additional data sync from staging to Pizza environments (which currently has production data, but staging secrets). By only copying across the relevant column for the environment, we can avoid managing an additional data sync process. The slight compromise here is that if we allow the setting of these values in the Editor, we'll just need to ensure we just access the environment-appropriate column.

## Next steps...
- Merge to `production`
- Populate table with values currently stored as env vars
- Test sync script from prod → staging (note - data sync will fail whilst `team_integrations` table is live on `main` but not `production`)
- Get env vars from db using https://github.com/theopensystemslab/planx-core/pull/212
- Drop `BOPS_SUBMISSION_URL_*` env vars 🗑️ 