### PR TITLE
chore: Remove obsolete Source Sans Pro ref from header

### DIFF
--- a/editor.planx.uk/.storybook/preview-head.html
+++ b/editor.planx.uk/.storybook/preview-head.html
@@ -3,10 +3,3 @@
   href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
   rel="stylesheet"
 />
-<!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap"
-  rel="stylesheet"
-/>

--- a/editor.planx.uk/public/index.html
+++ b/editor.planx.uk/public/index.html
@@ -25,16 +25,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>PlanX</title>
-    <!--
-      Fonts for @opensystemslab/map:
-      OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly
-    -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## What does this PR do?

The header files for PlanX contain obsolete references to Source Sans Pro, served from Google Fonts.

Removing these should save on potential unnecessary files being loaded in a user session.