### PR TITLE
chore: tidy logic tests

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/flags.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/flags.test.ts
@@ -94,33 +94,33 @@ describe("changing flag inside flag filter doesn't affect the filter's behaviour
             val: "MISSING_INFO",
             text: "Missing information",
           },
-          type: 200,
+          type: TYPES.Response,
           edges: ["missing_info_content"],
         },
         q2: {
           data: {
             text: "another",
           },
-          type: 100,
+          type: TYPES.Statement,
           edges: ["missing_2", "nothing_2"],
         },
         missing_info_content: {
           data: {
             content: "missing info",
           },
-          type: 250,
+          type: TYPES.Content,
         },
         nothing_2: {
           data: {
             text: "nothing",
           },
-          type: 200,
+          type: TYPES.Response,
         },
         no_result: {
           data: {
             text: "(No Result)",
           },
-          type: 200,
+          type: TYPES.Response,
           edges: ["q2"],
         },
         missing_2: {
@@ -128,38 +128,38 @@ describe("changing flag inside flag filter doesn't affect the filter's behaviour
             flag: "MISSING_INFO",
             text: "missing",
           },
-          type: 200,
+          type: TYPES.Response,
         },
         immune: {
           data: {
             val: "IMMUNE",
             text: "Immune",
           },
-          type: 200,
+          type: TYPES.Response,
         },
         filter: {
           data: {
             fn: "flag",
           },
-          type: 500,
+          type: TYPES.Filter,
           edges: ["missing_info", "immune", "no_result"],
         },
         q1: {
-          type: 100,
+          type: TYPES.Statement,
           data: {
             text: "q",
           },
           edges: ["missing_1", "nothing_1"],
         },
         missing_1: {
-          type: 200,
+          type: TYPES.Response,
           data: {
             text: "missing",
             flag: "MISSING_INFO",
           },
         },
         nothing_1: {
-          type: 200,
+          type: TYPES.Response,
           data: {
             text: "nothing",
           },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
@@ -1,54 +1,56 @@
-import { Store, vanillaStore } from "../store";
+import { TYPES } from "@planx/components/types";
+
+import { Store, vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
 
 // https://imgur.com/VFV64ax
 const flow: Store.flow = {
   _root: {
-    edges: ["XYoJeox7F0", "8ZSxuIfFYE", "bmsSl3ScbV", "ltuI9xrBHk"],
+    edges: ["Question", "Pay", "Content", "Confirmation"],
   },
-  XYoJeox7F0: {
-    type: 100,
+  Question: {
+    type: TYPES.Statement,
     data: {
       text: "first question",
     },
-    edges: ["VfJAj7agvC", "YQXjsVsGqf"],
+    edges: ["NoFeeAnswerPath", "FeeAnswerPath"],
   },
-  VfJAj7agvC: {
-    type: 200,
+  NoFeeAnswerPath: {
+    type: TYPES.Response,
     data: {
       text: "no fee",
     },
   },
-  YQXjsVsGqf: {
-    type: 200,
+  FeeAnswerPath: {
+    type: TYPES.Response,
     data: {
       text: "fee",
     },
-    edges: ["DlgsufM3OK"],
+    edges: ["Calculate"],
   },
-  DlgsufM3OK: {
-    type: 700,
+  Calculate: {
+    type: TYPES.Calculate,
     data: {
       output: "fee",
       formula: "10",
     },
   },
-  "8ZSxuIfFYE": {
-    type: 400,
+  Pay: {
+    type: TYPES.Pay,
     data: {
       title: "Pay for your application",
       fn: "fee",
     },
   },
-  ltuI9xrBHk: {
-    type: 725,
+  Confirmation: {
+    type: TYPES.Confirmation,
     data: {
       heading: "Application sent",
     },
   },
-  bmsSl3ScbV: {
-    type: 250,
+  Content: {
+    type: TYPES.Content,
     data: {
       content: "<p>after payment</p>\n",
     },
@@ -66,9 +68,9 @@ describe("can go back if", () => {
   test("the previous component was manually answered", () => {
     setState({
       breadcrumbs: {
-        XYoJeox7F0: {
+        Question: {
           auto: false,
-          answers: ["VfJAj7agvC"],
+          answers: ["NoFeeAnswerPath"],
         },
       },
     });
@@ -78,11 +80,11 @@ describe("can go back if", () => {
   test("the user skipped the payment component", () => {
     setState({
       breadcrumbs: {
-        XYoJeox7F0: {
+        Question: {
           auto: false,
-          answers: ["VfJAj7agvC"],
+          answers: ["NoFeeAnswerPath"],
         },
-        "8ZSxuIfFYE": {
+        Pay: {
           auto: true,
         },
       },
@@ -99,9 +101,9 @@ describe("cannot go back if", () => {
   test("the only previous component was auto-answered", () => {
     setState({
       breadcrumbs: {
-        XYoJeox7F0: {
+        Question: {
           auto: true,
-          answers: ["VfJAj7agvC"],
+          answers: ["NoFeeAnswerPath"],
         },
       },
     });
@@ -111,17 +113,17 @@ describe("cannot go back if", () => {
   test("the applicant made a payment", () => {
     setState({
       breadcrumbs: {
-        XYoJeox7F0: {
+        Question: {
           auto: false,
-          answers: ["YQXjsVsGqf"],
+          answers: ["FeeAnswerPath"],
         },
-        DlgsufM3OK: {
+        Calculate: {
           auto: true,
           data: {
             fee: 10,
           },
         },
-        "8ZSxuIfFYE": {
+        Pay: {
           auto: false,
         },
       },
@@ -132,21 +134,21 @@ describe("cannot go back if", () => {
   test("changing a component's answer", () => {
     setState({
       breadcrumbs: {
-        XYoJeox7F0: {
+        Question: {
           auto: false,
-          answers: ["YQXjsVsGqf"],
+          answers: ["FeeAnswerPath"],
         },
-        DlgsufM3OK: {
+        Calculate: {
           auto: true,
           data: {
             fee: 10,
           },
         },
-        "8ZSxuIfFYE": {
+        Pay: {
           auto: false,
         },
       },
-      changedNode: "ltuI9xrBHk",
+      changedNode: "Confirmation",
     });
     expect(getState().canGoBack(getState().currentCard())).toStrictEqual(false);
   });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
@@ -1,0 +1,71 @@
+import cloneDeep from "lodash/cloneDeep";
+
+import { Store, vanillaStore } from "../../store";
+import flowWithAutoAnswersMock from "../mocks/flowWithAutoAnswers.json";
+
+const { getState, setState } = vanillaStore;
+
+const flowWithAutoAnswers = cloneDeep(flowWithAutoAnswersMock) as Store.flow;
+
+const { record, changeAnswer, computePassport } = getState();
+
+describe("changeAnswer", () => {
+  test("should auto-answer future nodes with the updated passport variable correctly", () => {
+    // See https://trello.com/c/B8xMMJLo/1930-changes-from-the-review-page-that-affect-the-fee-do-not-update-the-fee
+    //   and https://editor.planx.uk/testing/autoanswer-change-test
+    const flow = { ...flowWithAutoAnswers };
+
+    // Mock initial state as if we've initially answered "Yes" to the question and reached the Review component, about to click "change"
+    const breadcrumbs = {
+      rCjETwjwE3: {
+        auto: false,
+        answers: ["b0qdvLAxIL"],
+      },
+      vgj2UNYK9r: {
+        answers: ["X9JjnbPpnd"],
+        auto: true,
+      },
+    } as Store.breadcrumbs;
+    const cachedBreadcrumbs = {} as Store.cachedBreadcrumbs;
+
+    setState({
+      flow,
+      breadcrumbs,
+      cachedBreadcrumbs,
+    });
+
+    // Assert our initial passport state is correct
+    expect(computePassport()).toEqual({
+      data: {
+        "application.fee.exemption.disability": ["true"],
+      },
+    });
+
+    // Change the question answer from "Yes" to "No"
+    changeAnswer("rCjETwjwE3");
+    record("rCjETwjwE3", {
+      answers: ["ykNZocRJtQ"],
+      auto: false,
+    });
+
+    expect(getState().changedNode).toEqual("rCjETwjwE3");
+
+    // Confirm the passport has updated to reflect new answer and has not retained previous answer
+    expect(computePassport()).toEqual({
+      data: {
+        "application.fee.exemption.disability": ["false"],
+      },
+    });
+
+    const originalAnswer = {
+      vgj2UNYK9r: {
+        answers: ["X9JjnbPpnd"],
+        auto: true,
+      },
+    } as Store.cachedBreadcrumbs;
+
+    // Confirm that our original answer is still preserved in cachedBreadcrumbs, but not included in current breadcrumbs
+    expect(getState().breadcrumbs).not.toContain(originalAnswer);
+    expect(getState().cachedBreadcrumbs).toStrictEqual(originalAnswer);
+  });
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/getResultData.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/getResultData.test.ts
@@ -1,6 +1,6 @@
-import { getResultData } from "../store/preview";
+import { getResultData } from "../../store/preview";
 
-test("result data", () => {
+test("Default result data", () => {
   const result = getResultData({}, {});
 
   expect(result).toEqual({
@@ -18,3 +18,11 @@ test("result data", () => {
     },
   });
 });
+
+test.todo("Returns correct result based on collected flags");
+
+test.todo(
+  "Returns correct, custom text based on collected flags and overrides",
+);
+
+test.todo("Returns result data for flagsets beyond `Planning permission`");

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/hasPaid.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/hasPaid.test.ts
@@ -1,0 +1,40 @@
+import { TYPES } from "@planx/components/types";
+
+import { vanillaStore } from "../../store";
+
+const { getState, setState } = vanillaStore;
+const { record, hasPaid } = getState();
+
+test("hasPaid is updated if a Pay component has been recorded", () => {
+  setState({
+    flow: {
+      _root: {
+        edges: ["a", "b"],
+      },
+      a: {
+        type: TYPES.Statement,
+        edges: ["c"],
+      },
+      b: {
+        type: TYPES.Statement,
+      },
+      c: {
+        type: TYPES.Pay,
+      },
+
+      d: { type: TYPES.Response },
+      e: { type: TYPES.Review },
+    },
+  });
+
+  record("a", { answers: ["c"] });
+  expect(hasPaid()).toBe(false);
+
+  record("c", {});
+  expect(getState().breadcrumbs).toEqual({
+    a: { answers: ["c"], auto: false },
+    c: { auto: false },
+  });
+
+  expect(hasPaid()).toBe(true);
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
@@ -1,4 +1,4 @@
-import { vanillaStore } from "../store";
+import { vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/previousCard.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/previousCard.test.ts
@@ -1,9 +1,11 @@
-import { vanillaStore } from "../store";
+import { vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
 
+const { resetPreview, previousCard, currentCard } = getState();
+
 beforeEach(() => {
-  getState().resetPreview();
+  resetPreview();
 });
 
 const setup = (args = {}) =>
@@ -22,7 +24,7 @@ const setup = (args = {}) =>
 describe("store.previousCard is", () => {
   test("undefined when there are no breadcrumbs", () => {
     setup();
-    expect(getState().previousCard(getState().currentCard())).toBeUndefined();
+    expect(previousCard(currentCard())).toBeUndefined();
   });
 
   test("undefined when cards were automatically answered", () => {
@@ -32,7 +34,7 @@ describe("store.previousCard is", () => {
         b: { auto: true },
       },
     });
-    expect(getState().previousCard(getState().currentCard())).toBeUndefined();
+    expect(previousCard(currentCard())).toBeUndefined();
   });
 
   test("the most recent human-answered card id", () => {
@@ -43,6 +45,6 @@ describe("store.previousCard is", () => {
       },
     });
 
-    expect(getState().previousCard(getState().currentCard())).toEqual("a");
+    expect(previousCard(currentCard())).toEqual("a");
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/record.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/record.test.ts
@@ -1,0 +1,68 @@
+import { TYPES } from "@planx/components/types";
+
+import { vanillaStore } from "../../store";
+
+const { getState, setState } = vanillaStore;
+const { record } = getState();
+
+describe("error handling", () => {
+  test("cannot record id that doesn't exist", () => {
+    setState({
+      flow: {
+        _root: {
+          edges: ["a", "b"],
+        },
+        a: {
+          type: TYPES.InternalPortal,
+          edges: ["c"],
+        },
+        b: {
+          edges: ["d"],
+        },
+        c: {
+          edges: ["d"],
+        },
+        d: {},
+      },
+    });
+
+    expect(() => record("x", {})).toThrow("id not found");
+  });
+});
+
+test("record(id, undefined) clears up breadcrumbs", () => {
+  setState({
+    flow: {
+      _root: {
+        edges: ["a", "b"],
+      },
+      a: {
+        type: TYPES.Statement,
+        edges: ["c"],
+      },
+      b: {
+        type: TYPES.Statement,
+      },
+      c: {
+        type: TYPES.Response,
+        edges: ["d"],
+      },
+      d: {
+        type: TYPES.Statement,
+        edges: ["e", "f"],
+      },
+      e: { type: TYPES.Response },
+      f: { type: TYPES.Response },
+    },
+  });
+  record("a", { answers: ["c"] });
+  record("d", { answers: ["e", "f"] });
+  expect(getState().breadcrumbs).toEqual({
+    a: { answers: ["c"], auto: false },
+    d: { answers: ["e", "f"], auto: false },
+  });
+
+  record("a");
+
+  expect(getState().breadcrumbs).toEqual({});
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
@@ -1,0 +1,158 @@
+import { removeOrphansFromBreadcrumbs } from "../../store/preview";
+
+describe("removeOrphansFromBreadcrumbs", () => {
+  test("Deletes orphans from breadcrumbs when changing answers", () => {
+    const payload = {
+      ...mockFlowData,
+      userData: {
+        auto: false,
+        answers: ["4FRZMfNlXf"],
+      },
+    };
+
+    const actual = removeOrphansFromBreadcrumbs(payload);
+
+    const expected = {
+      mBFPszBssY: mockBreadcrumbs["mBFPszBssY"],
+      OjcsvOxVum: mockBreadcrumbs["OjcsvOxVum"],
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
+  test("Should keep breadcrumbs when tree is not changed", () => {
+    const payload = {
+      ...mockFlowData,
+      userData: {
+        auto: false,
+        answers: ["4FRZMfNlXf", "IzT93uCmyF"],
+      },
+    };
+
+    const actual = removeOrphansFromBreadcrumbs(payload);
+
+    const expected = mockBreadcrumbs;
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+const mockBreadcrumbs = {
+  mBFPszBssY: {
+    auto: false,
+    answers: ["IzT93uCmyF", "4FRZMfNlXf"],
+  },
+  "1eJjMmhGBU": {
+    auto: false,
+    answers: ["GxcDrNTW26"],
+  },
+  J5SvQgzuK0: {
+    auto: false,
+    answers: ["DTXNs02JmU"],
+  },
+  AHOdMRaRGK: {
+    auto: false,
+    data: {
+      AHOdMRaRGK: "Answer",
+    },
+  },
+  OjcsvOxVum: {
+    auto: false,
+    data: {
+      OjcsvOxVum: "Test",
+    },
+  },
+};
+
+const mockFlowData = {
+  id: "mBFPszBssY",
+  flow: {
+    _root: {
+      edges: ["mBFPszBssY", "fCg1EeibAD"],
+    },
+    "1eJjMmhGBU": {
+      data: {
+        text: "Question",
+      },
+      type: 100,
+      edges: ["Om0CWNHoDs", "GxcDrNTW26"],
+    },
+    "4FRZMfNlXf": {
+      data: {
+        flag: "PP-NOT_DEVELOPMENT",
+        text: "Not development",
+      },
+      type: 200,
+      edges: ["OjcsvOxVum"],
+    },
+    AHOdMRaRGK: {
+      data: {
+        title: "Question text",
+      },
+      type: 110,
+    },
+    DTXNs02JmU: {
+      data: {
+        text: "A2",
+      },
+      type: 200,
+      edges: ["AHOdMRaRGK"],
+    },
+    GM8yVE4Fgm: {
+      data: {
+        title: "Prior approval ",
+      },
+      type: 110,
+    },
+    GxcDrNTW26: {
+      data: {
+        text: "path2",
+      },
+      type: 200,
+      edges: ["J5SvQgzuK0"],
+    },
+    IzT93uCmyF: {
+      data: {
+        flag: "PRIOR_APPROVAL",
+        text: "Prior",
+      },
+      type: 200,
+      edges: ["1eJjMmhGBU"],
+    },
+    J5SvQgzuK0: {
+      data: {
+        text: "Question 2",
+      },
+      type: 100,
+      edges: ["fSN4QxmM2w", "DTXNs02JmU"],
+    },
+    OjcsvOxVum: {
+      data: {
+        title: "Non development text",
+      },
+      type: 110,
+    },
+    Om0CWNHoDs: {
+      data: {
+        text: "path1",
+      },
+      type: 200,
+      edges: ["GM8yVE4Fgm"],
+    },
+    fSN4QxmM2w: {
+      data: {
+        text: "A1",
+      },
+      type: 200,
+    },
+    mBFPszBssY: {
+      data: {
+        text: "Checklist for review",
+        allRequired: false,
+      },
+      type: 105,
+      edges: ["IzT93uCmyF", "4FRZMfNlXf"],
+    },
+  },
+  breadcrumbs: mockBreadcrumbs,
+};

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resetPreview.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resetPreview.test.ts
@@ -1,0 +1,27 @@
+import { vanillaStore } from "../../store";
+
+const { getState, setState } = vanillaStore;
+
+const { resetPreview } = getState();
+
+describe("resetPreview", () => {
+  test("should reset preview state correctly for a local storage session", async () => {
+    setState({
+      sessionId: "123",
+    });
+
+    resetPreview();
+    expect(getState().sessionId).toBe("");
+  });
+
+  test("should reset preview state correctly for a save & return session", async () => {
+    setState({
+      sessionId: "123",
+      saveToEmail: "test@council.gov.uk",
+    });
+
+    resetPreview();
+    expect(getState().sessionId).toBe("");
+    expect(getState().saveToEmail).toBe("");
+  });
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
@@ -1,0 +1,151 @@
+import { TYPES } from "@planx/components/types";
+
+import { Store, vanillaStore } from "../../store";
+
+const { getState, setState } = vanillaStore;
+const { upcomingCardIds, resetPreview, record, currentCard } = getState();
+
+const flow: Store.flow = {
+  _root: {
+    edges: ["SetValue", "Content", "AutomatedQuestion"],
+  },
+  ResponseApple: {
+    data: {
+      val: "apple",
+      text: "Apple",
+    },
+    type: TYPES.Response,
+  },
+  ResponsePear: {
+    data: {
+      val: "pear",
+      text: "Pear",
+    },
+    type: TYPES.Response,
+  },
+  SetValue: {
+    data: {
+      fn: "fruit",
+      val: "apple",
+    },
+    type: TYPES.SetValue,
+  },
+  AutomatedQuestion: {
+    data: {
+      fn: "fruit",
+      text: "Which fruit?",
+    },
+    type: TYPES.Statement,
+    edges: ["ResponseApple", "ResponsePear"],
+  },
+  Content: {
+    data: {
+      content: "<p>Pause</p>",
+    },
+    type: TYPES.Content,
+  },
+};
+
+beforeEach(() => {
+  resetPreview();
+  setState({ flow });
+});
+
+test("Root nodes are immediately queued up", () => {
+  expect(upcomingCardIds()).toEqual([
+    "SetValue",
+    "Content",
+    "AutomatedQuestion",
+  ]);
+});
+
+test.skip("A node is only auto-answered when it is the first upcomingCardId(), not when its' `fn` is first added to the breadcrumbs/passport", () => {
+  const visitedNodes = () => Object.keys(getState().breadcrumbs);
+
+  // mimic "Continue" button and properly set visitedNodes()
+  const clickContinue = () => upcomingCardIds();
+
+  expect(upcomingCardIds()).toEqual([
+    "SetValue",
+    "Content",
+    "AutomatedQuestion",
+  ]);
+
+  // Step forwards through the SetValue
+  record("SetValue", { data: { fruit: ["apple"] }, auto: true });
+  clickContinue();
+
+  expect(currentCard()?.id).toBe("Content");
+
+  // "AutomatedQuestion" should still be queued up, not already answered based on SetValue
+  expect(visitedNodes()).not.toContain("AutomatedQuestion");
+  expect(upcomingCardIds()).toContain("AutomatedQuestion");
+
+  // Step forwards through Content
+  record("Content", { data: {}, auto: false });
+  clickContinue();
+
+  // "AutomatedQuestion" has now been auto-answered now, end of flow
+  expect(visitedNodes()).toContain("AutomatedQuestion");
+  expect(upcomingCardIds()).toEqual([]);
+});
+
+test("it lists upcoming cards", () => {
+  setState({
+    flow: {
+      _root: {
+        edges: ["a", "b"],
+      },
+      a: {
+        type: TYPES.Statement,
+        edges: ["c"],
+      },
+      b: {
+        type: TYPES.Statement,
+      },
+      c: {
+        type: TYPES.Response,
+        edges: ["d"],
+      },
+      d: {
+        type: TYPES.Statement,
+        edges: ["e", "f"],
+      },
+      e: { type: TYPES.Response },
+      f: { type: TYPES.Response },
+    },
+  });
+
+  expect(upcomingCardIds()).toEqual(["a"]);
+
+  record("a", { answers: ["c"] });
+
+  expect(upcomingCardIds()).toEqual(["d"]);
+
+  record("d", { answers: ["e", "f"] });
+
+  expect(upcomingCardIds()).toEqual([]);
+});
+
+test("crawling with portals", () => {
+  setState({
+    flow: {
+      _root: {
+        edges: ["a", "b"],
+      },
+      a: {
+        type: TYPES.InternalPortal,
+        edges: ["c"],
+      },
+      b: {
+        edges: ["d"],
+      },
+      c: {
+        edges: ["d"],
+      },
+      d: {},
+    },
+  });
+
+  expect(upcomingCardIds()).toEqual(["c", "b"]);
+});


### PR DESCRIPTION
Replaces #2299 

Changes:
- Splits up `preview.test.ts` by method name for more isolated testing (this isn't perfect because so many store methods call each other, but definitely an improvement in readability I think!)
- Takes a first pass through mock flow data and tidies up types (import from `TYPES`), replaces node ids with human readable ones, etc. Definitely more that could be consolidated here, but there's enough initial changes here for now

There's a few new & existing `.skip` and `.todo` annotated tests throughout which detail future expected behavior for autoAnswers, filters, getResult and more. 