### PR TITLE
fix: Typo in sync script again...

### DIFF
--- a/scripts/seed-database/write/team_integrations.sql
+++ b/scripts/seed-database/write/team_integrations.sql
@@ -5,7 +5,7 @@ CREATE TEMPORARY TABLE sync_team_integrations (
   staging_bops_submission_url text
 );
 
-\ COPY sync_team_integrations
+\COPY sync_team_integrations
 FROM
   '/tmp/team_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
 


### PR DESCRIPTION
Apologies - I should have been a bit more diligent here.... 

Looks like my linter is breaking `psql` commands - `\COPY` becomes `\ COPY` when formatted 🤦 

https://github.com/theopensystemslab/planx-new/assets/20502206/3927b345-fb55-4d3c-8761-a1b63ae292ca

