### PR TITLE
fix: api client should be able to select * from `payment_status`

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1002,6 +1002,18 @@
           - flow_id
           - session_id
           - amount
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - payment_id
+          - status
+          - team_slug
+          - created_at
+          - flow_id
+          - session_id
+          - amount
+        filter: {}
 - table:
     schema: public
     name: payment_status_enum

--- a/hasura.planx.uk/tests/payment_status.test.js
+++ b/hasura.planx.uk/tests/payment_status.test.js
@@ -73,9 +73,9 @@ describe("payment_status", () => {
       i = await introspectAs("api");
     });
 
-    test("cannot query payment_status", () => {
-      expect(i.queries).not.toContain("payment_status");
-    })
+    test("can query payment_status", () => {
+      expect(i.queries).toContain("payment_status");
+    });
 
     test("can insert payment_status", () => {
       expect(i.mutations).toContain("insert_payment_status");


### PR DESCRIPTION
hit this minor permissions issue while trying to use the `/summary` admin endpoint ! 

eg https://api.editor.planx.uk/admin/session/978e8024-e7ba-471d-8656-088c76b8cd56/summary