### PR TITLE
feat: Restrict certain users from production environments

### DIFF
--- a/api.planx.uk/modules/auth/service.test.ts
+++ b/api.planx.uk/modules/auth/service.test.ts
@@ -1,0 +1,69 @@
+import { checkUserCanAccessEnv } from "./service";
+
+const mockIsStagingOnly = jest.fn();
+
+jest.mock("../../client", () => {
+  return {
+    $api: {
+      user: {
+        isStagingOnly: () => mockIsStagingOnly(),
+      },
+    },
+  };
+});
+
+describe("canUserAccessEnv() helper function", () => {
+  describe("a staging-only user", () => {
+    beforeAll(() => mockIsStagingOnly.mockResolvedValue(true));
+
+    test("can't access production", async () => {
+      const result = await checkUserCanAccessEnv(
+        "test@example.com",
+        "production",
+      );
+      expect(result).toBe(false);
+    });
+
+    test("can access staging", async () => {
+      const result = await checkUserCanAccessEnv("test@example.com", "staging");
+      expect(result).toBe(true);
+    });
+
+    test("can access pizzas", async () => {
+      const result = await checkUserCanAccessEnv("test@example.com", "pizza");
+      expect(result).toBe(true);
+    });
+
+    test("can access test envs", async () => {
+      const result = await checkUserCanAccessEnv("test@example.com", "test");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("a non staging-only user", () => {
+    beforeAll(() => mockIsStagingOnly.mockResolvedValue(false));
+
+    test("can access production", async () => {
+      const result = await checkUserCanAccessEnv(
+        "test@example.com",
+        "production",
+      );
+      expect(result).toBe(true);
+    });
+
+    test("can access staging", async () => {
+      const result = await checkUserCanAccessEnv("test@example.com", "staging");
+      expect(result).toBe(true);
+    });
+
+    test("can access pizzas", async () => {
+      const result = await checkUserCanAccessEnv("test@example.com", "pizza");
+      expect(result).toBe(true);
+    });
+
+    test("can access test envs", async () => {
+      const result = await checkUserCanAccessEnv("test@example.com", "test");
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#415ae86",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#22bb6a0",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#22bb6a0",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b78ca10",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#415ae86
-    version: github.com/theopensystemslab/planx-core/415ae86
+    specifier: git+https://github.com/theopensystemslab/planx-core#22bb6a0
+    version: github.com/theopensystemslab/planx-core/22bb6a0
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8582,10 +8582,11 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/415ae86:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/415ae86}
+  github.com/theopensystemslab/planx-core/22bb6a0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/22bb6a0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
+    prepare: true
     requiresBuild: true
     dependencies:
       '@emotion/react': 11.11.1(react@18.2.0)

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#22bb6a0
-    version: github.com/theopensystemslab/planx-core/22bb6a0
+    specifier: git+https://github.com/theopensystemslab/planx-core#b78ca10
+    version: github.com/theopensystemslab/planx-core/b78ca10
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6209,9 +6209,9 @@ packages:
       object-visit: 1.0.1
     dev: true
 
-  /marked@9.1.6:
-    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
-    engines: {node: '>= 16'}
+  /marked@11.0.0:
+    resolution: {integrity: sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw==}
+    engines: {node: '>= 18'}
     hasBin: true
     dev: false
 
@@ -8582,8 +8582,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/22bb6a0:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/22bb6a0}
+  github.com/theopensystemslab/planx-core/b78ca10:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b78ca10}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -8613,7 +8613,7 @@ packages:
       lodash.omit: 4.5.0
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
-      marked: 9.1.6
+      marked: 11.0.0
       prettier: 3.0.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#415ae86",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b78ca10",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#415ae86
-    version: github.com/theopensystemslab/planx-core/415ae86
+    specifier: git+https://github.com/theopensystemslab/planx-core#b78ca10
+    version: github.com/theopensystemslab/planx-core/b78ca10
   axios:
     specifier: ^1.6.0
     version: 1.6.0
@@ -1971,9 +1971,9 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
-  /marked@9.1.6:
-    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
-    engines: {node: '>= 16'}
+  /marked@11.0.0:
+    resolution: {integrity: sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw==}
+    engines: {node: '>= 18'}
     hasBin: true
     dev: false
 
@@ -2821,8 +2821,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/415ae86:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/415ae86}
+  github.com/theopensystemslab/planx-core/b78ca10:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b78ca10}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2852,7 +2852,7 @@ packages:
       lodash.omit: 4.5.0
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
-      marked: 9.1.6
+      marked: 11.0.0
       prettier: 3.0.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#415ae86",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b78ca10",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.44.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#415ae86
-    version: github.com/theopensystemslab/planx-core/415ae86
+    specifier: git+https://github.com/theopensystemslab/planx-core#b78ca10
+    version: github.com/theopensystemslab/planx-core/b78ca10
   axios:
     specifier: ^1.6.0
     version: 1.6.0
@@ -1820,9 +1820,9 @@ packages:
       es5-ext: 0.10.62
     dev: false
 
-  /marked@9.1.6:
-    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
-    engines: {node: '>= 16'}
+  /marked@11.0.0:
+    resolution: {integrity: sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw==}
+    engines: {node: '>= 18'}
     hasBin: true
     dev: false
 
@@ -2625,8 +2625,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/415ae86:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/415ae86}
+  github.com/theopensystemslab/planx-core/b78ca10:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b78ca10}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2656,7 +2656,7 @@ packages:
       lodash.omit: 4.5.0
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
-      marked: 9.1.6
+      marked: 11.0.0
       prettier: 3.0.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.14.5",
     "@mui/utils": "^5.14.5",
     "@opensystemslab/map": "^0.7.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#415ae86",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b78ca10",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.6",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: ^0.7.5
     version: 0.7.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#415ae86
-    version: github.com/theopensystemslab/planx-core/415ae86(@types/react@18.2.20)
+    specifier: git+https://github.com/theopensystemslab/planx-core#b78ca10
+    version: github.com/theopensystemslab/planx-core/b78ca10(@types/react@18.2.20)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -3192,7 +3192,7 @@ packages:
     resolution: {integrity: sha512-+KdYrpKC5TgomQr2DlZF4lDEpHcoxnj5IGddYYfBWJAKfj1JtuHUIqMa+E1pJJ+z3kvDViWMqyqPlG4Ja7amQA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
       postcss: 8.4.31
@@ -3202,7 +3202,7 @@ packages:
     resolution: {integrity: sha512-Bc0f62WmHdtRDjf5f3e2STwRAl89N2CLb+9iAwzrv4L2hncrbDwnQD9PCq0gtAt7pOI2leIV08HIBUd4jxD8cw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -3212,7 +3212,7 @@ packages:
     resolution: {integrity: sha512-ZgrlzuUAjXIOc2JueK0X5sZDjCtgimVp/O5CEqTcs5ShWBa6smhWYbS0x5cVc/+rycTDbjjzoP0KTDnUneZGOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3221,7 +3221,7 @@ packages:
     resolution: {integrity: sha512-YHdEru4o3Rsbjmu6vHy4UKOXZD+Rn2zmkAmLRfPet6+Jz4Ojw8cbWxe1n42VaXQhD3CQUXXTooIy8OkVbUcL+w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3230,7 +3230,7 @@ packages:
     resolution: {integrity: sha512-Ot1rcwRAaRHNKC9tAqoqNZhjdYBzKk1POgWfhN4uCOE47ebGcLRqXjKkApVDpjifL6u2/55ekkpnFcp+s/OZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -3240,7 +3240,7 @@ packages:
     resolution: {integrity: sha512-7JPeVVZHd+jxYdULl87lvjgvWldYu+Bc62s9vD/ED6/QTGjy0jy0US/f6BG53sVMTBJ1lzKZFpYmofBN9eaRiA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
       postcss: 8.4.31
@@ -3250,7 +3250,7 @@ packages:
     resolution: {integrity: sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3259,7 +3259,7 @@ packages:
     resolution: {integrity: sha512-jcOanIbv55OFKQ3sYeFD/T0Ti7AMXc9nM1hZWu8m/2722gOTxFg7xYu4RDLJLeZmPUVQlGzo4jhzvTUq3x4ZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3268,7 +3268,7 @@ packages:
     resolution: {integrity: sha512-nJpJgsdA3dA9y5pgyb/UfEzE7W5Ka7u0CX0/HIMVBNWzWemdcTH3XwANECU6anWv/ao4vVNLTMxhiPNZsTK6iA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -3278,7 +3278,7 @@ packages:
     resolution: {integrity: sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.3
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3287,7 +3287,7 @@ packages:
     resolution: {integrity: sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3296,7 +3296,7 @@ packages:
     resolution: {integrity: sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3305,7 +3305,7 @@ packages:
     resolution: {integrity: sha512-woKaLO///4bb+zZC2s80l+7cm07M7268MsyG3M0ActXXEFi6SuhvriQYcb58iiKGbjwwIU7n45iRLEHypB47Og==}
     engines: {node: ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -3314,7 +3314,7 @@ packages:
     resolution: {integrity: sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
 
@@ -8565,7 +8565,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       browserslist: 4.22.1
       caniuse-lite: 1.0.30001565
@@ -9837,7 +9837,7 @@ packages:
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -9856,7 +9856,7 @@ packages:
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.9
     dependencies:
       postcss: 8.4.31
 
@@ -9865,7 +9865,7 @@ packages:
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -9933,7 +9933,7 @@ packages:
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
 
@@ -10015,7 +10015,7 @@ packages:
     resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       css-declaration-sorter: 6.4.1(postcss@8.4.31)
       cssnano-utils: 3.1.0(postcss@8.4.31)
@@ -10052,7 +10052,7 @@ packages:
     resolution: {integrity: sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
 
@@ -10060,7 +10060,7 @@ packages:
     resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       cssnano-preset-default: 5.2.14(postcss@8.4.31)
       lilconfig: 2.1.0
@@ -12833,7 +12833,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.31
 
@@ -14743,15 +14743,15 @@ packages:
       react: 18.2.0
     dev: true
 
-  /marked@4.3.0:
-    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
-    engines: {node: '>= 12'}
+  /marked@11.0.0:
+    resolution: {integrity: sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw==}
+    engines: {node: '>= 18'}
     hasBin: true
     dev: false
 
-  /marked@9.1.6:
-    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
-    engines: {node: '>= 16'}
+  /marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
     hasBin: true
     dev: false
 
@@ -16011,7 +16011,7 @@ packages:
     resolution: {integrity: sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16021,7 +16021,7 @@ packages:
     engines: {node: '>=8'}
     peerDependencies:
       browserslist: '>=4'
-      postcss: '>=8.4.31'
+      postcss: '>=8'
     dependencies:
       browserslist: 4.22.1
       postcss: 8.4.31
@@ -16029,7 +16029,7 @@ packages:
   /postcss-calc@8.2.4(postcss@8.4.31):
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.2
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16039,7 +16039,7 @@ packages:
     resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
     engines: {node: '>=7.6.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4.6
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16048,7 +16048,7 @@ packages:
     resolution: {integrity: sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16057,7 +16057,7 @@ packages:
     resolution: {integrity: sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16066,7 +16066,7 @@ packages:
     resolution: {integrity: sha512-pGxkuVEInwLHgkNxUc4sdg4g3py7zUeCQ9sMfwyHAT+Ezk8a4OaaVZ8lIY5+oNqA/BXXgLyXv0+5wHP68R79hg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16075,7 +16075,7 @@ packages:
     resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       caniuse-api: 3.0.0
@@ -16087,7 +16087,7 @@ packages:
     resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       postcss: 8.4.31
@@ -16097,7 +16097,7 @@ packages:
     resolution: {integrity: sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.3
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16106,7 +16106,7 @@ packages:
     resolution: {integrity: sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16115,7 +16115,7 @@ packages:
     resolution: {integrity: sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.3
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16124,7 +16124,7 @@ packages:
     resolution: {integrity: sha512-eqn4m70P031PF7ZQIvSgy9RSJ5uI2171O/OO/zcRNYpJbvaeKFUlar1aJ7rmgiQtbm0FSPsRewjpdS0Oew7MPA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16133,7 +16133,7 @@ packages:
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
 
@@ -16141,7 +16141,7 @@ packages:
     resolution: {integrity: sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
 
@@ -16149,7 +16149,7 @@ packages:
     resolution: {integrity: sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
 
@@ -16157,7 +16157,7 @@ packages:
     resolution: {integrity: sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
 
@@ -16165,7 +16165,7 @@ packages:
     resolution: {integrity: sha512-GX+FuE/uBR6eskOK+4vkXgT6pDkexLokPaz/AbJna9s5Kzp/yl488pKPjhy0obB475ovfT1Wv8ho7U/cHNaRgQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -16175,7 +16175,7 @@ packages:
     resolution: {integrity: sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16183,7 +16183,7 @@ packages:
   /postcss-flexbugs-fixes@5.0.2(postcss@8.4.31):
     resolution: {integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.4
     dependencies:
       postcss: 8.4.31
 
@@ -16191,7 +16191,7 @@ packages:
     resolution: {integrity: sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16200,7 +16200,7 @@ packages:
     resolution: {integrity: sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16208,7 +16208,7 @@ packages:
   /postcss-font-variant@5.0.0(postcss@8.4.31):
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.31
 
@@ -16216,7 +16216,7 @@ packages:
     resolution: {integrity: sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
 
@@ -16224,7 +16224,7 @@ packages:
     resolution: {integrity: sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16233,7 +16233,7 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.0
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16243,7 +16243,7 @@ packages:
   /postcss-initial@4.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.0
     dependencies:
       postcss: 8.4.31
 
@@ -16251,7 +16251,7 @@ packages:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.31
@@ -16260,7 +16260,7 @@ packages:
     resolution: {integrity: sha512-xuXll4isR03CrQsmxyz92LJB2xX9n+pZJ5jE9JgcnmsCammLyKdlzrBin+25dy6wIjfhJpKBAN80gsTlCgRk2w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -16270,7 +16270,7 @@ packages:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -16286,7 +16286,7 @@ packages:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.0.0
     dependencies:
       cosmiconfig: 7.1.0
@@ -16299,7 +16299,7 @@ packages:
     resolution: {integrity: sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.31
 
@@ -16307,7 +16307,7 @@ packages:
     resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.31
 
@@ -16315,7 +16315,7 @@ packages:
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16325,7 +16325,7 @@ packages:
     resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       caniuse-api: 3.0.0
@@ -16337,7 +16337,7 @@ packages:
     resolution: {integrity: sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16346,7 +16346,7 @@ packages:
     resolution: {integrity: sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       colord: 2.9.3
       cssnano-utils: 3.1.0(postcss@8.4.31)
@@ -16357,7 +16357,7 @@ packages:
     resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       cssnano-utils: 3.1.0(postcss@8.4.31)
@@ -16368,7 +16368,7 @@ packages:
     resolution: {integrity: sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16377,7 +16377,7 @@ packages:
     resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.31
 
@@ -16385,7 +16385,7 @@ packages:
     resolution: {integrity: sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -16396,7 +16396,7 @@ packages:
     resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16405,7 +16405,7 @@ packages:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -16414,7 +16414,7 @@ packages:
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.14
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16423,7 +16423,7 @@ packages:
     resolution: {integrity: sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
       postcss: 8.4.31
@@ -16433,7 +16433,7 @@ packages:
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
 
@@ -16441,7 +16441,7 @@ packages:
     resolution: {integrity: sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16450,7 +16450,7 @@ packages:
     resolution: {integrity: sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16459,7 +16459,7 @@ packages:
     resolution: {integrity: sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16468,7 +16468,7 @@ packages:
     resolution: {integrity: sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16477,7 +16477,7 @@ packages:
     resolution: {integrity: sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16486,7 +16486,7 @@ packages:
     resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       postcss: 8.4.31
@@ -16496,7 +16496,7 @@ packages:
     resolution: {integrity: sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       normalize-url: 6.1.0
       postcss: 8.4.31
@@ -16506,7 +16506,7 @@ packages:
     resolution: {integrity: sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16516,7 +16516,7 @@ packages:
     engines: {node: '>= 12'}
     peerDependencies:
       browserslist: '>= 4'
-      postcss: '>=8.4.31'
+      postcss: '>= 8'
     dependencies:
       '@csstools/normalize.css': 12.0.0
       browserslist: 4.22.1
@@ -16528,7 +16528,7 @@ packages:
     resolution: {integrity: sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
 
@@ -16536,7 +16536,7 @@ packages:
     resolution: {integrity: sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       cssnano-utils: 3.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -16546,7 +16546,7 @@ packages:
     resolution: {integrity: sha512-otYl/ylHK8Y9bcBnPLo3foYFLL6a6Ak+3EQBPOTR7luMYCOsiVTUk1iLvNf6tVPNGXcoL9Hoz37kpfriRIFb4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16554,7 +16554,7 @@ packages:
   /postcss-page-break@3.0.4(postcss@8.4.31):
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8
     dependencies:
       postcss: 8.4.31
 
@@ -16562,7 +16562,7 @@ packages:
     resolution: {integrity: sha512-wR8igaZROA6Z4pv0d+bvVrvGY4GVHihBCBQieXFY3kuSuMyOmEnnfFzHl/tQuqHZkfkIVBEbDvYcFfHmpSet9g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16571,7 +16571,7 @@ packages:
     resolution: {integrity: sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-cascade-layers': 1.1.1(postcss@8.4.31)
       '@csstools/postcss-color-function': 1.1.1(postcss@8.4.31)
@@ -16628,7 +16628,7 @@ packages:
     resolution: {integrity: sha512-9sCtZkO6f/5ML9WcTLcIyV1yz9D1rf0tWc+ulKcvV30s0iZKS/ONyETvoWsr6vnrmW+X+KmuK3gV/w5EWnT37w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16637,7 +16637,7 @@ packages:
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       caniuse-api: 3.0.0
@@ -16647,7 +16647,7 @@ packages:
     resolution: {integrity: sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16655,7 +16655,7 @@ packages:
   /postcss-replace-overflow-wrap@4.0.0(postcss@8.4.31):
     resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.3
     dependencies:
       postcss: 8.4.31
 
@@ -16663,7 +16663,7 @@ packages:
     resolution: {integrity: sha512-1i9affjAe9xu/y9uqWH+tD4r6/hDaXJruk8xn2x1vzxC2U3J3LKO3zJW4CyxlNhA56pADJ/djpEwpH1RClI2rQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -16679,7 +16679,7 @@ packages:
     resolution: {integrity: sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
@@ -16689,7 +16689,7 @@ packages:
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
@@ -19024,7 +19024,7 @@ packages:
     resolution: {integrity: sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.1
       postcss: 8.4.31
@@ -20782,11 +20782,12 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/415ae86(@types/react@18.2.20):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/415ae86}
-    id: github.com/theopensystemslab/planx-core/415ae86
+  github.com/theopensystemslab/planx-core/b78ca10(@types/react@18.2.20):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b78ca10}
+    id: github.com/theopensystemslab/planx-core/b78ca10
     name: '@opensystemslab/planx-core'
     version: 1.0.0
+    prepare: true
     requiresBuild: true
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.2.20)(react@18.2.0)
@@ -20813,7 +20814,7 @@ packages:
       lodash.omit: 4.5.0
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
-      marked: 9.1.6
+      marked: 11.0.0
       prettier: 3.1.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/hasura.planx.uk/migrations/1701434967109_alter_table_public_users_add_column_is_staging_only/down.sql
+++ b/hasura.planx.uk/migrations/1701434967109_alter_table_public_users_add_column_is_staging_only/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."users"."is_staging_only" is NULL;
+
+ALTER TABLE "public"."users" DROP COLUMN "is_staging_only";

--- a/hasura.planx.uk/migrations/1701434967109_alter_table_public_users_add_column_is_staging_only/up.sql
+++ b/hasura.planx.uk/migrations/1701434967109_alter_table_public_users_add_column_is_staging_only/up.sql
@@ -1,4 +1,4 @@
 alter table "public"."users" add column "is_staging_only" boolean
  not null default 'false';
 
-comment on column "public"."users"."is_staging_only" is E 'Controls if this user can access all environments. Some users are restricted to Pizza / Staging environments only.';
+comment on column "public"."users"."is_staging_only" is E'Controls if this user can access all environments. Some users are restricted to Pizza / Staging environments only.';

--- a/hasura.planx.uk/migrations/1701434967109_alter_table_public_users_add_column_is_staging_only/up.sql
+++ b/hasura.planx.uk/migrations/1701434967109_alter_table_public_users_add_column_is_staging_only/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."users" add column "is_staging_only" boolean
+ not null default 'false';
+
+comment on column "public"."users"."is_staging_only" is E 'Controls if this user can access all environments. Some users are restricted to Pizza / Staging environments only.';

--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -6,8 +6,9 @@ CREATE TEMPORARY TABLE sync_users (
   email text,
   created_at timestamptz,
   updated_at timestamptz,
-  is_platform_admin boolean,
-  is_staging_only boolean
+  is_platform_admin boolean
+  -- ,
+  -- is_staging_only boolean
 );
 
 \copy sync_users FROM '/tmp/users.csv'  WITH (FORMAT csv, DELIMITER ';');
@@ -22,16 +23,18 @@ INSERT INTO users (
   first_name,
   last_name,
   email,
-  is_platform_admin,
-  is_staging_only
+  is_platform_admin
+  -- ,
+  -- is_staging_only
 )
 SELECT
   id,
   first_name,
   last_name,
   email,
-  is_platform_admin,
-  is_staging_only
+  is_platform_admin
+  -- ,
+  -- is_staging_only
 FROM sync_users
 ON CONFLICT (id) DO UPDATE
 SET
@@ -39,7 +42,7 @@ SET
   last_name = EXCLUDED.last_name,
   email = EXCLUDED.email,
   is_platform_admin = EXCLUDED.is_platform_admin;
-  is_staging_only = EXCLUDED.is_staging_only;
+  -- is_staging_only = EXCLUDED.is_staging_only;
 
 ALTER TABLE
   users ENABLE TRIGGER grant_new_user_template_team_access;

--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -6,7 +6,8 @@ CREATE TEMPORARY TABLE sync_users (
   email text,
   created_at timestamptz,
   updated_at timestamptz,
-  is_platform_admin boolean
+  is_platform_admin boolean,
+  is_staging_only boolean
 );
 
 \copy sync_users FROM '/tmp/users.csv'  WITH (FORMAT csv, DELIMITER ';');
@@ -21,14 +22,16 @@ INSERT INTO users (
   first_name,
   last_name,
   email,
-  is_platform_admin
+  is_platform_admin,
+  is_staging_only
 )
 SELECT
   id,
   first_name,
   last_name,
   email,
-  is_platform_admin
+  is_platform_admin,
+  is_staging_only
 FROM sync_users
 ON CONFLICT (id) DO UPDATE
 SET
@@ -36,6 +39,7 @@ SET
   last_name = EXCLUDED.last_name,
   email = EXCLUDED.email,
   is_platform_admin = EXCLUDED.is_platform_admin;
+  is_staging_only = EXCLUDED.is_staging_only;
 
 ALTER TABLE
   users ENABLE TRIGGER grant_new_user_template_team_access;


### PR DESCRIPTION
## What does this PR do?
 - Adds an additional check on login, to ensure users can access production environment

## Why?
 As we sync the users table across environments, this means all users can access production. Generally this is what we want as "real" users live on production and this allows them to access test and staging environments - all good.

The catch is that occasionally we have a set of users who we do not wish to grant access to production - for example the user accounts associated with the recent pen test, or certain sets of users with "demo" access (until we have these roles set up). This is not a common occurrence or user type, but it feels like a sensible restriction to put in place restrictions here as a bit of a guard rail.

## TODO
- [x] Test sync script - working locally with commented out columns, will uncomment once column is on prod
- [x] Merge https://github.com/theopensystemslab/planx-core/pull/219 to `main`
- [x] Update commit refs across all projects to `planx-core` latest