### PR TITLE
fix: Assign missing A4 category

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -230,6 +230,7 @@ async function go(
           value: true,
           text: baseSchema["article4"].pos,
           data: formattedResult[localCaz].data,
+          category: baseSchema["article4"].category,
         };
       }
     }

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/base.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/base.ts
@@ -144,13 +144,13 @@ const baseSchema: PlanningConstraintsBaseSchema = {
     active: false,
     neg: "is not an Explosives or Ordnance Storage site",
     pos: "is an Explosives or Ordnance Storage site",
-    category: "Military and defense",
+    category: "Military and defence",
   },
   "defence.safeguarded": {
     active: false,
     neg: "is not on Safeguarded land",
     pos: "is on Safeguarded land",
-    category: "Military and defense",
+    category: "Military and defence",
   },
   hazard: {
     active: false,


### PR DESCRIPTION
Just spotted this when testing - it looks like category for article 4s are not being returned by API so the UI is defaulting to `undefined`.

I don’t think there have really been any recent changes here that could have caused this - there might be another solution (or cause!) I'm missing here so this might be a naive fix...!

Waiting on Pizza to test changes 🚀 

<img width="1435" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/7d13604e-98ae-4ad4-9219-bab686466b04">



Original request URL (undefined): 
https://api.2529.planx.pizza/gis/southwark?geom=POLYGON+%28%28-0.0807095109084621+51.50357969225416%2C+-0.08026678402163087+51.50357732850256%2C+-0.0803878763290122+51.50339599741571%2C+-0.0807095109084621+51.50357969225416%29%29&analytics=false