### PR TITLE
Revert "fix: remove sessionId from URLs"

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -16,7 +16,6 @@ import { ApplicationPath, SendEmailPayload } from "types";
 import Input from "ui/Input";
 import InputLabel from "ui/InputLabel";
 import InputRow from "ui/InputRow";
-import { removeSessionIdSearchParamWithoutReloading } from "utils";
 import { object, string } from "yup";
 
 import ReconciliationPage from "./ReconciliationPage";
@@ -216,14 +215,7 @@ const ResumePage: React.FC = () => {
     getInitialEmailValue(route.url.query.email),
   );
   const [paymentRequest, setPaymentRequest] = useState<MinPaymentRequest>();
-
-  // Read the sessionId from the url to validate against
-  const sessionId = route.url.query.sessionId;
-
-  // As the sessionId has been extracted it can now be removed to avoid
-  // unnecessarily exposing it
-  removeSessionIdSearchParamWithoutReloading();
-
+  const sessionId = useCurrentRoute().url.query.sessionId;
   const [reconciliationResponse, setReconciliationResponse] =
     useState<ReconciliationResponse>();
 

--- a/editor.planx.uk/src/pages/Preview/SaveAndReturn.test.tsx
+++ b/editor.planx.uk/src/pages/Preview/SaveAndReturn.test.tsx
@@ -67,7 +67,7 @@ describe("Save and Return component", () => {
     expect(results).toHaveNoViolations();
   });
 
-  it("does not store the sessionId as part of the URL once an email has been submitted", async () => {
+  it("stores the sessionId as part of the URL once an email has been submitted", async () => {
     const children = <Button>Testing 123</Button>;
     const { user } = setup(<SaveAndReturn children={children}></SaveAndReturn>);
 
@@ -89,7 +89,7 @@ describe("Save and Return component", () => {
       expect(screen.getByText("Testing 123")).toBeInTheDocument();
     });
 
-    expect(window.location.href).not.toContain(`sessionId=${sessionId}`);
+    expect(window.location.href).toContain(`sessionId=${sessionId}`);
   });
 });
 

--- a/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
+++ b/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
@@ -84,10 +84,20 @@ const SaveAndReturn: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const isEmailCaptured = Boolean(useStore((state) => state.saveToEmail));
+  const sessionId = useStore((state) => state.sessionId);
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
+
+  // Setting the URL search param "sessionId" will route the user to ApplicationPath.Resume
+  // Without this the user will need to click the magic link in their email after a refresh
+  const allowResumeOnBrowserRefresh = () => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("sessionId", sessionId);
+    window.history.pushState({}, document.title, url);
+  };
 
   const handleSubmit = (email: string) => {
     useStore.setState({ saveToEmail: email });
+    allowResumeOnBrowserRefresh();
   };
 
   return (

--- a/editor.planx.uk/src/utils.ts
+++ b/editor.planx.uk/src/utils.ts
@@ -62,9 +62,3 @@ export const removeSessionIdSearchParam = () => {
   window.history.pushState({}, document.title, currentURL);
   window.location.reload();
 };
-
-export const removeSessionIdSearchParamWithoutReloading = () => {
-  const currentURL = new URL(window.location.href);
-  currentURL.searchParams.delete("sessionId");
-  window.history.replaceState({}, document.title, currentURL);
-};


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2485

From Jumpsec - 

> Regarding the issue with a session value being contained within GET parameters, I believe this should be fine and I have removed it from the findings (due to an email address being required for further authorisation).

Reverting this restores the `allowResumeOnBrowserRefresh()` functionality which I didn't really have a decent / simple fix in mind for 👍 

Related change https://github.com/theopensystemslab/planx-new/pull/2494 is good to stay in place as this is still a valid alternate method of grabbing the `sessionId` value.