### PR TITLE
fix(api): Allow reserved characters for FeedbackFish endpoints

### DIFF
--- a/api.planx.uk/modules/admin/docs.yaml
+++ b/api.planx.uk/modules/admin/docs.yaml
@@ -18,6 +18,7 @@ paths:
           type: string
           description: Cookie from FeedbackFish to authenticate request
           required: true
+          allowReserved: true
       responses:
         "200":
           content:


### PR DESCRIPTION
Quick fix for an issue I noticed the other day when discussing the FeedbackFish API.

Currently the URL stored in 1Password works, but this is inaccessible via Swagger as the cookie is encoded when entered into the API docs.

Docs: https://swagger.io/docs/specification/describing-parameters/ (see "Reserved Characters in Query Parameters")