### PR TITLE
fix(style): ITP button underline

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -125,7 +125,6 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
             <Button
               variant="contained"
               color="secondary"
-              style={{ borderBottom: `solid 2px lightgrey` }}
               size="large"
               onClick={props.changePage}
               disabled={Boolean(props?.paymentStatus)}

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -239,6 +239,9 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
             padding: "0.7em 1.25em",
             lineHeight: LINE_HEIGHT_BASE,
             minWidth: "3em",
+            "&:hover": {
+              boxShadow: "inset 0 -2px 0 rgba(0,0,0,0.5)",
+            }
           },
           text: {
             color: palette.text.secondary,


### PR DESCRIPTION
Another quick fix I've been meaning to get round to since a while - 

| Before | After |
|--------|--------|
| <img width="580" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/71bc0ed7-3c56-4e7c-bba9-15fdf6a3ce72"> |<img width="614" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/865cb3a1-8765-4ef5-acca-753a03d7fe7d"> | 

This also now more closely aligns to GDS style in that the underline / box shadow is retained on hover - https://design-system.service.gov.uk/components/button/