### PR TITLE
fix: Allow `target="_blank"` in anchors

### DIFF
--- a/api.planx.uk/modules/flows/findReplace/controller.ts
+++ b/api.planx.uk/modules/flows/findReplace/controller.ts
@@ -26,7 +26,9 @@ export const findAndReplaceSchema = z.object({
     replace: z
       .string()
       .optional()
-      .transform((val) => val && DOMPurify.sanitize(val)),
+      .transform(
+        (val) => val && DOMPurify.sanitize(val, { ADD_ATTR: ["target"] }),
+      ),
   }),
 });
 

--- a/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/ReactMarkdownOrHtml.tsx
@@ -69,7 +69,7 @@ export default function ReactMarkdownOrHtml(props: {
       <HTMLRoot
         color={props.textColor}
         dangerouslySetInnerHTML={{
-          __html: DOMPurify.sanitize(incrementHeaders),
+          __html: DOMPurify.sanitize(incrementHeaders, { ADD_ATTR: ["target"] }),
         }}
         id={props.id}
       />

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -63,7 +63,7 @@ function sanitiseOperation(op) {
  */
 function sanitise(input) {
   if ((input && typeof input === "string") || input instanceof String) {
-    return DOMPurify.sanitize(input);
+    return DOMPurify.sanitize(input, { ADD_ATTR: ["target"] });
   } else if ((input && typeof input === "object") || input instanceof Object) {
     return Object.entries(input).reduce((acc, [k, v]) => {
       v = sanitise(v);


### PR DESCRIPTION
Reason DOMPurify strips this - https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/

> When you link to a page on another site using the target="_blank" attribute, you can expose your site to performance and security issues:
>
> The other page may run on the same process as your page. If the other page is running a lot of JavaScript, your page's performance may suffer.
>
> The other page can access your window object with the window.opener property. This may allow the other page to redirect your page to a malicious URL.
> Adding `rel="noopener"` or `rel="noreferrer"` to your `target="_blank"` links avoids these issues.

Discussion / solution found here: https://github.com/cure53/DOMPurify/issues/317