### PR TITLE
fix: drop pg function `get_flow_schema` in favor of simpler js data munging

### DIFF
--- a/api.planx.uk/modules/flows/downloadSchema/controller.ts
+++ b/api.planx.uk/modules/flows/downloadSchema/controller.ts
@@ -6,8 +6,6 @@ import { ServerError } from "../../../errors";
 
 interface DownloadFlowSchemaResponse {
   message: string;
-  alteredNodes: Node[] | null;
-  description?: string;
 }
 
 export const downloadFlowSchema = z.object({
@@ -34,7 +32,7 @@ export const downloadFlowSchemaController: DownloadFlowSchemaController =
     } catch (error) {
       return next(
         new ServerError({
-          message: `Failed to download flow schema: ${error}`,
+          message: `Failed to download schema for flow ${res.locals.parsedReq.params?.flowId}: ${error}`,
         }),
       );
     }

--- a/hasura.planx.uk/metadata/functions.yaml
+++ b/hasura.planx.uk/metadata/functions.yaml
@@ -1,6 +1,3 @@
 - function:
     schema: public
     name: diff_latest_published_flow
-- function:
-    schema: public
-    name: get_flow_schema

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -238,19 +238,6 @@
         filter: {}
 - table:
     schema: public
-    name: flow_schemas
-  select_permissions:
-    - role: public
-      permission:
-        columns:
-          - flow_id
-          - node
-          - planx_variable
-          - text
-          - type
-        filter: {}
-- table:
-    schema: public
     name: flows
   object_relationships:
     - name: creator

--- a/hasura.planx.uk/migrations/1701881725039_drop_function_get_flow_schema/down.sql
+++ b/hasura.planx.uk/migrations/1701881725039_drop_function_get_flow_schema/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- DROP FUNCTION public.get_flow_schema CASCADE;
+-- DROP TABLE public.flow_schemas CASCADE;

--- a/hasura.planx.uk/migrations/1701881725039_drop_function_get_flow_schema/up.sql
+++ b/hasura.planx.uk/migrations/1701881725039_drop_function_get_flow_schema/up.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION public.get_flow_schema CASCADE;
+DROP TABLE public.flow_schemas CASCADE;


### PR DESCRIPTION
Refactors the `/flows/:flowId/download-schema` endpoint to fetch & transform flow data directly in our API rather than via PostgreSQL function which would historically timeout for large flows.

This is an edge-casey utility endpoint exposed in the Editor debug console only. I've been using it a lot the last couple days to quickly return all the passport variables a given flow sets while fixing `proposal.projectType` validation issues / missing data dictionary values over here: https://github.com/theopensystemslab/digital-planning-data-schemas/pull/88

Lots of room to think about a more meaningful return data shape in the future as we move towards actual in-editor schema validation, but this simplification & db migration feel like a fresher starting point.