### PR TITLE
refactor: Simplify help text button

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -59,10 +59,7 @@ export const InfoButton = styled(Button)(({ theme }) => ({
   marginLeft: theme.spacing(1.5),
   boxShadow: "none",
   color: theme.palette.primary.main,
-  padding: "0.33em 0.5em",
   minHeight: "44px",
-  textDecoration: "underline",
-  textUnderlineOffset: "0.15em",
 })) as typeof Button;
 
 function Component(props: Props) {
@@ -301,6 +298,7 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
       </Box>
       {!!(info || policyRef || howMeasured) && (
         <InfoButton
+          variant="help"
           title={`More information`}
           aria-label={`See more information about "${props.name}"`}
           onClick={() => handleHelpClick({ [props.fn]: props.name })}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -36,7 +36,7 @@ export const HelpButton = styled(Button)(({ theme }) => ({
   alignItems: "center",
   marginTop: theme.spacing(1.5),
   "& > svg": {
-    marginRight: theme.spacing(0.25),
+    marginRight: theme.spacing(0.5),
   },
 })) as typeof Button;
 
@@ -97,7 +97,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
               aria-haspopup="dialog"
               data-testid="more-info-button"
             >
-              <HelpIcon /> Help
+              <HelpIcon /> More info
           </HelpButton>
         )}
         <MoreInfo open={open} handleClose={() => setOpen(false)}>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -29,12 +29,14 @@ const Description = styled(Box)(({ theme }) => ({
 
 const TitleWrapper = styled(Box)(({ theme }) => ({
   width: theme.breakpoints.values.formWrap,
+  maxWidth: "100%",
 }));
 
 export const HelpButton = styled(Button)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   marginTop: theme.spacing(1.5),
+  fontSize: "inherit",
   "& > svg": {
     marginRight: theme.spacing(0.5),
   },
@@ -88,18 +90,18 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           </Description>
         )}
         {!!(info || policyRef || howMeasured) && (
-          <HelpButton
-            variant="help"
-            size="large"
-            title={`More information`}
-            aria-label={`See more information about "${title}"`}
-            onClick={handleHelpClick}
-            aria-haspopup="dialog"
-            data-testid="more-info-button"
-            sx={{ mt: 2 }}
-          >
-            <HelpIcon /> More information
-          </HelpButton>
+          <Typography variant="subtitle1" component="div">
+            <HelpButton
+              variant="help"
+              title={`More information`}
+              aria-label={`See more information about "${title}"`}
+              onClick={handleHelpClick}
+              aria-haspopup="dialog"
+              data-testid="more-info-button"
+            >
+              <HelpIcon /> More information
+            </HelpButton>
+          </Typography>
         )}
         <MoreInfo open={open} handleClose={() => setOpen(false)}>
           {info && info !== emptyContent ? (

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -1,3 +1,4 @@
+import HelpIcon from '@mui/icons-material/Help';
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
@@ -10,8 +11,6 @@ import { emptyContent } from "ui/RichTextInput";
 import { DESCRIPTION_TEXT } from "../constants";
 import MoreInfo from "./MoreInfo";
 import MoreInfoSection from "./MoreInfoSection";
-
-const HelpButtonMinWidth = "70px";
 
 interface IQuestionHeader {
   title?: string;
@@ -30,57 +29,14 @@ const Description = styled(Box)(({ theme }) => ({
 
 const TitleWrapper = styled(Box)(({ theme }) => ({
   width: theme.breakpoints.values.formWrap,
-  maxWidth: `calc(100% - (${HelpButtonMinWidth} + 4px))`,
-  [theme.breakpoints.up("contentWrap")]: {
-    maxWidth: "100%",
-  },
-}));
-
-const HelpButtonWrapper = styled(Box)(({ theme }) => ({
-  position: "absolute",
-  maxWidth: "none",
-  height: "100%",
-  zIndex: "1000",
-  flexShrink: 0,
-  display: "flex",
-  justifyContent: "stretch",
-  width: HelpButtonMinWidth,
-  top: "-4px",
-  right: "-6px",
-  pointerEvents: "none",
-  [theme.breakpoints.up("md")]: {
-    width: "80px",
-    top: 0,
-    right: 0,
-  },
-  [theme.breakpoints.up("lg")]: {
-    width: "100px",
-  },
-  "#embedded-browser &": {
-    top: "-60px",
-    width: "80px",
-  },
 }));
 
 export const HelpButton = styled(Button)(({ theme }) => ({
-  top: theme.spacing(0.75),
-  position: "sticky",
-  right: 0,
-  minHeight: "44px",
-  padding: "0.35em 0.5em",
-  alignSelf: "flex-start",
-  minWidth: "100%",
-  boxShadow: "none",
-  fontSize: "1.125em",
-  filter: "drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.5))",
-  pointerEvents: "auto",
-  [theme.breakpoints.up("lg")]: {
-    minHeight: "48px",
-    fontSize: "1.25em",
-    top: theme.spacing(1),
-  },
-  "#embedded-browser &": {
-    fontSize: "1em",
+  display: "flex",
+  alignItems: "center",
+  marginTop: theme.spacing(1.5),
+  "& > svg": {
+    marginRight: theme.spacing(0.25),
   },
 })) as typeof Button;
 
@@ -132,20 +88,17 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           </Description>
         )}
         {!!(info || policyRef || howMeasured) && (
-          <HelpButtonWrapper>
-            <HelpButton
+          <HelpButton
+              variant="help"
+              size="large"
               title={`More information`}
               aria-label={`See more information about "${title}"`}
               onClick={handleHelpClick}
               aria-haspopup="dialog"
               data-testid="more-info-button"
-              variant="outlined"
-              color="primary"
-              sx={{ width: "100%" }}
             >
-              Help
-            </HelpButton>
-          </HelpButtonWrapper>
+              <HelpIcon /> Help
+          </HelpButton>
         )}
         <MoreInfo open={open} handleClose={() => setOpen(false)}>
           {info && info !== emptyContent ? (

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -1,4 +1,4 @@
-import HelpIcon from '@mui/icons-material/Help';
+import HelpIcon from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
@@ -89,15 +89,16 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
         )}
         {!!(info || policyRef || howMeasured) && (
           <HelpButton
-              variant="help"
-              size="large"
-              title={`More information`}
-              aria-label={`See more information about "${title}"`}
-              onClick={handleHelpClick}
-              aria-haspopup="dialog"
-              data-testid="more-info-button"
-            >
-              <HelpIcon /> More info
+            variant="help"
+            size="large"
+            title={`More information`}
+            aria-label={`See more information about "${title}"`}
+            onClick={handleHelpClick}
+            aria-haspopup="dialog"
+            data-testid="more-info-button"
+            sx={{ mt: 2 }}
+          >
+            <HelpIcon /> More information
           </HelpButton>
         )}
         <MoreInfo open={open} handleClose={() => setOpen(false)}>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -226,6 +226,25 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
         },
       },
       MuiButton: {
+        variants: [
+          {
+            props: { variant: 'help' },
+            style: {
+              color: palette.primary.main,
+              backgroundColor: palette.background.paper,
+              boxShadow: "none",
+              borderBottom: `2px dotted ${palette.primary.main}`,
+              padding: "0.5em 0.5em",
+              "&:hover": {
+                boxShadow: `0 1px 0 ${palette.primary.main}`,
+              },
+              "&:hover, &:focus": {
+                borderColor: palette.text.primary,
+                borderStyle: "solid",
+              },
+            },
+          },
+        ],
         defaultProps: {
           // Removes default box shadow on buttons
           disableElevation: true,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -228,13 +228,13 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
       MuiButton: {
         variants: [
           {
-            props: { variant: 'help' },
+            props: { variant: "help" },
             style: {
               color: palette.primary.main,
-              backgroundColor: palette.background.paper,
               boxShadow: "none",
               borderBottom: `2px dotted ${palette.primary.main}`,
-              padding: "0.5em 0.5em",
+              padding: "0.25em 0.1em",
+              width: "auto",
               "&:hover": {
                 boxShadow: `0 1px 0 ${palette.primary.main}`,
               },
@@ -260,7 +260,7 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
             minWidth: "3em",
             "&:hover": {
               boxShadow: "inset 0 -2px 0 rgba(0,0,0,0.5)",
-            }
+            },
           },
           text: {
             color: palette.text.secondary,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -232,13 +232,21 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
             style: {
               color: palette.primary.main,
               boxShadow: "none",
-              borderBottom: `2px dotted ${palette.primary.main}`,
               padding: "0.25em 0.1em",
               width: "auto",
+              fontWeight: "initial",
+              fontSize: "inherit",
+              textDecoration: "underline",
+              textDecorationThickness: "2px",
+              textDecorationStyle: "dotted",
+              textUnderlineOffset: "4px",
               "&:hover": {
-                boxShadow: `0 1px 0 ${palette.primary.main}`,
+                textDecoration: "underline",
+                textDecorationThickness: "3px",
+                background: "transparent",
+                boxShadow: "none",
               },
-              "&:hover, &:focus": {
+              "&:focus": {
                 borderColor: palette.text.primary,
                 borderStyle: "solid",
               },

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -31,3 +31,10 @@ declare module "@mui/material/styles/createPalette" {
     border?: { main: string; input: string; light: string };
   }
 }
+
+// Append our custom variants to MUI Button
+declare module '@mui/material/Button' {
+  interface ButtonPropsVariantOverrides {
+    help: true;
+  }
+}

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -33,7 +33,7 @@ declare module "@mui/material/styles/createPalette" {
 }
 
 // Append our custom variants to MUI Button
-declare module '@mui/material/Button' {
+declare module "@mui/material/Button" {
   interface ButtonPropsVariantOverrides {
     help: true;
   }


### PR DESCRIPTION
# What does this PR do

After further user-testing, we are still seeing a reduction in clicks on the help text button. This PR simplifies the button setup by bringing it inline with the content, similar to how the GOV.UK system uses their Details component.

A new button variant `help` has been created to style help associated buttons.

Example:
https://2543.planx.pizza/lambeth/help-text-test/preview