### PR TITLE
test: Cover HTML anchor target attribute stipping

### DIFF
--- a/api.planx.uk/modules/flows/findReplace/findReplace.test.ts
+++ b/api.planx.uk/modules/flows/findReplace/findReplace.test.ts
@@ -268,9 +268,6 @@ describe("string replacement", () => {
 
 describe("HTML replacement", () => {
   const originalHTML = `<img src="cuteDogs.jpg"/>`;
-  const unsafeHTML = "<img src=x onerror=prompt('Stored XSS')/>";
-  const safeHTML = '<img src="x"/>';
-
   const mockFlowData: Flow["data"] = {
     _root: {
       edges: ["RRQwM2zAgy", "vcTgmVQAre", "QsEdip17H5"],
@@ -334,69 +331,6 @@ describe("HTML replacement", () => {
     },
   };
 
-  const replacedFlowData: Flow["data"] = {
-    _root: {
-      edges: ["RRQwM2zAgy", "vcTgmVQAre", "QsEdip17H5"],
-    },
-    "6dwuQp5xjA": {
-      data: {
-        text: "No",
-      },
-      type: 200,
-    },
-    "8AWcYxZgBw": {
-      data: {
-        fn: "property.constraints.planning",
-        text: "Is it monument inside a portal?",
-      },
-      type: 100,
-      edges: ["AJnWX6O1xt", "6dwuQp5xjA"],
-    },
-    AJnWX6O1xt: {
-      data: {
-        val: "monument",
-        text: "Yes",
-        description: safeHTML,
-      },
-      type: 200,
-    },
-    Hfh8KuSzUq: {
-      data: {
-        val: "monument",
-        text: "Yes",
-        description: safeHTML,
-      },
-      type: 200,
-    },
-    RRQwM2zAgy: {
-      data: {
-        fn: "property.constraints.planning",
-        text: "Is it a monument",
-      },
-      type: 100,
-      edges: ["Hfh8KuSzUq", "ft26KlH7Oy"],
-    },
-    ft26KlH7Oy: {
-      data: {
-        text: "No",
-      },
-      type: 200,
-    },
-    vcTgmVQAre: {
-      data: {
-        text: "internal-portal-test",
-      },
-      type: 300,
-      edges: ["8AWcYxZgBw"],
-    },
-    QsEdip17H5: {
-      type: 310,
-      data: {
-        flowId: "f54b6505-c352-4fbc-aca3-7c4be99b49d4",
-      },
-    },
-  };
-
   beforeEach(() => {
     queryMock.mockQuery({
       name: "GetFlowData",
@@ -408,42 +342,202 @@ describe("HTML replacement", () => {
         },
       },
     });
+  });
 
-    queryMock.mockQuery({
-      name: "UpdateFlow",
-      matchOnVariables: false,
-      data: {
-        flow: {
-          data: replacedFlowData,
-          slug: "test",
+  describe("Replacing unsafe HTML", () => {
+    const unsafeHTML = "<img src=x onerror=prompt('Stored XSS')/>";
+    const safeHTML = '<img src="x"/>';
+
+    const replacedFlowData: Flow["data"] = {
+      _root: {
+        edges: ["RRQwM2zAgy", "vcTgmVQAre", "QsEdip17H5"],
+      },
+      "6dwuQp5xjA": {
+        data: {
+          text: "No",
+        },
+        type: 200,
+      },
+      "8AWcYxZgBw": {
+        data: {
+          fn: "property.constraints.planning",
+          text: "Is it monument inside a portal?",
+        },
+        type: 100,
+        edges: ["AJnWX6O1xt", "6dwuQp5xjA"],
+      },
+      AJnWX6O1xt: {
+        data: {
+          val: "monument",
+          text: "Yes",
+          description: safeHTML,
+        },
+        type: 200,
+      },
+      Hfh8KuSzUq: {
+        data: {
+          val: "monument",
+          text: "Yes",
+          description: safeHTML,
+        },
+        type: 200,
+      },
+      RRQwM2zAgy: {
+        data: {
+          fn: "property.constraints.planning",
+          text: "Is it a monument",
+        },
+        type: 100,
+        edges: ["Hfh8KuSzUq", "ft26KlH7Oy"],
+      },
+      ft26KlH7Oy: {
+        data: {
+          text: "No",
+        },
+        type: 200,
+      },
+      vcTgmVQAre: {
+        data: {
+          text: "internal-portal-test",
+        },
+        type: 300,
+        edges: ["8AWcYxZgBw"],
+      },
+      QsEdip17H5: {
+        type: 310,
+        data: {
+          flowId: "f54b6505-c352-4fbc-aca3-7c4be99b49d4",
         },
       },
+    };
+
+    beforeEach(() => {
+      queryMock.mockQuery({
+        name: "UpdateFlow",
+        matchOnVariables: false,
+        data: {
+          flow: {
+            data: replacedFlowData,
+            slug: "test",
+          },
+        },
+      });
+    });
+
+    it("sanitises unsafe replace values", async () => {
+      await supertest(app)
+        .post(`/flows/2/search?find=${originalHTML}&replace=${unsafeHTML}`)
+        .set(auth)
+        .expect(200)
+        .then((res) => {
+          expect(res.body).toEqual({
+            message:
+              'Found 2 matches of "<img src="cuteDogs.jpg"/>" and replaced with "<img src="x">"',
+            matches: {
+              AJnWX6O1xt: {
+                data: {
+                  description: '<img src="cuteDogs.jpg"/>',
+                },
+              },
+              Hfh8KuSzUq: {
+                data: {
+                  description: '<img src="cuteDogs.jpg"/>',
+                },
+              },
+            },
+            updatedFlow: replacedFlowData,
+          });
+        });
     });
   });
 
-  it("sanitises unsafe replace values", async () => {
-    await supertest(app)
-      .post(`/flows/2/search?find=${originalHTML}&replace=${unsafeHTML}`)
-      .set(auth)
-      .expect(200)
-      .then((res) => {
-        expect(res.body).toEqual({
-          message:
-            'Found 2 matches of "<img src="cuteDogs.jpg"/>" and replaced with "<img src="x">"',
-          matches: {
-            AJnWX6O1xt: {
-              data: {
-                description: '<img src="cuteDogs.jpg"/>',
-              },
-            },
-            Hfh8KuSzUq: {
-              data: {
-                description: '<img src="cuteDogs.jpg"/>',
-              },
-            },
+  describe("Replacing safe HTML", () => {
+    const replacementHTML = `<a target="_blank" href="https://www.cute-dogs.com" rel="noopener noreferrer"/>`;
+    const replacedFlowData: Flow["data"] = {
+      _root: {
+        edges: ["RRQwM2zAgy", "vcTgmVQAre", "QsEdip17H5"],
+      },
+      "6dwuQp5xjA": {
+        data: {
+          text: "No",
+        },
+        type: 200,
+      },
+      "8AWcYxZgBw": {
+        data: {
+          fn: "property.constraints.planning",
+          text: "Is it monument inside a portal?",
+        },
+        type: 100,
+        edges: ["AJnWX6O1xt", "6dwuQp5xjA"],
+      },
+      AJnWX6O1xt: {
+        data: {
+          val: "monument",
+          text: "Yes",
+          description: replacementHTML,
+        },
+        type: 200,
+      },
+      Hfh8KuSzUq: {
+        data: {
+          val: "monument",
+          text: "Yes",
+          description: replacementHTML,
+        },
+        type: 200,
+      },
+      RRQwM2zAgy: {
+        data: {
+          fn: "property.constraints.planning",
+          text: "Is it a monument",
+        },
+        type: 100,
+        edges: ["Hfh8KuSzUq", "ft26KlH7Oy"],
+      },
+      ft26KlH7Oy: {
+        data: {
+          text: "No",
+        },
+        type: 200,
+      },
+      vcTgmVQAre: {
+        data: {
+          text: "internal-portal-test",
+        },
+        type: 300,
+        edges: ["8AWcYxZgBw"],
+      },
+      QsEdip17H5: {
+        type: 310,
+        data: {
+          flowId: "f54b6505-c352-4fbc-aca3-7c4be99b49d4",
+        },
+      },
+    };
+
+    beforeEach(() => {
+      queryMock.mockQuery({
+        name: "UpdateFlow",
+        matchOnVariables: false,
+        data: {
+          flow: {
+            data: replacedFlowData,
+            slug: "test",
           },
-          updatedFlow: replacedFlowData,
-        });
+        },
       });
+    });
+
+    it("does not remove the 'target' attribute from anchors", async () => {
+      await supertest(app)
+        .post(`/flows/2/search?find=${originalHTML}&replace=${replacementHTML}`)
+        .set(auth)
+        .expect(200)
+        .then((res) => {
+          // Checking substring as DOMPurify rearranges attribute order in a non-deterministic manner
+          expect(res.body.message).toMatch(/target=["]\\?_blank\\?["]/);
+        });
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?
- Adds test coverage for changes made in this PR - https://github.com/theopensystemslab/planx-new/pull/2536
- Very much imperfect - we'd need E2E tests for all scenarios to be covered, but my main aim here is to write a test that fails if DOMPurify is replaced / removed to the config updated in a breaking way