### PR TITLE
chore: Update Hasura to v2.36.0

### DIFF
--- a/hasura.planx.uk/Dockerfile
+++ b/hasura.planx.uk/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.8.4.cli-migrations-v2
+FROM hasura/graphql-engine:v2.36.0.cli-migrations-v2
 WORKDIR /
 COPY metadata hasura-metadata
 COPY migrations hasura-migrations

--- a/hasura.planx.uk/metadata/functions.yaml
+++ b/hasura.planx.uk/metadata/functions.yaml
@@ -1,3 +1,3 @@
 - function:
-    schema: public
     name: diff_latest_published_flow
+    schema: public

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1,6 +1,6 @@
 - table:
-    schema: public
     name: analytics
+    schema: public
   insert_permissions:
     - role: public
       permission:
@@ -26,8 +26,8 @@
         filter: {}
         check: null
 - table:
-    schema: public
     name: analytics_logs
+    schema: public
   insert_permissions:
     - role: public
       permission:
@@ -65,11 +65,11 @@
         filter: {}
         check: null
 - table:
-    schema: public
     name: analytics_summary
-- table:
     schema: public
+- table:
     name: blpu_codes
+    schema: public
   select_permissions:
     - role: public
       permission:
@@ -79,8 +79,8 @@
           - value
         filter: {}
 - table:
-    schema: public
     name: bops_applications
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -134,27 +134,27 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 1
         interval_sec: 30
+        num_retries: 1
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
-        version: 2
         query_params:
           type: bops-submission
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
-    schema: public
     name: document_template
+    schema: public
   is_enum: true
 - table:
-    schema: public
     name: email_applications
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -202,23 +202,23 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 1
         interval_sec: 30
+        num_retries: 1
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
-        version: 2
         query_params:
           type: email-submission
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
-    schema: public
     name: flow_document_templates
+    schema: public
   object_relationships:
     - name: flow
       using:
@@ -237,8 +237,8 @@
           - flow_id
         filter: {}
 - table:
-    schema: public
     name: flows
+    schema: public
   object_relationships:
     - name: creator
       using:
@@ -252,28 +252,28 @@
         foreign_key_constraint_on:
           column: flow_id
           table:
-            schema: public
             name: flow_document_templates
+            schema: public
     - name: operations
       using:
         foreign_key_constraint_on:
           column: flow_id
           table:
-            schema: public
             name: operations
+            schema: public
     - name: published_flows
       using:
         foreign_key_constraint_on:
           column: flow_id
           table:
-            schema: public
             name: published_flows
+            schema: public
   computed_fields:
     - name: data_merged
       definition:
         function:
-          schema: public
           name: compile_flow_portals
+          schema: public
       comment: Flow data with portals merged in
   insert_permissions:
     - role: api
@@ -429,11 +429,9 @@
   delete_permissions:
     - role: platformAdmin
       permission:
-        backend_only: false
         filter: {}
     - role: teamEditor
       permission:
-        backend_only: false
         filter:
           team:
             members:
@@ -443,8 +441,8 @@
                 - role:
                     _eq: teamEditor
 - table:
-    schema: public
     name: global_settings
+    schema: public
   insert_permissions:
     - role: platformAdmin
       permission:
@@ -479,35 +477,35 @@
         filter: {}
         check: {}
 - table:
-    schema: public
     name: lowcal_sessions
+    schema: public
   object_relationships:
     - name: flow
       using:
         manual_configuration:
-          remote_table:
-            schema: public
-            name: flows
-          insertion_order: null
           column_mapping:
             flow_id: id
+          insertion_order: null
+          remote_table:
+            name: flows
+            schema: public
   array_relationships:
     - name: payment_requests
       using:
         foreign_key_constraint_on:
           column: session_id
           table:
-            schema: public
             name: payment_requests
+            schema: public
     - name: payment_status
       using:
         manual_configuration:
-          remote_table:
-            schema: public
-            name: payment_status
-          insertion_order: null
           column_mapping:
             id: session_id
+          insertion_order: null
+          remote_table:
+            name: payment_status
+            schema: public
   insert_permissions:
     - role: public
       permission:
@@ -599,8 +597,8 @@
           columns:
             - submitted_at
       retry_conf:
-        num_retries: 0
         interval_sec: 10
+        num_retries: 0
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -617,11 +615,11 @@
                 "lockedAt": {{$body.event.data.new.locked_at}}
               }
             }
-        url: '{{$base_url}}/send-email/confirmation'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/send-email/confirmation'
+        version: 2
     - name: setup_lowcal_expiry_events
       definition:
         enable_manual: false
@@ -629,8 +627,8 @@
           columns:
             - has_user_saved
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -647,11 +645,11 @@
                 "email": {{$body.event.data.new.email}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
+        version: 2
     - name: setup_lowcal_reminder_events
       definition:
         enable_manual: false
@@ -659,8 +657,8 @@
           columns:
             - has_user_saved
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -677,14 +675,14 @@
                 "email": {{$body.event.data.new.email}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
+        version: 2
 - table:
-    schema: public
     name: operations
+    schema: public
   object_relationships:
     - name: actor
       using:
@@ -780,8 +778,8 @@
                       _eq: teamEditor
         check: {}
 - table:
-    schema: public
     name: payment_requests
+    schema: public
   object_relationships:
     - name: session
       using:
@@ -848,7 +846,6 @@
   delete_permissions:
     - role: api
       permission:
-        backend_only: false
         filter: {}
   event_triggers:
     - name: setup_payment_expiry_events
@@ -857,8 +854,8 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -874,19 +871,19 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
+        version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -902,19 +899,19 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
+        version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -930,11 +927,11 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
+        version: 2
     - name: setup_payment_send_events
       definition:
         enable_manual: false
@@ -942,8 +939,8 @@
           columns:
             - paid_at
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -959,24 +956,24 @@
                 "sessionId": {{$body.event.data.new.session_id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
+        version: 2
 - table:
-    schema: public
     name: payment_status
+    schema: public
   object_relationships:
     - name: lowcal_session
       using:
         manual_configuration:
-          remote_table:
-            schema: public
-            name: lowcal_sessions
-          insertion_order: null
           column_mapping:
             session_id: id
+          insertion_order: null
+          remote_table:
+            name: lowcal_sessions
+            schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1002,12 +999,12 @@
           - amount
         filter: {}
 - table:
-    schema: public
     name: payment_status_enum
+    schema: public
   is_enum: true
 - table:
-    schema: public
     name: planning_constraints_requests
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1029,8 +1026,8 @@
           - created_at
         filter: {}
 - table:
-    schema: public
     name: project_types
+    schema: public
   select_permissions:
     - role: public
       permission:
@@ -1039,8 +1036,8 @@
           - value
         filter: {}
 - table:
-    schema: public
     name: published_flows
+    schema: public
   object_relationships:
     - name: flow
       using:
@@ -1129,8 +1126,8 @@
           - summary
         filter: {}
 - table:
-    schema: public
     name: reconciliation_requests
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1154,17 +1151,16 @@
   delete_permissions:
     - role: api
       permission:
-        backend_only: false
         filter: {}
 - table:
-    schema: public
     name: sessions
+    schema: public
   computed_fields:
     - name: payment_id
       definition:
         function:
-          schema: public
           name: sessions_payment
+          schema: public
       comment: A computed field to find the latest successful payment associated with a session
   insert_permissions:
     - role: public
@@ -1220,8 +1216,8 @@
                 _is_null: true
         check: null
 - table:
-    schema: public
     name: team_integrations
+    schema: public
   select_permissions:
     - role: api
       permission:
@@ -1232,8 +1228,8 @@
           - production_bops_submission_url
         filter: {}
 - table:
-    schema: public
     name: team_members
+    schema: public
   object_relationships:
     - name: team
       using:
@@ -1290,40 +1286,39 @@
   delete_permissions:
     - role: platformAdmin
       permission:
-        backend_only: false
         filter: {}
 - table:
-    schema: public
     name: teams
+    schema: public
   object_relationships:
     - name: integrations
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            schema: public
             name: team_integrations
+            schema: public
   array_relationships:
     - name: flows
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            schema: public
             name: flows
+            schema: public
     - name: members
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            schema: public
             name: team_members
+            schema: public
   computed_fields:
     - name: boundary_bbox
       definition:
         function:
-          schema: public
           name: boundary_bbox
+          schema: public
       comment: Bounding box of the team's full boundary
   insert_permissions:
     - role: platformAdmin
@@ -1423,8 +1418,8 @@
         filter: {}
         check: null
 - table:
-    schema: public
     name: uniform_applications
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1475,49 +1470,49 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 1
         interval_sec: 30
+        num_retries: 1
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
-        version: 2
         query_params:
           type: uniform-submission
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
-    schema: public
     name: user_roles
+    schema: public
   is_enum: true
 - table:
-    schema: public
     name: users
+    schema: public
   array_relationships:
     - name: created_flows
       using:
         foreign_key_constraint_on:
           column: creator_id
           table:
-            schema: public
             name: flows
+            schema: public
     - name: operations
       using:
         foreign_key_constraint_on:
           column: actor_id
           table:
-            schema: public
             name: operations
+            schema: public
     - name: teams
       using:
         foreign_key_constraint_on:
           column: user_id
           table:
-            schema: public
             name: team_members
+            schema: public
   insert_permissions:
     - role: platformAdmin
       permission:


### PR DESCRIPTION
## What?
- Update Hasura from v2.8.4 → v.2.36.0
- Automated updates `tables.yaml` and `function.yaml`
  - I added/removed a permission (so no changes) which triggered an update to alphabetise these files
  - Without this step the next PR that touches the file gets very noisy
  - This also removed 5 instances of `backend_only: false` which is redundant as this is the default value

## Why?
- It's been a while! Last update was July 2022.
- There are a few features I'd love to pick up - inherited roles could be helpful (and we've previously discussed this), and I'm looking to implement [Postgres input validation](https://hasura.io/docs/latest/schema/postgres/input-validations/) to tackle recent sanitation questions

## Testing
- Testing locally seems fine ✅ 
- Testing on Pizza 🚀 
- Regression tests on branch ✅ 