### PR TITLE
feature: add analytics session ended_at to view

### DIFF
--- a/hasura.planx.uk/migrations/1702312905340_alter_view_analytics_summary_add_analytics_session_length_data/down.sql
+++ b/hasura.planx.uk/migrations/1702312905340_alter_view_analytics_summary_add_analytics_session_length_data/down.sql
@@ -1,0 +1,24 @@
+DROP VIEW public.analytics_summary CASCADE;
+
+CREATE OR REPLACE VIEW public.analytics_summary AS 
+select 
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	a.created_at as analytics_created_at,
+	user_agent,
+	referrer,
+	flow_direction,
+	metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(EXTRACT(EPOCH FROM (al.next_log_created_at - al.created_at)) as numeric (10, 1)) as time_spent_on_node_seconds
+from analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;

--- a/hasura.planx.uk/migrations/1702312905340_alter_view_analytics_summary_add_analytics_session_length_data/up.sql
+++ b/hasura.planx.uk/migrations/1702312905340_alter_view_analytics_summary_add_analytics_session_length_data/up.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE VIEW public.analytics_summary AS 
+select 
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	a.created_at as analytics_created_at,
+	user_agent,
+	referrer,
+	flow_direction,
+	metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(EXTRACT(EPOCH FROM (al.next_log_created_at - al.created_at)) as numeric (10, 1)) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(EXTRACT(EPOCH FROM (a.ended_at - a.created_at))/60 as numeric (10, 1)) as time_spent_on_analytics_session_minutes
+from analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;


### PR DESCRIPTION
## What

- Found that it wasn't possible to replicate the ["Average time spent"](https://metabase.editor.planx.uk/question/15-average-time-spent?flow_id=0e9d79ec-9cf3-497d-a1a1-8e70469bb52d) card without analytics session ended at
- Added this to the view to make it accessible in the "Question" GUI.

## Why

- For council users to use the GUI and edit their dashboard it's necessary for their questions to be written against the "Analytics Summary" or "Submission Services Summary" views with the GUI.

