### PR TITLE
fix: Long URL wrapping in editor

### DIFF
--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -51,9 +51,6 @@ const StyledInputBase = styled(InputBase, {
   "& input": {
     fontWeight: "inherit",
   },
-  "& input a": {
-    wordBreak: "break-all",
-  },
   "& ::placeholder": {
     color: theme.palette.text.secondary,
     opacity: "0.5",

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -51,6 +51,9 @@ const StyledInputBase = styled(InputBase, {
   "& input": {
     fontWeight: "inherit",
   },
+  "& input a": {
+    wordBreak: "break-all",
+  },
   "& ::placeholder": {
     color: theme.palette.text.secondary,
     opacity: "0.5",

--- a/editor.planx.uk/src/ui/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.tsx
@@ -74,6 +74,7 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
     justifyContent: "center",
     "& a": {
       color: "currentColor",
+      wordBreak: "break-all",
     },
     "& > *": {
       margin: 0,

--- a/editor.planx.uk/src/ui/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/RichTextInput.tsx
@@ -72,9 +72,9 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
+    wordBreak: "break-word",
     "& a": {
       color: "currentColor",
-      wordBreak: "break-all",
     },
     "& > *": {
       margin: 0,


### PR DESCRIPTION
# What does this PR do?

URLs entered into the editor rich-text input do not currently wrap and therefore longer URLs will expand the container beyond the layout. Adding a `word-wrap` property to inserted URLs fixes this.

**Current example:**
https://editor.planx.uk/barnet/article4/nodes/_root/nodes/CnIGlaoSRM/edit

**Fixed example:**
https://2552.planx.pizza/barnet/article4/nodes/_root/nodes/CnIGlaoSRM/edit