### PR TITLE
fix: Editor layout for small screens

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -178,7 +178,7 @@ const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
                     </IconButton>
                   </Box>
                 </Box>
-                <Box pl={4}>
+                <Box pl={{ md: 2 }}>
                   <ListManager
                     values={groupedOption.children}
                     onChange={(newOptions) => {

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -86,7 +86,7 @@ const OptionEditor: React.FC<{
             },
           });
         }}
-        sx={{ width: "160px", maxWidth: "160px" }}
+        sx={{ width: { md: "160px" }, maxWidth: "160px" }}
       />
     </InputRow>
     <InputRow>

--- a/editor.planx.uk/src/ui/Input.tsx
+++ b/editor.planx.uk/src/ui/Input.tsx
@@ -67,7 +67,6 @@ const StyledInputBase = styled(InputBase, {
   ...(format === "large" && {
     backgroundColor: theme.palette.common.white,
     height: 50,
-    fontSize: 25,
     width: "100%",
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
   }),

--- a/editor.planx.uk/src/ui/ModalSectionContent.tsx
+++ b/editor.planx.uk/src/ui/ModalSectionContent.tsx
@@ -16,16 +16,26 @@ const SectionContentGrid = styled(Grid)(({ theme }) => ({
   paddingTop: theme.spacing(2),
   paddingBottom: theme.spacing(2),
   flexWrap: "nowrap",
+  [theme.breakpoints.down("md")]: {
+    flexDirection: "column",
+    alignItems: "flex-start",
+  },
 }));
 
 const LeftGutter = styled(Grid)(({ theme }) => ({
-  flex: `0 0 ${theme.spacing(6)}`,
+  flex: `0 0 ${theme.spacing(3)}`,
   textAlign: "center",
+  [theme.breakpoints.up("md")]: {
+    flex: `0 0 ${theme.spacing(6)}`,
+  },
 }));
 
 const SectionContent = styled(Grid)(({ theme }) => ({
   flexGrow: 1,
-  paddingRight: theme.spacing(6),
+  width: "100%",
+  [theme.breakpoints.up("md")]: {
+    paddingRight: theme.spacing(6),
+  },
 }));
 
 const Title = styled(Typography)(({ theme }) => ({


### PR DESCRIPTION
# What does this PR do?

The current editor layout becomes unusable at smaller screen sizes due to columns and indentation. This PR introduces small changes to make it somewhat more usable. Also removes a rogue 25px hardcoded size for inputs that was only showing up at smaller breakpoints.

**Before (left) & after (right):**
![image](https://github.com/theopensystemslab/planx-new/assets/51156018/39da57a1-0a5a-4710-bf46-fad98a80aaaa)
