### PR TITLE
fix: Touch area for MUI Select

### DIFF
--- a/editor.planx.uk/src/ui/SelectInput.tsx
+++ b/editor.planx.uk/src/ui/SelectInput.tsx
@@ -22,9 +22,13 @@ const classes = {
 
 const Root = styled(Select)(({ theme }) => ({
   width: "100%",
-  padding: theme.spacing(0, 1.5),
+  padding: 0,
   height: 50,
   backgroundColor: "#fff",
+  "& .MuiSelect-select": {
+    width: "100%",
+    padding: theme.spacing(1, 1.5),
+  },
   [`&.${classes.rootSelect}`]: {
     paddingRight: theme.spacing(6),
     boxSizing: "border-box",


### PR DESCRIPTION
# What does this PR do?

Reported by August — The click area of the MUI Select component used in the editor is smaller than the input container, meaning that there are clickable areas (including the chevron/arrow) that focus the input but do not toggle the select. Small changes to element and parent padding ensure that the clickable area fills the container.

**Visual example (pink is clickable area that toggles select):**
<img width="240" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/445c0a5c-2897-4aba-9bd9-248b0e904642">

**Current example:**
https://editor.planx.uk/barking-and-dagenham/find-out-if-you-need-planning-permission/nodes/_root/nodes/XqMey8xqx4/edit

**Fixed example:**
https://2555.planx.pizza/barking-and-dagenham/find-out-if-you-need-planning-permission/nodes/_root/nodes/XqMey8xqx4/edit

