### PR TITLE
feat: add basic metadata to GOV.UK Pay requests

### DIFF
--- a/api.planx.uk/modules/pay/index.test.ts
+++ b/api.planx.uk/modules/pay/index.test.ts
@@ -53,6 +53,11 @@ describe("sending a payment to GOV.UK Pay", () => {
         reference: "12343543",
         description: "New application",
         return_url: "https://editor.planx.uk",
+        metadata: {
+          source: "PlanX",
+          flow: "apply-for-a-lawful-development-certificate",
+          inviteToPay: false,
+        },
       })
       .expect(200)
       .then((res) => {

--- a/api.planx.uk/modules/pay/middleware.ts
+++ b/api.planx.uk/modules/pay/middleware.ts
@@ -128,7 +128,7 @@ export async function buildPaymentPayload(
     metadata: {
       source: "PlanX",
       flow:
-        req.query.returnURL.toString().split("?")?.[0]?.split("/").pop() ||
+        new URL(req.query.returnURL as string).pathname.split("/")[0] ||
         (req.query.returnURL as string),
       inviteToPay: true,
     },

--- a/api.planx.uk/modules/pay/middleware.ts
+++ b/api.planx.uk/modules/pay/middleware.ts
@@ -90,6 +90,11 @@ interface GovPayCreatePayment {
   reference: string;
   description: string;
   return_url: string;
+  metadata?: {
+    source: "PlanX";
+    flow: string;
+    inviteToPay: boolean;
+  };
 }
 
 export async function buildPaymentPayload(
@@ -120,6 +125,13 @@ export async function buildPaymentPayload(
     reference: req.query.sessionId as string,
     description: "New application (nominated payee)",
     return_url: req.query.returnURL as string,
+    metadata: {
+      source: "PlanX",
+      flow:
+        req.query.returnURL.toString().split("?")?.[0]?.split("/").pop() ||
+        (req.query.returnURL as string),
+      inviteToPay: true,
+    },
   };
 
   req.body = createPaymentBody;

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -40,7 +40,11 @@ export interface GovUKCreatePaymentPayload {
     };
   };
   language?: string;
-  metadata?: any;
+  metadata?: {
+    source: "PlanX";
+    flow: string;
+    inviteToPay: boolean;
+  };
 }
 
 export const toPence = (decimal: number) => Math.trunc(decimal * 100);
@@ -63,6 +67,11 @@ export const createPayload = (
   reference,
   description: "New application",
   return_url: getReturnURL(reference),
+  metadata: {
+    source: "PlanX",
+    flow: useStore.getState().flowSlug,
+    inviteToPay: false,
+  },
 });
 
 /**


### PR DESCRIPTION
Short & simple as this is a bit of an exploratory task still at this point - we'll see if any councils notice & can extend the `metadata` type as necesary based on any future requests ! 