### PR TITLE
test: Add basic tests describing `isEqual()` function

### DIFF
--- a/api.planx.uk/modules/auth/middleware.test.ts
+++ b/api.planx.uk/modules/auth/middleware.test.ts
@@ -1,0 +1,36 @@
+import { isEqual } from "./middleware";
+
+describe("isEqual() helper function", () => {
+  it("handles undefined secrets", () => {
+    const req = { headers: { "api-key": undefined } };
+    const result = isEqual(req.headers["api-key"], process.env.UNSET_SECRET!);
+    expect(result).toBe(false);
+  });
+
+  it("handles null values", () => {
+    const req = { headers: { "api-key": null } };
+    // @ts-expect-error "api-key" purposefully set to wrong type
+    const result = isEqual(req.headers["api-key"], null!);
+    expect(result).toBe(false);
+  });
+
+  it("handles undefined headers", () => {
+    const req = { headers: { "some-other-header": "test123" } };
+    // @ts-expect-error "api-key" purposefully not set
+    const result = isEqual(req.headers["api-key"]!, process.env.UNSET_SECRET!);
+    expect(result).toBe(false);
+  });
+
+  it("handles empty strings", () => {
+    const req = { headers: { "api-key": "" } };
+    expect(isEqual(req.headers["api-key"], "")).toBe(false);
+  });
+
+  it("matches equal values", () => {
+    expect(isEqual("square", "square")).toBe(true);
+  });
+
+  it("does not match different values", () => {
+    expect(isEqual("circle", "triangle")).toBe(false);
+  });
+});

--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -16,7 +16,10 @@ export const userContext = new AsyncLocalStorage<{ user: Express.User }>();
 /**
  * Validate that a provided string (e.g. API key) matches the expected value
  */
-const isEqual = (provided = "", expected: string): boolean => {
+export const isEqual = (provided = "", expected: string): boolean => {
+  // Reject test against falsey values - could indicate unset secret
+  if (!expected) return false;
+
   const hash = crypto.createHash("SHA512");
   return crypto.timingSafeEqual(
     hash.copy().update(provided).digest(),


### PR DESCRIPTION
Follow on from https://github.com/theopensystemslab/planx-new/pull/2557 as I was unsure how the API would handle an undefined API key.

Turns out it handles it just fine and an error is thrown 👍 

It will still match on `"" === ""` which isn't wrong but is very likely not going to be a valid check in the context we use `isEqual()` - I've added a guard for this. If you think this is redundant please let me know....!

This function already has coverage from a number other test suites (e.g. `api.planx.uk/modules/file/file.test.ts` and `api.planx.uk/modules/send/bops/bops.test.ts`) but a few unit tests just explaining how it handles these edge cases is a bit more reassuring I think!