### PR TITLE
fix: correctly parse flow slug for invite-to-pay cases for GOV Pay metadata

### DIFF
--- a/api.planx.uk/modules/pay/middleware.ts
+++ b/api.planx.uk/modules/pay/middleware.ts
@@ -127,9 +127,12 @@ export async function buildPaymentPayload(
     return_url: req.query.returnURL as string,
     metadata: {
       source: "PlanX",
+      // Payment requests have /pay path suffix, so get flow-slug from second-to-last position
       flow:
-        new URL(req.query.returnURL as string).pathname.split("/")[0] ||
-        (req.query.returnURL as string),
+        (req.query.returnURL as string)
+          .split("?")?.[0]
+          ?.split("/")
+          ?.slice(-2, -1)?.[0] || "Could not parse service name",
       inviteToPay: true,
     },
   };


### PR DESCRIPTION
Fixes failed regression tests on `main` this morning: https://github.com/theopensystemslab/planx-new/actions/runs/7191369572

Now passing on this branch: https://github.com/theopensystemslab/planx-new/actions/runs/7193346466

Gov Pay was throwing this error: 
```
code: "P0102"
description: "Invalid attribute value: metadata. Values must be no greater than 100 characters long"
field: "metadata"
```

This was only effecting invite-to-pay cases, _not_ "regular" payments initiated on the frontend - as these always have direct access to the `flowSlug` in state and do not rely on parsing the `returnUrl`.

Metadata is now correctly captured:
![Screenshot from 2023-12-13 10-32-25](https://github.com/theopensystemslab/planx-new/assets/5132349/fa67773e-59b2-425a-8ec3-b5c1b4bace42)