### PR TITLE
fix: Set `X-Content-Type-Options` headers on CloudFront

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -680,6 +680,10 @@ export = async () => {
                 includeSubdomains: true,
                 preload: true,
               },
+              // Set X-Content-Type-Options = "nosniff"
+              contentTypeOptions: { 
+                override: true,
+              },
             },
           }
         ).id,


### PR DESCRIPTION
## What does this PR do?
Please see https://docs.google.com/document/d/1jGUW7319B64Zr07qNDoUF4m-u2EuuM1_5yohEvwh33Q/edit for more context (internal OSL doc).

This PR sets the `X-Content-Type-Options` header to `nosniff` for out CloudFront CDN (our React app hosted on S3).

Pulumi docs - https://www.pulumi.com/registry/packages/aws/api-docs/cloudfront/responseheaderspolicy/#responseheaderspolicysecurityheadersconfig

AWS CloudFront Docs - https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-security-headers.html

### Testing
We actually can't test this until we get to staging (the first AWS / Pulumi environment).