### PR TITLE
fix: Set `httpOnly` attribute on JWT cookie

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -53,6 +53,7 @@ export const handleSuccess = (req: Request, res: Response) => {
       if (isLiveEnv()) {
         cookie.secure = true;
         cookie.sameSite = "none";
+        cookie.httpOnly = true;
       }
 
       res.cookie("jwt", req.user.jwt, cookie);


### PR DESCRIPTION
## What does this PR do?
Set `httpOnly` attribute on JWT cookie to be true on all non-dev and non-Pizza environments

## Why?
Flagged in Jumpsec report 2023, page 9.

## Why doesn't this work on Pizzas?
Good question! I suspect that that the auth logic pre-dates Pizzas and so this environment isn't correctly accounted for - take a look at `handleSuccess()` in `api.planx.uk/modules/auth/controller.ts`.

I'm going to try to resolve this in other PR later today 👍 

## Testing
This needs to be on staging for us to test it (see above).