### PR TITLE
fix: decode organisation details from `access_token` for Uniform authentication

### DIFF
--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
@@ -22,6 +22,8 @@
     body: >
       {
         "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbmlzYXRpb24tbmFtZSI6Ik1PQ0tFRCIsIm9yZ2FuaXNhdGlvbi1pZCI6Ik1PQ0tFRCJ9.p0DE8MUc9obE751XWOYPQWWtLXtq8-kJMPre4VuOBHg",
+        "token_type": "Bearer",
+        "expires_in": 35999
       }
 
 # UNIFORM submissions

--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
@@ -11,7 +11,7 @@
         "messsage": "MOCKED RESPONSE"
       }
 
-# UNIFORM token generation
+# UNIFORM token generation, access_token is mock JWT with "organisation-name" & "organisation-id" properties
 - request:
     method: POST
     path: /
@@ -21,9 +21,7 @@
       Content-Type: application/json
     body: >
       {
-        "access_token": "TEST_TOKEN",
-        "organisation-name": "MOCKED",
-        "organisation-id": "MOCKED"
+        "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbmlzYXRpb24tbmFtZSI6Ik1PQ0tFRCIsIm9yZ2FuaXNhdGlvbi1pZCI6Ik1PQ0tFRCJ9.p0DE8MUc9obE751XWOYPQWWtLXtq8-kJMPre4VuOBHg",
       }
 
 # UNIFORM submissions


### PR DESCRIPTION
We had a failed Southwark submission this morning and found out that there was a new release of the Submissions API Tuesday that changes the response shape of our authentication endpoint. 

This change addresses that update, and we'll figure out a process for more pro-active communication and documentation with Idox going forward.

Regression tests failing against this branch but passing locally, going to pick up fix outside of this PR: https://github.com/theopensystemslab/planx-new/actions/runs/7222293774