### PR TITLE
Revert "fix: Set `httpOnly` attribute on JWT cookie"

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -53,7 +53,6 @@ export const handleSuccess = (req: Request, res: Response) => {
       if (isLiveEnv()) {
         cookie.secure = true;
         cookie.sameSite = "none";
-        cookie.httpOnly = true;
       }
 
       res.cookie("jwt", req.user.jwt, cookie);


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2570

So this breaks login on staging...! (but does fix the issue - see screenshot)

Taking another look here, let's roll this back whilst I get to the bottom of it.

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/0f43309d-886e-4e14-a0cb-d46f6a1c1ac4)