### PR TITLE
feat: add & populate column `analytics_logs.node_id`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -155,12 +155,15 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       node?.type === TYPES.Content
         ? getContentTitle(node)
         : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
+    const nodeId = node?.id || "Unknown";
+
     // On component transition create the new analytics log
     const result = await insertNewAnalyticsLog(
       direction,
       analyticsId,
       metadata,
       nodeTitle,
+      nodeId,
     );
     const id = result?.data.insert_analytics_logs_one?.id;
     const newLogCreatedAt = result?.data.insert_analytics_logs_one?.created_at;
@@ -179,6 +182,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     analyticsId: number,
     metadata: NodeMetadata,
     nodeTitle: string,
+    nodeId: string,
   ) {
     const result = await publicClient.mutate({
       mutation: gql`
@@ -188,7 +192,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
           $metadata: jsonb
           $node_type: Int
           $node_title: String
-          $user_agent: jsonb
+          $node_id: String
         ) {
           insert_analytics_logs_one(
             object: {
@@ -198,6 +202,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
               metadata: $metadata
               node_type: $node_type
               node_title: $node_title
+              node_id: $node_id
             }
           ) {
             id
@@ -211,6 +216,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         metadata: metadata,
         node_type: node?.type,
         node_title: nodeTitle,
+        node_id: nodeId,
       },
     });
     return result;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -155,7 +155,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       node?.type === TYPES.Content
         ? getContentTitle(node)
         : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
-    const nodeId = node?.id || "Unknown";
+    const nodeId = node?.id || null;
 
     // On component transition create the new analytics log
     const result = await insertNewAnalyticsLog(
@@ -182,7 +182,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     analyticsId: number,
     metadata: NodeMetadata,
     nodeTitle: string,
-    nodeId: string,
+    nodeId: string | null,
   ) {
     const result = await publicClient.mutate({
       mutation: gql`

--- a/hasura.planx.uk/metadata/functions.yaml
+++ b/hasura.planx.uk/metadata/functions.yaml
@@ -1,3 +1,3 @@
 - function:
-    schema: public
     name: diff_latest_published_flow
+    schema: public

--- a/hasura.planx.uk/metadata/functions.yaml
+++ b/hasura.planx.uk/metadata/functions.yaml
@@ -1,3 +1,3 @@
 - function:
-    name: diff_latest_published_flow
     schema: public
+    name: diff_latest_published_flow

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1,6 +1,6 @@
 - table:
-    schema: public
     name: analytics
+    schema: public
   insert_permissions:
     - role: public
       permission:
@@ -26,8 +26,8 @@
         filter: {}
         check: null
 - table:
-    schema: public
     name: analytics_logs
+    schema: public
   insert_permissions:
     - role: public
       permission:
@@ -66,11 +66,11 @@
         filter: {}
         check: null
 - table:
-    schema: public
     name: analytics_summary
-- table:
     schema: public
+- table:
     name: blpu_codes
+    schema: public
   select_permissions:
     - role: public
       permission:
@@ -80,8 +80,8 @@
           - value
         filter: {}
 - table:
-    schema: public
     name: bops_applications
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -135,27 +135,27 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 1
         interval_sec: 30
+        num_retries: 1
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
-        version: 2
         query_params:
           type: bops-submission
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
-    schema: public
     name: document_template
+    schema: public
   is_enum: true
 - table:
-    schema: public
     name: email_applications
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -203,23 +203,23 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 1
         interval_sec: 30
+        num_retries: 1
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
-        version: 2
         query_params:
           type: email-submission
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
-    schema: public
     name: flow_document_templates
+    schema: public
   object_relationships:
     - name: flow
       using:
@@ -238,8 +238,8 @@
           - flow_id
         filter: {}
 - table:
-    schema: public
     name: flows
+    schema: public
   object_relationships:
     - name: creator
       using:
@@ -253,28 +253,28 @@
         foreign_key_constraint_on:
           column: flow_id
           table:
-            schema: public
             name: flow_document_templates
+            schema: public
     - name: operations
       using:
         foreign_key_constraint_on:
           column: flow_id
           table:
-            schema: public
             name: operations
+            schema: public
     - name: published_flows
       using:
         foreign_key_constraint_on:
           column: flow_id
           table:
-            schema: public
             name: published_flows
+            schema: public
   computed_fields:
     - name: data_merged
       definition:
         function:
-          schema: public
           name: compile_flow_portals
+          schema: public
       comment: Flow data with portals merged in
   insert_permissions:
     - role: api
@@ -430,11 +430,9 @@
   delete_permissions:
     - role: platformAdmin
       permission:
-        backend_only: false
         filter: {}
     - role: teamEditor
       permission:
-        backend_only: false
         filter:
           team:
             members:
@@ -444,8 +442,8 @@
                 - role:
                     _eq: teamEditor
 - table:
-    schema: public
     name: global_settings
+    schema: public
   insert_permissions:
     - role: platformAdmin
       permission:
@@ -480,35 +478,35 @@
         filter: {}
         check: {}
 - table:
-    schema: public
     name: lowcal_sessions
+    schema: public
   object_relationships:
     - name: flow
       using:
         manual_configuration:
-          remote_table:
-            schema: public
-            name: flows
-          insertion_order: null
           column_mapping:
             flow_id: id
+          insertion_order: null
+          remote_table:
+            name: flows
+            schema: public
   array_relationships:
     - name: payment_requests
       using:
         foreign_key_constraint_on:
           column: session_id
           table:
-            schema: public
             name: payment_requests
+            schema: public
     - name: payment_status
       using:
         manual_configuration:
-          remote_table:
-            schema: public
-            name: payment_status
-          insertion_order: null
           column_mapping:
             id: session_id
+          insertion_order: null
+          remote_table:
+            name: payment_status
+            schema: public
   insert_permissions:
     - role: public
       permission:
@@ -600,8 +598,8 @@
           columns:
             - submitted_at
       retry_conf:
-        num_retries: 0
         interval_sec: 10
+        num_retries: 0
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -618,11 +616,11 @@
                 "lockedAt": {{$body.event.data.new.locked_at}}
               }
             }
-        url: '{{$base_url}}/send-email/confirmation'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/send-email/confirmation'
+        version: 2
     - name: setup_lowcal_expiry_events
       definition:
         enable_manual: false
@@ -630,8 +628,8 @@
           columns:
             - has_user_saved
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -648,11 +646,11 @@
                 "email": {{$body.event.data.new.email}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
+        version: 2
     - name: setup_lowcal_reminder_events
       definition:
         enable_manual: false
@@ -660,8 +658,8 @@
           columns:
             - has_user_saved
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -678,14 +676,14 @@
                 "email": {{$body.event.data.new.email}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
+        version: 2
 - table:
-    schema: public
     name: operations
+    schema: public
   object_relationships:
     - name: actor
       using:
@@ -781,8 +779,8 @@
                       _eq: teamEditor
         check: {}
 - table:
-    schema: public
     name: payment_requests
+    schema: public
   object_relationships:
     - name: session
       using:
@@ -849,7 +847,6 @@
   delete_permissions:
     - role: api
       permission:
-        backend_only: false
         filter: {}
   event_triggers:
     - name: setup_payment_expiry_events
@@ -858,8 +855,8 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -875,19 +872,19 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
+        version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -903,19 +900,19 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
+        version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -931,11 +928,11 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
+        version: 2
     - name: setup_payment_send_events
       definition:
         enable_manual: false
@@ -943,8 +940,8 @@
           columns:
             - paid_at
       retry_conf:
-        num_retries: 3
         interval_sec: 10
+        num_retries: 3
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -960,24 +957,24 @@
                 "sessionId": {{$body.event.data.new.session_id}}
               }
             }
-        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
         method: POST
-        version: 2
         query_params: {}
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
+        version: 2
 - table:
-    schema: public
     name: payment_status
+    schema: public
   object_relationships:
     - name: lowcal_session
       using:
         manual_configuration:
-          remote_table:
-            schema: public
-            name: lowcal_sessions
-          insertion_order: null
           column_mapping:
             session_id: id
+          insertion_order: null
+          remote_table:
+            name: lowcal_sessions
+            schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1003,12 +1000,12 @@
           - amount
         filter: {}
 - table:
-    schema: public
     name: payment_status_enum
+    schema: public
   is_enum: true
 - table:
-    schema: public
     name: planning_constraints_requests
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1030,8 +1027,8 @@
           - created_at
         filter: {}
 - table:
-    schema: public
     name: project_types
+    schema: public
   select_permissions:
     - role: public
       permission:
@@ -1040,8 +1037,8 @@
           - value
         filter: {}
 - table:
-    schema: public
     name: published_flows
+    schema: public
   object_relationships:
     - name: flow
       using:
@@ -1130,8 +1127,8 @@
           - summary
         filter: {}
 - table:
-    schema: public
     name: reconciliation_requests
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1155,17 +1152,16 @@
   delete_permissions:
     - role: api
       permission:
-        backend_only: false
         filter: {}
 - table:
-    schema: public
     name: sessions
+    schema: public
   computed_fields:
     - name: payment_id
       definition:
         function:
-          schema: public
           name: sessions_payment
+          schema: public
       comment: A computed field to find the latest successful payment associated with a session
   insert_permissions:
     - role: public
@@ -1221,8 +1217,8 @@
                 _is_null: true
         check: null
 - table:
-    schema: public
     name: team_integrations
+    schema: public
   select_permissions:
     - role: api
       permission:
@@ -1233,8 +1229,8 @@
           - production_bops_submission_url
         filter: {}
 - table:
-    schema: public
     name: team_members
+    schema: public
   object_relationships:
     - name: team
       using:
@@ -1291,40 +1287,39 @@
   delete_permissions:
     - role: platformAdmin
       permission:
-        backend_only: false
         filter: {}
 - table:
-    schema: public
     name: teams
+    schema: public
   object_relationships:
     - name: integrations
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            schema: public
             name: team_integrations
+            schema: public
   array_relationships:
     - name: flows
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            schema: public
             name: flows
+            schema: public
     - name: members
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            schema: public
             name: team_members
+            schema: public
   computed_fields:
     - name: boundary_bbox
       definition:
         function:
-          schema: public
           name: boundary_bbox
+          schema: public
       comment: Bounding box of the team's full boundary
   insert_permissions:
     - role: platformAdmin
@@ -1424,8 +1419,8 @@
         filter: {}
         check: null
 - table:
-    schema: public
     name: uniform_applications
+    schema: public
   insert_permissions:
     - role: api
       permission:
@@ -1476,49 +1471,49 @@
         insert:
           columns: '*'
       retry_conf:
-        num_retries: 1
         interval_sec: 30
+        num_retries: 1
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
-        version: 2
         query_params:
           type: uniform-submission
         template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
-    schema: public
     name: user_roles
+    schema: public
   is_enum: true
 - table:
-    schema: public
     name: users
+    schema: public
   array_relationships:
     - name: created_flows
       using:
         foreign_key_constraint_on:
           column: creator_id
           table:
-            schema: public
             name: flows
+            schema: public
     - name: operations
       using:
         foreign_key_constraint_on:
           column: actor_id
           table:
-            schema: public
             name: operations
+            schema: public
     - name: teams
       using:
         foreign_key_constraint_on:
           column: user_id
           table:
-            schema: public
             name: team_members
+            schema: public
   insert_permissions:
     - role: platformAdmin
       permission:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1,6 +1,6 @@
 - table:
-    name: analytics
     schema: public
+    name: analytics
   insert_permissions:
     - role: public
       permission:
@@ -26,8 +26,8 @@
         filter: {}
         check: null
 - table:
-    name: analytics_logs
     schema: public
+    name: analytics_logs
   insert_permissions:
     - role: public
       permission:
@@ -40,6 +40,7 @@
           - id
           - input_errors
           - metadata
+          - node_id
           - node_title
           - node_type
           - user_exit
@@ -65,11 +66,11 @@
         filter: {}
         check: null
 - table:
+    schema: public
     name: analytics_summary
-    schema: public
 - table:
-    name: blpu_codes
     schema: public
+    name: blpu_codes
   select_permissions:
     - role: public
       permission:
@@ -79,8 +80,8 @@
           - value
         filter: {}
 - table:
-    name: bops_applications
     schema: public
+    name: bops_applications
   insert_permissions:
     - role: api
       permission:
@@ -134,27 +135,27 @@
         insert:
           columns: '*'
       retry_conf:
-        interval_sec: 30
         num_retries: 1
+        interval_sec: 30
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
+        version: 2
         query_params:
           type: bops-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
-        version: 2
 - table:
-    name: document_template
     schema: public
+    name: document_template
   is_enum: true
 - table:
-    name: email_applications
     schema: public
+    name: email_applications
   insert_permissions:
     - role: api
       permission:
@@ -202,23 +203,23 @@
         insert:
           columns: '*'
       retry_conf:
-        interval_sec: 30
         num_retries: 1
+        interval_sec: 30
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
+        version: 2
         query_params:
           type: email-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
-        version: 2
 - table:
-    name: flow_document_templates
     schema: public
+    name: flow_document_templates
   object_relationships:
     - name: flow
       using:
@@ -237,8 +238,8 @@
           - flow_id
         filter: {}
 - table:
-    name: flows
     schema: public
+    name: flows
   object_relationships:
     - name: creator
       using:
@@ -252,28 +253,28 @@
         foreign_key_constraint_on:
           column: flow_id
           table:
-            name: flow_document_templates
             schema: public
+            name: flow_document_templates
     - name: operations
       using:
         foreign_key_constraint_on:
           column: flow_id
           table:
-            name: operations
             schema: public
+            name: operations
     - name: published_flows
       using:
         foreign_key_constraint_on:
           column: flow_id
           table:
-            name: published_flows
             schema: public
+            name: published_flows
   computed_fields:
     - name: data_merged
       definition:
         function:
-          name: compile_flow_portals
           schema: public
+          name: compile_flow_portals
       comment: Flow data with portals merged in
   insert_permissions:
     - role: api
@@ -429,9 +430,11 @@
   delete_permissions:
     - role: platformAdmin
       permission:
+        backend_only: false
         filter: {}
     - role: teamEditor
       permission:
+        backend_only: false
         filter:
           team:
             members:
@@ -441,8 +444,8 @@
                 - role:
                     _eq: teamEditor
 - table:
-    name: global_settings
     schema: public
+    name: global_settings
   insert_permissions:
     - role: platformAdmin
       permission:
@@ -477,35 +480,35 @@
         filter: {}
         check: {}
 - table:
-    name: lowcal_sessions
     schema: public
+    name: lowcal_sessions
   object_relationships:
     - name: flow
       using:
         manual_configuration:
+          remote_table:
+            schema: public
+            name: flows
+          insertion_order: null
           column_mapping:
             flow_id: id
-          insertion_order: null
-          remote_table:
-            name: flows
-            schema: public
   array_relationships:
     - name: payment_requests
       using:
         foreign_key_constraint_on:
           column: session_id
           table:
-            name: payment_requests
             schema: public
+            name: payment_requests
     - name: payment_status
       using:
         manual_configuration:
+          remote_table:
+            schema: public
+            name: payment_status
+          insertion_order: null
           column_mapping:
             id: session_id
-          insertion_order: null
-          remote_table:
-            name: payment_status
-            schema: public
   insert_permissions:
     - role: public
       permission:
@@ -597,8 +600,8 @@
           columns:
             - submitted_at
       retry_conf:
-        interval_sec: 10
         num_retries: 0
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -615,11 +618,11 @@
                 "lockedAt": {{$body.event.data.new.locked_at}}
               }
             }
+        url: '{{$base_url}}/send-email/confirmation'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/send-email/confirmation'
-        version: 2
     - name: setup_lowcal_expiry_events
       definition:
         enable_manual: false
@@ -627,8 +630,8 @@
           columns:
             - has_user_saved
       retry_conf:
-        interval_sec: 10
         num_retries: 3
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -645,11 +648,11 @@
                 "email": {{$body.event.data.new.email}}
               }
             }
+        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
-        version: 2
     - name: setup_lowcal_reminder_events
       definition:
         enable_manual: false
@@ -657,8 +660,8 @@
           columns:
             - has_user_saved
       retry_conf:
-        interval_sec: 10
         num_retries: 3
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -675,14 +678,14 @@
                 "email": {{$body.event.data.new.email}}
               }
             }
+        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
-        version: 2
 - table:
-    name: operations
     schema: public
+    name: operations
   object_relationships:
     - name: actor
       using:
@@ -778,8 +781,8 @@
                       _eq: teamEditor
         check: {}
 - table:
-    name: payment_requests
     schema: public
+    name: payment_requests
   object_relationships:
     - name: session
       using:
@@ -846,6 +849,7 @@
   delete_permissions:
     - role: api
       permission:
+        backend_only: false
         filter: {}
   event_triggers:
     - name: setup_payment_expiry_events
@@ -854,8 +858,8 @@
         insert:
           columns: '*'
       retry_conf:
-        interval_sec: 10
         num_retries: 3
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -871,19 +875,19 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
+        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
-        version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
           columns: '*'
       retry_conf:
-        interval_sec: 10
         num_retries: 3
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -899,19 +903,19 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
+        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
-        version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
           columns: '*'
       retry_conf:
-        interval_sec: 10
         num_retries: 3
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -927,11 +931,11 @@
                 "paymentRequestId": {{$body.event.data.new.id}}
               }
             }
+        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
-        version: 2
     - name: setup_payment_send_events
       definition:
         enable_manual: false
@@ -939,8 +943,8 @@
           columns:
             - paid_at
       retry_conf:
-        interval_sec: 10
         num_retries: 3
+        interval_sec: 10
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
@@ -956,24 +960,24 @@
                 "sessionId": {{$body.event.data.new.session_id}}
               }
             }
+        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
         method: POST
+        version: 2
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
-        version: 2
 - table:
-    name: payment_status
     schema: public
+    name: payment_status
   object_relationships:
     - name: lowcal_session
       using:
         manual_configuration:
+          remote_table:
+            schema: public
+            name: lowcal_sessions
+          insertion_order: null
           column_mapping:
             session_id: id
-          insertion_order: null
-          remote_table:
-            name: lowcal_sessions
-            schema: public
   insert_permissions:
     - role: api
       permission:
@@ -999,12 +1003,12 @@
           - amount
         filter: {}
 - table:
-    name: payment_status_enum
     schema: public
+    name: payment_status_enum
   is_enum: true
 - table:
-    name: planning_constraints_requests
     schema: public
+    name: planning_constraints_requests
   insert_permissions:
     - role: api
       permission:
@@ -1026,8 +1030,8 @@
           - created_at
         filter: {}
 - table:
-    name: project_types
     schema: public
+    name: project_types
   select_permissions:
     - role: public
       permission:
@@ -1036,8 +1040,8 @@
           - value
         filter: {}
 - table:
-    name: published_flows
     schema: public
+    name: published_flows
   object_relationships:
     - name: flow
       using:
@@ -1126,8 +1130,8 @@
           - summary
         filter: {}
 - table:
-    name: reconciliation_requests
     schema: public
+    name: reconciliation_requests
   insert_permissions:
     - role: api
       permission:
@@ -1151,16 +1155,17 @@
   delete_permissions:
     - role: api
       permission:
+        backend_only: false
         filter: {}
 - table:
-    name: sessions
     schema: public
+    name: sessions
   computed_fields:
     - name: payment_id
       definition:
         function:
-          name: sessions_payment
           schema: public
+          name: sessions_payment
       comment: A computed field to find the latest successful payment associated with a session
   insert_permissions:
     - role: public
@@ -1216,8 +1221,8 @@
                 _is_null: true
         check: null
 - table:
-    name: team_integrations
     schema: public
+    name: team_integrations
   select_permissions:
     - role: api
       permission:
@@ -1228,8 +1233,8 @@
           - production_bops_submission_url
         filter: {}
 - table:
-    name: team_members
     schema: public
+    name: team_members
   object_relationships:
     - name: team
       using:
@@ -1286,39 +1291,40 @@
   delete_permissions:
     - role: platformAdmin
       permission:
+        backend_only: false
         filter: {}
 - table:
-    name: teams
     schema: public
+    name: teams
   object_relationships:
     - name: integrations
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            name: team_integrations
             schema: public
+            name: team_integrations
   array_relationships:
     - name: flows
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            name: flows
             schema: public
+            name: flows
     - name: members
       using:
         foreign_key_constraint_on:
           column: team_id
           table:
-            name: team_members
             schema: public
+            name: team_members
   computed_fields:
     - name: boundary_bbox
       definition:
         function:
-          name: boundary_bbox
           schema: public
+          name: boundary_bbox
       comment: Bounding box of the team's full boundary
   insert_permissions:
     - role: platformAdmin
@@ -1418,8 +1424,8 @@
         filter: {}
         check: null
 - table:
-    name: uniform_applications
     schema: public
+    name: uniform_applications
   insert_permissions:
     - role: api
       permission:
@@ -1470,49 +1476,49 @@
         insert:
           columns: '*'
       retry_conf:
-        interval_sec: 30
         num_retries: 1
+        interval_sec: 30
         timeout_sec: 60
       webhook_from_env: HASURA_PLANX_API_URL
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
       request_transform:
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         method: POST
+        version: 2
         query_params:
           type: uniform-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
-        version: 2
 - table:
-    name: user_roles
     schema: public
+    name: user_roles
   is_enum: true
 - table:
-    name: users
     schema: public
+    name: users
   array_relationships:
     - name: created_flows
       using:
         foreign_key_constraint_on:
           column: creator_id
           table:
-            name: flows
             schema: public
+            name: flows
     - name: operations
       using:
         foreign_key_constraint_on:
           column: actor_id
           table:
-            name: operations
             schema: public
+            name: operations
     - name: teams
       using:
         foreign_key_constraint_on:
           column: user_id
           table:
-            name: team_members
             schema: public
+            name: team_members
   insert_permissions:
     - role: platformAdmin
       permission:

--- a/hasura.planx.uk/migrations/1702897470388_alter_table_public_analytics_logs_add_column_node_id/down.sql
+++ b/hasura.planx.uk/migrations/1702897470388_alter_table_public_analytics_logs_add_column_node_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."analytics_logs" drop column "node_id";

--- a/hasura.planx.uk/migrations/1702897470388_alter_table_public_analytics_logs_add_column_node_id/up.sql
+++ b/hasura.planx.uk/migrations/1702897470388_alter_table_public_analytics_logs_add_column_node_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."analytics_logs" add column "node_id" text null;

--- a/hasura.planx.uk/migrations/1702899813258_update_view_analytics_summary_node_id/down.sql
+++ b/hasura.planx.uk/migrations/1702899813258_update_view_analytics_summary_node_id/down.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE VIEW public.analytics_summary AS 
+select 
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	a.created_at as analytics_created_at,
+	user_agent,
+	referrer,
+	flow_direction,
+	metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(EXTRACT(EPOCH FROM (al.next_log_created_at - al.created_at)) as numeric (10, 1)) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(EXTRACT(EPOCH FROM (a.ended_at - a.created_at))/60 as numeric (10, 1)) as time_spent_on_analytics_session_minutes
+from analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;

--- a/hasura.planx.uk/migrations/1702899813258_update_view_analytics_summary_node_id/up.sql
+++ b/hasura.planx.uk/migrations/1702899813258_update_view_analytics_summary_node_id/up.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE VIEW public.analytics_summary AS 
+select 
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	a.created_at as analytics_created_at,
+	user_agent,
+	referrer,
+	flow_direction,
+	metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(EXTRACT(EPOCH FROM (al.next_log_created_at - al.created_at)) as numeric (10, 1)) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(EXTRACT(EPOCH FROM (a.ended_at - a.created_at))/60 as numeric (10, 1)) as time_spent_on_analytics_session_minutes,
+	node_id
+from analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;


### PR DESCRIPTION
Changes:
- Alters table `analytics_logs` to add new column `node_id`, populates value on record creation
- Updates view `analytics_summary` to add new column `node_id`