### PR TITLE
fix: log the viewed node rather than root node when creating new analytics session

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -122,12 +122,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Track component transition
   useEffect(() => {
-    if (shouldTrackAnalytics && analyticsId) {
+    if (shouldTrackAnalytics && analyticsId && node?.id) {
       const curLength = Object.keys(breadcrumbs).length;
       const prevLength = Object.keys(previousBreadcrumbs).length;
 
-      if (curLength > prevLength) track("forwards", analyticsId);
-      if (curLength < prevLength) track("backwards", analyticsId);
+      if (curLength > prevLength) track("forwards", analyticsId, node.id);
+      if (curLength < prevLength) track("backwards", analyticsId, node.id);
 
       setPreviousBreadcrumb(breadcrumbs);
     }
@@ -149,14 +149,17 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     </Provider>
   );
 
-  async function track(direction: AnalyticsLogDirection, analyticsId: number) {
-    if (!node) {
-      return;
-    }
-    const metadata = getNodeMetadata(node);
-    const nodeTitle = extractNodeTitle(node);
+  async function track(
+    direction: AnalyticsLogDirection,
+    analyticsId: number,
+    nodeId: string,
+  ) {
+    const nodeToTrack = flow[nodeId];
+
+    const metadata = getNodeMetadata(nodeToTrack);
+    const nodeTitle = extractNodeTitle(nodeToTrack);
+
     // On component transition create the new analytics log
-    const nodeId = node?.id || null;
     const result = await insertNewAnalyticsLog(
       direction,
       analyticsId,
@@ -381,7 +384,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       });
       const id = response.data.insert_analytics_one.id;
       setAnalyticsId(id);
-      track(type, id);
+      if (node?.id) track(type, id, node?.id);
     }
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -123,11 +123,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   // Track component transition
   useEffect(() => {
     if (shouldTrackAnalytics && analyticsId && node?.id) {
-      const curLength = Object.keys(breadcrumbs).length;
-      const prevLength = Object.keys(previousBreadcrumbs).length;
-
-      if (curLength > prevLength) track("forwards", analyticsId, node.id);
-      if (curLength < prevLength) track("backwards", analyticsId, node.id);
+      const logDirection = detemineLogDirection();
+      if (logDirection) track(logDirection, analyticsId, node.id);
 
       setPreviousBreadcrumb(breadcrumbs);
     }
@@ -444,6 +441,14 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         ? getContentTitle(node)
         : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
     return nodeTitle;
+  }
+
+  function detemineLogDirection() {
+    const curLength = Object.keys(breadcrumbs).length;
+    const prevLength = Object.keys(previousBreadcrumbs).length;
+
+    if (curLength > prevLength) return "forwards";
+    if (curLength < prevLength) return "backwards";
   }
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -381,7 +381,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       });
       const id = response.data.insert_analytics_one.id;
       setAnalyticsId(id);
-      if (node?.id) track(type, id, node?.id);
+      const currentNodeId = currentCard()?.id;
+      if (currentNodeId) track(type, id, currentNodeId);
     }
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -150,7 +150,10 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   async function track(direction: AnalyticsLogDirection, analyticsId: number) {
-    const metadata = getNodeMetadata();
+    if (!node) {
+      return 
+    }
+    const metadata = getNodeMetadata(node);
     const nodeTitle =
       node?.type === TYPES.Content
         ? getContentTitle(node)
@@ -385,7 +388,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }
 
-  function getNodeMetadata() {
+  function getNodeMetadata (node: Store.node) {
     switch (node?.type) {
       case TYPES.Result:
         const flagSet = node?.data?.flagSet || DEFAULT_FLAG_CATEGORY;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -151,16 +151,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   async function track(direction: AnalyticsLogDirection, analyticsId: number) {
     if (!node) {
-      return 
+      return;
     }
     const metadata = getNodeMetadata(node);
-    const nodeTitle =
-      node?.type === TYPES.Content
-        ? getContentTitle(node)
-        : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
-    const nodeId = node?.id || null;
-
+    const nodeTitle = extractNodeTitle(node);
     // On component transition create the new analytics log
+    const nodeId = node?.id || null;
     const result = await insertNewAnalyticsLog(
       direction,
       analyticsId,
@@ -168,6 +164,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       nodeTitle,
       nodeId,
     );
+
     const id = result?.data.insert_analytics_logs_one?.id;
     const newLogCreatedAt = result?.data.insert_analytics_logs_one?.created_at;
 
@@ -388,7 +385,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }
 
-  function getNodeMetadata (node: Store.node) {
+  function getNodeMetadata(node: Store.node) {
     switch (node?.type) {
       case TYPES.Result:
         const flagSet = node?.data?.flagSet || DEFAULT_FLAG_CATEGORY;
@@ -436,6 +433,14 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         },
       });
     }
+  }
+
+  function extractNodeTitle(node: Store.node) {
+    const nodeTitle =
+      node?.type === TYPES.Content
+        ? getContentTitle(node)
+        : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
+    return nodeTitle;
   }
 };
 


### PR DESCRIPTION
##  What:

- Refactor for readability
- Refactor to make some of the analytics functions more abstract
- When creating an analytics session check the `currentCard` rather than relying on the `node`

## Why:

- Refactoring to improve readability to lay ground work for changing the analytics logging strategy.
- Making the functions more abstract works towards decoupling the logic from the `node` which is checked on instantiation but can become out of sync. 
- Currently, when creating an analytics session we log the data of the root node.
- This is somewhat misleading and doesn't provide a great deal of context on the users journey. 
- Update to instead log the `currentCard` i.e. the node being shown to the user on resume, init etc.

## Example: 

What would currently be logged for a FOIYNPP on creating a new analytics session: 

```json
{
   "analytics_id":322,
   "created_at":"2023-12-18T11:49:21.416227+00:00",
   "node_title":null,
   "has_clicked_help":false,
   "metadata":{},
   "id":1457,
   "next_log_created_at":null,
   "flow_direction":"resume",
   "input_errors":[],
   "node_type":380,
   "user_exit":false
}
```

What would be logged after this change

```json
{
   "analytics_id":323,
   "created_at":"2023-12-18T11:49:28.310598+00:00",
   "node_title":"Draw the outline of your property and any areas affected by your project",
   "has_clicked_help":false,
   "metadata":{},
   "id":1458,
   "next_log_created_at":null,
   "flow_direction":"resume",
   "input_errors":[],
   "node_type":380,
   "user_exit":false
}
```



