### PR TITLE
fix: rationalise analytics logs to remove duplication and inconsistencies

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -3,8 +3,9 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Fade from "@mui/material/Fade";
 import { styled, Theme, useTheme } from "@mui/material/styles";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useEffect } from "react";
 import { ApplicationPath } from "types";
 
 import SaveResumeButton from "./SaveResumeButton";
@@ -47,9 +48,20 @@ const Card: React.FC<Props> = ({
   ...props
 }) => {
   const theme = useTheme();
-  const path = useStore((state) => state.path);
+  const [path, currentCard] = useStore((state) => [
+    state.path,
+    state.currentCard,
+  ]);
   const showSaveResumeButton =
     path === ApplicationPath.SaveAndReturn && handleSubmit;
+  const { track } = useAnalyticsTracking();
+
+  useEffect(() => {
+    // The Card component is only rendered when there's content the user will
+    // see
+    const visibileNode = currentCard();
+    if (visibileNode?.id) track(visibileNode?.id);
+  }, []);
 
   return (
     <Fade

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -59,8 +59,8 @@ const Card: React.FC<Props> = ({
   useEffect(() => {
     // The Card component is only rendered when there's content the user will
     // see
-    const visibileNode = currentCard();
-    if (visibileNode?.id) track(visibileNode?.id);
+    const visibleNode = currentCard();
+    if (visibleNode?.id) track(visibleNode?.id);
   }, []);
 
   return (

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -157,7 +157,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     analyticsSessionId?: number,
   ) {
     const nodeToTrack = flow[nodeId];
-    const logDirection = direction || detemineLogDirection();
+    const logDirection = direction || determineLogDirection();
     const analyticsSession = analyticsSessionId || analyticsId;
 
     if (!nodeToTrack || !logDirection || !analyticsSession) {
@@ -472,7 +472,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     return nodeTitle;
   }
 
-  function detemineLogDirection() {
+  function determineLogDirection() {
     if (previousBreadcrumbs) {
       const curLength = Object.keys(breadcrumbs).length;
       const prevLength = Object.keys(previousBreadcrumbs).length;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -100,7 +100,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     previewEnvironment === "standalone" && isAnalyticsEnabled;
   const previousBreadcrumbs = usePrevious(breadcrumbs);
 
-  const onPageExit = () => {
+  const trackVisibilityChange = () => {
     if (lastVisibleNodeAnalyticsLogId && shouldTrackAnalytics) {
       if (document.visibilityState === "hidden") {
         send(
@@ -119,14 +119,16 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   };
 
-  useEffect(() => {
+  const onVisibilityChange = () => {
     if (shouldTrackAnalytics)
-      document.addEventListener("visibilitychange", onPageExit);
+      document.addEventListener("visibilitychange", trackVisibilityChange);
     return () => {
       if (shouldTrackAnalytics)
-        document.removeEventListener("visibilitychange", onPageExit);
+        document.removeEventListener("visibilitychange", trackVisibilityChange);
     };
-  }, []);
+  };
+
+  useEffect(onVisibilityChange, []);
 
   // Track if nodes have been auto answered on component transistion
   useEffect(() => {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -8,6 +8,7 @@ import { TYPES } from "@planx/components/types";
 import Bowser from "bowser";
 import { publicClient } from "lib/graphql";
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { usePrevious } from "react-use";
 
 import { Store, useStore } from "./store";
 
@@ -90,7 +91,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     new URL(window.location.href).searchParams.get("analytics") !== "false";
   const shouldTrackAnalytics =
     previewEnvironment === "standalone" && isAnalyticsEnabled;
-  const [previousBreadcrumbs, setPreviousBreadcrumb] = useState(breadcrumbs);
+  const previousBreadcrumbs = usePrevious(breadcrumbs);
 
   const onPageExit = () => {
     if (lastAnalyticsLogId && shouldTrackAnalytics) {
@@ -125,8 +126,6 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     if (shouldTrackAnalytics && analyticsId && node?.id) {
       const logDirection = detemineLogDirection();
       if (logDirection) track(logDirection, analyticsId, node.id);
-
-      setPreviousBreadcrumb(breadcrumbs);
     }
   }, [breadcrumbs]);
 
@@ -448,11 +447,13 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   function detemineLogDirection() {
-    const curLength = Object.keys(breadcrumbs).length;
-    const prevLength = Object.keys(previousBreadcrumbs).length;
+    if (previousBreadcrumbs) {
+      const curLength = Object.keys(breadcrumbs).length;
+      const prevLength = Object.keys(previousBreadcrumbs).length;
 
-    if (curLength > prevLength) return "forwards";
-    if (curLength < prevLength) return "backwards";
+      if (curLength > prevLength) return "forwards";
+      if (curLength < prevLength) return "backwards";
+    }
   }
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -50,6 +50,11 @@ const analyticsContext = createContext<{
   ) => Promise<void>;
   node: Store.node | null;
   trackInputErrors: (error: string) => Promise<void>;
+  track: (
+    nodeId: string,
+    direction?: AnalyticsLogDirection,
+    analyticsSessionId?: number,
+  ) => Promise<void>;
 }>({
   createAnalytics: () => Promise.resolve(),
   trackHelpClick: () => Promise.resolve(),
@@ -58,6 +63,7 @@ const analyticsContext = createContext<{
   trackBackwardsNavigationByNodeId: () => Promise.resolve(),
   node: null,
   trackInputErrors: () => Promise.resolve(),
+  track: () => Promise.resolve(),
 });
 const { Provider } = analyticsContext;
 
@@ -140,6 +146,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         trackBackwardsNavigationByNodeId,
         node,
         trackInputErrors,
+        track,
       }}
     >
       {children}
@@ -477,6 +484,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     if (updatedBreadcrumbKeys) {
       updatedBreadcrumbKeys.forEach((breadcrumbKey) => {
         const breadcrumb = breadcrumbs[breadcrumbKey];
+        //Note the changes implemented with this approach break the ordering as
+        // the visible node can have mutliple subsequent logs which aren't answered.
         if (breadcrumb.auto) {
           track(breadcrumbKey);
         }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -25,7 +25,7 @@ export type SelectedUrlsMetadata = Record<"selectedUrls", string[]>;
 export type BackwardsNavigationInitiatorType = "change" | "back";
 
 type NodeMetadata = {
-  flagset?: FlagSet;
+  flagSet?: FlagSet;
   displayText?: {
     heading?: string;
     description?: string;
@@ -421,12 +421,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
           flagSet,
           displayText,
           flag,
-          isAutoAnswered
+          isAutoAnswered,
         };
 
       default:
         return {
-          isAutoAnswered
+          isAutoAnswered,
         };
     }
   }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -130,13 +130,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(onVisibilityChange, []);
 
-  // Track if nodes have been auto answered on component transistion
   useEffect(() => {
-    if (shouldTrackAnalytics && analyticsId) {
-      // Note that when going backwards through flows when a node is landed on
-      // it might auto answer nodes in the future which will still be 'forwards' direction logs
-      trackAutoTrueNodes();
-    }
+    if (shouldTrackAnalytics && analyticsId) trackAutoTrueNodes();
   }, [breadcrumbs]);
 
   return (


### PR DESCRIPTION
## What: 

- Update the approach to gathering analytics
- Differentiate between `auto` answered questions and those the user explicitly sees in approach but also in logs.
- Capture `auto` question when breadcrumbs change
- Capture logs for nodes users see when rendered by the `Card` component 
- Ensure that when a user interacts with a visible component the meta info is recorded against the visible node

## Why:
- Previously when navigating between nodes if there were auto answered questions they may be logged but subsequently many duplicates of the visible node were added to the log. 
- This could result in logging info being inaccurate and not being representative of  the way the user navigates through a flow
- Now explicitly logging all auto answered questions but also differentiating them from those the user interacted with

## To do: 

- [x] Further testing
- [x] Rebase on main and resolve `node_type` conflict
- [x] Review logic and consider optimisations / improvements
- [x] Resolve issue with `input_errors` disappearing
- [x] Update as per feedback

## Testing Notes

Known Issue:

- I've noticed that nodes like `Planning Constraints` render twice and therefore are duplicated in the logs. I'm not sure if this is _wrong_ as such as the user did see this component twice i.e. once in loading state and the second with results although we don't differentiate at the moment. Personally, I'm curious is user wait to see the result or just hit 'continue' 😅

```json
{
  "id": 10,
  "node_id": "4gKrBdC9wk",
  "analytics_id": 2,
  "created_at": "2023-12-20T10:19:54.826965+00:00",
  "flow_direction": "forwards",
  "has_clicked_help": false,
  "input_errors": [],
  "metadata": {
    "isAutoAnswered": false
  },
  "next_log_created_at": "2023-12-20T10:20:13.669525+00:00",
  "node_title": "Planning constraints",
  "node_type": "PlanningConstraints",
  "user_exit": false
},
{
  "id": 9,
  "node_id": "4gKrBdC9wk",
  "analytics_id": 2,
  "created_at": "2023-12-20T10:19:51.592435+00:00",
  "flow_direction": "forwards",
  "has_clicked_help": false,
  "input_errors": [],
  "metadata": {
    "isAutoAnswered": false
  },
  "next_log_created_at": "2023-12-20T10:19:54.826965+00:00",
  "node_title": "Planning constraints",
  "node_type": "PlanningConstraints",
  "user_exit": false
},
``` 

- In testing this I noticed that I missed tracking a user hitting `change` on their "About property" so it won't be visible in the logs in the way other `change` clicks are. 

<img width="885" alt="Screenshot 2023-12-20 at 11 02 18" src="https://github.com/theopensystemslab/planx-new/assets/36415632/e4cc9a96-4a46-4b06-94b8-f4b62231779e">

Potentially useful:

- Adding `where: {metadata: {_contains: {isAutoAnswered: false}}}` to queries is useful for assessing what the user directly saw and comparing metadata like if the user hit "back" or comparing `created_at` of following nodes against `next_log_created_at`

```GraphQL
query MyQuery {
  analytics_logs(order_by: {created_at: desc}, where: {metadata:{_contains: {isAutoAnswered: false}}}) {
    id
    node_id
    analytics_id
    created_at
    flow_direction
    has_clicked_help
    input_errors
    metadata
    next_log_created_at
    node_title
    node_type
    user_exit
  }
}
```

Potential Gotcha:

- Something which I think is correct but unintuitive is that when you go `back` logs can show `forwards` these are because there'll be a `backwards` associated with the visible node but in the background questions can be auto answered and these are classed as going `forwards` which I makes sense as we're answering nodes in the future but was not immediately obvious to me. 

```json
{
  "id": 34,
  "node_id": "9MHz4F7MdL",
  "analytics_id": 2,
  "created_at": "2023-12-20T11:01:56.580244+00:00",
  "flow_direction": "forwards",
  "has_clicked_help": false,
  "input_errors": [],
  "metadata": {
    "isAutoAnswered": true
  },
  "next_log_created_at": null,
  "node_title": "What type of property is it?",
  "node_type": "Statement",
  "user_exit": false
},
{
  "id": 35,
  "node_id": "PyCAP4tqg0",
  "analytics_id": 2,
  "created_at": "2023-12-20T11:01:56.579727+00:00",
  "flow_direction": "forwards",
  "has_clicked_help": false,
  "input_errors": [],
  "metadata": {
    "isAutoAnswered": true
  },
  "next_log_created_at": null,
  "node_title": "What type of property is it?",
  "node_type": "Statement",
  "user_exit": false
},
{
  "id": 33,
  "node_id": "ybK0sfPqep",
  "analytics_id": 2,
  "created_at": "2023-12-20T11:01:56.567269+00:00",
  "flow_direction": "backwards",
  "has_clicked_help": false,
  "input_errors": [],
  "metadata": {
    "isAutoAnswered": false
  },
  "next_log_created_at": null,
  "node_title": "About the property",
  "node_type": "PropertyInformation",
  "user_exit": false
},
```

To do next: 

- [ ] Update the `type` associated with `back` and `change` navigation to use the string value. Also, update historical record and view to reflect this change: https://trello.com/c/vGxXLOBw/2738-update-nodetype-stored-in-analyticslogs-metadata?completedInviteSignup=1&filter=label:Analytics
- [ ] Track `change` via `overrideAnswer` https://trello.com/c/0iGhckG4/2739-track-change-on-overrideanswer
- [ ] Track `allow_list` answers https://trello.com/c/fauHLsFu/2569-track-answers-to-allow-listed-questions-for-guidance-services-non-save-return