### PR TITLE
infra: add frontend values for Barnet's subdomain

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -16,6 +16,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.buckinghamshire.gov.uk":
     case "planningservices.camden.gov.uk":
     case "planningservices.stalbans.gov.uk":
+    case "planningservices.barnet.gov.uk":
     case "editor.planx.uk":
       return "production";
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -57,6 +57,7 @@ const PREVIEW_ONLY_DOMAINS = [
   "planningservices.medway.gov.uk",
   "planningservices.camden.gov.uk",
   "planningservices.stalbans.gov.uk",
+  "planningservices.barnet.gov.uk",
   // XXX: un-comment the next line to test custom domains locally
   // "localhost",
 ];


### PR DESCRIPTION
Queuing this up now, but it needs to merge after #2582 & #2583. 

This covers step 10 in the how-to, and is the final code change.