### PR TITLE
fix: Syntax issue in `SetupTeamIntegrationE2E` mutation

### DIFF
--- a/api.planx.uk/modules/send/bops/bops.ts
+++ b/api.planx.uk/modules/send/bops/bops.ts
@@ -50,7 +50,6 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
     localAuthority,
     env,
   );
-  console.log({ bopsSubmissionURL });
   const isSupported = Boolean(bopsSubmissionURL);
   if (!isSupported) {
     return next(
@@ -186,7 +185,6 @@ const sendToBOPSV2 = async (
     localAuthority,
     env,
   );
-  console.log({ bopsSubmissionURL });
   const isSupported = Boolean(bopsSubmissionURL);
   if (!isSupported) {
     return next(

--- a/api.planx.uk/modules/send/bops/bops.ts
+++ b/api.planx.uk/modules/send/bops/bops.ts
@@ -44,11 +44,13 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
   // a local or staging API instance should send to the BOPS staging endpoint
   // production should send to the BOPS production endpoint
   const localAuthority = req.params.localAuthority;
-  const env = process.env.NODE_ENV === "production" ? "production" : "staging";
+  const env =
+    process.env.APP_ENVIRONMENT === "production" ? "production" : "staging";
   const bopsSubmissionURL = await $api.team.getBopsSubmissionURL(
     localAuthority,
     env,
   );
+  console.log({ bopsSubmissionURL });
   const isSupported = Boolean(bopsSubmissionURL);
   if (!isSupported) {
     return next(
@@ -178,21 +180,14 @@ const sendToBOPSV2 = async (
   // a local or staging API instance should send to the BOPS staging endpoint
   // production should send to the BOPS production endpoint
   const localAuthority = req.params.localAuthority;
-  const env = process.env.NODE_ENV === "production" ? "production" : "staging";
+  const env =
+    process.env.APP_ENVIRONMENT === "production" ? "production" : "staging";
   const bopsSubmissionURL = await $api.team.getBopsSubmissionURL(
     localAuthority,
     env,
   );
+  console.log({ bopsSubmissionURL });
   const isSupported = Boolean(bopsSubmissionURL);
-  if (!isSupported) {
-    return next(
-      new ServerError({
-        status: 400,
-        message: `Back-office Planning System (BOPS) is not enabled for this local authority (${localAuthority})`,
-      }),
-    );
-  }
-
   if (!isSupported) {
     return next(
       new ServerError({

--- a/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
@@ -164,13 +164,13 @@ const setupMockBopsSubmissionUrl = async (teamId: number) => {
   await $admin.client.request(
     gql`
       mutation SetupTeamIntegrationE2E(
-        $staging_bops_submission_url: String
-        $team_id: Int
+        $stagingBopsSubmissionUrl: String
+        $teamId: Int
       ) {
         insert_team_integrations_one(
           object: {
-            teamId: $team_id
-            stagingBopsSubmissionUrl: $staging_bops_submission_url
+            team_id: $teamId
+            staging_bops_submission_url: $stagingBopsSubmissionUrl
           }
         ) {
           id


### PR DESCRIPTION
## What does this PR do?
 - Fixes failing regression test due to bug introduced in https://github.com/theopensystemslab/planx-new/pull/2581
 
 ## What was the cause?
- Relying on `NODE_ENV` over `APP_ENVIRONMENT`

Failing regression test now passing locally on this branch - 

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/4c125870-98fd-480b-b4b5-8add581bac1c)

🚀 Regression tests running against this branch here - https://github.com/theopensystemslab/planx-new/actions/runs/7275585116