### PR TITLE
fix: Form wrapper for upload + label

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -54,7 +54,7 @@ const DropzoneContainer = styled(Box)(({ theme }) => ({
   },
 }));
 
-const FileList = styled(List)(({ theme }) => ({
+const UploadList = styled(List)(({ theme }) => ({
   width: "100%",
   maxWidth: theme.breakpoints.values.formWrap,
   [theme.breakpoints.up("md")]: {
@@ -182,7 +182,7 @@ function Component(props: Props) {
               </ErrorWrapper>
             </>
           )}
-          <FileList disablePadding>
+          <UploadList disablePadding>
             {(Object.keys(fileList) as Array<keyof typeof fileList>)
               .filter(isCategoryVisible)
               .flatMap((fileListCategory) => [
@@ -211,7 +211,7 @@ function Component(props: Props) {
                   </ListItem>
                 )),
               ])}
-          </FileList>
+          </UploadList>
         </DropzoneContainer>
         <ErrorWrapper error={fileListError} id={`${props.id}-fileList`}>
           <Box>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -54,6 +54,14 @@ const DropzoneContainer = styled(Box)(({ theme }) => ({
   },
 }));
 
+const FileList = styled(List)(({ theme }) => ({
+  width: "100%",
+  maxWidth: theme.breakpoints.values.formWrap,
+  [theme.breakpoints.up("md")]: {
+    marginTop: "-1em",
+  },
+}));
+
 export const InfoButton = styled(Button)(({ theme }) => ({
   minWidth: 0,
   marginLeft: theme.spacing(1.5),
@@ -174,13 +182,7 @@ function Component(props: Props) {
               </ErrorWrapper>
             </>
           )}
-          <List
-            disablePadding
-            sx={{
-              width: "100%",
-              marginTop: { md: "-1em" },
-            }}
-          >
+          <FileList disablePadding>
             {(Object.keys(fileList) as Array<keyof typeof fileList>)
               .filter(isCategoryVisible)
               .flatMap((fileListCategory) => [
@@ -209,7 +211,7 @@ function Component(props: Props) {
                   </ListItem>
                 )),
               ])}
-          </List>
+          </FileList>
         </DropzoneContainer>
         <ErrorWrapper error={fileListError} id={`${props.id}-fileList`}>
           <Box>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -28,6 +28,11 @@ const Description = styled(Box)(({ theme }) => ({
   },
 }));
 
+const QuestionHeaderWrapper = styled(Box)(({ theme }) => ({
+  maxWidth: theme.breakpoints.values.formWrap,
+  marginBottom: theme.spacing(1),
+}));
+
 const TitleWrapper = styled(Box)(({ theme }) => ({
   width: theme.breakpoints.values.formWrap,
   maxWidth: `calc(100% - (${HelpButtonMinWidth} + 4px))`,
@@ -107,7 +112,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
 
   return (
     <>
-      <Box mb={1} sx={{ minHeight: "2em" }}>
+      <QuestionHeaderWrapper>
         {title && (
           <TitleWrapper mr={1} pt={0.5}>
             <Typography
@@ -170,7 +175,7 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
           ) : undefined}
         </MoreInfo>
         {img && <Image src={img} alt="question" />}
-      </Box>
+      </QuestionHeaderWrapper>
     </>
   );
 };


### PR DESCRIPTION
# What does this PR do?

The upload + label component sits in a full-width wrapper, when the file list is shown without the upload dropzone it inherits the full-width.

This PR introduces `formWidth` max-width wrappers to both the question header and file list.

**Preview (current):**
https://editor.planx.dev/testing/upload-label-file-list/preview?analytics=false

**Preview (fixed):**
https://2588.planx.pizza/testing/upload-label-file-list/preview?analytics=false