### PR TITLE
chore: Ignore AWS healthcheck from API logs

### DIFF
--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -63,6 +63,17 @@ if (process.env.NODE_ENV !== "test") {
   app.use(
     pinoLogger({
       serializers: noir(["req.headers.authorization"], "**REDACTED**"),
+      autoLogging: {
+        ignore: (req) => {
+          const isAWSHealthchecker =
+            req.headers["user-agent"] === "ELB-HealthChecker/2.0";
+          const isLocalDockerHealthchecker =
+            req.headers["user-agent"] === "Wget" &&
+            req.headers.host === "localhost:7002";
+
+          return isAWSHealthchecker || isLocalDockerHealthchecker;
+        },
+      },
     }),
   );
 }


### PR DESCRIPTION
## What does this PR do?
- Excludes AWS healthcheck logs
- Excludes local docker healthcheck logs

## Context
Been meaning to take a look at this small one for a while! 95%+ of the AWS logs are noise, just the healthchecker calling the API which makes troubleshooting locally or on the AWS console a more painful and slow experience.