### PR TITLE
fix: Detect presence of `httpOnly` cookie

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -41,17 +41,25 @@ export const handleSuccess = (req: Request, res: Response) => {
  * The client will then use the JWT to make authenticated requests to the API.
  */
 function setJWTCookie(returnTo: string, res: Response, req: Request) {
-  const cookie: CookieOptions = {
+  const defaultCookieOptions: CookieOptions = {
     domain: `.${new URL(returnTo).host}`,
     maxAge: new Date(
       new Date().setFullYear(new Date().getFullYear() + 1),
     ).getTime(),
-    httpOnly: true,
-    secure: true,
     sameSite: "none",
   };
 
-  res.cookie("jwt", req.user!.jwt, cookie);
+  const httpOnlyCookieOptions: CookieOptions = {
+    ...defaultCookieOptions,
+    httpOnly: true,
+    secure: true,
+  };
+
+  // Set secure, httpOnly cookie with JWT
+  res.cookie("jwt", req.user!.jwt, httpOnlyCookieOptions);
+
+  // Set second cookie which can be read by browser to detect presence of the unreadable httpOnly cookie
+  res.cookie("loggedIn", true, defaultCookieOptions);
 
   res.redirect(returnTo);
 }

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -62,6 +62,12 @@ export async function createAuthenticatedSession({
       path: "/",
       value: token,
     },
+    {
+      name: "loggedIn",
+      domain: "localhost",
+      path: "/",
+      value: true,
+    },
   ]);
   return page;
 }

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -35,8 +35,9 @@ if (!window.customElements.get("my-map")) {
 }
 
 const hasJWT = (): boolean | void => {
-  const jwtCookie = getCookie("jwt");
-  if (jwtCookie) return true;
+  // This cookie indicates the presence of the secure httpOnly "jwt" cookie
+  const loggedInCookie = getCookie("loggedIn");
+  if (loggedInCookie) return true;
 
   // If JWT not set via cookie, check search params
   const jwtSearchParams = new URLSearchParams(window.location.search).get(

--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -35,7 +35,7 @@ const editorRoutes = mount({
     } catch (err) {
       console.error(err);
     } finally {
-      const cookieString = `jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      const cookieString = `loggedIn=; jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
       // remove jwt cookie for non planx domains (netlify preview urls)
       document.cookie = cookieString;
       // remove jwt cookie for planx domains (staging and production)


### PR DESCRIPTION
## What the problem?
Following the deploy of #2591, the login / logout flow on staging is now broken. I believe that this is due to the fact that the browser cannot even detect the presence of the `httpOnly` cookie, so the `hasJWT()` function is always returning false on staging.

## What's the solution?
Add a second cookie without the `httpOnly` flag which can be used as a proxy to detect the presence of the `jwt` cookie.

Solution found here - https://stackoverflow.com/a/63877877