### PR TITLE
feat: track allow list answers

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -434,9 +434,6 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
               $node_id: String!
             ) {
               update_analytics_logs(
-                // Update the analytics log for the last visible node but
-                // additionally check that the node_ids match to avoid
-                // incorrectly capturing incorrect data 
                 where: { id: { _eq: $id }, node_id: { _eq: $node_id } }
                 _set: { allow_list_answers: $allow_list_answers }
               ) {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -20,10 +20,10 @@ type AnalyticsLogDirection =
   | "reset"
   | "save";
 
-const allowList = [
+const ALLOW_LIST = [
   "proposal.projectType",
   "application.declaration.connection",
-];
+] as const;
 
 export type HelpClickMetadata = Record<string, string>;
 export type SelectedUrlsMetadata = Record<"selectedUrls", string[]>;
@@ -456,7 +456,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   function getAllowListAnswers(nodeId: string) {
     const { data } = flow[nodeId];
     const nodeFn = data?.fn || data?.val;
-    if (nodeFn && allowList.includes(nodeFn)) {
+    if (nodeFn && ALLOW_LIST.includes(nodeFn)) {
       const answerIds = breadcrumbs[nodeId]?.answers;
       const answerValues = answerIds?.map((answerId) => {
         return flow[answerId]?.data?.val;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -168,6 +168,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     const metadata: NodeMetadata = getNodeMetadata(nodeToTrack, nodeId);
     const nodeType = nodeToTrack?.type ? TYPES[nodeToTrack.type] : null;
     const nodeTitle = extractNodeTitle(nodeToTrack);
+    const nodeFn = nodeToTrack?.data?.fn || nodeToTrack?.data?.val;
 
     const result = await insertNewAnalyticsLog(
       logDirection,
@@ -176,6 +177,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
       nodeType,
       nodeTitle,
       nodeId,
+      nodeFn,
     );
 
     const { id, created_at: newLogCreatedAt } =
@@ -208,6 +210,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     nodeType: string | null,
     nodeTitle: string,
     nodeId: string | null,
+    nodeFn: string | null,
   ) {
     const result = await publicClient.mutate({
       mutation: gql`
@@ -218,6 +221,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
           $node_type: String
           $node_title: String
           $node_id: String
+          $node_fn: String
         ) {
           insert_analytics_logs_one(
             object: {
@@ -228,6 +232,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
               node_type: $node_type
               node_title: $node_title
               node_id: $node_id
+              node_fn: $node_fn
             }
           ) {
             id
@@ -242,6 +247,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         node_type: nodeType,
         node_title: nodeTitle,
         node_id: nodeId,
+        node_fn: nodeFn,
       },
     });
     return result;

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -52,6 +52,7 @@
           - analytics_id
           - created_at
           - id
+          - node_id
           - user_exit
         filter: {}
   update_permissions:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -40,6 +40,7 @@
           - id
           - input_errors
           - metadata
+          - node_fn
           - node_id
           - node_title
           - node_type
@@ -57,6 +58,7 @@
     - role: public
       permission:
         columns:
+          - allow_list_answers
           - flow_direction
           - has_clicked_help
           - input_errors

--- a/hasura.planx.uk/migrations/1704731606083_squashed/down.sql
+++ b/hasura.planx.uk/migrations/1704731606083_squashed/down.sql
@@ -1,0 +1,8 @@
+
+comment on column "public"."analytics_logs"."allow_list_answers" is NULL;
+
+comment on column "public"."analytics_logs"."node_fn" is NULL;
+
+alter table "public"."analytics_logs" drop column "node_fn";
+
+alter table "public"."analytics_logs" drop column "allow_list_answers";

--- a/hasura.planx.uk/migrations/1704731606083_squashed/up.sql
+++ b/hasura.planx.uk/migrations/1704731606083_squashed/up.sql
@@ -1,0 +1,10 @@
+
+alter table "public"."analytics_logs" add column "node_fn" text
+ null;
+
+alter table "public"."analytics_logs" add column "allow_list_answers" JSONB
+ null default '[]'::jsonb;
+
+comment on column "public"."analytics_logs"."node_fn" is E'The passport variable a node can relate to as stored on the `fn` or `val` of the node';
+
+comment on column "public"."analytics_logs"."allow_list_answers" is E'If the node sets a passport variable deemed as safe to track then any answers are stored in this field';


### PR DESCRIPTION
## What

- Track the `node_fn` in `analytics_log` table to tie together nodes and the passport variables they relate to
- Track `allow_list_answers` in `analytics` when a user directly answers a question

## Why

- Adding `node_fn` makes it easier to reason about how nodes can affect the passport. 
- Metrics requested the `allow_list_answers`

## Note

- This supersedes https://github.com/theopensystemslab/planx-new/pull/2487