### PR TITLE
chore: Restore permissions for `flow.data` column

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -307,6 +307,7 @@
           - copied_from
           - created_at
           - creator_id
+          - data
           - id
           - settings
           - slug
@@ -336,6 +337,7 @@
           - copied_from
           - created_at
           - creator_id
+          - data
           - id
           - settings
           - slug
@@ -443,6 +445,7 @@
     - role: platformAdmin
       permission:
         columns:
+          - data
           - settings
           - slug
           - team_id
@@ -460,6 +463,7 @@
     - role: teamEditor
       permission:
         columns:
+          - data
           - settings
           - slug
           - team_id


### PR DESCRIPTION
## What does this PR do?
Restore access for `platformAdmin` and `teamEditor` roles to `flow.data` column.

## Why?
This is now redundant following https://github.com/theopensystemslab/planx-new/pull/2551 - we're handling sanitation via input validation so we don't need to restrict access here.

## Context
Introduced in https://github.com/theopensystemslab/planx-new/pull/2488 as an inital attempt at handling sanitation.