### PR TITLE
feat: Drop permission workaround for copy flow

### DIFF
--- a/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -28,16 +28,6 @@ beforeEach(() => {
   });
 
   queryMock.mockQuery({
-    name: "UpdateFlowData",
-    matchOnVariables: false,
-    data: {
-      flow: {
-        id: 2,
-      },
-    },
-  });
-
-  queryMock.mockQuery({
     name: "InsertOperation",
     matchOnVariables: false,
     data: {


### PR DESCRIPTION
## What does this PR do?
Removes permission workaround for the copy flow API endpoint.

## Why?
This is now redundant following https://github.com/theopensystemslab/planx-new/pull/2551

## Context
Introduced in https://github.com/theopensystemslab/planx-new/pull/2488 as an inital attempt at handling sanitation.