### PR TITLE
feat: track in analytics_logs instances where `changeAnswer` is called

### DIFF
--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -11,6 +11,7 @@ import { useFormik } from "formik";
 import { submitFeedback } from "lib/feedback";
 import { publicClient } from "lib/graphql";
 import find from "lodash/find";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
 import React from "react";
@@ -237,6 +238,13 @@ function PropertyDetails(props: PropertyDetailsProps) {
   const { data, showPropertyTypeOverride, overrideAnswer } = props;
   const filteredData = data.filter((d) => Boolean(d.detail));
 
+  const { trackBackwardsNavigation } = useAnalyticsTracking();
+
+  const handleOverrideAnswer = (fn: string) => {
+    trackBackwardsNavigation("change");
+    overrideAnswer(fn);
+  };
+
   return (
     <PropertyDetailsList component="dl">
       {filteredData.map(({ heading, detail, fn }: PropertyDetail) => (
@@ -251,7 +259,7 @@ function PropertyDetails(props: PropertyDetailsProps) {
                 onClick={(event) => {
                   event.stopPropagation();
                   // Specify the passport key (eg data.fn, data.val) that should be overwritten
-                  overrideAnswer(fn);
+                  handleOverrideAnswer(fn);
                 }}
               >
                 Change

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -141,10 +141,10 @@ const ResultReason: React.FC<IResultReason> = ({
       : ""
   }`;
 
-  const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+  const { trackBackwardsNavigation } = useAnalyticsTracking();
 
   const handleChangeAnswer = (id: string) => {
-    trackBackwardsNavigationByNodeId(id, "change");
+    trackBackwardsNavigation("change", id);
     changeAnswer(id);
   };
 

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import Tag, { TagType } from "@planx/components/shared/Buttons/Tag";
 import type { PublicProps } from "@planx/components/ui";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { SectionNode, SectionStatus } from "types";
@@ -14,7 +15,6 @@ import Card from "../shared/Preview/Card";
 import QuestionHeader from "../shared/Preview/QuestionHeader";
 import type { Section } from "./model";
 import { computeSectionStatuses } from "./model";
-import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 
 export type Props = PublicProps<Section>;
 
@@ -135,15 +135,15 @@ export function SectionsOverviewList({
     alteredSectionIds,
   });
 
-  const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+  const { trackBackwardsNavigation } = useAnalyticsTracking();
 
   const changeFirstAnswerInSection = (sectionId: string) => {
     const sectionIndex = flow._root.edges?.indexOf(sectionId);
     if (sectionIndex !== undefined) {
       const firstNodeInSection = flow._root.edges?.[sectionIndex + 1];
       if (firstNodeInSection) {
-        trackBackwardsNavigationByNodeId(firstNodeInSection, "change");
-        changeAnswer(firstNodeInSection)
+        trackBackwardsNavigation("change", firstNodeInSection);
+        changeAnswer(firstNodeInSection);
       }
     }
   };

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -14,6 +14,7 @@ import Card from "../shared/Preview/Card";
 import QuestionHeader from "../shared/Preview/QuestionHeader";
 import type { Section } from "./model";
 import { computeSectionStatuses } from "./model";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 
 export type Props = PublicProps<Section>;
 
@@ -134,11 +135,16 @@ export function SectionsOverviewList({
     alteredSectionIds,
   });
 
+  const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+
   const changeFirstAnswerInSection = (sectionId: string) => {
     const sectionIndex = flow._root.edges?.indexOf(sectionId);
     if (sectionIndex !== undefined) {
       const firstNodeInSection = flow._root.edges?.[sectionIndex + 1];
-      if (firstNodeInSection) changeAnswer(firstNodeInSection);
+      if (firstNodeInSection) {
+        trackBackwardsNavigationByNodeId(firstNodeInSection, "change");
+        changeAnswer(firstNodeInSection)
+      }
     }
   };
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -157,6 +157,13 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
       .map(removeNonPresentationalNodes)
       .map((section) => section.map(makeSummaryBreadcrumb));
 
+    const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+
+    const handleChangeAnswer = (id: string) => {
+      trackBackwardsNavigationByNodeId(id, "change");
+      props.changeAnswer(id);
+    };
+
     return (
       <>
         {sectionsWithFilteredBreadcrumbs.map(
@@ -178,7 +185,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
                   </Typography>
                   <Link
                     onClick={() =>
-                      props.changeAnswer(filteredBreadcrumbs[0].nodeId)
+                      handleChangeAnswer(filteredBreadcrumbs[0].nodeId)
                     }
                     component="button"
                     fontSize="body1.fontSize"

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -113,6 +113,8 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
     state.getSortedBreadcrumbsBySection,
   ]);
 
+  const { trackBackwardsNavigation } = useAnalyticsTracking();
+
   const isValidComponent = ([nodeId, userData]: BreadcrumbEntry) => {
     const node = props.flow[nodeId];
     const doesNodeExist = Boolean(props.flow[nodeId]);
@@ -157,10 +159,8 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
       .map(removeNonPresentationalNodes)
       .map((section) => section.map(makeSummaryBreadcrumb));
 
-    const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
-
     const handleChangeAnswer = (id: string) => {
-      trackBackwardsNavigationByNodeId(id, "change");
+      trackBackwardsNavigation("change", id);
       props.changeAnswer(id);
     };
 
@@ -227,10 +227,10 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
 // For applicable component types, display a list of their question & answers with a "change" link
 //  ref https://design-system.service.gov.uk/components/summary-list/
 function SummaryList(props: SummaryListProps) {
-  const { trackBackwardsNavigationByNodeId } = useAnalyticsTracking();
+  const { trackBackwardsNavigation } = useAnalyticsTracking();
 
   const handleChangeAnswer = (id: string) => {
-    trackBackwardsNavigationByNodeId(id, "change");
+    trackBackwardsNavigation("change", id);
     props.changeAnswer(id);
   };
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -33,6 +33,7 @@ type NodeMetadata = {
   flag?: Flag;
   title?: string;
   type?: TYPES;
+  id?: string;
   isAutoAnswered?: boolean;
 };
 
@@ -344,7 +345,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     initiator: BackwardsNavigationInitiatorType,
     nodeId?: string,
   ) {
-    const targetNodeMetadata = nodeId ? getTitleAndTypeFromFlow(nodeId) : {};
+    const targetNodeMetadata = nodeId ? getTargetNodeDataFromFlow(nodeId) : {};
     const metadata: Record<string, NodeMetadata> = {};
     metadata[`${initiator}`] = targetNodeMetadata;
 
@@ -431,11 +432,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }
 
-  function getTitleAndTypeFromFlow(nodeId: string) {
+  function getTargetNodeDataFromFlow(nodeId: string) {
     const node = flow[nodeId];
     const nodeMetadata: NodeMetadata = {
       title: extractNodeTitle(node),
       type: node.type,
+      id: nodeId,
     };
     return nodeMetadata;
   }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -432,10 +432,10 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   function getTitleAndTypeFromFlow(nodeId: string) {
-    const { data, type } = flow[nodeId];
+    const node = flow[nodeId];
     const nodeMetadata: NodeMetadata = {
-      title: data?.text,
-      type: type,
+      title: extractNodeTitle(node),
+      type: node.type,
     };
     return nodeMetadata;
   }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -45,9 +45,9 @@ const analyticsContext = createContext<{
   trackFlowDirectionChange: (
     flowDirection: AnalyticsLogDirection,
   ) => Promise<void>;
-  trackBackwardsNavigationByNodeId: (
-    nodeId: string,
+  trackBackwardsNavigation: (
     backwardsNavigationType: BackwardsNavigationInitiatorType,
+    nodeId?: string,
   ) => Promise<void>;
   node: Store.node | null;
   trackInputErrors: (error: string) => Promise<void>;
@@ -61,7 +61,7 @@ const analyticsContext = createContext<{
   trackHelpClick: () => Promise.resolve(),
   trackNextStepsLinkClick: () => Promise.resolve(),
   trackFlowDirectionChange: () => Promise.resolve(),
-  trackBackwardsNavigationByNodeId: () => Promise.resolve(),
+  trackBackwardsNavigation: () => Promise.resolve(),
   node: null,
   trackInputErrors: () => Promise.resolve(),
   track: () => Promise.resolve(),
@@ -141,7 +141,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         trackHelpClick,
         trackNextStepsLinkClick,
         trackFlowDirectionChange,
-        trackBackwardsNavigationByNodeId,
+        trackBackwardsNavigation,
         node,
         trackInputErrors,
         track,
@@ -340,11 +340,11 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }
 
-  async function trackBackwardsNavigationByNodeId(
-    nodeId: string,
+  async function trackBackwardsNavigation(
     initiator: BackwardsNavigationInitiatorType,
+    nodeId?: string,
   ) {
-    const targetNodeMetadata = getTitleAndTypeFromFlow(nodeId);
+    const targetNodeMetadata = nodeId ? getTitleAndTypeFromFlow(nodeId) : {};
     const metadata: Record<string, NodeMetadata> = {};
     metadata[`${initiator}`] = targetNodeMetadata;
 

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -77,7 +77,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.getType,
   ]);
   const isStandalone = previewEnvironment === "standalone";
-  const { createAnalytics, node, trackBackwardsNavigationByNodeId } =
+  const { createAnalytics, node, trackBackwardsNavigation } =
     useAnalyticsTracking();
   const [gotFlow, setGotFlow] = useState(false);
   const isUsingLocalStorage =
@@ -151,7 +151,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   const goBack = useCallback(() => {
     const previous = previousCard(node);
     if (previous) {
-      trackBackwardsNavigationByNodeId(previous, "back");
+      trackBackwardsNavigation("back", previous);
       record(previous);
     }
   }, [node?.id]);


### PR DESCRIPTION
## What

- More comprehensively track instances where a user makes a `change` 
- This is associated with `changeAnswer` being called
- On `overrideAnswer` track "change" click but leave the target node metadata as `{}`
- Track the the id of the target node
- Refactor to use the existing `extractNodeTitle` function to more comprehensively extract the title. 

## Why 

- The metrics team have requested "change" clicks are tracked
- In the instance of `overrideAnswer` the logic is unlike `changeAnswer` and the basic requirement is tracking the "change" click not the target node. 
- When tracking target node data add the id as it can be helpful rather than relying on just the node title and type
- Also, in testing noticed that the node title was often undefined due to the limited way it was being extracted. Refactored to use an existing more comprehensive function. 

## Screen recording

https://github.com/theopensystemslab/planx-new/assets/36415632/455af116-1861-4e39-8f4d-c3c35f8ecaba

