### PR TITLE
feat: Team settings page and routes

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -495,7 +495,18 @@ const EditorToolbar: React.FC<{
               </MenuItem>
             )}
 
-            {/* only show flow settings link if inside a flow route  */}
+            {/* Only show team settings link if inside a team route  */}
+            {(route.data.team && !route.data.flow) &&(
+              <MenuItem
+                onClick={() =>
+                  navigate([rootFlowPath(true), "settings"].join("/"))
+                }
+              >
+                Team Settings
+              </MenuItem>
+            )}
+
+            {/* Only show flow settings link if inside a flow route  */}
             {route.data.flow && (
               <MenuItem
                 onClick={() =>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -502,7 +502,7 @@ const EditorToolbar: React.FC<{
                   navigate([rootFlowPath(true), "settings"].join("/"))
                 }
               >
-                Settings
+                Flow Settings
               </MenuItem>
             )}
 

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -40,7 +40,7 @@ import { ApplicationPath } from "types";
 import Reset from "ui/icons/Reset";
 
 import { useStore } from "../pages/FlowEditor/lib/store";
-import { rootFlowPath } from "../routes/utils";
+import { rootFlowPath, rootTeamPath } from "../routes/utils";
 import AnalyticsDisabledBanner from "./AnalyticsDisabledBanner";
 import FeatureFlagBanner from "./FeatureFlagBanner";
 import TestEnvironmentBanner from "./TestEnvironmentBanner";
@@ -499,7 +499,7 @@ const EditorToolbar: React.FC<{
             {(route.data.team && !route.data.flow) &&(
               <MenuItem
                 onClick={() =>
-                  navigate([rootFlowPath(true), "settings"].join("/"))
+                  navigate(`${rootTeamPath()}/settings`)
                 }
               >
                 Team Settings

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -8,20 +8,22 @@ import { styled } from "@mui/material/styles";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import { HEADER_HEIGHT } from "components/Header";
-import React from "react";
-import { Link, useCurrentRoute, useNavigation } from "react-navi";
-import { rootFlowPath } from "routes/utils";
+import React  from "react";
+import { Link, useNavigation } from "react-navi";
 
-import DataManagerSettings from "./DataManagerSettings";
-import DesignSettings from "./DesignSettings";
-import ServiceFlags from "./ServiceFlags";
-import ServiceSettings from "./ServiceSettings";
-import TeamSettings from "./TeamSettings";
+interface SettingsProps {
+  currentTab: string,
+  tabs: {
+    route: string,
+    name: string,
+    Component: React.FC,
+  }[]
+}
 
 interface TabPanelProps {
   children?: React.ReactNode;
-  index: any;
-  value: any;
+  index: number;
+  value: number;
 }
 
 function TabPanel(props: TabPanelProps) {
@@ -44,7 +46,7 @@ function TabPanel(props: TabPanelProps) {
   );
 }
 
-function a11yProps(index: any) {
+function a11yProps(index: number) {
   return {
     id: `nav-tab-${index}`,
     "aria-controls": `nav-tabpanel-${index}`,
@@ -103,22 +105,14 @@ const Root = styled(Box)(({ theme }) => ({
   },
 }));
 
-const tabsOrder = ["team", "service", "flags", "design", "data-manager"];
-
-const NavTabs: React.FC<{ tab?: string }> = (props) => {
+const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {
   const { navigate } = useNavigation();
-  const { data } = useCurrentRoute();
-
-  const flowBaseRoute = rootFlowPath(true);
-
-  const makeHref = (path: any) =>
-    [data.mountpath, path].filter(Boolean).join("/");
 
   const handleChange = (event: React.ChangeEvent<any>) => {
     navigate(event.currentTarget.pathname);
   };
 
-  const value = tabsOrder.indexOf(props.tab || "");
+  const value = tabs.findIndex(({ route }) => route === currentTab);
 
   return (
     <Root>
@@ -137,33 +131,20 @@ const NavTabs: React.FC<{ tab?: string }> = (props) => {
                 indicator: classes.tabIndicator,
               }}
             >
-              <LinkTab label="Team" href={makeHref("")} {...a11yProps(0)} />
-              <LinkTab
-                label="Service"
-                href={makeHref("service")}
-                {...a11yProps(1)}
-              />
-              <LinkTab
-                label="Flags"
-                href={makeHref("flags")}
-                {...a11yProps(2)}
-              />
-              <LinkTab
-                label="Design"
-                href={makeHref("design")}
-                {...a11yProps(3)}
-              />
-              <LinkTab
-                label="Data Manager"
-                href={makeHref("data-manager")}
-                {...a11yProps(4)}
-              />
+              {tabs.map(({ name, route }, index) =>
+                <LinkTab
+                  key={`${name}-LinkTab`}
+                  label={name}
+                  href={`./${route}`}
+                  {...a11yProps(index)}
+                />
+              )}
             </Tabs>
           </Grid>
           <Grid item>
             <IconButton
               component={Link}
-              href={flowBaseRoute}
+              href={"../../"}
               aria-label="Close"
               size="large"
             >
@@ -172,23 +153,13 @@ const NavTabs: React.FC<{ tab?: string }> = (props) => {
           </Grid>
         </Grid>
       </AppBar>
-      <TabPanel value={value} index={0}>
-        <TeamSettings />
-      </TabPanel>
-      <TabPanel value={value} index={1}>
-        <ServiceSettings />
-      </TabPanel>
-      <TabPanel value={value} index={2}>
-        <ServiceFlags />
-      </TabPanel>
-      <TabPanel value={value} index={3}>
-        <DesignSettings />
-      </TabPanel>
-      <TabPanel value={value} index={4}>
-        <DataManagerSettings />
-      </TabPanel>
+      {tabs.map(({ name, Component }, index) =>
+        <TabPanel value={value} index={index} key={`${name}-TabPanel`}>
+          <Component />
+        </TabPanel>
+      )}
     </Root>
   );
 };
 
-export default NavTabs;
+export default Settings;

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -236,7 +236,7 @@ const routes = compose(
 
     "/nodes": nodeRoutes,
 
-    "/settings": lazy(() => import("./settings")),
+    "/settings": lazy(() => import("./flowSettings")),
   }),
 );
 

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -1,6 +1,11 @@
 import gql from "graphql-tag";
 import { publicClient } from "lib/graphql";
 import { compose, mount, redirect, route, withData } from "navi";
+import DataManagerSettings from "pages/FlowEditor/components/Settings/DataManagerSettings";
+import DesignSettings from "pages/FlowEditor/components/Settings/DesignSettings";
+import ServiceFlags from "pages/FlowEditor/components/Settings/ServiceFlags";
+import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
+import TeamSettings from "pages/FlowEditor/components/Settings/TeamSettings";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
@@ -42,9 +47,38 @@ const flowSettingsRoutes = compose(
 
       return {
         title: makeTitle(
-          [req.params.team, req.params.flow, "Settings"].join("/"),
+          [req.params.team, req.params.flow, "Flow Settings"].join("/"),
         ),
-        view: <Settings tab={req.params.tab} />,
+        view: <Settings 
+          currentTab={req.params.tab}
+          tabs={[
+            {
+              name: "Team",
+              route: "team",
+              Component: TeamSettings,
+            },
+            {
+              name: "Service",
+              route: "service",
+              Component: ServiceSettings,
+            },
+            {
+              name: "Service Flags",
+              route: "flags",
+              Component: ServiceFlags,
+            },
+            {
+              name: "Design",
+              route: "design",
+              Component: DesignSettings,
+            },
+            {
+              name: "Data",
+              route: "data-manager",
+              Component: DataManagerSettings,
+            },
+          ]}
+          />,
       };
     }),
   }),

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -2,10 +2,8 @@ import gql from "graphql-tag";
 import { publicClient } from "lib/graphql";
 import { compose, mount, redirect, route, withData } from "navi";
 import DataManagerSettings from "pages/FlowEditor/components/Settings/DataManagerSettings";
-import DesignSettings from "pages/FlowEditor/components/Settings/DesignSettings";
 import ServiceFlags from "pages/FlowEditor/components/Settings/ServiceFlags";
 import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
-import TeamSettings from "pages/FlowEditor/components/Settings/TeamSettings";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
@@ -19,7 +17,7 @@ const flowSettingsRoutes = compose(
   })),
 
   mount({
-    "/": redirect("./team"),
+    "/": redirect("./service"),
     "/:tab": route(async (req) => {
       const { data } = await publicClient.query({
         query: gql`
@@ -53,11 +51,6 @@ const flowSettingsRoutes = compose(
           currentTab={req.params.tab}
           tabs={[
             {
-              name: "Team",
-              route: "team",
-              Component: TeamSettings,
-            },
-            {
               name: "Service",
               route: "service",
               Component: ServiceSettings,
@@ -66,11 +59,6 @@ const flowSettingsRoutes = compose(
               name: "Service Flags",
               route: "flags",
               Component: ServiceFlags,
-            },
-            {
-              name: "Design",
-              route: "design",
-              Component: DesignSettings,
             },
             {
               name: "Data",

--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import { compose, lazy, mount, route, withView } from "navi";
+import { compose, lazy, mount, route, withData, withView } from "navi";
 import React from "react";
 
 import { client } from "../lib/graphql";
@@ -14,6 +14,10 @@ let cached: { flowSlug?: string; teamSlug?: string } = {
 };
 
 const routes = compose(
+  withData((req) => ({
+    team: req.params.team,
+  })),
+
   withView(async (req) => await teamView(req)),
 
   mount({
@@ -21,6 +25,8 @@ const routes = compose(
       title: makeTitle(useStore.getState().teamName),
       view: <Team />,
     })),
+
+    "/settings": lazy(() => import("./teamSettings")),
 
     "/:flow": lazy(async (req) => {
       const [slug] = req.params.flow.split(",");

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -1,0 +1,40 @@
+
+import { compose, mount, redirect, route, withData } from "navi";
+import DesignSettings from "pages/FlowEditor/components/Settings/DesignSettings";
+import TeamSettings from "pages/FlowEditor/components/Settings/TeamSettings";
+import React from "react";
+
+import Settings from "../pages/FlowEditor/components/Settings";
+import { makeTitle } from "./utils";
+
+const flowSettingsRoutes = compose(
+  withData((req) => ({
+    mountpath: req.mountpath
+  })),
+
+  mount({
+    "/": redirect("./team"),
+    "/:tab": route(async (req) => ({
+        title: makeTitle(
+          [req.params.team, "Team Settings"].join("/"),
+        ),
+        view: <Settings
+          currentTab={req.params.tab}
+          tabs={[
+            {
+              name: "Team",
+              route: "team",
+              Component: TeamSettings,
+            },
+            {
+              name: "Design",
+              route: "design",
+              Component: DesignSettings,
+            },
+          ]}
+          />,
+      }))
+  }),
+);
+
+export default flowSettingsRoutes;

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -15,6 +15,8 @@ export const rootFlowPath = (includePortals = false) => {
   return includePortals ? path : path.split(",")[0];
 };
 
+export const rootTeamPath = () => window.location.pathname.split("/").slice(0, 2).join("/");
+
 export const isSaveReturnFlow = (flowData: Record<string, any>): boolean =>
   Boolean(
     Object.values(flowData).find(


### PR DESCRIPTION
## What does this PR do?
 - Makes the `Settings` component more generic, so it can be reused in different contexts
 - Splits current tabs up across "Team Settings" and "Flow Settings"
 - Just a UI change, nothing is wired up


https://github.com/theopensystemslab/planx-new/assets/20502206/3d4f6376-bc75-4115-82b3-adc7065518b1

