### PR TITLE
Revert "chore(deps): bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -87,7 +87,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: build
           path: ./editor.planx.uk/build

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -89,7 +89,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: build
           path: ./editor.planx.uk/build


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2621

This one is only triggered on deploys to `main` & `production`, so PR CI success isn't particularly meaningful. `pulumi up` step has failed twice - once before #2620 was merged & successfully deployed, and once after. https://github.com/theopensystemslab/planx-new/actions/runs/7383295642
