### PR TITLE
Revert "Revert "chore(deps): bump actions/download-artifact from 3 to 4""

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -87,7 +87,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: ./editor.planx.uk/build

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -89,7 +89,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: ./editor.planx.uk/build


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2623

Getting a little sidetracked by action failures here - but I think they're do to cache issues rather than v4 actually being faulty! This "revert revert" gets us back up v4.