### PR TITLE
feat(wip): do not auto-answer questions into the future by only calculating one `upcomingCardIds`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
@@ -51,8 +51,8 @@ beforeEach(() => {
   setState({ flow });
 });
 
-test("The first _root edge is immediately queued up", () => {
-  expect(upcomingCardIds()).toEqual(["SetValue"]);
+test("All _root edges that are not a SUPPORTED_DECISION_TYPE node type are immediately queued up", () => {
+  expect(upcomingCardIds()).toEqual(["SetValue", "Content"]);
 });
 
 test("A node is only auto-answered when it is the first upcomingCardId(), not when its' `fn` is first added to the breadcrumbs/passport", () => {
@@ -61,7 +61,7 @@ test("A node is only auto-answered when it is the first upcomingCardId(), not wh
   // mimic "Continue" button and properly set visitedNodes()
   const clickContinue = () => upcomingCardIds();
 
-  expect(upcomingCardIds()).toEqual(["SetValue"]);
+  expect(upcomingCardIds()).toEqual(["SetValue", "Content"]);
 
   // Step forwards through the SetValue
   record("SetValue", { data: { fruit: ["apple"] }, auto: true });
@@ -71,7 +71,6 @@ test("A node is only auto-answered when it is the first upcomingCardId(), not wh
 
   // "AutomatedQuestion" should still be queued up, not already answered based on SetValue
   expect(visitedNodes()).not.toContain("AutomatedQuestion");
-  // expect(upcomingCardIds()).toContain("AutomatedQuestion");
 
   // Step forwards through Content
   record("Content", { data: {}, auto: false });
@@ -139,5 +138,5 @@ test("crawling with portals", () => {
     },
   });
 
-  expect(upcomingCardIds()).toEqual(["c"]);
+  expect(upcomingCardIds()).toEqual(["a", "c"]);
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
@@ -51,25 +51,17 @@ beforeEach(() => {
   setState({ flow });
 });
 
-test("Root nodes are immediately queued up", () => {
-  expect(upcomingCardIds()).toEqual([
-    "SetValue",
-    "Content",
-    "AutomatedQuestion",
-  ]);
+test("The first _root edge is immediately queued up", () => {
+  expect(upcomingCardIds()).toEqual(["SetValue"]);
 });
 
-test.skip("A node is only auto-answered when it is the first upcomingCardId(), not when its' `fn` is first added to the breadcrumbs/passport", () => {
+test("A node is only auto-answered when it is the first upcomingCardId(), not when its' `fn` is first added to the breadcrumbs/passport", () => {
   const visitedNodes = () => Object.keys(getState().breadcrumbs);
 
   // mimic "Continue" button and properly set visitedNodes()
   const clickContinue = () => upcomingCardIds();
 
-  expect(upcomingCardIds()).toEqual([
-    "SetValue",
-    "Content",
-    "AutomatedQuestion",
-  ]);
+  expect(upcomingCardIds()).toEqual(["SetValue"]);
 
   // Step forwards through the SetValue
   record("SetValue", { data: { fruit: ["apple"] }, auto: true });
@@ -79,7 +71,7 @@ test.skip("A node is only auto-answered when it is the first upcomingCardId(), n
 
   // "AutomatedQuestion" should still be queued up, not already answered based on SetValue
   expect(visitedNodes()).not.toContain("AutomatedQuestion");
-  expect(upcomingCardIds()).toContain("AutomatedQuestion");
+  // expect(upcomingCardIds()).toContain("AutomatedQuestion");
 
   // Step forwards through Content
   record("Content", { data: {}, auto: false });
@@ -147,5 +139,5 @@ test("crawling with portals", () => {
     },
   });
 
-  expect(upcomingCardIds()).toEqual(["c", "b"]);
+  expect(upcomingCardIds()).toEqual(["c"]);
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -405,6 +405,7 @@ export const previewStore: StateCreator<
               (node.type && !SUPPORTED_DECISION_TYPES.includes(node.type)))
           );
         })
+        .slice(0, 1)
         .forEach((id) => {
           const node = flow[id];
 


### PR DESCRIPTION
Getting expected behavior in simple cases, lots of testing still needed  / preview store unit tests need updated

Building a pizza to share with August & co for content testing !! 

Test flow with question, checklist & flag/filter auto-answer behavior:
- After: https://2629.planx.pizza/testing/auto-answer-next
- Before: https://editor.planx.uk/testing/auto-answer-next