### PR TITLE
fix: Unescape HTML entities for alternate DOMPurify check

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -77,7 +77,7 @@ const insertFlow = async (
     return { id };
   } catch (error) {
     throw Error(
-      `User ${creatorId} failed to insert flow to teamId ${teamId}. Please check permissions.`,
+      `User ${creatorId} failed to insert flow to teamId ${teamId}. Please check permissions. Error: ${error}`,
     );
   }
 };

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.test.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.test.ts
@@ -104,7 +104,7 @@ describe("isCleanHTML() helper function", () => {
     `<h2>Subheading</h2><p>This is a paragraph under the subheading.</p>`,
     `<div><h1>Main Title</h1><p>This is a <b>nested</b> paragraph with a <i>nested</i> element.</p></div>`,
     `<div><h1>Content with image</h1><img src="dogs.png" alt="Dog photo"></div>`,
-    `<div><p>Content with HTML entitie&apos;s&lt;&gt;&quot;&amp;</p></div>`,
+    `<div><p>Content&nbsp;with HTML entitie&apos;s&lt;&gt;&quot;&amp;</p></div>`,
   ];
 
   for (const example of cleanHTML) {

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.test.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.test.ts
@@ -104,6 +104,7 @@ describe("isCleanHTML() helper function", () => {
     `<h2>Subheading</h2><p>This is a paragraph under the subheading.</p>`,
     `<div><h1>Main Title</h1><p>This is a <b>nested</b> paragraph with a <i>nested</i> element.</p></div>`,
     `<div><h1>Content with image</h1><img src="dogs.png" alt="Dog photo"></div>`,
+    `<div><p>Content with HTML entitie&apos;s&lt;&gt;&quot;&amp;</p></div>`,
   ];
 
   for (const example of cleanHTML) {

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -40,9 +40,20 @@ export const isCleanHTML = (input: unknown): boolean => {
 
   const cleanHTML = DOMPurify.sanitize(input, { ADD_ATTR: ["target"] });
   // DOMPurify has not removed any attributes or values
-  const isClean = cleanHTML.length === unescapeHTML(input).length;
+  const isClean =
+    cleanHTML.length === input.length ||
+    unescapeHTML(cleanHTML).length === unescapeHTML(input).length;
+
+  if (!isClean) {
+    console.log("CLEAN HTML: ", cleanHTML);
+    console.log("INPUT HTML: ", input);
+    console.log("UNESCAPED HTML: ", unescapeHTML(input));
+  }
   return isClean;
 };
 
 const unescapeHTML = (input: string): string =>
-  input.replace(/&quot;/gi, '"').replace(/&apos;/gi, "'");
+  input
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'")
+    .replace(/&nbsp;/gi, " ");

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -40,6 +40,9 @@ export const isCleanHTML = (input: unknown): boolean => {
 
   const cleanHTML = DOMPurify.sanitize(input, { ADD_ATTR: ["target"] });
   // DOMPurify has not removed any attributes or values
-  const isClean = cleanHTML.length === input.length;
+  const isClean = cleanHTML.length === unescapeHTML(input).length;
   return isClean;
 };
+
+const unescapeHTML = (input: string): string =>
+  input.replace(/&quot;/gi, '"').replace(/&apos;/gi, "'");

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -1,6 +1,7 @@
 import { isObject } from "lodash";
 import { JSDOM } from "jsdom";
 import createDOMPurify from "dompurify";
+import { userContext } from "../../../auth/middleware";
 
 // Setup JSDOM and DOMPurify
 const window = new JSDOM("").window;
@@ -39,17 +40,31 @@ export const isCleanHTML = (input: unknown): boolean => {
   if (typeof input !== "string") return true;
 
   const cleanHTML = DOMPurify.sanitize(input, { ADD_ATTR: ["target"] });
+
   // DOMPurify has not removed any attributes or values
   const isClean =
     cleanHTML.length === input.length ||
     unescapeHTML(cleanHTML).length === unescapeHTML(input).length;
 
-  if (!isClean) {
-    console.log("CLEAN HTML: ", cleanHTML);
-    console.log("INPUT HTML: ", input);
-    console.log("UNESCAPED HTML: ", unescapeHTML(input));
-  }
+  if (!isClean) logUncleanHTMLError(input, cleanHTML);
+
   return isClean;
+};
+
+/**
+ * Explicity log error when unsafe HTML is encountered
+ * This is very likely a content / sanitation error as opposed to a security issue
+ * Logging this should help us identify and resolve these
+ */
+const logUncleanHTMLError = (input: string, cleanHTML: string) => {
+  const userId = userContext.getStore()?.user.sub;
+
+  console.error({
+    message: `Warning: Unclean HTML submitted!`,
+    userId,
+    input,
+    cleanHTML,
+  });
 };
 
 const unescapeHTML = (input: string): string =>


### PR DESCRIPTION
## What's the problem?
Originally picked up here - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1703175603781519 (OSL Slack)

A permission error is thrown when attempting to copy some flows from the "Templates" team, despite the users in question having the requisite permission level.

## What's the cause?
The logged error is misleading, it's actually an [input validation](https://github.com/theopensystemslab/planx-new/pull/2551) error that's being thrown - the try/catch block just didn't account for this.

What's happening here is that the simple `length === length` check for DOMPurify is not accounting for HTML entities (see screenshot below).

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/1577cb22-87ef-408f-9a0f-3faf6114b56d)

There isn't a simple alternative way of checking that DOMPurify has modified content unfortunately. We can't check string equality directly as the order of HTML attributes in sanitised content can differ from the original (and there's not a method of preserving this). Please see comment from DOMPurify readme below on checking for removed attributes directly -

> After sanitizing your markup, you can also have a look at the property DOMPurify.removed and find out, what elements and attributes were thrown out. Please **do not use** this property for making any security critical decisions. This is just a little helper for curious minds.

Source: https://github.com/cure53/DOMPurify?tab=readme-ov-file#okay-makes-sense-lets-move-on

## What's the solution?
Check length, and then unescape known HTML entities which are converted, and re-check. I'll be honest this doesn't feel ideal but it's the best / simplest solution I've reached.

I'm throwing noisy errors here so that we can more easily spot any more issues going forward.