### PR TITLE
chore: Update sync script for `team_themes` table

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -18,7 +18,7 @@ mkdir -p /tmp
 # Create sync.sql file for all our comnands which will be executed in a single transaction
 touch '/tmp/sync.sql'
 
-tables=(flows users teams flow_document_templates team_members)
+tables=(flows users teams flow_document_templates team_members team_themes)
 
 # run copy commands on remote  db
 for table in "${tables[@]}"; do

--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -5,3 +5,4 @@
 \include write/published_flows.sql
 \include write/team_members.sql
 \include write/team_integrations.sql
+\include write/team_themes.sql

--- a/scripts/seed-database/write/team_themes.sql
+++ b/scripts/seed-database/write/team_themes.sql
@@ -1,0 +1,41 @@
+-- insert teams_themes overwriting conflicts
+CREATE TEMPORARY TABLE sync_team_themes (
+  id integer,
+  team_id integer,
+  primary_colour text,
+  secondary_colour text,
+  logo text,
+  favicon text
+);
+
+\copy sync_team_themes FROM '/tmp/team_themes.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  team_themes (
+    id,
+    team_id,
+    primary_colour,
+    secondary_colour,
+    logo,
+    favicon
+  )
+SELECT
+  id,
+  team_id,
+  primary_colour,
+  secondary_colour,
+  logo,
+  favicon
+FROM
+  sync_team_themes ON CONFLICT (id) DO
+UPDATE
+SET
+  team_id = EXCLUDED.team_id,
+  primary_colour = EXCLUDED.primary_colour,
+  secondary_colour = EXCLUDED.secondary_colour,
+  logo = EXCLUDED.logo,
+  favicon = EXCLUDED.favicon;
+SELECT
+  setval('team_themes_id_seq', max(id))
+FROM
+  team_themes;

--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -3,8 +3,6 @@ CREATE TEMPORARY TABLE sync_teams (
   id integer,
   name text,
   slug text,
-  -- TODO: Drop this and fetch from team_themes
-  theme jsonb,
   created_at timestamptz,
   updated_at timestamptz,
   settings jsonb,


### PR DESCRIPTION
## What does this PR do?
- Syncs new `team_themes` table from production to staging and local dev environments
- Tested locally with `pnpm test-sync` script ✅ 
- Permissions manually granted on production database with `GRANT SELECT on team_themes TO github_actions;` - my understanding is that this isn't tracked anywhere currently and is just a manual process.