### PR TITLE
feat: Set `httpOnly` flag in cookie, use cookie for auth

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -41,17 +41,25 @@ export const handleSuccess = (req: Request, res: Response) => {
  * The client will then use the JWT to make authenticated requests to the API.
  */
 function setJWTCookie(returnTo: string, res: Response, req: Request) {
-  const cookie: CookieOptions = {
+  const defaultCookieOptions: CookieOptions = {
     domain: `.${new URL(returnTo).host}`,
     maxAge: new Date(
       new Date().setFullYear(new Date().getFullYear() + 1),
     ).getTime(),
-    httpOnly: true,
-    secure: true,
     sameSite: "none",
   };
 
-  res.cookie("jwt", req.user!.jwt, cookie);
+  const httpOnlyCookieOptions: CookieOptions = {
+    ...defaultCookieOptions,
+    httpOnly: true,
+    secure: true,
+  };
+
+  // Set secure, httpOnly cookie with JWT
+  res.cookie("jwt", req.user!.jwt, httpOnlyCookieOptions);
+
+  // Set second cookie which can be read by browser to detect presence of the unreadable httpOnly cookie
+  res.cookie("loggedIn", true, defaultCookieOptions);
 
   res.redirect(returnTo);
 }

--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -1,8 +1,6 @@
 import { CookieOptions, RequestHandler, Response } from "express";
 import { Request } from "express-jwt";
 
-import { isLiveEnv } from "../../helpers";
-
 export const failedLogin: RequestHandler = (_req, _res, next) =>
   next({
     status: 401,
@@ -17,61 +15,53 @@ export const logout: RequestHandler = (req, res) => {
 };
 
 export const handleSuccess = (req: Request, res: Response) => {
-  if (req.user) {
-    const { returnTo = process.env.EDITOR_URL_EXT } = req.session!;
-
-    const domain = (() => {
-      if (isLiveEnv()) {
-        if (returnTo?.includes("editor.planx.")) {
-          // user is logging in to staging from editor.planx.dev
-          // or production from editor.planx.uk
-          return `.${new URL(returnTo).host}`;
-        } else {
-          // user is logging in from either a netlify preview build,
-          // or from localhost, to staging (or production... temporarily)
-          return undefined;
-        }
-      } else {
-        // user is logging in from localhost, to development
-        return "localhost";
-      }
-    })();
-
-    if (domain) {
-      // As domain is set, we know that we're either redirecting back to
-      // editor.planx.dev/login, editor.planx.uk, or localhost:PORT
-      // (if this code is running in development). With the respective
-      // domain set in the cookie.
-      const cookie: CookieOptions = {
-        domain,
-        maxAge: new Date(
-          new Date().setFullYear(new Date().getFullYear() + 1),
-        ).getTime(),
-        httpOnly: false,
-      };
-
-      if (isLiveEnv()) {
-        cookie.secure = true;
-        cookie.sameSite = "none";
-      }
-
-      res.cookie("jwt", req.user.jwt, cookie);
-
-      res.redirect(returnTo);
-    } else {
-      // Redirect back to localhost:PORT/login (if this API is in staging or
-      // production), or a netlify preview build url. As the login page is on a
-      // different domain to whatever this API is running on, we can't set a
-      // cookie. To solve this issue we inject the JWT into the return url as
-      // a parameter that can be extracted by the frontend code instead.
-      const url = new URL(returnTo);
-      url.searchParams.set("jwt", req.user.jwt);
-      res.redirect(url.href);
-    }
-  } else {
-    res.json({
+  if (!req.user) {
+    return res.json({
       message: "no user",
       success: true,
     });
   }
+
+  const { returnTo = process.env.EDITOR_URL_EXT } = req.session!;
+  if (!returnTo) throw Error("Can't generate returnTo URL from session");
+
+  const isStagingOrProd = returnTo.includes("editor.planx.");
+
+  isStagingOrProd
+    ? setJWTCookie(returnTo, res, req)
+    : setJWTSearchParams(returnTo, res, req);
 };
+
+/**
+ * Handle auth for staging and production
+ *
+ * Use a httpOnly cookie to pass the JWT securely back to the client.
+ * The client will then use the JWT to make authenticated requests to the API.
+ */
+function setJWTCookie(returnTo: string, res: Response, req: Request) {
+  const cookie: CookieOptions = {
+    domain: `.${new URL(returnTo).host}`,
+    maxAge: new Date(
+      new Date().setFullYear(new Date().getFullYear() + 1),
+    ).getTime(),
+    httpOnly: true,
+    secure: true,
+    sameSite: "none",
+  };
+
+  res.cookie("jwt", req.user!.jwt, cookie);
+
+  res.redirect(returnTo);
+}
+
+/**
+ * Handle auth for local development and Pizzas
+ *
+ * We can't use cookies cross-domain.
+ * Inject the JWT into the return URL, which can then be set as a cookie by the frontend
+ */
+function setJWTSearchParams(returnTo: string, res: Response, req: Request) {
+  const url = new URL(returnTo);
+  url.searchParams.set("jwt", req.user!.jwt);
+  res.redirect(url.href);
+}

--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -59,7 +59,7 @@ function setJWTCookie(returnTo: string, res: Response, req: Request) {
   res.cookie("jwt", req.user!.jwt, httpOnlyCookieOptions);
 
   // Set second cookie which can be read by browser to detect presence of the unreadable httpOnly cookie
-  res.cookie("loggedIn", true, defaultCookieOptions);
+  res.cookie("auth", { loggedIn: true }, defaultCookieOptions);
 
   res.redirect(returnTo);
 }

--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -22,6 +22,8 @@ export const handleSuccess = (req: Request, res: Response) => {
     });
   }
 
+  // Check referrer of original request
+  // This means requests from Pizzas to the staging API will not get flagged as `isStagingOrProd`
   const { returnTo = process.env.EDITOR_URL_EXT } = req.session!;
   if (!returnTo) throw Error("Can't generate returnTo URL from session");
 

--- a/api.planx.uk/modules/user/controller.ts
+++ b/api.planx.uk/modules/user/controller.ts
@@ -69,7 +69,7 @@ export const deleteUser: DeleteUser = async (_req, res, next) => {
 
 export const getLoggedInUserDetails: RequestHandler<
   Record<string, never>,
-  User
+  User & { jwt: string | undefined }
 > = async (_req, res, next) => {
   try {
     const $client = getClient();
@@ -88,7 +88,12 @@ export const getLoggedInUserDetails: RequestHandler<
         status: 400,
       });
 
-    res.json(user);
+    const jwt = userContext.getStore()?.user.jwt;
+
+    res.json({
+      ...user,
+      jwt: jwt,
+    });
   } catch (error) {
     next(error);
   }

--- a/api.planx.uk/modules/user/docs.yaml
+++ b/api.planx.uk/modules/user/docs.yaml
@@ -91,6 +91,9 @@ paths:
                   isPlatformAdmin:
                     type: boolean
                     example: true
+                  jwt:
+                    type: string
+                    example: xxxxx.yyyyy.zzzzz
                   teams:
                     type: array
                     items:

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -38,19 +38,12 @@ useSwaggerDocs(app);
 
 app.set("trust proxy", 1);
 
-app.use((req, res, next) => {
-  res.header("Access-Control-Allow-Origin", req.headers.origin);
-  res.header(
-    "Access-Control-Allow-Headers",
-    "Origin, X-Requested-With, Content-Type, Accept",
-  );
-  next();
-});
-
 app.use(
   cors({
     credentials: true,
     methods: "*",
+    origin: process.env.EDITOR_URL_EXT,
+    allowedHeaders: "Origin, X-Requested-With, Content-Type, Accept",
   }),
 );
 

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -43,7 +43,13 @@ app.use(
     credentials: true,
     methods: "*",
     origin: process.env.EDITOR_URL_EXT,
-    allowedHeaders: "Origin, X-Requested-With, Content-Type, Accept",
+    allowedHeaders: [
+      "Accept",
+      "Authorization",
+      "Content-Type",
+      "Origin",
+      "X-Requested-With",
+    ],
   }),
 );
 

--- a/e2e/tests/ui-driven/src/create-flow/helpers.ts
+++ b/e2e/tests/ui-driven/src/create-flow/helpers.ts
@@ -1,11 +1,8 @@
 import { Browser, Page, Request } from "@playwright/test";
 import { createAuthenticatedSession } from "../globalHelpers";
 
-export const isGetUserRequest = (req: Request) => {
-  const isHasuraRequest = req.url().includes("/graphql");
-  const isGetUserOperation = req.postData()?.toString().includes("GetUserById");
-  return Boolean(isHasuraRequest && isGetUserOperation);
-};
+export const isGetUserRequest = (req: Request) =>
+  req.url().includes("/user/me");
 
 export async function getAdminPage({
   browser,

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -66,7 +66,7 @@ export async function createAuthenticatedSession({
       name: "auth",
       domain: "localhost",
       path: "/",
-      value: { loggedIn: true },
+      value: JSON.stringify({ loggedIn: true }),
     },
   ]);
   return page;

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -62,6 +62,12 @@ export async function createAuthenticatedSession({
       path: "/",
       value: token,
     },
+    {
+      name: "loggedIn",
+      domain: "localhost",
+      path: "/",
+      value: true,
+    },
   ]);
   return page;
 }

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -63,10 +63,10 @@ export async function createAuthenticatedSession({
       value: token,
     },
     {
-      name: "loggedIn",
+      name: "auth",
       domain: "localhost",
       path: "/",
-      value: true,
+      value: { loggedIn: true },
     },
   ]);
   return page;

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -25,7 +25,7 @@
     "@tiptap/extension-history": "^2.0.3",
     "@tiptap/extension-image": "^2.0.3",
     "@tiptap/extension-italic": "^2.0.3",
-    "@tiptap/extension-link": "^2.0.3",
+    "@tiptap/extension-link": "^2.1.13",
     "@tiptap/extension-list-item": "^2.0.3",
     "@tiptap/extension-mention": "^2.1.13",
     "@tiptap/extension-ordered-list": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -52,7 +52,6 @@
     "graphql-tag": "^2.12.6",
     "immer": "^9.0.21",
     "js-cookie": "^3.0.5",
-    "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "marked": "^4.3.0",
     "mathjs": "^11.8.2",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -158,9 +158,6 @@ dependencies:
   js-cookie:
     specifier: ^3.0.5
     version: 3.0.5
-  jwt-decode:
-    specifier: ^4.0.0
-    version: 4.0.0
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
@@ -14630,11 +14627,6 @@ packages:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
-    dev: false
-
-  /jwt-decode@4.0.0:
-    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
-    engines: {node: '>=18'}
     dev: false
 
   /keyv@4.5.4:

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -78,8 +78,8 @@ dependencies:
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)
   '@tiptap/extension-link':
-    specifier: ^2.0.3
-    version: 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
+    specifier: ^2.1.13
+    version: 2.1.13(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
   '@tiptap/extension-list-item':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)
@@ -7328,8 +7328,8 @@ packages:
       '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
     dev: false
 
-  /@tiptap/extension-link@2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3):
-    resolution: {integrity: sha512-H72tXQ5rkVCkAhFaf08fbEU7EBUCK0uocsqOF+4th9sOlrhfgyJtc8Jv5EXPDpxNgG5jixSqWBo0zKXQm9s9eg==}
+  /@tiptap/extension-link@2.1.13(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3):
+    resolution: {integrity: sha512-wuGMf3zRtMHhMrKm9l6Tft5M2N21Z0UP1dZ5t1IlOAvOeYV2QZ5UynwFryxGKLO0NslCBLF/4b/HAdNXbfXWUA==}
     peerDependencies:
       '@tiptap/core': ^2.0.0
       '@tiptap/pm': ^2.0.0

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
@@ -19,6 +19,7 @@ describe("FileUploadAndLabel - Editor Modal", () => {
       isPlatformAdmin: true,
       email: "test@test.com",
       teams: [],
+      jwt: "x.y.z",
     });
   });
 

--- a/editor.planx.uk/src/api/upload.ts
+++ b/editor.planx.uk/src/api/upload.ts
@@ -1,5 +1,5 @@
 import axios, { RawAxiosRequestHeaders } from "axios";
-import { getCookie } from "lib/cookie";
+import { useStore } from "pages/FlowEditor/lib/store";
 
 export { uploadPrivateFile, uploadPublicFile };
 
@@ -9,7 +9,7 @@ async function uploadPublicFile(
   file: any,
   { onProgress }: { onProgress?: (p: any) => void } = {},
 ) {
-  const token = getCookie("jwt");
+  const token = useStore.getState().jwt;
   const authRequestHeader = { Authorization: `Bearer ${token}` };
   const { data } = await handleUpload(
     file,

--- a/editor.planx.uk/src/client/index.ts
+++ b/editor.planx.uk/src/client/index.ts
@@ -1,5 +1,6 @@
 import { CoreDomainClient } from "@opensystemslab/planx-core";
-import { getCookie } from "lib/cookie";
+import { useStore } from "pages/FlowEditor/lib/store";
+
 /**
  * core doesn't expose a graphql interface like the graphql/hasura clients do
  * instead, it encapsulates query and business logic to only expose declarative interfaces
@@ -10,5 +11,5 @@ export const _public = new CoreDomainClient({
 
 export const _client = new CoreDomainClient({
   targetURL: process.env.REACT_APP_HASURA_URL!,
-  auth: { jwt: getCookie("jwt") || "" },
+  auth: { jwt: useStore.getState().jwt || "" },
 });

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -9,7 +9,6 @@ import { ApolloProvider } from "@apollo/client";
 import CssBaseline from "@mui/material/CssBaseline";
 import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 import { MyMap } from "@opensystemslab/map";
-import { jwtDecode } from "jwt-decode";
 import { getCookie, setCookie } from "lib/cookie";
 import ErrorPage from "pages/ErrorPage";
 import { AnalyticsProvider } from "pages/FlowEditor/lib/analyticsProvider";
@@ -36,30 +35,18 @@ if (!window.customElements.get("my-map")) {
 }
 
 const hasJWT = (): boolean | void => {
-  let jwt = getCookie("jwt");
-  if (jwt) {
-    try {
-      if (
-        Number(
-          (jwtDecode(jwt) as any)["https://hasura.io/jwt/claims"][
-            "x-hasura-user-id"
-          ],
-        ) > 0
-      ) {
-        return true;
-      }
-    } catch (e) {}
-    window.location.href = "/logout";
-  } else {
-    jwt = new URLSearchParams(window.location.search).get("jwt");
-    if (jwt) {
-      setCookie("jwt", jwt);
-      // set the jwt, and remove it from the url, then re-run this function
-      window.location.href = "/";
-    } else {
-      return false;
-    }
-  }
+  const jwtCookie = getCookie("jwt");
+  if (jwtCookie) return true;
+
+  // If JWT not set via cookie, check search params
+  const jwtSearchParams = new URLSearchParams(window.location.search).get(
+    "jwt",
+  );
+  if (!jwtSearchParams) return false;
+
+  // Remove JWT from URL, and re-run this function
+  setCookie("jwt", jwtSearchParams);
+  window.location.href = "/";
 };
 
 const Layout: React.FC<{

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -36,8 +36,8 @@ if (!window.customElements.get("my-map")) {
 
 const hasJWT = (): boolean | void => {
   // This cookie indicates the presence of the secure httpOnly "jwt" cookie
-  const loggedInCookie = getCookie("loggedIn");
-  if (loggedInCookie) return true;
+  const authCookie = getCookie("auth");
+  if (authCookie) return true;
 
   // If JWT not set via cookie, check search params
   const jwtSearchParams = new URLSearchParams(window.location.search).get(
@@ -47,6 +47,7 @@ const hasJWT = (): boolean | void => {
 
   // Remove JWT from URL, and re-run this function
   setCookie("jwt", jwtSearchParams);
+  setCookie("auth", { loggedIn: true });
   window.location.href = "/";
 };
 

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -35,8 +35,9 @@ if (!window.customElements.get("my-map")) {
 }
 
 const hasJWT = (): boolean | void => {
-  const jwtCookie = getCookie("jwt");
-  if (jwtCookie) return true;
+  // This cookie indicates the presence of the secure httpOnly "jwt" cookie
+  const loggedInCookie = getCookie("loggedIn");
+  if (loggedInCookie) return true;
 
   // If JWT not set via cookie, check search params
   const jwtSearchParams = new URLSearchParams(window.location.search).get(

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -13,8 +13,6 @@ import { logger } from "airbrake";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { toast } from "react-toastify";
 
-import { getCookie } from "./cookie";
-
 const toastId = "error_toast";
 
 // function used to verify response status
@@ -39,7 +37,7 @@ const authHttpLink = createHttpLink({
   uri: process.env.REACT_APP_HASURA_URL,
   fetch: customFetch,
   headers: {
-    authorization: `Bearer ${getCookie("jwt")}`,
+    authorization: `Bearer ${useStore.getState().jwt}`,
   },
 });
 

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -13,6 +13,8 @@ import { logger } from "airbrake";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { toast } from "react-toastify";
 
+import { getCookie } from "./cookie";
+
 const toastId = "error_toast";
 
 // function used to verify response status
@@ -37,7 +39,7 @@ const authHttpLink = createHttpLink({
   uri: process.env.REACT_APP_HASURA_URL,
   fetch: customFetch,
   headers: {
-    authorization: `Bearer ${useStore.getState().jwt}`,
+    authorization: `Bearer ${getCookie("jwt")}`,
   },
 });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -10,7 +10,6 @@ import {
   update,
 } from "@planx/graph";
 import axios from "axios";
-import { getCookie } from "lib/cookie";
 import { client } from "lib/graphql";
 import debounce from "lodash/debounce";
 import isEmpty from "lodash/isEmpty";
@@ -21,7 +20,7 @@ import type { StateCreator } from "zustand";
 
 import { FlowLayout } from "../../components/Flow";
 import { connectToDB, getConnection } from "./../sharedb";
-import type { Store } from ".";
+import { type Store } from ".";
 import type { SharedStore } from "./shared";
 import { UserStore } from "./user";
 
@@ -141,7 +140,7 @@ export const editorStore: StateCreator<
   },
 
   copyFlow: async (flowId: string) => {
-    const token = getCookie("jwt");
+    const token = get().jwt;
 
     // when copying a flow, we make nodeIds unique by replacing part of the original nodeId string.
     //   the onboarding script will often provide a meaningful string reflecting the team name (eg "LAM"),
@@ -237,7 +236,7 @@ export const editorStore: StateCreator<
   },
 
   validateAndDiffFlow(flowId: string) {
-    const token = getCookie("jwt");
+    const token = get().jwt;
 
     return axios.post(
       `${process.env.REACT_APP_API_URL}/flows/${flowId}/diff`,
@@ -340,7 +339,7 @@ export const editorStore: StateCreator<
       return Promise.resolve();
     }
 
-    const token = getCookie("jwt");
+    const token = get().jwt;
 
     return axios
       .post(
@@ -390,7 +389,7 @@ export const editorStore: StateCreator<
   },
 
   publishFlow(flowId: string, summary?: string) {
-    const token = getCookie("jwt");
+    const token = get().jwt;
 
     const urlWithParams = (url: string, params: any) =>
       [url, new URLSearchParams(omitBy(params, isEmpty))]

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -1,6 +1,6 @@
 import { User, UserTeams } from "@opensystemslab/planx-core/types";
+import axios from "axios";
 import { _client } from "client";
-import { jwtDecode } from "jwt-decode";
 import { Team } from "types";
 import type { StateCreator } from "zustand";
 
@@ -10,7 +10,7 @@ export interface UserStore {
   setUser: (user: User) => void;
   getUser: () => User | undefined;
   canUserEditTeam: (teamSlug: Team["slug"]) => boolean;
-  initUserStore: (jwt: string) => Promise<void>;
+  initUserStore: () => Promise<void>;
 }
 
 export const userStore: StateCreator<UserStore, [], [], UserStore> = (
@@ -31,15 +31,22 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
     return user.isPlatformAdmin || user.teams.some(hasTeamEditorRole);
   },
 
-  async initUserStore(jwt: string) {
+  async initUserStore() {
     const { getUser, setUser } = get();
 
     if (getUser()) return;
 
-    const id = (jwtDecode(jwt) as any)["sub"];
-    const user = await _client.user.getById(id);
-    if (!user) throw new Error(`Failed to get user with ID ${id}`);
-
+    const user = await getLoggedInUser();
     setUser(user);
   },
 });
+
+const getLoggedInUser = async () => {
+  const url = `${process.env.REACT_APP_API_URL}/user/me`;
+  try {
+    const response = await axios.get<User>(url, { withCredentials: true });
+    return response.data;
+  } catch (error) {
+    throw Error("Failed to fetch user matching JWT cookie");
+  }
+};

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -6,8 +6,9 @@ import type { StateCreator } from "zustand";
 
 export interface UserStore {
   user?: User;
+  jwt?: string;
 
-  setUser: (user: User) => void;
+  setUser: (user: User & { jwt: string }) => void;
   getUser: () => User | undefined;
   canUserEditTeam: (teamSlug: Team["slug"]) => boolean;
   initUserStore: () => Promise<void>;
@@ -17,7 +18,7 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
   set,
   get,
 ) => ({
-  setUser: (user: User) => set({ user }),
+  setUser: ({ jwt, ...user }) => set({ jwt, user }),
 
   getUser: () => get().user,
 
@@ -44,7 +45,9 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
 const getLoggedInUser = async () => {
   const url = `${process.env.REACT_APP_API_URL}/user/me`;
   try {
-    const response = await axios.get<User>(url, { withCredentials: true });
+    const response = await axios.get<User & { jwt: string }>(url, {
+      withCredentials: true,
+    });
     return response.data;
   } catch (error) {
     throw Error("Failed to fetch user matching JWT cookie");

--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -35,7 +35,7 @@ const editorRoutes = mount({
     } catch (err) {
       console.error(err);
     } finally {
-      const cookieString = `jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      const cookieString = `loggedIn=; jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
       // remove jwt cookie for non planx domains (netlify preview urls)
       document.cookie = cookieString;
       // remove jwt cookie for planx domains (staging and production)

--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -35,7 +35,7 @@ const editorRoutes = mount({
     } catch (err) {
       console.error(err);
     } finally {
-      const cookieString = `loggedIn=; jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      const cookieString = `auth=; jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
       // remove jwt cookie for non planx domains (netlify preview urls)
       document.cookie = cookieString;
       // remove jwt cookie for planx domains (staging and production)

--- a/editor.planx.uk/src/routes/views/authenticated.tsx
+++ b/editor.planx.uk/src/routes/views/authenticated.tsx
@@ -1,4 +1,3 @@
-import { getCookie } from "lib/cookie";
 import { redirect } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -11,7 +10,7 @@ import AuthenticatedLayout from "../../pages/layout/AuthenticatedLayout";
  * Initialises user store
  */
 export const authenticatedView = async () => {
-  const jwt = getCookie("jwt");
+  const jwt = useStore.getState().jwt;
   if (!jwt) return redirect("/login");
 
   await useStore.getState().initUserStore();

--- a/editor.planx.uk/src/routes/views/authenticated.tsx
+++ b/editor.planx.uk/src/routes/views/authenticated.tsx
@@ -1,3 +1,4 @@
+import { getCookie } from "lib/cookie";
 import { redirect } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -10,8 +11,8 @@ import AuthenticatedLayout from "../../pages/layout/AuthenticatedLayout";
  * Initialises user store
  */
 export const authenticatedView = async () => {
-  const jwt = useStore.getState().jwt;
-  if (!jwt) return redirect("/login");
+  const authCookie = getCookie("auth");
+  if (!authCookie) return redirect("/login");
 
   await useStore.getState().initUserStore();
 

--- a/editor.planx.uk/src/routes/views/authenticated.tsx
+++ b/editor.planx.uk/src/routes/views/authenticated.tsx
@@ -8,13 +8,13 @@ import AuthenticatedLayout from "../../pages/layout/AuthenticatedLayout";
 
 /**
  * View wrapper for all authenticated routes
- * Parses JWT and inits user store
+ * Initialises user store
  */
 export const authenticatedView = async () => {
   const jwt = getCookie("jwt");
   if (!jwt) return redirect("/login");
 
-  await useStore.getState().initUserStore(jwt);
+  await useStore.getState().initUserStore();
 
   useStore.getState().setPreviewEnvironment("editor");
 


### PR DESCRIPTION
## Context
Merges PRs https://github.com/theopensystemslab/planx-new/pull/2591 and https://github.com/theopensystemslab/planx-new/pull/2595 which were previously reverted. These two PRs have had their commits cherry picked and have been previously reviewed.

Code from [`ecb270a`](https://github.com/theopensystemslab/planx-new/pull/2634/commits/ecb270a3e65990c098ea4aea043a7105a029133d) is new to this branch.

## What does this PR do?
- Sets `httpOnly` flag in cookie (see https://github.com/theopensystemslab/planx-new/pull/2591)
- Adds additional `auth` cookie to detect presence of unreadable `httpOnly` cookie (see https://github.com/theopensystemslab/planx-new/pull/2595)
- Pass JWT from `user/me` endpoint and retains in `UserStore` - this is required to pass `JWT` to `planx-core` as well as to pass into auth headers.

## Testing
- I can log in / log out locally
- I can log in / log out on Pizza
- I can make requests via Apollo (e.g. GetTeams), `planx-core` (e.g. get user permissions) and axios/fetch (e.g. file upload) on Pizza

## Other
 - I'm not totally convinced this will work as is with regards to CORS on staging - I'd like to merge and test this (and then fix forward).
 - There's room for simplification here - we could avoid the repetitive  process of building the auth headers if we used a custom Axios instance or followed an [interceptor](https://axios-http.com/docs/interceptors) pattern. I've not picked this up here as we use both `fetch` and `Axios` in places and there's enough change on this PR as is. I'll add an issue or ticket to look into this.
