### PR TITLE
fix: Handle duplicate `team_id` on re-sync

### DIFF
--- a/scripts/seed-database/write/team_themes.sql
+++ b/scripts/seed-database/write/team_themes.sql
@@ -30,7 +30,6 @@ FROM
   sync_team_themes ON CONFLICT (id) DO
 UPDATE
 SET
-  team_id = EXCLUDED.team_id,
   primary_colour = EXCLUDED.primary_colour,
   secondary_colour = EXCLUDED.secondary_colour,
   logo = EXCLUDED.logo,


### PR DESCRIPTION
Quick fix-forward for https://github.com/theopensystemslab/planx-new/pull/2633!

Currently hitting [the following issue on CI](https://github.com/theopensystemslab/planx-new/commit/c9b7810ceab63f21ac1c9be6e54147ea1d93b6e4/checks) which I didn't hit locally - 

```bash
psql:write/team_themes.sql:37: ERROR:  duplicate key value violates unique constraint "team_themes_team_id_key"
DETAIL:  Key (team_id)=(15) already exists.
Database sync failed!
```