### PR TITLE
fix: Add `secure` flag to auth cookie

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -47,12 +47,12 @@ function setJWTCookie(returnTo: string, res: Response, req: Request) {
       new Date().setFullYear(new Date().getFullYear() + 1),
     ).getTime(),
     sameSite: "none",
+    secure: true,
   };
 
   const httpOnlyCookieOptions: CookieOptions = {
     ...defaultCookieOptions,
     httpOnly: true,
-    secure: true,
   };
 
   // Set secure, httpOnly cookie with JWT


### PR DESCRIPTION
Currently getting an issue setting the auth cookie on staging - please see screenshots below.

Login cannot be tested on the Pizza as this is pointing to the staging API for auth.

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/92f066d8-6505-4a4d-b193-95d8689013b6)

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/854c3687-b736-4869-a748-c7a4163a1380)
