### PR TITLE
fix: Setup `authMiddleware` for Apollo

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -59,7 +59,8 @@ function setJWTCookie(returnTo: string, res: Response, req: Request) {
   res.cookie("jwt", req.user!.jwt, httpOnlyCookieOptions);
 
   // Set second cookie which can be read by browser to detect presence of the unreadable httpOnly cookie
-  res.cookie("auth", { loggedIn: true }, defaultCookieOptions);
+  const authCookie = btoa(JSON.stringify({ loggedIn: true }));
+  res.cookie("auth", authCookie, defaultCookieOptions);
 
   res.redirect(returnTo);
 }

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -13,8 +13,6 @@ import { logger } from "airbrake";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { toast } from "react-toastify";
 
-import { getCookie } from "./cookie";
-
 const toastId = "error_toast";
 
 // function used to verify response status
@@ -38,9 +36,7 @@ const customFetch = async (
 const authHttpLink = createHttpLink({
   uri: process.env.REACT_APP_HASURA_URL,
   fetch: customFetch,
-  headers: {
-    authorization: `Bearer ${getCookie("jwt")}`,
-  },
+  credentials: "include",
 });
 
 const publicHttpLink = createHttpLink({

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -34,8 +34,8 @@ export const userStore: StateCreator<UserStore, [], [], UserStore> = (
 
   async initUserStore() {
     const { getUser, setUser } = get();
-
-    if (getUser()) return;
+    const currentUser = getUser();
+    if (currentUser) return;
 
     const user = await getLoggedInUser();
     setUser(user);

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -16,7 +16,7 @@ const editorRoutes = compose(
     "/": route(async () => {
       const { data } = await client.query({
         query: gql`
-          query {
+          query GetTeams {
             teams(order_by: { name: asc }) {
               id
               name


### PR DESCRIPTION
**Take 1**
~~This seems like the simplest solution here - to use the cookie for requests via Apollo directly, instead of trying to read it (which isn't possible as it's now `httpOnly`!)~~

~~My original idea was to wait for the JWT to be returned before making the failing query, but it's actually a bit more complex as the client is already instantiated by this point.~~

**Take 2**
So it turns out Hasura won't accept either a cookie or an auth header - is has to be one or the other. This would mean a number of changes to how we handle tests, and authenticate via scripts, or the API etc, so seems a non-starter. For reference - this setting can be controlled via the [`header`](https://hasura.io/docs/latest/auth/authentication/jwt/#header) JWT configuration option.

I've gone back to my initial ideal of waiting for authentication first using a middleware pattern ([Apollo docs](https://www.apollographql.com/docs/react/networking/authentication/#header)).