### PR TITLE
wip: UI setup for team design settings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -43,7 +43,7 @@ const DesignSettings: React.FC = () => {
   const isUsingFeatureFlag = () => hasFeatureFlag("SHOW_TEAM_SETTINGS");
 
   return (
-    <form onSubmit={formik.handleSubmit}>
+    <>
       <EditorRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Design
@@ -59,167 +59,226 @@ const DesignSettings: React.FC = () => {
       ) : (
         <>
           <EditorRow background>
-            <InputGroup flowSpacing>
-              <InputLegend>Theme colour & logo</InputLegend>
-              <InputDescription>
-                The theme colour and logo, are used in the header of the
-                service. The theme colour should be a dark colour that contrasts
-                with white ("#ffffff"). The logo should contrast with a dark
-                background colour (your theme colour) and have a transparent
-                background.
-              </InputDescription>
-              <InputDescription>
-                <Link href="https://www.planx.uk">
-                  See our guide for setting theme colours and logos
-                </Link>
-              </InputDescription>
-              <InputRow>
-                <InputRowItem>
-                  <ColorPicker
-                    color={formik.values.themeColor}
-                    onChange={(color) =>
-                      formik.setFieldValue("themeColor", color)
-                    }
-                    label="Theme colour"
-                  />
-                </InputRowItem>
-              </InputRow>
-              <InputRow>
-                <InputRowLabel>Logo:</InputRowLabel>
-                <InputRowItem width={50}>
-                  <PublicFileUploadButton />
-                </InputRowItem>
-                <Typography
-                  color="text.secondary"
-                  variant="body2"
-                  pl={2}
-                  alignSelf="center"
-                >
-                  .png or .svg
+            <form onSubmit={formik.handleSubmit}>
+              <InputGroup flowSpacing>
+                <InputLegend>Theme colour & logo</InputLegend>
+                <InputDescription>
+                  The theme colour and logo, are used in the header of the
+                  service. The theme colour should be a dark colour that
+                  contrasts with white ("#ffffff"). The logo should contrast
+                  with a dark background colour (your theme colour) and have a
+                  transparent background.
+                </InputDescription>
+                <InputDescription>
+                  <Link href="https://www.planx.uk">
+                    See our guide for setting theme colours and logos
+                  </Link>
+                </InputDescription>
+                <InputRow>
+                  <InputRowItem>
+                    <ColorPicker
+                      color={formik.values.themeColor}
+                      onChange={(color) =>
+                        formik.setFieldValue("themeColor", color)
+                      }
+                      label="Theme colour"
+                    />
+                  </InputRowItem>
+                </InputRow>
+                <InputRow>
+                  <InputRowLabel>Logo:</InputRowLabel>
+                  <InputRowItem width={50}>
+                    <PublicFileUploadButton />
+                  </InputRowItem>
+                  <Typography
+                    color="text.secondary"
+                    variant="body2"
+                    pl={2}
+                    alignSelf="center"
+                  >
+                    .png or .svg
+                  </Typography>
+                </InputRow>
+              </InputGroup>
+              <Box>
+                <Typography variant="h4" my={1}>
+                  Preview:
                 </Typography>
-              </InputRow>
-            </InputGroup>
-            <Box>
-              <Typography variant="h4" my={1}>
-                Preview:
-              </Typography>
-              <DesignPreview bgcolor={exampleColor}>
-                <img
-                  width="140"
-                  src="https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/barnet.svg"
-                  alt="council logo"
-                />
-              </DesignPreview>
-            </Box>
-          </EditorRow>
-          <EditorRow background>
-            <InputGroup flowSpacing>
-              <InputLegend>Button colour</InputLegend>
-              <InputDescription>
-                The button background colour should be either a dark or light
-                colour. The text will be programatically selected to contrast
-                with the selected colour (being either black or white).
-              </InputDescription>
-              <InputDescription>
-                <Link href="https://www.planx.uk">
-                  See our guide for setting button colours
-                </Link>
-              </InputDescription>
-              <InputRow>
-                <InputRowItem>
-                  <ColorPicker
-                    color={formik.values.buttonColor}
-                    onChange={(color) =>
-                      formik.setFieldValue("buttonColor", color)
-                    }
-                    label="Button colour"
+                <DesignPreview bgcolor={exampleColor}>
+                  <img
+                    width="140"
+                    src="https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/barnet.svg"
+                    alt="council logo"
                   />
-                </InputRowItem>
-              </InputRow>
-            </InputGroup>
-            <Box>
-              <Typography variant="h4" my={1}>
-                Preview:
-              </Typography>
-              <DesignPreview bgcolor="white">
-                <Button
-                  variant="contained"
-                  sx={{ backgroundColor: exampleColor }}
-                >
-                  Example primary button
+                </DesignPreview>
+              </Box>
+              <Box>
+                <Button type="submit" variant="contained" disabled>
+                  Save
                 </Button>
-              </DesignPreview>
-            </Box>
-          </EditorRow>
-          <EditorRow background>
-            <InputGroup flowSpacing>
-              <InputLegend>Text link colour</InputLegend>
-              <InputDescription>
-                The text link colour should be a dark colour that contrasts with
-                white ("#ffffff").
-              </InputDescription>
-              <InputDescription>
-                <Link href="https://www.planx.uk">
-                  See our guide for setting text link colours
-                </Link>
-              </InputDescription>
-              <InputRow>
-                <InputRowItem>
-                  <ColorPicker
-                    color={formik.values.linkColor}
-                    onChange={(color) =>
-                      formik.setFieldValue("linkColor", color)
-                    }
-                    label="Text link colour"
-                  />
-                </InputRowItem>
-              </InputRow>
-            </InputGroup>
-            <Box>
-              <Typography variant="h4" my={1}>
-                Preview:
-              </Typography>
-              <DesignPreview bgcolor="white">
-                <Link sx={{ color: exampleColor }}>Example text link</Link>
-              </DesignPreview>
-            </Box>
-          </EditorRow>
-          <EditorRow background>
-            <InputGroup flowSpacing>
-              <InputLegend>Favicon</InputLegend>
-              <InputDescription>
-                Set the favicon to be used in the browser tab. The favicon
-                should be 32x32px and in .ico or .png format.
-              </InputDescription>
-              <InputDescription>
-                <Link href="https://www.planx.uk">
-                  See our guide for favicons
-                </Link>
-              </InputDescription>
-              <InputRow>
-                <InputRowLabel>Favicon:</InputRowLabel>
-                <InputRowItem width={50}>
-                  <PublicFileUploadButton />
-                </InputRowItem>
-                <Typography
-                  color="text.secondary"
-                  variant="body2"
-                  pl={2}
-                  alignSelf="center"
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled
+                  color="secondary"
+                  sx={{ ml: 1.5 }}
                 >
-                  .ico or .png
-                </Typography>
-              </InputRow>
-            </InputGroup>
+                  Reset changes
+                </Button>
+              </Box>
+            </form>
           </EditorRow>
-          <EditorRow>
-            <Button type="submit" variant="contained" color="primary">
-              Update design settings
-            </Button>
+          <EditorRow background>
+            <form onSubmit={formik.handleSubmit}>
+              <InputGroup flowSpacing>
+                <InputLegend>Button colour</InputLegend>
+                <InputDescription>
+                  The button background colour should be either a dark or light
+                  colour. The text will be programatically selected to contrast
+                  with the selected colour (being either black or white).
+                </InputDescription>
+                <InputDescription>
+                  <Link href="https://www.planx.uk">
+                    See our guide for setting button colours
+                  </Link>
+                </InputDescription>
+                <InputRow>
+                  <InputRowItem>
+                    <ColorPicker
+                      color={formik.values.buttonColor}
+                      onChange={(color) =>
+                        formik.setFieldValue("buttonColor", color)
+                      }
+                      label="Button colour"
+                    />
+                  </InputRowItem>
+                </InputRow>
+              </InputGroup>
+              <Box>
+                <Typography variant="h4" my={1}>
+                  Preview:
+                </Typography>
+                <DesignPreview bgcolor="white">
+                  <Button
+                    variant="contained"
+                    sx={{ backgroundColor: exampleColor }}
+                  >
+                    Example primary button
+                  </Button>
+                </DesignPreview>
+              </Box>
+              <Box>
+                <Button type="submit" variant="contained" disabled>
+                  Save
+                </Button>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled
+                  color="secondary"
+                  sx={{ ml: 1.5 }}
+                >
+                  Reset changes
+                </Button>
+              </Box>
+            </form>
+          </EditorRow>
+          <EditorRow background>
+            <form onSubmit={formik.handleSubmit}>
+              <InputGroup flowSpacing>
+                <InputLegend>Text link colour</InputLegend>
+                <InputDescription>
+                  The text link colour should be a dark colour that contrasts
+                  with white ("#ffffff").
+                </InputDescription>
+                <InputDescription>
+                  <Link href="https://www.planx.uk">
+                    See our guide for setting text link colours
+                  </Link>
+                </InputDescription>
+                <InputRow>
+                  <InputRowItem>
+                    <ColorPicker
+                      color={formik.values.linkColor}
+                      onChange={(color) =>
+                        formik.setFieldValue("linkColor", color)
+                      }
+                      label="Text link colour"
+                    />
+                  </InputRowItem>
+                </InputRow>
+              </InputGroup>
+              <Box>
+                <Typography variant="h4" my={1}>
+                  Preview:
+                </Typography>
+                <DesignPreview bgcolor="white">
+                  <Link sx={{ color: exampleColor }}>Example text link</Link>
+                </DesignPreview>
+              </Box>
+              <Box>
+                <Button type="submit" variant="contained" disabled>
+                  Save
+                </Button>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled
+                  color="secondary"
+                  sx={{ ml: 1.5 }}
+                >
+                  Reset changes
+                </Button>
+              </Box>
+            </form>
+          </EditorRow>
+          <EditorRow background>
+            <form onSubmit={formik.handleSubmit}>
+              <InputGroup flowSpacing>
+                <InputLegend>Favicon</InputLegend>
+                <InputDescription>
+                  Set the favicon to be used in the browser tab. The favicon
+                  should be 32x32px and in .ico or .png format.
+                </InputDescription>
+                <InputDescription>
+                  <Link href="https://www.planx.uk">
+                    See our guide for favicons
+                  </Link>
+                </InputDescription>
+                <InputRow>
+                  <InputRowLabel>Favicon:</InputRowLabel>
+                  <InputRowItem width={50}>
+                    <PublicFileUploadButton />
+                  </InputRowItem>
+                  <Typography
+                    color="text.secondary"
+                    variant="body2"
+                    pl={2}
+                    alignSelf="center"
+                  >
+                    .ico or .png
+                  </Typography>
+                </InputRow>
+              </InputGroup>
+              <Box>
+                <Button type="submit" variant="contained" disabled>
+                  Save
+                </Button>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled
+                  color="secondary"
+                  sx={{ ml: 1.5 }}
+                >
+                  Reset changes
+                </Button>
+              </Box>
+            </form>
           </EditorRow>
         </>
       )}
-    </form>
+    </>
   );
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -1,5 +1,7 @@
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { hasFeatureFlag } from "lib/featureFlags";
@@ -15,16 +17,24 @@ import InputRowItem from "ui/shared/InputRowItem";
 import InputRowLabel from "ui/shared/InputRowLabel";
 import PublicFileUploadButton from "ui/shared/PublicFileUploadButton";
 
+const DesignPreview = styled(Box)(({ theme }) => ({
+  border: `2px solid ${theme.palette.border.input}`,
+  padding: theme.spacing(2),
+  boxShadow: "4px 4px 0px rgba(150, 150, 150, 0.5)",
+}));
+
+const exampleColor = "#007078";
+
 const DesignSettings: React.FC = () => {
   const formik = useFormik<{
-    bgColor: string;
-    primaryColor: string;
-    secondaryColor: string;
+    themeColor: string;
+    buttonColor: string;
+    linkColor: string;
   }>({
     initialValues: {
-      bgColor: "#000",
-      primaryColor: "#000",
-      secondaryColor: "#000",
+      themeColor: exampleColor,
+      buttonColor: exampleColor,
+      linkColor: exampleColor,
     },
     onSubmit: () => {},
     validate: () => {},
@@ -50,74 +60,30 @@ const DesignSettings: React.FC = () => {
         <>
           <EditorRow background>
             <InputGroup flowSpacing>
-              <InputLegend>Theme colour</InputLegend>
+              <InputLegend>Theme colour & logo</InputLegend>
               <InputDescription>
-                Set the theme colour. The theme colour should be a dark colour
-                that contrasts with white ("#ffffff").
+                The theme colour and logo, are used in the header of the
+                service. The theme colour should be a dark colour that contrasts
+                with white ("#ffffff"). The logo should contrast with a dark
+                background colour (your theme colour) and have a transparent
+                background.
               </InputDescription>
               <InputDescription>
                 <Link href="https://www.planx.uk">
-                  See our guide for setting theme colours
+                  See our guide for setting theme colours and logos
                 </Link>
               </InputDescription>
               <InputRow>
                 <InputRowItem>
                   <ColorPicker
-                    color={formik.values.bgColor}
-                    onChange={(color) => formik.setFieldValue("bgColor", color)}
+                    color={formik.values.themeColor}
+                    onChange={(color) =>
+                      formik.setFieldValue("themeColor", color)
+                    }
                     label="Theme colour"
                   />
                 </InputRowItem>
               </InputRow>
-            </InputGroup>
-          </EditorRow>
-          <EditorRow background>
-            <InputGroup flowSpacing>
-              <InputLegend>Action/link colours</InputLegend>
-              <InputDescription>
-                Set the theme colour. The theme colour should be a dark colour
-                that contrasts with white ("#ffffff").
-              </InputDescription>
-              <InputDescription>
-                <Link href="https://www.planx.uk">
-                  See our guide for setting action colours
-                </Link>
-              </InputDescription>
-              <InputRow>
-                <InputRowItem>
-                  <ColorPicker
-                    color={formik.values.primaryColor}
-                    onChange={(color) =>
-                      formik.setFieldValue("primaryColor", color)
-                    }
-                    label="Primary button colour"
-                  />
-                </InputRowItem>
-              </InputRow>
-              <InputRow>
-                <InputRowItem>
-                  <ColorPicker
-                    color={formik.values.secondaryColor}
-                    onChange={(color) =>
-                      formik.setFieldValue("secondaryColor", color)
-                    }
-                    label="Text link colour"
-                  />
-                </InputRowItem>
-              </InputRow>
-            </InputGroup>
-          </EditorRow>
-          <EditorRow background>
-            <InputGroup flowSpacing>
-              <InputLegend>Logo</InputLegend>
-              <InputDescription>
-                Set the logo to be used in the header of the service. The logo
-                should contrast with a dark background colour and have a
-                transparent background.
-              </InputDescription>
-              <InputDescription>
-                <Link href="https://www.planx.uk">See our guide for logos</Link>
-              </InputDescription>
               <InputRow>
                 <InputRowLabel>Logo:</InputRowLabel>
                 <InputRowItem width={50}>
@@ -133,6 +99,90 @@ const DesignSettings: React.FC = () => {
                 </Typography>
               </InputRow>
             </InputGroup>
+            <Box>
+              <Typography variant="h4" my={1}>
+                Preview:
+              </Typography>
+              <DesignPreview bgcolor={exampleColor}>
+                <img
+                  width="140"
+                  src="https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/barnet.svg"
+                  alt="council logo"
+                />
+              </DesignPreview>
+            </Box>
+          </EditorRow>
+          <EditorRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Button colour</InputLegend>
+              <InputDescription>
+                The button background colour should be either a dark or light
+                colour. The text will be programatically selected to contrast
+                with the selected colour (being either black or white).
+              </InputDescription>
+              <InputDescription>
+                <Link href="https://www.planx.uk">
+                  See our guide for setting button colours
+                </Link>
+              </InputDescription>
+              <InputRow>
+                <InputRowItem>
+                  <ColorPicker
+                    color={formik.values.buttonColor}
+                    onChange={(color) =>
+                      formik.setFieldValue("buttonColor", color)
+                    }
+                    label="Button colour"
+                  />
+                </InputRowItem>
+              </InputRow>
+            </InputGroup>
+            <Box>
+              <Typography variant="h4" my={1}>
+                Preview:
+              </Typography>
+              <DesignPreview bgcolor="white">
+                <Button
+                  variant="contained"
+                  sx={{ backgroundColor: exampleColor }}
+                >
+                  Example primary button
+                </Button>
+              </DesignPreview>
+            </Box>
+          </EditorRow>
+          <EditorRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Text link colour</InputLegend>
+              <InputDescription>
+                The text link colour should be a dark colour that contrasts with
+                white ("#ffffff").
+              </InputDescription>
+              <InputDescription>
+                <Link href="https://www.planx.uk">
+                  See our guide for setting text link colours
+                </Link>
+              </InputDescription>
+              <InputRow>
+                <InputRowItem>
+                  <ColorPicker
+                    color={formik.values.linkColor}
+                    onChange={(color) =>
+                      formik.setFieldValue("linkColor", color)
+                    }
+                    label="Text link colour"
+                  />
+                </InputRowItem>
+              </InputRow>
+            </InputGroup>
+            <Box>
+              <Typography variant="h4" my={1}>
+                Preview:
+              </Typography>
+              <DesignPreview bgcolor="white">
+                <Link sx={{ color: exampleColor }}>Example text link</Link>
+              </DesignPreview>
+            </Box>
           </EditorRow>
           <EditorRow background>
             <InputGroup flowSpacing>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings.tsx
@@ -16,9 +16,15 @@ import InputRowLabel from "ui/shared/InputRowLabel";
 import PublicFileUploadButton from "ui/shared/PublicFileUploadButton";
 
 const DesignSettings: React.FC = () => {
-  const formik = useFormik<{ bgColor: string }>({
+  const formik = useFormik<{
+    bgColor: string;
+    primaryColor: string;
+    secondaryColor: string;
+  }>({
     initialValues: {
       bgColor: "#000",
+      primaryColor: "#000",
+      secondaryColor: "#000",
     },
     onSubmit: () => {},
     validate: () => {},
@@ -60,6 +66,42 @@ const DesignSettings: React.FC = () => {
                     color={formik.values.bgColor}
                     onChange={(color) => formik.setFieldValue("bgColor", color)}
                     label="Theme colour"
+                  />
+                </InputRowItem>
+              </InputRow>
+            </InputGroup>
+          </EditorRow>
+          <EditorRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Action/link colours</InputLegend>
+              <InputDescription>
+                Set the theme colour. The theme colour should be a dark colour
+                that contrasts with white ("#ffffff").
+              </InputDescription>
+              <InputDescription>
+                <Link href="https://www.planx.uk">
+                  See our guide for setting action colours
+                </Link>
+              </InputDescription>
+              <InputRow>
+                <InputRowItem>
+                  <ColorPicker
+                    color={formik.values.primaryColor}
+                    onChange={(color) =>
+                      formik.setFieldValue("primaryColor", color)
+                    }
+                    label="Primary button colour"
+                  />
+                </InputRowItem>
+              </InputRow>
+              <InputRow>
+                <InputRowItem>
+                  <ColorPicker
+                    color={formik.values.secondaryColor}
+                    onChange={(color) =>
+                      formik.setFieldValue("secondaryColor", color)
+                    }
+                    label="Text link colour"
                   />
                 </InputRowItem>
               </InputRow>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -8,16 +8,16 @@ import { styled } from "@mui/material/styles";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import { HEADER_HEIGHT } from "components/Header";
-import React  from "react";
+import React from "react";
 import { Link, useNavigation } from "react-navi";
 
 interface SettingsProps {
-  currentTab: string,
+  currentTab: string;
   tabs: {
-    route: string,
-    name: string,
-    Component: React.FC,
-  }[]
+    route: string;
+    name: string;
+    Component: React.FC;
+  }[];
 }
 
 interface TabPanelProps {
@@ -95,7 +95,6 @@ const Root = styled(Box)(({ theme }) => ({
   left: 0,
   right: 0,
   minHeight: `calc(100% - ${HEADER_HEIGHT}px)`,
-  zIndex: "2000",
   [`& .${classes.tabs}`]: {
     backgroundColor: theme.palette.border.main,
   },
@@ -132,14 +131,14 @@ const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {
                 indicator: classes.tabIndicator,
               }}
             >
-              {tabs.map(({ name, route }, index) =>
+              {tabs.map(({ name, route }, index) => (
                 <LinkTab
                   key={`${name}-LinkTab`}
                   label={name}
                   href={`./${route}`}
                   {...a11yProps(index)}
                 />
-              )}
+              ))}
             </Tabs>
           </Grid>
           <Grid item>
@@ -154,11 +153,11 @@ const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {
           </Grid>
         </Grid>
       </AppBar>
-      {tabs.map(({ name, Component }, index) =>
+      {tabs.map(({ name, Component }, index) => (
         <TabPanel value={value} index={index} key={`${name}-TabPanel`}>
           <Component />
         </TabPanel>
-      )}
+      ))}
     </Root>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -95,6 +95,7 @@ const Root = styled(Box)(({ theme }) => ({
   left: 0,
   right: 0,
   minHeight: `calc(100% - ${HEADER_HEIGHT}px)`,
+  zIndex: "2000",
   [`& .${classes.tabs}`]: {
     backgroundColor: theme.palette.border.main,
   },

--- a/editor.planx.uk/src/ui/editor/EditorRow.tsx
+++ b/editor.planx.uk/src/ui/editor/EditorRow.tsx
@@ -16,7 +16,7 @@ const Root = styled(Box, {
   "&:first-of-type": {
     paddingTop: 0,
   },
-  "& > * + *": {
+  "& > * + *, & > form > * + *": {
     ...contentFlowSpacing(theme),
   },
   ...(background && {

--- a/editor.planx.uk/src/ui/editor/EditorRow.tsx
+++ b/editor.planx.uk/src/ui/editor/EditorRow.tsx
@@ -27,7 +27,7 @@ const Root = styled(Box, {
   }),
 }));
 
-export default function InputRow({
+export default function EditorRow({
   children,
   background,
 }: {


### PR DESCRIPTION
# What does this PR do?

Builds UI for editor team design settings, currently hidden behind a feature flag.

Example:
https://2643.planx.pizza/barnet/settings/design

Feature flag to toggle design settings:
`window.featureFlags.toggle("SHOW_TEAM_SETTINGS")`