### PR TITLE
feat: create parallel BOPS send events for v1 & v2 on all environments

### DIFF
--- a/api.planx.uk/modules/send/bops/bops.ts
+++ b/api.planx.uk/modules/send/bops/bops.ts
@@ -261,16 +261,16 @@ const sendToBOPSV2 = async (
       .catch((error) => {
         if (error.response) {
           throw new Error(
-            `Sending to BOPS v2 failed (${localAuthority}):\n${JSON.stringify(
-              error.response.data,
-              null,
-              2,
-            )}`,
+            `Sending to BOPS v2 failed (${[localAuthority, payload?.sessionId]
+              .filter(Boolean)
+              .join(" - ")}):\n${JSON.stringify(error.response.data, null, 2)}`,
           );
         } else {
           // re-throw other errors
           throw new Error(
-            `Sending to BOPS v2 failed (${localAuthority}):\n${error}`,
+            `Sending to BOPS v2 failed (${[localAuthority, payload?.sessionId]
+              .filter(Boolean)
+              .join(" - ")}):\n${error}`,
           );
         }
       });
@@ -279,7 +279,12 @@ const sendToBOPSV2 = async (
     next(
       new ServerError({
         status: 500,
-        message: `Sending to BOPS v2 failed (${localAuthority})`,
+        message: `Sending to BOPS v2 failed (${[
+          localAuthority,
+          payload?.sessionId,
+        ]
+          .filter(Boolean)
+          .join(" - ")})`,
         cause: err,
       }),
     );

--- a/api.planx.uk/modules/send/createSendEvents/controller.ts
+++ b/api.planx.uk/modules/send/createSendEvents/controller.ts
@@ -30,28 +30,25 @@ const createSendEvents: CreateSendEventsController = async (
     if (bops) {
       const bopsEvent = await createScheduledEvent({
         webhook: `{{HASURA_PLANX_API_URL}}/bops/${bops.localAuthority}`,
-        schedule_at: new Date(now.getTime() + 30 * 1000),
+        schedule_at: new Date(now.getTime() + 25 * 1000),
         payload: bops.body,
         comment: `bops_submission_${sessionId}`,
       });
       combinedResponse["bops"] = bopsEvent;
 
-      const isProduction = process.env.APP_ENVIRONMENT === "production";
-      if (!isProduction) {
-        const bopsV2Event = await createScheduledEvent({
-          webhook: `{{HASURA_PLANX_API_URL}}/bops-v2/${bops.localAuthority}`,
-          schedule_at: new Date(now.getTime() + 45 * 1000),
-          payload: bops.body,
-          comment: `bops_v2_submission_${sessionId}`,
-        });
-        combinedResponse["bops_v2"] = bopsV2Event;
-      }
+      const bopsV2Event = await createScheduledEvent({
+        webhook: `{{HASURA_PLANX_API_URL}}/bops-v2/${bops.localAuthority}`,
+        schedule_at: new Date(now.getTime() + 50 * 1000),
+        payload: bops.body,
+        comment: `bops_v2_submission_${sessionId}`,
+      });
+      combinedResponse["bops_v2"] = bopsV2Event;
     }
 
     if (uniform) {
       const uniformEvent = await createScheduledEvent({
         webhook: `{{HASURA_PLANX_API_URL}}/uniform/${uniform.localAuthority}`,
-        schedule_at: new Date(now.getTime() + 60 * 1000),
+        schedule_at: new Date(now.getTime() + 75 * 1000),
         payload: uniform.body,
         comment: `uniform_submission_${sessionId}`,
       });


### PR DESCRIPTION
Per dev call update that v2 API is available on BOPS production.

Satisfying PR will be the next one when we can retire this parallel approach and only submit via v2 :slightly_smiling_face: 