### PR TITLE
chore: `pnpm lint:fix` in `editor.planx.uk`

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -496,12 +496,8 @@ const EditorToolbar: React.FC<{
             )}
 
             {/* Only show team settings link if inside a team route  */}
-            {(route.data.team && !route.data.flow) &&(
-              <MenuItem
-                onClick={() =>
-                  navigate(`${rootTeamPath()}/settings`)
-                }
-              >
+            {route.data.team && !route.data.flow && (
+              <MenuItem onClick={() => navigate(`${rootTeamPath()}/settings`)}>
                 Team Settings
               </MenuItem>
             )}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -8,16 +8,16 @@ import { styled } from "@mui/material/styles";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import { HEADER_HEIGHT } from "components/Header";
-import React  from "react";
+import React from "react";
 import { Link, useNavigation } from "react-navi";
 
 interface SettingsProps {
-  currentTab: string,
+  currentTab: string;
   tabs: {
-    route: string,
-    name: string,
-    Component: React.FC,
-  }[]
+    route: string;
+    name: string;
+    Component: React.FC;
+  }[];
 }
 
 interface TabPanelProps {
@@ -131,14 +131,14 @@ const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {
                 indicator: classes.tabIndicator,
               }}
             >
-              {tabs.map(({ name, route }, index) =>
+              {tabs.map(({ name, route }, index) => (
                 <LinkTab
                   key={`${name}-LinkTab`}
                   label={name}
                   href={`./${route}`}
                   {...a11yProps(index)}
                 />
-              )}
+              ))}
             </Tabs>
           </Grid>
           <Grid item>
@@ -153,11 +153,11 @@ const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {
           </Grid>
         </Grid>
       </AppBar>
-      {tabs.map(({ name, Component }, index) =>
+      {tabs.map(({ name, Component }, index) => (
         <TabPanel value={value} index={index} key={`${name}-TabPanel`}>
           <Component />
         </TabPanel>
-      )}
+      ))}
     </Root>
   );
 };

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -47,26 +47,28 @@ const flowSettingsRoutes = compose(
         title: makeTitle(
           [req.params.team, req.params.flow, "Flow Settings"].join("/"),
         ),
-        view: <Settings 
-          currentTab={req.params.tab}
-          tabs={[
-            {
-              name: "Service",
-              route: "service",
-              Component: ServiceSettings,
-            },
-            {
-              name: "Service Flags",
-              route: "flags",
-              Component: ServiceFlags,
-            },
-            {
-              name: "Data",
-              route: "data-manager",
-              Component: DataManagerSettings,
-            },
-          ]}
-          />,
+        view: (
+          <Settings
+            currentTab={req.params.tab}
+            tabs={[
+              {
+                name: "Service",
+                route: "service",
+                Component: ServiceSettings,
+              },
+              {
+                name: "Service Flags",
+                route: "flags",
+                Component: ServiceFlags,
+              },
+              {
+                name: "Data",
+                route: "data-manager",
+                Component: DataManagerSettings,
+              },
+            ]}
+          />
+        ),
       };
     }),
   }),

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -1,4 +1,3 @@
-
 import { compose, mount, redirect, route, withData } from "navi";
 import DesignSettings from "pages/FlowEditor/components/Settings/DesignSettings";
 import TeamSettings from "pages/FlowEditor/components/Settings/TeamSettings";
@@ -9,16 +8,15 @@ import { makeTitle } from "./utils";
 
 const flowSettingsRoutes = compose(
   withData((req) => ({
-    mountpath: req.mountpath
+    mountpath: req.mountpath,
   })),
 
   mount({
     "/": redirect("./team"),
     "/:tab": route(async (req) => ({
-        title: makeTitle(
-          [req.params.team, "Team Settings"].join("/"),
-        ),
-        view: <Settings
+      title: makeTitle([req.params.team, "Team Settings"].join("/")),
+      view: (
+        <Settings
           currentTab={req.params.tab}
           tabs={[
             {
@@ -32,8 +30,9 @@ const flowSettingsRoutes = compose(
               Component: DesignSettings,
             },
           ]}
-          />,
-      }))
+        />
+      ),
+    })),
   }),
 );
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -15,7 +15,8 @@ export const rootFlowPath = (includePortals = false) => {
   return includePortals ? path : path.split(",")[0];
 };
 
-export const rootTeamPath = () => window.location.pathname.split("/").slice(0, 2).join("/");
+export const rootTeamPath = () =>
+  window.location.pathname.split("/").slice(0, 2).join("/");
 
 export const isSaveReturnFlow = (flowData: Record<string, any>): boolean =>
   Boolean(


### PR DESCRIPTION
Noticed this when working on another branch - not sure if it's an issue with Husky, but I suspect it's just from bumping eslint versions without running `pnpm lint:fix`. I'll check this out next time there's a version bump.