### PR TITLE
fix: for backwards tracking events update analytics_logs.metadata to use the text component type rather than integer for new and historical records

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -32,7 +32,7 @@ type NodeMetadata = {
   };
   flag?: Flag;
   title?: string;
-  type?: TYPES;
+  type?: string | null;
   id?: string;
   isAutoAnswered?: boolean;
 };
@@ -434,9 +434,10 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   function getTargetNodeDataFromFlow(nodeId: string) {
     const node = flow[nodeId];
+    const nodeType = node?.type ? TYPES[node.type] : null;
     const nodeMetadata: NodeMetadata = {
       title: extractNodeTitle(node),
-      type: node.type,
+      type: nodeType,
       id: nodeId,
     };
     return nodeMetadata;

--- a/hasura.planx.uk/migrations/1704887727847_sql_migration_update_analytics_logs_metadata_to_use_text_node_type/down.sql
+++ b/hasura.planx.uk/migrations/1704887727847_sql_migration_update_analytics_logs_metadata_to_use_text_node_type/down.sql
@@ -1,0 +1,80 @@
+UPDATE public.analytics_logs
+SET metadata = jsonb_set(
+    metadata,
+    '{back,type}',
+    CASE 
+        WHEN metadata->'back'->>'type' = 'Flow' THEN '1'
+        WHEN metadata->'back'->>'type' = 'Result' THEN '3'
+        WHEN metadata->'back'->>'type' = 'TaskList' THEN '7'
+        WHEN metadata->'back'->>'type' = 'Notice' THEN '8'
+        WHEN metadata->'back'->>'type' = 'FindProperty' THEN '9'
+        WHEN metadata->'back'->>'type' = 'DrawBoundary' THEN '10'
+        WHEN metadata->'back'->>'type' = 'PlanningConstraints' THEN '11'
+        WHEN metadata->'back'->>'type' = 'PropertyInformation' THEN '12'
+        WHEN metadata->'back'->>'type' = 'Statement' THEN '100'
+        WHEN metadata->'back'->>'type' = 'Checklist' THEN '105'
+        WHEN metadata->'back'->>'type' = 'TextInput' THEN '110'
+        WHEN metadata->'back'->>'type' = 'DateInput' THEN '120'
+        WHEN metadata->'back'->>'type' = 'AddressInput' THEN '130'
+        WHEN metadata->'back'->>'type' = 'ContactInput' THEN '135'
+        WHEN metadata->'back'->>'type' = 'FileUpload' THEN '140'
+        WHEN metadata->'back'->>'type' = 'FileUploadAndLabel' THEN '145'
+        WHEN metadata->'back'->>'type' = 'NumberInput' THEN '150'
+        WHEN metadata->'back'->>'type' = 'Response' THEN '200'
+        WHEN metadata->'back'->>'type' = 'Content' THEN '250'
+        WHEN metadata->'back'->>'type' = 'InternalPortal' THEN '300'
+        WHEN metadata->'back'->>'type' = 'ExternalPortal' THEN '310'
+        WHEN metadata->'back'->>'type' = 'Section' THEN '360'
+        WHEN metadata->'back'->>'type' = 'SetValue' THEN '380'
+        WHEN metadata->'back'->>'type' = 'Pay' THEN '400'
+        WHEN metadata->'back'->>'type' = 'Filter' THEN '500'
+        WHEN metadata->'back'->>'type' = 'Review' THEN '600'
+        WHEN metadata->'back'->>'type' = 'Send' THEN '650'
+        WHEN metadata->'back'->>'type' = 'Calculate' THEN '700'
+        WHEN metadata->'back'->>'type' = 'Confirmation' THEN '725'
+        WHEN metadata->'back'->>'type' = 'NextSteps' THEN '730'
+        ELSE metadata->'back'->>'type'
+    END::jsonb
+)
+WHERE metadata->'back'->>'type' IN ('Flow', 'Result', 'TaskList', 'Notice', 'FindProperty', 'DrawBoundary', 'PlanningConstraints', 'PropertyInformation', 'Statement', 'Checklist', 'TextInput', 'DateInput', 'AddressInput', 'ContactInput', 'FileUpload', 'FileUploadAndLabel', 'NumberInput', 'Response', 'Content', 'InternalPortal', 'ExternalPortal', 'Section', 'SetValue', 'Pay', 'Filter', 'Review', 'Send', 'Calculate', 'Confirmation', 'NextSteps');
+
+
+UPDATE public.analytics_logs
+SET metadata = jsonb_set(
+    metadata,
+    '{change,type}',
+    CASE 
+        WHEN metadata->'change'->>'type' = 'Flow' THEN '1'
+        WHEN metadata->'change'->>'type' = 'Result' THEN '3'
+        WHEN metadata->'change'->>'type' = 'TaskList' THEN '7'
+        WHEN metadata->'change'->>'type' = 'Notice' THEN '8'
+        WHEN metadata->'change'->>'type' = 'FindProperty' THEN '9'
+        WHEN metadata->'change'->>'type' = 'DrawBoundary' THEN '10'
+        WHEN metadata->'change'->>'type' = 'PlanningConstraints' THEN '11'
+        WHEN metadata->'change'->>'type' = 'PropertyInformation' THEN '12'
+        WHEN metadata->'change'->>'type' = 'Statement' THEN '100'
+        WHEN metadata->'change'->>'type' = 'Checklist' THEN '105'
+        WHEN metadata->'change'->>'type' = 'TextInput' THEN '110'
+        WHEN metadata->'change'->>'type' = 'DateInput' THEN '120'
+        WHEN metadata->'change'->>'type' = 'AddressInput' THEN '130'
+        WHEN metadata->'change'->>'type' = 'ContactInput' THEN '135'
+        WHEN metadata->'change'->>'type' = 'FileUpload' THEN '140'
+        WHEN metadata->'change'->>'type' = 'FileUploadAndLabel' THEN '145'
+        WHEN metadata->'change'->>'type' = 'NumberInput' THEN '150'
+        WHEN metadata->'change'->>'type' = 'Response' THEN '200'
+        WHEN metadata->'change'->>'type' = 'Content' THEN '250'
+        WHEN metadata->'change'->>'type' = 'InternalPortal' THEN '300'
+        WHEN metadata->'change'->>'type' = 'ExternalPortal' THEN '310'
+        WHEN metadata->'change'->>'type' = 'Section' THEN '360'
+        WHEN metadata->'change'->>'type' = 'SetValue' THEN '380'
+        WHEN metadata->'change'->>'type' = 'Pay' THEN '400'
+        WHEN metadata->'change'->>'type' = 'Filter' THEN '500'
+        WHEN metadata->'change'->>'type' = 'Review' THEN '600'
+        WHEN metadata->'change'->>'type' = 'Send' THEN '650'
+        WHEN metadata->'change'->>'type' = 'Calculate' THEN '700'
+        WHEN metadata->'change'->>'type' = 'Confirmation' THEN '725'
+        WHEN metadata->'change'->>'type' = 'NextSteps' THEN '730'
+        ELSE metadata->'change'->>'type'
+    END::jsonb
+)
+WHERE metadata->'change'->>'type' IN ('Flow', 'Result', 'TaskList', 'Notice', 'FindProperty', 'DrawBoundary', 'PlanningConstraints', 'PropertyInformation', 'Statement', 'Checklist', 'TextInput', 'DateInput', 'AddressInput', 'ContactInput', 'FileUpload', 'FileUploadAndLabel', 'NumberInput', 'Response', 'Content', 'InternalPortal', 'ExternalPortal', 'Section', 'SetValue', 'Pay', 'Filter', 'Review', 'Send', 'Calculate', 'Confirmation', 'NextSteps');

--- a/hasura.planx.uk/migrations/1704887727847_sql_migration_update_analytics_logs_metadata_to_use_text_node_type/up.sql
+++ b/hasura.planx.uk/migrations/1704887727847_sql_migration_update_analytics_logs_metadata_to_use_text_node_type/up.sql
@@ -1,0 +1,80 @@
+UPDATE public.analytics_logs
+SET metadata = jsonb_set(
+    metadata,
+    '{back,type}',
+    CASE 
+        WHEN metadata->'back'->>'type' = '1' THEN '"Flow"'
+        WHEN metadata->'back'->>'type' = '3' THEN '"Result"'
+        WHEN metadata->'back'->>'type' = '7' THEN '"TaskList"'
+        WHEN metadata->'back'->>'type' = '8' THEN '"Notice"'
+        WHEN metadata->'back'->>'type' = '9' THEN '"FindProperty"'
+        WHEN metadata->'back'->>'type' = '10' THEN '"DrawBoundary"'
+        WHEN metadata->'back'->>'type' = '11' THEN '"PlanningConstraints"'
+        WHEN metadata->'back'->>'type' = '12' THEN '"PropertyInformation"'
+        WHEN metadata->'back'->>'type' = '100' THEN '"Statement"'
+        WHEN metadata->'back'->>'type' = '105' THEN '"Checklist"'
+        WHEN metadata->'back'->>'type' = '110' THEN '"TextInput"'
+        WHEN metadata->'back'->>'type' = '120' THEN '"DateInput"'
+        WHEN metadata->'back'->>'type' = '130' THEN '"AddressInput"'
+        WHEN metadata->'back'->>'type' = '135' THEN '"ContactInput"'
+        WHEN metadata->'back'->>'type' = '140' THEN '"FileUpload"'
+        WHEN metadata->'back'->>'type' = '145' THEN '"FileUploadAndLabel"'
+        WHEN metadata->'back'->>'type' = '150' THEN '"NumberInput"'
+        WHEN metadata->'back'->>'type' = '200' THEN '"Response"'
+        WHEN metadata->'back'->>'type' = '250' THEN '"Content"'
+        WHEN metadata->'back'->>'type' = '300' THEN '"InternalPortal"'
+        WHEN metadata->'back'->>'type' = '310' THEN '"ExternalPortal"'
+        WHEN metadata->'back'->>'type' = '360' THEN '"Section"'
+        WHEN metadata->'back'->>'type' = '380' THEN '"SetValue"'
+        WHEN metadata->'back'->>'type' = '400' THEN '"Pay"'
+        WHEN metadata->'back'->>'type' = '500' THEN '"Filter"'
+        WHEN metadata->'back'->>'type' = '600' THEN '"Review"'
+        WHEN metadata->'back'->>'type' = '650' THEN '"Send"'
+        WHEN metadata->'back'->>'type' = '700' THEN '"Calculate"'
+        WHEN metadata->'back'->>'type' = '725' THEN '"Confirmation"'
+        WHEN metadata->'back'->>'type' = '730' THEN '"NextSteps"'
+        ELSE metadata->'back'->>'type'
+    END::jsonb
+)
+WHERE metadata->'back'->>'type' IN ('1', '3', '7', '8', '9', '10', '11', '12', '100', '105', '110', '120', '130', '135', '140', '145', '150', '200', '250', '300', '310', '360', '380', '400', '500', '600', '650', '700', '725', '730');
+
+
+UPDATE public.analytics_logs
+SET metadata = jsonb_set(
+    metadata,
+    '{change,type}',
+    CASE 
+        WHEN metadata->'change'->>'type' = '1' THEN '"Flow"'
+        WHEN metadata->'change'->>'type' = '3' THEN '"Result"'
+        WHEN metadata->'change'->>'type' = '7' THEN '"TaskList"'
+        WHEN metadata->'change'->>'type' = '8' THEN '"Notice"'
+        WHEN metadata->'change'->>'type' = '9' THEN '"FindProperty"'
+        WHEN metadata->'change'->>'type' = '10' THEN '"DrawBoundary"'
+        WHEN metadata->'change'->>'type' = '11' THEN '"PlanningConstraints"'
+        WHEN metadata->'change'->>'type' = '12' THEN '"PropertyInformation"'
+        WHEN metadata->'change'->>'type' = '100' THEN '"Statement"'
+        WHEN metadata->'change'->>'type' = '105' THEN '"Checklist"'
+        WHEN metadata->'change'->>'type' = '110' THEN '"TextInput"'
+        WHEN metadata->'change'->>'type' = '120' THEN '"DateInput"'
+        WHEN metadata->'change'->>'type' = '130' THEN '"AddressInput"'
+        WHEN metadata->'change'->>'type' = '135' THEN '"ContactInput"'
+        WHEN metadata->'change'->>'type' = '140' THEN '"FileUpload"'
+        WHEN metadata->'change'->>'type' = '145' THEN '"FileUploadAndLabel"'
+        WHEN metadata->'change'->>'type' = '150' THEN '"NumberInput"'
+        WHEN metadata->'change'->>'type' = '200' THEN '"Response"'
+        WHEN metadata->'change'->>'type' = '250' THEN '"Content"'
+        WHEN metadata->'change'->>'type' = '300' THEN '"InternalPortal"'
+        WHEN metadata->'change'->>'type' = '310' THEN '"ExternalPortal"'
+        WHEN metadata->'change'->>'type' = '360' THEN '"Section"'
+        WHEN metadata->'change'->>'type' = '380' THEN '"SetValue"'
+        WHEN metadata->'change'->>'type' = '400' THEN '"Pay"'
+        WHEN metadata->'change'->>'type' = '500' THEN '"Filter"'
+        WHEN metadata->'change'->>'type' = '600' THEN '"Review"'
+        WHEN metadata->'change'->>'type' = '650' THEN '"Send"'
+        WHEN metadata->'change'->>'type' = '700' THEN '"Calculate"'
+        WHEN metadata->'change'->>'type' = '725' THEN '"Confirmation"'
+        WHEN metadata->'change'->>'type' = '730' THEN '"NextSteps"'
+        ELSE metadata->'change'->>'type'
+    END::jsonb
+)
+WHERE metadata->'change'->>'type' IN ('1', '3', '7', '8', '9', '10', '11', '12', '100', '105', '110', '120', '130', '135', '140', '145', '150', '200', '250', '300', '310', '360', '380', '400', '500', '600', '650', '700', '725', '730');


### PR DESCRIPTION
## What 

- Update the way `back` and `change` events are tracked to store the node type as text rather than an integer for all new tracking events
- Add a migration to update historical records

## Why 

- It can be difficult to understand the node type by their integer alone, using the text makes it more human readable

## Testing 

- I tried running the migrations via the Hasura console locally ensuring that the data updated in the correct way for both `up` and `down`
- Then ensured this worked using `hasura` cli to apply `up`/`down` migrations