### PR TITLE
fix: Exit parent function on `shouldSkipTracking()`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -107,7 +107,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   const previousBreadcrumbs = usePrevious(breadcrumbs);
 
   const trackVisibilityChange = () => {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
     switch (document.visibilityState) {
       case "hidden":
         send(
@@ -285,14 +286,13 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }
 
-  function skipUpdateIfNotTracking() {
-    if (!shouldTrackAnalytics || !lastVisibleNodeAnalyticsLogId) {
-      return;
-    }
+  function shouldSkipTracking() {
+    return (!shouldTrackAnalytics || !lastVisibleNodeAnalyticsLogId)
   }
 
   async function trackHelpClick(metadata?: HelpClickMetadata) {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
     await publicClient.mutate({
       mutation: gql`
         mutation UpdateHasClickedHelp($id: bigint!, $metadata: jsonb = {}) {
@@ -313,7 +313,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   async function trackNextStepsLinkClick(metadata?: SelectedUrlsMetadata) {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
     await publicClient.mutate({
       mutation: gql`
         mutation UpdateHasClickNextStepsLink(
@@ -338,7 +339,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   async function trackFlowDirectionChange(
     flowDirection: AnalyticsLogDirection,
   ) {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
     await publicClient.mutate({
       mutation: gql`
         mutation UpdateFlowDirection($id: bigint!, $flow_direction: String) {
@@ -361,7 +363,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     initiator: BackwardsNavigationInitiatorType,
     nodeId?: string,
   ) {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
     const targetNodeMetadata = nodeId ? getTargetNodeDataFromFlow(nodeId) : {};
     const metadata: Record<string, NodeMetadata> = {};
     metadata[`${initiator}`] = targetNodeMetadata;
@@ -426,7 +429,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   async function updateLastVisibleNodeLogWithAllowListAnswers(nodeId: string) {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
 
     const allowListAnswers = getAllowListAnswers(nodeId);
     if (!allowListAnswers) return;
@@ -505,7 +509,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
    * Capture user input errors caught by ErrorWrapper component
    */
   async function trackInputErrors(error: string) {
-    skipUpdateIfNotTracking();
+    if (shouldSkipTracking()) return;
+    
     await publicClient.mutate({
       mutation: gql`
         mutation TrackInputErrors($id: bigint!, $error: jsonb) {


### PR DESCRIPTION
## What does this PR do?
- Fixes small logical bug introduced in https://github.com/theopensystemslab/planx-new/pull/2597
- `skipUpdateIfNotTracking()` does not correctly return from parent function
- I encountered an issue with this when the `ErrorWrapper` component was trying to write a log to the DB from within the Editor. You can test this by triggering an error state a "Send" node - https://editor.planx.dev/buckinghamshire/request-a-building-control-site-inspection/nodes/_root/nodes/9VzYz3damo/edit