### PR TITLE
feat: Apply new theme colours across app

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#af52a96",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b8da594",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#af52a96
-    version: github.com/theopensystemslab/planx-core/af52a96
+    specifier: git+https://github.com/theopensystemslab/planx-core#b8da594
+    version: github.com/theopensystemslab/planx-core/b8da594
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -5648,6 +5648,7 @@ packages:
       chalk: 3.0.0
       diff-match-patch: 1.0.5
     dev: false
+    bundledDependencies: []
 
   /jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
@@ -8311,8 +8312,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/af52a96:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/af52a96}
+  github.com/theopensystemslab/planx-core/b8da594:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b8da594}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,8 +6,8 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#af52a96",
-    "axios": "^1.6.5",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b8da594",
+    "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",
     "graphql": "^16.8.1",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,10 +9,10 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#af52a96
-    version: github.com/theopensystemslab/planx-core/af52a96
+    specifier: git+https://github.com/theopensystemslab/planx-core#b8da594
+    version: github.com/theopensystemslab/planx-core/b8da594
   axios:
-    specifier: ^1.6.5
+    specifier: ^1.6.0
     version: 1.6.5
   dotenv:
     specifier: ^16.3.1
@@ -2821,8 +2821,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/af52a96:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/af52a96}
+  github.com/theopensystemslab/planx-core/b8da594:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b8da594}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,8 +8,8 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#af52a96",
-    "axios": "^1.6.5",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b8da594",
+    "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",
     "graphql": "^16.8.1",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,10 +6,10 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#af52a96
-    version: github.com/theopensystemslab/planx-core/af52a96
+    specifier: git+https://github.com/theopensystemslab/planx-core#b8da594
+    version: github.com/theopensystemslab/planx-core/b8da594
   axios:
-    specifier: ^1.6.5
+    specifier: ^1.6.2
     version: 1.6.5
   dotenv:
     specifier: ^16.3.1
@@ -2568,8 +2568,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/af52a96:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/af52a96}
+  github.com/theopensystemslab/planx-core/b8da594:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b8da594}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.7.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#af52a96",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b8da594",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.5
     version: 0.7.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#af52a96
-    version: github.com/theopensystemslab/planx-core/af52a96(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#b8da594
+    version: github.com/theopensystemslab/planx-core/b8da594(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -21035,9 +21035,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/af52a96(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/af52a96}
-    id: github.com/theopensystemslab/planx-core/af52a96
+  github.com/theopensystemslab/planx-core/b8da594(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b8da594}
+    id: github.com/theopensystemslab/planx-core/b8da594
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -20,7 +20,7 @@ const Content = styled(Box, {
       theme.palette.text.primary,
     ])?.toHexString() || theme.palette.text.primary,
   "& a": {
-    color: getContrastTextColor(color || "#fff", theme.palette.primary.main),
+    color: getContrastTextColor(color || "#fff", theme.palette.link.main),
   },
   "& *:first-child": {
     marginTop: 0,

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -117,6 +117,7 @@ export const FileTaggingModal = ({
               variant="contained"
               onClick={handleValidation}
               data-testid="modal-done-button"
+              color="prompt"
             >
               Done
             </Button>
@@ -202,7 +203,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
         sx={{
           top: "16%",
           textDecoration: "underline",
-          color: (theme) => theme.palette.primary.main,
+          color: (theme) => theme.palette.link.main,
           "&[data-shrink=true]": {
             textDecoration: "none",
             color: (theme) => theme.palette.text.primary,
@@ -284,6 +285,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
             </Typography>
             <Button
               variant="contained"
+              color="prompt"
               onClick={handleClose}
               aria-label="Close list"
             >

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -66,7 +66,6 @@ export const InfoButton = styled(Button)(({ theme }) => ({
   minWidth: 0,
   marginLeft: theme.spacing(1.5),
   boxShadow: "none",
-  color: theme.palette.primary.main,
   minHeight: "44px",
 })) as typeof Button;
 

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -29,10 +29,14 @@ const Container = styled(Box, {
     justifyContent: "space-between",
     padding: theme.spacing(2),
     backgroundColor: customColor,
-    color: mostReadable(customColor, [
-      "#fff",
-      theme.palette.text.primary,
-    ])?.toHexString(),
+    color:
+    mostReadable(customColor || "#fff", [
+        "#fff",
+        theme.palette.text.primary,
+      ])?.toHexString() || theme.palette.text.primary,
+    "& a": {
+      color: "inherit !important",
+    },
     "&:before": {
       content: "' '",
       position: "absolute",

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -83,7 +83,7 @@ const Card: React.FC<Props> = ({
             {handleSubmit && (
               <Button
                 variant="contained"
-                color="primary"
+                color="prompt"
                 size="large"
                 type="submit"
                 disabled={!isValid}

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -22,7 +22,7 @@ interface RootProps extends ButtonBaseProps {
 }
 
 const FauxLink = styled(Box)(({ theme }) => ({
-  color: theme.palette.primary.main,
+  color: theme.palette.link.main,
   textDecoration: "underline",
   whiteSpace: "nowrap",
 }));

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -1,10 +1,10 @@
+import { Team } from "@opensystemslab/planx-core/types";
 import { screen } from "@testing-library/react";
 import { vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import * as ReactNavi from "react-navi";
 import { axe, setup } from "testUtils";
-import { Team } from "types";
 
 import flowWithoutSections from "../pages/FlowEditor/lib/__tests__/mocks/flowWithClones.json";
 import flowWithThreeSections from "../pages/FlowEditor/lib/__tests__/mocks/flowWithThreeSections.json";
@@ -18,8 +18,9 @@ const mockTeam1: Team = {
   slug: "opensystemslab",
   theme: {
     logo: "logo.jpg",
-    primary: "#0010A4",
-    secondary: null,
+    primaryColour: "#0010A4",
+    actionColour: "#0010A4",
+    linkColour: "#0010A4",
     favicon: null,
   },
 };

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -565,7 +565,7 @@ const Header: React.FC = () => {
       elevation={0}
       color="transparent"
       ref={headerRef}
-      style={{ backgroundColor: theme?.primary || "#2c2c2c" }}
+      style={{ backgroundColor: theme?.primaryColour || "#2c2c2c" }}
     >
       <Toolbar headerRef={headerRef}></Toolbar>
     </Root>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -1,9 +1,11 @@
-import { GeoJSONObject } from "@turf/helpers";
+import {
+  NotifyPersonalisation,
+  Team,
+  TeamSettings,
+  TeamTheme,
+} from "@opensystemslab/planx-core/types";
 import gql from "graphql-tag";
 import { client } from "lib/graphql";
-import { NotifyPersonalisation, TeamSettings } from "types";
-import { TeamTheme } from "types";
-import { Team } from "types";
 import type { StateCreator } from "zustand";
 
 export interface TeamStore {
@@ -13,7 +15,7 @@ export interface TeamStore {
   teamSettings?: TeamSettings;
   teamSlug: string;
   notifyPersonalisation?: NotifyPersonalisation;
-  boundaryBBox?: GeoJSONObject;
+  boundaryBBox?: Team["boundaryBBox"];
 
   setTeam: (team: Team) => void;
   getTeam: () => Team;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -1,7 +1,6 @@
-import { User, UserTeams } from "@opensystemslab/planx-core/types";
+import { Team, User, UserTeams } from "@opensystemslab/planx-core/types";
 import axios from "axios";
 import { _client } from "client";
-import { Team } from "types";
 import type { StateCreator } from "zustand";
 
 export interface UserStore {

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -4,10 +4,10 @@ import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { Team } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { Link } from "react-navi";
 
-import type { Team } from "../types";
 import { useStore } from "./FlowEditor/lib/store";
 
 interface Props {

--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -88,8 +88,8 @@ const PublicFooter: React.FC = () => {
 };
 
 const PublicLayout: React.FC<PropsWithChildren> = ({ children }) => {
-  const teamPrimaryColor = useStore((state) => state.teamTheme?.primary);
-  const teamMUITheme = generateTeamTheme(teamPrimaryColor);
+  const teamTheme = useStore((state) => state.teamTheme);
+  const teamMUITheme = generateTeamTheme(teamTheme);
 
   return (
     <StyledEngineProvider injectFirst>

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -72,8 +72,9 @@ const fetchDataForPublishedView = async (
             id
             team {
               theme {
-                primary: primary_colour
-                secondary: secondary_colour
+                primaryColour: primary_colour
+                actionColour: action_colour
+                linkColour: link_colour
                 logo
                 favicon
               }

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -60,8 +60,9 @@ const fetchDataForStandaloneView = async (
             id
             team {
               theme {
-                primary: primary_colour
-                secondary: secondary_colour
+                primaryColour: primary_colour
+                actionColour: action_colour
+                linkColour: link_colour
                 logo
                 favicon
               }

--- a/editor.planx.uk/src/routes/views/unpublished.tsx
+++ b/editor.planx.uk/src/routes/views/unpublished.tsx
@@ -63,8 +63,9 @@ const fetchDataForUnpublishedView = async (
             id
             team {
               theme {
-                primary: primary_colour
-                secondary: secondary_colour
+                primaryColour: primary_colour
+                actionColour: action_colour
+                linkColour: link_colour
                 logo
                 favicon
               }

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -14,9 +14,10 @@ import createPalette, {
 } from "@mui/material/styles/createPalette";
 import { deepmerge } from "@mui/utils";
 import { TeamTheme } from "@opensystemslab/planx-core/types";
+import { getContrastTextColor } from "styleUtils";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
-const DEFAULT_SECONDARY_COLOR = "#F3F2F1";
+const DEFAULT_TONAL_OFFSET = 0.2;
 
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
@@ -34,11 +35,20 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     paper: "#F9F8F8",
   },
   secondary: {
-    main: DEFAULT_SECONDARY_COLOR,
+    main: "#F3F2F1",
   },
   text: {
     primary: "#0B0C0C",
     secondary: "#505A5F",
+  },
+  link: {
+    main: DEFAULT_PRIMARY_COLOR
+  },
+  prompt: {
+    main: DEFAULT_PRIMARY_COLOR,
+    contrastText: "#FFFFFF",
+    light: lighten(DEFAULT_PRIMARY_COLOR, DEFAULT_TONAL_OFFSET),
+    dark: darken(DEFAULT_PRIMARY_COLOR, DEFAULT_TONAL_OFFSET),
   },
   action: {
     selected: "#F8F8F8",
@@ -59,6 +69,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     input: "#0B0C0C",
     light: "#E0E0E0",
   },
+  tonalOffset: DEFAULT_TONAL_OFFSET,
 };
 
 // GOVUK Focus style
@@ -87,8 +98,8 @@ export const borderedFocusStyle = {
   background: "transparent",
 };
 
-export const linkStyle = (primaryColor?: string) => ({
-  color: primaryColor || "inherit",
+export const linkStyle = (linkColour: string) => ({
+  color: linkColour || "inherit",
   textDecoration: "underline",
   textDecorationThickness: "1px",
   textUnderlineOffset: "0.1em",
@@ -102,10 +113,19 @@ export const linkStyle = (primaryColor?: string) => ({
   "&:focus-visible": focusStyle,
 });
 
-const getThemeOptions = (teamTheme?: TeamTheme): ThemeOptions => {
+const getThemeOptions = ({ primaryColour, linkColour, actionColour}: TeamTheme): ThemeOptions => {
   const teamPalette: Partial<PaletteOptions> = {
     primary: {
-      main: teamTheme?.primaryColour || DEFAULT_PRIMARY_COLOR,
+      main: primaryColour,
+    },
+    link: {
+      main: linkColour,
+    },
+    prompt: {
+      main: actionColour,
+      light: lighten(actionColour, DEFAULT_TONAL_OFFSET),
+      dark: darken(actionColour, DEFAULT_TONAL_OFFSET),
+      contrastText: getContrastTextColor(actionColour, "#FFF")!,
     },
   };
   const palette = createPalette(deepmerge(DEFAULT_PALETTE, teamPalette));
@@ -339,7 +359,7 @@ const getThemeOptions = (teamTheme?: TeamTheme): ThemeOptions => {
       MuiLink: {
         styleOverrides: {
           root: {
-            ...linkStyle(palette.primary.main),
+            ...linkStyle(palette.link.main),
             "&:disabled": {
               color: palette.text.disabled,
               cursor: "default",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -13,7 +13,7 @@ import createPalette, {
   PaletteOptions,
 } from "@mui/material/styles/createPalette";
 import { deepmerge } from "@mui/utils";
-import { TeamTheme } from "types";
+import { TeamTheme } from "@opensystemslab/planx-core/types";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
 const DEFAULT_SECONDARY_COLOR = "#F3F2F1";
@@ -105,10 +105,7 @@ export const linkStyle = (primaryColor?: string) => ({
 const getThemeOptions = (teamTheme?: TeamTheme): ThemeOptions => {
   const teamPalette: Partial<PaletteOptions> = {
     primary: {
-      main: teamTheme?.primary || DEFAULT_PRIMARY_COLOR,
-    },
-    secondary: {
-      main: teamTheme?.secondary || DEFAULT_SECONDARY_COLOR,
+      main: teamTheme?.primaryColour || DEFAULT_PRIMARY_COLOR,
     },
   };
   const palette = createPalette(deepmerge(DEFAULT_PALETTE, teamPalette));
@@ -436,8 +433,9 @@ const getThemeOptions = (teamTheme?: TeamTheme): ThemeOptions => {
 // Generate a MUI theme based on a team's primary color
 const generateTeamTheme = (
   teamTheme: TeamTheme = {
-    primary: DEFAULT_PRIMARY_COLOR,
-    secondary: DEFAULT_SECONDARY_COLOR,
+    primaryColour: DEFAULT_PRIMARY_COLOR,
+    actionColour: DEFAULT_PRIMARY_COLOR,
+    linkColour: DEFAULT_PRIMARY_COLOR,
     logo: null,
     favicon: null,
   },

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -17,7 +17,7 @@ import { TeamTheme } from "@opensystemslab/planx-core/types";
 import { getContrastTextColor } from "styleUtils";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
-const DEFAULT_TONAL_OFFSET = 0.2;
+const DEFAULT_TONAL_OFFSET = 0.1;
 
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
@@ -252,7 +252,7 @@ const getThemeOptions = ({ primaryColour, linkColour, actionColour}: TeamTheme):
           {
             props: { variant: "help" },
             style: {
-              color: palette.primary.main,
+              color: palette.link.main,
               boxShadow: "none",
               padding: "0.25em 0.1em",
               width: "auto",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -13,8 +13,10 @@ import createPalette, {
   PaletteOptions,
 } from "@mui/material/styles/createPalette";
 import { deepmerge } from "@mui/utils";
+import { TeamTheme } from "types";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
+const DEFAULT_SECONDARY_COLOR = "#F3F2F1";
 
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
@@ -32,7 +34,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     paper: "#F9F8F8",
   },
   secondary: {
-    main: "#F3F2F1",
+    main: DEFAULT_SECONDARY_COLOR,
   },
   text: {
     primary: "#0B0C0C",
@@ -100,10 +102,13 @@ export const linkStyle = (primaryColor?: string) => ({
   "&:focus-visible": focusStyle,
 });
 
-const getThemeOptions = (primaryColor: string): ThemeOptions => {
+const getThemeOptions = (teamTheme?: TeamTheme): ThemeOptions => {
   const teamPalette: Partial<PaletteOptions> = {
     primary: {
-      main: primaryColor,
+      main: teamTheme?.primary || DEFAULT_PRIMARY_COLOR,
+    },
+    secondary: {
+      main: teamTheme?.secondary || DEFAULT_SECONDARY_COLOR,
     },
   };
   const palette = createPalette(deepmerge(DEFAULT_PALETTE, teamPalette));
@@ -430,14 +435,19 @@ const getThemeOptions = (primaryColor: string): ThemeOptions => {
 
 // Generate a MUI theme based on a team's primary color
 const generateTeamTheme = (
-  primaryColor: string = DEFAULT_PRIMARY_COLOR,
+  teamTheme: TeamTheme = {
+    primary: DEFAULT_PRIMARY_COLOR,
+    secondary: DEFAULT_SECONDARY_COLOR,
+    logo: null,
+    favicon: null,
+  },
 ): MUITheme => {
-  const themeOptions = getThemeOptions(primaryColor);
+  const themeOptions = getThemeOptions(teamTheme);
   const theme = responsiveFontSizes(createTheme(themeOptions), { factor: 3 });
   return theme;
 };
 
 // A static MUI theme based on PlanX's default palette
-const defaultTheme = generateTeamTheme(DEFAULT_PRIMARY_COLOR);
+const defaultTheme = generateTeamTheme();
 
 export { defaultTheme, generateTeamTheme };

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -25,10 +25,14 @@ declare module "@mui/material/styles" {
 declare module "@mui/material/styles/createPalette" {
   interface Palette {
     border: { main: string; input: string; light: string };
+    link: { main: string; };
+    prompt: { main: string; contrastText: string; light: string; dark: string; };
   }
 
   interface PaletteOptions {
     border?: { main: string; input: string; light: string };
+    link?: { main: string; };
+    prompt?: { main: string; contrastText: string; light: string; dark: string; };
   }
 }
 
@@ -36,5 +40,9 @@ declare module "@mui/material/styles/createPalette" {
 declare module "@mui/material/Button" {
   interface ButtonPropsVariantOverrides {
     help: true;
+  }
+
+  interface ButtonPropsColorOverrides {
+    prompt: true;
   }
 }

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -1,5 +1,4 @@
-import { GovUKPayment } from "@opensystemslab/planx-core/types";
-import { GeoJSONObject } from "@turf/helpers";
+import { GovUKPayment, Team } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 
 import { Store } from "./pages/FlowEditor/lib/store/index";
@@ -15,45 +14,6 @@ export interface Flow {
   team: Team;
   settings?: FlowSettings;
 }
-
-export interface Team {
-  id: number;
-  name: string;
-  slug: string;
-  settings?: TeamSettings;
-  theme?: TeamTheme;
-  notifyPersonalisation?: NotifyPersonalisation;
-  boundaryBBox?: GeoJSONObject;
-}
-
-export interface TeamTheme {
-  primary: string;
-  secondary: string | null;
-  logo: string | null;
-  favicon: string | null;
-}
-
-export interface TeamSettings {
-  design?: {
-    color?: string;
-  };
-  homepage?: string;
-  externalPlanningSite: {
-    name: string;
-    url: string;
-  };
-  supportEmail?: string;
-  boundary?: string;
-  hasPlanningData?: boolean;
-}
-
-export interface NotifyPersonalisation {
-  helpEmail: string;
-  helpPhone: string;
-  emailReplyToId: string;
-  helpOpeningHours: string;
-}
-
 export interface GlobalSettings {
   footerContent?: { [key: string]: TextContent };
 }

--- a/editor.planx.uk/src/ui/public/ExternalPlanningSiteDialog.tsx
+++ b/editor.planx.uk/src/ui/public/ExternalPlanningSiteDialog.tsx
@@ -6,10 +6,10 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
+import { TeamSettings } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { useState } from "react";
-import { TeamSettings } from "types";
 
 export enum DialogPurpose {
   MissingProjectType,

--- a/editor.planx.uk/src/ui/public/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/public/NextStepsList.tsx
@@ -40,10 +40,11 @@ const innerStyle = (theme: Theme) => ({
   textDecoration: "none",
   borderBottom: `1px solid theme.palette.text.secondary`,
   "&:hover > .arrowButton": {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.prompt.dark,
   },
   "&:focus > .arrowButton": {
     backgroundColor: theme.palette.text.primary,
+    color: theme.palette.common.white,
   },
 });
 
@@ -67,8 +68,8 @@ const ArrowButton = styled("span")(({ theme }) => ({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  backgroundColor: theme.palette.primary.main,
-  color: theme.palette.common.white,
+  backgroundColor: theme.palette.prompt.main,
+  color: theme.palette.prompt.contrastText,
   width: "50px",
   height: "50px",
   flexShrink: "0",

--- a/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml.tsx
@@ -6,7 +6,7 @@ import ReactMarkdown from "react-markdown";
 import { FONT_WEIGHT_SEMI_BOLD, linkStyle } from "theme";
 
 const styles = (theme: Theme) => ({
-  "& a": linkStyle(theme.palette.primary.main),
+  "& a": linkStyle(theme.palette.link.main),
   "& h1": theme.typography.h2,
   "& h2": theme.typography.h3,
   "& h3": theme.typography.h3,

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1376,65 +1376,71 @@
     - role: api
       permission:
         columns:
-          - id
-          - team_id
+          - action_colour
           - favicon
+          - id
+          - link_colour
           - logo
           - primary_colour
-          - secondary_colour
+          - team_id
         filter: {}
       comment: ""
     - role: platformAdmin
       permission:
         columns:
-          - id
-          - team_id
+          - action_colour
           - favicon
+          - id
+          - link_colour
           - logo
           - primary_colour
-          - secondary_colour
+          - team_id
         filter: {}
       comment: ""
     - role: public
       permission:
         columns:
-          - id
-          - team_id
+          - action_colour
           - favicon
+          - id
+          - link_colour
           - logo
           - primary_colour
-          - secondary_colour
+          - team_id
         filter: {}
       comment: ""
     - role: teamEditor
       permission:
         columns:
-          - id
-          - team_id
+          - action_colour
           - favicon
+          - id
+          - link_colour
           - logo
           - primary_colour
-          - secondary_colour
+          - team_id
         filter: {}
       comment: ""
   update_permissions:
     - role: platformAdmin
       permission:
         columns:
+          - action_colour
           - favicon
+          - link_colour
           - logo
           - primary_colour
-          - secondary_colour
         filter: {}
         check: null
       comment: ""
     - role: teamEditor
       permission:
         columns:
+          - action_colour
           - favicon
+          - link_colour
           - logo
           - primary_colour
-          - secondary_colour
         filter: {}
         check: null
       comment: ""

--- a/hasura.planx.uk/migrations/1704892559414_alter_table_public_team_themes_add_column_link_colour/down.sql
+++ b/hasura.planx.uk/migrations/1704892559414_alter_table_public_team_themes_add_column_link_colour/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."team_themes" add column "secondary_colour" text;
+
+comment on column "public"."team_themes"."secondary_colour" is E'Must be hex triplet (e.g. #112233)';

--- a/hasura.planx.uk/migrations/1704892559414_alter_table_public_team_themes_add_column_link_colour/up.sql
+++ b/hasura.planx.uk/migrations/1704892559414_alter_table_public_team_themes_add_column_link_colour/up.sql
@@ -1,0 +1,10 @@
+alter table "public"."team_themes" drop column "secondary_colour" cascade;
+
+alter table "public"."team_themes" add column "link_colour" text
+  not null default '#0010A4';
+alter table "public"."team_themes" add column "action_colour" text
+  not null default '#0010A4';
+
+
+comment on column "public"."team_themes"."link_colour" is E'Must be hex triplet (e.g. #112233)';
+comment on column "public"."team_themes"."action_colour" is E'Must be hex triplet (e.g. #112233)';

--- a/scripts/seed-database/write/team_themes.sql
+++ b/scripts/seed-database/write/team_themes.sql
@@ -1,3 +1,5 @@
+-- TODO: Update to add action_color and link_colour columns
+
 -- insert teams_themes overwriting conflicts
 CREATE TEMPORARY TABLE sync_team_themes (
   id integer,
@@ -15,7 +17,7 @@ INSERT INTO
     id,
     team_id,
     primary_colour,
-    secondary_colour,
+    -- secondary_colour,
     logo,
     favicon
   )
@@ -23,7 +25,7 @@ SELECT
   id,
   team_id,
   primary_colour,
-  secondary_colour,
+  -- secondary_colour,
   logo,
   favicon
 FROM
@@ -31,7 +33,7 @@ FROM
 UPDATE
 SET
   primary_colour = EXCLUDED.primary_colour,
-  secondary_colour = EXCLUDED.secondary_colour,
+  -- secondary_colour = EXCLUDED.secondary_colour,
   logo = EXCLUDED.logo,
   favicon = EXCLUDED.favicon;
 SELECT


### PR DESCRIPTION
# What does this pull request do?

Applies new theme colours created in https://github.com/theopensystemslab/planx-new/pull/2646 across the components and UI of the app.

Notes:
- The content component is correctly selecting the appropriate colours for contrast link text (default: link colour, plus black or white depending on contrast), however I was not able to get this to function in the notice component due to overriding specificity set in the theme. This is also a current issue on the live services. For simplicity I've set the link text to inherit paragraph text colour in this component, and will revisit this in a future PR.
- As we are now using both dark and light button background colours, I've adjusted the tonal offset to 0.1, ensuring that darkening a light background colour on hover does not reduce it's contrast with dark overlay by too much a margin.