### PR TITLE
feat: Apply theme colours across app

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -20,7 +20,7 @@ const Content = styled(Box, {
       theme.palette.text.primary,
     ])?.toHexString() || theme.palette.text.primary,
   "& a": {
-    color: getContrastTextColor(color || "#fff", theme.palette.primary.main),
+    color: getContrastTextColor(color || "#fff", theme.palette.link.main),
   },
   "& *:first-child": {
     marginTop: 0,

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -115,6 +115,7 @@ export const FileTaggingModal = ({
           <Box>
             <Button
               variant="contained"
+              color="prompt"
               onClick={handleValidation}
               data-testid="modal-done-button"
             >
@@ -202,7 +203,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
         sx={{
           top: "16%",
           textDecoration: "underline",
-          color: (theme) => theme.palette.primary.main,
+          color: (theme) => theme.palette.link.main,
           "&[data-shrink=true]": {
             textDecoration: "none",
             color: (theme) => theme.palette.text.primary,
@@ -284,6 +285,7 @@ const SelectMultiple = (props: SelectMultipleProps) => {
             </Typography>
             <Button
               variant="contained"
+              color="prompt"
               onClick={handleClose}
               aria-label="Close list"
             >

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -66,7 +66,6 @@ export const InfoButton = styled(Button)(({ theme }) => ({
   minWidth: 0,
   marginLeft: theme.spacing(1.5),
   boxShadow: "none",
-  color: theme.palette.primary.main,
   minHeight: "44px",
 })) as typeof Button;
 

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -29,10 +29,14 @@ const Container = styled(Box, {
     justifyContent: "space-between",
     padding: theme.spacing(2),
     backgroundColor: customColor,
-    color: mostReadable(customColor, [
-      "#fff",
-      theme.palette.text.primary,
-    ])?.toHexString(),
+    color:
+      mostReadable(customColor || "#fff", [
+        "#fff",
+        theme.palette.text.primary,
+      ])?.toHexString() || theme.palette.text.primary,
+    "& a": {
+      color: "inherit !important",
+    },
     "&:before": {
       content: "' '",
       position: "absolute",

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -83,7 +83,7 @@ const Card: React.FC<Props> = ({
             {handleSubmit && (
               <Button
                 variant="contained"
-                color="primary"
+                color="prompt"
                 size="large"
                 type="submit"
                 disabled={!isValid}

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -22,7 +22,7 @@ interface RootProps extends ButtonBaseProps {
 }
 
 const FauxLink = styled(Box)(({ theme }) => ({
-  color: theme.palette.primary.main,
+  color: theme.palette.link.main,
   textDecoration: "underline",
   whiteSpace: "nowrap",
 }));

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -17,7 +17,7 @@ import { TeamTheme } from "@opensystemslab/planx-core/types";
 import { getContrastTextColor } from "styleUtils";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
-const DEFAULT_TONAL_OFFSET = 0.2;
+const DEFAULT_TONAL_OFFSET = 0.1;
 
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";
@@ -252,7 +252,7 @@ const getThemeOptions = ({ primaryColour, linkColour, actionColour}: TeamTheme):
           {
             props: { variant: "help" },
             style: {
-              color: palette.primary.main,
+              color: palette.link.main,
               boxShadow: "none",
               padding: "0.25em 0.1em",
               width: "auto",

--- a/editor.planx.uk/src/ui/public/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/public/NextStepsList.tsx
@@ -40,10 +40,11 @@ const innerStyle = (theme: Theme) => ({
   textDecoration: "none",
   borderBottom: `1px solid theme.palette.text.secondary`,
   "&:hover > .arrowButton": {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.prompt.dark,
   },
   "&:focus > .arrowButton": {
     backgroundColor: theme.palette.text.primary,
+    color: theme.palette.common.white,
   },
 });
 
@@ -67,8 +68,8 @@ const ArrowButton = styled("span")(({ theme }) => ({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  backgroundColor: theme.palette.primary.main,
-  color: theme.palette.common.white,
+  backgroundColor: theme.palette.prompt.main,
+  color: theme.palette.prompt.contrastText,
   width: "50px",
   height: "50px",
   flexShrink: "0",


### PR DESCRIPTION
# What does this pull request do?

Applies new theme colours created in https://github.com/theopensystemslab/planx-new/pull/2646 across the components and UI of the app.

Notes:
- The content component is correctly selecting the appropriate colours for contrast link text (default: link colour, plus black or white depending on contrast), however I was not able to get this to function in the notice component due to overriding specificity set in the theme. This is also a current issue on the live services. For simplicity I've set the link text to inherit paragraph text colour in this component, and will revisit this in a future PR.
- As we are now using both dark and light button background colours, I've adjusted the tonal offset to 0.1, ensuring that darkening a light background colour on hover does not reduce it's contrast with dark overlay by too much a margin.