### PR TITLE
fix: use email as default destination for new Send components and add warnings when selecting BOPS or Uniform

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -73,6 +73,25 @@ const SendComponent: React.FC<Props> = (props) => {
         return originalValues.indexOf(a) - originalValues.indexOf(b);
       }),
     );
+
+    // Show warnings on selection of BOPS or Uniform for likely unsupported services
+    //   Don't actually restrict selection because flowSlug matching is imperfect for some valid test cases
+    const flowSlug = window.location.pathname?.split("/")?.[1];
+    if (
+      value === Destination.BOPS && 
+      newCheckedValues.includes(value) &&
+      !["apply-for-a-lawful-development-certificate", "apply-for-prior-approval", "apply-for-planning-permission"].includes(flowSlug)
+    ) {
+      alert("BOPS only accepts Lawful Development Certificate, Prior Approval, and Planning Permission submissions. Please do not select if you're building another type of submission service!");
+    }
+    
+    if (
+      value === Destination.Uniform &&
+      newCheckedValues.includes(value) && 
+      flowSlug !== "apply-for-a-lawful-development-certificate"
+    ) {
+      alert("Uniform only accepts Lawful Development Certificate submissions. Please do not select if you're building another type of submission service!");
+    }
   };
 
   return (
@@ -109,10 +128,8 @@ const SendComponent: React.FC<Props> = (props) => {
           <Box display="flex" mt={2}>
             <Warning titleAccess="Warning" color="primary" fontSize="large" />
             <Typography variant="body2" ml={1}>
-              API tokens are required to submit successfully to the selected
-              destinations. Check in with PlanX developers before launching your
-              service to make sure that tokens are available and configured for
-              your environment.
+              API tokens may be required to submit successfully. Check in with PlanX developers before launching your
+              service to make sure that submissions are configured for your environment.
             </Typography>
           </Box>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -13,7 +13,7 @@ export interface Send extends MoreInformation {
 }
 
 export const DEFAULT_TITLE = "Send";
-export const DEFAULT_DESTINATION = Destination.BOPS;
+export const DEFAULT_DESTINATION = Destination.Email;
 
 export const parseContent = (data: Record<string, any> | undefined): Send => ({
   ...parseMoreInformation(data),


### PR DESCRIPTION
We've had a number of BOPS submission failures recently for services that shouldn't be attempting to send to BOPS in the first place because they're unsupported application types.

This makes two simple changes to the Send component: 
- Switches default "destination" from BOPS to email for all newly created Send components in the Editor
- Adds a simple window alert on selection of BOPS or Uniform if the flow slug isn't an obviously supported application type. This is just meant to be a quick deterent for now, and we'll revisit and think about more robust on-publish validation later this phase via [this Trello ticket](https://trello.com/c/LGIoRgym/2641-validate-that-flow-meets-schema-requirements-on-publish)