### PR TITLE
chore: Sync new `team_themes` columns from production

### DIFF
--- a/scripts/seed-database/write/team_themes.sql
+++ b/scripts/seed-database/write/team_themes.sql
@@ -1,13 +1,12 @@
--- TODO: Update to add action_color and link_colour columns
-
 -- insert teams_themes overwriting conflicts
 CREATE TEMPORARY TABLE sync_team_themes (
   id integer,
   team_id integer,
   primary_colour text,
-  secondary_colour text,
   logo text,
-  favicon text
+  favicon text,
+  link_colour text,
+  action_colour text
 );
 
 \copy sync_team_themes FROM '/tmp/team_themes.csv' WITH (FORMAT csv, DELIMITER ';');
@@ -17,26 +16,29 @@ INSERT INTO
     id,
     team_id,
     primary_colour,
-    -- secondary_colour,
     logo,
-    favicon
+    favicon,
+    link_colour,
+    action_colour
   )
 SELECT
   id,
   team_id,
   primary_colour,
-  -- secondary_colour,
   logo,
-  favicon
+  favicon,
+  link_colour,
+  action_colour
 FROM
   sync_team_themes ON CONFLICT (id) DO
 UPDATE
 SET
   team_id = EXCLUDED.team_id,
   primary_colour = EXCLUDED.primary_colour,
-  -- secondary_colour = EXCLUDED.secondary_colour,
   logo = EXCLUDED.logo,
-  favicon = EXCLUDED.favicon;
+  favicon = EXCLUDED.favicon,
+  link_colour = EXCLUDED.link_colour,
+  action_colour = EXCLUDED.action_colour;
 SELECT
   setval('team_themes_id_seq', max(id))
 FROM


### PR DESCRIPTION
Tested locally with `pnpm test-sync` ✅ 