### PR TITLE
fix(css): Change `first-child` to `nth-child(1)`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -22,7 +22,7 @@ const Content = styled(Box, {
   "& a": {
     color: getContrastTextColor(color || "#fff", theme.palette.primary.main),
   },
-  "& *:first-child": {
+  "& *:nth-child(1)": {
     marginTop: 0,
   },
 }));

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -171,7 +171,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
       opacity: 0.3;
     }
 
-    > span:not(:first-child) {
+    > span:not(:nth-child(1)) {
       margin-left: 6px;
     }
   }
@@ -352,7 +352,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
           $lineWidth;
         background-repeat: no-repeat, repeat-x, repeat-x;
 
-        &:first-child {
+        &:nth-child(1) {
           background-position:
             top center,
             top right,
@@ -392,7 +392,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
           $lineWidth 100%,
           1px 100%;
 
-        &:first-child {
+        &:nth-child(1) {
           background-position:
             left center,
             left bottom,

--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -97,7 +97,7 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
       },
     },
     // Styles for placeholder text, to match ui/Input.tsx
-    "& p.is-editor-empty:first-child::before": {
+    "& p.is-editor-empty:nth-child(1)::before": {
       color: theme.palette.text.secondary,
       opacity: "0.5",
       content: `attr(data-placeholder)`,

--- a/editor.planx.uk/src/ui/shared/InputRow.tsx
+++ b/editor.planx.uk/src/ui/shared/InputRow.tsx
@@ -14,7 +14,7 @@ const Root = styled(Box, {
     flexGrow: 1,
     marginLeft: 1,
     marginRight: 5,
-    "&:first-child": {
+    "&:nth-child(1)": {
       marginLeft: 0,
     },
     "&:last-child": {

--- a/editor.planx.uk/src/ui/shared/InputRowLabel.tsx
+++ b/editor.planx.uk/src/ui/shared/InputRowLabel.tsx
@@ -7,7 +7,7 @@ const Label = styled(Typography)(({ theme }) => ({
   flexGrow: 0,
   paddingRight: theme.spacing(2),
   alignSelf: "center",
-  "&:not(:first-child)": {
+  "&:not(:nth-child(1))": {
     paddingLeft: theme.spacing(2),
   },
 })) as typeof Typography;


### PR DESCRIPTION
## What does this PR do?
 - Fixes noisy React warning (in dev-mode console, and tests) warning about use of `:first-child` selector
 - Replaces with `:nth-child(1)` selector

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/83688dd3-b416-470e-9716-9961b57be53a)
