### PR TITLE
feat: add `property.type` to analytics allow list answers

### DIFF
--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
@@ -9,6 +9,7 @@ import { Operation } from "../sanitiseApplicationData/types";
 const ALLOW_LIST = [
   "proposal.projectType",
   "application.declaration.connection",
+  "property.type",
 ];
 
 export const getAnalyzeSessionOperations = (): Operation[] => [

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -23,6 +23,7 @@ type AnalyticsLogDirection =
 const ALLOW_LIST = [
   "proposal.projectType",
   "application.declaration.connection",
+  "property.type",
 ] as const;
 
 export type HelpClickMetadata = Record<string, string>;
@@ -108,7 +109,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const trackVisibilityChange = () => {
     if (shouldSkipTracking()) return;
-    
+
     switch (document.visibilityState) {
       case "hidden":
         send(
@@ -287,12 +288,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   function shouldSkipTracking() {
-    return (!shouldTrackAnalytics || !lastVisibleNodeAnalyticsLogId)
+    return !shouldTrackAnalytics || !lastVisibleNodeAnalyticsLogId;
   }
 
   async function trackHelpClick(metadata?: HelpClickMetadata) {
     if (shouldSkipTracking()) return;
-    
+
     await publicClient.mutate({
       mutation: gql`
         mutation UpdateHasClickedHelp($id: bigint!, $metadata: jsonb = {}) {
@@ -314,7 +315,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   async function trackNextStepsLinkClick(metadata?: SelectedUrlsMetadata) {
     if (shouldSkipTracking()) return;
-    
+
     await publicClient.mutate({
       mutation: gql`
         mutation UpdateHasClickNextStepsLink(
@@ -340,7 +341,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     flowDirection: AnalyticsLogDirection,
   ) {
     if (shouldSkipTracking()) return;
-    
+
     await publicClient.mutate({
       mutation: gql`
         mutation UpdateFlowDirection($id: bigint!, $flow_direction: String) {
@@ -364,7 +365,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     nodeId?: string,
   ) {
     if (shouldSkipTracking()) return;
-    
+
     const targetNodeMetadata = nodeId ? getTargetNodeDataFromFlow(nodeId) : {};
     const metadata: Record<string, NodeMetadata> = {};
     metadata[`${initiator}`] = targetNodeMetadata;
@@ -430,7 +431,6 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   async function updateLastVisibleNodeLogWithAllowListAnswers(nodeId: string) {
     if (shouldSkipTracking()) return;
-    
 
     const allowListAnswers = getAllowListAnswers(nodeId);
     if (!allowListAnswers) return;
@@ -510,7 +510,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
    */
   async function trackInputErrors(error: string) {
     if (shouldSkipTracking()) return;
-    
+
     await publicClient.mutate({
       mutation: gql`
         mutation TrackInputErrors($id: bigint!, $error: jsonb) {


### PR DESCRIPTION
Was wanting this while further reviewing title boundary feedback, feels useful to have in addition to `proposal.projectType` !