### PR TITLE
fix: disable new CORS rules for OS Proxy endpoint

### DIFF
--- a/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -1,6 +1,7 @@
 import { useProxy } from "../../shared/middleware/proxy";
 import { NextFunction, Request, Response } from "express";
 import { IncomingMessage } from "http";
+import { request } from "https";
 
 export const OS_DOMAIN = "https://api.os.uk";
 
@@ -28,7 +29,7 @@ export const useOrdnanceSurveyProxy = async (
 
   return useProxy({
     target: OS_DOMAIN,
-    onProxyRes: (proxyRes) => setCORPHeaders(proxyRes),
+    onProxyRes: (proxyRes) => setCORPHeaders(proxyRes, req),
     pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req),
   })(req, res, next);
 };
@@ -36,8 +37,10 @@ export const useOrdnanceSurveyProxy = async (
 const isValid = (req: Request): boolean =>
   MAP_ALLOWLIST.some((re) => re.test(req.headers?.referer as string));
 
-const setCORPHeaders = (proxyRes: IncomingMessage): void => {
+const setCORPHeaders = (proxyRes: IncomingMessage, req: Request): void => {
   proxyRes.headers["Cross-Origin-Resource-Policy"] = "cross-origin";
+  proxyRes.headers["Access-Control-Allow-Origin"] = req.headers.origin;
+  proxyRes.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept";
 };
 
 export const appendAPIKey = (fullPath: string, req: Request): string => {

--- a/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -40,7 +40,8 @@ const isValid = (req: Request): boolean =>
 const setCORPHeaders = (proxyRes: IncomingMessage, req: Request): void => {
   proxyRes.headers["Cross-Origin-Resource-Policy"] = "cross-origin";
   proxyRes.headers["Access-Control-Allow-Origin"] = req.headers.origin;
-  proxyRes.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept";
+  proxyRes.headers["Access-Control-Allow-Headers"] =
+    "Origin, X-Requested-With, Content-Type, Accept";
 };
 
 export const appendAPIKey = (fullPath: string, req: Request): string => {

--- a/api.planx.uk/modules/ordnanceSurvey/routes.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/routes.ts
@@ -11,6 +11,10 @@ const osProxyCORSOptions = {
 };
 
 router.options("/proxy/ordnance-survey", cors(osProxyCORSOptions));
-router.use("/proxy/ordnance-survey", cors(osProxyCORSOptions), useOrdnanceSurveyProxy);
+router.use(
+  "/proxy/ordnance-survey",
+  cors(osProxyCORSOptions),
+  useOrdnanceSurveyProxy,
+);
 
 export default router;

--- a/api.planx.uk/modules/ordnanceSurvey/routes.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/routes.ts
@@ -1,8 +1,16 @@
+import cors from "cors";
 import { Router } from "express";
 import { useOrdnanceSurveyProxy } from "./controller";
 
 const router = Router();
 
-router.use("/proxy/ordnance-survey", useOrdnanceSurveyProxy);
+// Because this route already uses MAP_ALLOWLIST, disable global CORS checks so map repo docs and HTML templates are accessible
+const osProxyCORSOptions = {
+  credentials: true,
+  methods: "*",
+};
+
+router.options("/proxy/ordnance-survey", cors(osProxyCORSOptions));
+router.use("/proxy/ordnance-survey", cors(osProxyCORSOptions), useOrdnanceSurveyProxy);
 
 export default router;


### PR DESCRIPTION
Fixes error thrown & discussed here: https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1705473868867069

Because this endpoint already uses a `MAP_ALLOWLIST`, we don't actually need to apply the new CORS rules. This PR reverts to the "[original](https://github.com/theopensystemslab/planx-new/pull/2634/files#diff-a23b8e0cdc75fc858dc3a73983f67d257f78158596c37832202cf963efcf0a6aL50)" CORS configuration for this endpoint only.

Testing: 
- Open the web components docs, navigate to "MyMap - Proxy", open an example in the "playground" and edit "[Template](https://oslmap.netlify.app/#!/components/vanilla/playground?tab=1&code=eyJ0ZW1wbGF0ZSI6IjxteS1tYXAgem9vbT1cIjE4XCIgb3NQcm94eUVuZHBvaW50PVwiaHR0cHM6Ly9hcGkuZWRpdG9yLnBsYW54LmRldi9wcm94eS9vcmRuYW5jZS1zdXJ2ZXlcIi8%252BIiwiY29udHJvbGxlciI6ImZ1bmN0aW9uIGNvbnRyb2xsZXIoZWxlbWVudCl7fVxuXG5yZXR1cm4gY29udHJvbGxlcjsiLCJzdHlsZXMiOiJcbiJ9&source=edit-link)" to swap out `osProxyEndpoint` from .dev to this pizza's API endpoint and confirm basemap loads