### PR TITLE
chore(editor): Setup Tewkesbury domain

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -17,6 +17,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.camden.gov.uk":
     case "planningservices.stalbans.gov.uk":
     case "planningservices.barnet.gov.uk":
+    case "planningservices.tewkesbury.gov.uk":
     case "editor.planx.uk":
       return "production";
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -61,6 +61,7 @@ const PREVIEW_ONLY_DOMAINS = [
   "planningservices.camden.gov.uk",
   "planningservices.stalbans.gov.uk",
   "planningservices.barnet.gov.uk",
+  "planningservices.tewkesbury.gov.uk",
   // XXX: un-comment the next line to test custom domains locally
   // "localhost",
 ];


### PR DESCRIPTION
## What does this PR do?
 - Sets up domain for Tewkesbury in frontend (Step 10 of https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-subdomains.md)
 - Depends on Tewkesbury IT creating CNAME record. Will merge once I get confirmation from them.