### PR TITLE
fix: Handle CORS for OS proxy endpoints

### DIFF
--- a/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -4,37 +4,16 @@ import { IncomingMessage } from "http";
 
 export const OS_DOMAIN = "https://api.os.uk";
 
-const MAP_ALLOWLIST: RegExp[] = [
-  // Local development
-  /^http:\/\/(127\.0\.0\.1|localhost):(3000|5173|6006|7007)\/$/i,
-  // Documentation
-  /^https:\/\/.*\.netlify\.app\/$/i,
-  // PlanX
-  /^https:\/\/.*planx\.(pizza|dev|uk)\/$/i,
-  // Custom domains
-  /^https:\/\/.*(\.gov\.uk\/)$/i,
-];
-
 export const useOrdnanceSurveyProxy = async (
   req: Request,
   res: Response,
   next: NextFunction,
-) => {
-  if (!isValid(req))
-    return next({
-      status: 401,
-      message: "Unauthorised",
-    });
-
-  return useProxy({
+) =>
+  useProxy({
     target: OS_DOMAIN,
     onProxyRes: (proxyRes) => setCORPHeaders(proxyRes),
     pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req),
   })(req, res, next);
-};
-
-const isValid = (req: Request): boolean =>
-  MAP_ALLOWLIST.some((re) => re.test(req.headers?.referer as string));
 
 const setCORPHeaders = (proxyRes: IncomingMessage): void => {
   proxyRes.headers["Cross-Origin-Resource-Policy"] = "cross-origin";

--- a/api.planx.uk/modules/ordnanceSurvey/ordnanceSurvey.test.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/ordnanceSurvey.test.ts
@@ -17,7 +17,6 @@ describe("Ordnance Survey proxy endpoint", () => {
       .reply(200, { test: "returned tile" });
 
     await get(ENDPOINT + TILE_PATH)
-      .set({ referer: "https://123.planx.pizza/" })
       .expect(200)
       .then((response) => {
         expect(response.body).toEqual({
@@ -33,7 +32,6 @@ describe("Ordnance Survey proxy endpoint", () => {
       .reply(200, { test: "returned tile" });
 
     await get(ENDPOINT + TILE_PATH + "?srs=3857")
-      .set({ referer: "https://www.planx.dev/" })
       .expect(200)
       .then((response) => {
         expect(response.body).toEqual({
@@ -49,83 +47,12 @@ describe("Ordnance Survey proxy endpoint", () => {
       .reply(401, { test: "failed request" });
 
     await get(ENDPOINT + TILE_PATH)
-      .set({ referer: "https://www.planx.uk/" })
       .expect(401)
       .then((response) => {
         expect(response.body).toEqual({
           test: "failed request",
         });
       });
-  });
-
-  describe("CORS functionality", () => {
-    it("blocks requests which are not from a valid referrer", async () => {
-      await get(ENDPOINT + TILE_PATH)
-        .set({ referer: "https://www.invalid-site.com/" })
-        .expect(401)
-        .then((response) => {
-          expect(response.body).toEqual({
-            error: "Unauthorised",
-          });
-        });
-    });
-
-    it("allows requests from allow-listed URLs", async () => {
-      nock(OS_DOMAIN)
-        .get(TILE_PATH)
-        .query({ key: process.env.ORDNANCE_SURVEY_API_KEY })
-        .reply(200, { test: "returned tile" });
-
-      await get(ENDPOINT + TILE_PATH)
-        .set({ referer: "https://oslmap.netlify.app/" })
-        .expect(200)
-        .then((response) => {
-          expect(response.body).toEqual({
-            test: "returned tile",
-          });
-          expect(response.headers["cross-origin-resource-policy"]).toEqual(
-            "cross-origin",
-          );
-        });
-    });
-
-    it("allows requests from PlanX", async () => {
-      nock(OS_DOMAIN)
-        .get(TILE_PATH)
-        .query({ key: process.env.ORDNANCE_SURVEY_API_KEY })
-        .reply(200, { test: "returned tile" });
-
-      await get(ENDPOINT + TILE_PATH)
-        .set({ referer: "https://www.planx.dev/" })
-        .expect(200)
-        .then((response) => {
-          expect(response.body).toEqual({
-            test: "returned tile",
-          });
-          expect(response.headers["cross-origin-resource-policy"]).toEqual(
-            "cross-origin",
-          );
-        });
-    });
-
-    it("allows requests from custom domains", async () => {
-      nock(OS_DOMAIN)
-        .get(TILE_PATH)
-        .query({ key: process.env.ORDNANCE_SURVEY_API_KEY })
-        .reply(200, { test: "returned tile" });
-
-      await get(ENDPOINT + TILE_PATH)
-        .set({ referer: "https://planningservices.buckinghamshire.gov.uk/" })
-        .expect(200)
-        .then((response) => {
-          expect(response.body).toEqual({
-            test: "returned tile",
-          });
-          expect(response.headers["cross-origin-resource-policy"]).toEqual(
-            "cross-origin",
-          );
-        });
-    });
   });
 });
 

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -39,12 +39,18 @@ useSwaggerDocs(app);
 app.set("trust proxy", 1);
 
 const checkAllowedOrigins: CorsOptions["origin"] = (origin, callback) => {
-  const isTest = process.env.NODE_ENV === "test";
-  const isDevelopment = process.env.APP_ENVIRONMENT === "development";
-  const allowList = process.env.CORS_ALLOWLIST?.split(", ") || [];
-  const isAllowed = Boolean(origin && allowList.includes(origin));
+  if (!origin) return callback(null, true);
 
-  !origin || isTest || isDevelopment || isAllowed
+  const isTest = process.env.NODE_ENV === "test";
+  const localDevEnvs =
+    /^http:\/\/(127\.0\.0\.1|localhost):(3000|5173|6006|7007)$/;
+  const isDevelopment =
+    process.env.APP_ENVIRONMENT === "development" || localDevEnvs.test(origin);
+  const allowList = process.env.CORS_ALLOWLIST?.split(", ") || [];
+  const isAllowed = Boolean(allowList.includes(origin));
+  const isMapDocs = Boolean(origin.endsWith("oslmap.netlify.app"));
+
+  isTest || isDevelopment || isAllowed || isMapDocs
     ? callback(null, true)
     : callback(new Error("Not allowed by CORS"));
 };


### PR DESCRIPTION
## What does this PR do?
- Fix OS proxy endpoints to allow correct list of origins defined in `MAP_ALLOWLIST`
- Pull this function out of the proxy, and place it into a middleware layer

**To test**
- [x] Works localhost → localhost
- [x] Works localhost → Pizza 
- [ ] Works from oslmap.netlify.app → Staging
- [ ] Works from <PR_NUMBER>--oslmap.netlify.app → Staging