### PR TITLE
feat: logic for conditionally rendering feedback UI

### DIFF
--- a/editor.planx.uk/src/components/Feedback.tsx
+++ b/editor.planx.uk/src/components/Feedback.tsx
@@ -67,48 +67,26 @@ const FeedbackForm = styled("form")(({ theme }) => ({
 }));
 
 const FeedbackComponent: React.FC = () => {
-  enum View {
-    PhaseBanner,
-    FeedbackTriage,
-    ReportAnIssue,
-    ShareAnIdea,
-    ShareAComment,
-    ThanksForFeedback,
-  }
+  type FeedbackCategory = "issue" | "idea" | "comment";
 
-  enum ClickEvents {
-    Close,
-    Back,
-    OpenTriage,
-    OpenReportAnIssue,
-    OpenShareAnIdea,
-    OpenShareAComment,
-  }
+  type View = "banner" | "triage" | FeedbackCategory | "thanks";
 
-  const [currentFeedbackView, setCurrentFeedbackView] = useState<View>(
-    View.PhaseBanner,
-  );
+  type ClickEvents = "close" | "back" | "triage" | FeedbackCategory;
+
+  const [currentFeedbackView, setCurrentFeedbackView] =
+    useState<View>("banner");
   const previousFeedbackView = usePrevious(currentFeedbackView);
 
   function handleFeedbackViewClick(event: ClickEvents) {
     switch (event) {
-      case ClickEvents.Close:
-        setCurrentFeedbackView(View.PhaseBanner);
+      case "close":
+        setCurrentFeedbackView("banner");
         break;
-      case ClickEvents.Back:
-        setCurrentFeedbackView(View.FeedbackTriage);
+      case "back":
+        setCurrentFeedbackView("triage");
         break;
-      case ClickEvents.OpenTriage:
-        setCurrentFeedbackView(View.FeedbackTriage);
-        break;
-      case ClickEvents.OpenReportAnIssue:
-        setCurrentFeedbackView(View.ReportAnIssue);
-        break;
-      case ClickEvents.OpenShareAnIdea:
-        setCurrentFeedbackView(View.ShareAnIdea);
-        break;
-      case ClickEvents.OpenShareAComment:
-        setCurrentFeedbackView(View.ShareAComment);
+      default:
+        setCurrentFeedbackView(event);
         break;
     }
   }
@@ -125,17 +103,17 @@ const FeedbackComponent: React.FC = () => {
     console.log("The user inputs", formDataPayload);
     // Prep the form data payload?
 
-    setCurrentFeedbackView(View.ThanksForFeedback);
+    setCurrentFeedbackView("thanks");
   };
 
   function BackAndCloseFeedbackHeader(): FCReturn {
     return (
       <FeedbackHeader>
-        <BackButton onClick={() => handleFeedbackViewClick(ClickEvents.Back)}>
+        <BackButton onClick={() => handleFeedbackViewClick("back")}>
           <ArrowBackIcon fontSize="small" />
           Back
         </BackButton>
-        <CloseButton onClick={() => handleFeedbackViewClick(ClickEvents.Close)}>
+        <CloseButton onClick={() => handleFeedbackViewClick("close")}>
           <IconButton
             role="button"
             title="Close panel"
@@ -164,7 +142,7 @@ const FeedbackComponent: React.FC = () => {
             {props.title}
           </Typography>
         </FeedbackTitle>
-        <CloseButton onClick={() => handleFeedbackViewClick(ClickEvents.Close)}>
+        <CloseButton onClick={() => handleFeedbackViewClick("close")}>
           <IconButton
             role="button"
             title="Close panel"
@@ -180,7 +158,7 @@ const FeedbackComponent: React.FC = () => {
   }
 
   function ReportAnIssueTopBar(): FCReturn {
-    if (previousFeedbackView === View.PhaseBanner) {
+    if (previousFeedbackView === "banner") {
       return (
         <TitleAndCloseFeedbackHeader
           icon={WarningIcon}
@@ -205,12 +183,8 @@ const FeedbackComponent: React.FC = () => {
     return (
       <FeedbackWrapper>
         <FeedbackPhaseBanner
-          handleFeedbackClick={() =>
-            handleFeedbackViewClick(ClickEvents.OpenTriage)
-          }
-          handleReportAnIssueClick={() =>
-            handleFeedbackViewClick(ClickEvents.OpenReportAnIssue)
-          }
+          handleFeedbackClick={() => handleFeedbackViewClick("triage")}
+          handleReportAnIssueClick={() => handleFeedbackViewClick("issue")}
         />
       </FeedbackWrapper>
     );
@@ -224,25 +198,19 @@ const FeedbackComponent: React.FC = () => {
             <TitleAndCloseFeedbackHeader title="What would you like to share?" />
             <FeedbackBody>
               <FeedbackOption
-                handleClick={() =>
-                  handleFeedbackViewClick(ClickEvents.OpenReportAnIssue)
-                }
+                handleClick={() => handleFeedbackViewClick("issue")}
                 Icon={WarningIcon}
                 label="Issue"
                 showArrow
               />
               <FeedbackOption
-                handleClick={() =>
-                  handleFeedbackViewClick(ClickEvents.OpenShareAnIdea)
-                }
+                handleClick={() => handleFeedbackViewClick("idea")}
                 Icon={LightbulbIcon}
                 label="Idea"
                 showArrow
               />
               <FeedbackOption
-                handleClick={() =>
-                  handleFeedbackViewClick(ClickEvents.OpenShareAComment)
-                }
+                handleClick={() => handleFeedbackViewClick("comment")}
                 Icon={MoreHorizIcon}
                 label="Comment"
                 showArrow
@@ -393,17 +361,17 @@ const FeedbackComponent: React.FC = () => {
 
   function Feedback(): FCReturn {
     switch (currentFeedbackView) {
-      case View.PhaseBanner:
+      case "banner":
         return <FeedbackPhaseBannerView />;
-      case View.FeedbackTriage:
+      case "triage":
         return <FeedbackTriage />;
-      case View.ReportAnIssue:
+      case "issue":
         return <FeedbackReportAnIssue />;
-      case View.ShareAnIdea:
+      case "idea":
         return <FeedbackShareAnIdea />;
-      case View.ShareAComment:
+      case "comment":
         return <FeedbackShareAComment />;
-      case View.ThanksForFeedback:
+      case "thanks":
         return <FeedbackThanksForFeedback />;
     }
   }

--- a/editor.planx.uk/src/components/Feedback.tsx
+++ b/editor.planx.uk/src/components/Feedback.tsx
@@ -12,7 +12,8 @@ import Typography from "@mui/material/Typography";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import FeedbackPhaseBanner from "components/FeedbackPhaseBanner";
 import { BackButton } from "pages/Preview/Questions";
-import React from "react";
+import React, { useState } from "react";
+import { usePrevious } from "react-use";
 import FeedbackDisclaimer from "ui/public/FeedbackDisclaimer";
 import FeedbackOption from "ui/public/FeedbackOption";
 import InputLabel from "ui/public/InputLabel";
@@ -66,79 +67,240 @@ const FeedbackForm = styled("form")(({ theme }) => ({
 }));
 
 const FeedbackComponent: React.FC = () => {
-  return (
-    <>
-      <FeedbackWrapper>
-        <FeedbackPhaseBanner />
-      </FeedbackWrapper>
+  enum FeedbackView {
+    PhaseBanner,
+    FeedbackTriage,
+    ReportAnIssue,
+    ShareAnIdea,
+    ShareAComment,
+    ThanksForFeedback,
+  }
 
+  enum FeedbackViewClickEvents {
+    Close,
+    Back,
+    OpenTriage,
+    OpenReportAnIssue,
+    OpenShareAnIdea,
+    OpenShareAComment,
+  }
+
+  const [currentFeedbackView, setCurrentFeedbackView] = useState<FeedbackView>(
+    FeedbackView.PhaseBanner,
+  );
+  const previousFeedbackView = usePrevious(currentFeedbackView);
+
+  function handleFeedbackViewClick(event: FeedbackViewClickEvents) {
+    switch (event) {
+      case FeedbackViewClickEvents.Close:
+        setCurrentFeedbackView(FeedbackView.PhaseBanner);
+        break;
+      case FeedbackViewClickEvents.Back:
+        setCurrentFeedbackView(FeedbackView.FeedbackTriage);
+        break;
+      case FeedbackViewClickEvents.OpenTriage:
+        setCurrentFeedbackView(FeedbackView.FeedbackTriage);
+        break;
+      case FeedbackViewClickEvents.OpenReportAnIssue:
+        setCurrentFeedbackView(FeedbackView.ReportAnIssue);
+        break;
+      case FeedbackViewClickEvents.OpenShareAnIdea:
+        setCurrentFeedbackView(FeedbackView.ShareAnIdea);
+        break;
+      case FeedbackViewClickEvents.OpenShareAComment:
+        setCurrentFeedbackView(FeedbackView.ShareAComment);
+        break;
+    }
+  }
+
+  const handleFeedbackFormSubmit = (e: any) => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    const formDataPayload: any = {};
+
+    for (const [key, value] of formData.entries()) {
+      formDataPayload[key] = value;
+    }
+
+    console.log("The user inputs", formDataPayload);
+    // Prep the form data payload?
+
+    setCurrentFeedbackView(FeedbackView.ThanksForFeedback);
+  };
+
+  function BackAndCloseFeedbackHeader(): FCReturn {
+    return (
+      <FeedbackHeader>
+        <BackButton
+          onClick={() => handleFeedbackViewClick(FeedbackViewClickEvents.Back)}
+        >
+          <ArrowBackIcon fontSize="small" />
+          Back
+        </BackButton>
+        <CloseButton
+          onClick={() => handleFeedbackViewClick(FeedbackViewClickEvents.Close)}
+        >
+          <IconButton
+            role="button"
+            title="Close panel"
+            aria-label="Close panel"
+            size="large"
+            color="inherit"
+          >
+            <CloseIcon />
+          </IconButton>
+        </CloseButton>
+      </FeedbackHeader>
+    );
+  }
+
+  interface TitleAndCloseProps {
+    title: string;
+    icon?: any;
+  }
+
+  function TitleAndCloseFeedbackHeader(props: TitleAndCloseProps): FCReturn {
+    return (
+      <FeedbackHeader>
+        <FeedbackTitle>
+          {props.icon && <props.icon />}
+          <Typography variant="h3" component="h2">
+            {props.title}
+          </Typography>
+        </FeedbackTitle>
+        <CloseButton
+          onClick={() => handleFeedbackViewClick(FeedbackViewClickEvents.Close)}
+        >
+          <IconButton
+            role="button"
+            title="Close panel"
+            aria-label="Close panel"
+            size="large"
+            color="inherit"
+          >
+            <CloseIcon />
+          </IconButton>
+        </CloseButton>
+      </FeedbackHeader>
+    );
+  }
+
+  function ReportAnIssueTopBar(): FCReturn {
+    if (previousFeedbackView === FeedbackView.PhaseBanner) {
+      return (
+        <TitleAndCloseFeedbackHeader
+          icon={WarningIcon}
+          title="Report an issue"
+        />
+      );
+    } else
+      return (
+        <>
+          <BackAndCloseFeedbackHeader />
+          <FeedbackTitle>
+            <WarningIcon />
+            <Typography variant="h3" component="h2">
+              Report an issue
+            </Typography>
+          </FeedbackTitle>
+        </>
+      );
+  }
+
+  function FeedbackPhaseBannerView(): FCReturn {
+    return (
+      <FeedbackWrapper>
+        <FeedbackPhaseBanner
+          handleFeedbackClick={() =>
+            handleFeedbackViewClick(FeedbackViewClickEvents.OpenTriage)
+          }
+          handleReportAnIssueClick={() =>
+            handleFeedbackViewClick(FeedbackViewClickEvents.OpenReportAnIssue)
+          }
+        />
+      </FeedbackWrapper>
+    );
+  }
+
+  function FeedbackTriage(): FCReturn {
+    return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
           <FeedbackRow>
-            <FeedbackHeader>
-              <Typography variant="h3" component="h2">
-                What would you like to share?
-              </Typography>
-              <CloseButton>
-                <IconButton
-                  role="button"
-                  title="Close panel"
-                  aria-label="Close panel"
-                  size="large"
-                  color="inherit"
-                >
-                  <CloseIcon />
-                </IconButton>
-              </CloseButton>
-            </FeedbackHeader>
+            <TitleAndCloseFeedbackHeader title="What would you like to share?" />
             <FeedbackBody>
-              <FeedbackOption Icon={WarningIcon} label="Issue" showArrow />
-              <FeedbackOption Icon={LightbulbIcon} label="Idea" showArrow />
-              <FeedbackOption Icon={MoreHorizIcon} label="Comment" showArrow />
+              <FeedbackOption
+                handleClick={() =>
+                  handleFeedbackViewClick(
+                    FeedbackViewClickEvents.OpenReportAnIssue,
+                  )
+                }
+                Icon={WarningIcon}
+                label="Issue"
+                showArrow
+              />
+              <FeedbackOption
+                handleClick={() =>
+                  handleFeedbackViewClick(
+                    FeedbackViewClickEvents.OpenShareAnIdea,
+                  )
+                }
+                Icon={LightbulbIcon}
+                label="Idea"
+                showArrow
+              />
+              <FeedbackOption
+                handleClick={() =>
+                  handleFeedbackViewClick(
+                    FeedbackViewClickEvents.OpenShareAComment,
+                  )
+                }
+                Icon={MoreHorizIcon}
+                label="Comment"
+                showArrow
+              />
             </FeedbackBody>
           </FeedbackRow>
         </Container>
       </FeedbackWrapper>
+    );
+  }
 
+  function FeedbackReportAnIssue(): FCReturn {
+    return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
           <FeedbackRow>
-            <FeedbackHeader>
-              <BackButton>
-                <ArrowBackIcon fontSize="small" />
-                Back
-              </BackButton>
-              <CloseButton>
-                <IconButton
-                  role="button"
-                  title="Close panel"
-                  aria-label="Close panel"
-                  size="large"
-                  color="inherit"
-                >
-                  <CloseIcon />
-                </IconButton>
-              </CloseButton>
-            </FeedbackHeader>
-            <FeedbackTitle>
-              <WarningIcon />
-              <Typography variant="h3" component="h2">
-                Report an issue
-              </Typography>
-            </FeedbackTitle>
+            <ReportAnIssueTopBar />
             <FeedbackBody>
-              <FeedbackForm>
+              <FeedbackForm onSubmit={(e) => handleFeedbackFormSubmit(e)}>
                 <InputLabel
                   label="What were you doing?"
                   htmlFor="issue-input-1"
                 >
-                  <Input multiline bordered id="issue-input-1" />
+                  <Input
+                    required
+                    multiline
+                    bordered
+                    id="issue-input-1"
+                    name="userContext"
+                  />
                 </InputLabel>
                 <InputLabel label="What went wrong?" htmlFor="issue-input-2">
-                  <Input multiline bordered id="issue-input-2" />
+                  <Input
+                    required
+                    multiline
+                    bordered
+                    id="issue-input-2"
+                    name="userComment"
+                  />
                 </InputLabel>
                 <FeedbackDisclaimer />
-                <Button variant="contained" sx={{ marginTop: 2.5 }}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  sx={{ marginTop: 2.5 }}
+                >
                   Send feedback
                 </Button>
               </FeedbackForm>
@@ -146,38 +308,36 @@ const FeedbackComponent: React.FC = () => {
           </FeedbackRow>
         </Container>
       </FeedbackWrapper>
+    );
+  }
 
+  function FeedbackShareAnIdea(): FCReturn {
+    return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
           <FeedbackRow>
-            <FeedbackHeader>
-              <BackButton>
-                <ArrowBackIcon fontSize="small" />
-                Back
-              </BackButton>
-              <CloseButton>
-                <IconButton
-                  role="button"
-                  title="Close panel"
-                  aria-label="Close panel"
-                  size="large"
-                  color="inherit"
-                >
-                  <CloseIcon />
-                </IconButton>
-              </CloseButton>
-            </FeedbackHeader>
+            <BackAndCloseFeedbackHeader />
             <FeedbackTitle>
               <LightbulbIcon />
               <Typography variant="h3" component="h2" id="idea-title">
                 Share an idea
               </Typography>
             </FeedbackTitle>
-            <FeedbackBody>
+            <FeedbackBody onSubmit={(e) => handleFeedbackFormSubmit(e)}>
               <FeedbackForm>
-                <Input multiline bordered aria-describedby="idea-title" />
+                <Input
+                  name="useComment"
+                  required
+                  multiline
+                  bordered
+                  aria-describedby="idea-title"
+                />
                 <FeedbackDisclaimer />
-                <Button variant="contained" sx={{ marginTop: 2.5 }}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  sx={{ marginTop: 2.5 }}
+                >
                   Send feedback
                 </Button>
               </FeedbackForm>
@@ -185,27 +345,15 @@ const FeedbackComponent: React.FC = () => {
           </FeedbackRow>
         </Container>
       </FeedbackWrapper>
+    );
+  }
 
+  function FeedbackShareAComment(): FCReturn {
+    return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
           <FeedbackRow>
-            <FeedbackHeader>
-              <BackButton>
-                <ArrowBackIcon fontSize="small" />
-                Back
-              </BackButton>
-              <CloseButton>
-                <IconButton
-                  role="button"
-                  title="Close panel"
-                  aria-label="Close panel"
-                  size="large"
-                  color="inherit"
-                >
-                  <CloseIcon />
-                </IconButton>
-              </CloseButton>
-            </FeedbackHeader>
+            <BackAndCloseFeedbackHeader />
             <FeedbackTitle>
               <MoreHorizIcon />
               <Typography variant="h3" component="h2" id="comment-title">
@@ -213,10 +361,20 @@ const FeedbackComponent: React.FC = () => {
               </Typography>
             </FeedbackTitle>
             <FeedbackBody>
-              <FeedbackForm>
-                <Input multiline bordered aria-describedby="comment-title" />
+              <FeedbackForm onSubmit={(e) => handleFeedbackFormSubmit(e)}>
+                <Input
+                  name="userComment"
+                  required
+                  multiline
+                  bordered
+                  aria-describedby="comment-title"
+                />
                 <FeedbackDisclaimer />
-                <Button variant="contained" sx={{ marginTop: 2.5 }}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  sx={{ marginTop: 2.5 }}
+                >
                   Send feedback
                 </Button>
               </FeedbackForm>
@@ -224,26 +382,15 @@ const FeedbackComponent: React.FC = () => {
           </FeedbackRow>
         </Container>
       </FeedbackWrapper>
+    );
+  }
 
+  function FeedbackThanksForFeedback(): FCReturn {
+    return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
           <FeedbackRow>
-            <FeedbackHeader>
-              <Typography variant="h3" component="h2">
-                Thank you for sharing feedback
-              </Typography>
-              <CloseButton>
-                <IconButton
-                  role="button"
-                  title="Close panel"
-                  aria-label="Close panel"
-                  size="large"
-                  color="inherit"
-                >
-                  <CloseIcon />
-                </IconButton>
-              </CloseButton>
-            </FeedbackHeader>
+            <TitleAndCloseFeedbackHeader title="Thank you for sharing feedback" />
             <FeedbackBody>
               <Typography variant="body1">
                 We appreciate it lorem ipsum dolor sit amet, consectetuer
@@ -253,8 +400,27 @@ const FeedbackComponent: React.FC = () => {
           </FeedbackRow>
         </Container>
       </FeedbackWrapper>
-    </>
-  );
+    );
+  }
+
+  function Feedback(): FCReturn {
+    switch (currentFeedbackView) {
+      case FeedbackView.PhaseBanner:
+        return <FeedbackPhaseBannerView />;
+      case FeedbackView.FeedbackTriage:
+        return <FeedbackTriage />;
+      case FeedbackView.ReportAnIssue:
+        return <FeedbackReportAnIssue />;
+      case FeedbackView.ShareAnIdea:
+        return <FeedbackShareAnIdea />;
+      case FeedbackView.ShareAComment:
+        return <FeedbackShareAComment />;
+      case FeedbackView.ThanksForFeedback:
+        return <FeedbackThanksForFeedback />;
+    }
+  }
+
+  return <Feedback />;
 };
 
 export default FeedbackComponent;

--- a/editor.planx.uk/src/components/Feedback.tsx
+++ b/editor.planx.uk/src/components/Feedback.tsx
@@ -199,19 +199,19 @@ const FeedbackComponent: React.FC = () => {
             <TitleAndCloseFeedbackHeader title="What would you like to share?" />
             <FeedbackBody>
               <FeedbackOption
-                handleClick={() => handleFeedbackViewClick("issue")}
+                onClick={() => handleFeedbackViewClick("issue")}
                 Icon={WarningIcon}
                 label="Issue"
                 showArrow
               />
               <FeedbackOption
-                handleClick={() => handleFeedbackViewClick("idea")}
+                onClick={() => handleFeedbackViewClick("idea")}
                 Icon={LightbulbIcon}
                 label="Idea"
                 showArrow
               />
               <FeedbackOption
-                handleClick={() => handleFeedbackViewClick("comment")}
+                onClick={() => handleFeedbackViewClick("comment")}
                 Icon={MoreHorizIcon}
                 label="Comment"
                 showArrow

--- a/editor.planx.uk/src/components/Feedback.tsx
+++ b/editor.planx.uk/src/components/Feedback.tsx
@@ -67,7 +67,7 @@ const FeedbackForm = styled("form")(({ theme }) => ({
 }));
 
 const FeedbackComponent: React.FC = () => {
-  enum FeedbackView {
+  enum View {
     PhaseBanner,
     FeedbackTriage,
     ReportAnIssue,
@@ -76,7 +76,7 @@ const FeedbackComponent: React.FC = () => {
     ThanksForFeedback,
   }
 
-  enum FeedbackViewClickEvents {
+  enum ClickEvents {
     Close,
     Back,
     OpenTriage,
@@ -85,30 +85,30 @@ const FeedbackComponent: React.FC = () => {
     OpenShareAComment,
   }
 
-  const [currentFeedbackView, setCurrentFeedbackView] = useState<FeedbackView>(
-    FeedbackView.PhaseBanner,
+  const [currentFeedbackView, setCurrentFeedbackView] = useState<View>(
+    View.PhaseBanner,
   );
   const previousFeedbackView = usePrevious(currentFeedbackView);
 
-  function handleFeedbackViewClick(event: FeedbackViewClickEvents) {
+  function handleFeedbackViewClick(event: ClickEvents) {
     switch (event) {
-      case FeedbackViewClickEvents.Close:
-        setCurrentFeedbackView(FeedbackView.PhaseBanner);
+      case ClickEvents.Close:
+        setCurrentFeedbackView(View.PhaseBanner);
         break;
-      case FeedbackViewClickEvents.Back:
-        setCurrentFeedbackView(FeedbackView.FeedbackTriage);
+      case ClickEvents.Back:
+        setCurrentFeedbackView(View.FeedbackTriage);
         break;
-      case FeedbackViewClickEvents.OpenTriage:
-        setCurrentFeedbackView(FeedbackView.FeedbackTriage);
+      case ClickEvents.OpenTriage:
+        setCurrentFeedbackView(View.FeedbackTriage);
         break;
-      case FeedbackViewClickEvents.OpenReportAnIssue:
-        setCurrentFeedbackView(FeedbackView.ReportAnIssue);
+      case ClickEvents.OpenReportAnIssue:
+        setCurrentFeedbackView(View.ReportAnIssue);
         break;
-      case FeedbackViewClickEvents.OpenShareAnIdea:
-        setCurrentFeedbackView(FeedbackView.ShareAnIdea);
+      case ClickEvents.OpenShareAnIdea:
+        setCurrentFeedbackView(View.ShareAnIdea);
         break;
-      case FeedbackViewClickEvents.OpenShareAComment:
-        setCurrentFeedbackView(FeedbackView.ShareAComment);
+      case ClickEvents.OpenShareAComment:
+        setCurrentFeedbackView(View.ShareAComment);
         break;
     }
   }
@@ -125,21 +125,17 @@ const FeedbackComponent: React.FC = () => {
     console.log("The user inputs", formDataPayload);
     // Prep the form data payload?
 
-    setCurrentFeedbackView(FeedbackView.ThanksForFeedback);
+    setCurrentFeedbackView(View.ThanksForFeedback);
   };
 
   function BackAndCloseFeedbackHeader(): FCReturn {
     return (
       <FeedbackHeader>
-        <BackButton
-          onClick={() => handleFeedbackViewClick(FeedbackViewClickEvents.Back)}
-        >
+        <BackButton onClick={() => handleFeedbackViewClick(ClickEvents.Back)}>
           <ArrowBackIcon fontSize="small" />
           Back
         </BackButton>
-        <CloseButton
-          onClick={() => handleFeedbackViewClick(FeedbackViewClickEvents.Close)}
-        >
+        <CloseButton onClick={() => handleFeedbackViewClick(ClickEvents.Close)}>
           <IconButton
             role="button"
             title="Close panel"
@@ -168,9 +164,7 @@ const FeedbackComponent: React.FC = () => {
             {props.title}
           </Typography>
         </FeedbackTitle>
-        <CloseButton
-          onClick={() => handleFeedbackViewClick(FeedbackViewClickEvents.Close)}
-        >
+        <CloseButton onClick={() => handleFeedbackViewClick(ClickEvents.Close)}>
           <IconButton
             role="button"
             title="Close panel"
@@ -186,7 +180,7 @@ const FeedbackComponent: React.FC = () => {
   }
 
   function ReportAnIssueTopBar(): FCReturn {
-    if (previousFeedbackView === FeedbackView.PhaseBanner) {
+    if (previousFeedbackView === View.PhaseBanner) {
       return (
         <TitleAndCloseFeedbackHeader
           icon={WarningIcon}
@@ -212,10 +206,10 @@ const FeedbackComponent: React.FC = () => {
       <FeedbackWrapper>
         <FeedbackPhaseBanner
           handleFeedbackClick={() =>
-            handleFeedbackViewClick(FeedbackViewClickEvents.OpenTriage)
+            handleFeedbackViewClick(ClickEvents.OpenTriage)
           }
           handleReportAnIssueClick={() =>
-            handleFeedbackViewClick(FeedbackViewClickEvents.OpenReportAnIssue)
+            handleFeedbackViewClick(ClickEvents.OpenReportAnIssue)
           }
         />
       </FeedbackWrapper>
@@ -231,9 +225,7 @@ const FeedbackComponent: React.FC = () => {
             <FeedbackBody>
               <FeedbackOption
                 handleClick={() =>
-                  handleFeedbackViewClick(
-                    FeedbackViewClickEvents.OpenReportAnIssue,
-                  )
+                  handleFeedbackViewClick(ClickEvents.OpenReportAnIssue)
                 }
                 Icon={WarningIcon}
                 label="Issue"
@@ -241,9 +233,7 @@ const FeedbackComponent: React.FC = () => {
               />
               <FeedbackOption
                 handleClick={() =>
-                  handleFeedbackViewClick(
-                    FeedbackViewClickEvents.OpenShareAnIdea,
-                  )
+                  handleFeedbackViewClick(ClickEvents.OpenShareAnIdea)
                 }
                 Icon={LightbulbIcon}
                 label="Idea"
@@ -251,9 +241,7 @@ const FeedbackComponent: React.FC = () => {
               />
               <FeedbackOption
                 handleClick={() =>
-                  handleFeedbackViewClick(
-                    FeedbackViewClickEvents.OpenShareAComment,
-                  )
+                  handleFeedbackViewClick(ClickEvents.OpenShareAComment)
                 }
                 Icon={MoreHorizIcon}
                 label="Comment"
@@ -405,17 +393,17 @@ const FeedbackComponent: React.FC = () => {
 
   function Feedback(): FCReturn {
     switch (currentFeedbackView) {
-      case FeedbackView.PhaseBanner:
+      case View.PhaseBanner:
         return <FeedbackPhaseBannerView />;
-      case FeedbackView.FeedbackTriage:
+      case View.FeedbackTriage:
         return <FeedbackTriage />;
-      case FeedbackView.ReportAnIssue:
+      case View.ReportAnIssue:
         return <FeedbackReportAnIssue />;
-      case FeedbackView.ShareAnIdea:
+      case View.ShareAnIdea:
         return <FeedbackShareAnIdea />;
-      case FeedbackView.ShareAComment:
+      case View.ShareAComment:
         return <FeedbackShareAComment />;
-      case FeedbackView.ThanksForFeedback:
+      case View.ThanksForFeedback:
         return <FeedbackThanksForFeedback />;
     }
   }

--- a/editor.planx.uk/src/components/Feedback.tsx
+++ b/editor.planx.uk/src/components/Feedback.tsx
@@ -8,6 +8,7 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
+import SvgIcon from "@mui/material/SvgIcon";
 import Typography from "@mui/material/Typography";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
 import FeedbackPhaseBanner from "components/FeedbackPhaseBanner";
@@ -130,14 +131,14 @@ const FeedbackComponent: React.FC = () => {
 
   interface TitleAndCloseProps {
     title: string;
-    icon?: any;
+    Icon?: typeof SvgIcon;
   }
 
   function TitleAndCloseFeedbackHeader(props: TitleAndCloseProps): FCReturn {
     return (
       <FeedbackHeader>
         <FeedbackTitle>
-          {props.icon && <props.icon />}
+          {props.Icon && <props.Icon />}
           <Typography variant="h3" component="h2">
             {props.title}
           </Typography>
@@ -161,7 +162,7 @@ const FeedbackComponent: React.FC = () => {
     if (previousFeedbackView === "banner") {
       return (
         <TitleAndCloseFeedbackHeader
-          icon={WarningIcon}
+          Icon={WarningIcon}
           title="Report an issue"
         />
       );

--- a/editor.planx.uk/src/components/Feedback.tsx
+++ b/editor.planx.uk/src/components/Feedback.tsx
@@ -190,7 +190,7 @@ const FeedbackComponent: React.FC = () => {
     );
   }
 
-  function FeedbackTriage(): FCReturn {
+  function Triage(): FCReturn {
     return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
@@ -222,7 +222,7 @@ const FeedbackComponent: React.FC = () => {
     );
   }
 
-  function FeedbackReportAnIssue(): FCReturn {
+  function ReportAnIssue(): FCReturn {
     return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
@@ -267,7 +267,7 @@ const FeedbackComponent: React.FC = () => {
     );
   }
 
-  function FeedbackShareAnIdea(): FCReturn {
+  function ShareAnIdea(): FCReturn {
     return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
@@ -304,7 +304,7 @@ const FeedbackComponent: React.FC = () => {
     );
   }
 
-  function FeedbackShareAComment(): FCReturn {
+  function ShareAComment(): FCReturn {
     return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
@@ -341,7 +341,7 @@ const FeedbackComponent: React.FC = () => {
     );
   }
 
-  function FeedbackThanksForFeedback(): FCReturn {
+  function ThanksForFeedback(): FCReturn {
     return (
       <FeedbackWrapper>
         <Container maxWidth="contentWrap">
@@ -364,15 +364,15 @@ const FeedbackComponent: React.FC = () => {
       case "banner":
         return <FeedbackPhaseBannerView />;
       case "triage":
-        return <FeedbackTriage />;
+        return <Triage />;
       case "issue":
-        return <FeedbackReportAnIssue />;
+        return <ReportAnIssue />;
       case "idea":
-        return <FeedbackShareAnIdea />;
+        return <ShareAnIdea />;
       case "comment":
-        return <FeedbackShareAComment />;
+        return <ShareAComment />;
       case "thanks":
-        return <FeedbackThanksForFeedback />;
+        return <ThanksForFeedback />;
     }
   }
 

--- a/editor.planx.uk/src/components/FeedbackPhaseBanner.tsx
+++ b/editor.planx.uk/src/components/FeedbackPhaseBanner.tsx
@@ -43,7 +43,12 @@ const BetaFlag = styled(Box)(({ theme }) => ({
   },
 }));
 
-export default function FeedbackPhaseBanner(): FCReturn {
+interface Props {
+  handleFeedbackClick: () => void;
+  handleReportAnIssueClick: () => void;
+}
+
+export default function PhaseBanner(props: Props): FCReturn {
   return (
     <Root>
       <Container maxWidth="contentWrap">
@@ -71,11 +76,14 @@ export default function FeedbackPhaseBanner(): FCReturn {
               textAlign="left"
               mt="0.2em"
             >
-              This is a new service. Your <Link>feedback</Link> will help us
-              improve it.
+              This is a new service. Your{" "}
+              <Link onClick={() => props.handleFeedbackClick()}>feedback</Link>{" "}
+              will help us improve it.
             </Typography>
           </PhaseWrap>
-          <ReportButton>Report an issue with this page</ReportButton>
+          <ReportButton onClick={() => props.handleReportAnIssueClick()}>
+            Report an issue with this page
+          </ReportButton>
         </Inner>
       </Container>
     </Root>

--- a/editor.planx.uk/src/components/MoreInfoFeedback.tsx
+++ b/editor.planx.uk/src/components/MoreInfoFeedback.tsx
@@ -27,33 +27,24 @@ const FeedbackBody = styled(Box)(({ theme }) => ({
 }));
 
 const MoreInfoFeedbackComponent: React.FC = () => {
-  enum FeedbackView {
-    YesNo,
-    Input,
-    ThankYou,
-  }
+  type View = "yes/no" | "input" | "thanks";
 
-  enum FeedbackSentimentOption {
-    Yes,
-    No,
-  }
+  type Sentiment = "helpful" | "unhelpful";
 
-  const [currentFeedbackView, setCurrentFeedbackView] = useState(
-    FeedbackView.YesNo,
-  );
-  const [feedbackOption, setFeedbackOption] =
-    useState<FeedbackSentimentOption | null>(null);
+  const [currentFeedbackView, setCurrentFeedbackView] =
+    useState<View>("yes/no");
+  const [feedbackOption, setFeedbackOption] = useState<Sentiment | null>(null);
 
-  const handleFeedbackOptionClick = (event: FeedbackSentimentOption) => {
+  const handleFeedbackOptionClick = (event: Sentiment) => {
     switch (event) {
-      case FeedbackSentimentOption.Yes:
-        setCurrentFeedbackView(FeedbackView.Input);
-        setFeedbackOption(FeedbackSentimentOption.Yes);
+      case "helpful":
+        setCurrentFeedbackView("input");
+        setFeedbackOption("helpful");
         break;
 
-      case FeedbackSentimentOption.No:
-        setCurrentFeedbackView(FeedbackView.Input);
-        setFeedbackOption(FeedbackSentimentOption.No);
+      case "unhelpful":
+        setCurrentFeedbackView("input");
+        setFeedbackOption("unhelpful");
         break;
     }
   };
@@ -73,7 +64,7 @@ const MoreInfoFeedbackComponent: React.FC = () => {
     console.log("The user inputs", formDataPayload);
     // Prep the form data payload?
 
-    setCurrentFeedbackView(FeedbackView.ThankYou);
+    setCurrentFeedbackView("thanks");
   };
 
   function FeedbackYesNo(): FCReturn {
@@ -85,17 +76,13 @@ const MoreInfoFeedbackComponent: React.FC = () => {
           </Typography>
           <FeedbackBody>
             <FeedbackOption
-              handleClick={() =>
-                handleFeedbackOptionClick(FeedbackSentimentOption.Yes)
-              }
+              handleClick={() => handleFeedbackOptionClick("helpful")}
               Icon={CheckCircleIcon}
               label="Yes"
               format="positive"
             />
             <FeedbackOption
-              handleClick={() =>
-                handleFeedbackOptionClick(FeedbackSentimentOption.No)
-              }
+              handleClick={() => handleFeedbackOptionClick("unhelpful")}
               Icon={CancelIcon}
               label="No"
               format="negative"
@@ -153,13 +140,13 @@ const MoreInfoFeedbackComponent: React.FC = () => {
 
   function MoreInfoFeedbackView(): FCReturn {
     switch (currentFeedbackView) {
-      case FeedbackView.YesNo:
+      case "yes/no":
         return <FeedbackYesNo />;
 
-      case FeedbackView.Input:
+      case "input":
         return <FeedbackInput />;
 
-      case FeedbackView.ThankYou:
+      case "thanks":
         return <FeedbackThankYou />;
     }
   }

--- a/editor.planx.uk/src/components/MoreInfoFeedback.tsx
+++ b/editor.planx.uk/src/components/MoreInfoFeedback.tsx
@@ -6,7 +6,7 @@ import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
-import React from "react";
+import React, { useState } from "react";
 import FeedbackDisclaimer from "ui/public/FeedbackDisclaimer";
 import FeedbackOption from "ui/public/FeedbackOption";
 import Input from "ui/shared/Input";
@@ -27,8 +27,57 @@ const FeedbackBody = styled(Box)(({ theme }) => ({
 }));
 
 const MoreInfoFeedbackComponent: React.FC = () => {
-  return (
-    <>
+  enum FeedbackView {
+    YesNo,
+    Input,
+    ThankYou,
+  }
+
+  enum FeedbackSentimentOption {
+    Yes,
+    No,
+  }
+
+  const [currentFeedbackView, setCurrentFeedbackView] = useState(
+    FeedbackView.YesNo,
+  );
+  const [feedbackOption, setFeedbackOption] =
+    useState<FeedbackSentimentOption | null>(null);
+
+  const handleFeedbackOptionClick = (event: FeedbackSentimentOption) => {
+    switch (event) {
+      case FeedbackSentimentOption.Yes:
+        setCurrentFeedbackView(FeedbackView.Input);
+        setFeedbackOption(FeedbackSentimentOption.Yes);
+        break;
+
+      case FeedbackSentimentOption.No:
+        setCurrentFeedbackView(FeedbackView.Input);
+        setFeedbackOption(FeedbackSentimentOption.No);
+        break;
+    }
+  };
+
+  const handleFeedbackFormSubmit = (e: any) => {
+    e.preventDefault();
+
+    const formData = new FormData(e.target);
+    const formDataPayload: any = {};
+
+    for (const [key, value] of formData.entries()) {
+      formDataPayload[key] = value;
+    }
+
+    console.log("The users selection", feedbackOption);
+
+    console.log("The user inputs", formDataPayload);
+    // Prep the form data payload?
+
+    setCurrentFeedbackView(FeedbackView.ThankYou);
+  };
+
+  function FeedbackYesNo(): FCReturn {
+    return (
       <MoreInfoFeedback>
         <Container maxWidth={false}>
           <Typography variant="h4" component="h3" gutterBottom>
@@ -36,32 +85,56 @@ const MoreInfoFeedbackComponent: React.FC = () => {
           </Typography>
           <FeedbackBody>
             <FeedbackOption
+              handleClick={() =>
+                handleFeedbackOptionClick(FeedbackSentimentOption.Yes)
+              }
               Icon={CheckCircleIcon}
               label="Yes"
               format="positive"
             />
-            <FeedbackOption Icon={CancelIcon} label="No" format="negative" />
+            <FeedbackOption
+              handleClick={() =>
+                handleFeedbackOptionClick(FeedbackSentimentOption.No)
+              }
+              Icon={CancelIcon}
+              label="No"
+              format="negative"
+            />
           </FeedbackBody>
         </Container>
       </MoreInfoFeedback>
+    );
+  }
 
+  function FeedbackInput(): FCReturn {
+    return (
       <MoreInfoFeedback>
         <Container maxWidth={false}>
           <Typography variant="h4" component="h3" gutterBottom>
             Please help us to improve this service by sharing feedback
           </Typography>
           <FeedbackBody>
-            <form>
-              <Input multiline bordered aria-describedby="comment-title" />
+            <form onSubmit={(e) => handleFeedbackFormSubmit(e)}>
+              <Input
+                name="userComment"
+                required
+                multiline
+                bordered
+                aria-describedby="comment-title"
+              />
               <FeedbackDisclaimer />
-              <Button variant="contained" sx={{ marginTop: 2.5 }}>
+              <Button type="submit" variant="contained" sx={{ marginTop: 2.5 }}>
                 Send feedback
               </Button>
             </form>
           </FeedbackBody>
         </Container>
       </MoreInfoFeedback>
+    );
+  }
 
+  function FeedbackThankYou(): FCReturn {
+    return (
       <MoreInfoFeedback>
         <Container maxWidth={false}>
           <Typography variant="h4" component="h3" gutterBottom>
@@ -75,8 +148,23 @@ const MoreInfoFeedbackComponent: React.FC = () => {
           </FeedbackBody>
         </Container>
       </MoreInfoFeedback>
-    </>
-  );
+    );
+  }
+
+  function MoreInfoFeedbackView(): FCReturn {
+    switch (currentFeedbackView) {
+      case FeedbackView.YesNo:
+        return <FeedbackYesNo />;
+
+      case FeedbackView.Input:
+        return <FeedbackInput />;
+
+      case FeedbackView.ThankYou:
+        return <FeedbackThankYou />;
+    }
+  }
+
+  return <MoreInfoFeedbackView />;
 };
 
 export default MoreInfoFeedbackComponent;

--- a/editor.planx.uk/src/components/MoreInfoFeedback.tsx
+++ b/editor.planx.uk/src/components/MoreInfoFeedback.tsx
@@ -76,13 +76,13 @@ const MoreInfoFeedbackComponent: React.FC = () => {
           </Typography>
           <FeedbackBody>
             <FeedbackOption
-              handleClick={() => handleFeedbackOptionClick("helpful")}
+              onClick={() => handleFeedbackOptionClick("helpful")}
               Icon={CheckCircleIcon}
               label="Yes"
               format="positive"
             />
             <FeedbackOption
-              handleClick={() => handleFeedbackOptionClick("unhelpful")}
+              onClick={() => handleFeedbackOptionClick("unhelpful")}
               Icon={CancelIcon}
               label="No"
               format="negative"

--- a/editor.planx.uk/src/ui/public/FeedbackOption.tsx
+++ b/editor.planx.uk/src/ui/public/FeedbackOption.tsx
@@ -10,6 +10,7 @@ interface Props {
   Icon?: typeof SvgIcon;
   showArrow?: boolean;
   format?: "positive" | "negative";
+  handleClick: () => void;
 }
 
 const Root = styled(Button, {
@@ -61,7 +62,7 @@ const ArrowButton = styled("span")(({ theme }) => ({
 
 export default function FeedbackOption(props: Props): FCReturn {
   return (
-    <Root {...props}>
+    <Root onClick={() => props.handleClick()} {...props}>
       {props.Icon && (
         <Icon className="buttonIcon">
           <props.Icon />

--- a/editor.planx.uk/src/ui/public/FeedbackOption.tsx
+++ b/editor.planx.uk/src/ui/public/FeedbackOption.tsx
@@ -10,7 +10,7 @@ interface Props {
   Icon?: typeof SvgIcon;
   showArrow?: boolean;
   format?: "positive" | "negative";
-  handleClick: () => void;
+  onClick: () => void;
 }
 
 const Root = styled(Button, {
@@ -62,7 +62,7 @@ const ArrowButton = styled("span")(({ theme }) => ({
 
 export default function FeedbackOption(props: Props): FCReturn {
   return (
-    <Root onClick={() => props.handleClick()} {...props}>
+    <Root {...props}>
       {props.Icon && (
         <Icon className="buttonIcon">
           <props.Icon />


### PR DESCRIPTION
## What

- Based on [Figma prototype](https://www.figma.com/proto/bnUUrsVRG6qPwDkTmVKACI/PlanX-Design?page-id=12766%3A9275&type=design&node-id=13794-32506&viewport=-1569%2C471%2C0.7&t=hHNmEtfB7iz7Lk6T-1&scaling=min-zoom&starting-point-node-id=13794%3A32506) conditionally render the new UI components
- Add dummy form submission methods and basic inout validation

## Why

- Sets up the paths for users to provide feedback
- Discrete chunk of work which can be tested / reviewed 

## Testing

- Testing link: https://2678.planx.pizza/testing/feedback-ui/unpublished
- As default no change to feedback banner
- As default no chance to the more info UI
- Toggle the feature `window.featureFlags.toggle("SHOW_INTERNAL_FEEDBACK")`
- Test the feedback banner behaviour works as per [Figma Prototype ](https://www.figma.com/proto/bnUUrsVRG6qPwDkTmVKACI/PlanX-Design?page-id=12766%3A9275&type=design&node-id=13794-32506&viewport=-1569%2C471%2C0.7&t=hHNmEtfB7iz7Lk6T-1&scaling=min-zoom&starting-point-node-id=13794%3A32506)
- Test the more info section works as per [Figma Prototype ](https://www.figma.com/proto/bnUUrsVRG6qPwDkTmVKACI/PlanX-Design?page-id=12766%3A9275&type=design&node-id=13794-32506&viewport=-1569%2C471%2C0.7&t=hHNmEtfB7iz7Lk6T-1&scaling=min-zoom&starting-point-node-id=13794%3A32506)

## Screen recording

https://github.com/theopensystemslab/planx-new/assets/36415632/333ffe93-e67c-4972-8e12-1403ee30e02d
