### PR TITLE
feat: Freeze rich text popover

### DIFF
--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -494,7 +494,11 @@ const RichTextInput: FC<Props> = (props) => {
       {editor && (
         <StyledBubbleMenu
           editor={editor}
-          tippyOptions={{ duration: 100 }}
+          tippyOptions={{
+            duration: 100,
+            // Hack to "stop" transition of BubbleMenu
+            moveTransition: "transform 600s"
+          }}
           className="bubble-menu"
         >
           {addingLink ? (


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1705661907092319 for context (OSL Slack)

This PR fixes the location of the rich text popover. A look through tiptap and tippy.js docs pointed at this solution which feels a little hacky but does the job!


https://github.com/theopensystemslab/planx-new/assets/20502206/6423b674-3619-4083-a6a0-c5683f1420f3

