### PR TITLE
chore: Update link to council design guide [skip pizza]

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
@@ -44,8 +44,12 @@ export const ButtonForm: React.FC<FormProps> = ({
             the selected colour (being either black or white).
           </InputDescription>
           <InputDescription>
-            <Link href="#">
-              See our guide for setting button colours (TODO)
+            <Link
+              href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              See our guide for setting button colours
             </Link>
           </InputDescription>
         </>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/FaviconForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/FaviconForm.tsx
@@ -46,7 +46,13 @@ export const FaviconForm: React.FC<FormProps> = ({
             32x32px and in .ico or .png format.
           </InputDescription>
           <InputDescription>
-            <Link href="#">See our guide for favicons (TODO)</Link>
+            <Link
+              href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              See our guide for favicons
+            </Link>
           </InputDescription>
         </>
       }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
@@ -53,8 +53,12 @@ export const TextLinkForm: React.FC<FormProps> = ({
             white ("#ffffff").
           </InputDescription>
           <InputDescription>
-            <Link href="#">
-              See our guide for setting text link colours (TODO)
+            <Link
+              href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              See our guide for setting text link colours
             </Link>
           </InputDescription>
         </>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
@@ -66,7 +66,11 @@ export const ThemeAndLogoForm: React.FC<FormProps> = ({
             (your theme colour) and have a transparent background.
           </InputDescription>
           <InputDescription>
-            <Link href="https://www.planx.uk">
+            <Link
+              href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               See our guide for setting theme colours and logos
             </Link>
           </InputDescription>


### PR DESCRIPTION
# What does this PR do?

Updates link provided in the design settings page to the correct guidance page on Notion.

https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193

This page has been updated to list instructions for button colour, text link colour and favicons. I shall be making a short guidance video to embed into this page.