### PR TITLE
feat: Only show "Team Settings" menu for users with `teamEditor` role

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -415,8 +415,14 @@ const EditorToolbar: React.FC<{
     setOpen(!open);
   };
 
+  const isFlowSettingsVisible =
+    route.data.flow && !route.data.flow && canUserEditTeam(team.slug);
+
   const isTeamSettingsVisible =
     route.data.team && !route.data.flow && canUserEditTeam(team.slug);
+
+  const isGlobalSettingsVisible =
+    !route.data.flow && !team.slug && user?.isPlatformAdmin;
 
   return (
     <>
@@ -507,7 +513,7 @@ const EditorToolbar: React.FC<{
             )}
 
             {/* Only show flow settings link if inside a flow route  */}
-            {route.data.flow && (
+            {isFlowSettingsVisible && (
               <MenuItem
                 onClick={() =>
                   navigate([rootFlowPath(true), "settings"].join("/"))
@@ -518,7 +524,7 @@ const EditorToolbar: React.FC<{
             )}
 
             {/* Only show global settings link from top-level admin view */}
-            {!route.data.flow && !team.slug && (
+            {isGlobalSettingsVisible && (
               <MenuItem onClick={() => navigate("/global-settings")}>
                 Global Settings
               </MenuItem>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -400,10 +400,11 @@ const EditorToolbar: React.FC<{
 }> = ({ headerRef, route }) => {
   const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
-  const [togglePreview, user, team] = useStore((state) => [
+  const [togglePreview, user, team, canUserEditTeam] = useStore((state) => [
     state.togglePreview,
     state.getUser(),
     state.getTeam(),
+    state.canUserEditTeam,
   ]);
 
   const handleClose = () => {
@@ -413,6 +414,9 @@ const EditorToolbar: React.FC<{
   const handleMenuToggle = () => {
     setOpen(!open);
   };
+
+  const isTeamSettingsVisible =
+    route.data.team && !route.data.flow && canUserEditTeam(team.slug);
 
   return (
     <>
@@ -496,7 +500,7 @@ const EditorToolbar: React.FC<{
             )}
 
             {/* Only show team settings link if inside a team route  */}
-            {route.data.team && !route.data.flow && (
+            {isTeamSettingsVisible && (
               <MenuItem onClick={() => navigate(`${rootTeamPath()}/settings`)}>
                 Team Settings
               </MenuItem>

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -1,6 +1,14 @@
 import gql from "graphql-tag";
 import { publicClient } from "lib/graphql";
-import { compose, mount, redirect, route, withData } from "navi";
+import {
+  compose,
+  map,
+  mount,
+  NotFoundError,
+  redirect,
+  route,
+  withData,
+} from "navi";
 import DataManagerSettings from "pages/FlowEditor/components/Settings/DataManagerSettings";
 import ServiceFlags from "pages/FlowEditor/components/Settings/ServiceFlags";
 import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
@@ -18,58 +26,66 @@ const flowSettingsRoutes = compose(
 
   mount({
     "/": redirect("./service"),
-    "/:tab": route(async (req) => {
-      const { data } = await publicClient.query({
-        query: gql`
-          query GetFlow($slug: String!, $team_slug: String!) {
-            flows(
-              limit: 1
-              where: {
-                slug: { _eq: $slug }
-                team: { slug: { _eq: $team_slug } }
+    "/:tab": map(async (req) => {
+      const isAuthorised = useStore.getState().canUserEditTeam(req.params.team);
+      if (!isAuthorised)
+        throw new NotFoundError(
+          `User does not have access to ${req.originalUrl}`,
+        );
+
+      return route(async (req) => {
+        const { data } = await publicClient.query({
+          query: gql`
+            query GetFlow($slug: String!, $team_slug: String!) {
+              flows(
+                limit: 1
+                where: {
+                  slug: { _eq: $slug }
+                  team: { slug: { _eq: $team_slug } }
+                }
+              ) {
+                id
+                settings
               }
-            ) {
-              id
-              settings
             }
-          }
-        `,
-        variables: {
-          slug: req.params.flow,
-          team_slug: req.params.team,
-        },
+          `,
+          variables: {
+            slug: req.params.flow,
+            team_slug: req.params.team,
+          },
+        });
+
+        const settings: FlowSettings = data.flows[0].settings;
+        useStore.getState().setFlowSettings(settings);
+
+        return {
+          title: makeTitle(
+            [req.params.team, req.params.flow, "Flow Settings"].join("/"),
+          ),
+          view: (
+            <Settings
+              currentTab={req.params.tab}
+              tabs={[
+                {
+                  name: "Service",
+                  route: "service",
+                  Component: ServiceSettings,
+                },
+                {
+                  name: "Service Flags",
+                  route: "flags",
+                  Component: ServiceFlags,
+                },
+                {
+                  name: "Data",
+                  route: "data-manager",
+                  Component: DataManagerSettings,
+                },
+              ]}
+            />
+          ),
+        };
       });
-
-      const settings: FlowSettings = data.flows[0].settings;
-      useStore.getState().setFlowSettings(settings);
-
-      return {
-        title: makeTitle(
-          [req.params.team, req.params.flow, "Flow Settings"].join("/"),
-        ),
-        view: (
-          <Settings
-            currentTab={req.params.tab}
-            tabs={[
-              {
-                name: "Service",
-                route: "service",
-                Component: ServiceSettings,
-              },
-              {
-                name: "Service Flags",
-                route: "flags",
-                Component: ServiceFlags,
-              },
-              {
-                name: "Data",
-                route: "data-manager",
-                Component: DataManagerSettings,
-              },
-            ]}
-          />
-        ),
-      };
     }),
   }),
 );

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -1,39 +1,56 @@
-import { compose, mount, redirect, route, withData } from "navi";
+import {
+  compose,
+  map,
+  mount,
+  NotFoundError,
+  redirect,
+  route,
+  withData,
+} from "navi";
 import DesignSettings from "pages/FlowEditor/components/Settings/DesignSettings";
 import TeamSettings from "pages/FlowEditor/components/Settings/TeamSettings";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import Settings from "../pages/FlowEditor/components/Settings";
 import { makeTitle } from "./utils";
 
-const flowSettingsRoutes = compose(
+const teamSettingsRoutes = compose(
   withData((req) => ({
     mountpath: req.mountpath,
   })),
 
   mount({
     "/": redirect("./team"),
-    "/:tab": route(async (req) => ({
-      title: makeTitle([req.params.team, "Team Settings"].join("/")),
-      view: (
-        <Settings
-          currentTab={req.params.tab}
-          tabs={[
-            {
-              name: "Team",
-              route: "team",
-              Component: TeamSettings,
-            },
-            {
-              name: "Design",
-              route: "design",
-              Component: DesignSettings,
-            },
-          ]}
-        />
-      ),
-    })),
+    "/:tab": map(async (req) => {
+      const isAuthorised = useStore.getState().canUserEditTeam(req.params.team);
+      if (!isAuthorised)
+        throw new NotFoundError(
+          `User does not have access to ${req.originalUrl}`,
+        );
+
+      return route(async (req) => ({
+        title: makeTitle([req.params.team, "Team Settings"].join("/")),
+        view: (
+          <Settings
+            currentTab={req.params.tab}
+            tabs={[
+              {
+                name: "Team",
+                route: "team",
+                Component: TeamSettings,
+              },
+              {
+                name: "Design",
+                route: "design",
+                Component: DesignSettings,
+              },
+            ]}
+          />
+        ),
+      }));
+    }),
   }),
 );
 
-export default flowSettingsRoutes;
+export default teamSettingsRoutes;

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1412,6 +1412,10 @@
 - table:
     name: team_themes
     schema: public
+  object_relationships:
+    - name: team
+      using:
+        foreign_key_constraint_on: team_id
   select_permissions:
     - role: api
       permission:
@@ -1481,7 +1485,14 @@
           - link_colour
           - logo
           - primary_colour
-        filter: {}
+        filter:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
         check: null
       comment: ""
 - table:


### PR DESCRIPTION
## What does this PR do?
 - Visually hides "Team Settings" menu for users who do not have the `teamEditor` or `platformAdmin` roles
   - Also handle "Global Settings" and "Flow Settings" displaying in the incorrect context
 - Adds route guard for `<team>/settings`
   - Also added a guard for `<team>/<flow>/settings` and `/global-setting` as these were previously missed
 - Correctly sets up Hasura permissions for the `teamEditor` role
 
 If we decide we want / need a `teamAdmin` role we can add one in future but this seems fine to me for the moment

**TeamEditor**
![image](https://github.com/theopensystemslab/planx-new/assets/20502206/a4dbb03c-69ed-46a2-8395-2ba88dc8beab)

**Not TeamEditor**
![image](https://github.com/theopensystemslab/planx-new/assets/20502206/e51cb54f-92f5-41fd-826e-12f843214af4)
