### PR TITLE
chore: account for title boundaries in document templates

### DIFF
--- a/api.planx.uk/modules/admin/session/html.ts
+++ b/api.planx.uk/modules/admin/session/html.ts
@@ -2,6 +2,7 @@ import { generateApplicationHTML } from "@opensystemslab/planx-core";
 import { $api } from "../../../client";
 import type { RequestHandler } from "express";
 import type { PlanXExportData } from "@opensystemslab/planx-core/types";
+import { DrawBoundaryUserAction } from "@opensystemslab/planx-core/dist/templates/html/map/Map";
 
 type HTMLExportHandler = RequestHandler<{ sessionId: string }, string>;
 
@@ -27,10 +28,14 @@ export const getHTMLExport: HTMLExportHandler = async (req, res, next) => {
     const boundingBox = session.data.passport.data[
       "property.boundary.site.buffered"
     ] as unknown as GeoJSON.Feature;
+    const userAction = session.data.passport.data?.[
+      "drawBoundary.action"
+    ] as unknown as DrawBoundaryUserAction | undefined;
 
     const html = generateApplicationHTML({
       planXExportData: responses as PlanXExportData[],
       boundingBox,
+      userAction,
     });
 
     res.header("Content-type", "text/html");
@@ -70,10 +75,14 @@ export const getRedactedHTMLExport: HTMLExportHandler = async (
     const boundingBox = session.data.passport.data[
       "property.boundary.site.buffered"
     ] as unknown as GeoJSON.Feature;
+    const userAction = session.data.passport.data?.[
+      "drawBoundary.action"
+    ] as unknown as DrawBoundaryUserAction | undefined;
 
     const html = generateApplicationHTML({
       planXExportData: redactedResponses as PlanXExportData[],
       boundingBox,
+      userAction,
     });
 
     res.header("Content-type", "text/html");

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -140,9 +140,11 @@ export async function buildSubmissionExportZip({
     });
 
     // generate and add an HTML boundary document for the submission to zip
+    const userAction = passport.data?.["drawBoundary.action"];
     const boundaryHTML = generateMapHTML({
       geojson,
       boundingBox,
+      userAction,
     });
     await zip.addFile({
       name: "LocationPlan.htm",

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -110,10 +110,12 @@ export async function buildSubmissionExportZip({
   }
 
   const boundingBox = passport.data["property.boundary.site.buffered"];
+  const userAction = passport.data?.["drawBoundary.action"];
   // generate and add an HTML overview document for the submission to zip
   const overviewHTML = generateApplicationHTML({
     planXExportData: responses as PlanXExportData[],
     boundingBox,
+    userAction,
   });
   await zip.addFile({
     name: "Overview.htm",
@@ -124,6 +126,7 @@ export async function buildSubmissionExportZip({
   const redactedOverviewHTML = generateApplicationHTML({
     planXExportData: redactedResponses as PlanXExportData[],
     boundingBox,
+    userAction,
   });
   await zip.addFile({
     name: "RedactedOverview.htm",
@@ -133,6 +136,7 @@ export async function buildSubmissionExportZip({
   // add an optional GeoJSON file to zip
   const geojson = passport?.data?.["property.boundary.site"];
   if (geojson) {
+    geojson["properties"]["planx_user_action"] = userAction;
     const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
     zip.addFile({
       name: "LocationPlanGeoJSON.geojson",
@@ -140,7 +144,6 @@ export async function buildSubmissionExportZip({
     });
 
     // generate and add an HTML boundary document for the submission to zip
-    const userAction = passport.data?.["drawBoundary.action"];
     const boundaryHTML = generateMapHTML({
       geojson,
       boundingBox,

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -136,7 +136,7 @@ export async function buildSubmissionExportZip({
   // add an optional GeoJSON file to zip
   const geojson = passport?.data?.["property.boundary.site"];
   if (geojson) {
-    geojson["properties"]["planx_user_action"] = userAction;
+    if (userAction) geojson["properties"]["planx_user_action"] = userAction;
     const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
     zip.addFile({
       name: "LocationPlanGeoJSON.geojson",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ab281d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9bf211f",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4b625d9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ab281d",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#0ab281d
-    version: github.com/theopensystemslab/planx-core/0ab281d
+    specifier: git+https://github.com/theopensystemslab/planx-core#9bf211f
+    version: github.com/theopensystemslab/planx-core/9bf211f
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8319,8 +8319,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/0ab281d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab281d}
+  github.com/theopensystemslab/planx-core/9bf211f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9bf211f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#4b625d9
-    version: github.com/theopensystemslab/planx-core/4b625d9
+    specifier: git+https://github.com/theopensystemslab/planx-core#0ab281d
+    version: github.com/theopensystemslab/planx-core/0ab281d
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -5595,8 +5595,8 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  /json-schema-to-typescript@13.1.1:
-    resolution: {integrity: sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==}
+  /json-schema-to-typescript@13.1.2:
+    resolution: {integrity: sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
@@ -6681,6 +6681,13 @@ packages:
     resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
+
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: false
 
   /pretty-format@23.6.0:
     resolution: {integrity: sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==}
@@ -8312,8 +8319,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/4b625d9:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4b625d9}
+  github.com/theopensystemslab/planx-core/0ab281d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab281d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -8332,7 +8339,7 @@ packages:
       fast-xml-parser: 4.3.3
       graphql: 16.8.1
       graphql-request: 6.1.0(graphql@16.8.1)
-      json-schema-to-typescript: 13.1.1
+      json-schema-to-typescript: 13.1.2
       lodash.capitalize: 4.2.1
       lodash.get: 4.4.2
       lodash.groupby: 4.6.0
@@ -8344,7 +8351,7 @@ packages:
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
       marked: 11.1.1
-      prettier: 3.1.1
+      prettier: 3.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       type-fest: 4.9.0

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4b625d9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ab281d",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ab281d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9bf211f",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#4b625d9
-    version: github.com/theopensystemslab/planx-core/4b625d9
+    specifier: git+https://github.com/theopensystemslab/planx-core#0ab281d
+    version: github.com/theopensystemslab/planx-core/0ab281d
   axios:
     specifier: ^1.6.0
     version: 1.6.5
@@ -1425,8 +1425,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: false
 
-  /fast-xml-parser@4.3.2:
-    resolution: {integrity: sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==}
+  /fast-xml-parser@4.3.3:
+    resolution: {integrity: sha512-coV/D1MhrShMvU6D0I+VAK3umz6hUaxxhL0yp/9RjfiYUfAv14rDhGQL+PLForhMdr0wq3PiV07WtkkNjJjNHg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -1744,8 +1744,8 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: false
 
-  /json-schema-to-typescript@13.1.1:
-    resolution: {integrity: sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==}
+  /json-schema-to-typescript@13.1.2:
+    resolution: {integrity: sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
@@ -2211,8 +2211,8 @@ packages:
     hasBin: true
     dev: false
 
-  /prettier@3.1.1:
-    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -2821,8 +2821,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/4b625d9:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4b625d9}
+  github.com/theopensystemslab/planx-core/0ab281d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab281d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2838,10 +2838,10 @@ packages:
       copyfiles: 2.4.1
       docx: 8.5.0
       eslint: 8.56.0
-      fast-xml-parser: 4.3.2
+      fast-xml-parser: 4.3.3
       graphql: 16.8.1
       graphql-request: 6.1.0(graphql@16.8.1)
-      json-schema-to-typescript: 13.1.1
+      json-schema-to-typescript: 13.1.2
       lodash.capitalize: 4.2.1
       lodash.get: 4.4.2
       lodash.groupby: 4.6.0
@@ -2853,7 +2853,7 @@ packages:
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
       marked: 11.1.1
-      prettier: 3.1.1
+      prettier: 3.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       type-fest: 4.9.0

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#0ab281d
-    version: github.com/theopensystemslab/planx-core/0ab281d
+    specifier: git+https://github.com/theopensystemslab/planx-core#9bf211f
+    version: github.com/theopensystemslab/planx-core/9bf211f
   axios:
     specifier: ^1.6.0
     version: 1.6.5
@@ -2821,8 +2821,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/0ab281d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab281d}
+  github.com/theopensystemslab/planx-core/9bf211f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9bf211f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4b625d9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9bf211f",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#4b625d9
-    version: github.com/theopensystemslab/planx-core/4b625d9
+    specifier: git+https://github.com/theopensystemslab/planx-core#9bf211f
+    version: github.com/theopensystemslab/planx-core/9bf211f
   axios:
     specifier: ^1.6.2
     version: 1.6.5
@@ -1274,8 +1274,8 @@ packages:
       punycode: 1.4.1
     dev: false
 
-  /fast-xml-parser@4.3.2:
-    resolution: {integrity: sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==}
+  /fast-xml-parser@4.3.3:
+    resolution: {integrity: sha512-coV/D1MhrShMvU6D0I+VAK3umz6hUaxxhL0yp/9RjfiYUfAv14rDhGQL+PLForhMdr0wq3PiV07WtkkNjJjNHg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -1579,8 +1579,8 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: false
 
-  /json-schema-to-typescript@13.1.1:
-    resolution: {integrity: sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==}
+  /json-schema-to-typescript@13.1.2:
+    resolution: {integrity: sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
@@ -2037,8 +2037,8 @@ packages:
     hasBin: true
     dev: false
 
-  /prettier@3.1.1:
-    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -2568,8 +2568,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/4b625d9:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4b625d9}
+  github.com/theopensystemslab/planx-core/9bf211f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9bf211f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2585,10 +2585,10 @@ packages:
       copyfiles: 2.4.1
       docx: 8.5.0
       eslint: 8.56.0
-      fast-xml-parser: 4.3.2
+      fast-xml-parser: 4.3.3
       graphql: 16.8.1
       graphql-request: 6.1.0(graphql@16.8.1)
-      json-schema-to-typescript: 13.1.1
+      json-schema-to-typescript: 13.1.2
       lodash.capitalize: 4.2.1
       lodash.get: 4.4.2
       lodash.groupby: 4.6.0
@@ -2600,7 +2600,7 @@ packages:
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
       marked: 11.1.1
-      prettier: 3.1.1
+      prettier: 3.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       type-fest: 4.9.0

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.7.9",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#4b625d9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ab281d",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.7.9",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ab281d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9bf211f",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.9
     version: 0.7.9
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#4b625d9
-    version: github.com/theopensystemslab/planx-core/4b625d9(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#0ab281d
+    version: github.com/theopensystemslab/planx-core/0ab281d(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -12075,8 +12075,8 @@ packages:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
     dev: false
 
-  /fast-xml-parser@4.3.2:
-    resolution: {integrity: sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==}
+  /fast-xml-parser@4.3.3:
+    resolution: {integrity: sha512-coV/D1MhrShMvU6D0I+VAK3umz6hUaxxhL0yp/9RjfiYUfAv14rDhGQL+PLForhMdr0wq3PiV07WtkkNjJjNHg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -14488,8 +14488,8 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  /json-schema-to-typescript@13.1.1:
-    resolution: {integrity: sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==}
+  /json-schema-to-typescript@13.1.2:
+    resolution: {integrity: sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
@@ -17062,8 +17062,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.1.1:
-    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -21153,9 +21153,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/4b625d9(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4b625d9}
-    id: github.com/theopensystemslab/planx-core/4b625d9
+  github.com/theopensystemslab/planx-core/0ab281d(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab281d}
+    id: github.com/theopensystemslab/planx-core/0ab281d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -21171,10 +21171,10 @@ packages:
       copyfiles: 2.4.1
       docx: 8.5.0
       eslint: 8.56.0
-      fast-xml-parser: 4.3.2
+      fast-xml-parser: 4.3.3
       graphql: 16.8.1
       graphql-request: 6.1.0(graphql@16.8.1)
-      json-schema-to-typescript: 13.1.1
+      json-schema-to-typescript: 13.1.2
       lodash.capitalize: 4.2.1
       lodash.get: 4.4.2
       lodash.groupby: 4.6.0
@@ -21186,7 +21186,7 @@ packages:
       lodash.set: 4.3.2
       lodash.startcase: 4.4.0
       marked: 11.1.1
-      prettier: 3.1.1
+      prettier: 3.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       type-fest: 4.9.0

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.7.9
     version: 0.7.9
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#0ab281d
-    version: github.com/theopensystemslab/planx-core/0ab281d(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#9bf211f
+    version: github.com/theopensystemslab/planx-core/9bf211f(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -21153,9 +21153,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/0ab281d(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab281d}
-    id: github.com/theopensystemslab/planx-core/0ab281d
+  github.com/theopensystemslab/planx-core/9bf211f(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9bf211f}
+    id: github.com/theopensystemslab/planx-core/9bf211f
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -126,7 +126,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
           drawType="Point"
           geojsonData={JSON.stringify(props?.boundary)}
           geojsonColor="#efefef"
-          geojsonBuffer="10"
+          geojsonBuffer={10}
           resetControlImage="trash"
           showScale
           showNorthArrow

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -411,7 +411,7 @@ function DrawBoundary(props: ComponentProps) {
               geojsonData={JSON.stringify(geodata)}
               geojsonColor="#ff0000"
               geojsonFill
-              geojsonBuffer="20"
+              geojsonBuffer={20}
               osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
               hideResetControl
               staticMode


### PR DESCRIPTION
See https://github.com/theopensystemslab/planx-core/pull/269

Not a blocker to merging public-facing aspects of title boundaries to production, but we do want to make sure any maps displayed on document templates in submission zips have proper attribution sooner than later.

To test:
- This small test flow sends to email devops@ https://2696.planx.pizza/testing/document-templates-test/preview - check the inbox for a recent existing submission or send your own
- In this example, each document should have correct attribution & clearly communiate that the user "Accepted the title boundary" - for visual maps this means a source line below the map & double OS licenses, and for .geojson this means a custom key `properties.planx_user_action` 