### PR TITLE
fix: Add bg colour to favicon `ImgInput` [skip pizza]

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/FaviconForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/FaviconForm.tsx
@@ -62,6 +62,7 @@ export const FaviconForm: React.FC<FormProps> = ({
           <InputRowItem width={formik.values.favicon ? 90 : 50}>
             <ImgInput
               img={formik.values.favicon || undefined}
+              backgroundColor={formik.values.primaryColour}
               onChange={updateFavicon}
               acceptedFileTypes={{
                 "image/png": [".png"],


### PR DESCRIPTION
Quick fix I noticed when watching @ianjon3s video!