### PR TITLE
fix: Post correct payload to `/download-application` endpoint

### DIFF
--- a/editor.planx.uk/src/ui/public/FileDownload.tsx
+++ b/editor.planx.uk/src/ui/public/FileDownload.tsx
@@ -17,7 +17,11 @@ const Root = styled(Box)(({ theme }) => ({
 }));
 
 // Render a button which lets the applicant download their application data as a CSV
-export default function FileDownload(props: Props): FCReturn {
+export default function FileDownload({
+  data,
+  filename,
+  text,
+}: Props): FCReturn {
   const downloadCsv = (filename: string, content: string) => {
     const csv = "data:text/csv;charset=utf-8," + content;
     const data = encodeURI(csv);
@@ -39,15 +43,15 @@ export default function FileDownload(props: Props): FCReturn {
               Accept: "application/json",
               "Content-Type": "application/json",
             },
-            body: JSON.stringify(props.data),
+            body: JSON.stringify({ data }),
           })
             .then((res) => res.text())
-            .then((data) => downloadCsv(props.filename, data))
+            .then((data) => downloadCsv(filename, data))
             .catch((error) => console.log(error));
         }}
       >
         <Typography variant="body2">
-          {props.text || "Download your application (.csv)"}
+          {text || "Download your application (.csv)"}
         </Typography>
       </Link>
     </Root>


### PR DESCRIPTION
## What's the problem?
- Issue raised by Stephen here - https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1706093472655149 (ODP Slack)
- Payload posted to `/download-application` endpoint does not match the definition set in the API (which expects a `data` key)
- This was introduced here and never caught / tested properly (sorry!) - https://github.com/theopensystemslab/planx-new/pull/2422

### To test 
- Start an application on a submission service on staging
- Save, then click "Download your application (.csv)"
- This will fail and return a 400 plus invalid CSV ❌ 
- Start an application on a submission service on Pizza
- Save, then click "Download your application (.csv)"
- This will return a 200 plus valid CSV ✅ 