### PR TITLE
feat: Add required fields for question and checklist options

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -63,7 +63,7 @@ const OptionEditor: React.FC<{
         ) : null}
         <InputRowItem width="50%">
           <Input
-            // required
+            required
             format="bold"
             value={props.value.data.text || ""}
             onChange={(ev) => {
@@ -155,6 +155,7 @@ const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
                 <Box display="flex" pb={1}>
                   <InputRow>
                     <Input
+                      required
                       format="bold"
                       name={`groupedOptions[${groupIndex}].title`}
                       value={groupedOption.title}

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -46,7 +46,7 @@ const OptionEditor: React.FC<{
       )}
       <InputRowItem width="100%">
         <Input
-          // required
+          required
           format="bold"
           value={props.value.data.text || ""}
           onChange={(ev) => {


### PR DESCRIPTION
# What does this PR do?

Previously August reported inconsistencies with how we require input for user-added fields in components.

The current behaviour for questions and checklists is that if an option is added and left blank it is deleted when the component is saved. The PR introduces required fields on user-added options for questions and checklists.

This brings it in line with the following components, which all require input on user-added fields:
- Next steps
- Upload + label
- Task list
- Confirmation (next steps)