### PR TITLE
fix: Safely assign geojson properties

### DIFF
--- a/api.planx.uk/modules/send/utils/exportZip.test.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.test.ts
@@ -109,7 +109,9 @@ describe("buildSubmissionExportZip", () => {
           ],
         ],
       },
-      properties: null,
+      properties: {
+        planx_user_action: "Amended the title boundary",
+      },
     };
     const expectedBuffer = Buffer.from(JSON.stringify(geojson, null, 2));
     await buildSubmissionExportZip({ sessionId: "1234" });

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -134,9 +134,13 @@ export async function buildSubmissionExportZip({
   });
 
   // add an optional GeoJSON file to zip
-  const geojson = passport?.data?.["property.boundary.site"];
+  const geojson: GeoJSON.Feature | undefined =
+    passport?.data?.["property.boundary.site"];
   if (geojson) {
-    if (userAction) geojson["properties"]["planx_user_action"] = userAction;
+    if (userAction) {
+      geojson["properties"] ??= {};
+      geojson["properties"]["planx_user_action"] = userAction;
+    }
     const geoBuff = Buffer.from(JSON.stringify(geojson, null, 2));
     zip.addFile({
       name: "LocationPlanGeoJSON.geojson",

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -37,6 +37,7 @@ export const mockLowcalSession: LowCalSession = {
         _address: {
           single_line_address: "1 High Street",
         },
+        "drawBoundary.action": "Amended the title boundary",
         "proposal.projectType": ["new.office"],
         "property.boundary.site": {
           type: "Feature",


### PR DESCRIPTION
## What does this PR do?
- Fixes bug with GeoJSON generation reported here - https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1706259470167559 (ODP Slack)
- Handles the `properties` of GeoJSON object being `null`
- Ensure unit tests pick up this logical branch by adding `drawBoundary.action` to mock data
