### PR TITLE
fix: logical error with assigning gov pay secret

### DIFF
--- a/infrastructure/application/utils/generateTeamSecrets.ts
+++ b/infrastructure/application/utils/generateTeamSecrets.ts
@@ -39,7 +39,7 @@ export const generateTeamSecrets = (
         });
         break;
       case "production":
-        if (!team.govPayStagingOnly) {
+        if (!team?.govPayStagingOnly) {
           secrets.push({
             name: `GOV_UK_PAY_TOKEN_${name(team.name)}`,
             value: config.require(`gov-uk-pay-token-${value(team.name)}`),

--- a/infrastructure/application/utils/generateTeamSecrets.ts
+++ b/infrastructure/application/utils/generateTeamSecrets.ts
@@ -25,15 +25,27 @@ export const generateTeamSecrets = (
 ): awsx.ecs.KeyValuePair[] => {
   const secrets: awsx.ecs.KeyValuePair[] = [];
   teams.forEach((team) => {
-    if ((team?.govPayStagingOnly && env !== "production") || !team?.govPayStagingOnly) {
-      secrets.push({
-        name: `GOV_UK_PAY_TOKEN_${name(team.name)}`,
-        value:
-          env === "sandbox"
-            ? "sandbox"
-            : config.require(`gov-uk-pay-token-${value(team.name)}`),
-      });
-    }
+    switch(env) {
+      case "sandbox":
+        secrets.push({
+          name: `GOV_UK_PAY_TOKEN_${name(team.name)}`,
+          value: "sandbox"
+        });
+        break;
+      case "staging":
+        secrets.push({
+          name: `GOV_UK_PAY_TOKEN_${name(team.name)}`,
+          value: config.require(`gov-uk-pay-token-${value(team.name)}`),
+        });
+        break;
+      case "production":
+        if (!team.govPayStagingOnly) {
+          secrets.push({
+            name: `GOV_UK_PAY_TOKEN_${name(team.name)}`,
+            value: config.require(`gov-uk-pay-token-${value(team.name)}`),
+          });
+        }
+    };
     team.uniformInstances?.forEach((instance) => {
       secrets.push({
         name: `UNIFORM_CLIENT_${name(instance)}`,

--- a/infrastructure/application/utils/generateTeamSecrets.ts
+++ b/infrastructure/application/utils/generateTeamSecrets.ts
@@ -25,7 +25,7 @@ export const generateTeamSecrets = (
 ): awsx.ecs.KeyValuePair[] => {
   const secrets: awsx.ecs.KeyValuePair[] = [];
   teams.forEach((team) => {
-    if (team?.govPayStagingOnly && env !== "production") {
+    if ((team?.govPayStagingOnly && env !== "production") || !team?.govPayStagingOnly) {
       secrets.push({
         name: `GOV_UK_PAY_TOKEN_${name(team.name)}`,
         value:


### PR DESCRIPTION
Assign the gov pay uk secret in every instance other than `goPayUkStagingOnly && env === "production"`