### PR TITLE
feat: scroll to feedback view on view change

### DIFF
--- a/editor.planx.uk/src/components/Feedback/MoreInfoFeedback.tsx
+++ b/editor.planx.uk/src/components/Feedback/MoreInfoFeedback.tsx
@@ -9,7 +9,7 @@ import {
   getInternalFeedbackMetadata,
   insertFeedbackMutation,
 } from "lib/feedback";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import FeedbackOption from "ui/public/FeedbackOption";
 
 import { FeedbackFormInput, UserFeedback } from ".";
@@ -36,6 +36,16 @@ const MoreInfoFeedbackComponent: React.FC = () => {
   const [currentFeedbackView, setCurrentFeedbackView] =
     useState<View>("yes/no");
   const [feedbackOption, setFeedbackOption] = useState<Sentiment | null>(null);
+  const feedbackComponentRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (currentFeedbackView === "input") {
+      feedbackComponentRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  }, [currentFeedbackView]);
 
   const handleFeedbackOptionClick = (event: Sentiment) => {
     switch (event) {
@@ -142,7 +152,11 @@ const MoreInfoFeedbackComponent: React.FC = () => {
     }
   }
 
-  return <MoreInfoFeedbackView />;
+  return (
+    <Box ref={feedbackComponentRef}>
+      <MoreInfoFeedbackView />
+    </Box>
+  );
 };
 
 export default MoreInfoFeedbackComponent;

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "lib/feedback";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { BackButton } from "pages/Preview/Questions";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { usePrevious } from "react-use";
 import FeedbackOption from "ui/public/FeedbackOption";
 
@@ -97,6 +97,17 @@ const Feedback: React.FC = () => {
       setCurrentFeedbackView("banner");
     }
   }, [breadcrumbs]);
+
+  const feedbackComponentRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (currentFeedbackView !== "banner" && currentFeedbackView !== "thanks") {
+      feedbackComponentRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  }, [currentFeedbackView]);
 
   function handleFeedbackViewClick(event: ClickEvents) {
     switch (event) {
@@ -364,7 +375,11 @@ const Feedback: React.FC = () => {
     }
   }
 
-  return <Feedback />;
+  return (
+    <div ref={feedbackComponentRef}>
+      <Feedback />
+    </div>
+  );
 };
 
 export default Feedback;

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -100,8 +100,19 @@ const Feedback: React.FC = () => {
 
   const feedbackComponentRef = useRef<HTMLDivElement | null>(null);
 
+  const shouldScrollToView = () => {
+    switch (currentFeedbackView) {
+      case "banner":
+        return false;
+      case "thanks":
+        return false;
+      default:
+        return true;
+    }
+  };
+
   useEffect(() => {
-    if (currentFeedbackView !== "banner" && currentFeedbackView !== "thanks") {
+    if (shouldScrollToView()) {
       feedbackComponentRef.current?.scrollIntoView({
         behavior: "smooth",
         block: "start",

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -376,9 +376,9 @@ const Feedback: React.FC = () => {
   }
 
   return (
-    <div ref={feedbackComponentRef}>
+    <Box ref={feedbackComponentRef}>
       <Feedback />
-    </div>
+    </Box>
   );
 };
 

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -103,7 +103,6 @@ const Feedback: React.FC = () => {
   const shouldScrollToView = () => {
     switch (currentFeedbackView) {
       case "banner":
-        return false;
       case "thanks":
         return false;
       default:


### PR DESCRIPTION
## What

Main Feedback:
- Add ref and useEffect to scroll down when it changes and isn't the "banner" or "thanks"

MoreInfo Feedback:
- Add ref and useEffect to scroll down when it changes is "input"

## Why

- When the currentFeedbackView changes the component can render partially off screen

## Risks

- This might have a negative impact on accessibility / usability?

## Screen recording

Before:

https://github.com/theopensystemslab/planx-new/assets/36415632/9ec4c454-b8c1-41e7-8bdd-adf20ae0e4bd

After:

https://github.com/theopensystemslab/planx-new/assets/36415632/bb9df931-e6c5-411f-9e38-eb9bd26cdbed

