### PR TITLE
feat: hook up granular Article 4 GIS variables for Barking & Dagenham

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -17,7 +17,9 @@ export interface LocalAuthorityMetadata {
   };
 }
 
+/** When a team publishes their granular Article 4 data, add them to this list */
 const localAuthorityMetadata: Record<string, LocalAuthorityMetadata> = {
+  barkingAndDagenham: require("./local_authorities/metadata/barkingAndDagenham"),
   barnet: require("./local_authorities/metadata/barnet"),
   birmingham: require("./local_authorities/metadata/birmingham"),
   buckinghamshire: require("./local_authorities/metadata/buckinghamshire"),

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/barkingAndDagenham.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/barkingAndDagenham.ts
@@ -1,0 +1,26 @@
+/*
+LAD20CD: E09000002
+LAD20NM: Barking and Dagenham
+LAD20NMW:
+FID:
+
+https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geometry_curie=statistical-geography%3AE09000002&entry_date_day=&entry_date_month=&entry_date_year=
+https://docs.google.com/spreadsheets/d/1UmxQ95SjU72j0KaVIIkrIfhdE_k_lcFNhUWBc53GEIA/edit#gid=0
+*/
+
+import { LocalAuthorityMetadata } from "../../digitalLand";
+
+const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
+  article4: {
+    // Planx granular values link to entity.reference on Planning Data
+    records: {
+      "article4.barkingAndDagenham.additionalStoreys.dagenhamVillage": "A4D01",
+      "article4.barkingAndDagenham.additionalStoreys.lymington": "A4D02",
+      "article4.barkingAndDagenham.becontree": "Proposed Becontree Design Guide Article 4",
+      // "article4.barkingAndDagenham.becontree.corners": "TBD",
+      "article4.barkingAndDagenham.hmo": "A4D03",
+    },
+  },
+};
+
+export { planningConstraints };

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/barkingAndDagenham.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/barkingAndDagenham.ts
@@ -16,7 +16,8 @@ const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
     records: {
       "article4.barkingAndDagenham.additionalStoreys.dagenhamVillage": "A4D01",
       "article4.barkingAndDagenham.additionalStoreys.lymington": "A4D02",
-      "article4.barkingAndDagenham.becontree": "Proposed Becontree Design Guide Article 4",
+      "article4.barkingAndDagenham.becontree":
+        "Proposed Becontree Design Guide Article 4",
       // "article4.barkingAndDagenham.becontree.corners": "TBD",
       "article4.barkingAndDagenham.hmo": "A4D03",
     },


### PR DESCRIPTION
Testing 
- From within B&G team on pizza, search an address in the Becontree estate area
- Proceed through constraints, confirm that if you've picked up a positive A4 intersection the granular A4 variables are set as expected (granular A4 variables will NOT be in passport if parent A4 intersection is false)