### PR TITLE
feat: add granular Listed Building grades to GIS responses

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -107,8 +107,9 @@ async function go(
   if (res && res.count > 0 && res.entities) {
     res.entities.forEach((entity: { dataset: any }) => {
       // get the planx variable that corresponds to this entity's 'dataset', should never be null because our initial request is filtered on 'dataset'
-      const key = Object.keys(baseSchema).find((key) =>
-        baseSchema[key]["digital-land-datasets"]?.includes(entity.dataset),
+      const key = Object.keys(baseSchema).find(
+        (key) =>
+          baseSchema[key]["digital-land-datasets"]?.includes(entity.dataset),
       );
       // because there can be many digital land datasets per planx variable, check if this key is already in our result
       if (key && Object.keys(formattedResult).includes(key)) {
@@ -170,7 +171,7 @@ async function go(
       formattedResult[broads] = { fn: broads, value: false };
   }
 
-  // FLOODING
+  // --- FLOODING ---
   if (formattedResult["flood"] && formattedResult["flood"].value) {
     ["flood.zone.1", "flood.zone.2", "flood.zone.3"].forEach(
       (zone) =>
@@ -186,7 +187,20 @@ async function go(
   }
 
   // --- LISTED BUILDINGS ---
-  // TODO add granular variables to reflect grade (eg `listed.grade1`), not reflected in content yet though
+  if (formattedResult["listed"] && formattedResult["listed"].value) {
+    ["listd.grade.I", "listed.grade.II", "listed.grade.II*"].forEach(
+      (grade) =>
+        (formattedResult[grade] = {
+          fn: grade,
+          value: Boolean(
+            formattedResult["listed"].data?.filter(
+              (entity) =>
+                entity["listed-building-grade"] === grade.split(".").pop(),
+            ).length,
+          ),
+        }),
+    );
+  }
 
   // --- ARTICLE 4S ---
   // only attempt to set granular a4s if we have metadata for this local authority; proceed with non-granular a4 queries under "opensystemslab" team etc
@@ -254,8 +268,11 @@ async function go(
     .then((responses) => {
       responses.forEach((response: any) => {
         // get the planx variable that corresponds to this 'dataset', should never be null because we only requested known datasets
-        const key = Object.keys(baseSchema).find((key) =>
-          baseSchema[key]["digital-land-datasets"]?.includes(response.dataset),
+        const key = Object.keys(baseSchema).find(
+          (key) =>
+            baseSchema[key]["digital-land-datasets"]?.includes(
+              response.dataset,
+            ),
         );
         if (key) metadata[key] = response;
       });


### PR DESCRIPTION
In cases where a Listed Building intersection is identified, add granular variables to reflect its' "grade": `listed.grade.I`, `listed.grade.II` or `listed.grade.II*`

API example endpoints for testing:
- Grade II only: `.../gis/southwark?geom=POLYGON+%28%28-0.07628999072266716+51.485963376950224%2C+-0.0763279585700623+51.48582963263951%2C+-0.07556375325646629+51.48576561328153%2C+-0.0755444474956225+51.48590221763399%2C+-0.07628999072266716+51.485963376950224%29%29&analytics=false`
- Grade I & II: `.../gis/southwark?geom=MULTIPOLYGON+%28%28%28-0.093153+51.486442%2C+-0.093132+51.486426%2C+-0.0931+51.486386%2C+-0.093107+51.486384%2C+-0.093094+51.486377%2C+-0.092932+51.486169%2C+-0.092913+51.486161%2C+-0.091762+51.486519%2C+-0.09175+51.486537%2C+-0.092086+51.487078%2C+-0.092533+51.486941%2C+-0.093019+51.486771%2C+-0.09301+51.48669%2C+-0.093051+51.486593%2C+-0.093102+51.486547%2C+-0.093188+51.486512%2C+-0.093137+51.486447%2C+-0.093153+51.486442%29%29%29&analytics=false`

