### PR TITLE
docs(api): Fix session param for `/create-send-events`

### DIFF
--- a/api.planx.uk/modules/send/docs.yaml
+++ b/api.planx.uk/modules/send/docs.yaml
@@ -112,7 +112,7 @@ paths:
                 - bops
                 - uniform
       parameters:
-        - in: query
+        - in: path
           name: sessionId
           required: true
           schema:


### PR DESCRIPTION
Quick docs issue I spotted whilst trying to submit something via the API.