### PR TITLE
chore: update DrawBoundary upload key from `proposal.drawing.locationPlan` to `locationPlan`

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -7,7 +7,7 @@ import DrawBoundary from "./";
 test("recovers previously submitted files when clicking the back button", async () => {
   const handleSubmit = jest.fn();
   const previouslySubmittedData = {
-    "proposal.drawing.locationPlan": [
+    "locationPlan": [
       {
         file: {
           path: "placeholder.png",

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -42,7 +42,7 @@ export const parseDrawBoundary = (
   definitionImg: data?.definitionImg || defaultContent?.["definitionImg"],
 });
 
-export const PASSPORT_UPLOAD_KEY = "proposal.drawing.locationPlan" as const; // not added to editor yet
+export const PASSPORT_UPLOAD_KEY = "locationPlan" as const; // not added to editor yet
 export const PASSPORT_COMPONENT_ACTION_KEY = "drawBoundary.action" as const; // internal use only
 
 // Default content as of Jan 2024 when title boundaries were introduced

--- a/editor.planx.uk/src/@planx/components/Review/Public/mocks/fileUpload.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/mocks/fileUpload.tsx
@@ -76,7 +76,7 @@ export const uploadedPlansBreadcrumb = {
   EO6DzPso8o: {
     auto: false,
     data: {
-      "proposal.drawing.locationPlan": [
+      locationPlan: [
         {
           file: {
             path: "fut.email.png",
@@ -113,7 +113,7 @@ export const uploadedPlansPassport = {
     "property.type": ["residential.dwelling.house.terrace"],
     "property.localAuthorityDistrict": ["Southwark"],
     "property.region": ["London"],
-    "proposal.drawing.locationPlan": [
+    locationPlan: [
       {
         file: {
           path: "fut.email.png",

--- a/editor.planx.uk/src/@planx/components/Send/bops/__tests__/files.test.ts
+++ b/editor.planx.uk/src/@planx/components/Send/bops/__tests__/files.test.ts
@@ -99,10 +99,10 @@ describe("It extracts tags for", () => {
     },
     "Location plan": {
       key:
-        PASSPORT_UPLOAD_KEY === "proposal.drawing.locationPlan"
+        PASSPORT_UPLOAD_KEY === "locationPlan"
           ? PASSPORT_UPLOAD_KEY
           : "key changed unexpectedly!",
-      tags: ["Proposed", /*"Drawing",*/ "Site", "Plan"],
+      tags: [/*"Proposed", "Drawing",*/ "Site", "Plan"],
     },
     "Existing site plan": {
       key: "property.drawing.sitePlan",


### PR DESCRIPTION
This one isn't exposed as editor props, so it'll be live across services as soon as it's merged ! We'll coordinate merge with other file key changes.

Related to https://github.com/theopensystemslab/planx-core/pull/289 & https://github.com/theopensystemslab/planx-data-migrations/pull/7

BOPS logic is repeated in the editor's `Send` component still for frontend CSV generation - I'll take a look at properly refactoring using the planx-core public client today so we don't have to repeat the same find-and-replace across the v1 tagging functions.