### PR TITLE
fix: correctly set granular Article 4 GIS keys for `barking-and-dagenham`

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -17,9 +17,9 @@ export interface LocalAuthorityMetadata {
   };
 }
 
-/** When a team publishes their granular Article 4 data, add them to this list */
+/** When a team publishes their granular Article 4 data, add them to this list. Key must match team slug */
 const localAuthorityMetadata: Record<string, LocalAuthorityMetadata> = {
-  barkingAndDagenham: require("./local_authorities/metadata/barkingAndDagenham"),
+  "barking-and-dagenham": require("./local_authorities/metadata/barkingAndDagenham"),
   barnet: require("./local_authorities/metadata/barnet"),
   birmingham: require("./local_authorities/metadata/birmingham"),
   buckinghamshire: require("./local_authorities/metadata/buckinghamshire"),


### PR DESCRIPTION
From https://opensystemslab.slack.com/archives/C5Q59R3HB/p1706874436756669

**Testing**
Before (only sets `article4`): https://api.editor.planx.dev/gis/barking-and-dagenham?geom=POLYGON+%28%280.13405814766883314+51.55540648395743%2C+0.13406082987784804+51.555344779619105%2C+0.13432636857032218+51.555348948833796%2C+0.13436526060103812+51.55534144424706%2C+0.13438671827315724+51.555358121104746%2C+0.1341748237609809+51.55547152357477%2C+0.13407692313193736+51.55540648395743%2C+0.13405814766883314+51.55540648395743%29%29&analytics=false

After (correctly sets granular variables): https://api.2760.planx.pizza/gis/barking-and-dagenham?geom=POLYGON+%28%280.13405814766883314+51.55540648395743%2C+0.13406082987784804+51.555344779619105%2C+0.13432636857032218+51.555348948833796%2C+0.13436526060103812+51.55534144424706%2C+0.13438671827315724+51.555358121104746%2C+0.1341748237609809+51.55547152357477%2C+0.13407692313193736+51.55540648395743%2C+0.13405814766883314+51.55540648395743%29%29&analytics=false