### PR TITLE
feat: add feedback_summary db view

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -253,6 +253,9 @@
     schema: public
   is_enum: true
 - table:
+    name: feedback_summary
+    schema: public
+- table:
     name: feedback_type_enum
     schema: public
   is_enum: true

--- a/hasura.planx.uk/migrations/1707234695689_create_view_feedback_summary/down.sql
+++ b/hasura.planx.uk/migrations/1707234695689_create_view_feedback_summary/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW public.feedback_summary CASCADE;

--- a/hasura.planx.uk/migrations/1707234695689_create_view_feedback_summary/up.sql
+++ b/hasura.planx.uk/migrations/1707234695689_create_view_feedback_summary/up.sql
@@ -20,10 +20,13 @@ SELECT
     published_flow_node.data ->> 'info' AS help_text,
     published_flow_node.data ->> 'policyRef' AS help_sources,
     published_flow_node.data ->> 'howMeasured' AS help_definition,
-    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'single_line_address') AS street_address,
-    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'uprn') AS UPRN,
+    COALESCE(
+        fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'single_line_address',
+        fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'title'
+    ) AS address,
+    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'uprn') AS uprn,
     (fb.user_data -> 'passport' -> 'data' ->> 'proposal.projectType') AS project_type,
-    (fb.user_data -> 'passport' -> 'data' ->> 'property.constraints.planning') AS constraints,
+    (fb.user_data -> 'passport' -> 'data' ->> 'property.constraints.planning') AS intersecting_constraints,
     published_flow_node.data AS node_data
 FROM 
     feedback fb

--- a/hasura.planx.uk/migrations/1707234695689_create_view_feedback_summary/up.sql
+++ b/hasura.planx.uk/migrations/1707234695689_create_view_feedback_summary/up.sql
@@ -1,0 +1,46 @@
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS
+SELECT 
+    fb.id AS feedback_id,
+    t.name AS team,
+    f.slug AS service_slug,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    COALESCE(
+        published_flow_node.data ->> 'title', 
+        published_flow_node.data ->> 'text', 
+        published_flow_node.data ->> 'flagSet'
+    ) AS node_title,
+    published_flow_node.data ->> 'description' AS node_text,
+    published_flow_node.data ->> 'info' AS help_text,
+    published_flow_node.data ->> 'policyRef' AS help_sources,
+    published_flow_node.data ->> 'howMeasured' AS help_definition,
+    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'single_line_address') AS street_address,
+    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'uprn') AS UPRN,
+    (fb.user_data -> 'passport' -> 'data' ->> 'proposal.projectType') AS project_type,
+    (fb.user_data -> 'passport' -> 'data' ->> 'property.constraints.planning') AS constraints,
+    published_flow_node.data AS node_data
+FROM 
+    feedback fb
+LEFT JOIN 
+    flows f ON f.id = fb.flow_id
+LEFT JOIN 
+    teams t ON t.id = fb.team_id
+LEFT JOIN LATERAL 
+    ( 
+        SELECT 
+            (published_flows.data -> fb.node_id) -> 'data' AS data
+        FROM 
+            published_flows
+        WHERE 
+            published_flows.flow_id = fb.flow_id 
+            AND published_flows.created_at < fb.created_at
+        ORDER BY 
+            published_flows.created_at DESC
+        LIMIT 1
+    ) AS published_flow_node ON true;


### PR DESCRIPTION
## What

- Adds a new db view called `feedback_summary` which displays the `feedback` data enriched with data pulled out from the `user_data` column and enriched with data extracted from the associated `published_flow`

## Why

- To provide a more human readable summary of the `feedback` table enriched with `published_flow` data and with the pertinent `user_data` extracted.

## Testing

- On the [pizza](https://2762.planx.pizza/) leave feedback on services: 
- Review the [feedback_summary](https://hasura.2762.planx.pizza/console/data/default/schema/public/views/feedback_summary/browse) and check the data extracted: 
- Where possible I've tried to give fallback `keys` for accessing things like the `node_title` but there might be more opportunities to account for situations where the node data is formatted differently

## What this PR doesn't do

### Capture Result Page Metadata 

- [Trello ticket](https://trello.com/c/Ojq2BzUj/2770-capture-result-metadata-in-internal-feedback-tool-view?completedInviteSignup=1)
- Feedback Fish adds the `resultData()` to the `componentMetadata` on the result page.
- Attempts were made to surface the result the user saw to capture similar data although this was deemed not to be feasible as it would required capturing the data at the point it was derived on the front end or replicating complex logic in the view. 
- The result data is a small subset of potential data so in discussion with @DafyddLlyr we opted to skip for now

### Capture "Report an Accuracy" type feedback

- [Trello ticket](https://trello.com/c/W8tbXnbX/2771-integrate-the-report-an-inaccuracy-type-feedback-into-new-feedback-tool)
- There are places where users have the opportunity to "Report an inaccuracy"  or "Is this information inaccurate? Tell us why"

<img width="740" alt="Screenshot 2024-02-06 at 16 25 38" src="https://github.com/theopensystemslab/planx-new/assets/36415632/70e877b4-a6f1-45bc-b424-1a2dcb573d67">

- This feedback is directly stored in the breadcrumbs

<img width="348" alt="Screenshot 2024-02-06 at 16 33 50" src="https://github.com/theopensystemslab/planx-new/assets/36415632/8ce8dc98-5b8f-4f20-ae28-dae1988f7f36">

- From discussion with @DafyddLlyr this is not a feature integrated with Feedback Fish so isn't required for feature parity.
- Integrating with the internal feedback feature could be a feature in the future 




