### PR TITLE
feat: Add `_requestedFiles` key to Passport

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -62,7 +62,7 @@ function Component(props: any) {
           </InputRow>
           <InputRow>
             <Input
-              // required
+              required
               format="data"
               name="fn"
               value={formik.values.fn}

--- a/editor.planx.uk/src/@planx/components/FileUpload/FileUpload.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/FileUpload.stories.tsx
@@ -16,6 +16,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Basic = {
   args: {
+    fn: "roofPlan",
     title: "Upload roof plan",
     description:
       "The plan should show the roof of the building as it looks today.",

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -23,12 +23,7 @@ test("recovers previously submitted files when clicking the back button", async 
   const uploadedFile = {
     data: {
       [dataField]: [dummyFile],
-      [PASSPORT_REQUESTED_FILES_KEY]: [
-        {
-          fn: dataField,
-          condition: "AlwaysRequired",
-        },
-      ],
+      [PASSPORT_REQUESTED_FILES_KEY]: [dataField],
     },
   };
 

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -23,7 +23,11 @@ test("recovers previously submitted files when clicking the back button", async 
   const uploadedFile = {
     data: {
       [dataField]: [dummyFile],
-      [PASSPORT_REQUESTED_FILES_KEY]: [dataField],
+      [PASSPORT_REQUESTED_FILES_KEY]: {
+        required: [dataField],
+        recommended: [],
+        optional: [],
+      },
     },
   };
 

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -8,7 +8,7 @@ import FileUpload from "./Public";
 test("renders correctly and blocks submit if there are no files added", async () => {
   const handleSubmit = jest.fn();
 
-  setup(<FileUpload handleSubmit={handleSubmit} />);
+  setup(<FileUpload fn="someKey" handleSubmit={handleSubmit} />);
 
   expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 
@@ -26,6 +26,7 @@ test("recovers previously submitted files when clicking the back button", async 
 
   const { user } = setup(
     <FileUpload
+      fn="someKey"
       id={componentId}
       handleSubmit={handleSubmit}
       previouslySubmittedData={uploadedFile}
@@ -85,6 +86,7 @@ it("should not have any accessibility violations", async () => {
 
   const { container } = setup(
     <FileUpload
+      fn="someKey"
       id={componentId}
       handleSubmit={handleSubmit}
       description="description"

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -3,6 +3,7 @@ import { uniqueId } from "lodash";
 import React from "react";
 import { axe, setup } from "testUtils";
 
+import { PASSPORT_REQUESTED_FILES_KEY } from "../FileUploadAndLabel/model";
 import FileUpload from "./Public";
 
 test("renders correctly and blocks submit if there are no files added", async () => {
@@ -18,33 +19,16 @@ test("renders correctly and blocks submit if there are no files added", async ()
 test("recovers previously submitted files when clicking the back button", async () => {
   const handleSubmit = jest.fn();
   const componentId = uniqueId();
-  const uploadedFile = {
-    data: {
-      [componentId]: [dummyFile],
-    },
-  };
-
-  const { user } = setup(
-    <FileUpload
-      fn="someKey"
-      id={componentId}
-      handleSubmit={handleSubmit}
-      previouslySubmittedData={uploadedFile}
-    />,
-  );
-
-  await user.click(screen.getByTestId("continue-button"));
-
-  expect(handleSubmit).toHaveBeenCalledWith(uploadedFile);
-});
-
-test("recovers previously submitted files when clicking the back button even if a data field is set", async () => {
-  const handleSubmit = jest.fn();
-  const componentId = uniqueId();
   const dataField = "data-field";
   const uploadedFile = {
     data: {
       [dataField]: [dummyFile],
+      [PASSPORT_REQUESTED_FILES_KEY]: [
+        {
+          fn: dataField,
+          condition: "AlwaysRequired",
+        },
+      ],
     },
   };
 

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -8,10 +8,7 @@ import { FileWithPath } from "react-dropzone";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { array } from "yup";
 
-import {
-  FileList,
-  PASSPORT_REQUESTED_FILES_KEY,
-} from "../FileUploadAndLabel/model";
+import { PASSPORT_REQUESTED_FILES_KEY } from "../FileUploadAndLabel/model";
 import { PrivateFileUpload } from "../shared/PrivateFileUpload/PrivateFileUpload";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -69,9 +69,17 @@ const FileUpload: React.FC<Props> = (props) => {
     );
 
   const updatedRequestedFiles = () => {
+    // const { required, recommended, optional } = useStore
+    //   .getState()
+    //   .requestedFiles();
+
     const { required, recommended, optional } = useStore
       .getState()
-      .requestedFiles();
+      .computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY] || {
+      required: [],
+      recommended: [],
+      optional: [],
+    };
 
     return {
       [PASSPORT_REQUESTED_FILES_KEY]: {

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -72,12 +72,9 @@ const FileUpload: React.FC<Props> = (props) => {
     );
 
   const updatedRequestedFiles = () => {
-    const emptyFileList = { required: [], recommended: [], optional: [] };
-
-    const { required, recommended, optional }: FileList =
-      useStore.getState().computePassport().data?.[
-        PASSPORT_REQUESTED_FILES_KEY
-      ] || emptyFileList;
+    const { required, recommended, optional } = useStore
+      .getState()
+      .requestedFiles();
 
     return {
       [PASSPORT_REQUESTED_FILES_KEY]: {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -660,23 +660,9 @@ describe("Submitting data", () => {
     const requestedFiles = submitted?.data?._requestedFiles;
 
     expect(requestedFiles).toBeDefined();
-    expect(requestedFiles).toHaveLength(3);
-    expect(requestedFiles).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          fn: "roofPlan",
-          condition: Condition.AlwaysRequired,
-        }),
-        expect.objectContaining({
-          fn: "heritage",
-          condition: Condition.AlwaysRecommended,
-        }),
-        expect.objectContaining({
-          fn: "utilityBill",
-          condition: Condition.NotRequired,
-        }),
-      ]),
-    );
+    expect(requestedFiles.required).toContain("roofPlan");
+    expect(requestedFiles.recommended).toContain("heritage");
+    expect(requestedFiles.optional).toContain("utilityBill");
   });
 
   it("appends to the list of existing requested files", async () => {
@@ -691,12 +677,11 @@ describe("Submitting data", () => {
               filename: "file.jpg",
             },
           ],
-          [PASSPORT_REQUESTED_FILES_KEY]: [
-            {
-              fn: "anotherFileType",
-              condition: Condition.AlwaysRequired,
-            },
-          ],
+          [PASSPORT_REQUESTED_FILES_KEY]: {
+            required: ["anotherFileType"],
+            recommended: [],
+            optional: [],
+          },
         },
       },
     };
@@ -750,28 +735,13 @@ describe("Submitting data", () => {
     const submitted = handleSubmit.mock.calls[0][0];
     const requestedFiles = submitted?.data?._requestedFiles;
 
-    expect(requestedFiles).toEqual(
-      expect.arrayContaining([
-        // Existing files from previous components
-        expect.objectContaining({
-          fn: "anotherFileType",
-          condition: Condition.AlwaysRequired,
-        }),
-        // Requested files from this component
-        expect.objectContaining({
-          fn: "roofPlan",
-          condition: Condition.AlwaysRequired,
-        }),
-        expect.objectContaining({
-          fn: "heritage",
-          condition: Condition.AlwaysRecommended,
-        }),
-        expect.objectContaining({
-          fn: "utilityBill",
-          condition: Condition.NotRequired,
-        }),
-      ]),
-    );
+    // Existing files from previous components
+    expect(requestedFiles.required).toContain("anotherFileType");
+
+    // Requested files from this component
+    expect(requestedFiles.required).toContain("roofPlan");
+    expect(requestedFiles.recommended).toContain("heritage");
+    expect(requestedFiles.optional).toContain("utilityBill");
   });
 });
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -1,10 +1,24 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import axios from "axios";
+import { vanillaStore } from "pages/FlowEditor/lib/store";
+import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { axe, setup } from "testUtils";
+import { Breadcrumbs } from "types";
 
 import { mockFileTypes, mockFileTypesUniqueKeys } from "./mocks";
+import { Condition, PASSPORT_REQUESTED_FILES_KEY } from "./model";
 import FileUploadAndLabelComponent from "./Public";
+
+const { getState, setState } = vanillaStore;
+let initialState: FullStore;
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -595,3 +609,195 @@ describe("Error handling", () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 });
+
+describe("Submitting data", () => {
+  beforeAll(() => (initialState = getState()));
+
+  afterEach(() => waitFor(() => setState(initialState)));
+
+  it("records the user uploaded files", async () => {
+    const handleSubmit = jest.fn();
+    const { user } = setup(
+      <FileUploadAndLabelComponent
+        title="Test title"
+        handleSubmit={handleSubmit}
+        fileTypes={mockFileTypesUniqueKeys}
+      />,
+    );
+
+    await uploadAndTagSingleFile(user);
+
+    await user.click(screen.getByText("Continue"));
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+
+    const submitted = handleSubmit.mock.calls[0][0];
+    const uploadedFile = submitted?.data?.roofPlan;
+
+    expect(uploadedFile).toBeDefined();
+    expect(uploadedFile).toHaveLength(1);
+    expect(uploadedFile[0]).toEqual(
+      expect.objectContaining({
+        filename: "test1.png",
+        url: "https://api.editor.planx.dev/file/private/gws7l5d1/test1.jpg",
+      }),
+    );
+  });
+
+  it("records the full file type list presented to the user", async () => {
+    const handleSubmit = jest.fn();
+    const { user } = setup(
+      <FileUploadAndLabelComponent
+        title="Test title"
+        handleSubmit={handleSubmit}
+        fileTypes={mockFileTypesUniqueKeys}
+      />,
+    );
+
+    await uploadAndTagSingleFile(user);
+    await user.click(screen.getByText("Continue"));
+
+    const submitted = handleSubmit.mock.calls[0][0];
+    const requestedFiles = submitted?.data?._requestedFiles;
+
+    expect(requestedFiles).toBeDefined();
+    expect(requestedFiles).toHaveLength(3);
+    expect(requestedFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fn: "roofPlan",
+          condition: Condition.AlwaysRequired,
+        }),
+        expect.objectContaining({
+          fn: "heritage",
+          condition: Condition.AlwaysRecommended,
+        }),
+        expect.objectContaining({
+          fn: "utilityBill",
+          condition: Condition.NotRequired,
+        }),
+      ]),
+    );
+  });
+
+  it("appends to the list of existing requested files", async () => {
+    // Mimic having passed file upload / file upload and label component
+    const breadcrumbs: Breadcrumbs = {
+      previousFileUploadComponent: {
+        auto: false,
+        data: {
+          anotherFileType: [
+            {
+              url: "http://test.com/file.jpg",
+              filename: "file.jpg",
+            },
+          ],
+          [PASSPORT_REQUESTED_FILES_KEY]: [
+            {
+              fn: "anotherFileType",
+              condition: Condition.AlwaysRequired,
+            },
+          ],
+        },
+      },
+    };
+
+    const flow = {
+      _root: {
+        edges: ["previousFileUploadComponent", "currentComponent"],
+      },
+      previousFileUploadComponent: {
+        data: {
+          fn: "anotherFileType",
+          color: "#EFEFEF",
+        },
+        type: 140,
+      },
+      currentComponent: {
+        type: 145,
+        data: {
+          title: "Upload and label",
+          fileTypes: [
+            {
+              name: "Floor Plan",
+              fn: "floorPlan",
+              rule: {
+                condition: "AlwaysRequired",
+              },
+            },
+          ],
+          hideDropZone: false,
+        },
+      },
+    };
+
+    act(() => setState({ flow, breadcrumbs }));
+
+    const passport = useStore.getState().computePassport();
+    console.log({ passport });
+
+    const handleSubmit = jest.fn();
+    const { user } = setup(
+      <FileUploadAndLabelComponent
+        title="Test title"
+        handleSubmit={handleSubmit}
+        fileTypes={mockFileTypesUniqueKeys}
+      />,
+    );
+
+    await uploadAndTagSingleFile(user);
+    await user.click(screen.getByText("Continue"));
+
+    const submitted = handleSubmit.mock.calls[0][0];
+    const requestedFiles = submitted?.data?._requestedFiles;
+
+    expect(requestedFiles).toEqual(
+      expect.arrayContaining([
+        // Existing files from previous components
+        expect.objectContaining({
+          fn: "anotherFileType",
+          condition: Condition.AlwaysRequired,
+        }),
+        // Requested files from this component
+        expect.objectContaining({
+          fn: "roofPlan",
+          condition: Condition.AlwaysRequired,
+        }),
+        expect.objectContaining({
+          fn: "heritage",
+          condition: Condition.AlwaysRecommended,
+        }),
+        expect.objectContaining({
+          fn: "utilityBill",
+          condition: Condition.NotRequired,
+        }),
+      ]),
+    );
+  });
+});
+
+/**
+ * Test helper which steps through the process of uploading and labelling a file
+ * Does not contain assertations - relies on these happening in other, more granular, passing tests
+ */
+const uploadAndTagSingleFile = async (user: UserEvent) => {
+  mockedAxios.post.mockResolvedValueOnce({
+    data: {
+      fileType: "image/png",
+      fileUrl: "https://api.editor.planx.dev/file/private/gws7l5d1/test1.jpg",
+    },
+  });
+
+  const file1 = new File(["test1"], "test1.png", { type: "image/png" });
+  const input = screen.getByTestId("upload-input");
+  await user.upload(input, [file1]);
+
+  const fileTaggingModal = await within(document.body).findByTestId(
+    "file-tagging-dialog",
+  );
+
+  const selects = await within(document.body).findAllByTestId("select");
+  fireEvent.change(selects[0], { target: { value: "Roof plan" } });
+
+  const submitModalButton = await within(fileTaggingModal).findByText("Done");
+  user.click(submitModalButton);
+};

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -239,12 +239,9 @@ const hasSlots = (userFile: UserFile): userFile is UserFileWithSlots =>
   Boolean(userFile?.slots);
 
 const getUpdatedRequestedFiles = (fileList: FileList) => {
-  const emptyFileList = { required: [], recommended: [], optional: [] };
-
-  const { required, recommended, optional }: FileList =
-    useStore.getState().computePassport().data?.[
-      PASSPORT_REQUESTED_FILES_KEY
-    ] || emptyFileList;
+  const { required, recommended, optional } = useStore
+    .getState()
+    .requestedFiles();
 
   return {
     [PASSPORT_REQUESTED_FILES_KEY]: {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -227,11 +227,6 @@ const formatUserFiles = (userFile: UserFileWithSlots): FormattedUserFile[] =>
     },
   }));
 
-const formatRequestedFiles = ({
-  fn,
-  rule: { condition },
-}: FileType): RequestedFile => ({ fn, condition });
-
 /**
  * Type guard to coerce UserFile -> UserFileWithSlot
  */

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -234,9 +234,17 @@ const hasSlots = (userFile: UserFile): userFile is UserFileWithSlots =>
   Boolean(userFile?.slots);
 
 const getUpdatedRequestedFiles = (fileList: FileList) => {
+  // const { required, recommended, optional } = useStore
+  //   .getState()
+  //   .requestedFiles();
+
   const { required, recommended, optional } = useStore
     .getState()
-    .requestedFiles();
+    .computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY] || {
+    required: [],
+    recommended: [],
+    optional: [],
+  };
 
   return {
     [PASSPORT_REQUESTED_FILES_KEY]: {

--- a/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -41,7 +41,7 @@ export const makeData = <T>(
   props: any,
   value: T,
   overwriteKey?: string,
-): {} | { data: Record<string, T> } => {
+): Record<string, never> | { data: Record<string, T> } => {
   if (isEmpty(value)) return {};
   else
     return {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -8,6 +8,10 @@ import {
   DEFAULT_FLAG_CATEGORY,
   flatFlags,
 } from "@opensystemslab/planx-core/types";
+import {
+  FileList,
+  PASSPORT_REQUESTED_FILES_KEY,
+} from "@planx/components/FileUploadAndLabel/model";
 import { TYPES } from "@planx/components/types";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { logger } from "airbrake";
@@ -74,6 +78,7 @@ export interface PreviewStore extends Store.Store {
   path: ApplicationPath;
   saveToEmail?: string;
   overrideAnswer: (fn: string) => void;
+  requestedFiles: () => FileList;
 }
 
 export const previewStore: StateCreator<
@@ -631,6 +636,15 @@ export const previewStore: StateCreator<
     } else {
       throw new Error("overrideNodeId not found");
     }
+  },
+
+  requestedFiles: () => {
+    const { computePassport } = get();
+    const currentRequestedFiles =
+      computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY];
+    const emptyFileList = { required: [], recommended: [], optional: [] };
+
+    return currentRequestedFiles || emptyFileList;
   },
 });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -78,7 +78,7 @@ export interface PreviewStore extends Store.Store {
   path: ApplicationPath;
   saveToEmail?: string;
   overrideAnswer: (fn: string) => void;
-  requestedFiles: () => FileList;
+  // requestedFiles: () => FileList;
 }
 
 export const previewStore: StateCreator<
@@ -638,14 +638,15 @@ export const previewStore: StateCreator<
     }
   },
 
-  requestedFiles: () => {
-    const { computePassport } = get();
-    const currentRequestedFiles =
-      computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY];
-    const emptyFileList = { required: [], recommended: [], optional: [] };
+  // TODO: Fix this!
+  // requestedFiles: () => {
+  //   const { computePassport } = get();
+  //   const currentRequestedFiles =
+  //     computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY];
+  //   const emptyFileList = { required: [], recommended: [], optional: [] };
 
-    return currentRequestedFiles || emptyFileList;
-  },
+  //   return currentRequestedFiles || emptyFileList;
+  // },
 });
 
 const knownNots = (


### PR DESCRIPTION
Prior art - https://github.com/theopensystemslab/planx-new/pull/2755

## What does this PR do?
 - Adds a new passport variable - `_requestedFile`
 - Keeps this updated each time we pass through an Upload or UploadAndLabel component

To do 
 - More test coverage
 - Capture files uploaded via DrawBoundary