### PR TITLE
chore: remove feedback records which are beyond retention policy

### DIFF
--- a/api.planx.uk/helpers.test.ts
+++ b/api.planx.uk/helpers.test.ts
@@ -38,7 +38,7 @@ describe("getEnvironment function", () => {
 
   test("Development env", () => {
     process.env.NODE_ENV = "development";
-    expect(getFormattedEnvironment()).toBe("Development");
+    expect(getFormattedEnvironment()).toBe("Local");
   });
 });
 

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -247,6 +247,10 @@ const getFormattedEnvironment = (): string => {
     const pizzaNumber = new URL(process.env.API_URL_EXT!).href.split(".")[1];
     environment += ` ${pizzaNumber}`;
   }
+  // For readability redefine development as local for slack warnings
+  if (environment === "development") {
+    environment = "local";
+  }
   return capitalize(environment);
 };
 

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/mocks/queries.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/mocks/queries.ts
@@ -67,3 +67,13 @@ export const mockGetExpiredSessionIdsQuery = {
     lowcal_sessions: [{ id: "id1" }, { id: "id2" }, { id: "id3" }],
   },
 };
+
+export const mockDeleteFeedbackMutation = {
+  name: "DeleteFeedback",
+  matchOnVariables: false,
+  data: {
+    feedback: {
+      returning: mockIds,
+    },
+  },
+};

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
@@ -9,6 +9,7 @@ import {
   mockSanitiseUniformApplicationsMutation,
   mockGetExpiredSessionIdsQuery,
   mockDeletePaymentRequests,
+  mockDeleteFeedbackMutation,
 } from "./mocks/queries";
 import {
   deleteHasuraEventLogs,
@@ -23,6 +24,7 @@ import {
   deleteApplicationFiles,
   deletePaymentRequests,
   deleteHasuraScheduledEventsForSubmittedSessions,
+  deleteFeedback,
 } from "./operations";
 
 jest.mock("../../../../lib/hasura/schema");
@@ -141,6 +143,10 @@ describe("Data sanitation operations", () => {
       {
         operation: deletePaymentRequests,
         query: mockDeletePaymentRequests,
+      },
+      {
+        operation: deleteFeedback,
+        query: mockDeleteFeedbackMutation,
       },
     ];
 

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -248,6 +248,29 @@
           - user_context
           - user_data
       comment: Allow users who want to leave feedback on their experience to write to the table
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - team_id
+          - device
+          - user_data
+          - feedback_type
+          - node_id
+          - created_at
+          - flow_id
+          - node_type
+          - status
+          - user_comment
+          - user_context
+        filter: {}
+      comment: ""
+  delete_permissions:
+    - role: api
+      permission:
+        filter: {}
+      comment: ""
 - table:
     name: feedback_status_enum
     schema: public

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -252,18 +252,8 @@
     - role: api
       permission:
         columns:
-          - id
-          - team_id
-          - device
-          - user_data
-          - feedback_type
-          - node_id
           - created_at
-          - flow_id
-          - node_type
-          - status
-          - user_comment
-          - user_context
+          - id
         filter: {}
       comment: ""
   delete_permissions:

--- a/hasura.planx.uk/tests/feedback.test.js
+++ b/hasura.planx.uk/tests/feedback.test.js
@@ -80,12 +80,21 @@ describe("feedback", () => {
       i = await introspectAs("api");
     });
 
-    test("cannot query feedback", () => {
-      expect(i.queries).not.toContain("feedback");
+    test("can query feedback", () => {
+      expect(i.queries).toContain("feedback");
     });
 
-    test("cannot create, update, or delete teams", () => {
-      expect(i).toHaveNoMutationsFor("feedback");
+    test("cannot update feedback", () => {
+      expect(i.mutations).not.toContain("update_feedback");
+      expect(i.mutations).not.toContain("update_feedback_by_pk");
+    });
+
+    test("can delete feedback", async () => {
+      expect(i.mutations).toContain("delete_feedback");
+    });
+    
+    test("cannot insert feedback", async () => {
+      expect(i.mutations).not.toContain("insert_feedback");
     });
   });
 });


### PR DESCRIPTION
## What

- Delete `feedback` records which were created before the retention policy date
- Rename `development` -> `local` for Slack warnings

## Why

- `feedback` can contain personally identifiable information so needs to be sanitised or deleted
- Records older than 28 days are likely to have little value and wou;d already have been downloaded and processed
- The `development` name is easy to conflate with `staging` i.e. our `.dev` environment
- Renaming to `Local` explicits shows there's been a failure running sanitisation based on local environment

## Screenshot

Rename
<img width="356" alt="Screenshot 2024-02-08 at 16 36 18" src="https://github.com/theopensystemslab/planx-new/assets/36415632/9166ae54-48ac-462e-a9e1-a4898bf0e8fb">

## Testing

- Added `feedback` records and manually changed the dates in the hasura console
- When cron job triggered the expected records were deleted successfully