### PR TITLE
fix: Handle additional breadcrumb info in `SummaryList` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Public/mocks/fileUpload.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/mocks/fileUpload.tsx
@@ -1,3 +1,5 @@
+import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
+
 export const mockLink = "my-file.png";
 export const uploadedPlanUrl = "http://someurl.com/whjhnh65/plan.png";
 
@@ -10,6 +12,11 @@ export const fileUploadBreadcrumbs = {
           filename: "my-file.png",
         },
       ],
+      [PASSPORT_REQUESTED_FILES_KEY]: {
+        required: ["fileUpload"],
+        recommended: [],
+        optional: [],
+      },
     },
   },
 };
@@ -44,6 +51,11 @@ export const fileUploadPassport = {
         filename: "my-file.png",
       },
     ],
+    [PASSPORT_REQUESTED_FILES_KEY]: {
+      required: ["fileUpload"],
+      recommended: [],
+      optional: [],
+    },
   },
 };
 
@@ -88,6 +100,11 @@ export const uploadedPlansBreadcrumb = {
         },
       ],
     },
+    [PASSPORT_REQUESTED_FILES_KEY]: {
+      required: ["locationPlan"],
+      recommended: [],
+      optional: [],
+    },
   },
 };
 
@@ -124,6 +141,11 @@ export const uploadedPlansPassport = {
         url: uploadedPlanUrl,
       },
     ],
+    [PASSPORT_REQUESTED_FILES_KEY]: {
+      required: ["locationPlan"],
+      recommended: [],
+      optional: [],
+    },
   },
 };
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -4,6 +4,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
+import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
 import { TYPES } from "@planx/components/types";
 import format from "date-fns/format";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
@@ -493,6 +494,7 @@ function ContactInput(props: ComponentProps) {
 function FileUploadAndLabel(props: ComponentProps) {
   const userFiles = Object.entries(props?.userData?.data || {});
   const allFilenames: string[] = userFiles
+    .filter(([key]) => key !== PASSPORT_REQUESTED_FILES_KEY)
     .map(([_key, value]) => value.map((file: any) => file.filename))
     .flat();
   const uniqueFilenames = [...new Set(allFilenames)];


### PR DESCRIPTION
## What does this PR do?
 - Handles additional info in breadcrumbs for `FileUploadAndLabel` components added in #2763 when rendering `SummaryList` component
 - Updates tests