### PR TITLE
feat: Capture `_requestedFiles` from `DrawBoundary` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -3,6 +3,7 @@ import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import { FileUploadSlot } from "@planx/components/FileUpload/Public";
+import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
 import Card from "@planx/components/shared/Preview/Card";
 import {
   MapContainer,
@@ -134,6 +135,17 @@ export default function Component(props: Props) {
           newPassportData[PASSPORT_UPLOAD_KEY] = slots;
           newPassportData[PASSPORT_COMPONENT_ACTION_KEY] =
             DrawBoundaryUserAction.Upload;
+
+          // Track as requested file
+          const { required, recommended, optional } = passport.data?.[
+            PASSPORT_REQUESTED_FILES_KEY
+          ] || { required: [], recommended: [], optional: [] };
+
+          newPassportData[PASSPORT_REQUESTED_FILES_KEY] = {
+            required: [...required, PASSPORT_UPLOAD_KEY],
+            recommended,
+            optional,
+          };
         }
 
         props.handleSubmit?.({ data: { ...newPassportData } });

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -8,13 +8,13 @@ import {
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import axios from "axios";
 import { vanillaStore } from "pages/FlowEditor/lib/store";
-import { FullStore, useStore } from "pages/FlowEditor/lib/store";
+import { FullStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { axe, setup } from "testUtils";
 import { Breadcrumbs } from "types";
 
 import { mockFileTypes, mockFileTypesUniqueKeys } from "./mocks";
-import { Condition, PASSPORT_REQUESTED_FILES_KEY } from "./model";
+import { PASSPORT_REQUESTED_FILES_KEY } from "./model";
 import FileUploadAndLabelComponent from "./Public";
 
 const { getState, setState } = vanillaStore;
@@ -716,9 +716,6 @@ describe("Submitting data", () => {
     };
 
     act(() => setState({ flow, breadcrumbs }));
-
-    const passport = useStore.getState().computePassport();
-    console.log({ passport });
 
     const handleSubmit = jest.fn();
     const { user } = setup(


### PR DESCRIPTION
## What does this PR do?
 - Follow up to https://github.com/theopensystemslab/planx-new/pull/2763 which only handled `FileUpload` and `FileUploadAndLabel`
 - Adds uploaded files to `_requestedFiles` in Passport