### PR TITLE
feat: Move `requestedFiles()` to store

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -2,7 +2,7 @@ import { Breadcrumbs } from "@opensystemslab/planx-core/types";
 import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
 import { screen } from "@testing-library/react";
 import axios from "axios";
-import { useStore, vanillaStore } from "pages/FlowEditor/lib/store";
+import { vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import { axe, setup } from "testUtils";
@@ -341,9 +341,7 @@ test("appends to existing '_requestedFiles' value", async () => {
   );
 
   // Check current passport setup
-  const passport = getState().computePassport();
-  const existingRequestedFiles = passport.data?.[PASSPORT_REQUESTED_FILES_KEY];
-  expect(existingRequestedFiles).toBeDefined();
+  const existingRequestedFiles = getState().requestedFiles();
   expect(existingRequestedFiles).toMatchObject({
     required: ["floorPlan", "utilityBill"],
     recommended: ["elevations.existing"],

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -137,9 +137,9 @@ export default function Component(props: Props) {
             DrawBoundaryUserAction.Upload;
 
           // Track as requested file
-          const { required, recommended, optional } = passport.data?.[
-            PASSPORT_REQUESTED_FILES_KEY
-          ] || { required: [], recommended: [], optional: [] };
+          const { required, recommended, optional } = useStore
+            .getState()
+            .requestedFiles();
 
           newPassportData[PASSPORT_REQUESTED_FILES_KEY] = {
             required: [...required, PASSPORT_UPLOAD_KEY],

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -69,17 +69,9 @@ const FileUpload: React.FC<Props> = (props) => {
     );
 
   const updatedRequestedFiles = () => {
-    // const { required, recommended, optional } = useStore
-    //   .getState()
-    //   .requestedFiles();
-
     const { required, recommended, optional } = useStore
       .getState()
-      .computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY] || {
-      required: [],
-      recommended: [],
-      optional: [],
-    };
+      .requestedFiles();
 
     return {
       [PASSPORT_REQUESTED_FILES_KEY]: {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -234,17 +234,9 @@ const hasSlots = (userFile: UserFile): userFile is UserFileWithSlots =>
   Boolean(userFile?.slots);
 
 const getUpdatedRequestedFiles = (fileList: FileList) => {
-  // const { required, recommended, optional } = useStore
-  //   .getState()
-  //   .requestedFiles();
-
   const { required, recommended, optional } = useStore
     .getState()
-    .computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY] || {
-    required: [],
-    recommended: [],
-    optional: [],
-  };
+    .requestedFiles();
 
   return {
     [PASSPORT_REQUESTED_FILES_KEY]: {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -639,8 +639,13 @@ export const previewStore: StateCreator<
   },
 
   requestedFiles: () => {
+    // Importing PASSPORT_REQUESTED_FILES_KEY causes tests to fail - possible circular dependency issue?
+    // Repeating it here so find and replace still points to this hardcoded value
+    const PASSPORT_REQUESTED_FILES_KEY = "_requiredFiles";
+
     const { computePassport } = get();
-    const currentRequestedFiles = computePassport().data?._requestedFiles;
+    const currentRequestedFiles =
+      computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY];
     const emptyFileList = { required: [], recommended: [], optional: [] };
 
     return currentRequestedFiles || emptyFileList;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -78,7 +78,7 @@ export interface PreviewStore extends Store.Store {
   path: ApplicationPath;
   saveToEmail?: string;
   overrideAnswer: (fn: string) => void;
-  // requestedFiles: () => FileList;
+  requestedFiles: () => FileList;
 }
 
 export const previewStore: StateCreator<
@@ -638,15 +638,13 @@ export const previewStore: StateCreator<
     }
   },
 
-  // TODO: Fix this!
-  // requestedFiles: () => {
-  //   const { computePassport } = get();
-  //   const currentRequestedFiles =
-  //     computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY];
-  //   const emptyFileList = { required: [], recommended: [], optional: [] };
+  requestedFiles: () => {
+    const { computePassport } = get();
+    const currentRequestedFiles = computePassport().data?._requestedFiles;
+    const emptyFileList = { required: [], recommended: [], optional: [] };
 
-  //   return currentRequestedFiles || emptyFileList;
-  // },
+    return currentRequestedFiles || emptyFileList;
+  },
 });
 
 const knownNots = (

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -641,8 +641,7 @@ export const previewStore: StateCreator<
   requestedFiles: () => {
     // Importing PASSPORT_REQUESTED_FILES_KEY causes tests to fail - possible circular dependency issue?
     // Repeating it here so find and replace still points to this hardcoded value
-    const PASSPORT_REQUESTED_FILES_KEY = "_requiredFiles";
-
+    const PASSPORT_REQUESTED_FILES_KEY = "_requestedFiles";
     const { computePassport } = get();
     const currentRequestedFiles =
       computePassport().data?.[PASSPORT_REQUESTED_FILES_KEY];


### PR DESCRIPTION
## What does this PR do?
 - Moves fetching, and returning default values, to a single shared store function
 - Previous attempt in https://github.com/theopensystemslab/planx-new/commit/f74f9da68edbce7406260051b8eb297fb21722ae led mysteriously failing tests - see comment on code explaining how this is now fixed