### PR TITLE
feat: Reposition change button, add dialog on change

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -268,9 +268,9 @@ function SummaryList(props: SummaryListProps) {
         cancelText="No"
       >
         <Typography>
-          If you change this answer, you’ll need confirm all the other answers
-          after it. This is because a changed answer might mean we have new or
-          different questions to ask.
+          If you change this answer, you’ll need to confirm all the other
+          answers after it. This is because a changed answer might mean we have
+          new or different questions to ask.
           <br />
           <br />
           Are you sure you want to change your answer?

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -114,8 +114,6 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
     state.getSortedBreadcrumbsBySection,
   ]);
 
-  const { trackBackwardsNavigation } = useAnalyticsTracking();
-
   const isValidComponent = ([nodeId, userData]: BreadcrumbEntry) => {
     const node = props.flow[nodeId];
     const doesNodeExist = Boolean(props.flow[nodeId]);
@@ -160,11 +158,6 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
       .map(removeNonPresentationalNodes)
       .map((section) => section.map(makeSummaryBreadcrumb));
 
-    const handleChangeAnswer = (id: string) => {
-      trackBackwardsNavigation("change", id);
-      props.changeAnswer(id);
-    };
-
     return (
       <>
         {sectionsWithFilteredBreadcrumbs.map(
@@ -184,25 +177,13 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
                   >
                     {props.flow[`${Object.keys(sections[i])[0]}`]?.data?.title}
                   </Typography>
-                  <Link
-                    onClick={() =>
-                      handleChangeAnswer(filteredBreadcrumbs[0].nodeId)
-                    }
-                    component="button"
-                    fontSize="body1.fontSize"
-                  >
-                    Change
-                    <span style={visuallyHidden}>
-                      the answers in this section
-                    </span>
-                  </Link>
                 </Box>
                 <SummaryList
                   summaryBreadcrumbs={filteredBreadcrumbs}
                   flow={props.flow}
                   passport={props.passport}
                   changeAnswer={props.changeAnswer}
-                  showChangeButton={false}
+                  showChangeButton={props.showChangeButton}
                 />
               </React.Fragment>
             ),

--- a/editor.planx.uk/src/components/ConfirmationDialog.tsx
+++ b/editor.planx.uk/src/components/ConfirmationDialog.tsx
@@ -1,0 +1,54 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import React, { PropsWithChildren } from "react";
+
+export interface ConfirmationDialogProps {
+  open: boolean;
+  onClose: (isConfirmed: boolean) => void;
+  title: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export const ConfirmationDialog: React.FC<
+  PropsWithChildren<ConfirmationDialogProps>
+> = (props) => {
+  const {
+    onClose,
+    open,
+    children,
+    title,
+    confirmText = "Ok",
+    cancelText = "Cancel ",
+  } = props;
+
+  const onCancel = () => onClose(false);
+  const onConfirm = () => onClose(true);
+
+  return (
+    <Dialog
+      data-testid="confirmation-dialog"
+      PaperProps={{
+        sx: {
+          width: "100%",
+          maxWidth: (theme) => theme.breakpoints.values.md,
+          borderRadius: 0,
+          background: "#FFF",
+          margin: (theme) => theme.spacing(2),
+        },
+      }}
+      maxWidth="xl"
+      open={open}
+    >
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent dividers>{children}</DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel}>{cancelText}</Button>
+        <Button onClick={onConfirm}>{confirmText}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## What does this PR do?
 - Moves "change" button back to per-question, not per-section
 - Adds a MUI dialog to warn user of changes - please [see here](https://trello.com/c/Xap6HPg2/2654-on-the-result-page-move-change-button-to-be-by-the-section-rather-than-by-the-question-set-up-a-pop-up-warning-for-users-who-cli#comment-65c37821daecef2b370963a9) for context
 - Basic test coverage for confirm modal behaviour

https://github.com/theopensystemslab/planx-new/assets/20502206/3aa288b0-3167-4152-90e6-864f854da6e5


