### PR TITLE
chore: Move `hasPlanningData` value to `team_integrations` table

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#1959a5d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#1959a5d
-    version: github.com/theopensystemslab/planx-core/1959a5d
+    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
+    version: github.com/theopensystemslab/planx-core/b184ea9
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6655,6 +6655,13 @@ packages:
     resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
+
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: false
 
   /pretty-format@23.6.0:
     resolution: {integrity: sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==}
@@ -7855,13 +7862,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest@4.6.0:
-    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
+  /type-fest@4.10.2:
+    resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}
     engines: {node: '>=16'}
     dev: false
 
-  /type-fest@4.9.0:
-    resolution: {integrity: sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==}
+  /type-fest@4.6.0:
+    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
     engines: {node: '>=16'}
     dev: false
 
@@ -8285,8 +8292,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/1959a5d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1959a5d}
+  github.com/theopensystemslab/planx-core/b184ea9:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -8308,10 +8315,10 @@ packages:
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
       marked: 11.2.0
-      prettier: 3.2.4
+      prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.9.0
+      type-fest: 4.10.2
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/doc/how-to/how-to-setup-planning-constraints.md
+++ b/doc/how-to/how-to-setup-planning-constraints.md
@@ -8,7 +8,7 @@ Our /gis API sets the passport variable `article4` by default for _any_ entities
 ## Process ⚙️
 1. **Council** - Shares & publishes their data on planning.data.gov.uk
 
-2. **Planx** - Updates `teams.settings` jsonb database record on production with `{ "hasPlanningData": true }` to enable queries. This will automatically sync to staging on the next scheduled Github Action run, or you can kick it off manually.
+2. **Planx** - Updates `team_integrations.has_planning_data` record on production with `true` to enable queries. This will automatically sync to staging on the next scheduled Github Action run, or you can kick it off manually.
 
 (Note that it's common for councils to be ready to complete steps 1 & 2 well before steps 3-5; that's completely okay for testing, but all steps should be completed before a service "goes live".)
 

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#1959a5d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#1959a5d
-    version: github.com/theopensystemslab/planx-core/1959a5d
+    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
+    version: github.com/theopensystemslab/planx-core/b184ea9
   axios:
     specifier: ^1.6.0
     version: 1.6.5
@@ -2171,8 +2171,8 @@ packages:
     hasBin: true
     dev: false
 
-  /prettier@3.2.4:
-    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -2597,8 +2597,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /type-fest@4.9.0:
-    resolution: {integrity: sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==}
+  /type-fest@4.10.2:
+    resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/1959a5d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1959a5d}
+  github.com/theopensystemslab/planx-core/b184ea9:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2804,10 +2804,10 @@ packages:
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
       marked: 11.2.0
-      prettier: 3.2.4
+      prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.9.0
+      type-fest: 4.10.2
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#1959a5d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#1959a5d
-    version: github.com/theopensystemslab/planx-core/1959a5d
+    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
+    version: github.com/theopensystemslab/planx-core/b184ea9
   axios:
     specifier: ^1.6.2
     version: 1.6.5
@@ -1997,8 +1997,8 @@ packages:
     hasBin: true
     dev: false
 
-  /prettier@3.2.4:
-    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -2378,8 +2378,8 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /type-fest@4.9.0:
-    resolution: {integrity: sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==}
+  /type-fest@4.10.2:
+    resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2528,8 +2528,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/1959a5d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1959a5d}
+  github.com/theopensystemslab/planx-core/b184ea9:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2551,10 +2551,10 @@ packages:
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
       marked: 11.2.0
-      prettier: 3.2.4
+      prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.9.0
+      type-fest: 4.10.2
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/styles": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#1959a5d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.8.0
     version: 0.8.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#1959a5d
-    version: github.com/theopensystemslab/planx-core/1959a5d(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
+    version: github.com/theopensystemslab/planx-core/b184ea9(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -16966,8 +16966,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.2.4:
-    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -19915,6 +19915,11 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
+  /type-fest@4.10.2:
+    resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}
+    engines: {node: '>=16'}
+    dev: false
+
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -21074,9 +21079,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/1959a5d(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/1959a5d}
-    id: github.com/theopensystemslab/planx-core/1959a5d
+  github.com/theopensystemslab/planx-core/b184ea9(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
+    id: github.com/theopensystemslab/planx-core/b184ea9
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -21098,10 +21103,10 @@ packages:
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
       marked: 11.2.0
-      prettier: 3.2.4
+      prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.10.0
+      type-fest: 4.10.2
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -58,7 +58,7 @@ function Component(props: Props) {
   // Check if this team should query Planning Data (or continue to use custom GIS) and set URL params accordingly
   //   In future, Planning Data will theoretically support any UK address and this db setting won't be necessary, but data collection still limited to select councils!
   const hasPlanningData = useStore(
-    (state) => state.teamSettings?.hasPlanningData,
+    (state) => state.teamIntegrations?.hasPlanningData,
   );
 
   const digitalLandParams: Record<string, string> = {

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -16,6 +16,9 @@ const mockTeam1: Team = {
   id: 123,
   name: "Open Systems Lab",
   slug: "opensystemslab",
+  integrations: {
+    hasPlanningData: false,
+  },
   theme: {
     logo: "logo.jpg",
     primaryColour: "#0010A4",
@@ -29,6 +32,9 @@ const mockTeam2: Team = {
   id: 456,
   name: "Closed Systems Lab",
   slug: "closedsystemslab",
+  integrations: {
+    hasPlanningData: false,
+  },
   theme: {
     logo: null,
     primaryColour: "#0010A4",

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -415,14 +415,12 @@ const EditorToolbar: React.FC<{
     setOpen(!open);
   };
 
-  const isFlowSettingsVisible =
-    route.data.flow && canUserEditTeam(team.slug);
+  const isFlowSettingsVisible = route.data.flow && canUserEditTeam(team.slug);
 
   const isTeamSettingsVisible =
     route.data.team && !route.data.flow && canUserEditTeam(team.slug);
 
-  const isGlobalSettingsVisible =
-    !route.data.team && user?.isPlatformAdmin;
+  const isGlobalSettingsVisible = !route.data.team && user?.isPlatformAdmin;
 
   return (
     <>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -1,6 +1,7 @@
 import {
   NotifyPersonalisation,
   Team,
+  TeamIntegrations,
   TeamSettings,
   TeamTheme,
 } from "@opensystemslab/planx-core/types";
@@ -11,13 +12,14 @@ import type { StateCreator } from "zustand";
 import { SharedStore } from "./shared";
 
 export interface TeamStore {
+  boundaryBBox?: Team["boundaryBBox"];
+  notifyPersonalisation?: NotifyPersonalisation;
   teamId: number;
-  teamTheme: TeamTheme;
+  teamIntegrations: TeamIntegrations;
   teamName: string;
   teamSettings?: TeamSettings;
   teamSlug: string;
-  notifyPersonalisation?: NotifyPersonalisation;
-  boundaryBBox?: Team["boundaryBBox"];
+  teamTheme: TeamTheme;
 
   setTeam: (team: Team) => void;
   getTeam: () => Team;
@@ -33,23 +35,25 @@ export const teamStore: StateCreator<
   [],
   TeamStore
 > = (set, get) => ({
+  boundaryBBox: undefined,
+  notifyPersonalisation: undefined,
   teamId: 0,
-  teamTheme: {} as TeamTheme,
+  teamIntegrations: {} as TeamIntegrations,
   teamName: "",
   teamSettings: undefined,
   teamSlug: "",
-  notifyPersonalisation: undefined,
-  boundaryBBox: undefined,
+  teamTheme: {} as TeamTheme,
 
   setTeam: (team) => {
     set({
+      boundaryBBox: team.boundaryBBox,
+      notifyPersonalisation: team.notifyPersonalisation,
       teamId: team.id,
-      teamTheme: team.theme,
+      teamIntegrations: team.integrations,
       teamName: team.name,
       teamSettings: team.settings,
       teamSlug: team.slug,
-      notifyPersonalisation: team.notifyPersonalisation,
-      boundaryBBox: team.boundaryBBox,
+      teamTheme: team.theme,
     });
 
     if (team.theme?.favicon) {
@@ -59,13 +63,14 @@ export const teamStore: StateCreator<
   },
 
   getTeam: () => ({
-    id: get().teamId,
-    name: get().teamName,
-    slug: get().teamSlug,
-    settings: get().teamSettings,
-    theme: get().teamTheme,
-    notifyPersonalisation: get().notifyPersonalisation,
     boundaryBBox: get().boundaryBBox,
+    id: get().teamId,
+    integrations: get().teamIntegrations,
+    name: get().teamName,
+    notifyPersonalisation: get().notifyPersonalisation,
+    settings: get().teamSettings,
+    slug: get().teamSlug,
+    theme: get().teamTheme,
   }),
 
   initTeamStore: async (slug) => {
@@ -104,13 +109,14 @@ export const teamStore: StateCreator<
 
   clearTeamStore: () =>
     set({
+      boundaryBBox: undefined,
+      notifyPersonalisation: undefined,
       teamId: 0,
-      teamTheme: undefined,
+      teamIntegrations: undefined,
       teamName: "",
       teamSettings: undefined,
       teamSlug: "",
-      notifyPersonalisation: undefined,
-      boundaryBBox: undefined,
+      teamTheme: undefined,
     }),
 
   /**

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -80,6 +80,9 @@ const fetchDataForPublishedView = async (
               }
               name
               settings
+              integrations {
+                hasPlanningData: has_planning_data
+              }
               slug
               notifyPersonalisation: notify_personalisation
               boundaryBBox: boundary_bbox

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -68,6 +68,9 @@ const fetchDataForStandaloneView = async (
               }
               name
               settings
+              integrations {
+                hasPlanningData: has_planning_data
+              }
               slug
               notifyPersonalisation: notify_personalisation
               boundaryBBox: boundary_bbox

--- a/editor.planx.uk/src/routes/views/unpublished.tsx
+++ b/editor.planx.uk/src/routes/views/unpublished.tsx
@@ -71,6 +71,9 @@ const fetchDataForUnpublishedView = async (
               }
               name
               settings
+              integrations {
+                hasPlanningData: has_planning_data
+              }
               slug
               notifyPersonalisation: notify_personalisation
               boundaryBBox: boundary_bbox

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1360,6 +1360,7 @@
     - role: api
       permission:
         columns:
+          - has_planning_data
           - id
           - production_bops_secret
           - production_bops_submission_url
@@ -1367,6 +1368,14 @@
           - staging_bops_submission_url
           - team_id
         filter: {}
+    - role: public
+      permission:
+        columns:
+          - has_planning_data
+          - id
+          - team_id
+        filter: {}
+      comment: ""
 - table:
     name: team_members
     schema: public

--- a/hasura.planx.uk/migrations/1707730766728_alter_table_public_team_integrations_add_column_has_planning_data/down.sql
+++ b/hasura.planx.uk/migrations/1707730766728_alter_table_public_team_integrations_add_column_has_planning_data/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."team_integrations"."has_planning_data" is NULL;
+
+alter table "public"."team_integrations" drop column "has_planning_data";

--- a/hasura.planx.uk/migrations/1707730766728_alter_table_public_team_integrations_add_column_has_planning_data/up.sql
+++ b/hasura.planx.uk/migrations/1707730766728_alter_table_public_team_integrations_add_column_has_planning_data/up.sql
@@ -1,0 +1,9 @@
+alter table "public"."team_integrations" add column "has_planning_data" boolean
+ not null default 'false';
+
+comment on column "public"."team_integrations"."has_planning_data" is E'Indicates if team has GIS data set up on planning.data.gov . This controls if GIS queries are proxied to Planning Data, or our custom GIS endpoints.';
+
+UPDATE team_integrations
+SET has_planning_data = COALESCE((teams.settings->>'hasPlanningData')::boolean, false)
+FROM teams
+WHERE team_integrations.team_id = teams.id;

--- a/hasura.planx.uk/tests/team_integrations.test.js
+++ b/hasura.planx.uk/tests/team_integrations.test.js
@@ -8,7 +8,7 @@ describe("team_integrations", () => {
     });
 
     test("cannot query team_integrations", () => {
-      expect(i.queries).not.toContain("team_integrations");
+      expect(i.queries).toContain("team_integrations");
     });
 
     test("cannot create, update, or delete team_integrations", () => {


### PR DESCRIPTION
## What does this PR do?
 - Creates new publicly queryable `team_integrations.has_planning_data` column
 - Populates column with data from from `teams.settings-->"hasPlanningData"`
 - Updates frontend to read from new location
 - Note: `teams.settings-->"hasPlanningData"` value not removed / tidied up, we can maybe address this when we just stop the `team_settings` column?

## Data migration
On the Pizza, the following query can be made to get a list of all teams which have `has_planing_data` set to `true` - 

```sql
SELECT slug FROM teams
JOIN team_integrations
ON teams.id = team_integrations.team_id
WHERE has_planning_data
ORDER BY slug ASC;
```

This gives the following list which matches the previous value of the hardcoded [`digitalLandOrganisations`](https://github.com/theopensystemslab/planx-new/blame/a7065013d0a002c3a78e62577533ac9dcd79436e/editor.planx.uk/src/%40planx/components/PlanningConstraints/Public.tsx#L60-L74) (plus the recently added `tewkesbury`, `barking-and-dagenham` & `west-berkshire`).

```
barking-and-dagenham
barnet
birmingham
buckinghamshire
camden
canterbury
doncaster
gloucester
lambeth
medway
newcastle
opensystemslab
southwark
st-albans
tewkesbury
west-berkshire
```

## Testing
- On the Pizza I can query via Planning Data for the above teams
- On the Pizza I cannot query a team not on this list