### PR TITLE
fix: format Airbrake API errors for more readable Slack

### DIFF
--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -157,7 +157,7 @@ const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
       airbrake &&
       (errorObject instanceof Error || errorObject instanceof ServerError)
     ) {
-      airbrake.notify(errorObject);
+      airbrake.notify(JSON.stringify(errorObject, null, 2));
       return {
         ...errorObject,
         message: errorObject.message.concat(", this error has been logged"),


### PR DESCRIPTION
Context https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1707753609576929

Before:
![Screenshot from 2024-02-13 17-25-39](https://github.com/theopensystemslab/planx-new/assets/5132349/05450adc-ccd1-4f10-9dc4-f4b49e6bf129)

After:
Forgot that Airbrake won't log on pizzas, let's merge to staging & see ! 