### PR TITLE
feat: Add GovPay columns to `team_integrations` table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1365,8 +1365,10 @@
           - id
           - production_bops_secret
           - production_bops_submission_url
+          - production_govpay_secret
           - staging_bops_secret
           - staging_bops_submission_url
+          - staging_govpay_secret
           - team_id
         filter: {}
     - role: public

--- a/hasura.planx.uk/migrations/1707838555655_alter_table_public_team_integrations_add_column_staging_govpay_secret/down.sql
+++ b/hasura.planx.uk/migrations/1707838555655_alter_table_public_team_integrations_add_column_staging_govpay_secret/down.sql
@@ -1,0 +1,5 @@
+comment on column "public"."team_integrations"."staging_govpay_secret" is NULL;
+comment on column "public"."team_integrations"."production_govpay_secret" is NULL;
+
+ALTER table "public"."team_integrations" DROP COLUMN "staging_govpay_secret";
+ALTER table "public"."team_integrations" DROP COLUMN "production_govpay_secret";

--- a/hasura.planx.uk/migrations/1707838555655_alter_table_public_team_integrations_add_column_staging_govpay_secret/up.sql
+++ b/hasura.planx.uk/migrations/1707838555655_alter_table_public_team_integrations_add_column_staging_govpay_secret/up.sql
@@ -1,0 +1,9 @@
+alter table "public"."team_integrations" add column "staging_govpay_secret" text
+ null;
+
+comment on column "public"."team_integrations"."staging_govpay_secret" is E'Secret required for GovPay submissions in the format <TOKEN>:<INITIALIZATION_VECTOR>';
+
+alter table "public"."team_integrations" add column "production_govpay_secret" text
+ null;
+
+comment on column "public"."team_integrations"."production_govpay_secret" is E'Secret required for GovPay submission in the format <API_KEY>:<INITIALIZATION_VECTOR>';


### PR DESCRIPTION
## What does this PR do?
 - Follow on from https://github.com/theopensystemslab/planx-new/pull/2499 and https://github.com/theopensystemslab/planx-core/pull/212
 - Adds columns for GovPay secrets to `team_integrations` table
 - Does not read or use these secrets yet, this will be a follow on PR as the sequencing is a little tricky. Purposefully breaking this down into small atomic steps will hopefully make things a bit simpler.

## Next steps
- Populate columns with encrypted secrets (will be done once columns added to production)
- Update sync scripts to read new columns - https://github.com/theopensystemslab/planx-new/pull/2787
- Read and decrypt secrets using `planx-core`. PR here - https://github.com/theopensystemslab/planx-core/pull/303
- Remove env vars
- Work out how to inject secrets into e2e tests
