### PR TITLE
chore: Sync govpay secrets

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -35,7 +35,7 @@ done
 
 # Copy subset of team_integrations columns
 # Do not copy production values
-psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
 echo team_integrations downloaded
 
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"

--- a/scripts/seed-database/write/team_integrations.sql
+++ b/scripts/seed-database/write/team_integrations.sql
@@ -4,19 +4,21 @@ CREATE TEMPORARY TABLE sync_team_integrations (
   team_id integer,
   staging_bops_submission_url text,
   staging_bops_secret text,
-  has_planning_data boolean
+  has_planning_data boolean,
+  staging_govpay_secret text
 );
 
 \COPY sync_team_integrations FROM '/tmp/team_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
-  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data)
+  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret)
 SELECT
   id,
   team_id,
   staging_bops_submission_url,
   staging_bops_secret,
-  has_planning_data
+  has_planning_data,
+  staging_govpay_secret
 FROM
   sync_team_integrations ON CONFLICT (id) DO
 UPDATE
@@ -24,7 +26,8 @@ SET
   team_id = EXCLUDED.team_id,
   staging_bops_submission_url = EXCLUDED.staging_bops_submission_url,
   staging_bops_secret = EXCLUDED.staging_bops_secret,
-  has_planning_data = EXCLUDED.has_planning_data;
+  has_planning_data = EXCLUDED.has_planning_data,
+  staging_govpay_secret = EXCLUDED.staging_govpay_secret;
 SELECT
   setval('team_integrations_id_seq', max(id))
 FROM


### PR DESCRIPTION
~~Relies on #2786 - please see this PR for context. Should be merged to `main` once the above PR is merged to `production`, and secrets populated.~~

Tested locally multiple times with `pnpm test-sync` ✅ 

Encrypted values added to prod db ✅ 