### PR TITLE
fix(types): Add better types to Airbrake logging

### DIFF
--- a/api.planx.uk/modules/send/utils/helpers.ts
+++ b/api.planx.uk/modules/send/utils/helpers.ts
@@ -21,8 +21,7 @@ export async function logPaymentStatus({
 }): Promise<void> {
   if (!flowId || !sessionId) {
     reportError({
-      message:
-        "Could not log the payment status due to missing context value(s)",
+      error: "Could not log the payment status due to missing context value(s)",
       context: { sessionId, flowId, teamSlug },
     });
   } else {
@@ -38,21 +37,20 @@ export async function logPaymentStatus({
       });
     } catch (e) {
       reportError({
-        message: "Failed to insert a payment status",
-        error: e,
-        govUkResponse,
+        error: `Failed to insert a payment status: ${e}`,
+        context: { govUkResponse },
       });
     }
   }
 }
 
 // tmp explicit error handling
-export function reportError(obj: object) {
+export function reportError(report: { error: any; context: object }) {
   if (airbrake) {
-    airbrake.notify(obj);
+    airbrake.notify(report);
     return;
   }
-  log(obj);
+  log(report);
 }
 
 // tmp logger

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -59,8 +59,10 @@ export const isCleanHTML = (input: unknown): boolean => {
  */
 const logUncleanHTMLError = (input: string, cleanHTML: string) => {
   reportError({
-    message: `Warning: Unclean HTML submitted!`,
-    input,
-    cleanHTML,
+    error: `Warning: Unclean HTML submitted!`,
+    context: {
+      input,
+      cleanHTML,
+    },
   });
 };


### PR DESCRIPTION
## What does this PR do?
- Improves types on `reportError()` to better match what Airbrake expects ([docs](https://github.com/airbrake/airbrake-js/tree/master/packages/browser#notice-annotations))
- Quick fix as this error did contain the expected context  - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1707928622915259 (OSL Slack)
- A proper review of Airbrake logging should be picked up here with this ticket https://trello.com/c/TfmJiwID/2686-fix-airbrake-error-logging-on-api