### PR TITLE
feat: Disable `/preview` for unpublished flows

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -145,7 +145,45 @@ test.describe("Navigation", () => {
     await expect(nodes.getByText(noBranchNoticeText)).toBeVisible();
   });
 
-  test("Preview a created flow", async ({ browser }: { browser: Browser }) => {
+  test("Cannot preview an unpublished flow", async ({
+    browser,
+  }: {
+    browser: Browser;
+  }) => {
+    const page = await createAuthenticatedSession({
+      browser,
+      userId: context.user!.id!,
+    });
+
+    await page.goto(
+      `/${context.team.slug}/${serviceProps.slug}/preview?analytics=false`,
+    );
+
+    await expect(page.getByText("Not Found")).toBeVisible();
+  });
+
+  test("Publish a flow", async ({ browser }) => {
+    const page = await createAuthenticatedSession({
+      browser,
+      userId: context.user!.id!,
+    });
+
+    await page.goto(`/${context.team.slug}/${serviceProps.slug}`);
+
+    page.getByRole("button", { name: "CHECK FOR CHANGES TO PUBLISH" }).click();
+    page.getByRole("button", { name: "PUBLISH", exact: true }).click();
+
+    const previewLink = page.getByRole("link", {
+      name: "Open published service",
+    });
+    await expect(previewLink).toBeVisible();
+  });
+
+  test("Can preview a published flow", async ({
+    browser,
+  }: {
+    browser: Browser;
+  }) => {
     const page = await createAuthenticatedSession({
       browser,
       userId: context.user!.id!,

--- a/editor.planx.uk/src/lib/dataMergedHotfix.ts
+++ b/editor.planx.uk/src/lib/dataMergedHotfix.ts
@@ -1,5 +1,6 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import gql from "graphql-tag";
+import { Store } from "pages/FlowEditor/lib/store";
 
 import { publicClient } from "../lib/graphql";
 
@@ -23,10 +24,14 @@ const getFlowData = async (id: string) => {
 // Flatten a flow's data to include main content & portals in a single JSON representation
 // XXX: getFlowData & dataMerged are currently repeated in api.planx.uk/helpers.ts
 //        in order to load frontend /preview routes for flows that are not published
-export const dataMerged = async (id: string, ob: Record<string, any> = {}) => {
+export const dataMerged = async (
+  id: string,
+  ob: Store.flow = {},
+): Promise<Store.flow> => {
   // get the primary flow data
-  const { slug, data }: { slug: string; data: Record<string, any> } =
-    await getFlowData(id);
+  const { slug, data }: { slug: string; data: Store.flow } = await getFlowData(
+    id,
+  );
 
   // recursively get and flatten internal portals & external portals
   for (const [nodeId, node] of Object.entries(data)) {

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -103,6 +103,7 @@ const PreviewBrowser: React.FC<{
     lastPublished,
     lastPublisher,
     validateAndDiffFlow,
+    isFlowPublished,
   ] = useStore((state) => [
     state.id,
     state.flowAnalyticsLink,
@@ -111,6 +112,7 @@ const PreviewBrowser: React.FC<{
     state.lastPublished,
     state.lastPublisher,
     state.validateAndDiffFlow,
+    state.isFlowPublished,
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
@@ -189,17 +191,26 @@ const PreviewBrowser: React.FC<{
               <OpenInNewIcon />
             </Link>
           </Tooltip>
-
-          <Tooltip arrow title="Open published service">
-            <Link
-              href={props.url + "?analytics=false"}
-              target="_blank"
-              rel="noopener noreferrer"
-              color="inherit"
-            >
-              <LanguageIcon />
-            </Link>
-          </Tooltip>
+          {isFlowPublished ? (
+            <Tooltip arrow title="Open published service">
+              <Link
+                href={props.url + "?analytics=false"}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <LanguageIcon />
+              </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip arrow title="Flow not yet published">
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <LanguageIcon />
+                </Link>
+              </Box>
+            </Tooltip>
+          )}
         </Box>
         <Box width="100%" mt={2}>
           <Box display="flex" flexDirection="column" alignItems="flex-end">
@@ -283,12 +294,14 @@ const PreviewBrowser: React.FC<{
                     try {
                       setDialogOpen(false);
                       setLastPublishedTitle("Publishing changes...");
-                      const publishedFlow = await publishFlow(flowId, summary);
+                      const { alteredNodes, message } = await publishFlow(
+                        flowId,
+                        summary,
+                      );
                       setLastPublishedTitle(
-                        publishedFlow?.data.alteredNodes
-                          ? `Successfully published changes to ${publishedFlow.data.alteredNodes.length} node(s)`
-                          : `${publishedFlow?.data?.message}` ||
-                              "No new changes to publish",
+                        alteredNodes
+                          ? `Successfully published changes to ${alteredNodes.length} node(s)`
+                          : `${message}` || "No new changes to publish",
                       );
                     } catch (error) {
                       setLastPublishedTitle("Error trying to publish");

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -3,6 +3,7 @@ import gql from "graphql-tag";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { NaviRequest, NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { Store } from "pages/FlowEditor/lib/store";
 import { ApplicationPath } from "types";
 
 import { publicClient } from "../lib/graphql";
@@ -18,14 +19,10 @@ export const rootFlowPath = (includePortals = false) => {
 export const rootTeamPath = () =>
   window.location.pathname.split("/").slice(0, 2).join("/");
 
-export const isSaveReturnFlow = (flowData: Record<string, any>): boolean =>
-  Boolean(
-    Object.values(flowData).find(
-      (node: Record<string, any>) => node.type === NodeTypes.Send,
-    ),
-  );
+export const isSaveReturnFlow = (flowData: Store.flow): boolean =>
+  Boolean(Object.values(flowData).find((node) => node.type === NodeTypes.Send));
 
-export const setPath = (flowData: Record<string, any>, req: NaviRequest) => {
+export const setPath = (flowData: Store.flow, req: NaviRequest) => {
   // XXX: store.path is SingleSession by default
   if (!isSaveReturnFlow(flowData)) return;
   if (hasFeatureFlag("DISABLE_SAVE_AND_RETURN")) return;

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -425,6 +425,7 @@
         computed_fields:
           - data_merged
         filter: {}
+        allow_aggregations: true
     - role: platformAdmin
       permission:
         columns:
@@ -441,6 +442,7 @@
         computed_fields:
           - data_merged
         filter: {}
+        allow_aggregations: true
     - role: public
       permission:
         columns:
@@ -456,6 +458,7 @@
         computed_fields:
           - data_merged
         filter: {}
+        allow_aggregations: true
     - role: teamEditor
       permission:
         columns:
@@ -472,6 +475,7 @@
         computed_fields:
           - data_merged
         filter: {}
+        allow_aggregations: true
   update_permissions:
     - role: api
       permission:
@@ -1230,6 +1234,7 @@
           - flow_id
           - data
         filter: {}
+        allow_aggregations: true
     - role: platformAdmin
       permission:
         columns:
@@ -1240,6 +1245,7 @@
           - publisher_id
           - summary
         filter: {}
+        allow_aggregations: true
     - role: public
       permission:
         columns:
@@ -1250,6 +1256,7 @@
           - publisher_id
           - summary
         filter: {}
+        allow_aggregations: true
     - role: teamEditor
       permission:
         columns:
@@ -1260,6 +1267,7 @@
           - publisher_id
           - summary
         filter: {}
+        allow_aggregations: true
 - table:
     name: reconciliation_requests
     schema: public


### PR DESCRIPTION
## Context
Quick proof of concept to follow up on discussion point from yesterday about publishing flows. No strong feelings about when / how this proceeds - it might make sense to bundle a bunch of related "publish" changes together such as https://github.com/theopensystemslab/planx-new/pull/2783?

## What does this PR do?
 - Disable "preview" icon in Editor if flow is unpublished
 - Throws a `NotFound` error on `/preview` routes for unpublished flows (no fallback to `dataMerged()` / "unpublished" version of the flow)
   - If we go ahead with this it's probably worth improving this - not found for public, a meaningful message for logged in Editors maybe?
 - A few type tidy ups 🧹 