### PR TITLE
fix: Add no-cache headers to file route

### DIFF
--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -212,7 +212,7 @@ export const useNoCache: RequestHandler = (_req, res, next) => {
   res.setHeader("Surrogate-Control", "no-store");
   res.setHeader(
     "Cache-Control",
-    "no-store, no-cache, must-revalidate, proxy-revalidate"
+    "no-store, no-cache, must-revalidate, proxy-revalidate",
   );
   res.setHeader("Expires", "0");
   next();

--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -207,3 +207,13 @@ export const useLoginAuth: RequestHandler = (req, res, next) =>
       });
     }
   });
+
+export const useNoCache: RequestHandler = (_req, res, next) => {
+  res.setHeader("Surrogate-Control", "no-store");
+  res.setHeader(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, proxy-revalidate"
+  );
+  res.setHeader("Expires", "0");
+  next();
+};

--- a/api.planx.uk/modules/file/routes.ts
+++ b/api.planx.uk/modules/file/routes.ts
@@ -1,7 +1,11 @@
 import { Router } from "express";
 
 import multer from "multer";
-import { useNoCache, useFilePermission, useTeamEditorAuth } from "../auth/middleware";
+import {
+  useNoCache,
+  useFilePermission,
+  useTeamEditorAuth,
+} from "../auth/middleware";
 import {
   downloadFileSchema,
   privateDownloadController,

--- a/api.planx.uk/modules/file/routes.ts
+++ b/api.planx.uk/modules/file/routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 
 import multer from "multer";
-import { useFilePermission, useTeamEditorAuth } from "../auth/middleware";
+import { useNoCache, useFilePermission, useTeamEditorAuth } from "../auth/middleware";
 import {
   downloadFileSchema,
   privateDownloadController,
@@ -37,6 +37,7 @@ router.get(
 
 router.get(
   "/file/private/:fileKey/:fileName",
+  useNoCache,
   useFilePermission,
   validate(downloadFileSchema),
   privateDownloadController,


### PR DESCRIPTION
Works on pizza and locally for me ✅ Will be sure to test on Staging and Prod also

### To test
- Example file - https://api.2793.planx.pizza/file/private/ktay5vj1/PXL_20230511_093922923.jpg
- Private file is inaccessible without key
- Private file is accessible with key
- Private file is then still inaccessible on subsequent requests