### PR TITLE
Revert "fix: format Airbrake API errors for more readable Slack"

### DIFF
--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -157,7 +157,7 @@ const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
       airbrake &&
       (errorObject instanceof Error || errorObject instanceof ServerError)
     ) {
-      airbrake.notify(JSON.stringify(errorObject, null, 2));
+      airbrake.notify(errorObject);
       return {
         ...errorObject,
         message: errorObject.message.concat(", this error has been logged"),


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#2781

Looks like this is actually a bit worse, so reverting! This should have been a "Failed to send to BOPS" error equivalent to the original PR "before" screenshot: 
![Screenshot from 2024-02-15 11-43-31](https://github.com/theopensystemslab/planx-new/assets/5132349/82f41f9d-074c-4378-a645-374cf32b6916)
