### PR TITLE
fix: Typo in `PropertyInformation` component [skip pizza]

### DIFF
--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
@@ -35,7 +35,7 @@ function PropertyInformationComponent(props: Props) {
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
         <ModalSectionContent
-          title="Propery information"
+          title="Property information"
           Icon={ICONS[TYPES.PropertyInformation]}
         >
           <InputRow>


### PR DESCRIPTION
<img width="412" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/d3305429-7b19-444f-8f77-22b5edf10109">
