### PR TITLE
fix: Restore flow privacy pages

### DIFF
--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -42,13 +42,6 @@ const PublicFooter: React.FC = () => {
     const setting = flowSettings?.elements && flowSettings?.elements[key];
 
     if (setting?.show) {
-      if (key == "privacy") {
-        return {
-          title: setting.heading,
-          href: "https://www.planx.uk/privacy",
-          newTab: true,
-        };
-      }
       return {
         title: setting.heading,
         href: makeHref(key),


### PR DESCRIPTION
I missed the significance of this change at review stage - apologies for that one @Mike-Heneghan 

Next steps (we can highlight at standup) would be to update privacy policy pages to drop FeedbackFish reference.