### PR TITLE
feat: include the ODP schema as "application.json" in submission zips for supported application types

### DIFF
--- a/api.planx.uk/modules/send/utils/exportZip.test.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.test.ts
@@ -1,6 +1,7 @@
 import { mockLowcalSession } from "../../../tests/mocks/saveAndReturnMocks";
 import { buildSubmissionExportZip } from "./exportZip";
 import type { LowCalSession } from "../../../types";
+import { expectedPlanningPermissionPayload } from "../../../tests/mocks/digitalPlanningDataMocks";
 
 jest.mock("fs", () => ({
   mkdtempSync: () => "tmpdir",
@@ -53,6 +54,9 @@ jest.mock("@opensystemslab/planx-core", () => {
 const mockGenerateOneAppXML = jest
   .fn()
   .mockResolvedValue({ trim: () => "<dummy:xml></dummy:xml>" });
+const mockGenerateDigitalPlanningDataPayload = jest
+  .fn()
+  .mockResolvedValue(expectedPlanningPermissionPayload);
 
 jest.mock("../../../client", () => {
   return {
@@ -73,6 +77,7 @@ jest.mock("../../../client", () => {
         ]),
         csvDataRedacted: jest.fn().mockResolvedValue([]),
         oneAppPayload: () => mockGenerateOneAppXML(),
+        digitalPlanningDataPayload: () => mockGenerateDigitalPlanningDataPayload(),
       },
     },
   };
@@ -92,6 +97,14 @@ describe("buildSubmissionExportZip", () => {
   test("the document viewer is added to zip", async () => {
     await buildSubmissionExportZip({ sessionId: "1234" });
     expect(mockAddFile).toHaveBeenCalledWith("Overview.htm", expect.anything());
+  });
+
+  test("ODP schema json is added to the zip", async () => {
+    const schema = expectedPlanningPermissionPayload;
+    const expectedBuffer = Buffer.from(JSON.stringify(schema, null, 2));
+
+    await buildSubmissionExportZip({ sessionId: "1234" });
+    expect(mockAddFile).toHaveBeenCalledWith("application.json", expectedBuffer);
   });
 
   test("boundary GeoJSON is added to zip", async () => {
@@ -159,6 +172,32 @@ describe("buildSubmissionExportZip", () => {
     );
   });
 
+  test("ODP schema json is excluded if unsupported application type", async () => {
+    // set-up mock session passport overwriting "application.type"
+    const lowcalSessionUnsupportedAppType: Partial<LowCalSession> = {
+      ...mockLowcalSession,
+      id: "1234",
+      data: {
+        ...mockLowcalSession.data,
+        id: "1234",
+        passport: {
+          data: {
+            ...mockLowcalSession.data!.passport.data,
+            "application.type": ["listedBuildingConsent"],
+          },
+        },
+      },
+    };
+    mockGetSessionById.mockResolvedValueOnce(lowcalSessionUnsupportedAppType);
+
+    await buildSubmissionExportZip({ sessionId: "1234" });
+
+    expect(mockAddFile).not.toHaveBeenCalledWith(
+      "application.json",
+      expect.anything(),
+    );
+  });
+
   test("a document template is added when the template is supported", async () => {
     await buildSubmissionExportZip({ sessionId: "1234" });
     expect(mockAddLocalFile).toHaveBeenCalledWith(
@@ -203,6 +242,15 @@ describe("buildSubmissionExportZip", () => {
           includeOneAppXML: true,
         }),
       ).rejects.toThrow(/Failed to generate OneApp XML/);
+    });
+
+    it("throws an error when ODP schema generation fails", async () => {
+      mockGenerateDigitalPlanningDataPayload.mockRejectedValueOnce(
+        new Error("validation test error"),
+      );
+      await expect(
+        buildSubmissionExportZip({ sessionId: "1234" })
+      ).rejects.toThrow(/Failed to generate ODP Schema JSON/);
     });
   });
 });

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -46,7 +46,22 @@ export async function buildSubmissionExportZip({
         stream: xmlStream,
       });
     } catch (error) {
-      throw Error(`Failed to generate OneApp XML. Error - ${error}`);
+      throw new Error(`Failed to generate OneApp XML for ${sessionId}. Error - ${error}`);
+    }
+  }
+
+  // add ODP Schema JSON to the zip for supported application types
+  const supportedApplicationPrefixes = ["ldc", "pa", "pp"];
+  if (supportedApplicationPrefixes.includes(passport.data?.["application.type"]?.[0])) {
+    try {
+      const schema = await $api.export.digitalPlanningDataPayload(sessionId);
+      const schemaBuff = Buffer.from(JSON.stringify(schema, null, 2));
+      zip.addFile({
+        name: "application.json",
+        buffer: schemaBuff,
+      });
+    } catch (error) {
+      throw new Error (`Failed to generate ODP Schema JSON for ${sessionId} zip. Error - ${error}`);
     }
   }
 
@@ -79,7 +94,7 @@ export async function buildSubmissionExportZip({
       stream: csvStream,
     });
   } catch (error) {
-    throw Error(`Failed to generate CSV. Error - ${error}`);
+    throw new Error(`Failed to generate CSV for ${sessionId} zip. Error - ${error}`);
   }
 
   // add template files to zip

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -46,13 +46,19 @@ export async function buildSubmissionExportZip({
         stream: xmlStream,
       });
     } catch (error) {
-      throw new Error(`Failed to generate OneApp XML for ${sessionId}. Error - ${error}`);
+      throw new Error(
+        `Failed to generate OneApp XML for ${sessionId}. Error - ${error}`,
+      );
     }
   }
 
   // add ODP Schema JSON to the zip for supported application types
   const supportedApplicationPrefixes = ["ldc", "pa", "pp"];
-  if (supportedApplicationPrefixes.includes(passport.data?.["application.type"]?.[0])) {
+  const applicationType = passport.data?.["application.type"]?.[0];
+  if (
+    applicationType &&
+    supportedApplicationPrefixes.includes(applicationType.split(".")?.[0])
+  ) {
     try {
       const schema = await $api.export.digitalPlanningDataPayload(sessionId);
       const schemaBuff = Buffer.from(JSON.stringify(schema, null, 2));
@@ -61,7 +67,9 @@ export async function buildSubmissionExportZip({
         buffer: schemaBuff,
       });
     } catch (error) {
-      throw new Error (`Failed to generate ODP Schema JSON for ${sessionId} zip. Error - ${error}`);
+      throw new Error(
+        `Failed to generate ODP Schema JSON for ${sessionId} zip. Error - ${error}`,
+      );
     }
   }
 
@@ -94,7 +102,9 @@ export async function buildSubmissionExportZip({
       stream: csvStream,
     });
   } catch (error) {
-    throw new Error(`Failed to generate CSV for ${sessionId} zip. Error - ${error}`);
+    throw new Error(
+      `Failed to generate CSV for ${sessionId} zip. Error - ${error}`,
+    );
   }
 
   // add template files to zip

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a68d840",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
-    version: github.com/theopensystemslab/planx-core/b184ea9
+    specifier: git+https://github.com/theopensystemslab/planx-core#a68d840
+    version: github.com/theopensystemslab/planx-core/a68d840
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -1871,8 +1871,8 @@ packages:
       '@types/qs': 6.9.11
       '@types/serve-static': 1.15.5
 
-  /@types/geojson@7946.0.13:
-    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
     dev: false
 
   /@types/glob@7.2.0:
@@ -5927,8 +5927,8 @@ packages:
       object-visit: 1.0.1
     dev: true
 
-  /marked@11.2.0:
-    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+  /marked@12.0.0:
+    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -8292,8 +8292,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b184ea9:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
+  github.com/theopensystemslab/planx-core/a68d840:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a68d840}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -8302,7 +8302,7 @@ packages:
       '@emotion/react': 11.11.3(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.3)(react@18.2.0)
       '@mui/material': 5.15.3(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
-      '@types/geojson': 7946.0.13
+      '@types/geojson': 7946.0.14
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       cheerio: 1.0.0-rc.12
@@ -8314,7 +8314,7 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 11.2.0
+      marked: 12.0.0
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -34,6 +34,7 @@ export const mockLowcalSession: LowCalSession = {
   data: {
     passport: {
       data: {
+        "application.type": ["ldc.proposed"],
         _address: {
           single_line_address: "1 High Street",
         },

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a68d840",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
-    version: github.com/theopensystemslab/planx-core/b184ea9
+    specifier: git+https://github.com/theopensystemslab/planx-core#a68d840
+    version: github.com/theopensystemslab/planx-core/a68d840
   axios:
     specifier: ^1.6.0
     version: 1.6.5
@@ -694,8 +694,8 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@types/geojson@7946.0.13:
-    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
     dev: false
 
   /@types/glob@7.2.0:
@@ -1931,8 +1931,8 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
-  /marked@11.2.0:
-    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+  /marked@12.0.0:
+    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b184ea9:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
+  github.com/theopensystemslab/planx-core/a68d840:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a68d840}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2791,7 +2791,7 @@ packages:
       '@emotion/react': 11.11.3(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.3)(react@18.2.0)
       '@mui/material': 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
-      '@types/geojson': 7946.0.13
+      '@types/geojson': 7946.0.14
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       cheerio: 1.0.0-rc.12
@@ -2803,7 +2803,7 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 11.2.0
+      marked: 12.0.0
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a68d840",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
-    version: github.com/theopensystemslab/planx-core/b184ea9
+    specifier: git+https://github.com/theopensystemslab/planx-core#a68d840
+    version: github.com/theopensystemslab/planx-core/a68d840
   axios:
     specifier: ^1.6.2
     version: 1.6.5
@@ -501,8 +501,8 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
-  /@types/geojson@7946.0.13:
-    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
     dev: false
 
   /@types/glob@7.2.0:
@@ -1728,8 +1728,8 @@ packages:
       es5-ext: 0.10.62
     dev: false
 
-  /marked@11.2.0:
-    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+  /marked@12.0.0:
+    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -2528,8 +2528,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b184ea9:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
+  github.com/theopensystemslab/planx-core/a68d840:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a68d840}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2538,7 +2538,7 @@ packages:
       '@emotion/react': 11.11.3(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.3)(react@18.2.0)
       '@mui/material': 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
-      '@types/geojson': 7946.0.13
+      '@types/geojson': 7946.0.14
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       cheerio: 1.0.0-rc.12
@@ -2550,7 +2550,7 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 11.2.0
+      marked: 12.0.0
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@mui/styles": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b184ea9",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a68d840",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -43,8 +43,8 @@ dependencies:
     specifier: ^0.8.0
     version: 0.8.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b184ea9
-    version: github.com/theopensystemslab/planx-core/b184ea9(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a68d840
+    version: github.com/theopensystemslab/planx-core/a68d840(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -3326,7 +3326,7 @@ packages:
     resolution: {integrity: sha512-+KdYrpKC5TgomQr2DlZF4lDEpHcoxnj5IGddYYfBWJAKfj1JtuHUIqMa+E1pJJ+z3kvDViWMqyqPlG4Ja7amQA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.15)
       postcss: 8.4.32
@@ -3336,7 +3336,7 @@ packages:
     resolution: {integrity: sha512-Bc0f62WmHdtRDjf5f3e2STwRAl89N2CLb+9iAwzrv4L2hncrbDwnQD9PCq0gtAt7pOI2leIV08HIBUd4jxD8cw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -3346,7 +3346,7 @@ packages:
     resolution: {integrity: sha512-ZgrlzuUAjXIOc2JueK0X5sZDjCtgimVp/O5CEqTcs5ShWBa6smhWYbS0x5cVc/+rycTDbjjzoP0KTDnUneZGOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3355,7 +3355,7 @@ packages:
     resolution: {integrity: sha512-YHdEru4o3Rsbjmu6vHy4UKOXZD+Rn2zmkAmLRfPet6+Jz4Ojw8cbWxe1n42VaXQhD3CQUXXTooIy8OkVbUcL+w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3364,7 +3364,7 @@ packages:
     resolution: {integrity: sha512-Ot1rcwRAaRHNKC9tAqoqNZhjdYBzKk1POgWfhN4uCOE47ebGcLRqXjKkApVDpjifL6u2/55ekkpnFcp+s/OZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -3374,7 +3374,7 @@ packages:
     resolution: {integrity: sha512-7JPeVVZHd+jxYdULl87lvjgvWldYu+Bc62s9vD/ED6/QTGjy0jy0US/f6BG53sVMTBJ1lzKZFpYmofBN9eaRiA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.15)
       postcss: 8.4.32
@@ -3384,7 +3384,7 @@ packages:
     resolution: {integrity: sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3393,7 +3393,7 @@ packages:
     resolution: {integrity: sha512-jcOanIbv55OFKQ3sYeFD/T0Ti7AMXc9nM1hZWu8m/2722gOTxFg7xYu4RDLJLeZmPUVQlGzo4jhzvTUq3x4ZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3402,7 +3402,7 @@ packages:
     resolution: {integrity: sha512-nJpJgsdA3dA9y5pgyb/UfEzE7W5Ka7u0CX0/HIMVBNWzWemdcTH3XwANECU6anWv/ao4vVNLTMxhiPNZsTK6iA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -3412,7 +3412,7 @@ packages:
     resolution: {integrity: sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.3
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3421,7 +3421,7 @@ packages:
     resolution: {integrity: sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3430,7 +3430,7 @@ packages:
     resolution: {integrity: sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3439,7 +3439,7 @@ packages:
     resolution: {integrity: sha512-woKaLO///4bb+zZC2s80l+7cm07M7268MsyG3M0ActXXEFi6SuhvriQYcb58iiKGbjwwIU7n45iRLEHypB47Og==}
     engines: {node: ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -3448,7 +3448,7 @@ packages:
     resolution: {integrity: sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
 
@@ -7666,8 +7666,8 @@ packages:
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
     dev: true
 
-  /@types/geojson@7946.0.13:
-    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
     dev: false
 
   /@types/glob@7.2.0:
@@ -8822,7 +8822,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       browserslist: 4.22.2
       caniuse-lite: 1.0.30001579
@@ -10062,7 +10062,7 @@ packages:
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -10081,7 +10081,7 @@ packages:
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.9
     dependencies:
       postcss: 8.4.32
 
@@ -10090,7 +10090,7 @@ packages:
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -10158,7 +10158,7 @@ packages:
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
 
@@ -10240,7 +10240,7 @@ packages:
     resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       css-declaration-sorter: 6.4.1(postcss@8.4.32)
       cssnano-utils: 3.1.0(postcss@8.4.32)
@@ -10277,7 +10277,7 @@ packages:
     resolution: {integrity: sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
 
@@ -10285,7 +10285,7 @@ packages:
     resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       cssnano-preset-default: 5.2.14(postcss@8.4.32)
       lilconfig: 2.1.0
@@ -13053,7 +13053,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.32
 
@@ -14942,8 +14942,8 @@ packages:
       react: 18.2.0
     dev: true
 
-  /marked@11.2.0:
-    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+  /marked@12.0.0:
+    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -16236,7 +16236,7 @@ packages:
     resolution: {integrity: sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16246,7 +16246,7 @@ packages:
     engines: {node: '>=8'}
     peerDependencies:
       browserslist: '>=4'
-      postcss: '>=8.4.31'
+      postcss: '>=8'
     dependencies:
       browserslist: 4.22.2
       postcss: 8.4.32
@@ -16254,7 +16254,7 @@ packages:
   /postcss-calc@8.2.4(postcss@8.4.32):
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.2
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16264,7 +16264,7 @@ packages:
     resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
     engines: {node: '>=7.6.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4.6
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16273,7 +16273,7 @@ packages:
     resolution: {integrity: sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16282,7 +16282,7 @@ packages:
     resolution: {integrity: sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16291,7 +16291,7 @@ packages:
     resolution: {integrity: sha512-pGxkuVEInwLHgkNxUc4sdg4g3py7zUeCQ9sMfwyHAT+Ezk8a4OaaVZ8lIY5+oNqA/BXXgLyXv0+5wHP68R79hg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16300,7 +16300,7 @@ packages:
     resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       caniuse-api: 3.0.0
@@ -16312,7 +16312,7 @@ packages:
     resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       postcss: 8.4.32
@@ -16322,7 +16322,7 @@ packages:
     resolution: {integrity: sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.3
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16331,7 +16331,7 @@ packages:
     resolution: {integrity: sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16340,7 +16340,7 @@ packages:
     resolution: {integrity: sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.3
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16349,7 +16349,7 @@ packages:
     resolution: {integrity: sha512-eqn4m70P031PF7ZQIvSgy9RSJ5uI2171O/OO/zcRNYpJbvaeKFUlar1aJ7rmgiQtbm0FSPsRewjpdS0Oew7MPA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16358,7 +16358,7 @@ packages:
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
 
@@ -16366,7 +16366,7 @@ packages:
     resolution: {integrity: sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
 
@@ -16374,7 +16374,7 @@ packages:
     resolution: {integrity: sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
 
@@ -16382,7 +16382,7 @@ packages:
     resolution: {integrity: sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
 
@@ -16390,7 +16390,7 @@ packages:
     resolution: {integrity: sha512-GX+FuE/uBR6eskOK+4vkXgT6pDkexLokPaz/AbJna9s5Kzp/yl488pKPjhy0obB475ovfT1Wv8ho7U/cHNaRgQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -16400,7 +16400,7 @@ packages:
     resolution: {integrity: sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16408,7 +16408,7 @@ packages:
   /postcss-flexbugs-fixes@5.0.2(postcss@8.4.32):
     resolution: {integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.4
     dependencies:
       postcss: 8.4.32
 
@@ -16416,7 +16416,7 @@ packages:
     resolution: {integrity: sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16425,7 +16425,7 @@ packages:
     resolution: {integrity: sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16433,7 +16433,7 @@ packages:
   /postcss-font-variant@5.0.0(postcss@8.4.32):
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.32
 
@@ -16441,7 +16441,7 @@ packages:
     resolution: {integrity: sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
 
@@ -16449,7 +16449,7 @@ packages:
     resolution: {integrity: sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16458,7 +16458,7 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.0
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16468,7 +16468,7 @@ packages:
   /postcss-initial@4.0.1(postcss@8.4.32):
     resolution: {integrity: sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.0
     dependencies:
       postcss: 8.4.32
 
@@ -16476,7 +16476,7 @@ packages:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.32
@@ -16485,7 +16485,7 @@ packages:
     resolution: {integrity: sha512-xuXll4isR03CrQsmxyz92LJB2xX9n+pZJ5jE9JgcnmsCammLyKdlzrBin+25dy6wIjfhJpKBAN80gsTlCgRk2w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -16495,7 +16495,7 @@ packages:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -16511,7 +16511,7 @@ packages:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.0.0
     dependencies:
       cosmiconfig: 7.1.0
@@ -16524,7 +16524,7 @@ packages:
     resolution: {integrity: sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.4
     dependencies:
       postcss: 8.4.32
 
@@ -16532,7 +16532,7 @@ packages:
     resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.32
 
@@ -16540,7 +16540,7 @@ packages:
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16550,7 +16550,7 @@ packages:
     resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       caniuse-api: 3.0.0
@@ -16562,7 +16562,7 @@ packages:
     resolution: {integrity: sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16571,7 +16571,7 @@ packages:
     resolution: {integrity: sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       colord: 2.9.3
       cssnano-utils: 3.1.0(postcss@8.4.32)
@@ -16582,7 +16582,7 @@ packages:
     resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       cssnano-utils: 3.1.0(postcss@8.4.32)
@@ -16593,7 +16593,7 @@ packages:
     resolution: {integrity: sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16602,7 +16602,7 @@ packages:
     resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.32
 
@@ -16610,7 +16610,7 @@ packages:
     resolution: {integrity: sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -16621,7 +16621,7 @@ packages:
     resolution: {integrity: sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16630,7 +16630,7 @@ packages:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.1.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -16639,7 +16639,7 @@ packages:
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.14
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16648,7 +16648,7 @@ packages:
     resolution: {integrity: sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.15)
       postcss: 8.4.32
@@ -16658,7 +16658,7 @@ packages:
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
 
@@ -16666,7 +16666,7 @@ packages:
     resolution: {integrity: sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16675,7 +16675,7 @@ packages:
     resolution: {integrity: sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16684,7 +16684,7 @@ packages:
     resolution: {integrity: sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16693,7 +16693,7 @@ packages:
     resolution: {integrity: sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16702,7 +16702,7 @@ packages:
     resolution: {integrity: sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16711,7 +16711,7 @@ packages:
     resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       postcss: 8.4.32
@@ -16721,7 +16721,7 @@ packages:
     resolution: {integrity: sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       normalize-url: 6.1.0
       postcss: 8.4.32
@@ -16731,7 +16731,7 @@ packages:
     resolution: {integrity: sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16741,7 +16741,7 @@ packages:
     engines: {node: '>= 12'}
     peerDependencies:
       browserslist: '>= 4'
-      postcss: '>=8.4.31'
+      postcss: '>= 8'
     dependencies:
       '@csstools/normalize.css': 12.1.1
       browserslist: 4.22.2
@@ -16753,7 +16753,7 @@ packages:
     resolution: {integrity: sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
 
@@ -16761,7 +16761,7 @@ packages:
     resolution: {integrity: sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       cssnano-utils: 3.1.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -16771,7 +16771,7 @@ packages:
     resolution: {integrity: sha512-otYl/ylHK8Y9bcBnPLo3foYFLL6a6Ak+3EQBPOTR7luMYCOsiVTUk1iLvNf6tVPNGXcoL9Hoz37kpfriRIFb4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16779,7 +16779,7 @@ packages:
   /postcss-page-break@3.0.4(postcss@8.4.32):
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8
     dependencies:
       postcss: 8.4.32
 
@@ -16787,7 +16787,7 @@ packages:
     resolution: {integrity: sha512-wR8igaZROA6Z4pv0d+bvVrvGY4GVHihBCBQieXFY3kuSuMyOmEnnfFzHl/tQuqHZkfkIVBEbDvYcFfHmpSet9g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16796,7 +16796,7 @@ packages:
     resolution: {integrity: sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       '@csstools/postcss-cascade-layers': 1.1.1(postcss@8.4.32)
       '@csstools/postcss-color-function': 1.1.1(postcss@8.4.32)
@@ -16853,7 +16853,7 @@ packages:
     resolution: {integrity: sha512-9sCtZkO6f/5ML9WcTLcIyV1yz9D1rf0tWc+ulKcvV30s0iZKS/ONyETvoWsr6vnrmW+X+KmuK3gV/w5EWnT37w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16862,7 +16862,7 @@ packages:
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       caniuse-api: 3.0.0
@@ -16872,7 +16872,7 @@ packages:
     resolution: {integrity: sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16880,7 +16880,7 @@ packages:
   /postcss-replace-overflow-wrap@4.0.0(postcss@8.4.32):
     resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.0.3
     dependencies:
       postcss: 8.4.32
 
@@ -16888,7 +16888,7 @@ packages:
     resolution: {integrity: sha512-1i9affjAe9xu/y9uqWH+tD4r6/hDaXJruk8xn2x1vzxC2U3J3LKO3zJW4CyxlNhA56pADJ/djpEwpH1RClI2rQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -16904,7 +16904,7 @@ packages:
     resolution: {integrity: sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -16914,7 +16914,7 @@ packages:
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       postcss: 8.4.32
       postcss-selector-parser: 6.0.15
@@ -19293,7 +19293,7 @@ packages:
     resolution: {integrity: sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.2.15
     dependencies:
       browserslist: 4.22.2
       postcss: 8.4.32
@@ -21067,17 +21067,18 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/b184ea9(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b184ea9}
-    id: github.com/theopensystemslab/planx-core/b184ea9
+  github.com/theopensystemslab/planx-core/a68d840(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a68d840}
+    id: github.com/theopensystemslab/planx-core/a68d840
     name: '@opensystemslab/planx-core'
     version: 1.0.0
+    prepare: true
     requiresBuild: true
     dependencies:
       '@emotion/react': 11.11.3(@types/react@18.2.45)(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.45)(react@18.2.0)
       '@mui/material': 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0)
-      '@types/geojson': 7946.0.13
+      '@types/geojson': 7946.0.14
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       cheerio: 1.0.0-rc.12
@@ -21089,7 +21090,7 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 11.2.0
+      marked: 12.0.0
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
Adds the ODP Schema JSON to the zip file for supported application types so that councils can build reports.

**Testing notes**
I've set up all flows under Lambeth on this pizza to email to `devops@opensystemslab.io`
1. You can submit an LDC successfully and the zip includes `application.json`: https://2804.planx.pizza/lambeth/apply-for-a-lawful-development-certificate/preview
    - Double check the [Hasura events](https://hasura.2804.planx.pizza/console/events/one-off-scheduled-events/processed) to confirm that each send to email, BOPS, and Uniform submissions succeed
2. You can submit a discretionary service successfully (send to email only) and the zip does NOT include `application.json`: https://2804.planx.pizza/lambeth/send-to-email-test/preview

Related https://github.com/theopensystemslab/planx-core/pull/309
 