### PR TITLE
feat: Styling for editor data inputs

### DIFF
--- a/editor.planx.uk/src/app.css
+++ b/editor.planx.uk/src/app.css
@@ -1,5 +1,4 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap");
 
 * {
   box-sizing: border-box;

--- a/editor.planx.uk/src/app.css
+++ b/editor.planx.uk/src/app.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap");
 
 * {
   box-sizing: border-box;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -7,9 +7,6 @@ $lineWidth: 1px;
 $padding: 7px;
 $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNc8B8AAkUBofXwZpQAAAAASUVORK5CYII=);
 
-// Import custom typeface for data inputs
-@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap");
-
 @mixin circle($radius) {
   user-select: none;
   border-radius: $radius;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -7,6 +7,9 @@ $lineWidth: 1px;
 $padding: 7px;
 $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNc8B8AAkUBofXwZpQAAAAASUVORK5CYII=);
 
+// Import custom typeface for data inputs
+@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap");
+
 @mixin circle($radius) {
   user-select: none;
   border-radius: $radius;

--- a/editor.planx.uk/src/ui/shared/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input.tsx
@@ -62,7 +62,14 @@ const StyledInputBase = styled(InputBase, {
     border: `2px solid ${theme.palette.text.primary}`,
   }),
   ...(format === "data" && {
-    backgroundColor: theme.palette.background.paper,
+    backgroundColor: theme.palette.grey[800],
+    borderColor: theme.palette.border.input,
+    color: "white",
+    fontFamily: `"Source Code Pro", monospace;`,
+    "& ::placeholder": {
+      color: theme.palette.common.white,
+      opacity: "0.5",
+    },
   }),
   ...(format === "bold" && {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,

--- a/editor.planx.uk/src/ui/shared/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input.tsx
@@ -62,13 +62,12 @@ const StyledInputBase = styled(InputBase, {
     border: `2px solid ${theme.palette.text.primary}`,
   }),
   ...(format === "data" && {
-    backgroundColor: theme.palette.grey[800],
-    borderColor: theme.palette.border.input,
-    color: "white",
+    backgroundColor: "#e9e9e9",
+    borderColor: theme.palette.border.main,
     fontFamily: `"Source Code Pro", monospace;`,
-    "& ::placeholder": {
-      color: theme.palette.common.white,
-      opacity: "0.5",
+    height: "44px",
+    "& input": {
+      fontSize: theme.typography.body2.fontSize,
     },
   }),
   ...(format === "bold" && {

--- a/editor.planx.uk/src/ui/shared/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input.tsx
@@ -62,8 +62,8 @@ const StyledInputBase = styled(InputBase, {
     border: `2px solid ${theme.palette.text.primary}`,
   }),
   ...(format === "data" && {
-    backgroundColor: "#e9e9e9",
-    borderColor: theme.palette.border.main,
+    backgroundColor: "#f0f0f0",
+    borderColor: "#d3d3d3",
     fontFamily: `"Source Code Pro", monospace;`,
     height: "44px",
     "& input": {

--- a/editor.planx.uk/src/ui/shared/InputRow.tsx
+++ b/editor.planx.uk/src/ui/shared/InputRow.tsx
@@ -12,7 +12,6 @@ const Root = styled(Box, {
   },
   "& > *": {
     flexGrow: 1,
-    marginLeft: 1,
     marginRight: 5,
     "&:nth-child(1)": {
       marginLeft: 0,


### PR DESCRIPTION
# What does this PR do?

Requested by August and a general usability win:
The current formatting for data inputs differs from default inputs with only a slight background tint, meaning that data is often added to the component description in error.

This PR introduces a monospace font (CSS embed from Google Fonts), and a slightly different input style.

Before:
<img width="766" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/eb2e20e3-48ee-47e4-a1fc-41e85310c1bc">

After:
<img width="766" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/572005e0-30ab-4be9-af31-d2698ca37782">

Still to do (if possible):
- [x] Update font ref so that it is only loaded in for editor screens