### PR TITLE
fix: Get allowlist answers from both breadcrumb data and answers

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -515,11 +515,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     const answerIds = breadcrumbs[nodeId]?.answers;
     if (!answerIds) return [];
 
-    const answerValues = answerIds.map((answerId) => ({
-      [nodeFn]: flow[answerId]?.data?.val,
-    }));
+    const answerValues = answerIds.map((answerId) => flow[answerId]?.data?.val);
 
-    return answerValues;
+    // Match data structure of `allow_list_answers` column
+    const answers = [ {[nodeFn]: answerValues } ];
+
+    return answers;
   }
 
   /**

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -462,7 +462,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   ) {
     if (shouldSkipTracking()) return;
 
-    const allowListAnswers = getAllowListAnswers(breadcrumb);
+    const allowListAnswers = getAllowListAnswers(nodeId, breadcrumb);
     if (!allowListAnswers) return;
 
     await publicClient.mutate({
@@ -491,16 +491,48 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   function getAllowListAnswers(
+    nodeId: string,
     breadcrumb: Store.userData,
-  ): Record<string, any>[] | undefined {
+  ): Record<string, unknown>[] | undefined {
+    const answers = getAnswers(nodeId);
+    const data = getData(breadcrumb);
+
+    const allowListAnswers = [...answers, ...data];
+    if (!allowListAnswers.length) return;
+
+    return allowListAnswers;
+  }
+
+  /**
+   * Extract allowlist answers from user answers
+   * e.g. from Checklist or Question components
+   */
+  function getAnswers(nodeId: string) {
+    const { data } = flow[nodeId];
+    const nodeFn: string = data?.fn || data?.val;
+    if (!nodeFn || !ALLOW_LIST.includes(nodeFn)) return [];
+
+    const answerIds = breadcrumbs[nodeId]?.answers;
+    if (!answerIds) return [];
+
+    const answerValues = answerIds.map((answerId) => ({
+      [nodeFn]: flow[answerId]?.data?.val,
+    }));
+
+    return answerValues;
+  }
+
+  /**
+   * Extract allowlist answers from breadcrumb data
+   * e.g. data set automatically by components such as DrawBoundary
+   */
+  function getData(breadcrumb: Store.userData) {
     const dataSetByNode = breadcrumb.data;
-    if (!dataSetByNode) return;
+    if (!dataSetByNode) return [];
 
     const answerValues = Object.entries(dataSetByNode)
       .filter(([key, value]) => ALLOW_LIST.includes(key) && Boolean(value))
       .map(([key, value]) => ({ [key]: value }));
-
-    if (!answerValues.length) return;
 
     return answerValues;
   }


### PR DESCRIPTION
Follow up from https://github.com/theopensystemslab/planx-new/pull/2835 following comments from @Mike-Heneghan 

## What does this PR do?
 - Captures data from breadcrumbs (e.g. `drawBoundary.action`)
 - Captures answers from breadcrumbs (e.g. `proposal.projectType`)
 - Both values for `allow_list_answers` column will be in the format `[ {nodeFn} : answers ]`
   - This matches `allow_list_answers` for session summary table
   - This is required if any components could set multiple allow list values
   - This is required where the `fn` field of the component won't match the variable used in the allow list (e.g. `drawBoundary.userAction` which is set automatically by the component)
   - This might cause some issues with existing captures allow list answers - open to ideas and comments!

I'd love to get some tests written for analytics as my previous PR inadvertently caused a breaking regression which was missed. I think this should be fairly stable going forward so let's wait and see on this one, but it's likely a good idea before the next set of potentially breaking changes 🤞 