### PR TITLE
fix: if same portal is nested many times at different levels, ensure latest version is always flattened and not old snapshot

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -259,6 +259,7 @@ const dataMerged = async (
   }
 
   // for every external portal that has been merged, confirm its' latest version was merged. If not, overwrite older snapshot with newest version
+  //   ** this is a final/separate step because older snapshots can be nested in _already_ flattened data (eg not picked up as ComponentType.ExternalPortal above)
   if (!draftDataOnly) {
     for (const [nodeId, node] of Object.entries(ob).filter(
       ([_nodeId, node]) => node.data?.publishedFlowId,

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -9,7 +9,15 @@ export interface FlowData {
   data: Flow["data"];
   team_id: number;
   team: { slug: string };
-  publishedFlows: { data: Flow["data"]; id: number }[] | [];
+  publishedFlows:
+    | {
+        data: Flow["data"];
+        id: number;
+        created_at: string;
+        summary: string;
+        publisher_id: number;
+      }[]
+    | [];
 }
 
 // Get a flow's data (unflattened, without external portal nodes)
@@ -30,6 +38,9 @@ const getFlowData = async (id: string): Promise<FlowData> => {
           ) {
             data
             id
+            created_at
+            summary
+            publisher_id
           }
         }
       }
@@ -195,11 +206,9 @@ const dataMerged = async (
   let { data } = response;
 
   // only flatten external portals that are published, unless we're loading draftDataOnly
-  let publishedFlowId;
   if (isPortal && !draftDataOnly) {
     if (publishedFlows?.[0]?.data) {
       data = publishedFlows[0].data;
-      publishedFlowId = publishedFlows[0].id;
     } else {
       throw new Error(
         `Publish flow ${team.slug}/${slug} before proceeding. All flows used as external portals must be published.`,
@@ -207,26 +216,32 @@ const dataMerged = async (
     }
   }
 
-  // recursively get and flatten internal portals & external portals
+  // recursively get and flatten external portals
   for (const [nodeId, node] of Object.entries(data)) {
     const isExternalPortalRoot =
       nodeId === "_root" && Object.keys(ob).length > 0;
     const isExternalPortal = node.type === ComponentType.ExternalPortal;
     const isMerged = ob[node.data?.flowId];
 
-    // merge external portal _root as a new node in the graph
+    // merge external portal _root node as a new node in the graph using its' flowId as nodeId
     if (isExternalPortalRoot) {
       ob[id] = {
-        ...node,
+        ...node, // includes _root edges for navigation to all child nodes in this portal
         type: ComponentType.InternalPortal,
         data: {
           text: `${team.slug}/${slug}`,
-          publishedFlowId: publishedFlowId,
+          // add extra metadata about latest published version when applicable
+          ...(!draftDataOnly && {
+            publishedFlowId: publishedFlows?.[0]?.id,
+            publishedAt: publishedFlows?.[0]?.created_at,
+            publishedBy: publishedFlows?.[0]?.publisher_id,
+            summary: publishedFlows?.[0]?.summary,
+          }),
         },
       };
     }
 
-    // merge external portal as an internal portal type node, with reference to flowId
+    // merge external portal type node as an internal portal type node, with an edge pointing to flowId (to navigate to the externalPortalRoot set above)
     else if (isExternalPortal) {
       ob[nodeId] = {
         type: ComponentType.InternalPortal,
@@ -245,13 +260,13 @@ const dataMerged = async (
 
   // for every external portal that has been merged, confirm its' latest version was merged. If not, overwrite older snapshot with newest version
   if (!draftDataOnly) {
-    for (const [nodeId, node] of Object.entries(ob)) {
-      if (node.data?.publishedFlowId) {
-        const mostRecentPublishedFlowId =
-          await getMostRecentPublishedFlowVersion(nodeId);
-        if (mostRecentPublishedFlowId !== node.data?.publishedFlowId) {
-          await dataMerged(nodeId, ob, true, draftDataOnly);
-        }
+    for (const [nodeId, node] of Object.entries(ob).filter(
+      ([_nodeId, node]) => node.data?.publishedFlowId,
+    )) {
+      const mostRecentPublishedFlowId =
+        await getMostRecentPublishedFlowVersion(nodeId);
+      if (mostRecentPublishedFlowId !== node.data?.publishedFlowId) {
+        await dataMerged(nodeId, ob, true, draftDataOnly);
       }
     }
   }

--- a/api.planx.uk/tests/mocks/flattenPortals.ts
+++ b/api.planx.uk/tests/mocks/flattenPortals.ts
@@ -1,0 +1,224 @@
+import { FlowGraph } from "@opensystemslab/planx-core/types";
+
+export const mockDraftParent: FlowGraph = {
+  _root: {
+    edges: ["4rrycjaUGg", "IgXmnffRPH", "N2efCk7D3G"],
+  },
+  "4rrycjaUGg": {
+    data: {
+      text: "Are you doing works to a house in London?",
+    },
+    type: 100,
+    edges: ["H5l1YcuVP4", "KJtvK7K2wn"],
+  },
+  H5l1YcuVP4: {
+    data: {
+      text: "Yes",
+    },
+    type: 200,
+    edges: ["Z4QpXm6CyR"],
+  },
+  IgXmnffRPH: {
+    data: {
+      title: "Check your answers before sending your application",
+    },
+    type: 600,
+  },
+  KJtvK7K2wn: {
+    data: {
+      text: "No",
+    },
+    type: 200,
+    edges: ["T0iJIxbOIn"],
+  },
+  N2efCk7D3G: {
+    data: {
+      color: "#EFEFEF",
+      title: "End of test",
+      resetButton: true,
+    },
+    type: 8,
+  },
+  T0iJIxbOIn: {
+    data: {
+      flowId: "63f80a88-b7b3-4554-b719-2293dd4de0d5",
+    },
+    type: 310,
+  },
+  Z4QpXm6CyR: {
+    data: {
+      flowId: "cb0ce521-2f8c-48e3-b61f-19e5f9e00a44",
+    },
+    type: 310,
+  },
+};
+
+export const mockPublishedParent: FlowGraph = {
+  _root: {
+    edges: ["4rrycjaUGg", "IgXmnffRPH", "N2efCk7D3G"],
+  },
+  "4rrycjaUGg": {
+    data: {
+      text: "Are you doing works to a house in London?",
+    },
+    type: 100,
+    edges: ["H5l1YcuVP4", "KJtvK7K2wn"],
+  },
+  H5l1YcuVP4: {
+    data: {
+      text: "Yes",
+    },
+    type: 200,
+    edges: ["Z4QpXm6CyR"],
+  },
+  IgXmnffRPH: {
+    data: {
+      title: "Check your answers before sending your application",
+    },
+    type: 600,
+  },
+  KJtvK7K2wn: {
+    data: {
+      text: "No",
+    },
+    type: 200,
+    edges: ["T0iJIxbOIn"],
+  },
+  N2efCk7D3G: {
+    data: {
+      color: "#EFEFEF",
+      title: "End of test",
+      resetButton: true,
+    },
+    type: 8,
+  },
+  T0iJIxbOIn: {
+    type: 300,
+    edges: ["63f80a88-b7b3-4554-b719-2293dd4de0d5"],
+  },
+  "63f80a88-b7b3-4554-b719-2293dd4de0d5": {
+    data: {
+      text: "testing/mock-units",
+    },
+    type: 300,
+    edges: ["pAiZxKp2pZ"],
+  },
+  pAiZxKp2pZ: {
+    data: {
+      title: "How many bedrooms are you adding?",
+      description: "<p>(This is v1)</p>",
+    },
+    type: 150,
+  },
+  Z4QpXm6CyR: {
+    type: 300,
+    edges: ["cb0ce521-2f8c-48e3-b61f-19e5f9e00a44"],
+  },
+  "cb0ce521-2f8c-48e3-b61f-19e5f9e00a44": {
+    edges: ["8OfL0QE39s", "95iLrV22Dn"],
+    type: 300,
+    data: {
+      text: "testing/mock-london-data-hub",
+    },
+  },
+  "8OfL0QE39s": {
+    data: {
+      type: "short",
+      title: "Which borough of London?",
+    },
+    type: 110,
+  },
+  "95iLrV22Dn": {
+    type: 300,
+    edges: ["63f80a88-b7b3-4554-b719-2293dd4de0d5"],
+  },
+};
+
+export const mockLondonDataHub: FlowGraph = {
+  _root: {
+    edges: ["8OfL0QE39s", "95iLrV22Dn"],
+  },
+  "8OfL0QE39s": {
+    data: {
+      type: "short",
+      title: "Which borough of London?",
+    },
+    type: 110,
+  },
+  "95iLrV22Dn": {
+    data: {
+      flowId: "63f80a88-b7b3-4554-b719-2293dd4de0d5",
+    },
+    type: 310,
+  },
+};
+
+export const mockLondonDataHubPublishedUnitsV1: FlowGraph = {
+  _root: {
+    edges: ["8OfL0QE39s", "95iLrV22Dn"],
+  },
+  "8OfL0QE39s": {
+    data: {
+      type: "short",
+      title: "Which borough of London?",
+    },
+    type: 110,
+  },
+  "95iLrV22Dn": {
+    type: 300,
+    edges: ["63f80a88-b7b3-4554-b719-2293dd4de0d5"],
+  },
+  pAiZxKp2pZ: {
+    data: {
+      title: "How many bedrooms are you adding?",
+      description: "<p>(This is v1)</p>",
+    },
+    type: 150,
+  },
+  "63f80a88-b7b3-4554-b719-2293dd4de0d5": {
+    data: {
+      text: "testing/mock-units",
+    },
+    type: 300,
+    edges: ["pAiZxKp2pZ"],
+  },
+};
+
+export const mockUnits: FlowGraph = {
+  _root: {
+    edges: ["pAiZxKp2pZ"],
+  },
+  pAiZxKp2pZ: {
+    data: {
+      title: "How many bedrooms are you adding?",
+      description: "<p>(This is v2)</p>",
+    },
+    type: 150,
+  },
+};
+
+export const mockUnitsPublishedV1: FlowGraph = {
+  _root: {
+    edges: ["pAiZxKp2pZ"],
+  },
+  pAiZxKp2pZ: {
+    data: {
+      title: "How many bedrooms are you adding?",
+      description: "<p>(This is v1)</p>",
+    },
+    type: 150,
+  },
+};
+
+export const mockUnitsPublishedV2: FlowGraph = {
+  _root: {
+    edges: ["pAiZxKp2pZ"],
+  },
+  pAiZxKp2pZ: {
+    data: {
+      title: "How many bedrooms are you adding?",
+      description: "<p>(This is v2)</p>",
+    },
+    type: 150,
+  },
+};

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -14,6 +14,9 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -99,7 +102,12 @@ function AlteredNodeItem(props: any) {
 
 interface AlteredNodesSummary {
   title: string;
-  portals: string[];
+  portals: {
+    text: string;
+    summary: string;
+    publishedBy: number;
+    publishedAt: string;
+  }[];
   updated: number;
   deleted: number;
 }
@@ -123,7 +131,7 @@ function AlteredNodesSummaryContent(props: any) {
       changeSummary["deleted"] += 1;
     } else if (node.type === TYPES.InternalPortal) {
       if (node.data?.text?.includes("/")) {
-        changeSummary["portals"].push(node.data?.text);
+        changeSummary["portals"].push(node.data);
       }
     } else if (node.type) {
       changeSummary["updated"] += 1;
@@ -196,19 +204,39 @@ function AlteredNodesSummaryContent(props: any) {
       {changeSummary["portals"].length > 0 && (
         <Box pt={2}>
           <Typography variant="body2">{`This includes recently published changes in the following nested services:`}</Typography>
-          <ul>
+          <List sx={{ listStyleType: "disc", marginLeft: 4 }}>
             {changeSummary["portals"].map((portal, i) => (
-              <li key={i}>
-                {useStore.getState().canUserEditTeam(portal.split("/")[0]) ? (
-                  <Link href={`../${portal}`} target="_blank">
-                    <Typography variant="body2">{portal}</Typography>
-                  </Link>
-                ) : (
-                  <Typography variant="body2">{portal}</Typography>
-                )}
-              </li>
+              <ListItem key={i} disablePadding sx={{ display: "list-item" }}>
+                <ListItemText
+                  primary={
+                    useStore
+                      .getState()
+                      .canUserEditTeam(portal.text.split("/")[0]) ? (
+                      <Link href={`../${portal.text}`} target="_blank">
+                        <Typography variant="body2">{portal.text}</Typography>
+                      </Link>
+                    ) : (
+                      <Typography variant="body2">{portal.text}</Typography>
+                    )
+                  }
+                  secondary={
+                    <>
+                      <Typography variant="body2" fontSize="small">
+                        {`Last published ${formatDistanceToNow(
+                          new Date(portal.publishedAt),
+                        )} ago by ${portal.publishedBy}`}
+                      </Typography>
+                      {portal.summary && (
+                        <Typography variant="body2" fontSize="small">
+                          {portal.summary}
+                        </Typography>
+                      )}
+                    </>
+                  }
+                />
+              </ListItem>
             ))}
-          </ul>
+          </List>
         </Box>
       )}
       <Divider />


### PR DESCRIPTION
Initially point to `main` to build fresh pizza for comparative testing, but will rebase this to point at `jess/fetch-published-portals-on-publish` before merging.

Context:
- The same portal can be referenced many times, but its' nodes only appear in the flattened flow data structure once 
- The same portal can be reference many times _at different levels_ 
  - For example, tthere's a parent flow that references two nested flows A & B. Flow B also references flow A. 
    - B can be published when A is at v1
    - The parent flow can be published when A is at v2 and B is at v1 (which snapshot A v1). 
    - In these cases, A v1 was captured in the flattened parent flow data, rather than forcing B to also consume the _latest_ published version of A (v2) which is a direct child of the parent flow

Technically, this means that A v2 could have a breaking change for portal B, but this isn't really different than content risks that already exist & will be tested/reviewed on the `/draft` route. August & I talked a lot about this behavior, can explain more if questions!

Needs updated complex unit test case if confirmed to work right on pizza now.

**Update**
- August confirmed working as expected on pizza now ! 
- Let's get this back over to original branch - and since subdomains are moving slow, I'm anticipating opening that pizza for PO testing next monday morning rather than staging - so I'll keep tidying/expanding complex test cases over there