### PR TITLE
chore: update default copy for FindProperty plot a new address 

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -17,12 +17,7 @@ import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
 import type { FindProperty } from "./model";
-import {
-  DEFAULT_NEW_ADDRESS_LABEL,
-  DEFAULT_NEW_ADDRESS_TITLE,
-  DEFAULT_TITLE,
-  parseFindProperty,
-} from "./model";
+import { parseFindProperty } from "./model";
 
 export type Props = EditorProps<TYPES.FindProperty, FindProperty>;
 
@@ -48,7 +43,7 @@ function FindPropertyComponent(props: Props) {
           <InputRow>
             <Input
               format="large"
-              placeholder={DEFAULT_TITLE}
+              placeholder="Title"
               name="title"
               value={formik.values.title}
               onChange={formik.handleChange}
@@ -82,7 +77,7 @@ function FindPropertyComponent(props: Props) {
               <InputRow>
                 <Input
                   format="large"
-                  placeholder={DEFAULT_NEW_ADDRESS_TITLE}
+                  placeholder="Title"
                   name="newAddressTitle"
                   value={formik.values.newAddressTitle}
                   onChange={formik.handleChange}
@@ -101,7 +96,7 @@ function FindPropertyComponent(props: Props) {
                   <InputRowItem width="100%">
                     <Input
                       id="new-address-description-label"
-                      placeholder={DEFAULT_NEW_ADDRESS_LABEL}
+                      placeholder="Label"
                       name="newAddressDescriptionLabel"
                       value={formik.values.newAddressDescriptionLabel}
                       onChange={formik.handleChange}

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -16,12 +16,7 @@ import ExternalPlanningSiteDialog, {
   DialogPurpose,
 } from "ui/public/ExternalPlanningSiteDialog";
 
-import {
-  DEFAULT_NEW_ADDRESS_TITLE,
-  DEFAULT_TITLE,
-  FindProperty,
-  SiteAddress,
-} from "../model";
+import { FindProperty, SiteAddress } from "../model";
 import PickOSAddress from "./Autocomplete";
 import PlotNewAddress from "./Map";
 
@@ -133,7 +128,7 @@ function Component(props: Props) {
       return (
         <>
           <QuestionHeader
-            title={props.newAddressTitle || DEFAULT_NEW_ADDRESS_TITLE}
+            title={props.newAddressTitle}
             description={props.newAddressDescription || ""}
           />
           <PlotNewAddress
@@ -155,7 +150,7 @@ function Component(props: Props) {
       return (
         <>
           <QuestionHeader
-            title={props.title || DEFAULT_TITLE}
+            title={props.title}
             description={props.description || ""}
           />
           <PickOSAddress

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -12,12 +12,14 @@ export interface FindProperty extends MoreInformation {
 export const parseFindProperty = (
   data: Record<string, any> | undefined,
 ): FindProperty => ({
-  title: data?.title || "",
+  title: data?.title || DEFAULT_TITLE,
   description: data?.description || "",
   allowNewAddresses: data?.allowNewAddresses || false,
-  newAddressTitle: data?.newAddressTitle || "",
-  newAddressDescription: data?.newAddressDescription || "",
-  newAddressDescriptionLabel: data?.newAddressDescriptionLabel || "",
+  newAddressTitle: data?.newAddressTitle || DEFAULT_NEW_ADDRESS_TITLE,
+  newAddressDescription:
+    data?.newAddressDescription || DEFAULT_NEW_ADDRESS_DESCRIPTION,
+  newAddressDescriptionLabel:
+    data?.newAddressDescriptionLabel || DEFAULT_NEW_ADDRESS_LABEL,
   ...parseMoreInformation(data),
 });
 
@@ -54,5 +56,8 @@ export interface SiteAddress extends MinimumSiteAddress {
 }
 
 export const DEFAULT_TITLE = "Find the property" as const;
-export const DEFAULT_NEW_ADDRESS_TITLE = "Propose a new address" as const;
+export const DEFAULT_NEW_ADDRESS_TITLE =
+  "Click or tap at where the property is on the map and name it below" as const;
+export const DEFAULT_NEW_ADDRESS_DESCRIPTION =
+  "You will need to select a location and provide a name to continue" as const;
 export const DEFAULT_NEW_ADDRESS_LABEL = "Name the site" as const;


### PR DESCRIPTION
Per Doncaster feedback, see Trello ticket

New components only, not migrating existing content in this case