### PR TITLE
feat: update and redirect `/preview` to `/published`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ AWS_SECRET_KEY=👻
 FILE_API_KEY=👻
 FILE_API_KEY_NEXUS=👻
 
-# Editor/Preview
+# Editor
 EDITOR_URL_EXT=http://localhost:3000
 
 # Hasura

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
@@ -57,7 +57,7 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=123`;
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -124,15 +124,15 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=123\n\nService: Apply for a lawful development certificate
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123\n\nService: Apply for a lawful development certificate
       Address: 2 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=456\n\nService: Apply for a lawful development certificate
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=456\n\nService: Apply for a lawful development certificate
       Address: 3 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=789`;
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=789`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -182,7 +182,7 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=123`;
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -214,7 +214,7 @@ describe("buildContentFromSessions function", () => {
       Address: Address not submitted
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=123`;
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -248,7 +248,7 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: Project type not submitted
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/preview?sessionId=123`;
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],

--- a/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
@@ -43,7 +43,7 @@ describe("getResumeLink util function", () => {
       propertyType: "house",
     };
     const testCase = getResumeLink(session, { slug: "team" } as Team, "flow");
-    const expectedResult = "example.com/team/flow/preview?sessionId=123";
+    const expectedResult = "example.com/team/flow/published?sessionId=123";
     expect(testCase).toEqual(expectedResult);
   });
 });

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -36,7 +36,7 @@ export const getServiceLink = (team: Team, flowSlug: string): string => {
   // Link to custom domain
   if (team.domain) return `https://${team.domain}/${flowSlug}`;
   // Fallback to PlanX domain
-  return `${process.env.EDITOR_URL_EXT}/${team.slug}/${flowSlug}/preview`;
+  return `${process.env.EDITOR_URL_EXT}/${team.slug}/${flowSlug}/published`;
 };
 
 /**

--- a/api.planx.uk/tests/mocks/digitalPlanningDataMocks.ts
+++ b/api.planx.uk/tests/mocks/digitalPlanningDataMocks.ts
@@ -1698,7 +1698,7 @@ export const expectedPlanningPermissionPayload = {
       flowId: "01e38c5d-e701-4e44-acdc-4d6b5cc3b854",
       name: "Apply for planning permission",
       owner: "Lambeth",
-      url: "https://www.editor.planx.dev/lambeth/apply-for-planning-permission/preview",
+      url: "https://www.editor.planx.dev/lambeth/apply-for-planning-permission/published",
     },
     session: {
       source: "PlanX",

--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -156,7 +156,7 @@ test.describe("Navigation", () => {
     });
 
     await page.goto(
-      `/${context.team.slug}/${serviceProps.slug}/preview?analytics=false`,
+      `/${context.team.slug}/${serviceProps.slug}/published?analytics=false`,
     );
 
     await expect(page.getByText("Not Found")).toBeVisible();
@@ -190,7 +190,7 @@ test.describe("Navigation", () => {
     });
 
     await page.goto(
-      `/${context.team.slug}/${serviceProps.slug}/preview?analytics=false`,
+      `/${context.team.slug}/${serviceProps.slug}/published?analytics=false`,
     );
 
     await answerQuestion({ page, title: "Is this a test?", answer: "Yes" });

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -102,7 +102,7 @@ export async function returnToSession({
   sessionId: string;
   shouldContinue?: boolean;
 }) {
-  const returnURL = `/${context.team?.slug}/${context.flow?.slug}/preview?analytics=false&sessionId=${sessionId}`;
+  const returnURL = `/${context.team?.slug}/${context.flow?.slug}/published?analytics=false&sessionId=${sessionId}`;
   log(`returning to http://localhost:3000/${returnURL}`);
   await page.goto(returnURL, { waitUntil: "load" });
   await page.locator("#email").fill(context.user?.email);

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -102,7 +102,7 @@ test.describe("Agent journey @regression", async () => {
 
     // Resume session
     const resumeLink = `/${context.team!.slug!}/${context.flow!
-      .slug!}/preview?analytics=false&sessionId=${sessionId}`;
+      .slug!}/published?analytics=false&sessionId=${sessionId}`;
     const secondPage = await browserContext.newPage();
     await secondPage.goto(resumeLink);
     await expect(
@@ -132,7 +132,7 @@ test.describe("Agent journey @regression", async () => {
 
     // Navigate to resume session link
     const resumeLink = `/${context.team!.slug!}/${context.flow!
-      .slug!}/preview?analytics=false&sessionId=${sessionId}`;
+      .slug!}/published?analytics=false&sessionId=${sessionId}`;
     const secondPage = await browserContext.newPage();
     await secondPage.goto(resumeLink);
     await expect(

--- a/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
@@ -17,7 +17,7 @@ import { Context } from "../context";
  */
 export async function navigateToPayComponent(page: Page, context: Context) {
   const previewURL = `/${context.team!.slug!}/${context.flow!
-    .slug!}/preview?analytics=false`;
+    .slug!}/published?analytics=false`;
   await page.goto(previewURL);
 
   await fillInEmail({ page, context });

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -27,7 +27,7 @@ let context: Context = {
   sessionIds: [], // used to collect and clean up sessions
 };
 const previewURL = `/${context.team!.slug!}/${context.flow!
-  .slug!}/preview?analytics=false`;
+  .slug!}/published?analytics=false`;
 
 const payButtonText = "Pay now using GOV.UK Pay";
 

--- a/e2e/tests/ui-driven/src/save-and-return.spec.ts
+++ b/e2e/tests/ui-driven/src/save-and-return.spec.ts
@@ -27,7 +27,7 @@ test.describe("Save and return", () => {
       data: simpleSendFlow,
     },
   };
-  const previewURL = `/${context.team?.slug}/${context.flow?.slug}/preview?analytics=false`;
+  const previewURL = `/${context.team?.slug}/${context.flow?.slug}/published?analytics=false`;
 
   test.beforeAll(async () => {
     try {

--- a/e2e/tests/ui-driven/src/sections.spec.ts
+++ b/e2e/tests/ui-driven/src/sections.spec.ts
@@ -52,7 +52,7 @@ test.describe("Section statuses", () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    const previewURL = `/${context.team?.slug}/${context.flow?.slug}/preview?analytics=false`;
+    const previewURL = `/${context.team?.slug}/${context.flow?.slug}/published?analytics=false`;
     await page.goto(previewURL);
   });
 

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -106,7 +106,7 @@ describe("Header Component - Editor Route", () => {
   });
 });
 
-for (const route of ["/preview", "/amber", "/draft", "/pay", "/invite"]) {
+for (const route of ["/published", "/amber", "/draft", "/pay", "/invite"]) {
   describe(`Header Component - ${route} Routes`, () => {
     beforeAll(() => {
       jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
@@ -165,7 +165,7 @@ describe("Section navigation bar", () => {
         ({
           url: {
             href: "test",
-            pathname: "/team-name/flow-name/preview",
+            pathname: "/team-name/flow-name/published",
           },
           data: {
             flow: "test-flow",

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -174,7 +174,7 @@ export const client = new ApolloClient({
 
 /**
  * Client used to make requests in all public interface
- * e.g. /preview, /amber, /draft, /pay
+ * e.g. /published, /amber, /draft, /pay
  */
 export const publicClient = new ApolloClient({
   link: from([retryLink, errorLink, publicHttpLink]),

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -242,11 +242,8 @@ function AlteredNodesSummaryContent(props: any) {
       <Divider />
       <Box pt={2}>
         <Typography variant="body2">
-          {`Review these content changes in-service before publishing `}
-          <Link
-            href={url.replace("/preview", "/publish-preview")}
-            target="_blank"
-          >
+          {`Preview these content changes in-service before publishing `}
+          <Link href={url.replace("/published", "/amber")} target="_blank">
             {`here`}
           </Link>
           {` (opens in a new tab).`}
@@ -317,7 +314,7 @@ const PreviewBrowser: React.FC<{
           <input
             type="text"
             disabled
-            value={props.url.replace("/preview", "/publish-preview")}
+            value={props.url.replace("/published", "/amber")}
           />
 
           <Tooltip arrow title="Refresh preview">
@@ -359,7 +356,7 @@ const PreviewBrowser: React.FC<{
           {isPlatformAdmin && (
             <Tooltip arrow title="Open draft service">
               <Link
-                href={props.url.replace("/preview", "/draft")}
+                href={props.url.replace("/published", "/draft")}
                 target="_blank"
                 rel="noopener noreferrer"
                 color="inherit"
@@ -371,7 +368,7 @@ const PreviewBrowser: React.FC<{
 
           <Tooltip arrow title="Open preview of changes to publish">
             <Link
-              href={props.url.replace("/preview", "/amber")}
+              href={props.url.replace("/published", "/amber")}
               target="_blank"
               rel="noopener noreferrer"
               color="inherit"

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -23,7 +23,7 @@ const FlowEditor: React.FC<any> = ({ flow, breadcrumbs }) => {
       </Box>
       {showPreview && (
         <PreviewBrowser
-          url={`${window.location.origin}${rootFlowPath(false)}/preview`}
+          url={`${window.location.origin}${rootFlowPath(false)}/published`}
         />
       )}
     </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -93,7 +93,7 @@ const createFullStore = (): StoreApi<FullStore> => {
 };
 
 const isPublic =
-  isPreviewOnlyDomain || window?.location?.href?.includes("/preview");
+  isPreviewOnlyDomain || window?.location?.href?.includes("/published");
 
 export const { vanillaStore, useStore }: PlanXStores = (() => {
   const vanillaStore: StoreApi<FullStore> = (() =>

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -89,7 +89,7 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
           </Box>
           <Divider sx={{ mt: 4 }} />
           <Box>
-            <Link href="../preview" variant="body2">
+            <Link href="../published" variant="body2">
               Start a new application
             </Link>
           </Box>

--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -63,17 +63,27 @@ const mountPayRoutes = () =>
 
 export default isPreviewOnlyDomain
   ? mount({
-      "/:team/:flow/preview": lazy(() => import("./published")), // XXX: keeps old URL working, but only for the team listed in the domain.
+      "/:team/:flow/published": lazy(() => import("./published")), // XXX: keeps old URL working, but only for the team listed in the domain.
       "/:flow": lazy(() => import("./published")),
       "/:flow/pay": mountPayRoutes(),
+      "/:team/:flow/preview": map(async (req) =>
+        redirect(
+          `/${req.params.team}/${req.params.flow}/published${req?.search}`,
+        ),
+      ),
       // XXX: We're not sure where to redirect `/` to so for now we'll just return the default 404
       // "/": redirect("somewhere?"),
     })
   : mount({
-      "/:team/:flow/preview": lazy(() => import("./published")), // loads current published flow if exists, or throws Not Found if unpublished
+      "/:team/:flow/published": lazy(() => import("./published")), // loads current published flow if exists, or throws Not Found if unpublished
       "/:team/:flow/amber": lazy(() => import("./preview")), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
       "/:team/:flow/draft": lazy(() => import("./draft")), // loads current draft flow and draft external portals
       "/:team/:flow/pay": mountPayRoutes(),
+      "/:team/:flow/preview": map(async (req) =>
+        redirect(
+          `/${req.params.team}/${req.params.flow}/published${req?.search}`,
+        ),
+      ),
       "/:team/:flow/unpublished": map(async (req) =>
         redirect(`/${req.params.team}/${req.params.flow}/amber`),
       ),

--- a/editor.planx.uk/src/routes/pay.tsx
+++ b/editor.planx.uk/src/routes/pay.tsx
@@ -73,10 +73,10 @@ const payRoutes = compose(
       view: <ErrorPage title={"Failed to generate payment request"} />,
     }),
     "/pages/:page": redirect(
-      (req) => `../../../preview/pages/${req.params.page}`,
+      (req) => `../../../published/pages/${req.params.page}`,
     ),
     "/invite/pages/:page": redirect(
-      (req) => `../../../../preview/pages/${req.params.page}`,
+      (req) => `../../../../published/pages/${req.params.page}`,
     ),
   }),
 );

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -92,7 +92,7 @@ export const getTeamFromDomain = async (domain: string) => {
 /**
  * Prevents accessing a different team than the one associated with the custom domain.
  * e.g. Custom domain is for Southwark but URL is looking for Lambeth
- * e.g. https://planningservices.southwark.gov.uk/lambeth/some-flow/preview
+ * e.g. https://planningservices.southwark.gov.uk/lambeth/some-flow
  */
 export const validateTeamRoute = async (req: NaviRequest) => {
   const externalTeamName = await getTeamFromDomain(window.location.hostname);


### PR DESCRIPTION
Last big functional update for #2783 ! 

Will rebase this branch once pizza builds against main. Opening as separate PR for easier review - this touches a lot of files.

**Testing:** 
- CI tests and nightly regression tests passing against this branch :white_check_mark: 
  - https://github.com/theopensystemslab/planx-new/actions/runs/8121796912
- Editor :globe_with_meridians: icon directly opens `/published` now (still disabled if flow is unpublished)
- Saving a session & inviting to pay generate magic links which have `/published` in the URL; you can resume successfully using those magic links
- After redirecting away to Gov Pay for any payment, you can redirect back to `/published` successfully
- `/preview` redirects to `/published` and **keeps query search params** like analytics, sessionId, email, etc

**Other considerations:**
- Update any planx-core references to `/preview` https://github.com/theopensystemslab/planx-core/pull/318 (can be merged later once publishing work is on staging, no direct dependencies here)
- "Preview" language is still a bit pervasive throughout frontend code and `isPreviewOnlyDomain` is especially confusing now, I think we'll want to reconsider our internal usage of "preview" environments and related terms like "standalone" - but let's address this separately as there aren't any external communication dependencies that will impact PO testing
