### PR TITLE
fix(a11y): Replace generic `alt` text with `aria-describedby`

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -322,8 +322,8 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
         {howMeasured && howMeasured !== emptyContent ? (
           <MoreInfoSection title="How is it defined?">
             <>
-              {definitionImg && <Image src={definitionImg} alt="definition" />}
-              <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab />
+              {definitionImg && <Image src={definitionImg} alt="" aria-describedby="howMeasured" />}
+              <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab id="howMeasured"/>
             </>
           </MoreInfoSection>
         ) : undefined}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/QuestionHeader.tsx
@@ -124,9 +124,9 @@ const QuestionHeader: React.FC<IQuestionHeader> = ({
             <MoreInfoSection title="How is it defined?">
               <>
                 {definitionImg && (
-                  <Image src={definitionImg} alt="definition" />
+                  <Image src={definitionImg} alt="" aria-describedby="howMeasured" />
                 )}
-                <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab />
+                <ReactMarkdownOrHtml source={howMeasured} openLinksOnNewTab id="howMeasured" />
               </>
             </MoreInfoSection>
           ) : undefined}


### PR DESCRIPTION
## What does this PR do?
 - Addresses issue `DAC_Non-Text_Content_02` in the Accessibility Report (page 15)
 - Removes the `alt` text in favour of `aria-describedby`
   - Example of this on MDN docs here - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#description
   - The conditional logic around `howMeasured` ensures that the image is only displayed if there is an associated description, so it's already not possible to have an image without text.

<img width="493" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/60ad2d8c-12ef-4925-a229-fe5eaa3f3715">
