### PR TITLE
fix(a11y): Remove redundant hidden text

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -1,11 +1,9 @@
 import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
 import FormLabel from "@mui/material/FormLabel";
 import Grid from "@mui/material/Grid";
 import RadioGroup from "@mui/material/RadioGroup";
 import { useTheme } from "@mui/material/styles";
 import { visuallyHidden } from "@mui/utils";
-import { DESCRIPTION_TEXT } from "@planx/components/shared/constants";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
@@ -95,9 +93,6 @@ const Question: React.FC<IQuestion> = (props) => {
       />
       <FullWidthWrapper>
         <FormControl sx={{ width: "100%" }}>
-          <FormHelperText style={visuallyHidden}>
-            {props.description ? DESCRIPTION_TEXT : ""}
-          </FormHelperText>
           <FormLabel
             style={visuallyHidden}
             id={`radio-buttons-group-label-${props.id}`}


### PR DESCRIPTION
## What does this PR do?
 - Addresses issue `DAC_Hidden_Text_01` in Accessability Report
 - Removes redundant `FormHelperText` component
   - Git blame shows this was introduced here https://github.com/theopensystemslab/planx-new/pull/1602

## Why is removing this the solution?
 - The description is already present and reachable by screen-readers
 - The markdown is actually wrong - rather than reference the id `DESCRIPTION_TEXT`, it's referencing the meaningless string `description-text` directly
 - 
<img width="492" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/6ad43293-e7df-49c0-825f-3330c10d3ff3">
