### PR TITLE
fix(a11y): Update default description in Pay component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -22,8 +22,7 @@ function Component(props: any) {
       description:
         props.node?.data?.description ||
         `<p>The planning fee covers the cost of processing your application.\
-         Find out more about how planning fees are calculated \
-         <a href="https://www.gov.uk/guidance/fees-for-planning-applications" target="_self">here</a>.</p>`,
+         <a href="https://www.gov.uk/guidance/fees-for-planning-applications" target="_self">Find out more about how planning fees are calculated</a> (opens in new tab).</p>`,
       fn: props.node?.data?.fn,
       instructionsTitle: props.node?.data?.instructionsTitle || "How to pay",
       instructionsDescription:


### PR DESCRIPTION
## What does this PR do?
 - Addresses issue `DAC_Link_Purpose_Out_of_Context_01` in Accessibility Report (page 63)
 - Updates default description for Pay component (content taken from template - this is consistent across services)
 - Updated content of flow where this issue was flagged - https://editor.planx.uk/lambeth/accessibility-test
   - Not yet published, will check on OSL Slack before proceeding
 - Manually checked current submission services for out-of-date content, no issues found (will cross-check on OSL Slack)

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/a2eaf262-2e33-42f4-9355-77fbc23bf0b6)
