### PR TITLE
feat: Contrast and both initials for user avatar

### DIFF
--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -95,7 +95,7 @@ describe("Header Component - Editor Route", () => {
 
   it("displays avatar and settings", () => {
     setup(<Header />);
-    expect(screen.getByText("T")).toBeInTheDocument();
+    expect(screen.getByText("TU")).toBeInTheDocument();
     expect(screen.getByLabelText("Toggle Menu")).toBeInTheDocument();
   });
 

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -6,6 +6,7 @@ import Visibility from "@mui/icons-material/Visibility";
 import AppBar from "@mui/material/AppBar";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
+import { grey } from '@mui/material/colors';
 import Container from "@mui/material/Container";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
@@ -453,7 +454,16 @@ const EditorToolbar: React.FC<{
                     </IconButton>
                   )}
                   <Box mr={1}>
-                    <Avatar>{user.firstName[0]}</Avatar>
+                    <Avatar 
+                      sx={{ 
+                        bgcolor: grey[200], 
+                        color: "text.primary",
+                        fontSize: "1em",
+                        fontWeight: "600",
+                      }}
+                    >
+                      {user.firstName[0]}{user.lastName[0]}
+                    </Avatar>
                   </Box>
                   <IconButton
                     edge="end"


### PR DESCRIPTION
## What does this PR do?

Small change to make the user avatar more visible and useful — increases contrast and adds the second user initial to the avatar.

Before:
<img width="181" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/c665bbd8-9c33-4d7e-beed-7eee4183c401">

After:
<img width="181" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/1d4855b5-1dee-4ffd-b9ca-d352fb2e48e1">