### PR TITLE
chore(a11y): Improve granularity of `DateInput` errors

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
@@ -5,7 +5,6 @@ import { axe, setup } from "testUtils";
 
 import { ERROR_MESSAGE } from "../shared/constants";
 import { fillInFieldsUsingPlaceholder } from "../shared/testHelpers";
-import { dateRangeSchema, dateSchema, paddedDate } from "./model";
 import DateInput from "./Public";
 
 test("submits a date", async () => {
@@ -137,58 +136,6 @@ test("date fields have a max length set", async () => {
   expect(day.maxLength).toBe(2);
   expect(month.maxLength).toBe(2);
   expect(year.maxLength).toBe(4);
-});
-
-test("padding on input", () => {
-  // Adds zero to single digits greater than 3 on input
-  expect(paddedDate("2021-12-6", "input")).toBe("2021-12-06");
-  expect(paddedDate("2021-4-22", "input")).toBe("2021-04-22");
-  expect(paddedDate("2021-8-4", "input")).toBe("2021-08-04");
-
-  // Leaves valid dates alone
-  expect(paddedDate("2021-01-06", "input")).toBe("2021-01-06");
-  expect(paddedDate("2021-04-22", "input")).toBe("2021-04-22");
-  expect(paddedDate("2021-08-04", "input")).toBe("2021-08-04");
-
-  // Leaves single 0 alone
-  expect(paddedDate("2021-0-4", "input")).toBe("2021-0-04");
-  expect(paddedDate("2021-10-0", "input")).toBe("2021-10-0");
-});
-
-test("padding on blur", () => {
-  // Adds zero to single digits less than or equal to 3 on blur
-  expect(paddedDate("2021-12-1", "blur")).toBe("2021-12-01");
-  expect(paddedDate("2021-3-22", "blur")).toBe("2021-03-22");
-  expect(paddedDate("2021-2-2", "blur")).toBe("2021-02-02");
-
-  // Leaves valid dates alone
-  expect(paddedDate("2021-01-06", "blur")).toBe("2021-01-06");
-  expect(paddedDate("2021-04-22", "blur")).toBe("2021-04-22");
-  expect(paddedDate("2021-08-04", "blur")).toBe("2021-08-04");
-
-  // Leaves single 0 alone
-  expect(paddedDate("2021-0-2", "blur")).toBe("2021-0-02");
-  expect(paddedDate("2021-10-0", "blur")).toBe("2021-10-0");
-});
-
-test("validation", async () => {
-  expect(await dateSchema().isValid("2021-03-23")).toBe(true);
-  expect(await dateSchema().isValid("2021-23-03")).toBe(false);
-  expect(
-    await dateRangeSchema({ min: "1990-01-01", max: "1999-12-31" }).isValid(
-      "1995-06-15",
-    ),
-  ).toBe(true);
-  expect(
-    await dateRangeSchema({ min: "1990-01-01", max: "1999-12-31" }).isValid(
-      "2021-06-15",
-    ),
-  ).toBe(false);
-  expect(
-    await dateRangeSchema({ min: "1990-01-01", max: "1999-12-31" }).isValid(
-      "1980-06-15",
-    ),
-  ).toBe(false);
 });
 
 it("should not have any accessibility violations upon initial load", async () => {

--- a/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
@@ -1,0 +1,148 @@
+import { dateRangeSchema, dateSchema, paddedDate, parseDate } from "./model";
+
+describe("parseDate helper function", () => {
+  it("returns a day value", () => {
+    const result = parseDate("2024-02-12");
+    expect(result.day).toBeDefined();
+    expect(result.day).toEqual(12);
+  });
+
+  it("returns a month value", () => {
+    const result = parseDate("2024-02-12");
+    expect(result.month).toBeDefined();
+    expect(result.month).toEqual(2);
+  });
+
+  it("returns a year value", () => {
+    const result = parseDate("2024-02-12");
+    expect(result.year).toBeDefined();
+    expect(result.year).toEqual(2024);
+  });
+
+  it("handles undefined inputs", () => {
+    const result = parseDate(undefined);
+    expect(result.day).not.toBeDefined();
+    expect(result.month).not.toBeDefined();
+    expect(result.year).not.toBeDefined();
+  });
+
+  it("handles invalid inputs", () => {
+    const result = parseDate("not a date");
+    expect(result.day).not.toBeDefined();
+    expect(result.month).not.toBeDefined();
+    expect(result.year).not.toBeDefined();
+  });
+
+  it("handles partial inputs", () => {
+    const result = parseDate("2024-MM-05");
+    expect(result.day).toEqual(5);
+    expect(result.month).not.toBeDefined();
+    expect(result.year).toEqual(2024);
+  });
+});
+
+describe("dateSchema", () => {
+  test("basic validation", async () => {
+    expect(await dateSchema().isValid("2021-03-23")).toBe(true);
+    expect(await dateSchema().isValid("2021-23-03")).toBe(false);
+  });
+
+  const validate = async (date?: string) => await dateSchema().validate(date).catch((err) => err.errors);
+
+  it("throws an error for an undefined value (empty form)", async () => {
+    const errors = await validate(undefined);
+    expect(errors[0]).toMatch(/Date must include a day/);
+  });
+
+  it("throws an error for an nonsensical value", async () => {
+    const errors = await validate("ab-cd-efgh");
+    expect(errors[0]).toMatch(/Date must include a day/);
+  });
+  
+  it("throws an error for a missing day", async () => {
+    const errors = await validate("2024-12-");
+    expect(errors[0]).toMatch(/Date must include a day/);
+  });
+  
+  it("throws an error for a missing month", async () => {
+    const errors = await validate("2024--25");
+    expect(errors[0]).toMatch(/Date must include a month/);
+  });
+
+  it("throws an error for a missing year", async () => {
+    const errors = await validate("-12-23");
+    expect(errors[0]).toMatch(/Date must include a year/);
+  });
+
+  it("throws an error for an invalid day", async () => {
+    const errors = await validate("2024-12-32");
+    expect(errors[0]).toMatch(/Day must be valid/);
+  });
+
+  it("throws an error for an invalid month", async () => {
+    const errors = await validate("2024-13-25");
+    expect(errors[0]).toMatch(/Month must be valid/);
+  });
+
+  it("throws an error for an invalid date (30th Feb)", async () => {
+    const errors = await validate("2024-02-30");
+    expect(errors[0]).toMatch(/Enter a valid date in DD.MM.YYYY format/);
+  });
+
+  it("throws an error for an invalid date (not a leap year)", async () => {
+    const errors = await validate("2023-02-29");
+    expect(errors[0]).toMatch(/Enter a valid date in DD.MM.YYYY format/);
+  });
+});
+
+describe("dateRangeSchema", () => {
+  test("basic validation", async () => {
+    expect(
+      await dateRangeSchema({ min: "1990-01-01", max: "1999-12-31" }).isValid(
+        "1995-06-15",
+      ),
+    ).toBe(true);
+    expect(
+      await dateRangeSchema({ min: "1990-01-01", max: "1999-12-31" }).isValid(
+        "2021-06-15",
+      ),
+    ).toBe(false);
+    expect(
+      await dateRangeSchema({ min: "1990-01-01", max: "1999-12-31" }).isValid(
+        "1980-06-15",
+      ),
+    ).toBe(false);
+  })
+});
+
+test("padding on input", () => {
+  // Adds zero to single digits greater than 3 on input
+  expect(paddedDate("2021-12-6", "input")).toBe("2021-12-06");
+  expect(paddedDate("2021-4-22", "input")).toBe("2021-04-22");
+  expect(paddedDate("2021-8-4", "input")).toBe("2021-08-04");
+
+  // Leaves valid dates alone
+  expect(paddedDate("2021-01-06", "input")).toBe("2021-01-06");
+  expect(paddedDate("2021-04-22", "input")).toBe("2021-04-22");
+  expect(paddedDate("2021-08-04", "input")).toBe("2021-08-04");
+
+  // Leaves single 0 alone
+  expect(paddedDate("2021-0-4", "input")).toBe("2021-0-04");
+  expect(paddedDate("2021-10-0", "input")).toBe("2021-10-0");
+});
+
+test("padding on blur", () => {
+  // Adds zero to single digits less than or equal to 3 on blur
+  expect(paddedDate("2021-12-1", "blur")).toBe("2021-12-01");
+  expect(paddedDate("2021-3-22", "blur")).toBe("2021-03-22");
+  expect(paddedDate("2021-2-2", "blur")).toBe("2021-02-02");
+
+  // Leaves valid dates alone
+  expect(paddedDate("2021-01-06", "blur")).toBe("2021-01-06");
+  expect(paddedDate("2021-04-22", "blur")).toBe("2021-04-22");
+  expect(paddedDate("2021-08-04", "blur")).toBe("2021-08-04");
+
+  // Leaves single 0 alone
+  expect(paddedDate("2021-0-2", "blur")).toBe("2021-0-02");
+  expect(paddedDate("2021-10-0", "blur")).toBe("2021-10-0");
+});

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -70,7 +70,6 @@ export const dateSchema = () => {
       "missing day",
       "Date must include a day",
       (date?: string) => {
-        console.log({date})
         const { day } = parseDate(date);
         return day !== undefined;
       })

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -14,12 +14,7 @@ export interface DateInput extends MoreInformation {
   max?: string;
 }
 
-export const isDateValid = (date: string) => {
-  // make sure we've got DD, MM, & YYYY
-  const isComplete = date.split("-").filter((n) => n.length > 0).length === 3;
-
-  return isComplete && isValid(parseISO(date));
-};
+const isDateValid = (date: string) => isValid(parseISO(date));
 
 export const paddedDate = (
   date: string,
@@ -64,41 +59,81 @@ const displayDate = (date: string): string | undefined => {
   return `${day}.${month}.${year}`;
 };
 
+export const parseDate = (date?: string) => {
+  const [year, month, day] = date?.split("-").map((val) => parseInt(val) || undefined) || [];
+  return { year, month, day };
+}
+
 export const dateSchema = () => {
-  return string().test(
-    "valid",
-    "Enter a valid date in DD.MM.YYYY format",
-    (date: string | undefined) => {
-      // test runs regardless of required status, so don't fail it if it's undefined
-      return Boolean(!date || isDateValid(date));
-    },
-  );
+  return string()
+    .test(
+      "missing day",
+      "Date must include a day",
+      (date?: string) => {
+        console.log({date})
+        const { day } = parseDate(date);
+        return day !== undefined;
+      })
+    .test(
+      "missing month",
+      "Date must include a month",
+      (date?: string) => {
+        const { month } = parseDate(date);
+        return month !== undefined;
+      })
+    .test(
+      "missing year",
+      "Date must include a year",
+      (date?: string) => {
+        const { year } = parseDate(date);
+        return year !== undefined;
+      })
+    .test(
+      "invalid day",
+      "Day must be valid",
+      (date?: string) => {
+        const { day } = parseDate(date);
+        return Boolean(day && day <= 31)
+      })
+    .test(
+      "invalid month",
+      "Month must be valid",
+      (date?: string) => {
+        const { month } = parseDate(date);
+        return Boolean(month && month <= 12);
+      })
+    .test(
+      "valid",
+      "Enter a valid date in DD.MM.YYYY format",
+      (date: string | undefined) => {
+        // test runs regardless of required status, so don't fail it if it's undefined
+        return Boolean(!date || isDateValid(date));
+      },
+    );
 };
 
 export const dateRangeSchema: (params: {
   min?: string;
   max?: string;
 }) => SchemaOf<string> = (params) =>
-  dateSchema()
-    .required("Enter a valid date in DD.MM.YYYY format")
-    .test({
-      name: "too soon",
-      message: `Enter a date later than ${
-        params.min && displayDate(params.min)
-      }`,
-      test: (date: string | undefined) => {
-        return Boolean(date && !(params.min && date < params.min));
-      },
-    })
-    .test({
-      name: "too late",
-      message: `Enter a date earlier than ${
-        params.max && displayDate(params.max)
-      }`,
-      test: (date: string | undefined) => {
-        return Boolean(date && !(params.max && date > params.max));
-      },
-    });
+    dateSchema()
+      .required("Enter a valid date in DD.MM.YYYY format")
+      .test({
+        name: "too soon",
+        message: `Enter a date later than ${params.min && displayDate(params.min)
+          }`,
+        test: (date: string | undefined) => {
+          return Boolean(date && !(params.min && date < params.min));
+        },
+      })
+      .test({
+        name: "too late",
+        message: `Enter a date earlier than ${params.max && displayDate(params.max)
+          }`,
+        test: (date: string | undefined) => {
+          return Boolean(date && !(params.max && date > params.max));
+        },
+      });
 
 export const parseDateInput = (
   data: Record<string, any> | undefined,


### PR DESCRIPTION
## What does this PR do?
 - Addresses issue `DAC_Vague_Error_Message_Usability_01` in Accessibility Report (page 73)
 - Adds granular error messages for missing day, month, or year values
 - Adds granular error messages for invalid day, month, or year values
 - Adds tests for the above errors
 - Splits existing DateInput tests into `Public.test.ts` (react-testing-library) and `model.test.ts` (jest)

https://github.com/theopensystemslab/planx-new/assets/20502206/e146bd53-59b2-4777-a60d-ac8be69ec68e