### PR TITLE
fix(a11y): Add additional context to buttons

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
@@ -1,5 +1,7 @@
+import Box from "@mui/material/Box";
 import MuiButtonBase, { ButtonBaseProps } from "@mui/material/ButtonBase";
 import { darken, styled } from "@mui/material/styles";
+import { visuallyHidden } from "@mui/utils";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
@@ -65,6 +67,7 @@ export default function Tag(props: Props): FCReturn {
       id={id}
       tagType={tagType}
     >
+      <Box sx={visuallyHidden} component="span">The status of this section of the application is:</Box>
       {children}
     </Root>
   );

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -7,6 +7,7 @@ import Link from "@mui/material/Link";
 import ListItem from "@mui/material/ListItem";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
 import { FileUploadSlot } from "@planx/components/FileUpload/Public";
 import ImagePreview from "components/ImagePreview";
 import React from "react";
@@ -147,6 +148,7 @@ export const UploadedFileCard: React.FC<Props> = ({
           variant="body2"
         >
           Change
+          <Box sx={visuallyHidden} component="span">the list of what file {file.path} shows</Box>
         </Link>
       </TagRoot>
     )}

--- a/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabledBanner.tsx
@@ -4,6 +4,7 @@ import Container from "@mui/material/Container";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
 import React, { useState } from "react";
 import AnalyticsChart from "ui/icons/AnalyticsChart";
 
@@ -56,6 +57,7 @@ const AnalyticsDisabledBanner: React.FC = () => {
             </Box>
             <Button size="small" onClick={() => setShowAnalyticsWarning(false)}>
               Hide
+              <Box sx={visuallyHidden} component="span">the analytics banner</Box>
             </Button>
           </Container>
         </AnalyticsWarning>

--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -4,6 +4,7 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
 import React, { useState } from "react";
 
 const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
@@ -41,6 +42,7 @@ const TestEnvironmentBanner: React.FC = () => {
             </Box>
             <Button size="small" onClick={() => setShowWarning(false)}>
               Hide
+              <Box sx={visuallyHidden} component="span">the test environment banner</Box>
             </Button>
           </Container>
         </TestEnvironmentWarning>


### PR DESCRIPTION
## What does this PR do?
 - Addresses issue `DAC_Headings_And_Labels_01` in the Accessibility Report (Page 56)
 - Adds additional context to buttons listed in the report

<img width="504" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/a7ef3f1d-698d-44a4-8afe-7ef59f161edb">
