### PR TITLE
feat(editor): Dynamic GOV.UK Pay Metadata in `Pay` component

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -166,6 +166,7 @@
     "start": "craco start",
     "build": "CI=false && craco build",
     "test": "react-scripts test",
+    "test:silent": "react-scripts test --silent",
     "eject": "react-scripts eject",
     "classic:start": "react-app-rewired start",
     "classic:build": "react-scripts build",

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -48,7 +48,7 @@ interface ChecklistProps extends Checklist {
 }
 
 const OptionEditor: React.FC<{
-  index?: number;
+  index: number;
   value: Option;
   onChange: (newVal: Option) => void;
   groupIndex?: number;

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
@@ -1,0 +1,216 @@
+import { User } from "@opensystemslab/planx-core/types";
+import { fireEvent, waitFor } from "@testing-library/react";
+import { FullStore, vanillaStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { act } from "react-dom/test-utils";
+import { axe, setup } from "testUtils";
+
+import PayComponent from "./Editor";
+
+describe("Pay component - Editor Modal", () => {
+  it("renders", () => {
+    const { getByText } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <PayComponent id="test" />
+      </DndProvider>,
+    );
+    expect(getByText("Payment")).toBeInTheDocument();
+  });
+
+  // Currently failing, Editor not a11y compliant
+  it.skip("should not have any accessibility violations upon initial load", async () => {
+    const { container } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <PayComponent id="test" />
+      </DndProvider>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  describe("GOV.UK Pay Metadata section", () => {
+    // Set up mock state with platformAdmin user so all Editor features are enabled
+    const { getState, setState } = vanillaStore;
+    const mockUser: User = {
+      id: 123,
+      email: "b.baggins@shire.com",
+      isPlatformAdmin: true,
+      firstName: "Bilbo",
+      lastName: "Baggins",
+      teams: [],
+    };
+
+    let initialState: FullStore;
+
+    beforeAll(() => (initialState = getState()));
+    afterEach(() => act(() => setState(initialState)));
+
+    it("renders the section", () => {
+      const { getByText } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" />
+        </DndProvider>,
+      );
+      expect(getByText("GOV.UK Pay Metadata")).toBeInTheDocument();
+    });
+
+    it("lists the default values", () => {
+      const { getByDisplayValue } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" />
+        </DndProvider>,
+      );
+      expect(getByDisplayValue("flow")).toBeInTheDocument();
+      expect(getByDisplayValue("source")).toBeInTheDocument();
+      expect(getByDisplayValue("isInviteToPay")).toBeInTheDocument();
+    });
+
+    it("does not allow default sections to be deleted", () => {
+      const { getAllByLabelText } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" />
+        </DndProvider>,
+      );
+
+      const deleteIcons = getAllByLabelText("Delete");
+
+      expect(deleteIcons).toHaveLength(3);
+      expect(deleteIcons[0]).toBeDisabled();
+      expect(deleteIcons[1]).toBeDisabled();
+      expect(deleteIcons[2]).toBeDisabled();
+    });
+
+    it("updates the 'isInviteToPay' metadata value inline with the 'isInviteToPay' form value", async () => {
+      const node = {
+        data: {
+          allowInviteToPay: false,
+        },
+      };
+
+      const { user, getAllByLabelText, getByText } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" node={node} />
+        </DndProvider>,
+      );
+
+      const keyInputs = getAllByLabelText("Key");
+      const valueInputs = getAllByLabelText("Value");
+
+      expect(keyInputs[2]).toHaveDisplayValue("isInviteToPay");
+      expect(valueInputs[2]).toHaveDisplayValue("false");
+
+      await user.click(
+        getByText("Allow applicants to invite someone else to pay"),
+      );
+
+      expect(valueInputs[2]).toHaveValue("true");
+    });
+
+    it("pre-populates existing values", () => {
+      const node = {
+        data: {
+          govPayMetadata: [
+            {
+              key: "myKey",
+              value: "myValue",
+            },
+          ],
+        },
+      };
+
+      const { getByDisplayValue } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" node={node} />
+        </DndProvider>,
+      );
+
+      expect(getByDisplayValue("myKey")).toBeInTheDocument();
+      expect(getByDisplayValue("myValue")).toBeInTheDocument();
+    });
+
+    it("allows new values to be added", async () => {
+      act(() => setState({ user: mockUser, flowName: "test flow" }));
+
+      const handleSubmit = jest.fn();
+
+      const { getAllByPlaceholderText, getAllByLabelText, user, getByRole } =
+        setup(
+          <DndProvider backend={HTML5Backend}>
+            <PayComponent
+              id="test"
+              handleSubmit={handleSubmit}
+              node={{ data: { fn: "fee" } }}
+            />
+          </DndProvider>,
+        );
+
+      // Three default rows displayed
+      expect(getAllByLabelText("Delete")).toHaveLength(3);
+
+      await user.click(getByRole("button", { name: "add new" }));
+
+      // New row added
+      expect(getAllByLabelText("Delete")).toHaveLength(4);
+
+      const keyInput = getAllByPlaceholderText("key")[3];
+      const valueInput = getAllByPlaceholderText("value")[3];
+
+      await user.type(keyInput, "myNewKey");
+      await user.type(valueInput, "myNewValue");
+
+      // Required to trigger submission outside the context of FormModal component
+      fireEvent.submit(getByRole("form"));
+
+      await waitFor(() => expect(handleSubmit).toHaveBeenCalled());
+    });
+
+    it("allows new values to be deleted", async () => {
+      act(() => setState({ user: mockUser, flowName: "test flow" }));
+      const mockNode = {
+        data: {
+          fn: "fee",
+          govPayMetadata: [
+            { key: "flow", value: "flowName" },
+            { key: "source", value: "PlanX" },
+            { key: "isInviteToPay", value: "true" },
+            { key: "deleteMe", value: "abc123" },
+          ],
+        },
+      };
+
+      const handleSubmit = jest.fn();
+
+      const { getAllByLabelText, user, getByRole } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" handleSubmit={handleSubmit} node={mockNode} />
+        </DndProvider>,
+      );
+
+      // Use delete buttons as proxy for rows
+      const deleteButtons = getAllByLabelText("Delete");
+      expect(deleteButtons).toHaveLength(4);
+      const finalDeleteButton = deleteButtons[3];
+      expect(finalDeleteButton).toBeDefined();
+
+      await user.click(finalDeleteButton);
+      expect(getAllByLabelText("Delete")).toHaveLength(3);
+
+      // Required to trigger submission outside the context of FormModal component
+      fireEvent.submit(getByRole("form"));
+
+      await waitFor(() => expect(handleSubmit).toHaveBeenCalled());
+
+      expect(handleSubmit.mock.lastCall[0].data.govPayMetadata).toEqual([
+        { key: "flow", value: "flowName" },
+        { key: "source", value: "PlanX" },
+        { key: "isInviteToPay", value: "true" },
+      ]);
+    });
+
+    it.todo(
+      "displays errors and applies the govUkPayMetadata schema validation rules",
+    );
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
@@ -230,7 +230,7 @@ describe("Pay component - Editor Modal", () => {
       await waitFor(() =>
         expect(getByText("Key is a required field")).toBeVisible(),
       );
-    });
+    }, 10000);
 
     it("displays array-level errors", async () => {
       act(() => setState({ user: mockUser, flowName: "test flow" }));
@@ -266,7 +266,7 @@ describe("Pay component - Editor Modal", () => {
       await waitFor(() =>
         expect(getByText("Keys must be unique")).toBeVisible(),
       );
-    });
+    }, 10000);
 
     it("only disables the first instance of a required filed", async () => {
       act(() => setState({ user: mockUser, flowName: "test flow" }));

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
@@ -209,8 +209,63 @@ describe("Pay component - Editor Modal", () => {
       ]);
     });
 
-    it.todo(
-      "displays errors and applies the govUkPayMetadata schema validation rules",
-    );
+    it("displays field-level errors", async () => {
+      act(() => setState({ user: mockUser, flowName: "test flow" }));
+
+      const handleSubmit = jest.fn();
+
+      const { getByText, user, getByRole } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" handleSubmit={handleSubmit} />
+        </DndProvider>,
+      );
+
+      await user.click(getByRole("button", { name: "add new" }));
+      fireEvent.submit(getByRole("form"));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      // Test that validation schema is wired up to UI
+      // model.test.ts tests validation schema behaviour in-depth
+      await waitFor(() =>
+        expect(getByText("Key is a required field")).toBeVisible(),
+      );
+    });
+
+    it("displays array-level errors", async () => {
+      act(() => setState({ user: mockUser, flowName: "test flow" }));
+
+      const handleSubmit = jest.fn();
+
+      const { getByText, user, getByRole, getAllByPlaceholderText } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent id="test" handleSubmit={handleSubmit} />
+        </DndProvider>,
+      );
+
+      // Add first duplicate key
+      await user.click(getByRole("button", { name: "add new" }));
+      const keyInput4 = getAllByPlaceholderText("key")[3];
+      const valueInput4 = getAllByPlaceholderText("value")[3];
+      await user.type(keyInput4, "duplicatedKey");
+      await user.type(valueInput4, "myNewValue");
+
+      // Add second duplicate key
+      await user.click(getByRole("button", { name: "add new" }));
+      const keyInput5 = getAllByPlaceholderText("key")[4];
+      const valueInput5 = getAllByPlaceholderText("value")[4];
+      await user.type(keyInput5, "duplicatedKey");
+      await user.type(valueInput5, "myNewValue");
+
+      fireEvent.submit(getByRole("form"));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      // Test that validation schema is wired up to UI
+      // model.test.ts tests validation schema behaviour in-depth
+      await waitFor(() =>
+        expect(getByText("Keys must be unique")).toBeVisible(),
+      );
+    });
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
@@ -267,5 +267,52 @@ describe("Pay component - Editor Modal", () => {
         expect(getByText("Keys must be unique")).toBeVisible(),
       );
     });
+
+    it("only disables the first instance of a required filed", async () => {
+      act(() => setState({ user: mockUser, flowName: "test flow" }));
+
+      const handleSubmit = jest.fn();
+
+      const {
+        getAllByPlaceholderText,
+        getAllByLabelText,
+        user,
+        getByRole,
+        getByText,
+      } = setup(
+        <DndProvider backend={HTML5Backend}>
+          <PayComponent
+            id="test"
+            handleSubmit={handleSubmit}
+            node={{ data: { fn: "fee" } }}
+          />
+        </DndProvider>,
+      );
+
+      await user.click(getByRole("button", { name: "add new" }));
+
+      const keyInput = getAllByPlaceholderText("key")[3];
+      const valueInput = getAllByPlaceholderText("value")[3];
+
+      await user.type(keyInput, "flow");
+
+      expect(valueInput).not.toBeDisabled();
+      await user.type(valueInput, "myNewValue");
+
+      // Required to trigger submission outside the context of FormModal component
+      fireEvent.submit(getByRole("form"));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      // Test that validation schema is wired up to UI
+      await waitFor(() =>
+        expect(getByText("Keys must be unique")).toBeVisible(),
+      );
+
+      const duplicateKeyDeleteIcon = getAllByLabelText("Delete")[3];
+
+      // This tests that the user is able to fix their mistake
+      expect(duplicateKeyDeleteIcon).not.toBeDisabled();
+    });
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
@@ -31,6 +31,8 @@ describe("Pay component - Editor Modal", () => {
   });
 
   describe("GOV.UK Pay Metadata section", () => {
+    jest.setTimeout(20000);
+
     // Set up mock state with platformAdmin user so all Editor features are enabled
     const { getState, setState } = vanillaStore;
     const mockUser: User = {
@@ -230,7 +232,7 @@ describe("Pay component - Editor Modal", () => {
       await waitFor(() =>
         expect(getByText("Key is a required field")).toBeVisible(),
       );
-    }, 10000);
+    });
 
     it("displays array-level errors", async () => {
       act(() => setState({ user: mockUser, flowName: "test flow" }));
@@ -266,7 +268,7 @@ describe("Pay component - Editor Modal", () => {
       await waitFor(() =>
         expect(getByText("Keys must be unique")).toBeVisible(),
       );
-    }, 10000);
+    });
 
     it("only disables the first instance of a required filed", async () => {
       act(() => setState({ user: mockUser, flowName: "test flow" }));

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.test.tsx
@@ -1,5 +1,6 @@
 import { User } from "@opensystemslab/planx-core/types";
 import { fireEvent, waitFor } from "@testing-library/react";
+import { toggleFeatureFlag } from "lib/featureFlags";
 import { FullStore, vanillaStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
@@ -32,6 +33,9 @@ describe("Pay component - Editor Modal", () => {
 
   describe("GOV.UK Pay Metadata section", () => {
     jest.setTimeout(20000);
+
+    beforeAll(() => toggleFeatureFlag("GOVPAY_METADATA"));
+    afterAll(() => toggleFeatureFlag("GOVPAY_METADATA"));
 
     // Set up mock state with platformAdmin user so all Editor features are enabled
     const { getState, setState } = vanillaStore;

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -60,9 +60,7 @@ const isFieldDisabled = (key: string, index: number) =>
   REQUIRED_GOVPAY_METADATA.includes(key) &&
   index === REQUIRED_GOVPAY_METADATA.indexOf(key);
 
-function GovPayMetadataEditor(
-  props: ListManagerEditorProps<GovPayMetadata> & { index: number },
-) {
+function GovPayMetadataEditor(props: ListManagerEditorProps<GovPayMetadata>) {
   const { key: currKey, value: currVal } = props.value;
   const isDisabled = isFieldDisabled(currKey, props.index);
   const formik = useFormikContext<Pay>();
@@ -276,6 +274,7 @@ const Component: React.FC<Props> = (props: Props) => {
                     </Typography>
                   </Box>
                   <ListManager
+                    maxItems={10}
                     disableDragAndDrop
                     values={values.govPayMetadata || []}
                     onChange={(metadata) => {

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -52,11 +52,19 @@ const parseError = (
   return errors[index].key || errors[index].value;
 };
 
+/**
+ * Disable required fields so they cannot be edited
+ * Only disable first instance, otherwise any field beginning with a required field will be disabled, and user will not be able to fix their mistake as the delete icon is also disabled
+ */
+const isFieldDisabled = (key: string, index: number) =>
+  REQUIRED_GOVPAY_METADATA.includes(key) &&
+  index === REQUIRED_GOVPAY_METADATA.indexOf(key);
+
 function GovPayMetadataEditor(
   props: ListManagerEditorProps<GovPayMetadata> & { index: number },
 ) {
   const { key: currKey, value: currVal } = props.value;
-  const isDisabled = REQUIRED_GOVPAY_METADATA.includes(currKey);
+  const isDisabled = isFieldDisabled(currKey, props.index);
   const formik = useFormikContext<Pay>();
   const error = parseError(
     formik.errors.govPayMetadata as string | undefined | GovPayMetadata[],
@@ -275,8 +283,8 @@ const Component: React.FC<Props> = (props: Props) => {
                     }}
                     Editor={GovPayMetadataEditor}
                     newValue={() => ({ key: "", value: "" })}
-                    isFieldDisabled={({ key }) =>
-                      REQUIRED_GOVPAY_METADATA.includes(key)
+                    isFieldDisabled={({ key }, index) =>
+                      isFieldDisabled(key, index)
                     }
                   />
                 </>

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -17,6 +17,7 @@ import {
   MoreInformation,
 } from "@planx/components/ui";
 import { Form, Formik, useFormikContext } from "formik";
+import { hasFeatureFlag } from "lib/featureFlags";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import ListManager, {
@@ -129,6 +130,7 @@ export type Props = EditorProps<TYPES.Pay, Pay>;
 
 const Component: React.FC<Props> = (props: Props) => {
   const [flowName] = useStore((store) => [store.flowName]);
+  const displayGovPayMetadataSection = hasFeatureFlag("GOVPAY_METADATA");
 
   const initialValues: Pay = {
     title: props.node?.data?.title || "Pay for your application",
@@ -265,77 +267,79 @@ const Component: React.FC<Props> = (props: Props) => {
               Hide the pay buttons and show fee for information only
             </OptionButton>
           </ModalSection>
-          <ModalSection>
-            <ModalSectionContent
-              title="GOV.UK Pay Metadata"
-              Icon={DataObjectIcon}
-            >
-              <Typography variant="subtitle2" sx={{ mb: 2 }}>
-                Include metadata alongside payments, such as VAT codes, cost
-                centers, or ledger codes. See{" "}
-                <Link
-                  href={GOVPAY_DOCS_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  GOV.UK Pay documentation
-                </Link>{" "}
-                for more details.
-              </Typography>
-              <ErrorWrapper
-                error={
-                  typeof errors.govPayMetadata === "string" &&
-                  touched.govPayMetadata
-                    ? errors.govPayMetadata
-                    : undefined
-                }
+          {displayGovPayMetadataSection && (
+            <ModalSection>
+              <ModalSectionContent
+                title="GOV.UK Pay Metadata"
+                Icon={DataObjectIcon}
               >
-                <>
-                  <Box
-                    sx={{
-                      width: "100%",
-                      mb: 1,
-                      display: "flex",
-                      justifyContent: "space-evenly",
-                    }}
+                <Typography variant="subtitle2" sx={{ mb: 2 }}>
+                  Include metadata alongside payments, such as VAT codes, cost
+                  centers, or ledger codes. See{" "}
+                  <Link
+                    href={GOVPAY_DOCS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
-                    <Typography
-                      sx={{ width: "100%", ml: 5 }}
-                      variant="subtitle2"
-                      component="label"
-                      id="key-label"
+                    GOV.UK Pay documentation
+                  </Link>{" "}
+                  for more details.
+                </Typography>
+                <ErrorWrapper
+                  error={
+                    typeof errors.govPayMetadata === "string" &&
+                    touched.govPayMetadata
+                      ? errors.govPayMetadata
+                      : undefined
+                  }
+                >
+                  <>
+                    <Box
+                      sx={{
+                        width: "100%",
+                        mb: 1,
+                        display: "flex",
+                        justifyContent: "space-evenly",
+                      }}
                     >
-                      Key
-                    </Typography>
-                    <Typography
-                      sx={{ width: "100%", ml: -5 }}
-                      variant="subtitle2"
-                      component="label"
-                      id="value-label"
-                    >
-                      Value
-                    </Typography>
-                  </Box>
-                  <ListManager
-                    maxItems={10}
-                    disableDragAndDrop
-                    values={values.govPayMetadata || []}
-                    onChange={(metadata) => {
-                      setFieldValue("govPayMetadata", metadata);
-                    }}
-                    Editor={GovPayMetadataEditor}
-                    newValue={() => {
-                      setTouched({});
-                      return { key: "", value: "" };
-                    }}
-                    isFieldDisabled={({ key }, index) =>
-                      isFieldDisabled(key, index)
-                    }
-                  />
-                </>
-              </ErrorWrapper>
-            </ModalSectionContent>
-          </ModalSection>
+                      <Typography
+                        sx={{ width: "100%", ml: 5 }}
+                        variant="subtitle2"
+                        component="label"
+                        id="key-label"
+                      >
+                        Key
+                      </Typography>
+                      <Typography
+                        sx={{ width: "100%", ml: -5 }}
+                        variant="subtitle2"
+                        component="label"
+                        id="value-label"
+                      >
+                        Value
+                      </Typography>
+                    </Box>
+                    <ListManager
+                      maxItems={10}
+                      disableDragAndDrop
+                      values={values.govPayMetadata || []}
+                      onChange={(metadata) => {
+                        setFieldValue("govPayMetadata", metadata);
+                      }}
+                      Editor={GovPayMetadataEditor}
+                      newValue={() => {
+                        setTouched({});
+                        return { key: "", value: "" };
+                      }}
+                      isFieldDisabled={({ key }, index) =>
+                        isFieldDisabled(key, index)
+                      }
+                    />
+                  </>
+                </ErrorWrapper>
+              </ModalSectionContent>
+            </ModalSection>
+          )}
           <ModalSection>
             <ModalSectionContent title="Invite to Pay" Icon={ICONS[TYPES.Pay]}>
               <OptionButton

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -16,7 +16,7 @@ import {
   InternalNotes,
   MoreInformation,
 } from "@planx/components/ui";
-import { useFormik } from "formik";
+import { Form, Formik, useFormikContext } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import ListManager, {
@@ -26,15 +26,19 @@ import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import OptionButton from "ui/editor/OptionButton";
 import RichTextInput from "ui/editor/RichTextInput";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 
 function GovPayMetadataEditor(props: ListManagerEditorProps<GovPayMetadata>) {
   const { key: currKey, value: currVal } = props.value;
   const isDisabled = REQUIRED_GOVPAY_METADATA.includes(currKey);
+  const formik = useFormikContext<GovPayMetadata>();
+  console.log({ formik });
 
   return (
     <Box sx={{ flex: 1 }} data-testid="rule-list-manager">
+      {/* <ErrorWrapper error={props.index && errors[props.index]}> */}
       <InputRow>
         <Input
           required
@@ -57,290 +61,297 @@ function GovPayMetadataEditor(props: ListManagerEditorProps<GovPayMetadata>) {
           placeholder="value"
         />
       </InputRow>
+      {/* </ErrorWrapper> */}
     </Box>
   );
 }
 
 export type Props = EditorProps<TYPES.Pay, Pay>;
 
-function Component(props: Props) {
+const Component: React.FC<Props> = (props: Props) => {
   const [flowName] = useStore((store) => [store.flowName]);
 
-  const formik = useFormik<Pay>({
-    initialValues: {
-      title: props.node?.data?.title || "Pay for your application",
-      bannerTitle:
-        props.node?.data?.bannerTitle ||
-        "The planning fee for this application is",
-      description:
-        props.node?.data?.description ||
-        `<p>The planning fee covers the cost of processing your application.\
+  const initialValues: Pay = {
+    title: props.node?.data?.title || "Pay for your application",
+    bannerTitle:
+      props.node?.data?.bannerTitle ||
+      "The planning fee for this application is",
+    description:
+      props.node?.data?.description ||
+      `<p>The planning fee covers the cost of processing your application.\
          <a href="https://www.gov.uk/guidance/fees-for-planning-applications" target="_self">Find out more about how planning fees are calculated</a> (opens in new tab).</p>`,
-      fn: props.node?.data?.fn,
-      instructionsTitle: props.node?.data?.instructionsTitle || "How to pay",
-      instructionsDescription:
-        props.node?.data?.instructionsDescription ||
-        `<p>You can pay for your application by using GOV.UK Pay.</p>\
+    fn: props.node?.data?.fn,
+    instructionsTitle: props.node?.data?.instructionsTitle || "How to pay",
+    instructionsDescription:
+      props.node?.data?.instructionsDescription ||
+      `<p>You can pay for your application by using GOV.UK Pay.</p>\
          <p>Your application will be sent after you have paid the fee. \
          Wait until you see an application sent message before closing your browser.</p>`,
-      hidePay: props.node?.data?.hidePay || false,
-      allowInviteToPay: props.node?.data?.allowInviteToPay ?? true,
-      secondaryPageTitle:
-        props.node?.data?.secondaryPageTitle ||
-        "Invite someone else to pay for this application",
-      nomineeTitle:
-        props.node?.data?.nomineeTitle || "Details of the person paying",
-      nomineeDescription: props.node?.data?.nomineeDescription,
-      yourDetailsTitle: props.node?.data?.yourDetailsTitle || "Your details",
-      yourDetailsDescription: props.node?.data?.yourDetailsDescription,
-      yourDetailsLabel:
-        props.node?.data?.yourDetailsLabel || "Your name or organisation name",
-      govPayMetadata: props.node?.data?.govPayMetadata || [
-        {
-          key: "flow",
-          value: flowName,
-        },
-        {
-          key: "source",
-          value: "PlanX",
-        },
-        {
-          key: "isInviteToPay",
-          value: props.node?.data?.allowInviteToPay ?? true,
-        },
-      ],
-      ...parseMoreInformation(props.node?.data),
-    },
-    onSubmit: (newValues) => {
-      if (props.handleSubmit) {
-        props.handleSubmit({ type: TYPES.Pay, data: newValues });
-      }
-    },
-    validationSchema,
-    validateOnChange: false,
-    validateOnBlur: false,
-  });
+    hidePay: props.node?.data?.hidePay || false,
+    allowInviteToPay: props.node?.data?.allowInviteToPay ?? true,
+    secondaryPageTitle:
+      props.node?.data?.secondaryPageTitle ||
+      "Invite someone else to pay for this application",
+    nomineeTitle:
+      props.node?.data?.nomineeTitle || "Details of the person paying",
+    nomineeDescription: props.node?.data?.nomineeDescription,
+    yourDetailsTitle: props.node?.data?.yourDetailsTitle || "Your details",
+    yourDetailsDescription: props.node?.data?.yourDetailsDescription,
+    yourDetailsLabel:
+      props.node?.data?.yourDetailsLabel || "Your name or organisation name",
+    govPayMetadata: props.node?.data?.govPayMetadata || [
+      {
+        key: "flow",
+        value: flowName,
+      },
+      {
+        key: "source",
+        value: "PlanX",
+      },
+      {
+        key: "isInviteToPay",
+        value: props.node?.data?.allowInviteToPay ?? true,
+      },
+    ],
+    ...parseMoreInformation(props.node?.data),
+  };
+
+  const onSubmit = (newValues: Pay) => {
+    if (props.handleSubmit) {
+      props.handleSubmit({ type: TYPES.Pay, data: newValues });
+    }
+  };
 
   return (
-    <form onSubmit={formik.handleSubmit} id="modal" name="modal">
-      <ModalSection>
-        <ModalSectionContent title="Payment" Icon={ICONS[TYPES.Pay]}>
-          <InputRow>
-            <Input
-              format="large"
-              placeholder="Page title"
-              name="title"
-              value={formik.values.title}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <Input
-              format="bold"
-              placeholder="Banner title"
-              name="bannerTitle"
-              value={formik.values.bannerTitle}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <RichTextInput
-              placeholder="Banner description"
-              name="description"
-              value={formik.values.description}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <Input
-              format="data"
-              name="fn"
-              value={formik.values.fn}
-              placeholder="Data field for calculated amount"
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-        </ModalSectionContent>
-        <ModalSectionContent>
-          <InputRow>
-            <Input
-              format="large"
-              placeholder="Instructions title"
-              name="instructionsTitle"
-              value={formik.values.instructionsTitle}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-          <InputRow>
-            <RichTextInput
-              placeholder="Instructions description"
-              name="instructionsDescription"
-              value={formik.values.instructionsDescription}
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-        </ModalSectionContent>
-        <OptionButton
-          selected={formik.values.hidePay}
-          onClick={() => {
-            formik.setFieldValue("hidePay", !formik.values.hidePay);
-          }}
-          style={{ width: "100%" }}
-        >
-          Hide the pay buttons and show fee for information only
-        </OptionButton>
-      </ModalSection>
-      <ModalSection>
-        <ModalSectionContent title="GOV.UK Pay Metadata" Icon={DataObjectIcon}>
-          <Typography variant="subtitle2" sx={{ mb: 2 }}>
-            Include metadata alongside payments, such as VAT codes, cost
-            centers, or ledger codes. See <Link href="#TODO">our guide</Link>{" "}
-            for more details.
-          </Typography>
-          <Box
-            sx={{
-              width: "100%",
-              mb: 1,
-              display: "flex",
-              justifyContent: "space-evenly",
-            }}
-          >
-            <Typography
-              sx={{ width: "100%", ml: 5 }}
-              variant="subtitle2"
-              component="label"
-              id="key-label"
+    <Formik<Pay>
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validationSchema={validationSchema}
+      validateOnChange={false}
+      validateOnBlur={false}
+    >
+      {({ values, handleChange, setFieldValue }) => (
+        <Form id="modal" name="modal">
+          <ModalSection>
+            <ModalSectionContent title="Payment" Icon={ICONS[TYPES.Pay]}>
+              <InputRow>
+                <Input
+                  format="large"
+                  placeholder="Page title"
+                  name="title"
+                  value={values.title}
+                  onChange={handleChange}
+                />
+              </InputRow>
+              <InputRow>
+                <Input
+                  format="bold"
+                  placeholder="Banner title"
+                  name="bannerTitle"
+                  value={values.bannerTitle}
+                  onChange={handleChange}
+                />
+              </InputRow>
+              <InputRow>
+                <RichTextInput
+                  placeholder="Banner description"
+                  name="description"
+                  value={values.description}
+                  onChange={handleChange}
+                />
+              </InputRow>
+              <InputRow>
+                <Input
+                  format="data"
+                  name="fn"
+                  value={values.fn}
+                  placeholder="Data field for calculated amount"
+                  onChange={handleChange}
+                />
+              </InputRow>
+            </ModalSectionContent>
+            <ModalSectionContent>
+              <InputRow>
+                <Input
+                  format="large"
+                  placeholder="Instructions title"
+                  name="instructionsTitle"
+                  value={values.instructionsTitle}
+                  onChange={handleChange}
+                />
+              </InputRow>
+              <InputRow>
+                <RichTextInput
+                  placeholder="Instructions description"
+                  name="instructionsDescription"
+                  value={values.instructionsDescription}
+                  onChange={handleChange}
+                />
+              </InputRow>
+            </ModalSectionContent>
+            <OptionButton
+              selected={values.hidePay}
+              onClick={() => {
+                setFieldValue("hidePay", !values.hidePay);
+              }}
+              style={{ width: "100%" }}
             >
-              Key
-            </Typography>
-            <Typography
-              sx={{ width: "100%", ml: -5 }}
-              variant="subtitle2"
-              component="label"
-              id="value-label"
+              Hide the pay buttons and show fee for information only
+            </OptionButton>
+          </ModalSection>
+          <ModalSection>
+            <ModalSectionContent
+              title="GOV.UK Pay Metadata"
+              Icon={DataObjectIcon}
             >
-              Value
-            </Typography>
-          </Box>
-          <ListManager
-            disableDragAndDrop
-            values={formik.values.govPayMetadata || []}
-            onChange={(metadata) => {
-              formik.setFieldValue("govPayMetadata", metadata);
-            }}
-            Editor={GovPayMetadataEditor}
-            newValue={() => ({ key: "", value: "" })}
-            isFieldDisabled={({ key }) =>
-              REQUIRED_GOVPAY_METADATA.includes(key)
-            }
+              <Typography variant="subtitle2" sx={{ mb: 2 }}>
+                Include metadata alongside payments, such as VAT codes, cost
+                centers, or ledger codes. See{" "}
+                <Link href="#TODO">our guide</Link> for more details.
+              </Typography>
+              <Box
+                sx={{
+                  width: "100%",
+                  mb: 1,
+                  display: "flex",
+                  justifyContent: "space-evenly",
+                }}
+              >
+                <Typography
+                  sx={{ width: "100%", ml: 5 }}
+                  variant="subtitle2"
+                  component="label"
+                  id="key-label"
+                >
+                  Key
+                </Typography>
+                <Typography
+                  sx={{ width: "100%", ml: -5 }}
+                  variant="subtitle2"
+                  component="label"
+                  id="value-label"
+                >
+                  Value
+                </Typography>
+              </Box>
+              <ListManager
+                disableDragAndDrop
+                values={values.govPayMetadata || []}
+                onChange={(metadata) => {
+                  setFieldValue("govPayMetadata", metadata);
+                }}
+                Editor={GovPayMetadataEditor}
+                newValue={() => ({ key: "", value: "" })}
+                isFieldDisabled={({ key }) =>
+                  REQUIRED_GOVPAY_METADATA.includes(key)
+                }
+              />
+            </ModalSectionContent>
+          </ModalSection>
+          <ModalSection>
+            <ModalSectionContent title="Invite to Pay" Icon={ICONS[TYPES.Pay]}>
+              <OptionButton
+                selected={values.allowInviteToPay}
+                onClick={() => {
+                  setFieldValue("allowInviteToPay", !values.allowInviteToPay);
+                  // Update GovUKMetadata
+                  const inviteToPayIndex = values.govPayMetadata?.findIndex(
+                    ({ key }) => key === "isInviteToPay",
+                  );
+                  setFieldValue(
+                    `govPayMetadata[${inviteToPayIndex}].value`,
+                    !values.allowInviteToPay,
+                  );
+                }}
+                style={{ width: "100%" }}
+              >
+                Allow applicants to invite someone else to pay
+              </OptionButton>
+              {values.allowInviteToPay ? (
+                <>
+                  <Box>
+                    <InputRow>
+                      <Input
+                        required
+                        format="large"
+                        name="secondaryPageTitle"
+                        placeholder="Card title"
+                        value={values.secondaryPageTitle}
+                        onChange={handleChange}
+                      />
+                    </InputRow>
+                  </Box>
+                  <Box pt={4}>
+                    <InputRow>
+                      <Input
+                        required
+                        format="large"
+                        name="nomineeTitle"
+                        placeholder="Title"
+                        value={values.nomineeTitle}
+                        onChange={handleChange}
+                      />
+                    </InputRow>
+                    <InputRow>
+                      <RichTextInput
+                        name="nomineeDescription"
+                        placeholder="Description"
+                        value={values.nomineeDescription}
+                        onChange={handleChange}
+                      />
+                    </InputRow>
+                  </Box>
+                  <Box pt={4}>
+                    <InputRow>
+                      <Input
+                        required
+                        format="large"
+                        name="yourDetailsTitle"
+                        placeholder="Title"
+                        value={values.yourDetailsTitle}
+                        onChange={handleChange}
+                      />
+                    </InputRow>
+                    <InputRow>
+                      <RichTextInput
+                        name="yourDetailsDescription"
+                        placeholder="Description"
+                        value={values.yourDetailsDescription}
+                        onChange={handleChange}
+                      />
+                    </InputRow>
+                    <InputRow>
+                      <Input
+                        required
+                        name="yourDetailsLabel"
+                        placeholder="Label"
+                        value={values.yourDetailsLabel}
+                        onChange={handleChange}
+                      />
+                    </InputRow>
+                  </Box>
+                </>
+              ) : (
+                <></>
+              )}
+            </ModalSectionContent>
+          </ModalSection>
+          <MoreInformation
+            changeField={handleChange}
+            definitionImg={values.definitionImg}
+            howMeasured={values.howMeasured}
+            policyRef={values.policyRef}
+            info={values.info}
           />
-        </ModalSectionContent>
-      </ModalSection>
-      <ModalSection>
-        <ModalSectionContent title="Invite to Pay" Icon={ICONS[TYPES.Pay]}>
-          <OptionButton
-            selected={formik.values.allowInviteToPay}
-            onClick={() => {
-              formik.setFieldValue(
-                "allowInviteToPay",
-                !formik.values.allowInviteToPay,
-              );
-              // Update GovUKMetadata
-              const inviteToPayIndex = formik.values.govPayMetadata?.findIndex(
-                ({ key }) => key === "isInviteToPay",
-              );
-              formik.setFieldValue(
-                `govPayMetadata[${inviteToPayIndex}].value`,
-                !formik.values.allowInviteToPay,
-              );
-            }}
-            style={{ width: "100%" }}
-          >
-            Allow applicants to invite someone else to pay
-          </OptionButton>
-          {formik.values.allowInviteToPay ? (
-            <>
-              <Box>
-                <InputRow>
-                  <Input
-                    required
-                    format="large"
-                    name="secondaryPageTitle"
-                    placeholder="Card title"
-                    value={formik.values.secondaryPageTitle}
-                    onChange={formik.handleChange}
-                  />
-                </InputRow>
-              </Box>
-              <Box pt={4}>
-                <InputRow>
-                  <Input
-                    required
-                    format="large"
-                    name="nomineeTitle"
-                    placeholder="Title"
-                    value={formik.values.nomineeTitle}
-                    onChange={formik.handleChange}
-                  />
-                </InputRow>
-                <InputRow>
-                  <RichTextInput
-                    name="nomineeDescription"
-                    placeholder="Description"
-                    value={formik.values.nomineeDescription}
-                    onChange={formik.handleChange}
-                  />
-                </InputRow>
-              </Box>
-              <Box pt={4}>
-                <InputRow>
-                  <Input
-                    required
-                    format="large"
-                    name="yourDetailsTitle"
-                    placeholder="Title"
-                    value={formik.values.yourDetailsTitle}
-                    onChange={formik.handleChange}
-                  />
-                </InputRow>
-                <InputRow>
-                  <RichTextInput
-                    name="yourDetailsDescription"
-                    placeholder="Description"
-                    value={formik.values.yourDetailsDescription}
-                    onChange={formik.handleChange}
-                  />
-                </InputRow>
-                <InputRow>
-                  <Input
-                    required
-                    name="yourDetailsLabel"
-                    placeholder="Label"
-                    value={formik.values.yourDetailsLabel}
-                    onChange={formik.handleChange}
-                  />
-                </InputRow>
-              </Box>
-            </>
-          ) : (
-            <></>
-          )}
-        </ModalSectionContent>
-      </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        onChange={formik.handleChange}
-        value={formik.values.notes}
-      />
-    </form>
+          <InternalNotes
+            name="notes"
+            onChange={handleChange}
+            value={values.notes}
+          />
+        </Form>
+      )}
+    </Formik>
   );
-}
+};
 
 export default Component;

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -30,6 +30,9 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 
+const GOVPAY_DOCS_URL =
+  "https://docs.payments.service.gov.uk/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39";
+
 /**
  * Helper method to handle Formik errors in arrays
  * Required as errors can be at array-level or field-level and the useFormikContext hook cannot correctly type infer this from the validation schema
@@ -270,7 +273,14 @@ const Component: React.FC<Props> = (props: Props) => {
               <Typography variant="subtitle2" sx={{ mb: 2 }}>
                 Include metadata alongside payments, such as VAT codes, cost
                 centers, or ledger codes. See{" "}
-                <Link href="#TODO">our guide</Link> for more details.
+                <Link
+                  href={GOVPAY_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  GOV.UK Pay documentation
+                </Link>{" "}
+                for more details.
               </Typography>
               <ErrorWrapper
                 error={

--- a/editor.planx.uk/src/@planx/components/Pay/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.test.ts
@@ -1,0 +1,106 @@
+import { govPayMetadataSchema } from "./model";
+
+describe("GovPayMetadata Schema", () => {
+  const validate = async (payload: unknown) => await govPayMetadataSchema.validate(payload).catch(err => err.errors);
+
+  const defaults = [
+    { key: "flow", value: "flowName" },
+    { key: "source", value: "PlanX" },
+    { key: "isInviteToPay", value: "true" },
+  ];
+
+  test("it requires all default values", async () => {
+    const errors = await validate([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Keys flow, source and isInviteToPay must be present/)
+  });
+
+  test("it allows valid data", async () => {
+    const input = [
+      ...defaults,  
+      { key: "someKey", value: "someValue" },
+      { key: "someOtherKey", value: "someOtherValue" },
+    ];
+    const result = await validate(input);
+
+    // No errors, input returned from validation
+    expect(result).toEqual(input)
+  });
+
+  test("key is required", async () => {
+    const input = [
+      ...defaults,
+      { value: "abc123" }
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Key is a required field/)
+  });
+
+  test("key cannot be greater than 30 characters", async () => {
+    const input = [
+      ...defaults,
+      { key: "this is a very long key which exceeds the amount allowed by GovPay", value: "def456" }
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Key length cannot exceed 30 characters/)
+  });
+
+  test("value is required", async () => {
+    const input = [
+      ...defaults,
+      { key: "abc123" }
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Value is a required field/)
+  });
+
+  test("value cannot be greater than 100 characters", async () => {
+    const input = [
+      ...defaults,
+      { key: "abc123", value: "this is a very long value which exceeds the one-hundred character limit currently allowed by GovUKPay" }
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Value length cannot exceed 100 characters/)
+  });
+
+  test("keys must be unique", async () => { 
+    const input = [
+      ...defaults,
+      { key: "duplicatedKey", value: "someValue" },
+      { key: "duplicatedKey", value: "someOtherValue" },
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Keys must be unique/)
+  });
+
+  test("max 10 entries can be added", async () => {
+    const input = [
+      ...defaults,
+      { key: "four", value: "someValue" },
+      { key: "five", value: "someValue" },
+      { key: "six", value: "someValue" },
+      { key: "seven", value: "someValue" },
+      { key: "eight", value: "someValue" },
+      { key: "nine", value: "someValue" },
+      { key: "ten", value: "someValue" },
+    ];
+
+    const result = await validate(input);
+
+    // No errors, input returned from validation
+    expect(result).toEqual(input);
+  
+    // Try 11 total values
+    const errors = await validate([
+      ...input,
+      { key: "eleven", value: "someValue" },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/A maximum of 10 fields can be set as metadata/)
+  });
+});

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["SUBMISSION_VIEW"] as const;
+const AVAILABLE_FEATURE_FLAGS = ["SUBMISSION_VIEW", "GOVPAY_METADATA"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/editor.planx.uk/src/ui/editor/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.tsx
@@ -33,6 +33,7 @@ export interface Props<T, EditorExtraProps = {}> {
   editorExtraProps?: EditorExtraProps;
   disableDragAndDrop?: boolean;
   isFieldDisabled?: (item: T, index: number) => boolean;
+  maxItems?: number;
 }
 
 const Item = styled(Box)(({ theme }) => ({
@@ -43,13 +44,14 @@ const Item = styled(Box)(({ theme }) => ({
 export default function ListManager<T, EditorExtraProps>(
   props: Props<T, EditorExtraProps>,
 ) {
-  const { Editor } = props;
+  const { Editor, maxItems = Infinity } = props;
   // Initialize a random ID when the component mounts
   const randomId = useRef(String(Math.random()));
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
   const isViewOnly = !useStore.getState().canUserEditTeam(teamSlug);
+  const isMaxLength = props.values.length >= maxItems;
 
   return props.disableDragAndDrop ? (
     <>
@@ -100,7 +102,7 @@ export default function ListManager<T, EditorExtraProps>(
         onClick={() => {
           props.onChange([...props.values, props.newValue()]);
         }}
-        disabled={isViewOnly}
+        disabled={isViewOnly || isMaxLength}
       >
         {props.newValueLabel || "add new"}
       </Button>
@@ -183,7 +185,7 @@ export default function ListManager<T, EditorExtraProps>(
         onClick={() => {
           props.onChange([...props.values, props.newValue()]);
         }}
-        disabled={isViewOnly}
+        disabled={isViewOnly || isMaxLength}
       >
         {props.newValueLabel || "add new"}
       </Button>

--- a/editor.planx.uk/src/ui/editor/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.tsx
@@ -19,7 +19,7 @@ import {
 import { removeAt, setAt } from "../../utils";
 
 export interface EditorProps<T> {
-  index?: number;
+  index: number;
   value: T;
   onChange: (newValue: T) => void;
 }
@@ -82,7 +82,10 @@ export default function ListManager<T, EditorExtraProps>(
                   }}
                   aria-label="Delete"
                   size="large"
-                  disabled={isViewOnly || (props?.isFieldDisabled && props.isFieldDisabled(item))}
+                  disabled={
+                    isViewOnly ||
+                    (props?.isFieldDisabled && props.isFieldDisabled(item))
+                  }
                 >
                   <Delete />
                 </IconButton>

--- a/editor.planx.uk/src/ui/editor/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.tsx
@@ -75,7 +75,7 @@ export default function ListManager<T, EditorExtraProps>(
                 }}
                 {...(props.editorExtraProps || {})}
               />
-              <Box>
+              <Box sx={{ display: "flex", alignItems: "flex-end" }}>
                 <IconButton
                   onClick={() => {
                     props.onChange(removeAt(index, props.values));

--- a/editor.planx.uk/src/ui/editor/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.tsx
@@ -32,7 +32,7 @@ export interface Props<T, EditorExtraProps = {}> {
   Editor: React.FC<EditorProps<T> & (EditorExtraProps | {})>;
   editorExtraProps?: EditorExtraProps;
   disableDragAndDrop?: boolean;
-  isFieldDisabled?: (item: T) => boolean;
+  isFieldDisabled?: (item: T, index: number) => boolean;
 }
 
 const Item = styled(Box)(({ theme }) => ({
@@ -84,7 +84,8 @@ export default function ListManager<T, EditorExtraProps>(
                   size="large"
                   disabled={
                     isViewOnly ||
-                    (props?.isFieldDisabled && props.isFieldDisabled(item))
+                    (props?.isFieldDisabled &&
+                      props.isFieldDisabled(item, index))
                   }
                 >
                   <Delete />

--- a/editor.planx.uk/src/ui/editor/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.tsx
@@ -160,7 +160,11 @@ export default function ListManager<T, EditorExtraProps>(
                           }}
                           aria-label="Delete"
                           size="large"
-                          disabled={isViewOnly}
+                          disabled={
+                            isViewOnly ||
+                            (props?.isFieldDisabled &&
+                              props.isFieldDisabled(item, index))
+                          }
                         >
                           <Delete />
                         </IconButton>

--- a/editor.planx.uk/src/ui/editor/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.tsx
@@ -32,6 +32,7 @@ export interface Props<T, EditorExtraProps = {}> {
   Editor: React.FC<EditorProps<T> & (EditorExtraProps | {})>;
   editorExtraProps?: EditorExtraProps;
   disableDragAndDrop?: boolean;
+  isFieldDisabled?: (item: T) => boolean;
 }
 
 const Item = styled(Box)(({ theme }) => ({
@@ -81,7 +82,7 @@ export default function ListManager<T, EditorExtraProps>(
                   }}
                   aria-label="Delete"
                   size="large"
-                  disabled={isViewOnly}
+                  disabled={isViewOnly || (props?.isFieldDisabled && props.isFieldDisabled(item))}
                 >
                   <Delete />
                 </IconButton>

--- a/editor.planx.uk/src/ui/shared/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input.tsx
@@ -101,6 +101,7 @@ export default forwardRef((props: Props, ref): FCReturn => {
     errorMessage,
     "aria-label": ariaLabel,
     "aria-describedby": ariaDescribedBy,
+    "aria-labelledby": ariaLabelledBy,
     id,
     ...restProps
   } = props;
@@ -127,6 +128,7 @@ export default forwardRef((props: Props, ref): FCReturn => {
         inputProps={{
           "aria-label": ariaLabel,
           "aria-describedby": ariaDescribedBy,
+          "aria-labelledby": ariaLabelledBy,
         }}
         id={id}
         ref={container}


### PR DESCRIPTION
## What does this PR do?
 - Adds new GOV.UK Pay Metadata section in Pay component
 - Adds form validation rules to match GOV.UK Pay requirements

## Context
Apologies - PR is much bigger than I'd like! A good chunk of it should just be tests though.

I'll pick up the API half of this in another PR 👍 

## TODO
- [ ] API - Pick up metadata from flow, format, and pass along to GovPay
- [x] Write testing notes on Trello

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/5699e352-03a7-41fd-a247-ef558334cd79)
