### PR TITLE
Production deploy

### DIFF
--- a/doc/how-to/how-to-grant-metabase-permissions.md
+++ b/doc/how-to/how-to-grant-metabase-permissions.md
@@ -1,0 +1,54 @@
+# How to grant Metabase permissions
+
+## What is Metabase?
+[Metabase](https://www.metabase.com/) is an open source BI service which we self-host as part of PlanX. It allows teams to view and self-serve analytics dashboards related to their flows, applications, and users.
+
+Metabase is set up and running on both Staging and Production environments, but only the Production instance (with Production data) has dashboards maintained and curated for teams.
+
+## Context
+Metabase accesses our staging and production databases through the `metabase_read_only` role which has `SELECT` (read-only) access to a subset of tables and views. This ensures that sensitive user data cannot be inadvertently exposed via Metabase, and any new tables added to the PlanX database have to be explicitly exposed via this role.
+
+The permissions granted for the `metabase_read_only` role are applied via Hasura migrations. This ensures that we have a version-controlled history of this role, and it's access level is documented in code. This is not controlled via Pulumi (IaC) as this is not used for local development or test environments ("Pizzas"), which would necessitate a second method for these environments.
+
+## How is this role used?
+
+### Staging & Production
+The `metabase_read_only` role is granted to the `metabase_user` database user, which is manually set up on both staging and production with the following SQL -
+
+```sql
+CREATE USER metabase_user WITH PASSWORD `$PASSWORD`;
+GRANT metabase_read_only TO metabase_user;
+```
+
+The password for Staging and Production databases can be found the OSL 1Password account.
+
+The username and password for Metabase are not controlled via IaC - they are manually entered via the Metabase "Admin" dashboard (`Admin Setting > Databases > "staging" | "production" > Username / Password fields`).
+
+Please note - this is separate to the role used to read/write Metabase internal application data (such as dashboard and queries). This role is setup in IaC [here](https://github.com/theopensystemslab/planx-new/blob/main/infrastructure/application/index.ts#L100). For more information, please see [the Metabase docs](https://www.metabase.com/docs/latest/installation-and-operation/configuring-application-database).
+
+### Locally & Pizzas
+If you wish to run Metabase locally using the "analytics" Docker profile (`pnpm analytics` from project root), you will need to manually run the above SQL on your local database with a password of your choice. Alternatively, you can use the root DB username/password.
+
+The Metabase service does not run on Pizzas.
+
+## Metabase permissions
+Metabase also operates it's own permissions model, which allows more fine-grained control over tables. This allows "Administrator" users access to all tables granted to the Postgres `metabase_read_only` role, but other users can only access summary views.
+
+## Process
+The process for exposing a new table / view to Metabase is as follows - 
+
+### Tables
+Generally, we'd favour exposing views of data via Metabase. This means only certain columns can be exposed, and data can be formatted in a more user-friendly manner. 
+
+If you need to expose a new table (e.g. public data) access can be granted via a Hasura migration, e.g. - 
+
+```sql
+GRANT SELECT ON public.flows TO metabase_read_only;
+```
+
+### Views
+When adding a new view, you will need to grant the `metabase_read_only` role `SELECT` access the view. Access should be applied via Hasura migrations, e.g. - 
+
+```sql
+GRANT SELECT ON public.YOUR_NEW_VIEW TO metabase_read_only;
+```

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -1,9 +1,9 @@
 import Check from "@mui/icons-material/Check";
 import Box from "@mui/material/Box";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { QuestionAndResponses } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
+import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
 import { PublicProps } from "@planx/components/ui";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
@@ -13,20 +13,6 @@ import NumberedList from "ui/public/NumberedList";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
 import type { Confirmation } from "./model";
-
-const Table = styled("table")(({ theme }) => ({
-  width: "100%",
-  borderCollapse: "collapse",
-  "& tr": {
-    borderBottom: `1px solid ${theme.palette.grey[400]}`,
-    "&:last-of-type": {
-      border: "none",
-    },
-    "& td": {
-      padding: theme.spacing(1.5, 1),
-    },
-  },
-}));
 
 export type Props = PublicProps<Confirmation>;
 
@@ -70,18 +56,14 @@ export default function ConfirmationComponent(props: Props) {
       </Banner>
       <Card>
         {props.details && (
-          <Table>
-            <tbody>
-              {Object.entries(props.details).map((item, i) => (
-                <tr key={i}>
-                  <td>{item[0]}</td>
-                  <td>
-                    <b>{item[1]}</b>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
+          <SummaryListTable>
+            {Object.entries(props.details).map((item) => (
+              <>
+                <Box component="dt">{item[0]}</Box>
+                <Box component="dd">{item[1]}</Box>
+              </>
+            ))}
+          </SummaryListTable>
         )}
 
         {<FileDownload data={data} filename={sessionId || "application"} />}

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
+import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
 import type { PublicProps } from "@planx/components/ui";
 import { Feature } from "@turf/helpers";
 import { useFormik } from "formik";
@@ -15,7 +16,6 @@ import { useAnalyticsTracking } from "pages/FlowEditor/lib/analyticsProvider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
 import React from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import type { SiteAddress } from "../FindProperty/model";
 import { FETCH_BLPU_CODES } from "../FindProperty/Public";
@@ -201,40 +201,9 @@ interface PropertyDetail {
 interface PropertyDetailsProps {
   data: PropertyDetail[];
   showPropertyTypeOverride?: boolean;
+  showChangeButton?: boolean;
   overrideAnswer: (fn: string) => void;
 }
-
-// Borrows and tweaks grid style from Review page's `SummaryList`
-const PropertyDetailsList = styled(Box)(({ theme }) => ({
-  display: "grid",
-  gridTemplateColumns: "1fr 2fr 100px",
-  marginTop: theme.spacing(2),
-  marginBottom: theme.spacing(2),
-  "& > *": {
-    borderBottom: `1px solid ${theme.palette.border.main}`,
-    paddingBottom: theme.spacing(1.5),
-    paddingTop: theme.spacing(1.5),
-    verticalAlign: "top",
-    margin: 0,
-  },
-  "& ul": {
-    listStylePosition: "inside",
-    padding: 0,
-    margin: 0,
-  },
-  "& dt": {
-    // left column
-    fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  },
-  "& dd:nth-of-type(n)": {
-    // middle column
-    paddingLeft: "10px",
-  },
-  "& dd:nth-of-type(2n)": {
-    // right column
-    textAlign: "right",
-  },
-}));
 
 function PropertyDetails(props: PropertyDetailsProps) {
   const { data, showPropertyTypeOverride, overrideAnswer } = props;
@@ -248,7 +217,7 @@ function PropertyDetails(props: PropertyDetailsProps) {
   };
 
   return (
-    <PropertyDetailsList component="dl">
+    <SummaryListTable showChangeButton={true}>
       {filteredData.map(({ heading, detail, fn }: PropertyDetail) => (
         <React.Fragment key={heading}>
           <Box component="dt">{heading}</Box>
@@ -275,6 +244,6 @@ function PropertyDetails(props: PropertyDetailsProps) {
           </Box>
         </React.Fragment>
       ))}
-    </PropertyDetailsList>
+    </SummaryListTable>
   );
 }

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -19,7 +19,7 @@ export default SummaryListsBySections;
 const FIND_PROPERTY_DT = "Property address";
 const DRAW_BOUNDARY_DT = "Location plan";
 
-const Grid = styled("dl", {
+export const SummaryListTable = styled("dl", {
   shouldForwardProp: (prop) => prop !== "showChangeButton",
 })<{ showChangeButton?: boolean }>(({ theme, showChangeButton }) => ({
   display: "grid",
@@ -49,7 +49,7 @@ const Grid = styled("dl", {
   },
   "& dd:nth-of-type(2n)": {
     // right column
-    textAlign: "right",
+    textAlign: showChangeButton ? "right" : "left",
   },
 }));
 
@@ -235,7 +235,7 @@ function SummaryList(props: SummaryListProps) {
 
   return (
     <>
-      <Grid showChangeButton={props.showChangeButton}>
+      <SummaryListTable showChangeButton={props.showChangeButton}>
         {props.summaryBreadcrumbs.map(
           ({ component: Component, nodeId, node, userData }, i) => (
             <React.Fragment key={i}>
@@ -247,7 +247,7 @@ function SummaryList(props: SummaryListProps) {
                 passport={props.passport}
               />
               {props.showChangeButton && (
-                <dd>
+                <Box component="dd">
                   <Link
                     onClick={() => handleChange(nodeId)}
                     component="button"
@@ -263,12 +263,12 @@ function SummaryList(props: SummaryListProps) {
                         "this answer"}
                     </span>
                   </Link>
-                </dd>
+                </Box>
               )}
             </React.Fragment>
           ),
         )}
-      </Grid>
+      </SummaryListTable>
       <ConfirmationDialog
         open={isDialogOpen}
         onClose={handleCloseDialog}
@@ -300,8 +300,8 @@ interface ComponentProps {
 function Question(props: ComponentProps) {
   return (
     <>
-      <dt>{props.node.data.text}</dt>
-      <dd>{getNodeText()}</dd>
+      <Box component="dt">{props.node.data.text}</Box>
+      <Box component="dd">{getNodeText()}</Box>
     </>
   );
 
@@ -323,26 +323,26 @@ function FindProperty(props: ComponentProps) {
       props.passport.data?._address;
     return (
       <>
-        <dt>{FIND_PROPERTY_DT}</dt>
-        <dd>
+        <Box component="dt">{FIND_PROPERTY_DT}</Box>
+        <Box component="dd">
           {`${single_line_address.split(`, ${town}`)[0]}`}
           <br />
           {town}
           <br />
           {postcode}
-        </dd>
+        </Box>
       </>
     );
   } else {
     const { x, y, title } = props.passport.data?._address;
     return (
       <>
-        <dt>{FIND_PROPERTY_DT}</dt>
-        <dd>
+        <Box component="dt">{FIND_PROPERTY_DT}</Box>
+        <Box component="dd">
           {`${title}`}
           <br />
           {`${Math.round(x)} Easting (X), ${Math.round(y)} Northing (Y)`}
-        </dd>
+        </Box>
       </>
     );
   }
@@ -351,14 +351,14 @@ function FindProperty(props: ComponentProps) {
 function Checklist(props: ComponentProps) {
   return (
     <>
-      <dt>{props.node.data.text}</dt>
-      <dd>
+      <Box component="dt">{props.node.data.text}</Box>
+      <Box component="dd">
         <ul>
           {getAnswers(props).map((nodeId, i: number) => (
             <li key={i}>{props.flow[nodeId].data.text}</li>
           ))}
         </ul>
-      </dd>
+      </Box>
     </>
   );
 }
@@ -366,8 +366,8 @@ function Checklist(props: ComponentProps) {
 function TextInput(props: ComponentProps) {
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>{getAnswersByNode(props)}</dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">{getAnswersByNode(props)}</Box>
     </>
   );
 }
@@ -375,8 +375,8 @@ function TextInput(props: ComponentProps) {
 function FileUpload(props: ComponentProps) {
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">
         <ul>
           {getAnswersByNode(props)?.map((file: any, i: number) => (
             <li key={i}>
@@ -384,7 +384,7 @@ function FileUpload(props: ComponentProps) {
             </li>
           ))}
         </ul>
-      </dd>
+      </Box>
     </>
   );
 }
@@ -392,8 +392,10 @@ function FileUpload(props: ComponentProps) {
 function DateInput(props: ComponentProps) {
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>{format(new Date(getAnswersByNode(props)), "d MMMM yyyy")}</dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">
+        {format(new Date(getAnswersByNode(props)), "d MMMM yyyy")}
+      </Box>
     </>
   );
 }
@@ -413,8 +415,8 @@ function DrawBoundary(props: ComponentProps) {
 
   return (
     <>
-      <dt>{DRAW_BOUNDARY_DT}</dt>
-      <dd>
+      <Box component="dt">{DRAW_BOUNDARY_DT}</Box>
+      <Box component="dd">
         {fileName && (
           <span data-testid="uploaded-plan-name">
             Your uploaded file: <b>{fileName}</b>
@@ -443,7 +445,7 @@ function DrawBoundary(props: ComponentProps) {
           !geodata &&
           props.node.data?.hideFileUpload &&
           "Not provided"}
-      </dd>
+      </Box>
     </>
   );
 }
@@ -451,8 +453,10 @@ function DrawBoundary(props: ComponentProps) {
 function NumberInput(props: ComponentProps) {
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>{`${getAnswersByNode(props)} ${props.node.data.units ?? ""}`}</dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">{`${getAnswersByNode(props)} ${
+        props.node.data.units ?? ""
+      }`}</Box>
     </>
   );
 }
@@ -463,8 +467,8 @@ function AddressInput(props: ComponentProps) {
 
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">
         {line1}
         <br />
         {line2}
@@ -480,7 +484,7 @@ function AddressInput(props: ComponentProps) {
             {country}
           </>
         ) : null}
-      </dd>
+      </Box>
     </>
   );
 }
@@ -492,8 +496,8 @@ function ContactInput(props: ComponentProps) {
 
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">
         {[title, firstName, lastName].filter(Boolean).join(" ").trim()}
         <br />
         {organisation ? (
@@ -505,7 +509,7 @@ function ContactInput(props: ComponentProps) {
         {phone}
         <br />
         {email}
-      </dd>
+      </Box>
     </>
   );
 }
@@ -520,8 +524,8 @@ function FileUploadAndLabel(props: ComponentProps) {
 
   return (
     <>
-      <dt>{props.node.data.title}</dt>
-      <dd>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">
         <ul>
           {uniqueFilenames.length
             ? uniqueFilenames.map((filename, index) => (
@@ -529,7 +533,7 @@ function FileUploadAndLabel(props: ComponentProps) {
               ))
             : "No files uploaded"}
         </ul>
-      </dd>
+      </Box>
     </>
   );
 }
@@ -537,8 +541,8 @@ function FileUploadAndLabel(props: ComponentProps) {
 function Debug(props: ComponentProps) {
   return (
     <>
-      <dt>{JSON.stringify(props.node.data)}</dt>
-      <dd>{JSON.stringify(props.userData?.answers)}</dd>
+      <Box component="dt">{JSON.stringify(props.node.data)}</Box>
+      <Box component="dd">{JSON.stringify(props.userData?.answers)}</Box>
     </>
   );
 }

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = [] as const;
+const AVAILABLE_FEATURE_FLAGS = ["SUBMISSION_VIEW"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -5,20 +5,18 @@ import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const ServiceFlags: React.FC = () => {
   return (
-    <>
-      <Box>
-        <Typography variant="h2" component="h3" gutterBottom>
-          Service flags
-        </Typography>
-        <Typography variant="body1">
-          Manage the flag sets that this service uses. Flags at the top of a set
-          override flags below.
-        </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
+    <Box>
+      <Typography variant="h2" component="h3" gutterBottom>
+        Service flags
+      </Typography>
+      <Typography variant="body1">
+        Manage the flag sets that this service uses. Flags at the top of a set
+        override flags below.
+      </Typography>
+      <Box py={5}>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
-    </>
+    </Box>
   );
 };
 export default ServiceFlags;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -3,14 +3,14 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
-const DataManagerSettings: React.FC = () => {
+const Submissions: React.FC = () => {
   return (
     <Box>
       <Typography variant="h2" component="h3" gutterBottom>
-        Data Manager
+        Submissions
       </Typography>
       <Typography variant="body1">
-        Manage the data that your service uses and makes available via its API
+        View data on the user submitted applications for this service.
       </Typography>
       <Box py={5}>
         <FeaturePlaceholder title="Feature in development" />
@@ -18,4 +18,5 @@ const DataManagerSettings: React.FC = () => {
     </Box>
   );
 };
-export default DataManagerSettings;
+
+export default Submissions;

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -1,4 +1,5 @@
 import gql from "graphql-tag";
+import { hasFeatureFlag } from "lib/featureFlags";
 import { publicClient } from "lib/graphql";
 import {
   compose,
@@ -12,12 +13,37 @@ import {
 import DataManagerSettings from "pages/FlowEditor/components/Settings/DataManagerSettings";
 import ServiceFlags from "pages/FlowEditor/components/Settings/ServiceFlags";
 import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
+import Submissions from "pages/FlowEditor/components/Settings/Submissions";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import Settings from "../pages/FlowEditor/components/Settings";
 import type { FlowSettings } from "../types";
 import { makeTitle } from "./utils";
+
+const standardTabs = [
+  {
+    name: "Service",
+    route: "service",
+    Component: ServiceSettings,
+  },
+  {
+    name: "Service Flags",
+    route: "flags",
+    Component: ServiceFlags,
+  },
+  {
+    name: "Data",
+    route: "data-manager",
+    Component: DataManagerSettings,
+  },
+];
+
+const submissionsTab = {
+  name: "Submissions",
+  route: "submissions",
+  Component: Submissions,
+};
 
 const flowSettingsRoutes = compose(
   withData((req) => ({
@@ -58,32 +84,18 @@ const flowSettingsRoutes = compose(
         const settings: FlowSettings = data.flows[0].settings;
         useStore.getState().setFlowSettings(settings);
 
+        function getTabs() {
+          const isUsingFeatureFlag = hasFeatureFlag("SUBMISSION_VIEW");
+          return isUsingFeatureFlag
+            ? [...standardTabs, submissionsTab]
+            : standardTabs;
+        }
+
         return {
           title: makeTitle(
             [req.params.team, req.params.flow, "Flow Settings"].join("/"),
           ),
-          view: (
-            <Settings
-              currentTab={req.params.tab}
-              tabs={[
-                {
-                  name: "Service",
-                  route: "service",
-                  Component: ServiceSettings,
-                },
-                {
-                  name: "Service Flags",
-                  route: "flags",
-                  Component: ServiceFlags,
-                },
-                {
-                  name: "Data",
-                  route: "data-manager",
-                  Component: DataManagerSettings,
-                },
-              ]}
-            />
-          ),
+          view: <Settings currentTab={req.params.tab} tabs={getTabs()} />,
         };
       });
     }),

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1359,6 +1359,54 @@
                 _is_null: true
         check: null
 - table:
+    name: submission_services_summary
+    schema: public
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - number_times_resumed
+          - sent_to_bops
+          - sent_to_email
+          - sent_to_uniform
+          - user_clicked_save
+          - user_invited_to_pay
+          - session_length_days
+          - bops_applications
+          - email_applications
+          - payment_requests
+          - payment_status
+          - uniform_applications
+          - service_slug
+          - session_id
+          - team_slug
+          - created_at
+          - submitted_at
+        filter: {}
+      comment: ""
+    - role: teamEditor
+      permission:
+        columns:
+          - number_times_resumed
+          - sent_to_bops
+          - sent_to_email
+          - sent_to_uniform
+          - user_clicked_save
+          - user_invited_to_pay
+          - session_length_days
+          - bops_applications
+          - email_applications
+          - payment_requests
+          - payment_status
+          - uniform_applications
+          - service_slug
+          - session_id
+          - team_slug
+          - created_at
+          - submitted_at
+        filter: {}
+      comment: ""
+- table:
     name: team_integrations
     schema: public
   object_relationships:

--- a/hasura.planx.uk/migrations/1709565833346_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1709565833346_run_sql_migration/down.sql
@@ -1,0 +1,14 @@
+-- Revoke select permissions from tables used by Metabase
+REVOKE SELECT ON public.analytics FROM metabase_read_only;
+REVOKE SELECT ON public.analytics_logs FROM metabase_read_only;
+
+-- Revoke select permissions from views used by Metabase
+REVOKE SELECT ON public.analytics_summary FROM metabase_read_only;
+REVOKE SELECT ON public.feedback_summary FROM metabase_read_only;
+REVOKE SELECT ON public.submission_services_summary FROM metabase_read_only;
+
+-- Revoke usage on schema
+REVOKE USAGE ON SCHEMA public FROM metabase_read_only;
+
+-- Drop the role
+DROP ROLE IF EXISTS metabase_read_only;

--- a/hasura.planx.uk/migrations/1709565833346_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1709565833346_run_sql_migration/up.sql
@@ -1,0 +1,14 @@
+-- Create the role
+CREATE ROLE metabase_read_only;
+
+-- Grant usage on schema
+GRANT USAGE ON SCHEMA public TO metabase_read_only;
+
+-- (Temp) Grant select permissions on tables used by Metabase in current SQL queries
+GRANT SELECT ON public.analytics TO metabase_read_only;
+GRANT SELECT ON public.analytics_logs TO metabase_read_only;
+
+-- Grant select permissions on views used by Metabase
+GRANT SELECT ON public.analytics_summary TO metabase_read_only;
+GRANT SELECT ON public.feedback_summary TO metabase_read_only;
+GRANT SELECT ON public.submission_services_summary TO metabase_read_only;

--- a/hasura.planx.uk/migrations/1710258204814_alter_view_submission_services_summary_expand_application_data/down.sql
+++ b/hasura.planx.uk/migrations/1710258204814_alter_view_submission_services_summary_expand_application_data/down.sql
@@ -1,0 +1,50 @@
+drop view public.submission_services_summary;
+
+-- Previous instance of view from hasura.planx.uk/migrations/1700072112794_create_view_submission_services_summary/up.sql
+CREATE OR REPLACE VIEW public.submission_services_summary AS 
+with resumes_per_session as (
+    select 
+        session_id,
+        count(id) as number_times_resumed
+    from reconciliation_requests
+    group by session_id
+)
+select 
+    ls.id as session_id,
+    t.slug as team_slug,
+    f.slug as service_slug,
+    ls.created_at,
+    ls.submitted_at,
+    (ls.submitted_at::date - ls.created_at::date) as session_length_days,
+    ls.has_user_saved as user_clicked_save,
+    rps.number_times_resumed,
+    case 
+      when pr.id is null
+      then false
+      else true
+    end as user_invited_to_pay,
+    case 
+      when ba.bops_id is null
+      then false
+      else true
+    end as sent_to_bops,
+    case 
+      when ua.idox_submission_id is null
+      then false
+      else true
+    end as sent_to_uniform,
+    case 
+      when ea.id is null
+      then false
+      else true
+    end as sent_to_email
+from lowcal_sessions ls
+ left join flows f on f.id = ls.flow_id
+ left join teams t on t.id = f.team_id
+ left join resumes_per_session rps on rps.session_id = ls.id::text
+ left join payment_requests pr on pr.session_id = ls.id
+ left join bops_applications ba on ba.session_id = ls.id::text
+ left join uniform_applications ua on ua.submission_reference = ls.id::text
+ left join email_applications ea on ea.session_id = ls.id
+where f.slug IS NOT NULL
+ and t.slug IS NOT NULL;

--- a/hasura.planx.uk/migrations/1710258204814_alter_view_submission_services_summary_expand_application_data/up.sql
+++ b/hasura.planx.uk/migrations/1710258204814_alter_view_submission_services_summary_expand_application_data/up.sql
@@ -1,0 +1,115 @@
+drop view "public"."submission_services_summary";
+
+create or replace view "public"."submission_services_summary" as
+ with resumes_per_session as (
+    select 
+        session_id,
+        count(id) as number_times_resumed
+    from reconciliation_requests
+    group by session_id
+), bops_agg as (
+    select
+        session_id,
+        json_agg(
+            json_build_object(
+                'id', bops_id,
+                'submitted_at', created_at,
+                'destination_url', destination_url
+            ) order by created_at desc
+        ) as bops_applications
+    from bops_applications
+    group by session_id
+), email_agg as (
+    select
+        session_id,
+        json_agg(
+            json_build_object(
+                'id', id,
+                'recipient', recipient,
+                'submitted_at', created_at
+            ) order by created_at desc
+        ) as email_applications
+    from email_applications
+    group by session_id
+), uniform_agg as (
+    select
+        submission_reference,
+        json_agg(
+            json_build_object(
+                'id', idox_submission_id,
+                'submitted_at', created_at
+            ) order by created_at desc
+        ) as uniform_applications
+    from uniform_applications
+    group by submission_reference
+), payment_requests_agg as (
+    select
+        session_id,
+        json_agg(
+            json_build_object(
+                'id', id,
+                'created_at', created_at,
+                'paid_at', paid_at,
+                'govpay_payment_id', govpay_payment_id
+            ) order by created_at desc
+        ) as payment_requests
+    from payment_requests
+    group by session_id
+), payment_status_agg as (
+    select
+        session_id,
+        json_agg(
+            json_build_object(
+                'govpay_payment_id', payment_id,
+                'created_at', created_at,
+                'status', status
+            ) order by created_at desc
+        ) as payment_status
+    from payment_status
+    group by session_id
+)
+select 
+    ls.id::text as session_id,
+    t.slug as team_slug,
+    f.slug as service_slug,
+    ls.created_at,
+    ls.submitted_at,
+    (ls.submitted_at::date - ls.created_at::date) as session_length_days,
+    ls.has_user_saved as user_clicked_save,
+    rps.number_times_resumed,
+    case
+        when pr.payment_requests::jsonb is not null and jsonb_array_length(pr.payment_requests::jsonb) > 0
+        then true
+        else false
+    end as user_invited_to_pay,
+    pr.payment_requests,
+    ps.payment_status,
+    case 
+      when ba.bops_applications::jsonb is not null and jsonb_array_length(ba.bops_applications::jsonb) > 0
+      then true
+      else false
+    end as sent_to_bops,
+    ba.bops_applications,
+    case 
+      when ua.uniform_applications::jsonb is not null and jsonb_array_length(ua.uniform_applications::jsonb) > 0
+      then true
+      else false
+    end as sent_to_uniform,
+    ua.uniform_applications,
+    case 
+      when ea.email_applications::jsonb is not null and jsonb_array_length(ea.email_applications::jsonb) > 0
+      then true
+      else false
+    end as sent_to_email,
+    ea.email_applications
+from lowcal_sessions ls
+ left join flows f on f.id = ls.flow_id
+ left join teams t on t.id = f.team_id
+ left join resumes_per_session rps on rps.session_id = ls.id::text
+ left join payment_requests_agg pr on pr.session_id = ls.id
+ left join payment_status_agg ps on ps.session_id = ls.id
+ left join bops_agg ba on ba.session_id = ls.id::text
+ left join uniform_agg ua on ua.submission_reference = ls.id::text
+ left join email_agg ea on ea.session_id = ls.id
+where f.slug is not null
+ and t.slug is not null;

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -21,7 +21,7 @@ config:
   application:gov-uk-pay-token-camden:
     secure: AAABAA2gkhNBs2hOfIkhHiA50MF3X8xnaGvLVzWdg0OOTl9qOKgtCjS76/XBIpGsGEyFbtHwuOgWhPw1qgql7MBO+pTnfLzDc8WcbxQFMbIjKUAgqF4yUMu75jcOiJ9XadNq
   application:gov-uk-pay-token-gloucester:
-    secure: AAABANCvH7gf+3Bs9vZxg1QkkFUDnDnn0dn9n0UlDo3rJdF5ThFzqg4dc+mSxAyQ4OXZLPxvFmVmMY9QZNSZKGqXYSY2CJjed2GeGmQ5zHAOzSjkomxQqtpaRANAb3s7NQkn
+    secure: AAABAMzflVg0cd5sjaETPp/s+OhgAr9UC4p8B72HiLHLUmNoFlsdWmCi4Z9rX6fEx+R008e0JHTz6REYQXWegH80QYMhKsUonmMON8/QMiz3AbDfZnEOGovMuC7mFLGpRDqn
   application:gov-uk-pay-token-lambeth:
     secure: AAABAPy5USkd8/hwq6vFXP45BXsYFUltR6gj8PoiZkOLRPUd1wgQ3Yhgc1Cyn+lb5cZrXBoVPjuVhm/UvBN82DNzRTl2TxAakCQQIrBU5xil+m9UnbY82CNSMDuEaWwMpR3C
   application:gov-uk-pay-token-medway:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -97,6 +97,10 @@ export = async () => {
     superuser: false,
   });
   const metabasePgPassword = config.requireSecret("metabasePgPassword");
+
+  // Setup role and database for internal Metabase application data, such as dashboards and queries
+  // This is separate to the postgres/public one used to hold PlanX application data
+  // Docs: https://www.metabase.com/docs/latest/installation-and-operation/configuring-application-database
   const role = new postgres.Role(
     "metabase",
     {


### PR DESCRIPTION
Once https://github.com/theopensystemslab/planx-new/pull/2856 is deployed to production, I can create the `metabase_user` on production as outlined [in the docs here](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-grant-metabase-permissions.md), and then use these credentials in the Metabase admin panel.

## To Do (Staging)
- [x] `metabase_user` manually added to database (staging)
- [x] `metabase_user` username/password used for Metbase connection (staging)
- [x] Metabase "sync" and "scan" operations kicked off (staging)
- [x] Manually migrate `allow_list_answers` to new data structure (see https://github.com/theopensystemslab/planx-new/pull/2838)
  - Not necessary, 0 records to update

## To Do (Prod - post-deployment)
- [ ] `metabase_user` manually added to database (production)
- [ ] `metabase_user` username/password used for Metbase connection (production)
- [ ] Metabase "sync" and "scan" operations kicked off (production)
- [ ] Manually migrate `allow_list_answers` to new data structure (see https://github.com/theopensystemslab/planx-new/pull/2838)