### PR TITLE
feat: add tab for submissions view to flowSettings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -5,19 +5,17 @@ import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const DataManagerSettings: React.FC = () => {
   return (
-    <>
-      <Box>
-        <Typography variant="h2" component="h3" gutterBottom>
-          Data Manager
-        </Typography>
-        <Typography variant="body1">
-          Manage the data that your service uses and makes available via its API
-        </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
+    <Box>
+      <Typography variant="h2" component="h3" gutterBottom>
+        Data Manager
+      </Typography>
+      <Typography variant="body1">
+        Manage the data that your service uses and makes available via its API
+      </Typography>
+      <Box py={5}>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
-    </>
+    </Box>
   );
 };
 export default DataManagerSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -5,20 +5,18 @@ import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const ServiceFlags: React.FC = () => {
   return (
-    <>
-      <Box>
-        <Typography variant="h2" component="h3" gutterBottom>
-          Service flags
-        </Typography>
-        <Typography variant="body1">
-          Manage the flag sets that this service uses. Flags at the top of a set
-          override flags below.
-        </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
+    <Box>
+      <Typography variant="h2" component="h3" gutterBottom>
+        Service flags
+      </Typography>
+      <Typography variant="body1">
+        Manage the flag sets that this service uses. Flags at the top of a set
+        override flags below.
+      </Typography>
+      <Box py={5}>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
-    </>
+    </Box>
   );
 };
 export default ServiceFlags;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -1,0 +1,24 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+
+const Submissions: React.FC = () => {
+  return (
+    <>
+      <Box>
+        <Typography variant="h2" component="h3" gutterBottom>
+          Submissions
+        </Typography>
+        <Typography variant="body1">
+          View data on the user submitted applications for this service.
+        </Typography>
+        <Box py={5}>
+          <FeaturePlaceholder title="Feature in development" />
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default Submissions;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -5,19 +5,17 @@ import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const Submissions: React.FC = () => {
   return (
-    <>
-      <Box>
-        <Typography variant="h2" component="h3" gutterBottom>
-          Submissions
-        </Typography>
-        <Typography variant="body1">
-          View data on the user submitted applications for this service.
-        </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
+    <Box>
+      <Typography variant="h2" component="h3" gutterBottom>
+        Submissions
+      </Typography>
+      <Typography variant="body1">
+        View data on the user submitted applications for this service.
+      </Typography>
+      <Box py={5}>
+        <FeaturePlaceholder title="Feature in development" />
       </Box>
-    </>
+    </Box>
   );
 };
 

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -1,4 +1,5 @@
 import gql from "graphql-tag";
+import { hasFeatureFlag } from "lib/featureFlags";
 import { publicClient } from "lib/graphql";
 import {
   compose,
@@ -12,12 +13,37 @@ import {
 import DataManagerSettings from "pages/FlowEditor/components/Settings/DataManagerSettings";
 import ServiceFlags from "pages/FlowEditor/components/Settings/ServiceFlags";
 import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
+import Submissions from "pages/FlowEditor/components/Settings/Submissions";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import Settings from "../pages/FlowEditor/components/Settings";
 import type { FlowSettings } from "../types";
 import { makeTitle } from "./utils";
+
+const standardTabs = [
+  {
+    name: "Service",
+    route: "service",
+    Component: ServiceSettings,
+  },
+  {
+    name: "Service Flags",
+    route: "flags",
+    Component: ServiceFlags,
+  },
+  {
+    name: "Data",
+    route: "data-manager",
+    Component: DataManagerSettings,
+  },
+];
+
+const submissionsTab = {
+  name: "Submissions",
+  route: "submissions",
+  Component: Submissions,
+};
 
 const flowSettingsRoutes = compose(
   withData((req) => ({
@@ -58,32 +84,18 @@ const flowSettingsRoutes = compose(
         const settings: FlowSettings = data.flows[0].settings;
         useStore.getState().setFlowSettings(settings);
 
+        function getTabs() {
+          const isUsingFeatureFlag = hasFeatureFlag("SUBMISSION_VIEW");
+          return isUsingFeatureFlag
+            ? [...standardTabs, submissionsTab]
+            : standardTabs;
+        }
+
         return {
           title: makeTitle(
             [req.params.team, req.params.flow, "Flow Settings"].join("/"),
           ),
-          view: (
-            <Settings
-              currentTab={req.params.tab}
-              tabs={[
-                {
-                  name: "Service",
-                  route: "service",
-                  Component: ServiceSettings,
-                },
-                {
-                  name: "Service Flags",
-                  route: "flags",
-                  Component: ServiceFlags,
-                },
-                {
-                  name: "Data",
-                  route: "data-manager",
-                  Component: DataManagerSettings,
-                },
-              ]}
-            />
-          ),
+          view: <Settings currentTab={req.params.tab} tabs={getTabs()} />,
         };
       });
     }),


### PR DESCRIPTION
## What

- Add a new placeholder component for a "Feature in development"
- Conditionally render this component as a flow settings tab based on the `SUBMISSION_VIEW` feature flag. 

## Why

- Adding development behind a feature flat allows the work to be shipped incrementally without being visible to user
- Setups the structure for adding a table for visualising application data

## Screenshots

Tab rendered with feature flag enabled:

<img width="1728" alt="Screenshot 2024-03-13 at 11 46 18" src="https://github.com/theopensystemslab/planx-new/assets/36415632/68b575d7-19f9-40ea-bd2a-45545babe356">
