### PR TITLE
fix: store full BOPS endpoint in `team_integrations`, don't concat in API

### DIFF
--- a/api.planx.uk/modules/send/bops/bops.test.ts
+++ b/api.planx.uk/modules/send/bops/bops.test.ts
@@ -27,7 +27,8 @@ jest.mock("@opensystemslab/planx-core", () => {
 });
 
 describe(`sending an application to BOPS (v2)`, () => {
-  const submissionURL = "https://test.bops-test.com";
+  const submissionURL =
+    "https://test.bops-test.com/api/v2/planning_applications";
 
   beforeEach(() => {
     queryMock.mockQuery({
@@ -81,7 +82,7 @@ describe(`sending an application to BOPS (v2)`, () => {
 
   it("successfully proxies request and returns hasura id", async () => {
     const expectedHeaders = { authorization: "Bearer abc123" };
-    const nockScope = nock(`${submissionURL}/api/v2/planning_applications`, {
+    const nockScope = nock(submissionURL, {
       reqheaders: expectedHeaders,
     })
       .post("")

--- a/api.planx.uk/modules/send/bops/bops.ts
+++ b/api.planx.uk/modules/send/bops/bops.ts
@@ -53,14 +53,13 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
       encryptionKey: process.env.ENCRYPTION_KEY!,
       env,
     });
-    const target = `${bopsSubmissionURL}/api/v2/planning_applications`;
     const exportData = await $api.export.digitalPlanningDataPayload(
       payload?.sessionId,
     );
 
     const bopsResponse = await axios({
       method: "POST",
-      url: target,
+      url: bopsSubmissionURL,
       adapter: "http",
       headers: {
         "Content-Type": "application/json",

--- a/api.planx.uk/modules/send/bops/bops.ts
+++ b/api.planx.uk/modules/send/bops/bops.ts
@@ -100,7 +100,7 @@ const sendToBOPS = async (req: Request, res: Response, next: NextFunction) => {
           `,
           {
             bops_id: res.data.id,
-            destination_url: target,
+            destination_url: bopsSubmissionURL,
             request: exportData,
             response: res.data,
             response_headers: res.headers,


### PR DESCRIPTION
Allows us to use Planning API for staging, and BOPS for production

See thread https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1710431607298759

To test: update BOPS staging `team_integrations` values on this pizza to Planning API endpoint and test a submission. Will need to coordinate merge & deploy with prod db updates & syncs