### PR TITLE
fix: Mute Stripe test notifications

### DIFF
--- a/api.planx.uk/modules/pay/service/utils.test.ts
+++ b/api.planx.uk/modules/pay/service/utils.test.ts
@@ -1,0 +1,42 @@
+import { GovUKPayment } from "@opensystemslab/planx-core/types";
+import { isTestPayment } from "./utils";
+
+describe("isTestPayment() helper function", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("sandbox payments", () => {
+    const result = isTestPayment({
+      payment_provider: "sandbox",
+    } as GovUKPayment);
+    expect(result).toBe(true);
+  });
+
+  test("other payment providers", () => {
+    const result = isTestPayment({ payment_provider: "Visa" } as GovUKPayment);
+    expect(result).toBe(false);
+  });
+
+  test("stripe payments (staging)", () => {
+    process.env.APP_ENVIRONMENT = "staging";
+    const result = isTestPayment({
+      payment_provider: "stripe",
+    } as GovUKPayment);
+    expect(result).toBe(true);
+  });
+
+  test("stripe payments (production)", () => {
+    process.env.APP_ENVIRONMENT = "production";
+    const result = isTestPayment({
+      payment_provider: "stripe",
+    } as GovUKPayment);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?
 - Mutes notifications on Slack triggered by test payments
 - Requires as Gloucester use Stripe in GovPay
 - Stripe does not have a specific test `payment_provider` code (Docs: https://docs.payments.service.gov.uk/testing_govuk_pay/#testing-recurring-payments-on-a-test-account)
 - Context: https://opensystemslab.slack.com/archives/C0405SQDP8B/p1710433238647279 (OSL Slack)

## Testing
 - [x] Pizza test payments don't trigger notifications
 - [ ] Staging test payments don't trigger notifications (post-merge)