### PR TITLE
fix(a11y): Add aria expanded and controls to collapse/expand components

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -100,6 +100,7 @@ export default function ConstraintsList({
                   data={con.value ? con.data : null}
                   metadata={metadata?.[con.fn]}
                   category={category}
+                  id={con.fn}
                 >
                   {metadata?.[con.fn]?.plural || ReactHtmlParser(con.text)}
                 </ConstraintListItem>
@@ -119,9 +120,14 @@ interface ConstraintListItemProps {
   metadata?: Metadata;
   category: string;
   children: ReactNode;
+  id: string;
 }
 
-function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
+function ConstraintListItem({
+  children,
+  id,
+  ...props
+}: ConstraintListItemProps) {
   const [showConstraintData, setShowConstraintData] = useState<boolean>(false);
 
   return (
@@ -139,6 +145,8 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
             onClick={() =>
               setShowConstraintData((showConstraintData) => !showConstraintData)
             }
+            aria-expanded={showConstraintData}
+            aria-controls={id}
             style={{
               display: "flex",
               flexDirection: "row",
@@ -161,7 +169,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
             />
           </Button>
         </Box>
-        <Collapse in={showConstraintData}>
+        <Collapse id={id} in={showConstraintData}>
           <Box py={1.5} px={2}>
             <>
               <Typography variant="h3" component="h4" gutterBottom>

--- a/editor.planx.uk/src/ui/public/CollapsibleInput.tsx
+++ b/editor.planx.uk/src/ui/public/CollapsibleInput.tsx
@@ -16,10 +16,15 @@ const CollapsibleInput: React.FC<Props> = (props: Props) => {
 
   return (
     <>
-      <Link component="button" onClick={() => setExpanded((x) => !x)}>
+      <Link
+        component="button"
+        aria-expanded={expanded}
+        aria-controls={props.name}
+        onClick={() => setExpanded((x) => !x)}
+      >
         {props.children}
       </Link>
-      <Collapse in={expanded}>
+      <Collapse in={expanded} id={props.name + `-collapse`}>
         <Input
           multiline
           bordered


### PR DESCRIPTION
Still to do:

- [ ] Add `aria-labelledby` to collapsed element