### PR TITLE
chore: Drop redundant `@testing-library/dom` dependency

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -112,7 +112,6 @@
     "@storybook/react-webpack5": "^7.6.7",
     "@storybook/testing-library": "^0.2.2",
     "@storybook/theming": "^7.6.7",
-    "@testing-library/dom": "^8.20.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.4.3",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -335,9 +335,6 @@ devDependencies:
   '@storybook/theming':
     specifier: ^7.6.7
     version: 7.6.7(react-dom@18.2.0)(react@18.2.0)
-  '@testing-library/dom':
-    specifier: ^8.20.1
-    version: 8.20.1
   '@testing-library/jest-dom':
     specifier: ^5.16.5
     version: 5.16.5
@@ -346,7 +343,7 @@ devDependencies:
     version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
   '@testing-library/user-event':
     specifier: ^14.4.3
-    version: 14.4.3(@testing-library/dom@8.20.1)
+    version: 14.4.3(@testing-library/dom@9.3.4)
   '@types/dompurify':
     specifier: ^3.0.5
     version: 3.0.5
@@ -7102,20 +7099,6 @@ packages:
   /@swc/types@0.1.5:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
 
-  /@testing-library/dom@8.20.1:
-    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/code-frame': 7.23.5
-      '@babel/runtime': 7.24.0
-      '@types/aria-query': 5.0.4
-      aria-query: 5.1.3
-      chalk: 4.1.2
-      dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
-      pretty-format: 27.5.1
-    dev: true
-
   /@testing-library/dom@9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
@@ -7157,15 +7140,6 @@ packages:
       '@types/react-dom': 18.2.18
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
-
-  /@testing-library/user-event@14.4.3(@testing-library/dom@8.20.1):
-    resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
-    engines: {node: '>=12', npm: '>=6'}
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
-    dependencies:
-      '@testing-library/dom': 8.20.1
     dev: true
 
   /@testing-library/user-event@14.4.3(@testing-library/dom@9.3.4):


### PR DESCRIPTION
Something small I noticed when working on tests for #2878  - this package isn't required, and can cause issues if it resolves to a different version.

> If you use one of the [framework wrappers](https://testing-library.com/docs/dom-testing-library/install#wrappers), it is important that @testing-library/dom is resolved to the same installation required by the framework wrapper of your choice.
>
> Usually this means that if you use one of the framework wrappers, you should not add @testing-library/dom to your project dependencies. 


Source: https://testing-library.com/docs/user-event/install/