### PR TITLE
chore: bump planx-core including ODP Schema v0.4.1

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dab9c39",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d58f78d",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dab9c39
-    version: github.com/theopensystemslab/planx-core/dab9c39
+    specifier: git+https://github.com/theopensystemslab/planx-core#d58f78d
+    version: github.com/theopensystemslab/planx-core/d58f78d
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6033,8 +6033,8 @@ packages:
       object-visit: 1.0.1
     dev: true
 
-  /marked@12.0.0:
-    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
+  /marked@12.0.1:
+    resolution: {integrity: sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -7984,8 +7984,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /type-fest@4.11.1:
-    resolution: {integrity: sha512-MFMf6VkEVZAETidGGSYW2B1MjXbGX+sWIywn2QPEaJ3j08V+MwVRHMXtf2noB8ENJaD0LIun9wh5Z6OPNf1QzQ==}
+  /type-fest@4.12.0:
+    resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -8409,8 +8409,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dab9c39:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dab9c39}
+  github.com/theopensystemslab/planx-core/d58f78d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d58f78d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -8431,11 +8431,11 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 12.0.0
+      marked: 12.0.1
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.11.1
+      type-fest: 4.12.0
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dab9c39",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d58f78d",
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dab9c39
-    version: github.com/theopensystemslab/planx-core/dab9c39
+    specifier: git+https://github.com/theopensystemslab/planx-core#d58f78d
+    version: github.com/theopensystemslab/planx-core/d58f78d
   axios:
     specifier: ^1.6.0
     version: 1.6.0
@@ -2026,8 +2026,8 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
-  /marked@12.0.0:
-    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
+  /marked@12.0.1:
+    resolution: {integrity: sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -2745,8 +2745,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /type-fest@4.11.1:
-    resolution: {integrity: sha512-MFMf6VkEVZAETidGGSYW2B1MjXbGX+sWIywn2QPEaJ3j08V+MwVRHMXtf2noB8ENJaD0LIun9wh5Z6OPNf1QzQ==}
+  /type-fest@4.12.0:
+    resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2943,8 +2943,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dab9c39:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dab9c39}
+  github.com/theopensystemslab/planx-core/d58f78d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d58f78d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2965,11 +2965,11 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 12.0.0
+      marked: 12.0.1
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.11.1
+      type-fest: 4.12.0
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dab9c39",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d58f78d",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dab9c39
-    version: github.com/theopensystemslab/planx-core/dab9c39
+    specifier: git+https://github.com/theopensystemslab/planx-core#d58f78d
+    version: github.com/theopensystemslab/planx-core/d58f78d
   axios:
     specifier: ^1.6.2
     version: 1.6.2
@@ -1805,8 +1805,8 @@ packages:
       es5-ext: 0.10.64
     dev: false
 
-  /marked@12.0.0:
-    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
+  /marked@12.0.1:
+    resolution: {integrity: sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -2455,8 +2455,8 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /type-fest@4.11.1:
-    resolution: {integrity: sha512-MFMf6VkEVZAETidGGSYW2B1MjXbGX+sWIywn2QPEaJ3j08V+MwVRHMXtf2noB8ENJaD0LIun9wh5Z6OPNf1QzQ==}
+  /type-fest@4.12.0:
+    resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2609,8 +2609,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dab9c39:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dab9c39}
+  github.com/theopensystemslab/planx-core/d58f78d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d58f78d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2631,11 +2631,11 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 12.0.0
+      marked: 12.0.1
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.11.1
+      type-fest: 4.12.0
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@mui/styles": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dab9c39",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d58f78d",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -43,8 +43,8 @@ dependencies:
     specifier: ^0.8.0
     version: 0.8.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dab9c39
-    version: github.com/theopensystemslab/planx-core/dab9c39(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#d58f78d
+    version: github.com/theopensystemslab/planx-core/d58f78d(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -14975,8 +14975,8 @@ packages:
       react: 18.2.0
     dev: true
 
-  /marked@12.0.0:
-    resolution: {integrity: sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==}
+  /marked@12.0.1:
+    resolution: {integrity: sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -19949,8 +19949,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /type-fest@4.11.1:
-    resolution: {integrity: sha512-MFMf6VkEVZAETidGGSYW2B1MjXbGX+sWIywn2QPEaJ3j08V+MwVRHMXtf2noB8ENJaD0LIun9wh5Z6OPNf1QzQ==}
+  /type-fest@4.12.0:
+    resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -21120,9 +21120,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/dab9c39(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dab9c39}
-    id: github.com/theopensystemslab/planx-core/dab9c39
+  github.com/theopensystemslab/planx-core/d58f78d(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d58f78d}
+    id: github.com/theopensystemslab/planx-core/d58f78d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -21143,11 +21143,11 @@ packages:
       graphql-request: 6.1.0(graphql@16.8.1)
       json-schema-to-typescript: 13.1.2
       lodash: 4.17.21
-      marked: 12.0.0
+      marked: 12.0.1
       prettier: 3.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      type-fest: 4.11.1
+      type-fest: 4.12.0
       uuid: 9.0.1
       zod: 3.22.4
     transitivePeerDependencies:


### PR DESCRIPTION
Would love to get this on staging today as I offered to do a staging re-submit for Freya that was invalid because of a missing file type yesterday: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1710434142767489