### PR TITLE
fix: Broken lockfile [skip pizza]

### DIFF
--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -7139,7 +7139,7 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.0
-      '@testing-library/dom': 8.20.1
+      '@testing-library/dom': 9.3.4
       '@types/react-dom': 18.2.18
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
<img width="1048" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/a9ab577e-67b5-4614-b969-1b0e88e234ef">

Latest staging deploy failed due to a conflict, see CI run here (https://github.com/theopensystemslab/planx-new/actions/runs/8300282701/job/22718062126)

Looks like it was just a missed conflict / omission in the lockfile when #2908 and #2904  were merged to `main`.