### PR TITLE
feat: Update logic graph styling

### DIFF
--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -7,6 +7,7 @@ import ContactPage from "@mui/icons-material/ContactPage";
 import CopyAll from "@mui/icons-material/CopyAll";
 import Create from "@mui/icons-material/Create";
 import Event from "@mui/icons-material/Event";
+import FilterAltOutlined from "@mui/icons-material/FilterAltOutlined";
 import FunctionsIcon from "@mui/icons-material/Functions";
 import Home from "@mui/icons-material/Home";
 import InfoOutlined from "@mui/icons-material/InfoOutlined";
@@ -17,13 +18,12 @@ import PaymentOutlined from "@mui/icons-material/PaymentOutlined";
 import Pin from "@mui/icons-material/Pin";
 import PlaylistAdd from "@mui/icons-material/PlaylistAdd";
 import PlaylistAddCheck from "@mui/icons-material/PlaylistAddCheck";
-import RateReview from "@mui/icons-material/RateReview";
+import RateReviewOutlined from "@mui/icons-material/RateReviewOutlined";
 import ReportProblemOutlined from "@mui/icons-material/ReportProblemOutlined";
 import SearchOutlined from "@mui/icons-material/SearchOutlined";
 import Send from "@mui/icons-material/Send";
 import SquareFoot from "@mui/icons-material/SquareFoot";
 import TextFields from "@mui/icons-material/TextFields";
-import ViewAgenda from "@mui/icons-material/ViewAgenda";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { Store } from "pages/FlowEditor/lib/store";
 import type { handleSubmit } from "pages/Preview/Node";
@@ -68,7 +68,7 @@ export const ICONS: {
   [TYPES.ExternalPortal]: CopyAll,
   [TYPES.FileUpload]: CloudUpload,
   [TYPES.FileUploadAndLabel]: CloudUpload,
-  [TYPES.Filter]: undefined,
+  [TYPES.Filter]: FilterAltOutlined,
   [TYPES.FindProperty]: SearchOutlined,
   [TYPES.Flow]: undefined,
   [TYPES.InternalPortal]: undefined,
@@ -80,8 +80,8 @@ export const ICONS: {
   [TYPES.PropertyInformation]: LocationOnOutlined,
   [TYPES.Answer]: undefined,
   [TYPES.Result]: PlaylistAddCheck,
-  [TYPES.Review]: RateReview,
-  [TYPES.Section]: ViewAgenda,
+  [TYPES.Review]: RateReviewOutlined,
+  [TYPES.Section]: List,
   [TYPES.Send]: Send,
   [TYPES.SetValue]: PlaylistAdd,
   [TYPES.Question]: CallSplit,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -73,7 +73,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
-        className={classNames("card", "decision", {
+        className={classNames("card", "decision", "question", {
           isDragging,
           isClone: isClone(props.id),
           isNote: childNodes.length === 0,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -12,7 +12,7 @@ const Option: React.FC<any> = (props) => {
 
   const href = "";
 
-  let background = "#AEAEAE"; // no flag color
+  let background = "#F9F8F8"; // no flag color
   let color = "#000";
   try {
     const flag = flatFlags.find(({ value }) =>
@@ -26,13 +26,9 @@ const Option: React.FC<any> = (props) => {
     <li
       className={classNames("card", "option", { wasVisited: props.wasVisited })}
     >
-      <Link
-        href={href}
-        prefetch={false}
-        onClick={(e) => e.preventDefault()}
-        style={{ background, color }}
-      >
-        <span>{props.data.text}</span>
+      <Link href={href} prefetch={false} onClick={(e) => e.preventDefault()}>
+        <div className="band" style={{ background, color }}></div>
+        <div className="text">{props.data.text}</div>
       </Link>
       <ol className="decisions">
         {childNodes.map((child: any) => (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -12,7 +12,7 @@ const Option: React.FC<any> = (props) => {
 
   const href = "";
 
-  let background = "#F9F8F8"; // no flag color
+  let background = "#666"; // no flag color
   let color = "#000";
   try {
     const flag = flatFlags.find(({ value }) =>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -84,7 +84,7 @@ const ExternalPortal: React.FC<any> = (props) => {
         <Link href={`/${href}`} prefetch={false} ref={drag}>
           <span>{href}</span>
         </Link>
-        <Link href={editHref} prefetch={false}>
+        <Link href={editHref} prefetch={false} className="portalMenu">
           <MoreVert titleAccess="Edit Portal" />
         </Link>
       </li>
@@ -134,7 +134,7 @@ const InternalPortal: React.FC<any> = (props) => {
         >
           <span>{props.data.text}</span>
         </Link>
-        <Link href={editHref} prefetch={false}>
+        <Link href={editHref} prefetch={false} className="portalMenu">
           <MoreVert titleAccess="Edit Portal" />
         </Link>
       </li>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@apollo/client";
+import DoorFrontOutlined from "@mui/icons-material/DoorFrontOutlined";
 import MoreVert from "@mui/icons-material/MoreVert";
 import classNames from "classnames";
 import gql from "graphql-tag";
@@ -132,6 +133,7 @@ const InternalPortal: React.FC<any> = (props) => {
           ref={drag}
           onContextMenu={handleContext}
         >
+          <DoorFrontOutlined />
           <span>{props.data.text}</span>
         </Link>
         <Link href={editHref} prefetch={false} className="portalMenu">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -57,7 +57,7 @@ const Question: React.FC<Props> = React.memo((props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
-        className={classNames("card", "decision", {
+        className={classNames("card", "decision", "type" + props.type, {
           isDragging,
           isClone: isClone(props.id),
           isNote: childNodes.length === 0,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -57,13 +57,18 @@ const Question: React.FC<Props> = React.memo((props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
-        className={classNames("card", "decision", "type" + props.type, {
-          isDragging,
-          isClone: isClone(props.id),
-          isNote: childNodes.length === 0,
-          wasVisited: props.wasVisited,
-          hasFailed: props.hasFailed,
-        })}
+        className={classNames(
+          "card",
+          "decision",
+          "type-" + TYPES[props.type as TYPES],
+          {
+            isDragging,
+            isClone: isClone(props.id),
+            isNote: childNodes.length === 0,
+            wasVisited: props.wasVisited,
+            hasFailed: props.hasFailed,
+          },
+        )}
       >
         <Link
           href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -1,5 +1,4 @@
 $black: #0b0c0c;
-$lineColor: #d0d0d0;
 $nodeBorder: $black;
 $optionBorder: #b1b4b6;
 $hangerBackground: #f2f2f2;
@@ -184,8 +183,8 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     background-image: linear-gradient(
       90deg,
       $optionBorder,
-      $optionBorder 50%,
-      transparent 50%,
+      $optionBorder 40%,
+      transparent 40%,
       transparent 100%
     );
     background-size: 12px 2px;
@@ -411,7 +410,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
         bottom: -$nodeBorderWidth;
         width: 0;
         height: 0;
-        border-top: 12px solid $nodeBorder;
+        border-top: 12px solid #555;
         border-right: 12px solid transparent;
       }
     }

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -1,8 +1,8 @@
-$background: #f2f2f2;
 $black: #0b0c0c;
-$lineColor: #cacaca;
-$nodeBorder: #0b0c0c;
+$lineColor: #d0d0d0;
+$nodeBorder: $black;
 $optionBorder: #b1b4b6;
+$hangerBackground: #f2f2f2;
 $focus: #ffdd00;
 
 $endpointWidth: 50px;
@@ -95,9 +95,6 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
 
 .card {
   position: relative;
-  [data-layout="top-down"] & {
-    width: 100%;
-  }
 
   &.isDragging {
     opacity: 0.3;
@@ -163,6 +160,15 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
 
     > span:not(:nth-child(1)) {
       margin-left: 6px;
+    }
+  }
+
+  &.type-Section {
+    [data-layout="top-down"] & {
+      width: 100%;
+    }
+    [data-layout="left-right"] & {
+      height: 100%;
     }
   }
 
@@ -283,7 +289,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     border-radius: $size;
     color: $black;
     padding: 5px;
-    background: $background;
+    background: $hangerBackground;
     line-height: 1.5;
 
     margin: $padding;
@@ -359,6 +365,11 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
 
 .decision > ol.options > li.option:only-child .hanger {
   display: none;
+}
+
+.category > span {
+  padding: 6px 12px;
+  background: #d0d0d0;
 }
 
 .decision,

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -166,7 +166,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     }
   }
 
-  &.type360::after {
+  &.type-Section::after {
     content: "";
     position: absolute;
     top: 50%;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -1,11 +1,16 @@
 $background: #f2f2f2;
-$black: #2c2c2c;
-$endpointRadius: 45px;
-$hangerRadius: 14px;
+$black: #0b0c0c;
 $lineColor: #cacaca;
-$lineWidth: 1px;
-$padding: 7px;
-$pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNc8B8AAkUBofXwZpQAAAAASUVORK5CYII=);
+$nodeBorder: #0b0c0c;
+$optionBorder: #b1b4b6;
+$focus: #ffdd00;
+
+$endpointWidth: 50px;
+$hangerWidth: 16px;
+$lineWidth: 2px;
+$padding: 10px;
+$editorPadding: 30px;
+$pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADElEQVQImWO4cOECAATkAnFXdNPtAAAAAElFTkSuQmCC);
 
 // Import custom typeface for data inputs
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap");
@@ -40,13 +45,19 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
 #editor {
   flex: 1;
   overflow: auto;
-  padding: 20px;
+  padding: $editorPadding;
 
   ol,
   li {
     list-style: none;
     padding: 0;
     margin: 0;
+
+    > a:focus,
+    > a:active {
+      outline: 4px solid $focus;
+      outline-offset: 0;
+    }
   }
 
   ol:empty {
@@ -83,6 +94,9 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
 // ------------------------------------------------
 
 .card {
+  position: relative;
+  width: 100%;
+
   &.isDragging {
     opacity: 0.3;
     & + .hanger {
@@ -103,7 +117,8 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     span {
       opacity: 1;
     }
-    border: 2px solid limegreen;
+    outline: 4px solid #8cc485;
+    outline-offset: 0;
   }
 
   &.isClone > a {
@@ -121,7 +136,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     text-decoration: none;
     cursor: pointer;
     color: $black;
-    border: 1px solid $lineColor;
+    border: 1px solid $nodeBorder;
     background: white;
     user-select: none;
     padding: 6px 12px;
@@ -137,13 +152,47 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
 
     > svg {
       margin-left: -6px;
+      margin-top: 0.5px;
       width: 16px;
       height: 16px;
-      opacity: 0.3;
+      opacity: 0.6;
     }
 
     > span:not(:nth-child(1)) {
       margin-left: 6px;
+    }
+  }
+
+  &.type360::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    height: 2px;
+    margin-top: -1px;
+    width: calc(100% + ($editorPadding * 2));
+    z-index: -1;
+    background-image: linear-gradient(
+      90deg,
+      $optionBorder,
+      $optionBorder 50%,
+      transparent 50%,
+      transparent 100%
+    );
+    background-size: 12px 2px;
+    border: none;
+    [data-layout="left-right"] & {
+      top: unset;
+      width: 2px;
+      height: 100vh;
+      left: 50%;
+      background-image: linear-gradient(
+        0deg,
+        $optionBorder,
+        $optionBorder 50%,
+        transparent 50%,
+        transparent 100%
+      );
+      background-size: 2px 12px;
     }
   }
 }
@@ -161,9 +210,9 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
 }
 
 .endpoint > a {
-  @include circle($endpointRadius);
+  @include circle($endpointWidth);
   display: block;
-  line-height: $endpointRadius;
+  line-height: $endpointWidth;
   color: white;
   background: $black;
   text-align: center;
@@ -171,10 +220,28 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   cursor: pointer;
 }
 
+.option {
+  > a {
+    border-color: $optionBorder;
+    flex-direction: column;
+    padding: 0;
+  }
+  .band {
+    width: 100%;
+    height: 12px;
+    border-bottom: 1px solid $optionBorder;
+  }
+  .text {
+    margin: 0;
+    padding: 6px 12px;
+  }
+}
+
 .hanger {
   align-self: center;
   background-image: $pixel;
   background-size: $lineWidth;
+  line-height: 0;
 
   [data-layout="left-right"] & {
     background-position: left center;
@@ -199,11 +266,11 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   }
 
   > a {
-    $size: 14px;
+    $size: $hangerWidth;
     display: inline-block;
     // width: $size;
     text-decoration: none;
-    border: 1px solid #a0a0a0;
+    border: 1px solid $nodeBorder;
     min-width: $size;
     max-width: 200px;
     min-height: $size;
@@ -211,6 +278,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     color: $black;
     padding: 5px;
     background: $background;
+    line-height: 1.5;
 
     margin: $padding;
 
@@ -220,7 +288,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     transition: transform 0.2s;
 
     &:empty:hover {
-      background-color: yellow;
+      background-color: $focus;
       transform: scale(1.7);
     }
 
@@ -242,6 +310,19 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     > a {
       background: #666;
       margin: 5px 0;
+    }
+  }
+  .portalMenu {
+    border-left: 1px solid #aaa;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2px 6px;
+    svg {
+      opacity: 1;
+      margin: 0;
+      width: 16px;
+      height: 16px;
     }
   }
 }
@@ -274,9 +355,9 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   }
   align-items: center;
 
-  &.isNote {
+  &.question.isNote {
     > a {
-      background: yellow !important;
+      background: #fffdb0 !important;
     }
   }
 
@@ -289,10 +370,10 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
 
     [data-layout="top-down"] & {
       flex-direction: row;
-      padding-top: 5px !important;
+      padding-top: $padding !important;
 
       background-position: center top;
-      background-size: $lineWidth 5px;
+      background-size: $lineWidth $padding;
     }
 
     [data-layout="left-right"] & {
@@ -310,7 +391,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
     > li {
       background-image: $pixel, $pixel, $pixel;
       [data-layout="top-down"] & {
-        padding: 5px 5px 0 5px !important;
+        padding: $padding 5px 0 5px !important;
         flex-direction: column;
 
         background-position:
@@ -318,7 +399,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
           top center,
           bottom center;
         background-size:
-          $lineWidth 5px,
+          $lineWidth $padding,
           $lineWidth,
           $lineWidth;
         background-repeat: no-repeat, repeat-x, repeat-x;
@@ -329,7 +410,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
             top right,
             bottom right;
           background-size:
-            $lineWidth 5px,
+            $lineWidth $padding,
             50% $lineWidth,
             50% $lineWidth;
           background-repeat: no-repeat, no-repeat, no-repeat;
@@ -341,7 +422,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
             top left,
             bottom left;
           background-size:
-            $lineWidth 5px,
+            $lineWidth $padding,
             50% $lineWidth,
             50% $lineWidth;
           background-repeat: no-repeat, no-repeat, no-repeat;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -146,7 +146,8 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     }
 
     > span {
-      max-width: 170px;
+      min-width: 80px;
+      max-width: 200px;
       overflow-wrap: break-word;
     }
 
@@ -225,6 +226,8 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     border-color: $optionBorder;
     flex-direction: column;
     padding: 0;
+    min-width: 60px;
+    max-width: 200px;
   }
   .band {
     width: 100%;
@@ -232,6 +235,8 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     border-bottom: 1px solid $optionBorder;
   }
   .text {
+    width: 100%;
+    text-align: center;
     margin: 0;
     padding: 6px 12px;
   }

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -95,7 +95,9 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
 
 .card {
   position: relative;
-  width: 100%;
+  [data-layout="top-down"] & {
+    width: 100%;
+  }
 
   &.isDragging {
     opacity: 0.3;
@@ -235,8 +237,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     border-bottom: 1px solid $optionBorder;
   }
   .text {
-    width: 100%;
-    text-align: center;
+    align-self: center;
     margin: 0;
     padding: 6px 12px;
   }
@@ -311,10 +312,25 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     border: none;
   }
   &.breadcrumb {
-    background: none;
+    background-image: $pixel;
+    background-repeat: no-repeat;
+    [data-layout="top-down"] & {
+      background-position: center top;
+      background-size: $lineWidth $padding;
+      > a {
+        margin: $padding 0 0;
+      }
+    }
+    [data-layout="left-right"] & {
+      background-position: left center;
+      background-size: $padding $lineWidth;
+      > a {
+        margin: 0 0 0 $padding;
+      }
+    }
     > a {
       background: #666;
-      margin: 5px 0;
+      text-align: center;
     }
   }
   .portalMenu {
@@ -383,10 +399,10 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
 
     [data-layout="left-right"] & {
       flex-direction: column;
-      padding-left: 5px !important;
+      padding-left: $padding !important;
 
       background-position: left center;
-      background-size: 5px $lineWidth;
+      background-size: $padding $lineWidth;
     }
 
     &:empty {
@@ -396,7 +412,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     > li {
       background-image: $pixel, $pixel, $pixel;
       [data-layout="top-down"] & {
-        padding: $padding 5px 0 5px !important;
+        padding: $padding $padding 0 $padding !important;
         flex-direction: column;
 
         background-position:
@@ -434,7 +450,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
         }
       }
       [data-layout="left-right"] & {
-        padding: 5px 0 5px 5px !important;
+        padding: $padding 0 $padding $padding !important;
         flex-direction: row;
 
         background-position:
@@ -445,9 +461,9 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
 
         // BUG: 1px NOT VISIBLE IN CHROME
         background-size:
-          5px $lineWidth,
+          $padding $lineWidth,
           $lineWidth 100%,
-          1px 100%;
+          2px 100%;
 
         &:nth-child(1) {
           background-position:
@@ -455,7 +471,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
             left bottom,
             right bottom;
           background-size:
-            5px $lineWidth,
+            $padding $lineWidth,
             $lineWidth 50%,
             $lineWidth 50%;
         }
@@ -466,7 +482,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
             left top,
             right top;
           background-size:
-            5px $lineWidth,
+            $padding $lineWidth,
             $lineWidth 50%,
             $lineWidth 50%;
         }

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -8,6 +8,7 @@ $focus: #ffdd00;
 $endpointWidth: 50px;
 $hangerWidth: 16px;
 $lineWidth: 2px;
+$nodeBorderWidth: 1px;
 $padding: 10px;
 $editorPadding: 30px;
 $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADElEQVQImWO4cOECAATkAnFXdNPtAAAAAElFTkSuQmCC);
@@ -125,7 +126,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
   }
 
   &.hasFailed {
-    border: 1px dashed red;
+    border: $nodeBorderWidth dashed red;
   }
 
   & > a {
@@ -135,7 +136,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     text-decoration: none;
     cursor: pointer;
     color: $black;
-    border: 1px solid $nodeBorder;
+    border: $nodeBorderWidth solid $nodeBorder;
     background: white;
     user-select: none;
     padding: 6px 12px;
@@ -240,7 +241,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
   .band {
     width: 100%;
     height: 12px;
-    border-bottom: 1px solid $optionBorder;
+    border-bottom: $nodeBorderWidth solid $optionBorder;
   }
   .text {
     align-self: center;
@@ -282,7 +283,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     display: inline-block;
     // width: $size;
     text-decoration: none;
-    border: 1px solid $nodeBorder;
+    border: $nodeBorderWidth solid $nodeBorder;
     min-width: $size;
     max-width: 200px;
     min-height: $size;
@@ -340,7 +341,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     }
   }
   .portalMenu {
-    border-left: 1px solid #aaa;
+    border-left: $nodeBorderWidth solid #aaa;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -390,6 +391,29 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
   &.question.isNote {
     > a {
       background: #fffdb0 !important;
+      position: relative;
+      padding-right: 20px;
+      // Triangle shapes to simulate paper fold on sticky note
+      &::before {
+        content: "";
+        position: absolute;
+        right: -$nodeBorderWidth;
+        bottom: -$nodeBorderWidth;
+        width: 0;
+        height: 0;
+        border-bottom: 12px solid #fff;
+        border-left: 12px solid transparent;
+      }
+      &::after {
+        content: "";
+        position: absolute;
+        right: -$nodeBorderWidth;
+        bottom: -$nodeBorderWidth;
+        width: 0;
+        height: 0;
+        border-top: 12px solid $nodeBorder;
+        border-right: 12px solid transparent;
+      }
     }
   }
 


### PR DESCRIPTION
# What does this PR do?

Visual changes to the logic graph, summarised as:

- Increased contrast to nodes, branches and add-node links
- Standardised padding across hangers and branches to increase visibility of structure
- Updated styling of portal nodes to show clear demarcation between node link (enter portal) and menu link (configure portal)
- Only questions and checklists without answers present in sticky-note styling
- Section nodes have dashed border to add subtle visual organisation to graph
- Assigned flag colours no longer apply to full background of an option - reduces contrast issue (made more acute by small size)
- GOV.UK focus style on nodes and add-node links
- Clearer green outline to mark traversed nodes

### Preview

Before:
<img width="1228" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/bb0adbb8-762c-472d-93aa-6ce2386a84af">


After:
<img width="1228" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/df0ab1df-347a-4316-9479-4c40e5910c91">
