### PR TITLE
feat: Append, replace, removeOne, & removeAll operations for `SetValue`

### DIFF
--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -68,20 +68,18 @@ function SetValueComponent(props: Props) {
             />
           </InputRow>
         </ModalSectionContent>
-        {formik.values.operation !== "remove" && (
-          <ModalSectionContent title="Field value">
-            <InputRow>
-              <Input
-                required
-                format="data"
-                name="val"
-                value={formik.values.val}
-                placeholder="value"
-                onChange={formik.handleChange}
-              />
-            </InputRow>
-          </ModalSectionContent>
-        )}
+        <ModalSectionContent title="Field value">
+          <InputRow>
+            <Input
+              required
+              format="data"
+              name="val"
+              value={formik.values.val}
+              placeholder="value"
+              onChange={formik.handleChange}
+            />
+          </InputRow>
+        </ModalSectionContent>
         <ModalSectionContent title="Operation">
           <DescriptionText {...formik.values} />
           <Radio

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -15,6 +15,30 @@ type Props = EditorProps<TYPES.SetValue, SetValue>;
 
 export default SetValueComponent;
 
+interface Option {
+  value: SetValue["operation"];
+  label: string;
+}
+
+const options: Option[] = [
+  {
+    value: "replace",
+    label: "Replace",
+  },
+  {
+    value: "append",
+    label: "Append",
+  },
+  {
+    value: "removeOne",
+    label: "Remove single value",
+  },
+  {
+    value: "removeAll",
+    label: "Remove all values",
+  },
+];
+
 const DescriptionText: React.FC<SetValue> = ({ fn, val, operation }) => {
   if (!fn || !val) return null;
 
@@ -33,11 +57,17 @@ const DescriptionText: React.FC<SetValue> = ({ fn, val, operation }) => {
           <strong>{val}</strong> appended to it
         </Typography>
       );
-    case "remove":
+    case "removeOne":
       return (
         <Typography mb={2}>
           Any existing value for <strong>{fn}</strong> set to{" "}
           <strong>{val}</strong> will be removed
+        </Typography>
+      );
+    case "removeAll":
+      return (
+        <Typography mb={2}>
+          All existing values for <strong>{fn}</strong> will be removed
         </Typography>
       );
   }
@@ -84,20 +114,7 @@ function SetValueComponent(props: Props) {
         <ModalSectionContent title="Operation">
           <DescriptionText {...formik.values} />
           <Radio
-            options={[
-              {
-                value: "replace",
-                label: "Replace",
-              },
-              {
-                value: "append",
-                label: "Append",
-              },
-              {
-                value: "remove",
-                label: "Remove",
-              },
-            ]}
+            options={options}
             value={formik.values.operation}
             onChange={(newOperation) => {
               formik.setFieldValue("operation", newOperation);

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -36,7 +36,8 @@ const DescriptionText: React.FC<SetValue> = ({ fn, val, operation }) => {
     case "remove":
       return (
         <Typography mb={2}>
-          Any existing value for <strong>{fn}</strong> will be removed
+          Any existing value for <strong>{fn}</strong> set to{" "}
+          <strong>{val}</strong> will be removed
         </Typography>
       );
   }

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -21,22 +21,22 @@ const DescriptionText: React.FC<SetValue> = ({ fn, val, operation }) => {
   switch (operation) {
     case "replace":
       return (
-        <Typography mt={2}>
-          any existing value for <strong>{fn}</strong> will be replaced by{" "}
+        <Typography mb={2}>
+          Any existing value for <strong>{fn}</strong> will be replaced by{" "}
           <strong>{val}</strong>
         </Typography>
       );
     case "append":
       return (
-        <Typography mt={2}>
-          any existing value for <strong>{fn}</strong> will have{" "}
+        <Typography mb={2}>
+          Any existing value for <strong>{fn}</strong> will have{" "}
           <strong>{val}</strong> appended to it
         </Typography>
       );
     case "remove":
       return (
-        <Typography mt={2}>
-          any existing value for <strong>{fn}</strong> will be removed
+        <Typography mb={2}>
+          Any existing value for <strong>{fn}</strong> will be removed
         </Typography>
       );
   }
@@ -68,9 +68,9 @@ function SetValueComponent(props: Props) {
             />
           </InputRow>
         </ModalSectionContent>
-        <ModalSectionContent title="Field value">
-          <InputRow>
-            <div>
+        {formik.values.operation !== "remove" && (
+          <ModalSectionContent title="Field value">
+            <InputRow>
               <Input
                 required
                 format="data"
@@ -79,11 +79,11 @@ function SetValueComponent(props: Props) {
                 placeholder="value"
                 onChange={formik.handleChange}
               />
-              <DescriptionText {...formik.values} />
-            </div>
-          </InputRow>
-        </ModalSectionContent>
+            </InputRow>
+          </ModalSectionContent>
+        )}
         <ModalSectionContent title="Operation">
+          <DescriptionText {...formik.values} />
           <Radio
             options={[
               {

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -1,3 +1,4 @@
+import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps, InternalNotes } from "@planx/components/ui";
 import { useFormik } from "formik";
@@ -13,6 +14,33 @@ import { parseSetValue, SetValue } from "./model";
 type Props = EditorProps<TYPES.SetValue, SetValue>;
 
 export default SetValueComponent;
+
+const DescriptionText: React.FC<SetValue> = ({ fn, val, operation }) => {
+  if (!fn || !val) return null;
+
+  switch (operation) {
+    case "replace":
+      return (
+        <Typography mt={2}>
+          any existing value for <strong>{fn}</strong> will be replaced by{" "}
+          <strong>{val}</strong>
+        </Typography>
+      );
+    case "append":
+      return (
+        <Typography mt={2}>
+          any existing value for <strong>{fn}</strong> will have{" "}
+          <strong>{val}</strong> appended to it
+        </Typography>
+      );
+    case "remove":
+      return (
+        <Typography mt={2}>
+          any existing value for <strong>{fn}</strong> will be removed
+        </Typography>
+      );
+  }
+};
 
 function SetValueComponent(props: Props) {
   const formik = useFormik({
@@ -51,12 +79,7 @@ function SetValueComponent(props: Props) {
                 placeholder="value"
                 onChange={formik.handleChange}
               />
-              {formik.values.fn && formik.values.val && (
-                <p>
-                  any existing value for <strong>{formik.values.fn}</strong>{" "}
-                  will be replaced by <strong>{formik.values.val}</strong>
-                </p>
-              )}
+              <DescriptionText {...formik.values} />
             </div>
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -6,6 +6,7 @@ import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
+import Radio from "ui/shared/Radio";
 
 import { parseSetValue, SetValue } from "./model";
 
@@ -58,6 +59,28 @@ function SetValueComponent(props: Props) {
               )}
             </div>
           </InputRow>
+        </ModalSectionContent>
+        <ModalSectionContent title="Operation">
+          <Radio
+            options={[
+              {
+                value: "replace",
+                label: "Replace",
+              },
+              {
+                value: "append",
+                label: "Append",
+              },
+              {
+                value: "remove",
+                label: "Remove",
+              },
+            ]}
+            value={formik.values.operation}
+            onChange={(newOperation) => {
+              formik.setFieldValue("operation", newOperation);
+            }}
+          />
         </ModalSectionContent>
       </ModalSection>
       <InternalNotes

--- a/editor.planx.uk/src/@planx/components/SetValue/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/model.ts
@@ -3,6 +3,7 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 export interface SetValue extends MoreInformation {
   fn: string;
   val: string;
+  operation: "replace" | "append" | "remove";
 }
 
 export const parseSetValue = (
@@ -10,5 +11,6 @@ export const parseSetValue = (
 ): SetValue => ({
   fn: data?.fn || "",
   val: data?.val || "",
+  operation: "replace",
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/components/SetValue/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/model.ts
@@ -3,7 +3,7 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 export interface SetValue extends MoreInformation {
   fn: string;
   val: string;
-  operation: "replace" | "append" | "remove";
+  operation: "replace" | "append" | "removeOne" | "removeAll";
 }
 
 export const parseSetValue = (

--- a/editor.planx.uk/src/@planx/components/SetValue/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/model.ts
@@ -11,6 +11,6 @@ export const parseSetValue = (
 ): SetValue => ({
   fn: data?.fn || "",
   val: data?.val || "",
-  operation: "replace",
+  operation: data?.operation || "replace",
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.test.ts
@@ -1,0 +1,135 @@
+import { SetValue } from "./model";
+import { handleSetValue } from "./utils";
+import { Store } from "pages/FlowEditor/lib/store";
+
+
+describe("calculateNewValues() helper function", () => {
+  describe('"replace" operation', () => {
+    test.each([
+      { previous: undefined, expected: ["lion"] },
+      { previous: "panda", expected: ["lion"] },
+      { previous: "lion", expected: ["lion"] },
+      { previous: ["lion"], expected: ["lion"] },
+      { previous: ["bear", "dog", "monkey"], expected: ["lion"] },
+      { previous: ["bear", "dog", "lion"], expected: ["lion"] },
+    ])('input of $previous sets passport value to be $expected', ({ previous, expected }) => {
+      const mockKey = "myAnimals";
+      const mockSetValue: SetValue = {
+        operation: "replace",
+        fn: mockKey,
+        val: "lion",
+      };
+      const mockPassport: Store.passport = {
+        data: { mockNode: mockSetValue, [mockKey]: previous },
+      };
+
+      const updatedPassport = handleSetValue({
+        nodeData: mockSetValue,
+        previousValues: previous,
+        passport: mockPassport,
+      });
+
+      const actual = updatedPassport.data?.[mockKey];
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('"append" operation', () => {
+    test.each([
+      { previous: undefined, expected: ["lion"] },
+      { previous: "panda", expected: ["panda", "lion"] },
+      { previous: "lion", expected: ["lion"] },
+      { previous: ["lion"], expected: ["lion"] },
+      {
+        previous: ["bear", "dog", "monkey"],
+        expected: ["bear", "dog", "monkey", "lion"],
+      },
+      { previous: ["bear", "dog", "lion"], expected: ["bear", "dog", "lion"] },
+    ])('input of $previous sets passport value to be $expected', ({ previous, expected }) => {
+      const mockKey = "myAnimals";
+      const mockSetValue: SetValue = {
+        operation: "append",
+        fn: mockKey,
+        val: "lion",
+      };
+      const mockPassport: Store.passport = {
+        data: { mockNode: mockSetValue, [mockKey]: previous },
+      };
+
+      const updatedPassport = handleSetValue({
+        nodeData: mockSetValue,
+        previousValues: previous,
+        passport: mockPassport,
+      });
+
+      const actual = updatedPassport.data?.[mockKey];
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('"removeOne" operation', () => {
+    test.each([
+      { previous: undefined, expected: undefined },
+      { previous: "panda", expected: "panda" },
+      { previous: "lion", expected: undefined },
+      { previous: ["lion"], expected: undefined },
+      {
+        previous: ["bear", "dog", "monkey"],
+        expected: ["bear", "dog", "monkey"],
+      },
+      { previous: ["bear", "dog", "lion"], expected: ["bear", "dog"] },
+    ])('input of $previous sets passport value to be $expected', ({ previous, expected }) => {
+      const mockKey = "myAnimals";
+      const mockSetValue: SetValue = {
+        operation: "removeOne",
+        fn: mockKey,
+        val: "lion",
+      };
+      const mockPassport: Store.passport = {
+        data: { mockNode: mockSetValue, [mockKey]: previous },
+      };
+
+      const updatedPassport = handleSetValue({
+        nodeData: mockSetValue,
+        previousValues: previous,
+        passport: mockPassport,
+      });
+
+      const actual = updatedPassport.data?.[mockKey];
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('"removeAll" operation', () => {
+    test.each([
+      { previous: undefined, expected: undefined },
+      { previous: "panda", expected: undefined },
+      { previous: "lion", expected: undefined },
+      { previous: ["lion"], expected: undefined },
+      {
+        previous: ["bear", "dog", "monkey"],
+        expected: undefined,
+      },
+      { previous: ["bear", "dog", "lion"], expected: undefined },
+    ])('input of $previous sets passport value to be $expected', ({ previous, expected }) => {
+      const mockKey = "myAnimals";
+      const mockSetValue: SetValue = {
+        operation: "removeAll",
+        fn: mockKey,
+        val: "lion",
+      };
+      const mockPassport: Store.passport = {
+        data: { mockNode: mockSetValue, [mockKey]: previous },
+      };
+
+      const updatedPassport = handleSetValue({
+        nodeData: mockSetValue,
+        previousValues: previous,
+        passport: mockPassport,
+      });
+
+      const actual = updatedPassport.data?.[mockKey];
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.ts
@@ -1,0 +1,94 @@
+import { Store } from "pages/FlowEditor/lib/store";
+import { SetValue } from "./model";
+
+type PreviousValues = string | string[] | undefined;
+
+type HandleSetValue = (params: {
+  nodeData: SetValue;
+  previousValues: PreviousValues;
+  passport: Store.passport;
+}) => Store.passport;
+
+/**
+ * Handle modifying passport values when passing through a SetValue component
+ * Called by computePassport()
+ */
+export const handleSetValue: HandleSetValue = ({
+  nodeData: { operation, fn, val: current },
+  previousValues,
+  passport,
+}) => {
+  // We do not amend values set at objects
+  // These are internal exceptions we do not want to allow users to edit
+  // e.g. property.boundary.title
+  const isObject =
+    typeof previousValues === "object" &&
+    !Array.isArray(previousValues) &&
+    previousValues !== null;
+  if (isObject) return passport;
+
+  const previous = formatPreviousValues(previousValues);
+
+  const newValues = calculateNewValues({
+    operation,
+    previous,
+    current,
+  });
+
+  if (newValues) {
+    passport.data![fn] = newValues;
+
+    // Operation has cleared passport value
+    if (!newValues.length) delete passport.data![fn];
+  }
+
+  return passport;
+};
+
+type CalculateNewValues = (params: {
+  operation: SetValue["operation"];
+  previous: string | string[];
+  current: string;
+}) => string[] | undefined;
+
+const calculateNewValues: CalculateNewValues = ({
+  operation,
+  previous,
+  current,
+}) => {
+  switch (operation) {
+    case "replace":
+      // Default behaviour when assigning passport variables
+      // No custom logic needed
+      break;
+
+    case "removeOne": {
+      if (Array.isArray(previous)) {
+        const removeCurrent = (val: string) => val !== current;
+        const filtered = previous.filter(removeCurrent);
+        return filtered;
+      }
+
+      if (previous === current) {
+        return [];
+      }
+
+      break;
+    }
+
+    case "removeAll":
+      return [];
+
+    case "append": {
+      const combined = [...previous, current];
+      const unique = [...new Set(combined)];
+      return unique;
+    }
+  }
+};
+
+const formatPreviousValues = (values: PreviousValues): string[] => {
+  if (!values) return [];
+  if (Array.isArray(values)) return values;
+  return [values];
+};

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.ts
@@ -47,9 +47,9 @@ export const handleSetValue: HandleSetValue = ({
 
 type CalculateNewValues = (params: {
   operation: SetValue["operation"];
-  previous: string | string[];
+  previous: string[];
   current: string;
-}) => string[] | undefined;
+}) => string | string[] | undefined;
 
 const calculateNewValues: CalculateNewValues = ({
   operation,
@@ -58,22 +58,17 @@ const calculateNewValues: CalculateNewValues = ({
 }) => {
   switch (operation) {
     case "replace":
-      // Default behaviour when assigning passport variables
-      // No custom logic needed
-      break;
+      return [current];
 
     case "removeOne": {
-      if (Array.isArray(previous)) {
-        const removeCurrent = (val: string) => val !== current;
-        const filtered = previous.filter(removeCurrent);
-        return filtered;
+      // Do not convert output from string to string[] if operation not possible
+      if (previous.length === 1 && previous[0] !== current) {
+        return previous[0];
       }
 
-      if (previous === current) {
-        return [];
-      }
-
-      break;
+      const removeCurrent = (val: string) => val !== current;
+      const filtered = previous.filter(removeCurrent);
+      return filtered;
     }
 
     case "removeAll":

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -142,12 +142,12 @@ const Node: React.FC<any> = (props) => {
 
 const getSetValueText = ({ operation, fn, val }: Store.node["data"]) => {
   switch (operation) {
-    case "replace":
-      return `Replace ${fn} with ${val}`;
     case "append":
       return `Append ${val} to ${fn}`;
     case "remove":
       return `Remove ${fn}`;
+    default:
+      return `Replace ${fn} with ${val}`;
   }
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -2,7 +2,7 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
-import { useStore } from "../../../lib/store";
+import { Store, useStore } from "../../../lib/store";
 import { stripTagsAndLimitLength } from "../lib/utils";
 import Breadcrumb from "./Breadcrumb";
 import Checklist from "./Checklist";
@@ -102,12 +102,7 @@ const Node: React.FC<any> = (props) => {
     case TYPES.Send:
       return <Question {...allProps} text={node?.data?.title ?? "Send"} />;
     case TYPES.SetValue:
-      return (
-        <Question
-          {...allProps}
-          text={`${node?.data?.fn} = ${node?.data?.val}`}
-        />
-      );
+      return <Question {...allProps} text={getSetValueText(node.data)} />;
     case TYPES.TaskList:
       return (
         <Question
@@ -142,6 +137,17 @@ const Node: React.FC<any> = (props) => {
     default:
       console.error({ nodeNotFound: props });
       return exhaustiveCheck(type);
+  }
+};
+
+const getSetValueText = ({ operation, fn, val }: Store.node["data"]) => {
+  switch (operation) {
+    case "replace":
+      return `Replace ${fn} with ${val}`;
+    case "append":
+      return `Append ${val} to ${fn}`;
+    case "remove":
+      return `Remove ${fn}`;
   }
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -144,8 +144,10 @@ const getSetValueText = ({ operation, fn, val }: Store.node["data"]) => {
   switch (operation) {
     case "append":
       return `Append ${val} to ${fn}`;
-    case "remove":
+    case "removeOne":
       return `Remove ${val} from ${fn}`;
+    case "removeAll":
+      return `Remove ${fn}`;
     default:
       return `Replace ${fn} with ${val}`;
   }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -145,7 +145,7 @@ const getSetValueText = ({ operation, fn, val }: Store.node["data"]) => {
     case "append":
       return `Append ${val} to ${fn}`;
     case "remove":
-      return `Remove ${fn}`;
+      return `Remove ${val} from ${fn}`;
     default:
       return `Replace ${fn} with ${val}`;
   }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/record.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/record.test.ts
@@ -26,7 +26,7 @@ describe("error handling", () => {
       },
     });
 
-    expect(() => record("x", {})).toThrow("id not found");
+    expect(() => record("x", {})).toThrow('id "x" not found');
   });
 });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
@@ -1,0 +1,246 @@
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { cloneDeep, merge } from "lodash";
+
+import { Store, vanillaStore } from "../store";
+
+const { getState, setState } = vanillaStore;
+const { resetPreview, record, computePassport, currentCard } = getState();
+
+const baseFlow: Store.flow = {
+  _root: {
+    edges: ["setValue1", "middleOfService", "setValue2", "endOfService"],
+  },
+  setValue1: {
+    data: {
+      fn: "myKey",
+      val: "myFirstValue",
+      operation: null,
+    },
+    type: TYPES.SetValue,
+  },
+  middleOfService: {
+    type: TYPES.Notice,
+    data: {
+      title: "Middle of service",
+      color: "#EFEFEF",
+      resetButton: false,
+    },
+  },
+  setValue2: {
+    data: {
+      fn: "myKey",
+      val: "mySecondValue",
+      operation: null,
+    },
+    type: TYPES.SetValue,
+  },
+  endOfService: {
+    type: TYPES.Notice,
+    data: {
+      title: "End of service",
+      color: "#EFEFEF",
+      resetButton: true,
+    },
+  },
+};
+
+describe("SetValue component", () => {
+  describe("replace operation", () => {
+    const replaceFlow = merge(cloneDeep(baseFlow), {
+      setValue1: {
+        data: {
+          operation: "replace",
+        },
+      },
+      setValue2: {
+        data: {
+          operation: "replace",
+        },
+      },
+    });
+
+    beforeEach(() => {
+      resetPreview();
+      setState({ flow: replaceFlow });
+    });
+
+    it("sets a value if not previously set", () => {
+      // Value not set
+      expect(computePassport()?.data?.myKey1).not.toBeDefined();
+
+      // Step through first SetValue
+      record("setValue1", { data: { myKey1: ["myFirstValue"] } });
+
+      // SetValue is visited
+      const breadcrumbKeys = Object.keys(getState().breadcrumbs);
+      expect(breadcrumbKeys).toContain("setValue1");
+
+      // Middle of flow reached
+      expect(currentCard()?.id).toEqual("middleOfService");
+
+      // Passport correctly populated
+      expect(computePassport()?.data?.myKey1).toHaveLength(1);
+      expect(computePassport()?.data?.myKey1).toContain("myFirstValue");
+    });
+
+    it("replaces an existing value", () => {
+      // Step through second SetValue
+      record("setValue1", { data: { myKey1: ["myFirstValue"] } });
+      record("middleOfService", {});
+      record("setValue2", { data: { myKey1: ["mySecondValue"] } });
+
+      // Second SetValue is visited
+      const breadcrumbKeys = Object.keys(getState().breadcrumbs);
+      expect(breadcrumbKeys).toContain("setValue2");
+
+      // End of flow reached
+      expect(currentCard()?.id).toEqual("endOfService");
+
+      // Passport correctly populated
+      expect(computePassport()?.data?.myKey1).toHaveLength(1);
+      expect(computePassport()?.data?.myKey1).toContain("mySecondValue");
+    });
+  });
+
+  describe("append operation", () => {
+    const appendFlow = merge(cloneDeep(baseFlow), {
+      setValue1: {
+        data: {
+          operation: "append",
+        },
+      },
+      setValue2: {
+        data: {
+          operation: "append",
+        },
+      },
+    });
+
+    beforeEach(() => {
+      resetPreview();
+      setState({ flow: appendFlow });
+    });
+
+    it("sets a value if not previously set", () => {
+      // Value not set
+      expect(computePassport()?.data?.myKey1).not.toBeDefined();
+
+      // Step through first SetValue
+      record("setValue1", { data: { myKey1: ["myFirstValue"] } });
+
+      // SetValue is visited
+      const breadcrumbKeys = Object.keys(getState().breadcrumbs);
+      expect(breadcrumbKeys).toContain("setValue1");
+
+      // Middle of flow reached
+      expect(currentCard()?.id).toEqual("middleOfService");
+
+      // Passport correctly populated
+      expect(computePassport()?.data?.myKey1).toHaveLength(1);
+      expect(computePassport()?.data?.myKey1).toContain("myFirstValue");
+    });
+
+    it("appends to an existing value", () => {
+      // Step through second SetValue
+      record("setValue1", { data: { myKey: ["myFirstValue"] } });
+      record("middleOfService", {});
+
+      expect(computePassport()?.data?.myKey).toHaveLength(1);
+      expect(computePassport()?.data?.myKey).toContain("myFirstValue");
+
+      record("setValue2", { data: { myKey: ["mySecondValue"] } });
+
+      // Second SetValue is visited
+      const breadcrumbKeys = Object.keys(getState().breadcrumbs);
+      expect(breadcrumbKeys).toContain("setValue2");
+
+      // End of flow reached
+      expect(currentCard()?.id).toEqual("endOfService");
+
+      // Passport correctly populated
+      expect(computePassport()?.data?.myKey).toHaveLength(2);
+      expect(computePassport()?.data?.myKey).toContain("myFirstValue");
+      expect(computePassport()?.data?.myKey).toContain("mySecondValue");
+    });
+  });
+
+  describe("remove operation", () => {
+    const removeFlow = merge(cloneDeep(baseFlow), {
+      _root: {
+        edges: [
+          "setValue1",
+          "middleOfService",
+          "setValue2",
+          "setValue3",
+          "endOfService",
+        ],
+      },
+      setValue1: {
+        data: {
+          operation: "remove",
+        },
+      },
+      setValue2: {
+        data: {
+          operation: "replace",
+        },
+      },
+      setValue3: {
+        data: {
+          fn: "myKey",
+          // TODO: Do we need a val for remove?
+          val: "myFirstValue",
+          operation: "remove",
+        },
+        type: TYPES.SetValue,
+      },
+    });
+
+    beforeEach(() => {
+      resetPreview();
+      setState({ flow: removeFlow });
+    });
+
+    it("does nothing if a value is not previously set", () => {
+      // Value not set
+      expect(computePassport()?.data?.myKey).not.toBeDefined();
+
+      // Step through first SetValue
+      record("setValue1", { data: { myKey: ["myFirstValue"] } });
+
+      // SetValue is visited
+      const breadcrumbKeys = Object.keys(getState().breadcrumbs);
+      expect(breadcrumbKeys).toContain("setValue1");
+
+      // Middle of flow reached
+      expect(currentCard()?.id).toEqual("middleOfService");
+
+      // Passport correctly populated - value not present
+      expect(computePassport()?.data?.myKey).toBeUndefined();
+    });
+
+    it("removed a previously set value", () => {
+      // Step through second SetValue
+      record("setValue1", { data: { myKey: ["myFirstValue"] } });
+      record("middleOfService", {});
+      record("setValue2", { data: { myKey: ["mySecondValue"] } });
+
+      // Second SetValue is visited
+      const breadcrumbKeys = Object.keys(getState().breadcrumbs);
+      expect(breadcrumbKeys).toContain("setValue2");
+
+      // Value is set by "replace" operation
+      expect(computePassport()?.data?.myKey).toHaveLength(1);
+      expect(computePassport()?.data?.myKey).toContain("mySecondValue");
+
+      // Step through final SetValue component
+      record("setValue3", { data: { myKey: ["myFirstValue"] } });
+
+      // End of flow reached
+      expect(currentCard()?.id).toEqual("endOfService");
+
+      // Passport correctly populated - value no longer set
+      expect(computePassport()?.data?.myKey).toBeUndefined();
+    });
+  });
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
@@ -268,8 +268,7 @@ describe("SetValue component", () => {
       expect(currentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated - passport variable not removed as values do not match
-      expect(computePassport()?.data?.myKey).toHaveLength(1);
-      expect(computePassport()?.data?.myKey[0]).toEqual("mySecondValue");
+      expect(computePassport()?.data?.myKey).toEqual("mySecondValue");
     });
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
@@ -66,10 +66,10 @@ describe("SetValue component", () => {
 
     it("sets a value if not previously set", () => {
       // Value not set
-      expect(computePassport()?.data?.myKey1).not.toBeDefined();
+      expect(computePassport()?.data?.myKey).not.toBeDefined();
 
       // Step through first SetValue
-      record("setValue1", { data: { myKey1: ["myFirstValue"] } });
+      record("setValue1", { data: { myKey: ["myFirstValue"] } });
 
       // SetValue is visited
       const breadcrumbKeys = Object.keys(getState().breadcrumbs);
@@ -79,15 +79,15 @@ describe("SetValue component", () => {
       expect(currentCard()?.id).toEqual("middleOfService");
 
       // Passport correctly populated
-      expect(computePassport()?.data?.myKey1).toHaveLength(1);
-      expect(computePassport()?.data?.myKey1).toContain("myFirstValue");
+      expect(computePassport()?.data?.myKey).toHaveLength(1);
+      expect(computePassport()?.data?.myKey).toContain("myFirstValue");
     });
 
     it("replaces an existing value", () => {
       // Step through second SetValue
-      record("setValue1", { data: { myKey1: ["myFirstValue"] } });
+      record("setValue1", { data: { myKey: ["myFirstValue"] } });
       record("middleOfService", {});
-      record("setValue2", { data: { myKey1: ["mySecondValue"] } });
+      record("setValue2", { data: { myKey: ["mySecondValue"] } });
 
       // Second SetValue is visited
       const breadcrumbKeys = Object.keys(getState().breadcrumbs);
@@ -97,8 +97,8 @@ describe("SetValue component", () => {
       expect(currentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated
-      expect(computePassport()?.data?.myKey1).toHaveLength(1);
-      expect(computePassport()?.data?.myKey1).toContain("mySecondValue");
+      expect(computePassport()?.data?.myKey).toHaveLength(1);
+      expect(computePassport()?.data?.myKey).toContain("mySecondValue");
     });
   });
 
@@ -123,10 +123,10 @@ describe("SetValue component", () => {
 
     it("sets a value if not previously set", () => {
       // Value not set
-      expect(computePassport()?.data?.myKey1).not.toBeDefined();
+      expect(computePassport()?.data?.myKey).not.toBeDefined();
 
       // Step through first SetValue
-      record("setValue1", { data: { myKey1: ["myFirstValue"] } });
+      record("setValue1", { data: { myKey: ["myFirstValue"] } });
 
       // SetValue is visited
       const breadcrumbKeys = Object.keys(getState().breadcrumbs);
@@ -136,8 +136,8 @@ describe("SetValue component", () => {
       expect(currentCard()?.id).toEqual("middleOfService");
 
       // Passport correctly populated
-      expect(computePassport()?.data?.myKey1).toHaveLength(1);
-      expect(computePassport()?.data?.myKey1).toContain("myFirstValue");
+      expect(computePassport()?.data?.myKey).toHaveLength(1);
+      expect(computePassport()?.data?.myKey).toContain("myFirstValue");
     });
 
     it("appends to an existing value", () => {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -276,7 +276,7 @@ export const previewStore: StateCreator<
       updateSectionData,
     } = get();
 
-    if (!flow[id]) throw new Error("id not found");
+    if (!flow[id]) throw new Error(`id "${id}" not found`);
 
     if (userData) {
       // add breadcrumb

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -871,7 +871,8 @@ const handleSetValue = (
 
     case "append": {
       const combined = [...previousValues, ...currentValue];
-      passport.data![fn] = combined;
+      const uniqueValuesOnly = [...new Set(combined)];
+      passport.data![fn] = uniqueValuesOnly;
       break;
     }
   }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -843,12 +843,16 @@ const handleSetValue = (
   previousValues = formatPreviousValues(previousValues);
   const currentValue = responseData?.[fn] || [];
 
-  if (operation === "remove") {
+  if (operation === "removeOne") {
     const removeCurrentValue = (val: string | number | boolean) =>
       val !== currentValue[0];
     const filtered = previousValues.filter(removeCurrentValue);
 
     passport.data![fn] = filtered.length ? filtered : undefined;
+  }
+
+  if (operation === "removeAll") {
+    delete passport.data![fn];
   }
 
   if (operation === "append") {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -246,7 +246,7 @@ export const previewStore: StateCreator<
           {} as Store.passport["data"],
         );
 
-        return {
+        const passport: Store.passport = {
           ...acc,
           data: {
             ...acc.data,
@@ -254,6 +254,27 @@ export const previewStore: StateCreator<
             ...passportData,
           },
         };
+
+        const isSetValue = flow[id].type === TYPES.SetValue;
+
+        if (isSetValue) {
+          const { operation, fn }: { operation: string; fn: string } =
+            flow[id]?.data || {};
+
+          if (operation === "remove") {
+            delete passport.data?.[fn];
+          }
+
+          if (operation === "append") {
+            const previousValue = acc.data?.[fn] || [];
+            const currentValue = responseData?.[fn] || [];
+            const combined = [...previousValue, ...currentValue];
+
+            passport.data![fn] = combined;
+          }
+        }
+
+        return passport;
       },
       {
         data: {},

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -10,6 +10,7 @@ import {
 } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { FileList } from "@planx/components/FileUploadAndLabel/model";
+import { SetValue } from "@planx/components/SetValue/model";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { logger } from "airbrake";
 import { objectWithoutNullishValues } from "lib/objectHelpers";
@@ -258,17 +259,19 @@ export const previewStore: StateCreator<
         const isSetValue = flow[id].type === TYPES.SetValue;
 
         if (isSetValue) {
-          const { operation, fn }: { operation: string; fn: string } =
-            flow[id]?.data || {};
+          const { operation, fn } = flow[id]?.data as SetValue;
+          const previousValues = acc.data?.[fn] || [];
+          const currentValue = responseData?.[fn] || [];
 
           if (operation === "remove") {
-            delete passport.data?.[fn];
+            const removeCurrentValue = (val: string) => val !== currentValue[0];
+            const filtered = previousValues.filter(removeCurrentValue);
+
+            passport.data![fn] = filtered.length ? filtered : undefined;
           }
 
           if (operation === "append") {
-            const previousValue = acc.data?.[fn] || [];
-            const currentValue = responseData?.[fn] || [];
-            const combined = [...previousValue, ...currentValue];
+            const combined = [...previousValues, ...currentValue];
 
             passport.data![fn] = combined;
           }


### PR DESCRIPTION
## What does this PR do?
 - Changes SetValue component from having a single operation, to having an option to append, replace, removeOne or removeAll

## Testing
Basic test flow here - https://2914.planx.pizza/testing/set-value-playground

This (hopefully!) illustrates that the behaviour matches the desired outcomes discussion at our recent "Logic Camp" - full details here - https://miro.com/app/board/uXjVN9K07PQ=/?moveToWidget=3458764588027715730&cot=14

I feel like there's a decent level of unit testing here, as well as more psuedo-integration level tests calling store functions to mock a user's journey.

What I'm really interested in testing feedback on would be - 
- Unexpected, or breaking, changes in existing flows - possibly related to edge cases with current SetValue
- Is there something missing in how multiple SetValue components interact with each other?
- Anything that could break this!

## Next steps...
- Illustrative examples in Editor modar, similar to how Calculate shows examples to the user

<img width="710" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/6bbf0444-d607-47ec-82c6-4485ce8e8ba9">


