### PR TITLE
fix(temp): Pin `hasura-cli` version

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -93,7 +93,7 @@ jobs:
         run: ./scripts/start-containers-for-tests.sh
       - name: Postgres Tests
         run: ./hasura.planx.uk/run-postgres-tests.sh
-      - run: pnpm i -g hasura-cli
+      - run: pnpm i -g hasura-cli@2.36.1
       - name: Hasura Tests
         run: pnpm install --frozen-lockfile && pnpm test
         working-directory: hasura.planx.uk/tests

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./scripts/start-containers-for-tests.sh
       - name: Postgres Tests
         run: ./hasura.planx.uk/run-postgres-tests.sh
-      - run: pnpm i -g hasura-cli
+      - run: pnpm i -g hasura-cli@2.36.1
       - name: Hasura Tests
         run: pnpm install --frozen-lockfile && pnpm test
         working-directory: hasura.planx.uk/tests


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1711359461634859 for context.

Looks like there's a few issues with the latest releases - https://www.npmjs.com/package/hasura-cli?activeTab=versions

<img width="783" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/5cdb1687-b7b0-4119-bd62-b7c0296386c0">

Suggesting this as a temp fix for now, and I'll check in on it next few days. If it lasts any longer I'll open an issue in the `hasura-cli` repo.