### PR TITLE
fix: Set up defaults for non-updated Pay components

### DIFF
--- a/api.planx.uk/modules/pay/middleware.ts
+++ b/api.planx.uk/modules/pay/middleware.ts
@@ -136,12 +136,27 @@ export async function buildPaymentPayload(
     ]),
   );
 
+  const defaultGovPayMetadata = {
+    source: "PlanX",
+    // Payment requests have /pay path suffix, so get flow-slug from second-to-last position
+    flow:
+      (req.query.returnURL as string)
+        .split("?")?.[0]
+        ?.split("/")
+        ?.slice(-2, -1)?.[0] || "Could not parse service name",
+    inviteToPay: true,
+  };
+
+  const metadata = govPayMetadata.length
+    ? govPayMetadata
+    : defaultGovPayMetadata;
+
   const createPaymentBody: GovPayCreatePayment = {
     amount: parseInt(req.params.paymentAmount),
     reference: req.query.sessionId as string,
     description: "New application (nominated payee)",
     return_url: req.query.returnURL as string,
-    metadata: govPayMetadata,
+    metadata,
   };
 
   req.body = createPaymentBody;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -56,6 +56,7 @@ function Component(props: Props) {
     passport,
     environment,
     teamSlug,
+    flowSlug,
   ] = useStore((state) => [
     state.id,
     state.sessionId,
@@ -65,8 +66,17 @@ function Component(props: Props) {
     state.computePassport(),
     state.previewEnvironment,
     state.teamSlug,
+    state.flowSlug,
   ]);
   const fee = props.fn ? Number(passport.data?.[props.fn]) : 0;
+  const defaultMetadata = [
+    { key: "source", value: "PlanX" },
+    { key: "flow", value: flowSlug },
+    { key: "isInviteToPay", value: false },
+  ];
+  const metadata = props.govPayMetadata.length
+    ? props.govPayMetadata
+    : defaultMetadata;
 
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {
@@ -236,7 +246,7 @@ function Component(props: Props) {
     await axios
       .post(
         getGovUkPayUrlForTeam({ sessionId, flowId, teamSlug }),
-        createPayload(fee, sessionId, props.govPayMetadata),
+        createPayload(fee, sessionId, metadata),
       )
       .then(async (res) => {
         const payment = await resolvePaymentResponse(res.data);


### PR DESCRIPTION
## What does this PR do?
- Fixes an issue where existing, non-updated, Pay nodes were not handling default values correctly
- Alternatively, this could have been handled by a data migration but this seems a lighter-weight and quicker solution