### PR TITLE
feat: split allow_list_answers column in analytics_summary view

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -20,6 +20,10 @@ type AnalyticsLogDirection =
   | "reset"
   | "save";
 
+/**
+ * If appending to ALLOW_LIST please also update the `analytics_summary` view to
+ * extract it into it's own column.
+ */
 const ALLOW_LIST = [
   "proposal.projectType",
   "application.declaration.connection",
@@ -518,7 +522,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     const answerValues = answerIds.map((answerId) => flow[answerId]?.data?.val);
 
     // Match data structure of `allow_list_answers` column
-    const answers = [ {[nodeFn]: answerValues } ];
+    const answers = [{ [nodeFn]: answerValues }];
 
     return answers;
   }

--- a/hasura.planx.uk/migrations/1711457331702_alter_view_public_analytics_summary_split_allow_list_answers_into_columns/down.sql
+++ b/hasura.planx.uk/migrations/1711457331702_alter_view_public_analytics_summary_split_allow_list_answers_into_columns/down.sql
@@ -1,0 +1,58 @@
+-- Previous instance of view from hasura.planx.uk/migrations/1709208323190_run_sql_migration/up.sql
+DROP VIEW public.analytics_summary;
+
+CREATE
+OR REPLACE VIEW public.analytics_summary AS
+select
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	a.created_at as analytics_created_at,
+	(user_agent -> 'os' ->> 'name') :: text AS operating_system,
+	(user_agent -> 'browser' ->> 'name') :: text AS browser,
+	(user_agent -> 'platform' ->> 'type') :: text AS platform,
+	referrer,
+	flow_direction,
+	metadata ->> 'change' as change_metadata,
+	metadata ->> 'back' as back_metadata,
+	metadata ->> 'selectedUrls' as selected_urls,
+	metadata ->> 'flag' as result_flag,
+	metadata -> 'flagSet' as result_flagset,
+	metadata -> 'displayText' ->> 'heading' as result_heading,
+	metadata -> 'displayText' ->> 'description' as result_description,
+	case
+		when has_clicked_help then metadata
+		else null
+	end as help_metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(al.next_log_created_at - al.created_at)
+		) as numeric (10, 1)
+	) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(a.ended_at - a.created_at)
+		) / 60 as numeric (10, 1)
+	) as time_spent_on_analytics_session_minutes,
+	node_id,
+	al.allow_list_answers as allow_list_answers
+from
+	analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;
+
+--  After recreating the view grant Metabase access to it
+GRANT SELECT ON public.analytics_summary TO metabase_read_only;

--- a/hasura.planx.uk/migrations/1711457331702_alter_view_public_analytics_summary_split_allow_list_answers_into_columns/up.sql
+++ b/hasura.planx.uk/migrations/1711457331702_alter_view_public_analytics_summary_split_allow_list_answers_into_columns/up.sql
@@ -1,0 +1,65 @@
+DROP VIEW public.analytics_summary;
+
+CREATE
+OR REPLACE VIEW public.analytics_summary AS
+select
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	al.created_at as analytics_log_created_at,
+	a.created_at as analytics_created_at,
+	(user_agent -> 'os' ->> 'name') :: text AS operating_system,
+	(user_agent -> 'browser' ->> 'name') :: text AS browser,
+	(user_agent -> 'platform' ->> 'type') :: text AS platform,
+	referrer,
+	flow_direction,
+	metadata ->> 'change' as change_metadata,
+	metadata ->> 'back' as back_metadata,
+	metadata ->> 'selectedUrls' as selected_urls,
+	metadata ->> 'flag' as result_flag,
+	metadata -> 'flagSet' as result_flagset,
+	metadata -> 'displayText' ->> 'heading' as result_heading,
+	metadata -> 'displayText' ->> 'description' as result_description,
+	case
+		when has_clicked_help then metadata
+		else null
+	end as help_metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(al.next_log_created_at - al.created_at)
+		) as numeric (10, 1)
+	) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(a.ended_at - a.created_at)
+		) / 60 as numeric (10, 1)
+	) as time_spent_on_analytics_session_minutes,
+	node_id,
+	al.allow_list_answers as allow_list_answers,
+    allow_list_answer_elements->>'proposal.projectType' AS proposal_project_type,
+    allow_list_answer_elements->>'application.declaration.connection' AS application_declaration_connection,
+    allow_list_answer_elements->>'property.type' AS property_type,
+    allow_list_answer_elements->>'drawBoundary.action' AS draw_boundary_action,
+    allow_list_answer_elements->>'user.role' AS user_role,
+    allow_list_answer_elements->>'property.constraints.planning' AS property_constraints_planning
+from
+	analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id
+    left join lateral jsonb_array_elements(al.allow_list_answers) AS allow_list_answer_elements ON true;
+
+--  After recreating the view grant Metabase access to it
+GRANT SELECT ON public.analytics_summary TO metabase_read_only;


### PR DESCRIPTION
## What

- Add separate columns for each of the possible `ALLOW_LIST` variables
- Add the `created_at` for the `analytics_log` rather than just the `created_at` for the `analytics` session

## Why

- It was found that the `allow_list_answers` with the new data structure was difficult to work with on Metabase

## Follow Up

- Noticed that the `allow_list_answer` data structure is inconsistent i.e. `{key: value}` rather than `{key: [value]}` <img width="362" alt="Screenshot 2024-03-26 at 12 59 07" src="https://github.com/theopensystemslab/planx-new/assets/36415632/5b74421e-8264-40f1-ad2e-0c7e983aa16f">

- Noticed that the `null` values are no longer being filtered out: https://github.com/theopensystemslab/planx-new/blob/612fa877f30818b4d22c98df3e3b44158bdfa095/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx#L467 which leads to `[null]` surprisingly often? <img width="362" alt="Screenshot 2024-03-26 at 13 01 39" src="https://github.com/theopensystemslab/planx-new/assets/36415632/877104b8-fdca-4ec1-8852-0ef1ff63ff3b">

- Check that the value of allow list as an array is usable on Metabase: <img width="684" alt="Screenshot 2024-03-26 at 13 03 53" src="https://github.com/theopensystemslab/planx-new/assets/36415632/3f7199d1-5cdc-415b-91d6-375ef3908edc">

- Remove the `nodeFn` column from `analytics_logs` as it's not reliable with the previous changes to the way we gather allow_list answers i.e. it naively stores the `nodeToTrack?.data?.fn || nodeToTrack?.data?.val` and missed when the passport variable is defined by the breadcrumbs. <img width="812" alt="Screenshot 2024-03-26 at 13 15 28" src="https://github.com/theopensystemslab/planx-new/assets/36415632/8c294054-93a6-4474-a76c-91e33967c6d0">

- Align the data structure for the allow_list between `analytics_logs` and `lowcal_sessions` i.e.  `[{key: [value]}]`, vs `{key: [value]}` respectively.

  <img width="362" alt="Screenshot 2024-03-26 at 13 01 39" src="https://github.com/theopensystemslab/planx-new/assets/36415632/de4f5358-574f-4351-b0c4-7f7c16641f25">


  <img width="838" alt="Screenshot 2024-03-26 at 15 14 29" src="https://github.com/theopensystemslab/planx-new/assets/36415632/f9479c17-cd83-4be8-a7a3-adfe6bf12f09">

