### PR TITLE
fix: Update BOPS URL in E2E test

### DIFF
--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
@@ -1,7 +1,7 @@
 # BOPS submissions
 - request:
     method: POST
-    path: /api/v2/planning_applications
+    path: /
   response:
     headers:
       Content-Type: application/json


### PR DESCRIPTION
✅ Regression tests passing locally

✅ Regression tests passing on CI here - https://github.com/theopensystemslab/planx-new/actions/runs/8449763473