### PR TITLE
fix(a11y): Add labels to all feedback form inputs

### DIFF
--- a/editor.planx.uk/src/components/Feedback/FeedbackForm.stories.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackForm.stories.tsx
@@ -26,7 +26,9 @@ export const EmptyLabelledForm: Story = {
 
 export const EmptyUnlabelledForm: Story = {
   args: {
-    inputs: [{ id: "userComment", name: "userComment" }],
+    inputs: [
+      { id: "userComment", name: "userComment", label: "What's your comment?" },
+    ],
     handleSubmit: async (values) => {
       console.log(values);
     },

--- a/editor.planx.uk/src/components/Feedback/FeedbackForm.stories.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackForm.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 
-export const EmptyLabelledForm: Story = {
+export const EmptyForm: Story = {
   args: {
     inputs: [
       { id: "userContext", name: "userContext", label: "What were you doing?" },
@@ -24,19 +24,8 @@ export const EmptyLabelledForm: Story = {
   },
 };
 
-export const EmptyUnlabelledForm: Story = {
-  args: {
-    inputs: [
-      { id: "userComment", name: "userComment", label: "What's your comment?" },
-    ],
-    handleSubmit: async (values) => {
-      console.log(values);
-    },
-  },
-};
-
-export const SuccessfulLabelledFormSubmit: Story = {
-  ...EmptyLabelledForm,
+export const SuccessfulFormSubmit: Story = {
+  ...EmptyForm,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -57,8 +46,8 @@ export const SuccessfulLabelledFormSubmit: Story = {
   },
 };
 
-export const MissingInputLabelledForm: Story = {
-  ...EmptyLabelledForm,
+export const MissingInputForm: Story = {
+  ...EmptyForm,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -66,33 +55,6 @@ export const MissingInputLabelledForm: Story = {
     await userEvent.type(contextInput, "Trying to find my property", {
       delay: 100,
     });
-
-    const submitButton = canvas.getByRole("button", { name: "Send feedback" });
-    await userEvent.click(submitButton);
-  },
-};
-
-export const SuccessfulUnlabelledFormSubmit: Story = {
-  ...EmptyUnlabelledForm,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const commentInput = canvas.getByLabelText("Leave your feedback");
-    await userEvent.type(
-      commentInput,
-      "It said I own a house but it's actually a flat.",
-      { delay: 100 },
-    );
-
-    const submitButton = canvas.getByRole("button", { name: "Send feedback" });
-    await userEvent.click(submitButton);
-  },
-};
-
-export const MissingInputUnlabelledFormSubmit: Story = {
-  ...EmptyUnlabelledForm,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
 
     const submitButton = canvas.getByRole("button", { name: "Send feedback" });
     await userEvent.click(submitButton);

--- a/editor.planx.uk/src/components/Feedback/FeedbackForm.test.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackForm.test.tsx
@@ -6,13 +6,6 @@ import FeedbackForm from "./FeedbackForm";
 
 const mockHandleSubmit = jest.fn();
 
-const mockUnlabelledInput: FeedbackFormInput[] = [
-  {
-    name: "userComment",
-    ariaDescribedBy: "comment-title",
-  },
-];
-
 const mockLabelledInputs: FeedbackFormInput[] = [
   { name: "userContext", id: "userContext", label: "User Context" },
   { name: "userComment", id: "userComment", label: "User Comment" },
@@ -23,18 +16,7 @@ describe("FeedbackForm functionality", () => {
     jest.clearAllMocks();
   });
 
-  test("renders unlabelled input correctly", () => {
-    const { getByLabelText } = setup(
-      <FeedbackForm
-        inputs={mockUnlabelledInput}
-        handleSubmit={mockHandleSubmit}
-      />,
-    );
-    const renderedInput = getByLabelText("Leave your feedback");
-    expect(renderedInput).toBeInTheDocument();
-  });
-
-  test("renders labelled inputs correctly", () => {
+  test("renders inputs correctly", () => {
     const { getByLabelText } = setup(
       <FeedbackForm
         inputs={mockLabelledInputs}
@@ -47,42 +29,7 @@ describe("FeedbackForm functionality", () => {
     expect(commentInput).toBeInTheDocument();
   });
 
-  test("renders the feedback disclaimer with the input", () => {
-    const { getByText } = setup(
-      <FeedbackForm
-        inputs={mockUnlabelledInput}
-        handleSubmit={mockHandleSubmit}
-      />,
-    );
-    expect(
-      getByText(
-        /Do not share personal or financial information in your feedback./i,
-      ),
-    ).toBeInTheDocument();
-  });
-
-  test("can submit an unlabelled input", async () => {
-    const { getByLabelText, getByText, user } = setup(
-      <FeedbackForm
-        inputs={mockUnlabelledInput}
-        handleSubmit={mockHandleSubmit}
-      />,
-    );
-    await user.type(
-      getByLabelText("Leave your feedback"),
-      "This is a test comment",
-    );
-    await user.click(getByText("Send feedback"));
-
-    expect(mockHandleSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userComment: "This is a test comment",
-      }),
-      expect.any(Object),
-    );
-  });
-
-  test("can submit labelled inputs", async () => {
+  test("can submit inputs", async () => {
     const { getByLabelText, getByText, user } = setup(
       <FeedbackForm
         inputs={mockLabelledInputs}
@@ -109,18 +56,7 @@ describe("FeedbackForm accessibility tests", () => {
     jest.clearAllMocks();
   });
 
-  test("renders unlabelled inputs with no accessibility violations", async () => {
-    const { container } = setup(
-      <FeedbackForm
-        inputs={mockUnlabelledInput}
-        handleSubmit={mockHandleSubmit}
-      />,
-    );
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
-
-  test("renders labelled inputs with no accessibility violations", async () => {
+  test("renders inputs with no accessibility violations", async () => {
     const { container } = setup(
       <FeedbackForm
         inputs={mockLabelledInputs}

--- a/editor.planx.uk/src/components/Feedback/FeedbackForm.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackForm.tsx
@@ -23,34 +23,20 @@ function FormInputs({ inputs }: { inputs: FeedbackFormInput[] }): FCReturn {
         <ErrorWrapper
           key={input.name}
           error={errors?.[input.name]}
-          id={`${input.label || input.ariaDescribedBy}-error`}
+          id={`${input.label}-error`}
         >
-          {input.label ? (
-            <InputLabel label={input.label} htmlFor={input.id}>
-              <Input
-                required
-                multiline
-                bordered
-                id={input.id}
-                name={input.name}
-                value={values?.[input.name]}
-                onChange={handleChange}
-                data-testid={`${input.name}Textarea`}
-              />
-            </InputLabel>
-          ) : (
+          <InputLabel label={input.label} htmlFor={input.id}>
             <Input
-              name={input.name}
               required
               multiline
               bordered
-              aria-label={"Leave your feedback"}
-              aria-describedby={input.ariaDescribedBy}
+              id={input.id}
+              name={input.name}
               value={values?.[input.name]}
               onChange={handleChange}
               data-testid={`${input.name}Textarea`}
             />
-          )}
+          </InputLabel>
         </ErrorWrapper>
       ))}
     </>

--- a/editor.planx.uk/src/components/Feedback/MoreInfoFeedback.tsx
+++ b/editor.planx.uk/src/components/Feedback/MoreInfoFeedback.tsx
@@ -94,7 +94,8 @@ const MoreInfoFeedbackComponent: React.FC = () => {
     const commentFormInputs: FeedbackFormInput[] = [
       {
         name: "userComment",
-        ariaDescribedBy: "comment-title",
+        label: "What's your feedback?",
+        id: "feedback-input",
       },
     ];
 

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -76,9 +76,8 @@ export interface FormProps {
 
 export type FeedbackFormInput = {
   name: keyof UserFeedback;
-  label?: string;
-  id?: string;
-  ariaDescribedBy?: string;
+  label: string;
+  id: string;
 };
 
 const Feedback: React.FC = () => {
@@ -331,7 +330,8 @@ const Feedback: React.FC = () => {
     const shareFormInputs: FeedbackFormInput[] = [
       {
         name: "userComment",
-        ariaDescribedBy: "idea-title",
+        label: "What's your idea?",
+        id: "share-idea-input",
       },
     ];
 
@@ -362,7 +362,8 @@ const Feedback: React.FC = () => {
     const commentFormInputs: FeedbackFormInput[] = [
       {
         name: "userComment",
-        ariaDescribedBy: "comment-title",
+        label: "What's you comment?",
+        id: "comment-input",
       },
     ];
 


### PR DESCRIPTION
## What does this PR do?
- Address accessibility report issue "Label and Accessible Name" (page 43)
- Adds a label to each input used in the feedback from instead of conditionally relying on the title for this

This approach is very much up for discussion, I've hopefully explained my thought process below.

## Problem
> A text area was found to have an accessible name that does not match the one that is provided visually. This can be found across the service; however, this instance relates to the text area below the ‘please help us to improve the service by sharing feedback’. The visual label has not been programmatically associated with the related text area, and so the information presented visually is not relayed to screen reader users navigating out of context.

```jsx
<textarea 
  aria-describedby="comment-title" 
  name="userComment" 
  required="" 
  // Hardcoded aria-label is the issue
  aria-label="Leave your feedback"
  class="MuiInputBase-input MuiInputBase-inputMultiline css-10oer18" 
  style="height: 29px; overflow: hidden;">
 </textarea>
```

## Why I went for this approach
There are a few ways this issue could be addressed. The report suggests wrapping making the title (e.g. "Please help us to improve this service by sharing feedback" a `<label>` element and attaching to the input using `id` and `for` properties.

I've opted not to do this, and instead to always add a label for each input, separate from the title.

**Pros**
- It's consistent across all modes the feedback component can take. Currently labels are used where multiple inputs are used, but not single inputs (apart from "Report an inaccuracy").
- Relying on an _external_ title to label our form component is quite unexpected
  - The `FeedbackForm` component cannot pass automated accessibility tests unless accompanied by another label component
  - We rely on all future users of this component to know and understand this
- Passing a title component into the form ends up being fairly complex / invovled
  - It needs to have different styles in different contexts (e.g. icon or no icon, font size)
  - It needs the `component={label}` prop (or `aria-labelledby`) if there is only a single input
- I think the title and label are actually two different things in reality

**Cons**
- More text / cruft for the user
- Bad copy written by me!

Thoughts most welcome! 😄 