### PR TITLE
fix(a11y): Darken disabled colour in MUI theme

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -53,6 +53,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   action: {
     selected: "#F8F8F8",
     focus: "#FFDD00",
+    disabled: "#B4B4B4",
   },
   error: {
     main: "#D4351C",


### PR DESCRIPTION
## Problem
<img width="511" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/ec6cce79-b67e-4983-95b7-10c8f4a9099d">

## Solution
- Use [darken colour tool](https://mdigi.tools/darken-color/#bdbdbd) to find a shade of #BDBDBD which meet 1.99 contrast ratio 
- 5% darker achieves a ratio of 2.07 - see https://color.a11y.com/ContrastPair/?bgcolor=ffffff&fgcolor=000042

## Also...
 - It looks like jest-axe and jsdom can't automatically contrast ratio, so we can't automatically test for this - https://github.com/dequelabs/axe-core/issues/4021
 - The MUI palette has a default contrast threshold of 3:1, but it looks like this just applies to text ([docs](https://mui.com/material-ui/customization/palette/#contrast-threshold))