### PR TITLE
chore: default analytics_logs allow_list_answers to null

### DIFF
--- a/hasura.planx.uk/migrations/1711637066987_alter_table_public_analytics_logs_default_allow_list_answers_to_null/down.sql
+++ b/hasura.planx.uk/migrations/1711637066987_alter_table_public_analytics_logs_default_allow_list_answers_to_null/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."analytics_logs" alter column "allow_list_answers" set default '[]'::jsonb;
+
+UPDATE public.analytics_logs SET allow_list_answers = '[]'::jsonb WHERE allow_list_answers IS NULL;

--- a/hasura.planx.uk/migrations/1711637066987_alter_table_public_analytics_logs_default_allow_list_answers_to_null/up.sql
+++ b/hasura.planx.uk/migrations/1711637066987_alter_table_public_analytics_logs_default_allow_list_answers_to_null/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."analytics_logs" ALTER COLUMN "allow_list_answers" drop default;
+
+UPDATE "public"."analytics_logs" SET allow_list_answers = NULL WHERE allow_list_answers = '[]'::jsonb;


### PR DESCRIPTION
## What

- Default `analytics_logs` `allow_list_answers` to `null`
- Update existing empty arrays to `null`

## Why

- In Metabase the empty areas were found to be challenging to filter out

## Note

- Initially intended to allow do this for `metadata` and `input_errors` as per the ticket although due to the mutation using `_append` and the nature of those tracking events it wasn't practical to do. 

