### PR TITLE
chore: Finalise Gateshead subdomain

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -19,6 +19,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.barnet.gov.uk":
     case "planningservices.tewkesbury.gov.uk":
     case "planningservices.westberks.gov.uk":
+    case "planningservices.gateshead.gov.uk":
     case "editor.planx.uk":
       return "production";
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -60,6 +60,7 @@ const PREVIEW_ONLY_DOMAINS = [
   "planningservices.barnet.gov.uk",
   "planningservices.tewkesbury.gov.uk",
   "planningservices.westberks.gov.uk",
+  "planningservices.gateshead.gov.uk",
   // XXX: un-comment the next line to test custom domains locally
   // "localhost",
 ];


### PR DESCRIPTION
Currently awaiting a response from Gateshead's IT team to confirm they've set up a CNAME record. This PR can sit as a draft until I get that confirmation.

Remaining tasks (steps 10, 11, 12 from [docs](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-subdomains.md))

- [x] Receive confirmation from IT team that CNAME record is setup
- [x] Add to `PREVIEW_ONLY_DOMAINS`
- [x] Add to `getEnvForAllowedHosts()`
- [x] Add subdomain to `team.domain` column via Hasura
- [x] Setup UptimeRobot
- [x] Add certificate expiry date to PlanX CMS on Notion
- [ ] Merge to `main`, then `production`
- [ ] Notify Gateshead ✅ 