### PR TITLE
fix(a11y): Replace `Collapse` and `Button` with `Accordion` components in `PlanningConstraints`

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -1,6 +1,7 @@
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
 import Box, { BoxProps } from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import Collapse from "@mui/material/Collapse";
 import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -13,7 +14,7 @@ import type {
   Metadata,
 } from "@opensystemslab/planx-core/types";
 import groupBy from "lodash/groupBy";
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode } from "react";
 import ReactHtmlParser from "react-html-parser";
 import Caret from "ui/icons/Caret";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
@@ -26,17 +27,24 @@ const CATEGORY_COLORS: Record<string, string> = {
   Flooding: "#ECECEC",
 };
 
-interface StyledConstraintProps extends BoxProps {
+const PREFIX = "ConstraintsList";
+
+const classes = {
+  content: `${PREFIX}-content`
+}
+
+interface StyledAccordionProps extends BoxProps {
   category: string;
 }
 
-const StyledConstraint = styled(Box, {
-  shouldForwardProp: (prop) => prop !== "category",
-})<StyledConstraintProps>(({ theme, category }) => ({
+const StyledAccordion = styled(Accordion, {
+  shouldForwardProp: (prop) => !["category", "metadata", "content", "data"].includes(prop as string),
+})<StyledAccordionProps>(({ theme, category }) => ({
   borderLeft: `5px solid ${CATEGORY_COLORS[category]}`,
   paddingRight: 0,
   width: "100%",
   color: theme.palette.text.primary,
+  backgroundColor: theme.palette.background.default,
   position: "relative",
   "&::after": {
     content: "''",
@@ -46,6 +54,9 @@ const StyledConstraint = styled(Box, {
     width: "100%",
     height: "1px",
     background: theme.palette.border.main,
+  },
+  [`&.${classes.content}`]: {
+    margin: [1.5, 0]
   },
 }));
 
@@ -123,100 +134,77 @@ interface ConstraintListItemProps {
 }
 
 function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
-  const [showConstraintData, setShowConstraintData] = useState<boolean>(false);
 
   return (
     <ListItem disablePadding sx={{ backgroundColor: "white" }}>
-      <StyledConstraint {...props}>
-        <Box
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-between",
-          }}
-        >
-          <Button
-            disableRipple
-            onClick={() =>
-              setShowConstraintData((showConstraintData) => !showConstraintData)
+      <StyledAccordion {...props} square disableGutters>
+        <AccordionSummary
+          id={`${props.content}-header`}
+          aria-controls={`${props.content}-panel`}
+          classes={{ content: classes.content }}
+          expandIcon={<Caret />}
+          sx={(theme) => ({
+            fontSize: "1rem",
+            "&:hover": {
+              backgroundColor: theme.palette.background.paper
             }
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "space-between",
-              width: "100%",
-              boxShadow: "none",
-              color: "#0B0C0C",
-              fontWeight: "400",
-              padding: 15,
-              paddingLeft: 20,
-            }}
-          >
-            <Box>{children}</Box>
-            <Caret
-              expanded={showConstraintData}
-              color="primary"
-              titleAccess={
-                showConstraintData ? "Less Information" : "More Information"
-              }
-            />
-          </Button>
-        </Box>
-        <Collapse in={showConstraintData}>
-          <Box py={1.5} px={2}>
-            <>
-              <Typography variant="h3" component="h4" gutterBottom>
-                {`This property ${props?.content}`}
-              </Typography>
-              {Boolean(props.data?.length) && (
-                <List
-                  dense
-                  disablePadding
-                  sx={{ listStyleType: "disc", pl: 4, pt: 1 }}
-                >
-                  {props.data &&
-                    props.data.map(
-                      (record: any) =>
-                        record.name && (
-                          <ListItem
-                            key={record.entity}
-                            dense
-                            disableGutters
-                            sx={{ display: "list-item" }}
-                          >
-                            <Typography variant="body2">
-                              {record.name}{" "}
-                              {record.name && record["documentation-url"] && (
-                                <span>
-                                  (
-                                  <Link
-                                    href={record["documentation-url"]}
-                                    target="_blank"
-                                  >
-                                    source
-                                  </Link>
-                                  )
-                                </span>
-                              )}
-                            </Typography>
-                          </ListItem>
-                        ),
-                    )}
-                </List>
-              )}
-            </>
-            <Typography variant="body2">
-              <ReactMarkdownOrHtml
-                source={props.metadata?.text?.replaceAll(
-                  "(/",
-                  "(https://www.planning.data.gov.uk/",
-                )}
-                openLinksOnNewTab
-              />
+          })}
+        >
+          {children}
+        </AccordionSummary>
+        <AccordionDetails sx={{ px: 1.5, py: 2 }}>
+          <>
+            <Typography variant="h3" component="h4" gutterBottom>
+              {`This property ${props?.content}`}
             </Typography>
-          </Box>
-        </Collapse>
-      </StyledConstraint>
+            {Boolean(props.data?.length) && (
+              <List
+                dense
+                disablePadding
+                sx={{ listStyleType: "disc", pl: 4, pt: 1 }}
+              >
+                {props.data &&
+                  props.data.map(
+                    (record: any) =>
+                      record.name && (
+                        <ListItem
+                          key={record.entity}
+                          dense
+                          disableGutters
+                          sx={{ display: "list-item" }}
+                        >
+                          <Typography variant="body2">
+                            {record.name}{" "}
+                            {record.name && record["documentation-url"] && (
+                              <span>
+                                (
+                                <Link
+                                  href={record["documentation-url"]}
+                                  target="_blank"
+                                >
+                                  source
+                                </Link>
+                                )
+                              </span>
+                            )}
+                          </Typography>
+                        </ListItem>
+                      ),
+                  )}
+              </List>
+            )}
+          </>
+          <Typography variant="body2">
+            <ReactMarkdownOrHtml
+              source={props.metadata?.text?.replaceAll(
+                "(/",
+                "(https://www.planning.data.gov.uk/",
+              )}
+              openLinksOnNewTab
+            />
+          </Typography>
+        </AccordionDetails>
+      </StyledAccordion>
     </ListItem>
   );
 }

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -132,17 +132,19 @@ interface ConstraintListItemProps {
 }
 
 function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
+  const item = props.metadata?.name.replaceAll(" ", "-");
 
   return (
     <ListItem disablePadding sx={{ backgroundColor: "white" }}>
       <StyledAccordion {...props} disableGutters>
         <AccordionSummary
-          id={`${props.content}-header`}
-          aria-controls={`${props.content}-panel`}
+          id={`${item}-header`}
+          aria-controls={`${item}-panel`}
           classes={{ content: classes.content }}
           expandIcon={<Caret />}
+          sx={{ pr: 1.5 }}
         >
-          {children}
+          <Typography variant="body2" pr={1.5}>{children}</Typography>
         </AccordionSummary>
         <AccordionDetails sx={{ px: 1.5, py: 2 }}>
           <>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -43,8 +43,6 @@ const StyledAccordion = styled(Accordion, {
   borderLeft: `5px solid ${CATEGORY_COLORS[category]}`,
   paddingRight: 0,
   width: "100%",
-  color: theme.palette.text.primary,
-  backgroundColor: theme.palette.background.default,
   position: "relative",
   "&::after": {
     content: "''",
@@ -137,18 +135,12 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
 
   return (
     <ListItem disablePadding sx={{ backgroundColor: "white" }}>
-      <StyledAccordion {...props} square disableGutters>
+      <StyledAccordion {...props} disableGutters>
         <AccordionSummary
           id={`${props.content}-header`}
           aria-controls={`${props.content}-panel`}
           classes={{ content: classes.content }}
           expandIcon={<Caret />}
-          sx={(theme) => ({
-            fontSize: "1rem",
-            "&:hover": {
-              backgroundColor: theme.palette.background.paper
-            }
-          })}
         >
           {children}
         </AccordionSummary>

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -135,11 +135,10 @@ const ResultReason: React.FC<IResultReason> = ({
   const hasMoreInfo = question.data.info ?? question.data.policyRef;
   const toggleAdditionalInfo = () => setExpanded(!expanded);
 
-  const ariaLabel = `${question.data.text}: Your answer was: ${response}. ${
-    hasMoreInfo
+  const ariaLabel = `${question.data.text}: Your answer was: ${response}. ${hasMoreInfo
       ? "Click to expand for more information about this question."
       : ""
-  }`;
+    }`;
 
   const { trackBackwardsNavigation } = useAnalyticsTracking();
 
@@ -155,7 +154,6 @@ const ResultReason: React.FC<IResultReason> = ({
         onChange={() => hasMoreInfo && toggleAdditionalInfo()}
         expanded={expanded}
         elevation={0}
-        square
       >
         <Box sx={{ position: "relative" }}>
           <StyledAccordionSummary

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -202,6 +202,27 @@ const getThemeOptions = ({
       },
     },
     components: {
+      MuiAccordion: {
+        styleOverrides: {
+          root: {
+            color: palette.text.primary,
+            backgroundColor: palette.background.default,
+            fontSize: "1rem",
+          },
+        },
+        defaultProps: {
+          square: true,
+        },
+      },
+      MuiAccordionSummary: {
+        styleOverrides: {
+          root: {
+            "&:hover": {
+              backgroundColor: palette.background.paper,
+            },
+          },
+        },
+      },
       MuiContainer: {
         styleOverrides: {
           root: {
@@ -463,7 +484,7 @@ const generateTeamTheme = (
     linkColour: DEFAULT_PRIMARY_COLOR,
     logo: null,
     favicon: null,
-  },
+  }
 ): MUITheme => {
   const themeOptions = getThemeOptions(teamTheme);
   const theme = responsiveFontSizes(createTheme(themeOptions), { factor: 3 });


### PR DESCRIPTION
## What does this PR do?
 - Replaces the combination of `Button` and `Collapse` components with an `Accordion` component
 - Moves some Accordion theming to the MUI theme so that there's more consistency with our other accordions (currently just `ResultReason`)
 - No intentional visual changes
   - Apart from one! 
   - The colour for the Caret and hover is now fixed and not based on primary colour - I wasn't sure if this was intentional in the first place, or a hangover from using a `Button`.
   - If you could take a look at this one please @ianjon3s and confirm that would be much appreciated! 🙌 
   
| | Before | After |
|--------|--------|--------|
| **Screenshot** | <img width="721" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/fce37f6c-00a7-487e-949d-3dfe81b317a2">|<img width="703" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/ba595bc6-f1db-4ebc-9d4d-d1d4a75f6584">| 
| **Link** | [Storybook (Prod)](https://storybook.planx.uk/?path=/docs/planx-components-planningconstraints--docs) | [Storybook (Pizza)](https://storybook.2966.planx.pizza/?path=/docs/planx-components-planningconstraints--docs) | 

## Motivation
 - Suggested by accessibility report (page 19)
 - Removes boilerplate code for managing collapsed/expanded state
 - Handles accessibility properties natively (e.g. `expanded`, `aria-controls`) 
   - Docs: https://mui.com/material-ui/react-accordion/#accessibility