### PR TITLE
fix(a11y): Add visually hidden context to "Restart Application" button

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -19,6 +19,7 @@ import { styled, Theme } from "@mui/material/styles";
 import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { visuallyHidden } from "@mui/utils";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { clearLocalFlow } from "lib/local";
 import { capitalize } from "lodash";
@@ -359,7 +360,9 @@ const PublicToolbar: React.FC<{
                   onClick={openConfirmationDialog}
                   aria-label="Restart Application"
                   size="large"
+                  aria-describedby="restart-application-description"
                 >
+                  <Typography id="restart-application-description" style={visuallyHidden}>Open a dialog with the option to restart your application. If you chose to restart your application, this will delete your previous answers</Typography>
                   <Reset color="secondary" />
                 </IconButton>
               )}


### PR DESCRIPTION
<img width="510" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/28ac7ba9-4498-4ad5-afb1-2d08de0d6017">
<img width="491" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/dc2eaaaa-a5c3-4d65-a248-36f9a7ec5ba0">

## What does this PR do?
- Adds a visually hidden description to the "Restart application" button

## Context
I'd dispute this is really totally necessary as our current markdown matches [the suggestion on MDN perfectly](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) (`<button>` with `aria-label` wrapping an `<svg>` with `aria-hidden=true`), and clicking the button opens a dialog with more details. However, it's an easy fix to just add an additional description element here.
