### PR TITLE
feat: Move back button out of main component, ensure single main component only

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -199,10 +199,7 @@ test.describe("Navigation", () => {
       page.locator("h3", { hasText: "Yes! this is a test" }),
     ).toBeVisible();
 
-    await page
-      .locator("#main-content")
-      .getByRole("button", { name: "Back" })
-      .click();
+    await page.getByTestId("backButton").click();
 
     await answerQuestion({ page, title: "Is this a test?", answer: "No" });
     await clickContinue({ page });

--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -92,7 +92,7 @@ const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
         <CloseIcon />
       </IconButton>
     </CloseButton>
-    <Container maxWidth={false} role="main" sx={{ bgcolor: "white" }}>
+    <Container maxWidth={false} sx={{ bgcolor: "white" }}>
       <DrawerContent>{children}</DrawerContent>
     </Container>
     <MoreInfoFeedbackComponent />

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -130,22 +130,22 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   const handleSubmit =
     (id: string): handleSubmit =>
-    (userData) => {
-      const {
-        data = undefined,
-        answers = [],
-        auto = false,
-      } = (() => {
-        try {
-          const { answers = [], data, auto } = userData as any;
-          return { answers: answers.filter(Boolean), data, auto };
-        } catch (err) {
-          return {};
-        }
-      })();
+      (userData) => {
+        const {
+          data = undefined,
+          answers = [],
+          auto = false,
+        } = (() => {
+          try {
+            const { answers = [], data, auto } = userData as any;
+            return { answers: answers.filter(Boolean), data, auto };
+          } catch (err) {
+            return {};
+          }
+        })();
 
-      record(id, { answers, data, auto });
-    };
+        record(id, { answers, data, auto });
+      };
 
   const goBack = useCallback(() => {
     const previous = previousCard(node);
@@ -166,7 +166,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   );
 
   return (
-    <Box width="100%" role="main">
+    <Box width="100%" >
       <BackBar hidden={!showBackBar}>
         <Container maxWidth={false}>
           <BackButton
@@ -183,6 +183,8 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
       {node && (
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Node
+            id="main-content"
+            role="main"
             node={node}
             key={node.id}
             handleSubmit={handleSubmit(node.id!)}

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -130,22 +130,22 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   const handleSubmit =
     (id: string): handleSubmit =>
-      (userData) => {
-        const {
-          data = undefined,
-          answers = [],
-          auto = false,
-        } = (() => {
-          try {
-            const { answers = [], data, auto } = userData as any;
-            return { answers: answers.filter(Boolean), data, auto };
-          } catch (err) {
-            return {};
-          }
-        })();
+    (userData) => {
+      const {
+        data = undefined,
+        answers = [],
+        auto = false,
+      } = (() => {
+        try {
+          const { answers = [], data, auto } = userData as any;
+          return { answers: answers.filter(Boolean), data, auto };
+        } catch (err) {
+          return {};
+        }
+      })();
 
-        record(id, { answers, data, auto });
-      };
+      record(id, { answers, data, auto });
+    };
 
   const goBack = useCallback(() => {
     const previous = previousCard(node);
@@ -166,7 +166,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   );
 
   return (
-    <Box width="100%" >
+    <Box width="100%">
       <BackBar hidden={!showBackBar}>
         <Container maxWidth={false}>
           <BackButton
@@ -181,15 +181,15 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
       </BackBar>
 
       {node && (
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          <Node
-            id="main-content"
-            role="main"
-            node={node}
-            key={node.id}
-            handleSubmit={handleSubmit(node.id!)}
-          />
-        </ErrorBoundary>
+        <Box component="main" id="main-content">
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <Node
+              node={node}
+              key={node.id}
+              handleSubmit={handleSubmit(node.id!)}
+            />
+          </ErrorBoundary>
+        </Box>
       )}
     </Box>
   );

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -60,7 +60,7 @@ export const EmailRequired: React.FC<{ setEmail: (email: string) => void }> = ({
   });
 
   return (
-    <Box width="100%" role="main">
+    <Box width="100%" component="main">
       <Card handleSubmit={formik.handleSubmit}>
         <QuestionHeader
           title="Resume your application"

--- a/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
+++ b/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
@@ -33,7 +33,7 @@ export const ConfirmEmail: React.FC<{
   });
 
   return (
-    <Box width="100%" role="main">
+    <Box width="100%" component="main">
       <Card handleSubmit={formik.handleSubmit}>
         <QuestionHeader
           title="Enter your email address"

--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -52,10 +52,10 @@ const PublicFooter: React.FC = () => {
 
   const globalFooterItems = globalSettings?.footerContent
     ? Object.entries(globalSettings?.footerContent).map(([slug, item]) => ({
-        title: item.heading,
-        content: item.content,
-        href: makeHref(slug),
-      }))
+      title: item.heading,
+      content: item.content,
+      href: makeHref(slug),
+    }))
     : [];
 
   const footerItems = [...flowSettingsContent, ...globalFooterItems].filter(
@@ -96,7 +96,7 @@ const PublicLayout: React.FC<PropsWithChildren> = ({ children }) => {
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={teamMUITheme}>
         <Header />
-        <MainContainer id="main-content">
+        <MainContainer>
           <ErrorBoundary FallbackComponent={ErrorFallback}>
             {children}
           </ErrorBoundary>


### PR DESCRIPTION
## What does this PR do?
 - Move back component out of `#main` element (report page 91 - [Trello ticket](https://trello.com/c/C0e3PdIu/2835-back-button-positioning-usability))
 - Ensure we only use a single `#main` element (report page 82 - [Trello ticket](https://trello.com/c/ksGgKnK7/2830-multiple-main-roles-usability?search_id=23e5b034-13a3-424f-9c07-fd0dbf48fbb6))
 - Use `<main>` element instead of `<div role="main">` - not in report just something I spotted. From MDN docs - 
 
> Prefer using the `<main>` element over declaring role="main", unless there are [legacy browser support concerns](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main#browser_compatibility).