### PR TITLE
chore: Fix eslint rule "no-case-declarations"

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -42,16 +42,22 @@
           },
           {
             "name": "@testing-library/react",
-            "importNames": ["render"],
+            "importNames": [
+              "render"
+            ],
             "message": "Please import setup() from testUtils to render test component"
           },
           {
             "name": "@mui/styles",
-            "importNames": ["styled"],
+            "importNames": [
+              "styled"
+            ],
             "message": "Please import styled from '@mui/material/styles'. Reason: https://mui.com/system/styled/#what-problems-does-it-solve"
           }
         ],
-        "patterns": ["@mui/*/*/*"]
+        "patterns": [
+          "@mui/*/*/*"
+        ]
       }
     ],
     "@typescript-eslint/no-unused-vars": [
@@ -62,7 +68,6 @@
       }
     ],
     "no-empty": "warn",
-    "no-case-declarations": "warn",
     "no-unsafe-optional-chaining": "warn",
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/no-var-requires": "warn",
@@ -71,12 +76,18 @@
     "@typescript-eslint/ban-ts-comment": "off"
   },
   "settings": {
-    "jest": { "version": 27 }
+    "jest": {
+      "version": 27
+    }
   },
   "overrides": [
-		{
-			"files": ["**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)"],
-			"extends": ["plugin:testing-library/react"]
-		}
-	]
+    {
+      "files": [
+        "**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)"
+      ],
+      "extends": [
+        "plugin:testing-library/react"
+      ]
+    }
+  ]
 }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analyticsProvider.tsx
@@ -545,7 +545,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
   function getNodeMetadata(node: Store.node, nodeId: string) {
     const isAutoAnswered = breadcrumbs[nodeId]?.auto || false;
     switch (node?.type) {
-      case TYPES.Result:
+      case TYPES.Result: {
         const flagSet = node?.data?.flagSet || DEFAULT_FLAG_CATEGORY;
         const data = resultData(flagSet, node?.data?.overrides);
         const { displayText, flag } = data[flagSet];
@@ -555,7 +555,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
           flag,
           isAutoAnswered,
         };
-
+      }
       default:
         return {
           isAutoAnswered,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -9,10 +9,7 @@ import {
   flatFlags,
 } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import {
-  FileList,
-  PASSPORT_REQUESTED_FILES_KEY,
-} from "@planx/components/FileUploadAndLabel/model";
+import { FileList } from "@planx/components/FileUploadAndLabel/model";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { logger } from "airbrake";
 import { objectWithoutNullishValues } from "lib/objectHelpers";

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -85,7 +85,7 @@ const Node: React.FC<any> = (props: Props) => {
   switch (props.node.type) {
     case TYPES.Calculate:
       return <Calculate {...allProps} />;
-    case TYPES.Checklist:
+    case TYPES.Checklist: {
       const childNodes = childNodesOf(props.node.id);
       return (
         <Checklist
@@ -111,7 +111,8 @@ const Node: React.FC<any> = (props: Props) => {
           }
         />
       );
-    case TYPES.Confirmation:
+    }
+    case TYPES.Confirmation: {
       const payment: GovUKPayment | undefined =
         passport.data?.[GOV_PAY_PASSPORT_KEY];
 
@@ -147,6 +148,7 @@ const Node: React.FC<any> = (props: Props) => {
           color={{ text: "#000", background: "rgba(1, 99, 96, 0.1)" }}
         />
       );
+    }
     case TYPES.Content:
       return <Content {...allProps} />;
 
@@ -177,7 +179,7 @@ const Node: React.FC<any> = (props: Props) => {
     case TYPES.Pay:
       return <Pay {...allProps} />;
 
-    case TYPES.Result:
+    case TYPES.Result: {
       const flagSet = props.node?.data?.flagSet || DEFAULT_FLAG_CATEGORY;
       const data = resultData(flagSet, props.node?.data?.overrides);
 
@@ -198,7 +200,7 @@ const Node: React.FC<any> = (props: Props) => {
           disclaimer={flowSettings?.elements?.legalDisclaimer}
         />
       );
-
+    }
     case TYPES.Review:
       return <Review {...allProps} />;
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -1,6 +1,5 @@
 import { ComponentType as NodeTypes } from "@opensystemslab/planx-core/types";
 import gql from "graphql-tag";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { NaviRequest, NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { Store } from "pages/FlowEditor/lib/store";


### PR DESCRIPTION
Fixes https://eslint.org/docs/latest/rules/no-case-declarations by just wrapping the cases in `{}` as suggested.

Also removes a few unused imports 🗑️ 