### PR TITLE
fix(a11y): Use `role="alert"` as default value for `ErrorWrapper`

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
@@ -179,7 +179,7 @@ it("should not have any accessibility violations whilst in the error state", asy
   // Main ErrorWrapper does display, and is in error state
   await waitFor(() => expect(mainErrorMessage).not.toBeEmptyDOMElement());
   const [mainErrorWrapper, ..._rest] = screen.getAllByTestId("error-wrapper");
-  expect(mainErrorWrapper).toHaveAttribute("role", "status");
+  expect(mainErrorWrapper).toHaveAttribute("role", "alert");
 
   const results = await axe(container);
   expect(results).toHaveNoViolations();

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -160,5 +160,5 @@ it("should change the role of the ErrorWrapper when an invalid input is given", 
   user.click(screen.getByTestId("continue-button"));
 
   expect(errorWrapper).not.toBeEmptyDOMElement();
-  expect(errorWrapper).toHaveAttribute("role", "status");
+  expect(errorWrapper).toHaveAttribute("role", "alert");
 });

--- a/editor.planx.uk/src/ui/shared/ErrorWrapper.tsx
+++ b/editor.planx.uk/src/ui/shared/ErrorWrapper.tsx
@@ -10,6 +10,9 @@ export interface Props {
   error?: string;
   children?: ReactElement;
   id?: string;
+  // "alert" - important and time-sensitive information (e.g. invalid input feedback)
+  // "status" - advisory information which does not interrupt focus (e.g. file upload status)
+  role?: "alert" | "status";
 }
 
 const Root = styled(Box, {
@@ -35,7 +38,12 @@ const ErrorText = styled(Typography)(({ theme }) => ({
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
 }));
 
-export default function ErrorWrapper({ id, error, children }: Props): FCReturn {
+export default function ErrorWrapper({
+  id,
+  error,
+  children,
+  role = "alert",
+}: Props): FCReturn {
   const inputId = id ? `${ERROR_MESSAGE}-${id}` : undefined;
   const { trackInputErrors } = useAnalyticsTracking();
 
@@ -44,8 +52,7 @@ export default function ErrorWrapper({ id, error, children }: Props): FCReturn {
   }, [error, trackInputErrors]);
 
   return (
-    // role="status" immediately announces the error to screenreaders without interrupting focus
-    <Root error={error} role="status" data-testid="error-wrapper">
+    <Root error={error} role={role} data-testid="error-wrapper">
       <ErrorText id={inputId} data-testid={inputId} variant="body1">
         {error && error}
       </ErrorText>


### PR DESCRIPTION
## What does this PR do?
 - Adds an optional `role` property to the `ErrorWrapper` component, defaulting to `"alert"`
 - (I believe) `ErrorWrapper` is only currently used for input feedback errors, but I've allowed "status" to be a valid role prop if there are exceptions in future

## Why is this necessary?
 - Recommended several times throughout accessibility report (pages [40](https://trello.com/c/4rqZjL5Q/2813-error-identification-for-uploadlabel-a) & [53](https://trello.com/c/THkjn5rm/2818-status-messages-aa))
 - MDN docs show that "alert" is correct for form feedback - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
 
 > The alert role is used to communicate an important and usually time-sensitive message to the user. When this role is added to an element, the browser will send out an accessible alert event to assistive technology products which can then notify the user.
>
> The alert role should only be used for information that requires the user's immediate attention, for example:
>
> - An invalid value was entered into a form field
> - The user's login session is about to expire
> - The connection to the server was lost so local changes will not be saved