### PR TITLE
feat: Styling for submissions table

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -1,20 +1,24 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import EditorRow from "ui/editor/EditorRow";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const DataManagerSettings: React.FC = () => {
   return (
-    <Box>
-      <Typography variant="h2" component="h3" gutterBottom>
-        Data Manager
-      </Typography>
-      <Typography variant="body1">
-        Manage the data that your service uses and makes available via its API
-      </Typography>
-      <Box py={5}>
+    <Box maxWidth="formWrap" mx="auto">
+      <EditorRow>
+        <Typography variant="h2" component="h3">
+          Data Manager
+        </Typography>
+        <Typography variant="body1">
+          Manage the data that your service uses and makes available via its
+          API.
+        </Typography>
+      </EditorRow>
+      <EditorRow>
         <FeaturePlaceholder title="Feature in development" />
-      </Box>
+      </EditorRow>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -8,7 +8,7 @@ const DataManagerSettings: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
       <EditorRow>
-        <Typography variant="h2" component="h3">
+        <Typography variant="h2" component="h3" gutterBottom>
           Data Manager
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
@@ -133,13 +133,13 @@ const DesignSettings: React.FC = () => {
   const onSuccess = () => setOpen(true);
 
   return (
-    <>
+    <Box maxWidth="formWrap" mx="auto">
       <EditorRow>
-        <Typography variant="h2" component="h3" gutterBottom>
+        <Typography variant="h2" component="h3">
           Design
         </Typography>
         <Typography variant="body1">
-          How your service appears to public users
+          How your service appears to public users.
         </Typography>
       </EditorRow>
       {formikConfig && (
@@ -155,7 +155,7 @@ const DesignSettings: React.FC = () => {
           Theme updated successfully
         </Alert>
       </Snackbar>
-    </>
+    </Box>
   );
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
@@ -135,7 +135,7 @@ const DesignSettings: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
       <EditorRow>
-        <Typography variant="h2" component="h3">
+        <Typography variant="h2" component="h3" gutterBottom>
           Design
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -8,7 +8,7 @@ const ServiceFlags: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
       <EditorRow>
-        <Typography variant="h2" component="h3">
+        <Typography variant="h2" component="h3" gutterBottom>
           Service flags
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -1,21 +1,24 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import EditorRow from "ui/editor/EditorRow";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const ServiceFlags: React.FC = () => {
   return (
-    <Box>
-      <Typography variant="h2" component="h3" gutterBottom>
-        Service flags
-      </Typography>
-      <Typography variant="body1">
-        Manage the flag sets that this service uses. Flags at the top of a set
-        override flags below.
-      </Typography>
-      <Box py={5}>
+    <Box maxWidth="formWrap" mx="auto">
+      <EditorRow>
+        <Typography variant="h2" component="h3">
+          Service flags
+        </Typography>
+        <Typography variant="body1">
+          Manage the flag sets that this service uses. Flags at the top of a set
+          override flags below.
+        </Typography>
+      </EditorRow>
+      <EditorRow>
         <FeaturePlaceholder title="Feature in development" />
-      </Box>
+      </EditorRow>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -115,105 +115,111 @@ const ServiceSettings: React.FC = () => {
   });
 
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <EditorRow>
-        <Typography variant="h2" component="h3" gutterBottom>
-          Elements
-        </Typography>
-        <Typography variant="body1">
-          Manage the features that users will be able to see
-        </Typography>
-      </EditorRow>
-      <EditorRow background>
-        <TextInput
-          title="Legal Disclaimer"
-          description="Displayed before a user submits their application"
-          switchProps={{
-            name: "elements.legalDisclaimer.show",
-            checked: formik.values.elements?.legalDisclaimer?.show,
-            onChange: formik.handleChange,
-          }}
-          headingInputProps={{
-            name: "elements.legalDisclaimer.heading",
-            value: formik.values.elements?.legalDisclaimer?.heading,
-            onChange: formik.handleChange,
-          }}
-          contentInputProps={{
-            name: "elements.legalDisclaimer.content",
-            value: formik.values.elements?.legalDisclaimer?.content,
-            onChange: formik.handleChange,
-          }}
-        />
-      </EditorRow>
-      <EditorRow background>
-        <InputGroup flowSpacing>
-          <InputLegend>Footer Links</InputLegend>
-          <InputRow>
-            <TextInput
-              title="Help Page"
-              richText
-              description="A place to communicate FAQs, useful tips, or contact information"
-              switchProps={{
-                name: "elements.help.show",
-                checked: formik.values.elements?.help?.show,
-                onChange: formik.handleChange,
-              }}
-              headingInputProps={{
-                name: "elements.help.heading",
-                value: formik.values.elements?.help?.heading,
-                onChange: formik.handleChange,
-              }}
-              contentInputProps={{
-                name: "elements.help.content",
-                value: formik.values.elements?.help?.content,
-                onChange: formik.handleChange,
-              }}
-            />
-          </InputRow>
-          <InputRow>
-            <TextInput
-              title="Privacy Page"
-              richText
-              description="Your privacy policy"
-              switchProps={{
-                name: "elements.privacy.show",
-                checked: formik.values.elements?.privacy?.show,
-                onChange: formik.handleChange,
-              }}
-              headingInputProps={{
-                name: "elements.privacy.heading",
-                value: formik.values.elements?.privacy?.heading,
-                onChange: formik.handleChange,
-              }}
-              contentInputProps={{
-                name: "elements.privacy.content",
-                value: formik.values.elements?.privacy?.content,
-                onChange: formik.handleChange,
-              }}
-            />
-          </InputRow>
-        </InputGroup>
-      </EditorRow>
-      <EditorRow>
-        <Button
-          type="submit"
-          variant="contained"
-          color="primary"
-          disabled={!formik.dirty}
+    <Box maxWidth="formWrap" mx="auto">
+      <form onSubmit={formik.handleSubmit}>
+        <EditorRow>
+          <Typography variant="h2" component="h3">
+            Elements
+          </Typography>
+          <Typography variant="body1">
+            Manage the features that users will be able to see.
+          </Typography>
+        </EditorRow>
+        <EditorRow background>
+          <TextInput
+            title="Legal Disclaimer"
+            description="Displayed before a user submits their application"
+            switchProps={{
+              name: "elements.legalDisclaimer.show",
+              checked: formik.values.elements?.legalDisclaimer?.show,
+              onChange: formik.handleChange,
+            }}
+            headingInputProps={{
+              name: "elements.legalDisclaimer.heading",
+              value: formik.values.elements?.legalDisclaimer?.heading,
+              onChange: formik.handleChange,
+            }}
+            contentInputProps={{
+              name: "elements.legalDisclaimer.content",
+              value: formik.values.elements?.legalDisclaimer?.content,
+              onChange: formik.handleChange,
+            }}
+          />
+        </EditorRow>
+        <EditorRow background>
+          <InputGroup flowSpacing>
+            <InputLegend>Footer Links</InputLegend>
+            <InputRow>
+              <TextInput
+                title="Help Page"
+                richText
+                description="A place to communicate FAQs, useful tips, or contact information"
+                switchProps={{
+                  name: "elements.help.show",
+                  checked: formik.values.elements?.help?.show,
+                  onChange: formik.handleChange,
+                }}
+                headingInputProps={{
+                  name: "elements.help.heading",
+                  value: formik.values.elements?.help?.heading,
+                  onChange: formik.handleChange,
+                }}
+                contentInputProps={{
+                  name: "elements.help.content",
+                  value: formik.values.elements?.help?.content,
+                  onChange: formik.handleChange,
+                }}
+              />
+            </InputRow>
+            <InputRow>
+              <TextInput
+                title="Privacy Page"
+                richText
+                description="Your privacy policy"
+                switchProps={{
+                  name: "elements.privacy.show",
+                  checked: formik.values.elements?.privacy?.show,
+                  onChange: formik.handleChange,
+                }}
+                headingInputProps={{
+                  name: "elements.privacy.heading",
+                  value: formik.values.elements?.privacy?.heading,
+                  onChange: formik.handleChange,
+                }}
+                contentInputProps={{
+                  name: "elements.privacy.content",
+                  value: formik.values.elements?.privacy?.content,
+                  onChange: formik.handleChange,
+                }}
+              />
+            </InputRow>
+          </InputGroup>
+        </EditorRow>
+        <EditorRow>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            disabled={!formik.dirty}
+          >
+            Update elements
+          </Button>
+        </EditorRow>
+        <Snackbar
+          open={isAlertOpen}
+          autoHideDuration={6000}
+          onClose={handleClose}
         >
-          Update elements
-        </Button>
-      </EditorRow>
-      <Snackbar
-        open={isAlertOpen}
-        autoHideDuration={6000}
-        onClose={handleClose}
-      >
-        <Alert onClose={handleClose} severity="success" sx={{ width: "100%" }}>
-          Service settings updated successfully
-        </Alert>
-      </Snackbar>
-    </form>
+          <Alert
+            onClose={handleClose}
+            severity="success"
+            sx={{ width: "100%" }}
+          >
+            Service settings updated successfully
+          </Alert>
+        </Snackbar>
+      </form>
+    </Box>
   );
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -118,7 +118,7 @@ const ServiceSettings: React.FC = () => {
     <Box maxWidth="formWrap" mx="auto">
       <form onSubmit={formik.handleSubmit}>
         <EditorRow>
-          <Typography variant="h2" component="h3">
+          <Typography variant="h2" component="h3" gutterBottom>
             Elements
           </Typography>
           <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/SubmissionsTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/SubmissionsTable.tsx
@@ -12,18 +12,31 @@ import { SubmissionData } from "./submissionData";
 
 const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
   border: `1px solid ${theme.palette.divider}`,
-  overflow: "auto",
+  maxHeight: "70vh",
   "&:focus": {
     outline: `2px solid ${theme.palette.primary.main}`,
   },
 }));
 
-const StyledTable = styled(Table)({
+const StyledTable = styled(Table)(({ theme }) => ({
   borderCollapse: "collapse",
-});
+  "& th": {
+    background: theme.palette.text.primary,
+    color: theme.palette.common.white,
+    fontWeight: 600,
+  },
+  "& td": {
+    borderBottomColor: theme.palette.border.main,
+    borderBottomWidth: "2px",
+  },
+  "& tr:nth-child(odd) td": {
+    background: theme.palette.background.paper,
+  },
+}));
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   border: `1px solid ${theme.palette.divider}`,
+  lineHeight: "1.35",
 }));
 
 const DividerStyled = styled(Box)({
@@ -51,7 +64,7 @@ const SubmissionsTable: React.FC<SubmissionsTableProps> = ({
 }) => {
   return (
     <StyledTableContainer>
-      <StyledTable stickyHeader aria-label="sticky table">
+      <StyledTable stickyHeader>
         <TableHead>
           <TableRow>
             {[
@@ -70,9 +83,7 @@ const SubmissionsTable: React.FC<SubmissionsTableProps> = ({
         <TableBody>
           {applications.map((row) => (
             <TableRow key={row.sessionId}>
-              <StyledTableCell component="th" scope="row">
-                {row.sessionId}
-              </StyledTableCell>
+              <StyledTableCell scope="row">{row.sessionId}</StyledTableCell>
               <StyledTableCell>{formatDate(row.submittedAt)}</StyledTableCell>
               <StyledTableCell>
                 {row.paymentRequests && row.paymentRequests.length > 0

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import EditorRow from "ui/editor/EditorRow";
 
 import { useStore } from "../../../lib/store";
 import { useSubmittedApplications } from "./submissionData";
@@ -18,19 +19,21 @@ const Submissions: React.FC = () => {
 
   return (
     <Box>
-      <Typography variant="h2" component="h3" gutterBottom>
-        Submissions
-      </Typography>
-      <Typography variant="body1">
-        View data on the user submitted applications for this service.
-      </Typography>
-      <Box py={5}>
+      <EditorRow>
+        <Typography variant="h2" component="h3">
+          Submissions
+        </Typography>
+        <Typography variant="body1">
+          View data on the user submitted applications for this service.
+        </Typography>
+      </EditorRow>
+      <EditorRow>
         <SubmissionsView
           applications={applications}
           loading={loading}
           error={error}
         />
-      </Box>
+      </EditorRow>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -20,7 +20,7 @@ const Submissions: React.FC = () => {
   return (
     <Box>
       <EditorRow>
-        <Typography variant="h2" component="h3">
+        <Typography variant="h2" component="h3" gutterBottom>
           Submissions
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -1,34 +1,36 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import EditorRow from "ui/editor/EditorRow";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 
 const Team: React.FC = () => {
   return (
-    <>
-      <Box borderBottom={1}>
-        <Typography variant="h2" component="h3" gutterBottom>
+    <Box maxWidth="formWrap" mx="auto">
+      <EditorRow>
+        <Typography variant="h2" component="h3">
           Team
         </Typography>
         <Typography variant="body1">
-          Manage who has permission to edit this service
+          Manage who has permission to edit this service.
         </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
-      </Box>
-      <Box pt={3}>
-        <Typography variant="h2" component="h3" gutterBottom>
+      </EditorRow>
+      <EditorRow>
+        <FeaturePlaceholder title="Feature in development" />
+      </EditorRow>
+      <hr />
+      <EditorRow>
+        <Typography variant="h2" component="h3">
           Sharing
         </Typography>
         <Typography variant="body1">
-          Allow other teams on Plan✕ to find and use your service pattern
+          Allow other teams on Plan✕ to find and use your service pattern.
         </Typography>
-        <Box py={5}>
-          <FeaturePlaceholder title="Feature in development" />
-        </Box>
-      </Box>
-    </>
+      </EditorRow>
+      <EditorRow>
+        <FeaturePlaceholder title="Feature in development" />
+      </EditorRow>
+    </Box>
   );
 };
 export default Team;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -8,7 +8,7 @@ const Team: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
       <EditorRow>
-        <Typography variant="h2" component="h3">
+        <Typography variant="h2" component="h3" gutterBottom>
           Team
         </Typography>
         <Typography variant="body1">
@@ -20,7 +20,7 @@ const Team: React.FC = () => {
       </EditorRow>
       <hr />
       <EditorRow>
-        <Typography variant="h2" component="h3">
+        <Typography variant="h2" component="h3" gutterBottom>
           Sharing
         </Typography>
         <Typography variant="body1">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -38,7 +38,7 @@ function TabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Container maxWidth="formWrap" disableGutters>
+        <Container maxWidth={false} disableGutters>
           <Box py={7}>{children}</Box>
         </Container>
       )}


### PR DESCRIPTION
# What does this PR do?

Adds a basic level of styling to the submissions log table:

- Page containers adjusted to allow full width or 'form' width containers.
- Table given max-height to allow for sticky headers — this is a quirk with HTML tables in that they cannot have sticky headers and horizontal overflow scroll without an explicit height or max-height being set.
- Other settings pages updated to use same `<EditorRow>` component for consistency.

There is no data in the pizza environment but the table can be previewed on Storybook (thanks for @Mike-Heneghan for putting together the stories for this!):

https://storybook.2975.planx.pizza/?path=/docs/design-system-molecules-submissions--docs

Note: Storybook does squash up the columns somewhat, it'll be a lot more readable in the editor.

(currently behind a feature flag on production: `window.featureFlags.toggle("SUBMISSION_VIEW")`)