### PR TITLE
chore: Drop `SUBMISSION_VIEW` feature flag

### DIFF
--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["SUBMISSION_VIEW", "GOVPAY_METADATA"] as const;
+const AVAILABLE_FEATURE_FLAGS = ["GOVPAY_METADATA"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -11,13 +11,15 @@ import { HEADER_HEIGHT } from "components/Header";
 import React from "react";
 import { Link, useNavigation } from "react-navi";
 
+export interface SettingsTab {
+  route: string;
+  name: string;
+  Component: React.FC;
+}
+
 interface SettingsProps {
   currentTab: string;
-  tabs: {
-    route: string;
-    name: string;
-    Component: React.FC;
-  }[];
+  tabs: SettingsTab[];
 }
 
 interface TabPanelProps {

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -17,11 +17,11 @@ import Submissions from "pages/FlowEditor/components/Settings/Submissions";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
-import Settings from "../pages/FlowEditor/components/Settings";
+import Settings, { SettingsTab } from "../pages/FlowEditor/components/Settings";
 import type { FlowSettings } from "../types";
 import { makeTitle } from "./utils";
 
-const standardTabs = [
+const tabs: SettingsTab[] = [
   {
     name: "Service",
     route: "service",
@@ -37,13 +37,12 @@ const standardTabs = [
     route: "data-manager",
     Component: DataManagerSettings,
   },
+  {
+    name: "Submissions",
+    route: "submissions",
+    Component: Submissions,
+  },
 ];
-
-const submissionsTab = {
-  name: "Submissions",
-  route: "submissions",
-  Component: Submissions,
-};
 
 const flowSettingsRoutes = compose(
   withData((req) => ({
@@ -84,18 +83,11 @@ const flowSettingsRoutes = compose(
         const settings: FlowSettings = data.flows[0].settings;
         useStore.getState().setFlowSettings(settings);
 
-        function getTabs() {
-          const isUsingFeatureFlag = hasFeatureFlag("SUBMISSION_VIEW");
-          return isUsingFeatureFlag
-            ? [...standardTabs, submissionsTab]
-            : standardTabs;
-        }
-
         return {
           title: makeTitle(
             [req.params.team, req.params.flow, "Flow Settings"].join("/"),
           ),
-          view: <Settings currentTab={req.params.tab} tabs={getTabs()} />,
+          view: <Settings currentTab={req.params.tab} tabs={tabs} />,
         };
       });
     }),


### PR DESCRIPTION
## What does this PR do?
 - Drop feature flag to create Pizza for UAT
 - Some type tidy ups
 
In this instance we’re better off removing the feature flag and encouraging PO testing on production as - 
- there’s real submission data there to test against
 - it’s a pretty unobtrusive feature - if it needs changes we can easily do this without effecting anything else