### PR TITLE
fix: allow larger basemap buffer for large sites

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -31,10 +31,6 @@ export type Props = PublicProps<DrawBoundary>;
 
 export type Boundary = Feature | undefined;
 
-// Buffer applied to the address point to clip this map extent
-//   and applied to the site boundary and written to the passport to later clip the map extent in overview documents
-const BUFFER_IN_METERS = 100;
-
 export default function Component(props: Props) {
   const isMounted = useRef(false);
   const passport = useStore((state) => state.computePassport());
@@ -47,6 +43,10 @@ export default function Component(props: Props) {
     passport.data?.["property.boundary.title.area"];
   const [boundary, setBoundary] = useState<Boundary>(previousBoundary);
   const [area, setArea] = useState<number | undefined>(previousArea);
+  
+  // Buffer applied to the address point to clip this map extent
+  //   and applied to the site boundary and written to the passport to later clip the map extent in overview documents
+  const bufferInMeters = area && area > 15000 ? 300 : 120;
 
   const previousFile =
     props.previouslySubmittedData?.data?.[PASSPORT_UPLOAD_KEY];
@@ -104,7 +104,7 @@ export default function Component(props: Props) {
           newPassportData[props.dataFieldBoundary] = boundary;
           newPassportData[`${props.dataFieldBoundary}.buffered`] = buffer(
             boundary,
-            BUFFER_IN_METERS,
+            bufferInMeters,
             { units: "meters" },
           );
 
@@ -152,11 +152,11 @@ export default function Component(props: Props) {
       }}
       isValid={props.hideFileUpload ? true : Boolean(boundary || slots[0]?.url)}
     >
-      {getBody()}
+      {getBody(bufferInMeters)}
     </Card>
   );
 
-  function getBody() {
+  function getBody(bufferInMeters: number) {
     if (page === "draw") {
       return (
         <>
@@ -197,7 +197,7 @@ export default function Component(props: Props) {
                 clipGeojsonData={
                   addressPoint &&
                   JSON.stringify(
-                    buffer(addressPoint, BUFFER_IN_METERS, { units: "meters" }),
+                    buffer(addressPoint, bufferInMeters, { units: "meters" }),
                   )
                 }
                 zoom={20}


### PR DESCRIPTION
Now determines the basemap clip buffer based on the area of the site, meaning we don't unnecessarily expose more vector tiles to regular householder applicants.

Ticket only has one example address (5 Pancras Square, N1C 4AG) which is now fully in view if viewing the default title boundary: 
![Screenshot from 2024-04-04 12-47-49](https://github.com/theopensystemslab/planx-new/assets/5132349/f2be37d7-76e3-4c10-9278-6ece0ff32a9a)
