### PR TITLE
fix(a11y): Colour contrast issues

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -40,6 +40,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   text: {
     primary: "#0B0C0C",
     secondary: "#505A5F",
+    placeholder: "#617075",
   },
   link: {
     main: DEFAULT_PRIMARY_COLOR,
@@ -60,6 +61,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   },
   success: {
     main: "#4CAF50",
+    dark: "#265A26",
   },
   info: {
     main: "#2196F3",
@@ -484,7 +486,7 @@ const generateTeamTheme = (
     linkColour: DEFAULT_PRIMARY_COLOR,
     logo: null,
     favicon: null,
-  }
+  },
 ): MUITheme => {
   const themeOptions = getThemeOptions(teamTheme);
   const theme = responsiveFontSizes(createTheme(themeOptions), { factor: 3 });

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -40,7 +40,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   text: {
     primary: "#0B0C0C",
     secondary: "#505A5F",
-    placeholder: "#617075",
+    placeholder: "#68787D",
   },
   link: {
     main: DEFAULT_PRIMARY_COLOR,

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -39,6 +39,20 @@ declare module "@mui/material/styles/createPalette" {
       dark: string;
     };
   }
+
+  interface TypeText {
+    primary: string;
+    secondary: string;
+    disabled: string;
+    placeholder: string;
+  }
+
+  interface TypeTextOptions {
+    primary: string;
+    secondary: string;
+    disabled: string;
+    placeholder: string;
+  }
 }
 
 // Append our custom variants to MUI Button

--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -98,8 +98,8 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
     },
     // Styles for placeholder text, to match ui/Input.tsx
     "& p.is-editor-empty:nth-child(1)::before": {
-      color: theme.palette.text.secondary,
-      opacity: "0.5",
+      color: theme.palette.text.placeholder,
+      opacity: 1,
       content: `attr(data-placeholder)`,
       float: "left",
       height: 0,

--- a/editor.planx.uk/src/ui/shared/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input.tsx
@@ -54,9 +54,9 @@ const StyledInputBase = styled(InputBase, {
   "& input": {
     fontWeight: "inherit",
   },
-  "& ::placeholder": {
-    color: theme.palette.text.secondary,
-    opacity: "0.5",
+  "& input::placeholder": {
+    color: theme.palette.text.placeholder,
+    opacity: 1,
   },
   ...(bordered && {
     border: `2px solid ${theme.palette.text.primary}`,

--- a/editor.planx.uk/src/ui/shared/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input.tsx
@@ -54,7 +54,7 @@ const StyledInputBase = styled(InputBase, {
   "& input": {
     fontWeight: "inherit",
   },
-  "& input::placeholder": {
+  "& input::placeholder, & textarea::placeholder": {
     color: theme.palette.text.placeholder,
     opacity: 1,
   },


### PR DESCRIPTION
# What does this PR do?

- Addresses colour contrast issues highlighted by accessibility testing (pages 48–50).
- Introduces a new 'dark' success colour that adequately contrast with 'light' success.
- Introduces a dedicated colour for placeholder text that uses a solid opacity, rather than relying on a opacity reduction of a current colour (easier to test, not as dependent on background). This has also been applied to inputs and textareas in the editor.

## Context

To pass at AA level the contrast ratio of small text should be at least 4.5 : 1.

Three groups of contrast issues were highlighted in the report:

### 1 — p48–49: section status button for "READY TO START" and "COMPLETED"

READY TO START:

**Tested colours:**
Background: #e5f1eb
Text: #409444
Contrast Ratio: **3.27 : 1**

**Updated colours:**
Background: #e5f1eb
Text: #265A26 (new success dark colour)
Contrast Ratio: **7.04 : 1**

This also addresses the contrast issue for "COMPLETED" as this contrasts success dark with white = higher contrast.

### 2 — p49: disabled text "Upload a location plan instead"

This will be made permanently active in a separate PR so I've not updated this colour.

### 3 — p50: placeholder text for inputs and textareas

**Tested colours:**
Background: #ffffff
Text: #ACACAC (opacity of secondary text colour)
Contrast Ratio: **2.27 : 1**

**Updated colours:**
Background: #ffffff
Text: #68787D (new placeholder text colour)
Contrast Ratio: **4.59 : 1**

## Demo

https://2981.planx.pizza/testing/colour-contrast/published
