### PR TITLE
chore: Remove close tab option

### DIFF
--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -109,14 +109,13 @@ export const EmailError: React.FC<{ retry: () => void }> = ({ retry }) => {
 
 export const EmailSuccess: React.FC = () => {
   return (
-    <StatusPage
-      bannerHeading="Check your email"
-      buttonText="Close Tab"
-      onButtonClick={() => window.close()}
-    >
+    <StatusPage bannerHeading="Check your email">
       <Typography variant="body1">
         If you have any draft applications we have sent you an email that
         contains a link. Use this link to access your applications.
+        <br />
+        <br />
+        You may now close this tab.
       </Typography>
     </StatusPage>
   );

--- a/editor.planx.uk/src/pages/Preview/SavePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/SavePage.tsx
@@ -5,6 +5,7 @@ import { add } from "date-fns";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import { SendEmailPayload } from "types";
+import { removeSessionIdSearchParam } from "utils";
 
 import StatusPage from "./StatusPage";
 
@@ -21,9 +22,8 @@ export const SaveSuccess: React.FC<{
   <StatusPage
     bannerHeading="Application saved"
     showDownloadLink
-    buttonText="Close tab"
-    onButtonClick={() => window.close()}
-    additionalOption="startNewApplication"
+    buttonText="Start a new application"
+    onButtonClick={removeSessionIdSearchParam}
   >
     <Typography variant="body2">
       We have sent a link to {saveToEmail}. Use the link to continue your
@@ -34,6 +34,9 @@ export const SaveSuccess: React.FC<{
       <br />
       <br />
       Your application will be deleted if you do not complete it by this date.
+      <br />
+      <br />
+      You may now close this tab.
     </Typography>
   </StatusPage>
 );


### PR DESCRIPTION
## What does this PR do?
- Removes "Close tab" option 
- Replaces with a message ("You may now close this tab") and makes "Start a new application" the primary action

## Why?
- Reported as a bug, does not work in Firefox and Edge
- It turns out `window.close()` is not allowed by these browsers - https://caniuse.com/mdn-api_window_close

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/abcda625-0b86-4708-bc66-8b515615e1a9)
