### PR TITLE
feat: track feedback on help text usefulness

### DIFF
--- a/editor.planx.uk/src/components/Feedback/MoreInfoFeedback.tsx
+++ b/editor.planx.uk/src/components/Feedback/MoreInfoFeedback.tsx
@@ -8,6 +8,7 @@ import {
   getInternalFeedbackMetadata,
   insertFeedbackMutation,
 } from "lib/feedback";
+import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import React, { useEffect, useRef, useState } from "react";
 import FeedbackOption from "ui/public/FeedbackOption";
 
@@ -41,14 +42,24 @@ const MoreInfoFeedbackComponent: React.FC = () => {
     }
   }, [currentFeedbackView]);
 
+  const { trackEvent } = useAnalyticsTracking();
+
   const handleFeedbackOptionClick = (event: Sentiment) => {
     switch (event) {
       case "helpful":
+        trackEvent({
+          event: "helpTextFeedback",
+          metadata: { helpTextUseful: true },
+        });
         setCurrentFeedbackView("input");
         setFeedbackOption("helpful");
         break;
 
       case "unhelpful":
+        trackEvent({
+          event: "helpTextFeedback",
+          metadata: { helpTextUseful: false },
+        });
         setCurrentFeedbackView("input");
         setFeedbackOption("unhelpful");
         break;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -259,6 +259,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         updateMetadata(UPDATE_HAS_CLICKED_HELP, metadata);
         return;
       case "nextStepsClick":
+      case "helpTextFeedback":
         updateMetadata(UPDATE_ANALYTICS_LOG_METADATA, metadata);
         return;
       case "backwardsNavigation": {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/types.ts
@@ -72,6 +72,8 @@ export type BackwardsNavigationMetadata =
   | Record<"change", BackwardsTargetMetadata>
   | Record<"back", BackwardsTargetMetadata>;
 
+type HelpTextFeedbackMetadata = Record<"helpTextUseful", boolean>;
+
 /**
  * Describes the possible values that can be written to analytics_logs.metadata
  * by any one of the specific tracking event functions
@@ -80,7 +82,8 @@ export type Metadata =
   | NodeMetadata
   | BackwardsNavigationMetadata
   | SelectedUrlsMetadata
-  | HelpClickMetadata;
+  | HelpClickMetadata
+  | HelpTextFeedbackMetadata;
 
 /**
  * Discriminated union to describe the potential data required for tracking
@@ -91,7 +94,8 @@ export type EventData =
   | NextStepsClick
   | BackwardsNavigation
   | FlowDirectionChange
-  | InputErrors;
+  | InputErrors
+  | HelpTextFeedback;
 
 /**
  * Capture when a user clicks on the `More Information` i.e. the help on a
@@ -145,4 +149,13 @@ type InputErrors = {
   event: "inputErrors";
   metadata: null;
   error: string;
+};
+
+/**
+ * Captures when a user opens the help text and then gives feedback by selecting
+ * either "yes" or "no" to whether it helped answer their question.
+ */
+type HelpTextFeedback = {
+  event: "helpTextFeedback";
+  metadata: HelpTextFeedbackMetadata;
 };

--- a/hasura.planx.uk/migrations/1712323679734_alter_view_public_analytics_summary_unfold_metadata_help_text_useful/down.sql
+++ b/hasura.planx.uk/migrations/1712323679734_alter_view_public_analytics_summary_unfold_metadata_help_text_useful/down.sql
@@ -1,0 +1,66 @@
+DROP VIEW public.analytics_summary;
+
+
+-- Previous instance of view from hasura.planx.uk/migrations/1711643574155_update_analytics_logs_allow_list_answers_array_to_object/up.sql
+CREATE
+OR REPLACE VIEW public.analytics_summary AS
+select
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	al.created_at as analytics_log_created_at,
+	a.created_at as analytics_created_at,
+	(user_agent -> 'os' ->> 'name') :: text AS operating_system,
+	(user_agent -> 'browser' ->> 'name') :: text AS browser,
+	(user_agent -> 'platform' ->> 'type') :: text AS platform,
+	referrer,
+	flow_direction,
+	metadata ->> 'change' as change_metadata,
+	metadata ->> 'back' as back_metadata,
+	metadata ->> 'selectedUrls' as selected_urls,
+	metadata ->> 'flag' as result_flag,
+	metadata -> 'flagSet' as result_flagset,
+	metadata -> 'displayText' ->> 'heading' as result_heading,
+	metadata -> 'displayText' ->> 'description' as result_description,
+	case
+		when has_clicked_help then metadata
+		else null
+	end as help_metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(al.next_log_created_at - al.created_at)
+		) as numeric (10, 1)
+	) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(a.ended_at - a.created_at)
+		) / 60 as numeric (10, 1)
+	) as time_spent_on_analytics_session_minutes,
+	node_id,
+	al.allow_list_answers as allow_list_answers,
+    al.allow_list_answers -> 'proposal.projectType' as proposal_project_type,
+    al.allow_list_answers -> 'application.declaration.connection' as application_declaration_connection,
+    al.allow_list_answers -> 'property.type' as property_type,
+    al.allow_list_answers -> 'drawBoundary.action' as draw_boundary_action,
+    al.allow_list_answers -> 'user.role' as user_role,
+    al.allow_list_answers -> 'property.constraints.planning' as property_constraints_planning
+from
+	analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;
+
+--  After recreating the view grant Metabase access to it
+GRANT SELECT ON public.analytics_summary TO metabase_read_only;

--- a/hasura.planx.uk/migrations/1712323679734_alter_view_public_analytics_summary_unfold_metadata_help_text_useful/up.sql
+++ b/hasura.planx.uk/migrations/1712323679734_alter_view_public_analytics_summary_unfold_metadata_help_text_useful/up.sql
@@ -1,0 +1,66 @@
+DROP VIEW public.analytics_summary;
+
+CREATE
+OR REPLACE VIEW public.analytics_summary AS
+select
+	a.id as analytics_id,
+	al.id as analytics_log_id,
+	f.slug as service_slug,
+	t.slug as team_slug,
+	a.type as analytics_type,
+	al.created_at as analytics_log_created_at,
+	a.created_at as analytics_created_at,
+	(user_agent -> 'os' ->> 'name') :: text AS operating_system,
+	(user_agent -> 'browser' ->> 'name') :: text AS browser,
+	(user_agent -> 'platform' ->> 'type') :: text AS platform,
+	referrer,
+	flow_direction,
+	metadata ->> 'change' as change_metadata,
+	metadata ->> 'back' as back_metadata,
+	metadata ->> 'selectedUrls' as selected_urls,
+	metadata ->> 'flag' as result_flag,
+	metadata -> 'flagSet' as result_flagset,
+	metadata -> 'displayText' ->> 'heading' as result_heading,
+	metadata -> 'displayText' ->> 'description' as result_description,
+	metadata -> 'helpTextUseful' as help_text_useful,
+	case
+		when has_clicked_help then metadata
+		else null
+	end as help_metadata,
+	al.user_exit as is_user_exit,
+	node_type,
+	node_title,
+	has_clicked_help,
+	input_errors,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(al.next_log_created_at - al.created_at)
+		) as numeric (10, 1)
+	) as time_spent_on_node_seconds,
+	a.ended_at as analytics_ended_at,
+	CAST(
+		EXTRACT(
+			EPOCH
+			FROM
+				(a.ended_at - a.created_at)
+		) / 60 as numeric (10, 1)
+	) as time_spent_on_analytics_session_minutes,
+	node_id,
+	al.allow_list_answers as allow_list_answers,
+    al.allow_list_answers -> 'proposal.projectType' as proposal_project_type,
+    al.allow_list_answers -> 'application.declaration.connection' as application_declaration_connection,
+    al.allow_list_answers -> 'property.type' as property_type,
+    al.allow_list_answers -> 'drawBoundary.action' as draw_boundary_action,
+    al.allow_list_answers -> 'user.role' as user_role,
+    al.allow_list_answers -> 'property.constraints.planning' as property_constraints_planning
+from
+	analytics a
+	left join analytics_logs al on a.id = al.analytics_id
+	left join flows f on a.flow_id = f.id
+	left join teams t on t.id = f.team_id;
+
+--  After recreating the view grant Metabase access to it
+GRANT SELECT ON public.analytics_summary TO metabase_read_only;
+


### PR DESCRIPTION
## What

- Track when a user provides feedback on the helpfulness of help text
- Update the `analytics_summary` to expose this new metadata in it's own column

## Why

- Although we record feedback on help text it's necessary for user to explicitly leave a comment and it's not accessible in the `analytics_logs`
- Tracking "yes" / "no" clicks via analytics give us a higher level view of whether users are finding help text useful with a lower barrier 