### PR TITLE
feat: Replace `Select` with `Autocomplete` in `FileUploadAndLabel` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -1,11 +1,4 @@
-import {
-  act,
-  findByRole,
-  fireEvent,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import axios from "axios";
 import { vanillaStore } from "pages/FlowEditor/lib/store";
@@ -28,7 +21,7 @@ window.URL.createObjectURL = jest.fn();
 
 describe("Basic state and setup", () => {
   test("renders correctly", async () => {
-    setup(
+    const { getAllByRole, getByTestId, getByText } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -39,13 +32,13 @@ describe("Basic state and setup", () => {
       />,
     );
 
-    expect(screen.getAllByRole("heading")[0]).toHaveTextContent("Test title");
+    expect(getAllByRole("heading")[0]).toHaveTextContent("Test title");
 
     // Required file is listed
-    expect(screen.getByText("testKey")).toBeVisible();
+    expect(getByText("testKey")).toBeVisible();
 
     // Drop zone is available
-    expect(screen.getByTestId("upload-input")).toBeInTheDocument();
+    expect(getByTestId("upload-input")).toBeInTheDocument();
   });
 
   it("should not have any accessibility violations", async () => {
@@ -66,7 +59,7 @@ describe("Basic state and setup", () => {
   });
 
   test("shows help buttons for header and applicable file", async () => {
-    setup(
+    const { getAllByTestId } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={mockFileTypesUniqueKeys}
@@ -74,12 +67,12 @@ describe("Basic state and setup", () => {
       />,
     );
 
-    const helpButtons = screen.getAllByTestId("more-info-button");
+    const helpButtons = getAllByTestId("more-info-button");
     expect(helpButtons).toHaveLength(1);
   });
 
   it("does not show optional files if there are other types", () => {
-    setup(
+    const { queryByRole } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -90,28 +83,24 @@ describe("Basic state and setup", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("heading", { name: /Optional files/ }),
-    ).toBeNull();
+    expect(queryByRole("heading", { name: /Optional files/ })).toBeNull();
   });
 
   it("shows optional files if there are no other types", () => {
-    setup(
+    const { getByRole } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[mockFileTypes.NotRequired]}
       />,
     );
 
-    expect(
-      screen.getByRole("heading", { name: /Optional files/ }),
-    ).toBeVisible();
+    expect(getByRole("heading", { name: /Optional files/ })).toBeVisible();
   });
 });
 
 describe("Info-only mode with hidden drop zone", () => {
   test("renders correctly", async () => {
-    setup(
+    const { getAllByRole, queryByTestId, getByText } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -123,13 +112,13 @@ describe("Info-only mode with hidden drop zone", () => {
       />,
     );
 
-    expect(screen.getAllByRole("heading")[0]).toHaveTextContent("Test title");
+    expect(getAllByRole("heading")[0]).toHaveTextContent("Test title");
 
     // Required file is listed
-    expect(screen.getByText("testKey")).toBeVisible();
+    expect(getByText("testKey")).toBeVisible();
 
     // Drop zone is not available
-    expect(screen.queryByTestId("upload-input")).not.toBeInTheDocument();
+    expect(queryByTestId("upload-input")).not.toBeInTheDocument();
   });
 
   it("should not have any accessibility violations", async () => {
@@ -151,7 +140,7 @@ describe("Info-only mode with hidden drop zone", () => {
   });
 
   test("shows help buttons for header and applicable file", async () => {
-    setup(
+    const { getAllByTestId } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={mockFileTypesUniqueKeys}
@@ -160,12 +149,12 @@ describe("Info-only mode with hidden drop zone", () => {
       />,
     );
 
-    const helpButtons = screen.getAllByTestId("more-info-button");
+    const helpButtons = getAllByTestId("more-info-button");
     expect(helpButtons).toHaveLength(1);
   });
 
   it("shows optional files by default", () => {
-    setup(
+    const { queryByRole } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -177,9 +166,7 @@ describe("Info-only mode with hidden drop zone", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("heading", { name: /Optional files/ }),
-    ).toBeVisible();
+    expect(queryByRole("heading", { name: /Optional files/ })).toBeVisible();
   });
 });
 
@@ -206,7 +193,7 @@ describe("Modal trigger", () => {
   });
 
   test("Modal opens when a single file is uploaded", async () => {
-    const { user } = setup(
+    const { getByTestId, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -224,7 +211,7 @@ describe("Modal trigger", () => {
     });
 
     const file = new File(["test"], "test.png", { type: "image/png" });
-    const input = screen.getByTestId("upload-input");
+    const input = getByTestId("upload-input");
     await user.upload(input, file);
     expect(mockedPost).toHaveBeenCalled();
 
@@ -237,7 +224,7 @@ describe("Modal trigger", () => {
   });
 
   test("Modal opens when multiple files are uploaded", async () => {
-    const { user } = setup(
+    const { getByTestId, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -266,7 +253,7 @@ describe("Modal trigger", () => {
 
     const file1 = new File(["test1"], "test1.png", { type: "image/png" });
     const file2 = new File(["test2"], "test2.png", { type: "image/png" });
-    const input = screen.getByTestId("upload-input");
+    const input = getByTestId("upload-input");
     await user.upload(input, [file1, file2]);
     expect(mockedPost).toHaveBeenCalledTimes(2);
 
@@ -282,7 +269,7 @@ describe("Modal trigger", () => {
   });
 
   test("Modal does not open when a file is deleted", async () => {
-    const { user } = setup(
+    const { getByTestId, getByLabelText, queryByText, getByText, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -312,7 +299,7 @@ describe("Modal trigger", () => {
 
     const file1 = new File(["test1"], "test1.png", { type: "image/png" });
     const file2 = new File(["test2"], "test2.png", { type: "image/png" });
-    const input = screen.getByTestId("upload-input");
+    const input = getByTestId("upload-input");
     await user.upload(input, [file1, file2]);
 
     const fileTaggingModal = await within(document.body).findByTestId(
@@ -324,15 +311,15 @@ describe("Modal trigger", () => {
     await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
 
     // Uploaded files displayed as cards
-    expect(screen.getByText("test1.png")).toBeVisible();
-    expect(screen.getByText("test2.png")).toBeVisible();
+    expect(getByText("test1.png")).toBeVisible();
+    expect(getByText("test2.png")).toBeVisible();
 
     // Delete the second file
-    user.click(screen.getByLabelText("Delete test2.png"));
+    user.click(getByLabelText("Delete test2.png"));
 
     // Card removed from screen
     await waitFor(() =>
-      expect(screen.queryByText("test2.png")).not.toBeInTheDocument(),
+      expect(queryByText("test2.png")).not.toBeInTheDocument(),
     );
 
     // Modal not open
@@ -509,7 +496,7 @@ describe("Error handling", () => {
   test("An error is thrown if a user does not upload any files", async () => {
     const handleSubmit = jest.fn();
 
-    const { user } = setup(
+    const { getByTestId, getByRole, findByText, user } = setup(
       <FileUploadAndLabelComponent
         handleSubmit={handleSubmit}
         title="Test title"
@@ -529,14 +516,14 @@ describe("Error handling", () => {
     });
 
     const file = new File(["test"], "test.png", { type: "image/png" });
-    const input = screen.getByTestId("upload-input");
+    const input = getByTestId("upload-input");
 
     // User cannot submit without uploading a file
-    await user.click(screen.getByTestId("continue-button"));
+    await user.click(getByTestId("continue-button"));
     expect(handleSubmit).not.toHaveBeenCalled();
 
     // Error warns user of this
-    const dropzoneError = await screen.findByText("Upload at least one file");
+    const dropzoneError = await findByText("Upload at least one file");
     expect(dropzoneError).toBeVisible();
 
     await user.upload(input, file);
@@ -549,20 +536,20 @@ describe("Error handling", () => {
     // Error message is cleared
     expect(dropzoneError).toBeEmptyDOMElement();
 
-    const deleteButton = screen.getByRole("button", { name: /Delete/ });
+    const deleteButton = getByRole("button", { name: /Delete/ });
     await user.click(deleteButton);
 
     // Error message does not immediately re-appear
     expect(dropzoneError).toBeEmptyDOMElement();
 
     // Error appears again after user attempt to submit without files
-    await user.click(screen.getByTestId("continue-button"));
+    await user.click(getByTestId("continue-button"));
     expect(handleSubmit).not.toHaveBeenCalled();
     expect(dropzoneError).toBeVisible();
   });
 
   test("An error is thrown in the modal if a user does not tag all files", async () => {
-    const { user } = setup(
+    const { getByTestId, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         fileTypes={[
@@ -581,7 +568,7 @@ describe("Error handling", () => {
     });
 
     const file = new File(["test"], "test.jpg", { type: "image/jpg" });
-    const input = screen.getByTestId("upload-input");
+    const input = getByTestId("upload-input");
     await user.upload(input, file);
 
     const fileTaggingModal = await within(document.body).findByTestId(

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -257,10 +257,13 @@ function Component(props: Props) {
             )}
             {slots.map((slot) => {
               return (
-                <ErrorWrapper error={fileLabelErrors?.[slot.id]} id={slot.id}>
+                <ErrorWrapper
+                  error={fileLabelErrors?.[slot.id]}
+                  id={slot.id}
+                  key={slot.id}
+                >
                   <UploadedFileCard
                     {...slot}
-                    key={slot.id}
                     tags={getTagsForSlot(slot.id, fileList)}
                     onChange={onUploadedFileCardChange}
                     removeFile={() => removeFile(slot)}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -285,6 +285,9 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
       sx={{ display: "flex", flexDirection: "column" }}
     >
       <StyledAutocomplete
+        role="status"
+        aria-atomic={true}
+        aria-live="polite"
         disableClearable
         disableCloseOnSelect
         getOptionLabel={(option) => option.name}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -1,4 +1,7 @@
+import CheckBoxIcon from "@mui/icons-material/CheckBox";
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
 import ArrowIcon from "@mui/icons-material/KeyboardArrowDown";
+import Autocomplete from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
@@ -6,11 +9,14 @@ import Chip from "@mui/material/Chip";
 import FormControl from "@mui/material/FormControl";
 import Input from "@mui/material/Input";
 import InputLabel from "@mui/material/InputLabel";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
 import MenuItem from "@mui/material/MenuItem";
 import Select, { SelectChangeEvent, SelectProps } from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
+import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import React, { useEffect, useState } from "react";
@@ -117,17 +123,60 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
     updateFileListWithTags(previousTags, tags);
   }, [tags]);
 
+  const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
+  const checkedIcon = <CheckBoxIcon fontSize="small" />;
+
+  const options = (Object.keys(fileList) as Array<keyof typeof fileList>)
+    .filter((fileListCategory) => fileList[fileListCategory].length > 0)
+    .flatMap((category) =>
+      fileList[category].map((fileType) => ({ category, ...fileType })),
+    );
+
   return (
     <FormControl
       key={`form-${uploadedFile.id}`}
       sx={{ display: "flex", flexDirection: "column" }}
     >
-      <StyledInputLabel
-        id={`select-multiple-file-tags-label-${uploadedFile.id}`}
-      >
-        What does this file show?
-      </StyledInputLabel>
-      <StyledSelect
+      <Autocomplete
+        id={`select-multiple-file-tags-${uploadedFile.id}`}
+        options={options}
+        groupBy={(option) => option.category}
+        getOptionLabel={(option) => option.name}
+        renderInput={(params) => (
+          <TextField {...params} label="What does this file show?" />
+        )}
+        multiple
+        disableCloseOnSelect
+        disableClearable
+        popupIcon={<ArrowIcon />}
+        ListboxComponent={Box}
+        ChipProps={{
+          variant: "uploadedFileTag",
+          size: "small",
+          sx: { pointerEvents: "none" },
+          onDelete: undefined,
+        }}
+        renderGroup={({ group, key, children }) => (
+          <List key={key} role="group">
+            <ListSubheader role="presentation">
+              {capitalize(group)}
+            </ListSubheader>
+            {children}
+          </List>
+        )}
+        renderOption={(props, option, { selected }) => (
+          <ListItem {...props}>
+            <Checkbox
+              icon={icon}
+              checkedIcon={checkedIcon}
+              style={{ marginRight: 8 }}
+              checked={selected}
+            />
+            <ListItemText>{option.name}</ListItemText>
+          </ListItem>
+        )}
+      />
+      {/* <StyledSelect
         native={false}
         key={`select-${uploadedFile.id}`}
         id={`select-multiple-file-tags-${uploadedFile.id}`}
@@ -227,7 +276,7 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
               }),
             ];
           })}
-      </StyledSelect>
+      </StyledSelect> */}
     </FormControl>
   );
 };

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -1,29 +1,17 @@
-import CheckBoxIcon from "@mui/icons-material/CheckBox";
-import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
 import ArrowIcon from "@mui/icons-material/KeyboardArrowDown";
 import Autocomplete, {
   AutocompleteChangeReason,
-  AutocompleteProps,
 } from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
-import Chip from "@mui/material/Chip";
 import FormControl from "@mui/material/FormControl";
-import Input from "@mui/material/Input";
-import InputLabel from "@mui/material/InputLabel";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
-import MenuItem from "@mui/material/MenuItem";
-import Select, { SelectChangeEvent, SelectProps } from "@mui/material/Select";
-import { styled } from "@mui/material/styles";
 import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
-import React, { useEffect, useState } from "react";
-import { usePrevious } from "react-use";
+import React from "react";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import {
@@ -34,7 +22,7 @@ import {
   UserFile,
 } from "./model";
 
-interface SelectMultipleProps extends SelectProps {
+interface SelectMultipleProps {
   uploadedFile: FileUploadSlot;
   fileList: FileList;
   setFileList: (value: React.SetStateAction<FileList>) => void;
@@ -43,47 +31,6 @@ interface SelectMultipleProps extends SelectProps {
 interface Option extends UserFile {
   category: keyof FileList;
 }
-
-const ListHeader = styled(Box)(({ theme }) => ({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  padding: theme.spacing(1, 1.5),
-  background: theme.palette.grey[200],
-  // Offset default padding of MuiList
-  margin: "-8px 0 8px",
-}));
-
-const StyledInputLabel = styled(InputLabel)(({ theme }) => ({
-  top: "16%",
-  textDecoration: "underline",
-  color: theme.palette.link.main,
-  "&[data-shrink=true]": {
-    textDecoration: "none",
-    color: theme.palette.text.primary,
-    top: "0",
-    transform: "translate(14px, -5px) scale(0.85)",
-  },
-}));
-
-const StyledSelect = styled(Select<string[]>)(({ theme }) => ({
-  border: `1px solid ${theme.palette.border.main}`,
-  background: theme.palette.background.paper,
-  "& > div": {
-    minHeight: "50px",
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-  },
-  "& > div:focus": {
-    background: theme.palette.action.focus,
-  },
-  "& > svg": {
-    color: theme.palette.primary.main,
-    width: "1.25em",
-    height: "1.25em",
-    top: "unset",
-  },
-}));
 
 export const SelectMultiple = (props: SelectMultipleProps) => {
   const { uploadedFile, fileList, setFileList } = props;
@@ -157,7 +104,16 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
         groupBy={(option) => option.category}
         getOptionLabel={(option) => option.name}
         renderInput={(params) => (
-          <TextField {...params} label="What does this file show?" />
+          <TextField
+            {...params}
+            label="What does this file show?"
+            // Disable text input
+            onKeyDown={(e) => {
+              e.preventDefault();
+            }}
+            // Hide text input caret
+            sx={{ caretColor: "transparent" }}
+          />
         )}
         isOptionEqualToValue={(option, value) => option.name === value.name}
         multiple
@@ -192,52 +148,7 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
           </ListItem>
         )}
       />
-      {/* <StyledSelect
-        native={false}
-        key={`select-${uploadedFile.id}`}
-        id={`select-multiple-file-tags-${uploadedFile.id}`}
-        variant="standard"
-        multiple
-        value={tags}
-        onChange={handleChange}
-        open={open}
-        onClose={handleClose}
-        onOpen={handleOpen}
-        IconComponent={ArrowIcon}
-        input={<Input key={`select-input-${uploadedFile.id}`} />}
-        inputProps={{
-          name: uploadedFile.id,
-          "data-testid": "select",
-          "aria-labelledby": `select-multiple-file-tags-label-${uploadedFile.id}`,
-        }}
-        renderValue={(selected) => (
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              alignItems: "center",
-              gap: 0.5,
-              padding: "0 0.5em",
-            }}
-          >
-            {selected.map((value) => (
-              <Chip
-                key={`chip-${value}-${uploadedFile.id}`}
-                label={value}
-                variant="uploadedFileTag"
-                size="small"
-                sx={{ pointerEvents: "none" }}
-              />
-            ))}
-          </Box>
-        )}
-        MenuProps={{
-          anchorOrigin: {
-            vertical: "bottom",
-            horizontal: "center",
-          },
-        }}
-      >
+      {/*
         <ListSubheader disableGutters>
           <ListHeader>
             <Typography variant="h4" component="h3" pr={3}>
@@ -257,42 +168,20 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
           .filter((fileListCategory) => fileList[fileListCategory].length > 0)
           .map((fileListCategory) => {
             return [
-              <ListSubheader
-                key={`subheader-${fileListCategory}-${uploadedFile.id}`}
-                disableSticky
-              >
-                <Typography py={1} variant="subtitle2" component="h4">
-                  {`${capitalize(fileListCategory)} files`}
-                </Typography>
-              </ListSubheader>,
+
               ...fileList[fileListCategory].map((fileType) => {
                 return [
                   <MenuItem
-                    key={`menuitem-${fileType.name}-${uploadedFile.id}`}
-                    value={fileType.name}
-                    data-testid="select-menuitem"
                     disableRipple
                     disableTouchRipple
                   >
                     <Checkbox
-                      key={`checkbox-${fileType.name}-${uploadedFile.id}`}
-                      checked={tags.indexOf(fileType.name) > -1}
-                      data-testid="select-checkbox"
                       inputProps={{
                         "aria-label": `${fileType.name}`,
                       }}
                     />
-                    <ListItemText
-                      key={`listitemtext-${fileType.name}-${uploadedFile.id}`}
-                      primary={fileType.name}
-                      id={fileType.name}
-                    />
-                  </MenuItem>,
-                ];
-              }),
-            ];
-          })}
-      </StyledSelect> */}
+                  </MenuItem> 
+                    */}
     </FormControl>
   );
 };

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -123,8 +123,9 @@ const renderGroup: AutocompleteProps<
   false,
   "div"
 >["renderGroup"] = ({ group, key, children }) => (
-  <List key={`group-${key}`} role="group" sx={{ paddingY: 0 }}>
+  <List key={`group-${key}`} role="group" sx={{ paddingY: 0 }} aria-labelledby={`${group}-label`}>
     <ListSubheader
+      id={`${group}-label`}
       role="presentation"
       disableSticky
       sx={(theme) => ({

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -18,7 +18,7 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import React, { forwardRef, PropsWithChildren, useMemo, useState } from "react";
-import { focusStyle } from "theme";
+import { borderedFocusStyle } from "theme";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import {
@@ -65,7 +65,7 @@ const StyledAutocomplete = styled(
 
 const StyledTextField = styled(TextField)(({ theme }) => ({
   "&:focus-within": {
-    ...focusStyle,
+    ...borderedFocusStyle,
     [`& .${outlinedInputClasses.notchedOutline}`]: {
       border: "1px solid transparent !important",
     },
@@ -126,9 +126,9 @@ const renderGroup: AutocompleteProps<
   <List key={`group-${key}`} role="group" sx={{ paddingY: 0 }}>
     <ListSubheader
       role="presentation"
+      disableSticky
       sx={(theme) => ({
         borderTop: 1,
-        borderBottom: 1,
         borderColor: theme.palette.border.main,
       })}
     >

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -15,6 +15,7 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import React, { forwardRef, PropsWithChildren, useState } from "react";
+import { focusStyle } from "theme";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import {
@@ -41,8 +42,6 @@ const ListHeader = styled(Box)(({ theme }) => ({
   alignItems: "center",
   padding: theme.spacing(1, 1.5),
   background: theme.palette.grey[200],
-  // Offset default padding of MuiList
-  margin: "-8px 0 8px",
 }));
 
 export const SelectMultiple = (props: SelectMultipleProps) => {
@@ -114,9 +113,9 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
   const ListboxComponent = forwardRef<typeof Box, PropsWithChildren>(
     ({ children, ...props }, ref) => {
       return (
-        <Box ref={ref} {...props} role="listbox">
-          <ListHeader>
-            <ListSubheader disableGutters>
+        <>
+          <Box>
+            <ListHeader>
               <Typography variant="h4" component="h3" pr={3}>
                 Select all that apply
               </Typography>
@@ -128,10 +127,17 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
               >
                 Done
               </Button>
-            </ListSubheader>
-          </ListHeader>
-          {children}
-        </Box>
+            </ListHeader>
+          </Box>
+          <Box
+            ref={ref}
+            {...props}
+            role="listbox"
+            sx={{ paddingY: "0px !important" }}
+          >
+            {children}
+          </Box>
+        </>
       );
     },
   );
@@ -143,6 +149,18 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
     >
       <Autocomplete
         onChange={handleChange}
+        sx={(theme) => ({
+          // Vertically center "large" caret
+          "& .MuiAutocomplete-endAdornment": {
+            top: "unset",
+          },
+          marginTop: theme.spacing(2),
+          "&:focus-within": {
+            "& svg": {
+              color: "black",
+            },
+          },
+        })}
         value={value}
         open={open}
         onOpen={openPopper}
@@ -154,10 +172,49 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
         renderInput={(params) => (
           <TextField
             {...params}
+            inputProps={{
+              sx: {
+                cursor: "pointer",
+              },
+              ...params.inputProps,
+            }}
+            InputProps={{
+              notched: false,
+              sx: (theme) => ({
+                cursor: "pointer",
+                "&:focus-within": {
+                  ...focusStyle,
+                  "& .MuiOutlinedInput-notchedOutline": {
+                    border: "1px solid transparent !important",
+                  },
+                },
+                "& .MuiOutlinedInput-notchedOutline": {
+                  border: `1px solid${theme.palette.border.main} !important`,
+                },
+                "& fieldset": {
+                  borderColor: theme.palette.border.main,
+                },
+                backgroundColor: theme.palette.background.paper,
+                borderRadius: 0,
+              }),
+              ...params.InputProps,
+            }}
+            InputLabelProps={{
+              sx: (theme) => ({
+                textDecoration: "underline",
+                color: theme.palette.primary.main,
+                "&[data-shrink=true]": {
+                  textDecoration: "none",
+                  color: theme.palette.text.primary,
+                  paddingY: 0,
+                  transform: "translate(14px, -22px) scale(0.85)",
+                },
+              }),
+            }}
             label="What does this file show?"
-            // Disable text input
             onKeyDown={(e) => {
-              e.preventDefault();
+              // Disable text input but allow keyboard navigation
+              if (e.key !== "Tab") e.preventDefault();
             }}
             // Hide text input caret
             sx={{ caretColor: "transparent" }}
@@ -167,7 +224,19 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
         multiple
         disableCloseOnSelect
         disableClearable
-        popupIcon={<ArrowIcon />}
+        componentsProps={{
+          popupIndicator: {
+            disableRipple: true,
+          },
+          popper: {
+            sx: {
+              boxShadow: 10,
+            },
+          },
+        }}
+        popupIcon={
+          <ArrowIcon sx={{ color: "primary.main" }} fontSize="large" />
+        }
         ListboxComponent={ListboxComponent}
         ChipProps={{
           variant: "uploadedFileTag",
@@ -176,9 +245,11 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
           onDelete: undefined,
         }}
         renderGroup={({ group, key, children }) => (
-          <List key={`group-${key}`} role="group">
+          <List key={`group-${key}`} role="group" sx={{ paddingY: 0 }}>
             <ListSubheader role="presentation">
-              {capitalize(group)}
+              <Typography py={1} variant="subtitle2" component="h4">
+                {`${capitalize(group)} files`}
+              </Typography>
             </ListSubheader>
             {children}
           </List>
@@ -196,25 +267,6 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
           </ListItem>
         )}
       />
-      {/*
-        {(Object.keys(fileList) as Array<keyof typeof fileList>)
-          .filter((fileListCategory) => fileList[fileListCategory].length > 0)
-          .map((fileListCategory) => {
-            return [
-
-              ...fileList[fileListCategory].map((fileType) => {
-                return [
-                  <MenuItem
-                    disableRipple
-                    disableTouchRipple
-                  >
-                    <Checkbox
-                      inputProps={{
-                        "aria-label": `${fileType.name}`,
-                      }}
-                    />
-                  </MenuItem> 
-                    */}
     </FormControl>
   );
 };

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -6,7 +6,6 @@ import Autocomplete, {
 } from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Checkbox from "@mui/material/Checkbox";
 import FormControl from "@mui/material/FormControl";
 import { inputLabelClasses } from "@mui/material/InputLabel";
 import List from "@mui/material/List";
@@ -29,6 +28,7 @@ import {
   removeSlots,
   UserFile,
 } from "./model";
+import Checkbox from "ui/shared/Checkbox";
 
 interface SelectMultipleProps {
   uploadedFile: FileUploadSlot;
@@ -153,12 +153,12 @@ const renderOption: AutocompleteProps<
   <ListItem {...props}>
     <Checkbox
       data-testid="select-checkbox"
-      inputProps={{
-        "aria-label": `${option.name}`,
-      }}
       checked={selected}
+      inputProps={{
+        "aria-label": option.name
+      }}
     />
-    <ListItemText>{option.name}</ListItemText>
+    <ListItemText sx={{ ml: 2 }}>{option.name}</ListItemText>
   </ListItem>
 );
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -64,8 +64,6 @@ const StyledAutocomplete = styled(
 }));
 
 const StyledTextField = styled(TextField)(({ theme }) => ({
-  // Hide text input caret
-  caretColor: "transparent",
   "&:focus-within": {
     ...focusStyle,
     [`& .${outlinedInputClasses.notchedOutline}`]: {
@@ -111,15 +109,7 @@ const renderInput: AutocompleteProps<
       ...params.InputProps,
       notched: false,
     }}
-    inputProps={{
-      ...params.inputProps,
-      "aria-disabled": true,
-    }}
     label="What does this file show?"
-    onKeyDown={(e) => {
-      // Disable text input but allow keyboard navigation
-      if (e.key !== "Tab") e.preventDefault();
-    }}
   />
 );
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -19,6 +19,7 @@ import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import React, { forwardRef, PropsWithChildren, useMemo, useState } from "react";
 import { borderedFocusStyle } from "theme";
+import Checkbox from "ui/shared/Checkbox";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import {
@@ -28,7 +29,6 @@ import {
   removeSlots,
   UserFile,
 } from "./model";
-import Checkbox from "ui/shared/Checkbox";
 
 interface SelectMultipleProps {
   uploadedFile: FileUploadSlot;
@@ -123,7 +123,12 @@ const renderGroup: AutocompleteProps<
   false,
   "div"
 >["renderGroup"] = ({ group, key, children }) => (
-  <List key={`group-${key}`} role="group" sx={{ paddingY: 0 }} aria-labelledby={`${group}-label`}>
+  <List
+    key={`group-${key}`}
+    role="group"
+    sx={{ paddingY: 0 }}
+    aria-labelledby={`${group}-label`}
+  >
     <ListSubheader
       id={`${group}-label`}
       role="presentation"
@@ -156,7 +161,7 @@ const renderOption: AutocompleteProps<
       data-testid="select-checkbox"
       checked={selected}
       inputProps={{
-        "aria-label": option.name
+        "aria-label": option.name,
       }}
     />
     <ListItemText sx={{ ml: 2 }}>{option.name}</ListItemText>
@@ -165,11 +170,37 @@ const renderOption: AutocompleteProps<
 
 const PopupIcon = <ArrowIcon sx={{ color: "primary.main" }} fontSize="large" />;
 
+/**
+ * Custom Listbox component
+ * Used to wrap options within the autocomplete and append a custom element above the option list
+ */
+const ListboxComponent = forwardRef<typeof Box, PropsWithChildren>(
+  ({ children, ...props }, ref) => (
+    <>
+      <Box>
+        <ListHeader>
+          <Typography variant="h4" component="h3" pr={3}>
+            Select all that apply
+          </Typography>
+          <Button variant="contained" color="prompt" aria-label="Close list">
+            Done
+          </Button>
+        </ListHeader>
+      </Box>
+      <Box
+        ref={ref}
+        {...props}
+        role="listbox"
+        sx={{ paddingY: "0px !important" }}
+      >
+        {children}
+      </Box>
+    </>
+  ),
+);
+
 export const SelectMultiple = (props: SelectMultipleProps) => {
   const { uploadedFile, fileList, setFileList } = props;
-  const [open, setOpen] = useState(false);
-  const closePopper = () => setOpen(false);
-  const openPopper = () => setOpen(true);
 
   const initialTags = getTagsForSlot(uploadedFile.id, fileList);
 
@@ -234,42 +265,6 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
     }
   };
 
-  /**
-   * Custom Listbox component
-   * Used to wrap options within the autocomplete and append a custom element above the option list
-   */
-  const ListboxComponent = forwardRef<typeof Box, PropsWithChildren>(
-    ({ children, ...props }, ref) => {
-      return (
-        <>
-          <Box>
-            <ListHeader>
-              <Typography variant="h4" component="h3" pr={3}>
-                Select all that apply
-              </Typography>
-              <Button
-                variant="contained"
-                color="prompt"
-                onClick={closePopper}
-                aria-label="Close list"
-              >
-                Done
-              </Button>
-            </ListHeader>
-          </Box>
-          <Box
-            ref={ref}
-            {...props}
-            role="listbox"
-            sx={{ paddingY: "0px !important" }}
-          >
-            {children}
-          </Box>
-        </>
-      );
-    },
-  );
-
   return (
     <FormControl
       key={`form-${uploadedFile.id}`}
@@ -288,9 +283,6 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
         ListboxComponent={ListboxComponent}
         multiple
         onChange={handleChange}
-        onClose={closePopper}
-        onOpen={openPopper}
-        open={open}
         options={options}
         popupIcon={PopupIcon}
         renderGroup={renderGroup}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -111,6 +111,10 @@ const renderInput: AutocompleteProps<
       ...params.InputProps,
       notched: false,
     }}
+    inputProps={{
+      ...params.inputProps,
+      "aria-disabled": true,
+    }}
     label="What does this file show?"
     onKeyDown={(e) => {
       // Disable text input but allow keyboard navigation

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -20,8 +20,8 @@ interface Props extends FileUploadSlot {
 
 const Root = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
-  marginBottom: theme.spacing(1),
-  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(0.5),
+  marginTop: theme.spacing(5),
 }));
 
 const FileCard = styled(Box)(({ theme }) => ({

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -228,6 +228,14 @@ const getThemeOptions = ({
           },
         },
       },
+      MuiPopper: {
+        styleOverrides: {
+          root: {
+            // Override default popover box-shadow to increase visual separation
+            boxShadow: "0 0 10px 4px rgba(0, 0, 0, 0.5) !important",
+          },
+        },
+      },
       MuiContainer: {
         styleOverrides: {
           root: {

--- a/editor.planx.uk/src/ui/shared/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox.tsx
@@ -46,20 +46,22 @@ const Icon = styled("span", {
 export interface Props {
   id?: string;
   checked: boolean;
-  onChange: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  onChange?: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
 }
 
-export default function Checkbox(props: Props): FCReturn {
+export default function Checkbox({ id, checked, onChange, inputProps }: Props): FCReturn {
   return (
-    <Root onClick={() => props.onChange()}>
+    <Root onClick={() => onChange && onChange()}>
       <Input
-        defaultChecked={props.checked}
+        defaultChecked={checked}
         type="checkbox"
-        id={props.id}
-        data-testid={props.id}
-        onChange={() => props.onChange()}
+        id={id}
+        data-testid={id}
+        onChange={() => onChange && onChange()}
+        {...inputProps}
       />
-      <Icon checked={props.checked} />
+      <Icon checked={checked} />
     </Root>
   );
 }


### PR DESCRIPTION
## What does this PR do?
- Replaces the MUI Select component with a MUI Autocomplete component within the `FileUploadAndLabel` modal
- This is done in order to resolve the accessibility report issue "Customised Combobox" (Page 35)

## Why do we need to do this?
After spending a good while amending the markup of the `Select` I realised it wasn't possible to meet the requirements laid out the in report. These are the two fundamental barriers I hit -
 - MUI was hardcoding `role="option"` on the children of the Select - we require `role="group"`
 - A single `ul` element is forced as the first child element

Using the Autocomplete allows us access to grouping, which allows us to inject some custom HTML elements in the order and location we require. I've been aiming to match the following example of a grouped listbox shared in the report - https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped/

### Potential issues
~~As this autocomplete in a HTML `Input` under the hood, users can natively type here. I've disabled this to match the current user experience however this may be problematic in itself.~~

Update: At the dev call on 10/04 we agreed to reinstate typing (see [5769135](https://github.com/theopensystemslab/planx-new/pull/2993/commits/5769135a4242c04647168f0e968301764fdcf13e)). This is seen as an additional helpful feature, and resolves the accessibility concerns raised above.

### Outstanding visual regressions
There are a few small visual disparities between the two versions which I've not yet tackled.
- [x] Styling for sticky group headers (do we even want them to be sticky?)
- [ ] Transition in
- [ ] Popper positioning
- [x] Focus styles
- [x] Element is larger (more padding) than previous iteration