### PR TITLE
fix: update PlanningConstraints disclaimer to suppot rich text formatting

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
@@ -63,7 +63,7 @@ function PlanningConstraintsComponent(props: Props) {
           </InputGroup>
           <InputGroup label="Planning conditions disclaimer">
             <InputRow>
-              <Input
+              <RichTextInput
                 name="disclaimer"
                 placeholder="Planning conditions disclaimer"
                 value={formik.values.disclaimer}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -27,6 +27,7 @@ import {
   type IntersectingConstraints,
   type PlanningConstraints,
 } from "./model";
+import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
 type Props = PublicProps<PlanningConstraints>;
 
@@ -281,8 +282,8 @@ export function PlanningConstraintsContent(
 const Disclaimer = (props: { text: string }) => (
   <WarningContainer>
     <ErrorOutline />
-    <Typography variant="body1" ml={2} fontWeight={FONT_WEIGHT_SEMI_BOLD}>
-      {props.text || DEFAULT_PLANNING_CONDITIONS_DISCLAIMER}
+    <Typography variant="body1" component="div" ml={2} mb={1}>
+      <ReactMarkdownOrHtml source={props.text || DEFAULT_PLANNING_CONDITIONS_DISCLAIMER} openLinksOnNewTab />
     </Typography>
   </WarningContainer>
 );

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/model.ts
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/model.ts
@@ -22,4 +22,4 @@ export const parseContent = (
 export type IntersectingConstraints = Record<string, string[]>;
 
 export const DEFAULT_PLANNING_CONDITIONS_DISCLAIMER =
-  "This page does not include information about historic planning conditions that may apply to this property.";
+  "<p><strong>This page does not include information about historic planning conditions that may apply to this property.</strong></p>";


### PR DESCRIPTION
Per request from Doncaster, followup from #2891 

**Now:**
![Screenshot from 2024-04-08 16-17-11](https://github.com/theopensystemslab/planx-new/assets/5132349/487b2a9b-9dc4-4c3e-a365-f52f91aee23d)
![Screenshot from 2024-04-08 16-16-48](https://github.com/theopensystemslab/planx-new/assets/5132349/ad815be3-7ca7-4d04-9239-7c0f8d318ce1)
