### PR TITLE
feat: add AWS S3 bucket as "Send" destination for staging envs only

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -57,6 +57,14 @@ const SendComponent: React.FC<Props> = (props) => {
     },
   ];
 
+  // Show S3 option on staging only
+  if (process.env.REACT_APP_ENV !== "production") {
+    options.push({
+      value: Destination.S3,
+      label: "Upload to AWS S3 bucket",
+    });
+  }
+
   const changeCheckbox = (value: Destination) => (_checked: any) => {
     let newCheckedValues: Destination[];
 
@@ -76,7 +84,8 @@ const SendComponent: React.FC<Props> = (props) => {
 
     // Show warnings on selection of BOPS or Uniform for likely unsupported services
     //   Don't actually restrict selection because flowSlug matching is imperfect for some valid test cases
-    const flowSlug = window.location.pathname?.split("/")?.[1];
+    const teamSlug = window.location.pathname?.split("/")?.[1];
+    const flowSlug = window.location.pathname?.split("/")?.[2];
     if (
       value === Destination.BOPS &&
       newCheckedValues.includes(value) &&
@@ -94,10 +103,21 @@ const SendComponent: React.FC<Props> = (props) => {
     if (
       value === Destination.Uniform &&
       newCheckedValues.includes(value) &&
-      flowSlug !== "apply-for-a-lawful-development-certificate"
+      flowSlug !== "apply-for-a-lawful-development-certificate" &&
+      !["buckinghamshire", "lambeth", "southwark"].includes(teamSlug)
     ) {
       alert(
-        "Uniform only accepts Lawful Development Certificate submissions. Please do not select if you're building another type of submission service!",
+        "Uniform is only enabled for Bucks, Lambeth and Southwark to accept Lawful Development Certificate submissions. Please do not select if you're building another type of submission service!",
+      );
+    }
+
+    if (
+      value === Destination.S3 &&
+      newCheckedValues.includes(value) &&
+      teamSlug !== "barnet"
+    ) {
+      alert(
+        "AWS S3 uploads are currently being prototyped with Barnet only. Please do not select this option for other councils yet.",
       );
     }
   };

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -71,6 +71,16 @@ const SendComponent: React.FC<Props> = ({
         makeData(props, request.value.email?.event_id, "emailSendEventId"),
       );
     }
+
+    if (
+      destinations.includes(Destination.S3) &&
+      isReady &&
+      props.handleSubmit
+    ) {
+      props.handleSubmit(
+        makeData(props, request.value.s3?.event_id, "s3SendEventId"),
+      );
+    }
   }, [request.loading, request.error, request.value]);
 
   if (request.loading) {

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -5,6 +5,7 @@ export enum Destination {
   BOPS = "bops",
   Uniform = "uniform",
   Email = "email",
+  S3 = "s3",
 }
 
 export interface Send extends MoreInformation {
@@ -67,6 +68,13 @@ export function getCombinedEventsPayload({
 
     combinedEventsPayload[Destination.Uniform] = {
       localAuthority: uniformTeamSlug,
+      body: { sessionId },
+    };
+  }
+
+  if (destinations.includes(Destination.S3)) {
+    combinedEventsPayload[Destination.S3] = {
+      localAuthority: teamSlug,
       body: { sessionId },
     };
   }


### PR DESCRIPTION
Editor-side changes for the Barnet prototype described in linked Trello ticket. API changes to follow in a separate PR

![Screenshot from 2024-04-09 14-03-32](https://github.com/theopensystemslab/planx-new/assets/5132349/3e7368bb-1fef-4ff5-8975-8be9782a8b6c)
