### PR TITLE
feat: add send events and API endpoint for uploading submissions to S3

### DIFF
--- a/api.planx.uk/lib/hasura/metadata/index.ts
+++ b/api.planx.uk/lib/hasura/metadata/index.ts
@@ -13,6 +13,7 @@ export interface CombinedResponse {
   bops?: ScheduledEventResponse;
   uniform?: ScheduledEventResponse;
   email?: ScheduledEventResponse;
+  s3?: ScheduledEventResponse;
 }
 
 interface ScheduledEventArgs {

--- a/api.planx.uk/modules/send/createSendEvents/controller.ts
+++ b/api.planx.uk/modules/send/createSendEvents/controller.ts
@@ -10,7 +10,7 @@ const createSendEvents: CreateSendEventsController = async (
   res,
   next,
 ) => {
-  const { email, uniform, bops } = res.locals.parsedReq.body;
+  const { email, uniform, bops, s3 } = res.locals.parsedReq.body;
   const { sessionId } = res.locals.parsedReq.params;
 
   try {
@@ -45,6 +45,16 @@ const createSendEvents: CreateSendEventsController = async (
         comment: `uniform_submission_${sessionId}`,
       });
       combinedResponse["uniform"] = uniformEvent;
+    }
+
+    if (s3) {
+      const s3Event = await createScheduledEvent({
+        webhook: `{{HASURA_PLANX_API_URL}}/upload-submission/${s3.localAuthority}`,
+        schedule_at: now,
+        payload: s3.body,
+        comment: `upload_submission_${sessionId}`,
+      });
+      combinedResponse["s3"] = s3Event;
     }
 
     return res.json(combinedResponse);

--- a/api.planx.uk/modules/send/createSendEvents/types.ts
+++ b/api.planx.uk/modules/send/createSendEvents/types.ts
@@ -14,6 +14,7 @@ export const combinedEventsPayloadSchema = z.object({
     email: eventSchema.optional(),
     bops: eventSchema.optional(),
     uniform: eventSchema.optional(),
+    s3: eventSchema.optional(),
   }),
   params: z.object({
     sessionId: z.string().uuid(),

--- a/api.planx.uk/modules/send/routes.ts
+++ b/api.planx.uk/modules/send/routes.ts
@@ -7,6 +7,7 @@ import { sendToEmail } from "./email";
 import { validate } from "../../shared/middleware/validate";
 import { combinedEventsPayloadSchema } from "./createSendEvents/types";
 import { downloadApplicationFiles } from "./downloadApplicationFiles";
+import { sendToS3 } from "./s3";
 
 const router = Router();
 
@@ -19,5 +20,6 @@ router.post("/bops/:localAuthority", useHasuraAuth, sendToBOPS);
 router.post("/uniform/:localAuthority", useHasuraAuth, sendToUniform);
 router.post("/email-submission/:localAuthority", useHasuraAuth, sendToEmail);
 router.get("/download-application-files/:sessionId", downloadApplicationFiles);
+router.post("/upload-submission/:localAuthority", useHasuraAuth, sendToS3);
 
 export default router;

--- a/api.planx.uk/modules/send/s3/index.test.ts
+++ b/api.planx.uk/modules/send/s3/index.test.ts
@@ -1,0 +1,60 @@
+import supertest from "supertest";
+import app from "../../../server";
+import { expectedPlanningPermissionPayload } from "../../../tests/mocks/digitalPlanningDataMocks";
+
+jest.mock("../../saveAndReturn/service/utils", () => ({
+  markSessionAsSubmitted: jest.fn(),
+}));
+
+jest.mock("@opensystemslab/planx-core", () => {
+  const actualCoreDomainClient = jest.requireActual(
+    "@opensystemslab/planx-core",
+  ).CoreDomainClient;
+
+  return {
+    CoreDomainClient: class extends actualCoreDomainClient {
+      constructor() {
+        super();
+        this.export.digitalPlanningDataPayload = () =>
+          jest.fn().mockResolvedValue({
+            exportData: expectedPlanningPermissionPayload,
+          });
+      }
+    },
+  };
+});
+
+describe(`uploading an application to S3`, () => {
+  it("requires auth", async () => {
+    await supertest(app)
+      .post("/upload-submission/barnet")
+      .send({ payload: { sessionId: "123" } })
+      .expect(401);
+  });
+
+  it("throws an error if payload is missing", async () => {
+    await supertest(app)
+      .post("/upload-submission/barnet")
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+      .send({ payload: null })
+      .expect(400)
+      .then((res) => {
+        expect(res.body.error).toMatch(/Missing application payload/);
+      });
+  });
+
+  it("throws an error if team is unsupported", async () => {
+    await supertest(app)
+      .post("/upload-submission/unsupported-team")
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+      .send({ payload: { sessionId: "123" } })
+      .expect(400)
+      .then((res) => {
+        expect(res.body.error).toMatch(
+          "Send to S3 is not enabled for this local authority (unsupported-team)",
+        );
+      });
+  });
+
+  it.todo("succeeds"); // mock uploadPrivateFile ??
+});

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -35,7 +35,11 @@ export async function sendToS3(
     const exportData = await $api.export.digitalPlanningDataPayload(sessionId);
 
     // Create and upload the data as an S3 file
-    const { fileUrl } = await uploadPrivateFile(exportData, `${sessionId}.json`, "barnet-prototype");
+    const { fileUrl } = await uploadPrivateFile(
+      exportData,
+      `${sessionId}.json`,
+      "barnet-prototype",
+    );
 
     // Mark session as submitted so that reminder and expiry emails are not triggered
     markSessionAsSubmitted(sessionId);

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -1,0 +1,56 @@
+import type { NextFunction, Request, Response } from "express";
+import { $api } from "../../../client";
+import { uploadPrivateFile } from "../../file/service/uploadFile";
+import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils";
+
+export async function sendToS3(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  // `/upload-submission/:localAuthority` is only called via Hasura's scheduled event webhook, so body is wrapped in a "payload" key
+  const { payload } = req.body;
+  const localAuthority = req.params.localAuthority;
+
+  if (!payload?.sessionId) {
+    return next({
+      status: 400,
+      message: `Missing application payload data to send to email`,
+    });
+  }
+
+  try {
+    const { sessionId } = payload;
+
+    // Only prototyping with Barnet to begin
+    //   In future, confirm this local authority has an S3 bucket/folder configured in team_integrations or similar
+    if (localAuthority !== "barnet") {
+      return next({
+        status: 400,
+        message: `Send to S3 is not enabled for this local authority (${localAuthority})`,
+      });
+    }
+
+    // Generate the ODP Schema JSON
+    const exportData = await $api.export.digitalPlanningDataPayload(sessionId);
+
+    // Create and upload the data as an S3 file
+    const { fileUrl } = await uploadPrivateFile(exportData, `${sessionId}.json`, "barnet-prototype");
+
+    // Mark session as submitted so that reminder and expiry emails are not triggered
+    markSessionAsSubmitted(sessionId);
+
+    // TODO Create and update an audit table entry
+
+    return res.status(200).send({
+      message: `Successfully uploaded submission to S3: ${fileUrl}`,
+    });
+  } catch (error) {
+    return next({
+      error,
+      message: `Failed to upload submission to S3 (${localAuthority}): ${
+        (error as Error).message
+      }`,
+    });
+  }
+}

--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -65,62 +65,66 @@ const SendComponent: React.FC<Props> = (props) => {
     });
   }
 
-  const changeCheckbox = (value: Destination) => (_checked: any) => {
-    let newCheckedValues: Destination[];
+  const changeCheckbox =
+    (value: Destination) =>
+    (_checked: React.MouseEvent<HTMLButtonElement, MouseEvent> | undefined) => {
+      let newCheckedValues: Destination[];
 
-    if (formik.values.destinations.includes(value)) {
-      newCheckedValues = formik.values.destinations.filter((x) => x !== value);
-    } else {
-      newCheckedValues = [...formik.values.destinations, value];
-    }
+      if (formik.values.destinations.includes(value)) {
+        newCheckedValues = formik.values.destinations.filter(
+          (x) => x !== value,
+        );
+      } else {
+        newCheckedValues = [...formik.values.destinations, value];
+      }
 
-    formik.setFieldValue(
-      "destinations",
-      newCheckedValues.sort((a, b) => {
-        const originalValues = options.map((cb) => cb.value);
-        return originalValues.indexOf(a) - originalValues.indexOf(b);
-      }),
-    );
-
-    // Show warnings on selection of BOPS or Uniform for likely unsupported services
-    //   Don't actually restrict selection because flowSlug matching is imperfect for some valid test cases
-    const teamSlug = window.location.pathname?.split("/")?.[1];
-    const flowSlug = window.location.pathname?.split("/")?.[2];
-    if (
-      value === Destination.BOPS &&
-      newCheckedValues.includes(value) &&
-      ![
-        "apply-for-a-lawful-development-certificate",
-        "apply-for-prior-approval",
-        "apply-for-planning-permission",
-      ].includes(flowSlug)
-    ) {
-      alert(
-        "BOPS only accepts Lawful Development Certificate, Prior Approval, and Planning Permission submissions. Please do not select if you're building another type of submission service!",
+      formik.setFieldValue(
+        "destinations",
+        newCheckedValues.sort((a, b) => {
+          const originalValues = options.map((cb) => cb.value);
+          return originalValues.indexOf(a) - originalValues.indexOf(b);
+        }),
       );
-    }
 
-    if (
-      value === Destination.Uniform &&
-      newCheckedValues.includes(value) &&
-      flowSlug !== "apply-for-a-lawful-development-certificate" &&
-      !["buckinghamshire", "lambeth", "southwark"].includes(teamSlug)
-    ) {
-      alert(
-        "Uniform is only enabled for Bucks, Lambeth and Southwark to accept Lawful Development Certificate submissions. Please do not select if you're building another type of submission service!",
-      );
-    }
+      // Show warnings on selection of BOPS or Uniform for likely unsupported services
+      //   Don't actually restrict selection because flowSlug matching is imperfect for some valid test cases
+      const teamSlug = window.location.pathname?.split("/")?.[1];
+      const flowSlug = window.location.pathname?.split("/")?.[2];
+      if (
+        value === Destination.BOPS &&
+        newCheckedValues.includes(value) &&
+        ![
+          "apply-for-a-lawful-development-certificate",
+          "apply-for-prior-approval",
+          "apply-for-planning-permission",
+        ].includes(flowSlug)
+      ) {
+        alert(
+          "BOPS only accepts Lawful Development Certificate, Prior Approval, and Planning Permission submissions. Please do not select if you're building another type of submission service!",
+        );
+      }
 
-    if (
-      value === Destination.S3 &&
-      newCheckedValues.includes(value) &&
-      teamSlug !== "barnet"
-    ) {
-      alert(
-        "AWS S3 uploads are currently being prototyped with Barnet only. Please do not select this option for other councils yet.",
-      );
-    }
-  };
+      if (
+        value === Destination.Uniform &&
+        newCheckedValues.includes(value) &&
+        flowSlug !== "apply-for-a-lawful-development-certificate" &&
+        !["buckinghamshire", "lambeth", "southwark"].includes(teamSlug)
+      ) {
+        alert(
+          "Uniform is only enabled for Bucks, Lambeth and Southwark to accept Lawful Development Certificate submissions. Please do not select if you're building another type of submission service!",
+        );
+      }
+
+      if (
+        value === Destination.S3 &&
+        newCheckedValues.includes(value) &&
+        teamSlug !== "barnet"
+      ) {
+        alert(
+          "AWS S3 uploads are currently being prototyped with Barnet only. Please do not select this option for other councils yet.",
+        );
+      }
+    };
 
   return (
     <form onSubmit={formik.handleSubmit} id="modal">

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -81,7 +81,7 @@ const SendComponent: React.FC<Props> = ({
         makeData(props, request.value.s3?.event_id, "s3SendEventId"),
       );
     }
-  }, [request.loading, request.error, request.value]);
+  }, [request.loading, request.error, request.value, destinations, props]);
 
   if (request.loading) {
     return (

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -8,6 +8,13 @@ export enum Destination {
   S3 = "s3",
 }
 
+interface EventPayload {
+  localAuthority: string;
+  body: {
+    sessionId: string;
+  };
+}
+
 export interface Send extends MoreInformation {
   title: string;
   destinations: Destination[];
@@ -33,7 +40,7 @@ export function getCombinedEventsPayload({
   passport: Store.passport;
   sessionId: string;
 }) {
-  const combinedEventsPayload: any = {};
+  const combinedEventsPayload: Record<string, EventPayload> = {};
 
   // Format application user data as required by BOPS
   if (destinations.includes(Destination.BOPS)) {


### PR DESCRIPTION
These are the backend changes following on from #2999:
- Adds API endpoint `/upload-submisison/:localAuthority` within Send module to generate digital planning payload JSON & upload as a private file to a specified/static S3 folder within our main user data bucket
- Hooks up Hasura send events for this destination

**Testing:**
- Go to a supported submission service flow in Barnet's editor workspace (eg Prior Approval) 
  - Update Send component to select S3 option and publish
- Open `/published` link and fill out application (note that Pay is not enabled for Barnet and will show error, but you can "Continue" through without paying for this test and still generate a valid payload)
- After reaching Confirmation page, check Hasura events for successful audit log 
  - The success message will include a link the uploaded submission on S3 like below
  - Confirm that JSON file is private and you can download successfully if authenticated
  - The `lowcal_session` database record should also be marked as submitted

![Screenshot from 2024-04-11 09-43-39](https://github.com/theopensystemslab/planx-new/assets/5132349/5d8449ca-f919-42cb-8df5-7e9ceaf6fbdc)