### PR TITLE
fix: skip Send event creation if not a published route

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -1,3 +1,5 @@
+import ErrorOutline from "@mui/icons-material/ErrorOutline";
+import Typography from "@mui/material/Typography";
 import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -5,6 +7,7 @@ import React, { useEffect } from "react";
 import { useAsync } from "react-use";
 
 import Card from "../shared/Preview/Card";
+import { WarningContainer } from "../shared/Preview/WarningContainer";
 import { makeData } from "../shared/utils";
 import { PublicProps } from "../ui";
 import {
@@ -17,6 +20,37 @@ import {
 export type Props = PublicProps<Send>;
 
 const SendComponent: React.FC<Props> = ({
+  destinations = [DEFAULT_DESTINATION],
+  ...props
+}) => {
+  const fullProps = { destinations: destinations, ...props };
+  if (
+    window.location.pathname.endsWith("/draft") ||
+    window.location.pathname.endsWith("/amber")
+  ) {
+    return <SkipSendWarning {...fullProps} />;
+  } else {
+    return <CreateSendEvents {...fullProps} />;
+  }
+};
+
+/**
+ * Skip queuing up Send events on non-Save&Return layout routes because they don't record lowcal_session data
+ */
+const SkipSendWarning: React.FC<Props> = (props) => (
+  <Card handleSubmit={props.handleSubmit}>
+    <WarningContainer>
+      <ErrorOutline />
+      <Typography variant="body1" ml={2}>
+        You can only test submissions on <strong>published routes</strong> where
+        Save & Return is enabled. Click "Continue" to finish reviewing content
+        and skip submission.
+      </Typography>
+    </WarningContainer>
+  </Card>
+);
+
+const CreateSendEvents: React.FC<Props> = ({
   destinations = [DEFAULT_DESTINATION],
   ...props
 }) => {


### PR DESCRIPTION
Should cut down on these `cannot find session` errors on Send endpoints! 
![Screenshot from 2024-04-12 10-45-33](https://github.com/theopensystemslab/planx-new/assets/5132349/18db66ec-d607-4c48-8971-4efe53db202b)

**Testing:**
- On a `/draft` or `/amber` route, the Send component shows the following error message - you can click through to proceed to a Confirmation page but _no_ events will be created in Hasura
![Screenshot from 2024-04-12 10-40-04](https://github.com/theopensystemslab/planx-new/assets/5132349/e4b0bff3-6c31-4210-bff4-00450bc029cb)
- On a `/published` route, the Send component queues up the applicable events and only shows a brief loading indicator just as before