### PR TITLE
fix: Confirmation contact set in primary colour

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -88,8 +88,8 @@ export default function ConfirmationComponent(props: Props) {
 
         {props.contactInfo && (
           <>
-            <Box py={1} color="primary.main">
-              <Typography variant="h2" component="h3">
+            <Box py={1}>
+              <Typography variant="h2" component="h3" gutterBottom>
                 Contact us
               </Typography>
               <ReactMarkdownOrHtml source={props.contactInfo} />


### PR DESCRIPTION
# What does this PR do?

Quick one — the contact text on the confirmation page is currently set in council primary colour.

PR updates to use the default text colour.

**Current:**
<img width="782" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/23315f1b-970f-4b9b-8130-7fd872e060c3">


**Updated:**
<img width="782" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/71e26103-64c6-4e41-9855-7173ce7b4fff">


