### PR TITLE
chore(a11y): Re-order dropzone to be above file cards

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
@@ -23,6 +23,14 @@ export const PrivateFileUpload: React.FC<PrivateFileUploadProps> = ({
 
   return (
     <>
+      {hasEmptySlots && (
+        <Dropzone
+          slots={slots}
+          setSlots={setSlots}
+          setFileUploadStatus={setFileUploadStatus}
+          maxFiles={maxFiles}
+        />
+      )}
       {slots.map((slot) => {
         return (
           <UploadedFileCard
@@ -38,14 +46,6 @@ export const PrivateFileUpload: React.FC<PrivateFileUploadProps> = ({
         );
       })}
       <FileStatus status={fileUploadStatus} />
-      {hasEmptySlots && (
-        <Dropzone
-          slots={slots}
-          setSlots={setSlots}
-          setFileUploadStatus={setFileUploadStatus}
-          maxFiles={maxFiles}
-        />
-      )}
     </>
   );
 };


### PR DESCRIPTION
## What does this PR do?
 - Reorders the `Dropzone` component to be above the list of `UploadedFileCard` components

## Why?
 - Recommended as a usability improvement in accessibility report - issue "Organisation of Content", page 80
 - Matches file upload and label

<img width="1439" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/590a7236-be1f-4144-888d-f120179de71a">
