### PR TITLE
feat: basic platform admin panel for checking onboarding status & available integrations

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -20,63 +20,66 @@ const FIND_PROPERTY_DT = "Property address";
 const DRAW_BOUNDARY_DT = "Location plan";
 
 export const SummaryListTable = styled("dl", {
-  shouldForwardProp: (prop) => prop !== "showChangeButton",
-})<{ showChangeButton?: boolean }>(({ theme, showChangeButton }) => ({
-  display: "grid",
-  gridTemplateColumns: showChangeButton ? "1fr 2fr 100px" : "1fr 2fr",
-  gridRowGap: "10px",
-  marginTop: theme.spacing(2),
-  marginBottom: theme.spacing(4),
-  "& > *": {
-    borderBottom: `1px solid ${theme.palette.border.main}`,
-    paddingBottom: theme.spacing(2),
-    paddingTop: theme.spacing(2),
-    verticalAlign: "top",
-    margin: 0,
-  },
-  "& ul": {
-    listStylePosition: "inside",
-    padding: 0,
-    margin: 0,
-  },
-  "& dt": {
-    // left column
-    fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  },
-  "& dd:nth-of-type(n)": {
-    // middle column
-    paddingLeft: "10px",
-  },
-  "& dd:nth-of-type(2n)": {
-    // right column
-    textAlign: showChangeButton ? "right" : "left",
-  },
-  [theme.breakpoints.down("sm")]: {
-    display: "flex",
-    flexDirection: "column",
+  shouldForwardProp: (prop) => prop !== "showChangeButton" && prop !== "dense",
+})<{ showChangeButton?: boolean; dense?: boolean }>(
+  ({ theme, showChangeButton, dense }) => ({
+    display: "grid",
+    gridTemplateColumns: showChangeButton ? "1fr 2fr 100px" : "1fr 2fr",
+    gridRowGap: "10px",
+    marginTop: dense ? theme.spacing(1) : theme.spacing(2),
+    marginBottom: dense ? theme.spacing(2) : theme.spacing(4),
+    fontSize: dense ? theme.typography.body2.fontSize : "inherit",
+    "& > *": {
+      borderBottom: `1px solid ${theme.palette.border.main}`,
+      paddingBottom: dense ? theme.spacing(1) : theme.spacing(2),
+      paddingTop: dense ? theme.spacing(1) : theme.spacing(2),
+      verticalAlign: "top",
+      margin: 0,
+    },
+    "& ul": {
+      listStylePosition: "inside",
+      padding: 0,
+      margin: 0,
+    },
     "& dt": {
-      // top row
-      paddingLeft: theme.spacing(1),
-      paddingTop: theme.spacing(2),
-      marginTop: theme.spacing(1),
-      borderTop: `1px solid ${theme.palette.border.main}`,
-      borderBottom: "none",
+      // left column
       fontWeight: FONT_WEIGHT_SEMI_BOLD,
     },
     "& dd:nth-of-type(n)": {
-      // middle row
-      textAlign: "left",
-      paddingTop: 0,
-      paddingBottom: 0,
-      margin: 0,
-      borderBottom: "none",
+      // middle column
+      paddingLeft: "10px",
     },
     "& dd:nth-of-type(2n)": {
-      // bottom row
-      textAlign: "left",
+      // right column
+      textAlign: showChangeButton ? "right" : "left",
     },
-  },
-}));
+    [theme.breakpoints.down("sm")]: {
+      display: "flex",
+      flexDirection: "column",
+      "& dt": {
+        // top row
+        paddingLeft: theme.spacing(1),
+        paddingTop: dense ? theme.spacing(1) : theme.spacing(2),
+        marginTop: theme.spacing(1),
+        borderTop: `1px solid ${theme.palette.border.main}`,
+        borderBottom: "none",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+      },
+      "& dd:nth-of-type(n)": {
+        // middle row
+        textAlign: "left",
+        paddingTop: 0,
+        paddingBottom: 0,
+        margin: 0,
+        borderBottom: "none",
+      },
+      "& dd:nth-of-type(2n)": {
+        // bottom row
+        textAlign: "left",
+      },
+    },
+  }),
+);
 
 const presentationalComponents: {
   [key in TYPES]: React.FC<ComponentProps> | undefined;

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -20,7 +20,8 @@ const FIND_PROPERTY_DT = "Property address";
 const DRAW_BOUNDARY_DT = "Location plan";
 
 export const SummaryListTable = styled("dl", {
-  shouldForwardProp: (prop) => prop !== "showChangeButton" && prop !== "dense",
+  shouldForwardProp: (prop) =>
+    !["showChangeButton", "dense"].includes(prop as string),
 })<{ showChangeButton?: boolean; dense?: boolean }>(
   ({ theme, showChangeButton, dense }) => ({
     display: "grid",

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -554,11 +554,16 @@ const EditorToolbar: React.FC<{
               </MenuItem>
             )}
 
-            {/* Only show global settings link from top-level admin view */}
+            {/* Only show global settings & admin panel links from top-level view */}
             {isGlobalSettingsVisible && (
-              <MenuItem onClick={() => navigate("/global-settings")}>
-                Global Settings
-              </MenuItem>
+              <>
+                <MenuItem onClick={() => navigate("/global-settings")}>
+                  Global Settings
+                </MenuItem>
+                <MenuItem onClick={() => navigate("/admin-panel")}>
+                  Admin Panel
+                </MenuItem>
+              </>
             )}
 
             <MenuItem onClick={() => navigate("/logout")}>Log out</MenuItem>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -1,7 +1,12 @@
 import { gql } from "@apollo/client";
 import camelcaseKeys from "camelcase-keys";
 import { client } from "lib/graphql";
-import { FlowSettings, GlobalSettings, TextContent } from "types";
+import {
+  AdminPanelData,
+  FlowSettings,
+  GlobalSettings,
+  TextContent,
+} from "types";
 import type { StateCreator } from "zustand";
 
 import { SharedStore } from "./shared";
@@ -14,6 +19,8 @@ export interface SettingsStore {
   setGlobalSettings: (globalSettings: GlobalSettings) => void;
   updateFlowSettings: (newSettings: FlowSettings) => Promise<number>;
   updateGlobalSettings: (newSettings: { [key: string]: TextContent }) => void;
+  adminPanelData?: AdminPanelData[];
+  setAdminPanelData: (adminPanelData: AdminPanelData[]) => void;
 }
 
 export const settingsStore: StateCreator<
@@ -91,4 +98,8 @@ export const settingsStore: StateCreator<
       },
     });
   },
+
+  adminPanelData: undefined,
+
+  setAdminPanelData: (adminPanelData) => set({ adminPanelData }),
 });

--- a/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
@@ -16,6 +16,7 @@ import Caret from "ui/icons/Caret";
 const StyledTeamAccordion = styled(Accordion, {
   shouldForwardProp: (prop) => prop !== "primaryColour",
 })<{ primaryColour?: string }>(({ theme, primaryColour }) => ({
+  borderTop: "none", // TODO figure out how to remove top border (box shadow?) when collapsed
   borderLeft: `10px solid ${primaryColour}`,
   backgroundColor: theme.palette.background.paper,
   width: "100%",
@@ -36,7 +37,7 @@ function Component() {
       <Typography variant="h1">Platform Admin Panel</Typography>
       <Typography variant="body1" mb={3}>
         {`This is an overview of each team's integrations and settings for the `}
-        <strong>{process.env.NODE_ENV}</strong>
+        <strong>{process.env.REACT_APP_ENV}</strong>
         {` environment`}
       </Typography>
       {adminPanelData?.map((team) => <TeamData key={team.id} data={team} />)}
@@ -54,7 +55,7 @@ const Configured: React.FC = () => <Done color="success" fontSize="small" />;
 
 const TeamData: React.FC<TeamData> = ({ data }) => {
   return (
-    <StyledTeamAccordion primaryColour={data.primaryColour}>
+    <StyledTeamAccordion primaryColour={data.primaryColour} elevation={0}>
       <AccordionSummary
         id={`${data.name}-header`}
         aria-controls={`${data.name}-panel`}

--- a/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
@@ -1,5 +1,8 @@
 import Close from "@mui/icons-material/Close";
 import Done from "@mui/icons-material/Done";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import { styled } from "@mui/material/styles";
@@ -8,14 +11,21 @@ import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { AdminPanelData } from "types";
+import Caret from "ui/icons/Caret";
 
-const StyledTeam = styled(Box, {
+const StyledTeamAccordion = styled(Accordion, {
   shouldForwardProp: (prop) => prop !== "primaryColour",
 })<{ primaryColour?: string }>(({ theme, primaryColour }) => ({
-  border: `10px solid ${theme.palette.divider}`,
   borderLeft: `10px solid ${primaryColour}`,
+  backgroundColor: theme.palette.background.paper,
+  width: "100%",
+  position: "relative",
   marginBottom: theme.spacing(2),
-  padding: theme.spacing(2),
+  padding: theme.spacing(1),
+  "&::after": {
+    position: "absolute",
+    width: "100%",
+  },
 }));
 
 function Component() {
@@ -25,9 +35,11 @@ function Component() {
     <Box p={3}>
       <Typography variant="h1">Platform Admin Panel</Typography>
       <Typography variant="body1" mb={3}>
-        {`This is an overview of each team's integrations and settings for the **${process.env.NODE_ENV}** environment`}
+        {`This is an overview of each team's integrations and settings for the `}
+        <strong>{process.env.NODE_ENV}</strong>
+        {` environment`}
       </Typography>
-      {adminPanelData?.map((team) => <TeamData data={team} />)}
+      {adminPanelData?.map((team) => <TeamData key={team.id} data={team} />)}
     </Box>
   );
 }
@@ -42,88 +54,113 @@ const Configured: React.FC = () => <Done color="success" fontSize="small" />;
 
 const TeamData: React.FC<TeamData> = ({ data }) => {
   return (
-    <StyledTeam primaryColour={data.primaryColour} key={data.id}>
-      <Typography variant="h2" mb={2}>
-        {data.name}
-      </Typography>
-      <Grid
-        container
-        direction="row"
-        justifyContent="flex-start"
-        alignItems="flex-end"
-        spacing={3}
+    <StyledTeamAccordion primaryColour={data.primaryColour}>
+      <AccordionSummary
+        id={`${data.name}-header`}
+        aria-controls={`${data.name}-panel`}
+        expandIcon={<Caret />}
+        sx={{ pr: 1.5 }}
       >
-        <Grid item xs={4}>
-          <SummaryListTable dense={true}>
-            <>
-              <Box component="dt">{"Slug"}</Box>
-              <Box component="dd">
-                <code>
-                  {`/`}
-                  {data.slug}
-                </code>
-              </Box>
-            </>
-            <>
-              <Box component="dt">{"Reference code"}</Box>
-              <Box component="dd">
-                {data.referenceCode || <NotConfigured />}
-              </Box>
-            </>
-            <>
-              <Box component="dt">{"Homepage"}</Box>
-              <Box component="dd">{data.homepage || <NotConfigured />}</Box>
-            </>
-            <>
-              <Box component="dt">{"Subdomain"}</Box>
-              <Box component="dd">{data.subdomain || <NotConfigured />}</Box>
-            </>
-          </SummaryListTable>
+        <Typography variant="h2">{data.name}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Grid
+          container
+          direction="row"
+          justifyContent="flex-start"
+          alignItems="flex-start"
+          spacing={3}
+        >
+          <Grid item xs={4}>
+            <SummaryListTable dense={true}>
+              <>
+                <Box component="dt">{"Slug"}</Box>
+                <Box component="dd">
+                  <code>
+                    {`/`}
+                    {data.slug}
+                  </code>
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"Homepage"}</Box>
+                <Box component="dd">{data.homepage || <NotConfigured />}</Box>
+              </>
+              <>
+                <Box component="dt">{"Logo"}</Box>
+                <Box component="dd">
+                  {data.logo ? <Configured /> : <NotConfigured />}
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"Favicon"}</Box>
+                <Box component="dd">
+                  {data.favicon ? <Configured /> : <NotConfigured />}
+                </Box>
+              </>
+            </SummaryListTable>
+          </Grid>
+          <Grid item xs={4}>
+            <SummaryListTable dense={true}>
+              <>
+                <Box component="dt">{"Planning constraints"}</Box>
+                <Box component="dd">
+                  {data.planningDataEnabled ? (
+                    <Configured />
+                  ) : (
+                    <NotConfigured />
+                  )}
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"Article 4s"}</Box>
+                <Box component="dd">{"?"}</Box>
+              </>
+              <>
+                <Box component="dt">{"Reference code"}</Box>
+                <Box component="dd">
+                  {data.referenceCode || <NotConfigured />}
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"Subdomain"}</Box>
+                <Box component="dd">{data.subdomain || <NotConfigured />}</Box>
+              </>
+            </SummaryListTable>
+          </Grid>
+          <Grid item xs={4}>
+            <SummaryListTable dense={true}>
+              <>
+                <Box component="dt">{"GOV.UK Notify"}</Box>
+                <Box component="dd">
+                  {data.govnotifyPersonalisation?.helpEmail || (
+                    <NotConfigured />
+                  )}
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"GOV.UK Pay"}</Box>
+                <Box component="dd">
+                  {data.govpayEnabled ? <Configured /> : <NotConfigured />}
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"Send to email"}</Box>
+                <Box component="dd">
+                  {data.sendToEmailAddress || <NotConfigured />}
+                </Box>
+              </>
+              <>
+                <Box component="dt">{"BOPS"}</Box>
+                <Box component="dd">
+                  {data.bopsSubmissionURL ? <Configured /> : <NotConfigured />}
+                </Box>
+              </>
+            </SummaryListTable>
+          </Grid>
         </Grid>
-        <Grid item xs={4}>
-          <SummaryListTable dense={true}>
-            <>
-              <Box component="dt">{"Planning constraints"}</Box>
-              <Box component="dd">
-                {data.planningDataEnabled ? <Configured /> : <NotConfigured />}
-              </Box>
-            </>
-            <>
-              <Box component="dt">{"Article 4s"}</Box>
-              <Box component="dd">{"?"}</Box>
-            </>
-            <>
-              <Box component="dt">{"GOV.UK Notify"}</Box>
-              <Box component="dd">
-                {data.govnotifyPersonalisation?.helpEmail || <NotConfigured />}
-              </Box>
-            </>
-            <>
-              <Box component="dt">{"GOV.UK Pay"}</Box>
-              <Box component="dd">
-                {data.govpayEnabled ? <Configured /> : <NotConfigured />}
-              </Box>
-            </>
-          </SummaryListTable>
-        </Grid>
-        <Grid item xs={4}>
-          <SummaryListTable dense={true}>
-            <>
-              <Box component="dt">{"Send to email"}</Box>
-              <Box component="dd">
-                {data.sendToEmailAddress || <NotConfigured />}
-              </Box>
-            </>
-            <>
-              <Box component="dt">{"BOPS"}</Box>
-              <Box component="dd">
-                {data.bopsSubmissionURL ? <Configured /> : <NotConfigured />}
-              </Box>
-            </>
-          </SummaryListTable>
-        </Grid>
-      </Grid>
-    </StyledTeam>
+      </AccordionDetails>
+    </StyledTeamAccordion>
   );
 };
 

--- a/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
@@ -1,0 +1,130 @@
+import Close from "@mui/icons-material/Close";
+import Done from "@mui/icons-material/Done";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { AdminPanelData } from "types";
+
+const StyledTeam = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "primaryColour",
+})<{ primaryColour?: string }>(({ theme, primaryColour }) => ({
+  border: `10px solid ${theme.palette.divider}`,
+  borderLeft: `10px solid ${primaryColour}`,
+  marginBottom: theme.spacing(2),
+  padding: theme.spacing(2),
+}));
+
+function Component() {
+  const adminPanelData = useStore((state) => state.adminPanelData);
+
+  return (
+    <Box p={3}>
+      <Typography variant="h1">Platform Admin Panel</Typography>
+      <Typography variant="body1" mb={3}>
+        {`This is an overview of each team's integrations and settings for the **${process.env.NODE_ENV}** environment`}
+      </Typography>
+      {adminPanelData?.map((team) => <TeamData data={team} />)}
+    </Box>
+  );
+}
+
+interface TeamData {
+  data: AdminPanelData;
+}
+
+const NotConfigured: React.FC = () => <Close color="error" fontSize="small" />;
+
+const Configured: React.FC = () => <Done color="success" fontSize="small" />;
+
+const TeamData: React.FC<TeamData> = ({ data }) => {
+  return (
+    <StyledTeam primaryColour={data.primaryColour} key={data.id}>
+      <Typography variant="h2" mb={2}>
+        {data.name}
+      </Typography>
+      <Grid
+        container
+        direction="row"
+        justifyContent="flex-start"
+        alignItems="flex-end"
+        spacing={3}
+      >
+        <Grid item xs={4}>
+          <SummaryListTable dense={true}>
+            <>
+              <Box component="dt">{"Slug"}</Box>
+              <Box component="dd">
+                <code>
+                  {`/`}
+                  {data.slug}
+                </code>
+              </Box>
+            </>
+            <>
+              <Box component="dt">{"Reference code"}</Box>
+              <Box component="dd">
+                {data.referenceCode || <NotConfigured />}
+              </Box>
+            </>
+            <>
+              <Box component="dt">{"Homepage"}</Box>
+              <Box component="dd">{data.homepage || <NotConfigured />}</Box>
+            </>
+            <>
+              <Box component="dt">{"Subdomain"}</Box>
+              <Box component="dd">{data.subdomain || <NotConfigured />}</Box>
+            </>
+          </SummaryListTable>
+        </Grid>
+        <Grid item xs={4}>
+          <SummaryListTable dense={true}>
+            <>
+              <Box component="dt">{"Planning constraints"}</Box>
+              <Box component="dd">
+                {data.planningDataEnabled ? <Configured /> : <NotConfigured />}
+              </Box>
+            </>
+            <>
+              <Box component="dt">{"Article 4s"}</Box>
+              <Box component="dd">{"?"}</Box>
+            </>
+            <>
+              <Box component="dt">{"GOV.UK Notify"}</Box>
+              <Box component="dd">
+                {data.govnotifyPersonalisation?.helpEmail || <NotConfigured />}
+              </Box>
+            </>
+            <>
+              <Box component="dt">{"GOV.UK Pay"}</Box>
+              <Box component="dd">
+                {data.govpayEnabled ? <Configured /> : <NotConfigured />}
+              </Box>
+            </>
+          </SummaryListTable>
+        </Grid>
+        <Grid item xs={4}>
+          <SummaryListTable dense={true}>
+            <>
+              <Box component="dt">{"Send to email"}</Box>
+              <Box component="dd">
+                {data.sendToEmailAddress || <NotConfigured />}
+              </Box>
+            </>
+            <>
+              <Box component="dt">{"BOPS"}</Box>
+              <Box component="dd">
+                {data.bopsSubmissionURL ? <Configured /> : <NotConfigured />}
+              </Box>
+            </>
+          </SummaryListTable>
+        </Grid>
+      </Grid>
+    </StyledTeam>
+  );
+};
+
+export default Component;

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -1,4 +1,8 @@
-import { GovUKPayment, Team } from "@opensystemslab/planx-core/types";
+import {
+  GovUKPayment,
+  NotifyPersonalisation,
+  Team,
+} from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 
 import { Store } from "./pages/FlowEditor/lib/store/index";
@@ -97,4 +101,24 @@ export interface SectionNode extends Store.node {
     title: string;
     description?: string;
   };
+}
+
+export interface AdminPanelData {
+  id: string;
+  name: string;
+  slug: string;
+  referenceCode?: string;
+  homepage?: string;
+  subdomain?: string;
+  planningDataEnabled: boolean;
+  article4sEnabled: string;
+  govnotifyPersonalisation?: NotifyPersonalisation;
+  govpayEnabled: boolean;
+  sendToEmailAddress?: string;
+  bopsSubmissionURL?: string;
+  logo?: string;
+  favicon?: string;
+  primaryColour?: string;
+  linkColour?: string;
+  actionColour?: string;
 }

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1715,6 +1715,54 @@
         filter: {}
         check: null
 - table:
+    name: teams_summary
+    schema: public
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
+    - role: platformAdmin
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
+- table:
     name: uniform_applications
     schema: public
   insert_permissions:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1718,28 +1718,6 @@
     name: teams_summary
     schema: public
   select_permissions:
-    - role: api
-      permission:
-        columns:
-          - govpay_enabled
-          - planning_data_enabled
-          - id
-          - govnotify_personalisation
-          - action_colour
-          - article_4s_enabled
-          - bops_submission_url
-          - favicon
-          - homepage
-          - link_colour
-          - logo
-          - name
-          - primary_colour
-          - reference_code
-          - send_to_email_address
-          - slug
-          - subdomain
-        filter: {}
-      comment: ""
     - role: platformAdmin
       permission:
         columns:

--- a/hasura.planx.uk/migrations/1713084872473_create_view_teams_summary/down.sql
+++ b/hasura.planx.uk/migrations/1713084872473_create_view_teams_summary/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "public"."teams_summary" CASCADE;

--- a/hasura.planx.uk/migrations/1713084872473_create_view_teams_summary/up.sql
+++ b/hasura.planx.uk/migrations/1713084872473_create_view_teams_summary/up.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE VIEW "public"."teams_summary" AS SELECT 
+    t.id,
+    t.name,
+    t.slug,
+    t.reference_code,
+    t.settings->>'homepage' as homepage,
+    t.domain as subdomain,
+    ti.has_planning_data as planning_data_enabled,
+    '@todo' as article_4s_enabled,    
+    t.notify_personalisation as govnotify_personalisation,
+    CASE 
+        WHEN coalesce(ti.production_govpay_secret, ti.staging_govpay_secret) is not null 
+        THEN true
+        ELSE false
+    END as govpay_enabled,
+    t.submission_email as send_to_email_address,
+    coalesce(ti.production_bops_submission_url, ti.staging_bops_submission_url) as bops_submission_url,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour
+FROM teams t
+    JOIN team_integrations ti on ti.team_id = t.id
+    JOIN team_themes tt on tt.team_id = t.id
+ORDER BY t.name ASC;


### PR DESCRIPTION
**Why / current challenges / user stories:** 
- As more & more councils are onboarding or preparing to go live with services, we have a fair amount of back & forth in Slack about what's done versus still outstanding when it comes to their integrations. As a Planx product owner, I want to be able to check these details myself in one place and not rely on a dev to sign into the Hasura console/database to check ad-hoc. 
- For help-issues related to send to email, devs currently have to sign into the Hasura console/database to check if a submission email is configured. As anyone on the Planx team, I want to be able to see _if_ a submission email is configured for a certain environment, and which email it is so I can respond to the council person to help them troubleshoot.

**What I'm prototyping here:**
- Creates a database view `teams_summary` which collates info related to integrations, settings, and theme info for each team. It does _not_ expose any API keys, but it does expose the email addresses a council has configured for GOV Notify autoreplies and send to email. Currently it's only selectable by Platform Admins. 
- Adds a page "Admin Panel", which similar to Global Settings, is only visible to & accessible by Platform Admin users
- Displays a simple list of all Planx teams, with ability to expand to see their currently configured stuff (lots of room for visual improvement here I'm sure, but should do the job for now!) 

![Screenshot from 2024-04-15 09-31-04](https://github.com/theopensystemslab/planx-new/assets/5132349/20b30424-7010-4bcd-8800-10dcb0d1aca8)

![Screenshot from 2024-04-15 09-16-18](https://github.com/theopensystemslab/planx-new/assets/5132349/20df4432-00c7-4ab4-9cbf-26ad3274914d)