### PR TITLE
fix(e2e): Revert change to GovPay journey

### DIFF
--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -225,11 +225,6 @@ test.describe("Gov Pay integration @regression", async () => {
     // retry the payment
     await page.getByText("Retry payment").click();
     await page.getByText("Continue with your payment").click();
-    // Re-enter card details
-    await fillGovUkCardDetails({
-      page,
-      cardNumber: cards.successful_card_number,
-    });
     await submitCardDetails(page);
 
     const { paymentId } = await waitForPaymentResponse(page, context);


### PR DESCRIPTION
✔️  Regression tests passing on this branch here - https://github.com/theopensystemslab/planx-new/actions/runs/8686048354

This PR is a follow on from https://github.com/theopensystemslab/planx-new/pull/3009 from last week. 

GovPay have now reverted the change we were fixing in the previous PR - possibly this was caused by a bug on their end?

Traces from failing regression tests show that these fields are now already pre-populated when navigating back to them.