### PR TITLE
chore: Add `decrypt()` util to scripts

### DIFF
--- a/scripts/encrypt/decrypt.ts
+++ b/scripts/encrypt/decrypt.ts
@@ -1,0 +1,33 @@
+import { decrypt } from "@opensystemslab/planx-core";
+
+/**
+ * Decrypt a secret
+ * Currently used to read secure secrets from the team_integrations table back to plain text
+ * e.g using API keys in another context, checking values
+ *
+ * @param encryptionKey - The encryption key - a 32-byte string
+ * @param secret - The encrypted secret and initialization vector in the format ${secret}:${iv}
+ * @returns The decrypted secret
+ * @example pnpm decrypt <encryptionKey> <secret>
+ */
+function main() {
+  try {
+    if (process.argv.length < 4) {
+      console.error("Usage: pnpm decrypt <encryptionKey> <secret>");
+      process.exit(1);
+    }
+    
+    const encryptionKey = process.argv[2];
+    const secret = process.argv[3];
+    const decrypted = decrypt(secret, encryptionKey);
+
+    console.log("Success!");
+    console.log(decrypted);
+  } catch (error) {
+    console.log("Error!");
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/encrypt/encrypt.ts
+++ b/scripts/encrypt/encrypt.ts
@@ -5,20 +5,20 @@ import { encrypt } from "@opensystemslab/planx-core";
  * Currently used to generate secure secrets for the team_integrations table
  * e.g converting plain text 3rd-part API keys (such as BOPS tokens) to encrypted strings
  *
- * @param secret - The secret to be encrypted.
  * @param encryptionKey - The encryption key - a 32-byte string
+ * @param secret - The secret to be encrypted.
  * @returns The encrypted secret and initialization vector in the format ${secret}:${iv}
- * @example pnpm encode <secret> <encryptionKey> 
+ * @example pnpm encrypt <encryptionKey> <secret>
  */
 function main() {
   try {
     if (process.argv.length < 4) {
-      console.error("Usage: pnpm encode <secret> <encryptionKey>");
+      console.error("Usage: pnpm encrypt <encryptionKey> <secret>");
       process.exit(1);
     }
 
-    const secret = process.argv[2];
-    const encryptionKey = process.argv[3];
+    const encryptionKey = process.argv[2];
+    const secret = process.argv[3];
     const encrypted = encrypt(secret, encryptionKey);
 
     console.log("Success!");

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.ts",
   "scripts": {
-    "encrypt": "ts-node index.ts"
+    "encrypt": "ts-node encrypt.ts",
+    "decrypt": "ts-node decrypt.ts"
   },
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
Seems sensible to have this in place! I've just been toggling `encypt()` with `decrypt()` when needed but it's a bit of a faff.

The order of the arguments has also been changed as this is easier for writing or reading multiple values (the key stays constant, and only the secret needs to change).