### PR TITLE
feat: Tab styling for editor browser preview / history

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -8,6 +8,7 @@ import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
+import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -18,7 +19,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
-import Tab from '@mui/material/Tab';
+import Tab, { tabClasses } from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -55,7 +56,7 @@ const EmbeddedBrowser = styled(Box)(({ theme }) => ({
   },
 }));
 
-const PreviewContainer = styled(Box)(() => ({
+const SidebarContainer = styled(Box)(() => ({
   overflow: "auto",
   flex: 1,
   background: "#fff",
@@ -93,6 +94,10 @@ const TabList = styled(Box)(({ theme }) => ({
   "& .MuiTabs-root": {
     minHeight: "0",
   },
+  // Hide default MUI indicator as we're using custom styling
+  "& .MuiTabs-indicator": {
+    display: "none",
+  },
 }));
 
 
@@ -109,13 +114,12 @@ const StyledTab = styled(Tab)(({ theme }) => ({
   margin: theme.spacing(0, 0.5),
   marginBottom: "-1px",
   padding: "0.5em",
-  // Using as placeholder stying for active/current tab
-  "&[data-state='active']": {
+  [`&.${tabClasses.selected}`]: {
     background: theme.palette.background.default,
     borderColor: theme.palette.border.main,
     borderBottomColor: theme.palette.common.white,
     color: theme.palette.text.primary,
-    },
+  },
 })) as typeof Tab;
 
 
@@ -155,6 +159,8 @@ interface AlteredNode {
   type: TYPES;
   data?: any;
 }
+
+type SideBarTabs = "PreviewBrowser" | "History"
 
 const AlteredNodeListItem = (props: { node: AlteredNode }) => {
   const { node } = props;
@@ -388,6 +394,11 @@ const PreviewBrowser: React.FC<{
   const [alteredNodes, setAlteredNodes] = useState<AlteredNode[]>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
+  const [activeTab, setActiveTab] = useState<SideBarTabs>("PreviewBrowser");
+
+  const handleChange = (event: React.SyntheticEvent, newValue: SideBarTabs) => {
+    setActiveTab(newValue);
+  };
 
   const _lastPublishedRequest = useAsync(async () => {
     const date = await lastPublished(flowId);
@@ -618,14 +629,23 @@ const PreviewBrowser: React.FC<{
         </Box>
       </Header>
       <TabList>
-        <Tabs centered aria-label="">
-          <StyledTab disableRipple data-state="active" label="Preview" />
-          <StyledTab disableRipple label="History" />
+        <Tabs centered onChange={handleChange} value={activeTab} aria-label="">
+          <StyledTab disableFocusRipple disableTouchRipple disableRipple value="PreviewBrowser" label="Preview" />
+          <StyledTab disableFocusRipple disableTouchRipple disableRipple value="History" label="History" />
         </Tabs>
       </TabList>
-      <PreviewContainer>
-        <Questions previewEnvironment="editor" key={String(key)} />
-      </PreviewContainer>
+      {activeTab === "PreviewBrowser" &&
+        <SidebarContainer>
+          <Questions previewEnvironment="editor" key={String(key)} />
+        </SidebarContainer>
+      }
+      {activeTab === "History" &&
+        <SidebarContainer py={3}>
+          <Container>
+            <p>History</p>
+          </Container>
+        </SidebarContainer>
+      }
       {showDebugConsole && <DebugConsole />}
     </EmbeddedBrowser>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -46,6 +46,7 @@ const EmbeddedBrowser = styled(Box)(({ theme }) => ({
   bottom: "0",
   width: "500px",
   display: "flex",
+  flexShrink: 0,
   flexDirection: "column",
   borderLeft: `1px solid ${theme.palette.border.main}`,
   background: theme.palette.background.paper,

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -18,6 +18,8 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import { styled } from "@mui/material/styles";
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
@@ -37,16 +39,85 @@ const Console = styled(Box)(() => ({
   maxHeight: "50%",
 }));
 
+const EmbeddedBrowser = styled(Box)(({ theme }) => ({
+  position: "relative",
+  top: "0",
+  right: "0",
+  bottom: "0",
+  width: "500px",
+  display: "flex",
+  flexDirection: "column",
+  borderLeft: `1px solid ${theme.palette.border.main}`,
+  background: theme.palette.background.paper,
+  "& iframe": {
+    flex: "1",
+  },
+}));
+
 const PreviewContainer = styled(Box)(() => ({
   overflow: "auto",
   flex: 1,
   background: "#fff",
 }));
 
-const Header = styled("header")(() => ({
-  display: "flex",
-  flexDirection: "column",
+const Header = styled("header")(({ theme }) => ({
+  padding: theme.spacing(1),
+  "& input": {
+    flex: "1",
+    padding: "5px",
+    marginRight: "5px",
+    background: theme.palette.common.white,
+    border: "1px solid rgba(0, 0, 0, 0.2)",
+  },
+  "& svg": {
+    cursor: "pointer",
+    opacity: "0.7",
+    margin: "6px 4px 1px 4px",
+    fontSize: "1.2rem",
+  },
 }));
+
+const TabList = styled(Box)(({ theme }) => ({
+  position: "relative",
+  // Use a pseudo element as border to allow for tab border overlap without excessive MUI overrides
+  "&::after": {
+    content: "''",
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    width: "100%",
+    height: "1px",
+    backgroundColor: theme.palette.border.main,
+  },
+  "& .MuiTabs-root": {
+    minHeight: "0",
+  },
+}));
+
+
+const StyledTab = styled(Tab)(({ theme }) => ({
+  position: "relative",
+  zIndex: 1,
+  textTransform: "none",
+  background: "transparent",
+  border: `1px solid transparent`,
+  borderBottomColor: theme.palette.border.main,
+  color: theme.palette.primary.main,
+  fontWeight: "600",
+  minHeight: "36px",
+  margin: theme.spacing(0, 0.5),
+  marginBottom: "-1px",
+  padding: "0.5em",
+  // Using as placeholder stying for active/current tab
+  "&[data-state='active']": {
+    background: theme.palette.background.default,
+    borderColor: theme.palette.border.main,
+    borderBottomColor: theme.palette.common.white,
+    color: theme.palette.text.primary,
+    },
+})) as typeof Tab;
+
+
 
 const formatLastPublish = (date: string, user: string) =>
   `Last published ${formatDistanceToNow(new Date(date))} ago by ${user}`;
@@ -335,7 +406,7 @@ const PreviewBrowser: React.FC<{
   const teamSlug = window.location.pathname.split("/")[1];
 
   return (
-    <Box id="embedded-browser">
+    <EmbeddedBrowser id="embedded-browser">
       <Header>
         <Box width="100%" display="flex">
           <input
@@ -545,11 +616,17 @@ const PreviewBrowser: React.FC<{
           </Box>
         </Box>
       </Header>
+      <TabList>
+        <Tabs centered aria-label="">
+          <StyledTab disableRipple data-state="active" label="Preview" />
+          <StyledTab disableRipple label="History" />
+        </Tabs>
+      </TabList>
       <PreviewContainer>
         <Questions previewEnvironment="editor" key={String(key)} />
       </PreviewContainer>
       {showDebugConsole && <DebugConsole />}
-    </Box>
+    </EmbeddedBrowser>
   );
 });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -97,6 +97,8 @@ const Root = styled(Box)(({ theme }) => ({
   left: 0,
   right: 0,
   minHeight: `calc(100% - ${HEADER_HEIGHT}px)`,
+  // Ensure settings panels sit above editor content with explicit z-index set, will be redundent when we move to side-tabbed settings
+  zIndex: "100",
   [`& .${classes.tabs}`]: {
     backgroundColor: theme.palette.border.main,
   },

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -98,7 +98,7 @@ const Root = styled(Box)(({ theme }) => ({
   right: 0,
   minHeight: `calc(100% - ${HEADER_HEIGHT}px)`,
   // Ensure settings panels sit above editor content with explicit z-index set, will be redundent when we move to side-tabbed settings
-  zIndex: "100",
+  zIndex: theme.zIndex.appBar,
   [`& .${classes.tabs}`]: {
     backgroundColor: theme.palette.border.main,
   },
@@ -107,7 +107,6 @@ const Root = styled(Box)(({ theme }) => ({
     backgroundColor: "#f2f2f2",
     zIndex: 0,
   },
-  zIndex: theme.zIndex.appBar,
 }));
 
 const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -37,39 +37,6 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   overflow: hidden;
 }
 
-#embedded-browser {
-  position: relative;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 500px;
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  border-left: 1px solid #ccc;
-  header {
-    input {
-      flex: 1;
-      padding: 5px;
-      margin-right: 5px;
-      background: white;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-    }
-    svg {
-      cursor: pointer;
-      opacity: 0.7;
-      margin: 6px 4px 1px 4px;
-      font-size: 1.2rem;
-    }
-    display: flex;
-    background: #ddd;
-    padding: 10px;
-  }
-  iframe {
-    flex: 1;
-  }
-}
-
 #editor {
   flex: 1;
   overflow: auto;


### PR DESCRIPTION
# What does this PR do?

- Adds tabbed menu to the browser preview in the editor sidebar to allow for switching between browser preview and history views
- Updates React states for tab functionality