### PR TITLE
feat: add option to skipValidation when using `/digital-planning-application` admin endpoint

### DIFF
--- a/api.planx.uk/modules/admin/session/digitalPlanningData.test.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.test.ts
@@ -66,4 +66,15 @@ describe("Digital Planning Application payload admin endpoint", () => {
         expect(res.body).toEqual(expectedPlanningPermissionPayload),
       );
   });
+
+  it("returns an invalid JSON payload if the skipValidation query param is set", async () => {
+    await supertest(app)
+      .get(endpoint`123`.concat("?skipValidation=true"))
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(200)
+      .expect("content-type", "application/json; charset=utf-8")
+      .then((res) =>
+        expect(res.body).toEqual(expectedPlanningPermissionPayload),
+      );
+  });
 });

--- a/api.planx.uk/modules/admin/session/digitalPlanningData.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.ts
@@ -11,6 +11,11 @@ import { $api } from "../../../client";
  *      - admin
  *    parameters:
  *      - $ref: '#/components/parameters/sessionId'
+ *      - in: query
+ *        name: skipValidation
+ *        type: boolean
+ *        required: false
+ *        description: If invalid JSON data should still be returned, instead of logging validation errors
  *    security:
  *      - bearerAuth: []
  */
@@ -20,9 +25,17 @@ export const getDigitalPlanningApplicationPayload = async (
   next: NextFunction,
 ) => {
   try {
+    let skipValidation = false;
+    if (req.query?.skipValidation) {
+      skipValidation =
+        (req.query.skipValidation as string).toLowerCase() === "true";
+    }
+
     const data = await $api.export.digitalPlanningDataPayload(
       req.params.sessionId,
+      skipValidation,
     );
+
     res.set("content-type", "application/json");
     return res.send(data);
   } catch (error) {

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f48e494",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#15bde6b",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7ff62e4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f48e494",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f48e494
-    version: github.com/theopensystemslab/planx-core/f48e494
+    specifier: git+https://github.com/theopensystemslab/planx-core#15bde6b
+    version: github.com/theopensystemslab/planx-core/15bde6b
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8411,8 +8411,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/f48e494:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f48e494}
+  github.com/theopensystemslab/planx-core/15bde6b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/15bde6b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7ff62e4
-    version: github.com/theopensystemslab/planx-core/7ff62e4
+    specifier: git+https://github.com/theopensystemslab/planx-core#f48e494
+    version: github.com/theopensystemslab/planx-core/f48e494
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8411,8 +8411,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/7ff62e4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7ff62e4}
+  github.com/theopensystemslab/planx-core/f48e494:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f48e494}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7ff62e4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#15bde6b",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7ff62e4
-    version: github.com/theopensystemslab/planx-core/7ff62e4
+    specifier: git+https://github.com/theopensystemslab/planx-core#15bde6b
+    version: github.com/theopensystemslab/planx-core/15bde6b
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2943,8 +2943,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/7ff62e4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7ff62e4}
+  github.com/theopensystemslab/planx-core/15bde6b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/15bde6b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7ff62e4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#15bde6b",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7ff62e4
-    version: github.com/theopensystemslab/planx-core/7ff62e4
+    specifier: git+https://github.com/theopensystemslab/planx-core#15bde6b
+    version: github.com/theopensystemslab/planx-core/15bde6b
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2609,8 +2609,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/7ff62e4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7ff62e4}
+  github.com/theopensystemslab/planx-core/15bde6b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/15bde6b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -12,7 +12,7 @@
     "@mui/material": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7ff62e4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#15bde6b",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -38,8 +38,8 @@ dependencies:
     specifier: ^0.8.1
     version: 0.8.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7ff62e4
-    version: github.com/theopensystemslab/planx-core/7ff62e4(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#15bde6b
+    version: github.com/theopensystemslab/planx-core/15bde6b(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/pm@2.0.3)
@@ -21139,9 +21139,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/7ff62e4(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7ff62e4}
-    id: github.com/theopensystemslab/planx-core/7ff62e4
+  github.com/theopensystemslab/planx-core/15bde6b(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/15bde6b}
+    id: github.com/theopensystemslab/planx-core/15bde6b
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
Relies on https://github.com/theopensystemslab/planx-core/pull/353

**Testing:**
- I copied Freya's failed staging payload to this pizza
- This admin endpoint displays validation errors as before https://api.3021.planx.pizza/admin/session/22d8d2ee-df1f-4696-9713-fc366561ee98/digital-planning-application
- Adding the `skipValidation` query param now displays the invalid data payload https://api.3021.planx.pizza/admin/session/22d8d2ee-df1f-4696-9713-fc366561ee98/digital-planning-application?skipValidation=true 