### PR TITLE
fix(a11y): continue button should always be enabled on FindProperty & DrawBoundary

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -27,7 +27,6 @@ interface PickOSAddressProps {
   setShowPostcodeError: React.Dispatch<React.SetStateAction<boolean>>;
   initialSelectedAddress?: Option;
   showAddressSelectError: boolean;
-  setShowAddressSelectError: React.Dispatch<React.SetStateAction<boolean>>;
   id?: string;
   description?: string;
 }
@@ -55,7 +54,7 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
   );
   const [sanitizedPostcode, setSanitizedPostcode] = useState<string | null>(
     (props.initialPostcode && toNormalised(props.initialPostcode.trim())) ??
-    null,
+      null,
   );
   const [selectedOption, setSelectedOption] = useState<Option | undefined>(
     props.initialSelectedAddress ?? undefined,
@@ -187,7 +186,7 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
         />
       </InputLabel>
       {sanitizedPostcode && (
-        <ErrorWrapperRoot error={props.showAddressSelectError ? "Select an address to continue" : undefined} role="alert" data-testid="autocomplete-error-wrapper">
+        <ErrorWrapperRoot error={!selectedOption && props.showAddressSelectError ? "Select an address to continue" : undefined} role="alert" data-testid="autocomplete-error-wrapper">
           {/* @ts-ignore */
             <address-autocomplete
               id="address-autocomplete"

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -27,6 +27,7 @@ interface PickOSAddressProps {
   setShowPostcodeError: React.Dispatch<React.SetStateAction<boolean>>;
   initialSelectedAddress?: Option;
   showAddressSelectError: boolean;
+  setShowAddressSelectError: React.Dispatch<React.SetStateAction<boolean>>;
   id?: string;
   description?: string;
 }
@@ -186,8 +187,17 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
         />
       </InputLabel>
       {sanitizedPostcode && (
-        <ErrorWrapperRoot error={!selectedOption && props.showAddressSelectError ? "Select an address to continue" : undefined} role="alert" data-testid="autocomplete-error-wrapper">
-          {/* @ts-ignore */
+        <ErrorWrapperRoot
+          error={
+            !selectedOption && props.showAddressSelectError
+              ? "Select an address to continue"
+              : undefined
+          }
+          role="alert"
+          data-testid="autocomplete-error-wrapper"
+        >
+          {
+            /* @ts-ignore */
             <address-autocomplete
               id="address-autocomplete"
               data-testid="address-autocomplete-web-component"
@@ -196,7 +206,8 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
               osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
               arrowStyle="light"
               labelStyle="static"
-            />}
+            />
+          }
         </ErrorWrapperRoot>
       )}
     </AutocompleteWrapper>

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -27,6 +27,8 @@ interface PlotNewAddressProps {
   id?: string;
   description?: string;
   descriptionLabel?: string;
+  showSiteDescriptionError: boolean;
+  setShowSiteDescriptionError: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 type Coordinates = {
@@ -55,8 +57,6 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
   const [siteDescription, setSiteDescription] = useState<string | null>(
     props.initialProposedAddress?.title ?? null,
   );
-  const [showSiteDescriptionError, setShowSiteDescriptionError] =
-    useState<boolean>(false);
 
   const [environment, boundaryBBox] = useStore((state) => [
     state.previewEnvironment,
@@ -99,7 +99,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
   }, [coordinates, siteDescription]);
 
   const handleSiteDescriptionCheck = () => {
-    if (!siteDescription) setShowSiteDescriptionError(true);
+    if (!siteDescription) props.setShowSiteDescriptionError(true);
   };
 
   const handleSiteDescriptionInputChange = (
@@ -170,7 +170,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
             id={`${props.id}-siteDescription`}
             value={siteDescription || ""}
             errorMessage={
-              showSiteDescriptionError && !siteDescription
+              props.showSiteDescriptionError && !siteDescription
                 ? `Enter a site description such as "Land at..."`
                 : ""
             }
@@ -182,7 +182,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
             inputProps={{
               "aria-describedby": [
                 props.description ? DESCRIPTION_TEXT : "",
-                showSiteDescriptionError && !siteDescription
+                props.showSiteDescriptionError && !siteDescription
                   ? `${ERROR_MESSAGE}-${props.id}`
                   : "",
               ]

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -310,6 +310,10 @@ describe("picking an OS address", () => {
 
     await user.type(await screen.findByLabelText("Postcode"), "SE5{enter}");
     expect(screen.getByText("Enter a valid UK postcode")).toBeInTheDocument();
+    expect(screen.getByTestId("error-wrapper")).toHaveAttribute(
+      "role",
+      "alert",
+    );
   });
 
   it("updates the address-autocomplete props when the postcode is changed", async () => {
@@ -413,6 +417,10 @@ describe("plotting a new address that does not have a uprn yet", () => {
     expect(
       screen.getByText(`Enter a site description such as "Land at..."`),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("error-wrapper")).toHaveAttribute(
+      "role",
+      "alert",
+    );
 
     // expect continue to be disabled because we have incomplete address details
     expect(screen.getByTestId("continue-button")).toBeDisabled();

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -213,11 +213,9 @@ function Component(props: Props) {
       handleSubmit={() => {
         // Handle validation (eventually formalise with yup schema?)
         if (page === "os-address") {
-          if (showPostcodeError && !address) {
-            setShowAddressSelectError(true);
-            return;
-          } else if (!address) {
+          if (!address) {
             setShowPostcodeError(true);
+            setShowAddressSelectError(true);
             return;
           } else if (!localAuthorityDistricts) {
             setShowDataFetchingError(true);

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -174,7 +174,6 @@ function Component(props: Props) {
               previouslySubmittedData?._address
             }
             showAddressSelectError={showAddressSelectError}
-            setShowAddressSelectError={setShowAddressSelectError}
             id={props.id}
             description={props.description || ""}
           />
@@ -214,11 +213,11 @@ function Component(props: Props) {
       handleSubmit={() => {
         // Handle validation (eventually formalise with yup schema?)
         if (page === "os-address") {
-          if (!address?.postcode) {
-            setShowPostcodeError(true);
-            return;
-          } else if (!address?.title) {
+          if (showPostcodeError && !address) {
             setShowAddressSelectError(true);
+            return;
+          } else if (!address) {
+            setShowPostcodeError(true);
             return;
           } else if (!localAuthorityDistricts) {
             setShowDataFetchingError(true);

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -57,10 +57,13 @@ function Component(props: Props) {
   const [boundary, setBoundary] = useState<GeoJSONObject | undefined>();
 
   const [showPostcodeError, setShowPostcodeError] = useState<boolean>(false);
-  const [showAddressSelectError, setShowAddressSelectError] = useState<boolean>(false);
-  const [showDataFetchingError, setShowDataFetchingError] = useState<boolean>(false);
+  const [showAddressSelectError, setShowAddressSelectError] =
+    useState<boolean>(false);
+  const [showDataFetchingError, setShowDataFetchingError] =
+    useState<boolean>(false);
   const [showMapError, setShowMapError] = useState<boolean>(false);
-  const [showSiteDescriptionError, setShowSiteDescriptionError] = useState<boolean>(false);
+  const [showSiteDescriptionError, setShowSiteDescriptionError] =
+    useState<boolean>(false);
 
   const teamSettings = useStore((state) => state.teamSettings);
 
@@ -174,6 +177,7 @@ function Component(props: Props) {
               previouslySubmittedData?._address
             }
             showAddressSelectError={showAddressSelectError}
+            setShowAddressSelectError={setShowAddressSelectError}
             id={props.id}
             description={props.description || ""}
           />

--- a/editor.planx.uk/src/ui/shared/ErrorWrapper.tsx
+++ b/editor.planx.uk/src/ui/shared/ErrorWrapper.tsx
@@ -15,7 +15,7 @@ export interface Props {
   role?: "alert" | "status";
 }
 
-const Root = styled(Box, {
+export const ErrorWrapperRoot = styled(Box, {
   shouldForwardProp: (prop) => prop !== "error",
 })<BoxProps & { error: Props["error"] }>(({ theme, error }) => ({
   ...(error && {
@@ -52,11 +52,11 @@ export default function ErrorWrapper({
   }, [error, trackEvent]);
 
   return (
-    <Root error={error} role={role} data-testid="error-wrapper">
+    <ErrorWrapperRoot error={error} role={role} data-testid="error-wrapper">
       <ErrorText id={inputId} data-testid={inputId} variant="body1">
         {error && error}
       </ErrorText>
       {children || null}
-    </Root>
+    </ErrorWrapperRoot>
   );
 }


### PR DESCRIPTION
WIP

Ideas / questions / todos:
- Error handling for postcode input & address autocomplete
  - Can we conditionally render address autocomplete still or should we _always_ show a disabled select until valid postcode?
- How to error handle supplemental data fetch that FindPropery does? Wrap continue button in error if loading spinner still visible?
- ErrorWrapper for maps (Plot new address & draw boundary)
- ErrorWrapper for location plan upload (re-use FileUpload validation schema?)