### PR TITLE
fix: Add zIndex value to settings to cover badge

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/index.tsx
@@ -105,6 +105,7 @@ const Root = styled(Box)(({ theme }) => ({
     backgroundColor: "#f2f2f2",
     zIndex: 0,
   },
+  zIndex: theme.zIndex.appBar,
 }));
 
 const Settings: React.FC<SettingsProps> = ({ currentTab, tabs }) => {


### PR DESCRIPTION

https://github.com/theopensystemslab/planx-new/assets/20502206/bcd53e78-fadc-4608-8f15-50fd9c44e0fb

