### PR TITLE
fix: Editor layout overflow bug

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -99,7 +99,14 @@ const FlowEditor: React.FC<any> = ({ flow, breadcrumbs }) => {
 
   return (
     <Box id="editor-container">
-      <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          overflowX: "auto",
+        }}
+      >
         <LastEdited />
         <Box id="editor" ref={scrollContainerRef} sx={{ position: "relative" }}>
           <Flow flow={flow} breadcrumbs={breadcrumbs} />


### PR DESCRIPTION
Quick / dirty fix to a very odd regression currently live on staging and production. Replicable in Chrome, Firefox and Edge.

See screenshot below of current staging and production Editor. The flow is pushing the preview web browser off-screen. 

<img width="1440" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/90550742-770a-4677-8194-e6f055052ade">



<img width="1440" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/e18af70a-5760-4418-8a3b-6452ceef58b7">

There's a commit somewhere in https://github.com/theopensystemslab/planx-new/pull/3023 which introduced this and we missed. Will take a closer look through tomorrow to try and resolve this properly, but in the meantime this at least seems to resolve things.