### PR TITLE
chore: Rotate Postgres staging password

### DIFF
--- a/infrastructure/data/Pulumi.staging.yaml
+++ b/infrastructure/data/Pulumi.staging.yaml
@@ -1,3 +1,4 @@
 config:
+  aws:profile: planx-staging
   data:db-password:
-    secure: AAABAB8n9YndCWHacrUqhkHcPPKh4iWGyB2MT8xYq55zcyp2hCSANG69CWR+6JiehY73+W/eBqA=
+    secure: AAABANyYBkbNfKWlHJPgQchQUyXbkh/jFGevy7r9Mqsx6mAxtE9ff01Z4T0nCJJ30N0GFwfd6TyvdGcdvuNuXg==


### PR DESCRIPTION
`pulumi preview --stack staging` gives the following correct output here - https://app.pulumi.com/planx/data/staging/previews/72838b03-854f-47d4-9272-9810fe91e3e0

Next steps - 
 - [x] Merge this to `main`, which injects the new password into the Hasura and ShareDB Fargate services as part of `dbRootUrl`
 - [ ] Hasura and ShareDB staging will fail to connect to db
 - [ ] Manually run `pulumi up --stack staging` in the data layer