### PR TITLE
fix: Fix `standaloneView` width

### DIFF
--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -38,7 +38,7 @@ const standaloneView = async (req: NaviRequest) => {
 
   return (
     <PublicLayout>
-      <Box component="main" id="main-content">
+      <Box component="main" id="main-content" sx={{ width: "100%" }}>
         <View />
       </Box>
     </PublicLayout>


### PR DESCRIPTION
Visual regression introduced here https://github.com/theopensystemslab/planx-new/pull/2994

Highlighted in this comment - https://github.com/theopensystemslab/planx-new/pull/3015#pullrequestreview-2005278694

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/17c7f19a-b9c8-43eb-a92b-02dfaf02d32f)
