### PR TITLE
chore: Rotate `db-password` and `metabasePgPassword` (production)

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -28,7 +28,7 @@ config:
   application:metabase-encryption-secret-key:
     secure: AAABAKQ6L5aOwZWpj9YOsaW8bOOukjt1mZuTgdKjM/3nSmF/0nM/f9c9W9DXygUFj2wtq5/iugo1UTS0+bhEn8Dr9k1Qzr2EmuGpQw==
   application:metabasePgPassword:
-    secure: AAABAExf0rBVo04aPNIRtwE8DQKc0Ti5kvf6tPM35BXPdoa7Qu3KQrErrBkGQkI52PIpb+go78s=
+    secure: AAABACVXNwP6Fo0v2/PoiWklNGRECTSYLRX/Ypk6APtvt9e4iOdqPVt5+tZULOxwqnfO+1bL4B6AAJxjt8gAbQ==
   application:ordnance-survey-api-key:
     secure: AAABAE+wD6ahxO45tq/JWp6odrHX9jOhdjlMsCqS6kFqBgJ+3T56fOSgpZ26nEftv9IwWZQh/v93tRtTDEb+uw==
   application:session-secret:

--- a/infrastructure/data/Pulumi.production.yaml
+++ b/infrastructure/data/Pulumi.production.yaml
@@ -1,3 +1,4 @@
 config:
+  aws:profile: planx-production-pulumi
   data:db-password:
-    secure: AAABAPnsX5ZyNNmZs9phKRtK6vpFQtQxIbmEp39Vkd6B9r22qS5DfIvgls0d9KSnEXNRX7z7R6g=
+    secure: AAABACXx8m8VMNORq7t4OYe7Gabo6vAdhHDU3UIE1hbiMS+S0suVD0lG0nMKKneUTOoK7jMDb7eUAE36xaGb6w==


### PR DESCRIPTION
Next steps - 
 - [ ] Merge to `main`
 - [ ] Open reverted PR as insurance policy, allow to complete CI
 - [ ]  Merge to `production`
 - [ ] On `pulumi up` in CI, new passwords will get piped into Metabase and ShareDB as env vars, connections will fail
 - [ ] Run `pulumi up --stack production` in data layer locally
 - [ ] Re-run `pulumi up` step of previous production deploy to pick up new values
