### PR TITLE
fix: Prevent editor sidebar from shrinking

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -45,6 +45,7 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA
   width: 500px;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   border-left: 1px solid #ccc;
   header {
     input {


### PR DESCRIPTION
# What does this PR do?

Quick one: prevent the editor sidebar/preview pane from shrinking if no content is present.

**Before:**
<img width="1728" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/b5c30710-0843-4c84-b15a-70caa653ce0c">


**After:**
<img width="1728" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/e8affd42-5607-4198-8e27-2d10af48493b">
