### PR TITLE
feat: add Microsoft variables to `team_integrations`

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1421,11 +1421,14 @@
         columns:
           - has_planning_data
           - id
+          - power_automate_webhook_url
           - production_bops_secret
           - production_bops_submission_url
+          - production_file_api_key
           - production_govpay_secret
           - staging_bops_secret
           - staging_bops_submission_url
+          - staging_file_api_key
           - staging_govpay_secret
           - team_id
         filter: {}

--- a/hasura.planx.uk/migrations/1713793168052_alter_table_public_team_integrations_add_column_staging_file_api_key/down.sql
+++ b/hasura.planx.uk/migrations/1713793168052_alter_table_public_team_integrations_add_column_staging_file_api_key/down.sql
@@ -1,0 +1,6 @@
+alter table "public"."team_integrations" 
+drop column "staging_file_api_key";
+alter table "public"."team_integrations" 
+drop column "production_file_api_key";
+alter table "public"."team_integrations" 
+drop column "power_automate_webhook_url";

--- a/hasura.planx.uk/migrations/1713793168052_alter_table_public_team_integrations_add_column_staging_file_api_key/up.sql
+++ b/hasura.planx.uk/migrations/1713793168052_alter_table_public_team_integrations_add_column_staging_file_api_key/up.sql
@@ -1,0 +1,8 @@
+alter table "public"."team_integrations" 
+add column "staging_file_api_key" text null
+add column "production_file_api_key" text null
+add column "power_automate_webhook_url" text null;
+
+comment on column "public"."team_integrations"."staging_file_api_key" is E'Secret allowing a council to download private S3 user files via the Planx API in the format <API_KEY>:<INITIALIZATION_VECTOR>';
+comment on column "public"."team_integrations"."production_file_api_key" is E'Secret allowing a council to download private S3 user files via the Planx API in the format <API_KEY>:<INITIALIZATION_VECTOR>';
+comment on column "public"."team_integrations"."power_automate_webhook_url" is E'Webhook URL used to notify and trigger council-managed MS Power Automate scripts to process submissions';

--- a/hasura.planx.uk/migrations/1713793168052_alter_table_public_team_integrations_add_column_staging_file_api_key/up.sql
+++ b/hasura.planx.uk/migrations/1713793168052_alter_table_public_team_integrations_add_column_staging_file_api_key/up.sql
@@ -1,7 +1,7 @@
 alter table "public"."team_integrations" 
-add column "staging_file_api_key" text null
-add column "production_file_api_key" text null
-add column "power_automate_webhook_url" text null;
+add column staging_file_api_key text null,
+add column production_file_api_key text null,
+add column power_automate_webhook_url text null;
 
 comment on column "public"."team_integrations"."staging_file_api_key" is E'Secret allowing a council to download private S3 user files via the Planx API in the format <API_KEY>:<INITIALIZATION_VECTOR>';
 comment on column "public"."team_integrations"."production_file_api_key" is E'Secret allowing a council to download private S3 user files via the Planx API in the format <API_KEY>:<INITIALIZATION_VECTOR>';


### PR DESCRIPTION
**Changes:** 
- Adds `*_file_api_key` variables per environment (will retire existing env var `FILE_API_KEY_BARNET` in a future PR)
- Adds `power_automate_webhook_url` 
  - Currently assuming that councils are going to have a _single_ environment for this
  - Still exploring authorisation options with Kev, so only storing/handling URL to begin with

**Follow-ups / future PRs:**
- [x] Update types in planx-core https://github.com/theopensystemslab/planx-core/pull/358
- [ ] Add staging columns to data sync script https://github.com/theopensystemslab/planx-new/pull/3042
- [ ] Update API
- [ ] Populate variables for Barnet and test
