### PR TITLE
chore: add new staging `team_integrations` columns to data sync script

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -35,7 +35,7 @@ done
 
 # Copy subset of team_integrations columns
 # Do not copy production values
-psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
 echo team_integrations downloaded
 
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"

--- a/scripts/seed-database/write/team_integrations.sql
+++ b/scripts/seed-database/write/team_integrations.sql
@@ -5,20 +5,24 @@ CREATE TEMPORARY TABLE sync_team_integrations (
   staging_bops_submission_url text,
   staging_bops_secret text,
   has_planning_data boolean,
-  staging_govpay_secret text
+  staging_govpay_secret text,
+  staging_file_api_key text,
+  power_automate_webhook_url text
 );
 
 \COPY sync_team_integrations FROM '/tmp/team_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
-  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret)
+  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url)
 SELECT
   id,
   team_id,
   staging_bops_submission_url,
   staging_bops_secret,
   has_planning_data,
-  staging_govpay_secret
+  staging_govpay_secret,
+  staging_file_api_key,
+  power_automate_webhook_url
 FROM
   sync_team_integrations ON CONFLICT (id) DO
 UPDATE
@@ -27,7 +31,9 @@ SET
   staging_bops_submission_url = EXCLUDED.staging_bops_submission_url,
   staging_bops_secret = EXCLUDED.staging_bops_secret,
   has_planning_data = EXCLUDED.has_planning_data,
-  staging_govpay_secret = EXCLUDED.staging_govpay_secret;
+  staging_govpay_secret = EXCLUDED.staging_govpay_secret,
+  staging_file_api_key = EXCLUDED.staging_file_api_key,
+  power_automate_webhook_url = EXCLUDED.power_automate_webhook_url;
 SELECT
   setval('team_integrations_id_seq', max(id))
 FROM


### PR DESCRIPTION
A bit of tricky sequencing with this one - Hasura should be healthy, but expect pizza db to be empty with following error because these columns aren't merged to production yet! 
![Screenshot from 2024-04-23 08-56-01](https://github.com/theopensystemslab/planx-new/assets/5132349/bf4a2ae2-889d-4ab4-8116-0d11bcec7798)

Can be safely merged later after #3040 ! 