### PR TITLE
fix: Input widths for multi input rows

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -62,7 +62,7 @@ const OptionEditor: React.FC<{
         {props.value.id ? (
           <input type="hidden" value={props.value.id} readOnly />
         ) : null}
-        <InputRowItem width="50%">
+        <InputRowItem width="200%">
           <Input
             required
             format="bold"
@@ -104,6 +104,7 @@ const OptionEditor: React.FC<{
               },
             });
           }}
+          sx={{ width: { md: "160px" }, maxWidth: "160px" }}
         />
 
         {typeof props.index !== "undefined" &&

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -44,7 +44,7 @@ const OptionEditor: React.FC<{
       {props.value.id && (
         <input type="hidden" value={props.value.id} readOnly />
       )}
-      <InputRowItem width="100%">
+      <InputRowItem width="200%">
         <Input
           required
           format="bold"


### PR DESCRIPTION
# What does this PR do?

Fixes input widths for multi-input rows in the editor modal.


### Before:

<img width="710" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/64e45749-44d0-40ed-ba2c-783b14ea8007">

<img width="710" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/f216ff57-beed-4fb3-8b29-8b79fee11da2">



### After:

<img width="710" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/e8318149-3421-4063-87dc-611f772ab552">

<img width="710" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/8df14923-506f-4328-8d10-d31da8df1217">

