### PR TITLE
chore: add Gloucester subdomain to editor envs

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -9,17 +9,18 @@ export const logger = getErrorLogger();
  */
 function getEnvForAllowedHosts(host: string) {
   switch (host) {
-    case "planningservices.medway.gov.uk":
-    case "planningservices.doncaster.gov.uk":
-    case "planningservices.lambeth.gov.uk":
-    case "planningservices.southwark.gov.uk":
+    case "planningservices.barnet.gov.uk":
     case "planningservices.buckinghamshire.gov.uk":
     case "planningservices.camden.gov.uk":
+    case "planningservices.doncaster.gov.uk":
+    case "planningservices.gateshead.gov.uk":
+    case "planningservices.gloucester.gov.uk":
+    case "planningservices.lambeth.gov.uk":
+    case "planningservices.medway.gov.uk":
+    case "planningservices.southwark.gov.uk":
     case "planningservices.stalbans.gov.uk":
-    case "planningservices.barnet.gov.uk":
     case "planningservices.tewkesbury.gov.uk":
     case "planningservices.westberks.gov.uk":
-    case "planningservices.gateshead.gov.uk":
     case "editor.planx.uk":
       return "production";
 

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -49,17 +49,18 @@ export const setPath = (flowData: Store.flow, req: NaviRequest) => {
 //      So I've hard-coded these domain names until a better solution comes along.
 //
 const PREVIEW_ONLY_DOMAINS = [
-  "planningservices.buckinghamshire.gov.uk",
-  "planningservices.lambeth.gov.uk",
-  "planningservices.southwark.gov.uk",
-  "planningservices.doncaster.gov.uk",
-  "planningservices.medway.gov.uk",
-  "planningservices.camden.gov.uk",
-  "planningservices.stalbans.gov.uk",
   "planningservices.barnet.gov.uk",
+  "planningservices.buckinghamshire.gov.uk",
+  "planningservices.camden.gov.uk",
+  "planningservices.doncaster.gov.uk",
+  "planningservices.gateshead.gov.uk",
+  "planningservices.gloucester.gov.uk",
+  "planningservices.lambeth.gov.uk",
+  "planningservices.medway.gov.uk",
+  "planningservices.southwark.gov.uk",
+  "planningservices.stalbans.gov.uk",
   "planningservices.tewkesbury.gov.uk",
   "planningservices.westberks.gov.uk",
-  "planningservices.gateshead.gov.uk",
   // XXX: un-comment the next line to test custom domains locally
   // "localhost",
 ];


### PR DESCRIPTION
Step #10 of how-to plus an alphabetic re-ordering (sorry for extra noise).

I have _not_ updated `teams.domain` on Hasura yet.