### PR TITLE
feat: display formatted edit history of a flow

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -26,6 +26,7 @@ import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { AxiosError } from "axios";
 import formatDistanceToNow from "date-fns/formatDistanceToNow";
+import { hasFeatureFlag } from "lib/featureFlags";
 import React, { useState } from "react";
 import { useAsync } from "react-use";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
@@ -33,6 +34,7 @@ import Caret from "ui/icons/Caret";
 import Input from "ui/shared/Input";
 
 import Questions from "../../Preview/Questions";
+import { EditHistory } from "..";
 import { useStore } from "../lib/store";
 
 const Console = styled(Box)(() => ({
@@ -652,7 +654,11 @@ const PreviewBrowser: React.FC<{
       {activeTab === "History" && (
         <SidebarContainer py={3}>
           <Container>
-            <FeaturePlaceholder title="Coming soon" />
+            {hasFeatureFlag("UNDO") ? (
+              <EditHistory />
+            ) : (
+              <FeaturePlaceholder title="Coming soon" />
+            )}
           </Container>
         </SidebarContainer>
       )}

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -394,7 +394,9 @@ const PreviewBrowser: React.FC<{
   const [alteredNodes, setAlteredNodes] = useState<AlteredNode[]>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
-  const [activeTab, setActiveTab] = useState<SideBarTabs>("PreviewBrowser");
+  const [activeTab, setActiveTab] = useState<SideBarTabs>(
+    hasFeatureFlag("UNDO") ? "History" : "PreviewBrowser",
+  ); // temp hack to keep History panel in view while editing/re-rendering
 
   const handleChange = (event: React.SyntheticEvent, newValue: SideBarTabs) => {
     setActiveTab(newValue);


### PR DESCRIPTION
This remains behind the "UNDO" feature flag until full functionality in place, but getting this onto `main` sooner than later should make it easier for Ian to continue working in parallel on styling while I hook up API functionality to icon button. 

**Changes:**
- Populates side panel with formatted change history of last 15 edits
- If using the "UNDO" feature flag, sets default tab to `History` rather than `PreviewBrowser` - otherwise our known rendering bug makes checking/watching consecutive edits very annoying

Run `window.featureFlags.toggle("UNDO")` for tesitng please ! 


![Screenshot from 2024-04-24 13-43-07](https://github.com/theopensystemslab/planx-new/assets/5132349/4b09992a-f46e-462b-b4ff-89d4b50a86a4)