### PR TITLE
chore: add `team_integrations.power_automate_api_key` column

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1419,18 +1419,19 @@
     - role: api
       permission:
         columns:
-          - has_planning_data
           - id
-          - power_automate_webhook_url
-          - production_bops_secret
-          - production_bops_submission_url
-          - production_file_api_key
-          - production_govpay_secret
-          - staging_bops_secret
-          - staging_bops_submission_url
-          - staging_file_api_key
-          - staging_govpay_secret
           - team_id
+          - power_automate_api_key
+          - production_bops_submission_url
+          - staging_bops_submission_url
+          - has_planning_data
+          - production_file_api_key
+          - staging_file_api_key
+          - production_bops_secret
+          - staging_bops_secret
+          - production_govpay_secret
+          - staging_govpay_secret
+          - power_automate_webhook_url
         filter: {}
     - role: public
       permission:

--- a/hasura.planx.uk/migrations/1713964927926_alter_table_public_team_integrations_add_column_power_automate_api_key/down.sql
+++ b/hasura.planx.uk/migrations/1713964927926_alter_table_public_team_integrations_add_column_power_automate_api_key/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."team_integrations" 
+drop column "power_automate_api_key";

--- a/hasura.planx.uk/migrations/1713964927926_alter_table_public_team_integrations_add_column_power_automate_api_key/up.sql
+++ b/hasura.planx.uk/migrations/1713964927926_alter_table_public_team_integrations_add_column_power_automate_api_key/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."team_integrations" add column "power_automate_api_key" text null;
+comment on column "public"."team_integrations"."power_automate_api_key" is E'API key used to make authorised requests to the Power Automate Webhook URL stored in the format <API_KEY>:<INITIALIZATION_VECTOR>';

--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -35,7 +35,7 @@ done
 
 # Copy subset of team_integrations columns
 # Do not copy production values
-psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url, power_automate_api_key FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
 echo team_integrations downloaded
 
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"

--- a/scripts/seed-database/write/team_integrations.sql
+++ b/scripts/seed-database/write/team_integrations.sql
@@ -7,13 +7,14 @@ CREATE TEMPORARY TABLE sync_team_integrations (
   has_planning_data boolean,
   staging_govpay_secret text,
   staging_file_api_key text,
-  power_automate_webhook_url text
+  power_automate_webhook_url text,
+  power_automate_api_key text
 );
 
 \COPY sync_team_integrations FROM '/tmp/team_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
-  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url)
+  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url, power_automate_api_key)
 SELECT
   id,
   team_id,
@@ -22,7 +23,8 @@ SELECT
   has_planning_data,
   staging_govpay_secret,
   staging_file_api_key,
-  power_automate_webhook_url
+  power_automate_webhook_url,
+  power_automate_api_key
 FROM
   sync_team_integrations ON CONFLICT (id) DO
 UPDATE
@@ -33,7 +35,8 @@ SET
   has_planning_data = EXCLUDED.has_planning_data,
   staging_govpay_secret = EXCLUDED.staging_govpay_secret,
   staging_file_api_key = EXCLUDED.staging_file_api_key,
-  power_automate_webhook_url = EXCLUDED.power_automate_webhook_url;
+  power_automate_webhook_url = EXCLUDED.power_automate_webhook_url,
+  power_automate_api_key = EXCLUDED.power_automate_api_key;
 SELECT
   setval('team_integrations_id_seq', max(id))
 FROM


### PR DESCRIPTION
Based on most recent testing with Kev - this allows us to make an authorised request to the Power Automate Webhook

Plan is:
- Merge this to `main` and do prod deploy
- Update value on prod db
- Run data sync script to pull down to staging/local
- Rebase #3047 & bump planx-core commit to reflect https://github.com/theopensystemslab/planx-core/pull/359