### PR TITLE
fix: OS Places LPI data mapping for `pao` should also account for `PAO_TEXT`

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -83,9 +83,10 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
           pao: [
             selectedAddress.PAO_START_NUMBER,
             selectedAddress.PAO_START_SUFFIX,
+            selectedAddress.PAO_TEXT, // populated in cases of building name only, no street number
           ]
             .filter(Boolean)
-            .join(""), // docs reference PAO_TEXT, but not found in response so roll our own
+            .join(""),
           street: selectedAddress.STREET_DESCRIPTION,
           town: selectedAddress.TOWN_NAME,
           postcode: selectedAddress.POSTCODE_LOCATOR,


### PR DESCRIPTION
See bug report & thread here: https://opendigitalplanning.slack.com/archives/C0634B4B8TT/p1714122379423959