### PR TITLE
feat: undo the last N operations to a flow

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -9,6 +9,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.2",
+    "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.1",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -28,6 +28,9 @@ dependencies:
   '@mui/icons-material':
     specifier: ^5.15.2
     version: 5.15.2(@mui/material@5.15.2)(@types/react@18.2.45)(react@18.2.0)
+  '@mui/lab':
+    specifier: 5.0.0-alpha.170
+    version: 5.0.0-alpha.170(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.15.2)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0)
   '@mui/material':
     specifier: ^5.15.2
     version: 5.15.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0)
@@ -4788,7 +4791,30 @@ packages:
       '@babel/runtime': 7.24.1
       '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.45)
-      '@mui/utils': 5.15.2(@types/react@18.2.45)(react@18.2.0)
+      '@mui/utils': 5.15.14(@types/react@18.2.45)(react@18.2.0)
+      '@popperjs/core': 2.11.8
+      '@types/react': 18.2.45
+      clsx: 2.1.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@mui/base@5.0.0-beta.40(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.1
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@mui/types': 7.2.14(@types/react@18.2.45)
+      '@mui/utils': 5.15.14(@types/react@18.2.45)(react@18.2.0)
       '@popperjs/core': 2.11.8
       '@types/react': 18.2.45
       clsx: 2.1.0
@@ -4816,6 +4842,39 @@ packages:
       '@mui/material': 5.15.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.45
       react: 18.2.0
+    dev: false
+
+  /@mui/lab@5.0.0-alpha.170(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.15.2)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-0bDVECGmrNjd3+bLdcLiwYZ0O4HP5j5WSQm5DV6iA/Z9kr8O6AnvZ1bv9ImQbbX7Gj3pX4o43EKwCutj3EQxQg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material': '>=5.15.0'
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.1
+      '@emotion/react': 11.11.1(@types/react@18.2.45)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.45)(react@18.2.0)
+      '@mui/base': 5.0.0-beta.40(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/material': 5.15.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/system': 5.15.15(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react@18.2.0)
+      '@mui/types': 7.2.14(@types/react@18.2.45)
+      '@mui/utils': 5.15.14(@types/react@18.2.45)(react@18.2.0)
+      '@types/react': 18.2.45
+      clsx: 2.1.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@mui/material@5.15.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0):
@@ -5002,6 +5061,36 @@ packages:
       '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.45)(react@18.2.0)
       '@mui/private-theming': 5.15.14(@types/react@18.2.45)(react@18.2.0)
       '@mui/styled-engine': 5.15.14(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.2.0)
+      '@mui/types': 7.2.14(@types/react@18.2.45)
+      '@mui/utils': 5.15.14(@types/react@18.2.45)(react@18.2.0)
+      '@types/react': 18.2.45
+      clsx: 2.1.0
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/system@5.15.15(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.45)(react@18.2.0):
+    resolution: {integrity: sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.1
+      '@emotion/react': 11.11.1(@types/react@18.2.45)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.45)(react@18.2.0)
+      '@mui/private-theming': 5.15.14(@types/react@18.2.45)(react@18.2.0)
+      '@mui/styled-engine': 5.15.14(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.45)
       '@mui/utils': 5.15.14(@types/react@18.2.45)(react@18.2.0)
       '@types/react': 18.2.45

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -2,7 +2,7 @@ import "./components/Settings";
 import "./floweditor.scss";
 
 import { gql, useSubscription } from "@apollo/client";
-import UndoOutlined from "@mui/icons-material/UndoOutlined";
+import RestoreOutlined from "@mui/icons-material/RestoreOutlined";
 import Timeline from "@mui/lab/Timeline";
 import TimelineConnector from "@mui/lab/TimelineConnector";
 import TimelineContent from "@mui/lab/TimelineContent";
@@ -175,6 +175,10 @@ export const EditHistory = () => {
     undoOperation(flattenedOperationsData);
   };
 
+  const inFocus = (i: number): boolean => {
+    return focusedOpIndex !== undefined && i < focusedOpIndex;
+  };
+
   return (
     <Box>
       {loading && !data ? (
@@ -191,20 +195,12 @@ export const EditHistory = () => {
           {data?.operations?.map((op: Operation, i: number) => (
             <TimelineItem key={op.id}>
               <TimelineSeparator>
-                <TimelineDot
-                  color={
-                    focusedOpIndex !== undefined && i <= focusedOpIndex
-                      ? "primary"
-                      : undefined
-                  }
-                />
+                <TimelineDot color={inFocus(i) ? undefined : "primary"} />
                 {i < data.operations.length - 1 && (
                   <TimelineConnector
                     sx={{
                       bgcolor: (theme) =>
-                        focusedOpIndex !== undefined && i <= focusedOpIndex
-                          ? theme.palette.primary.main
-                          : undefined,
+                        inFocus(i) ? undefined : theme.palette.primary.main,
                     }}
                   />
                 )}
@@ -218,33 +214,46 @@ export const EditHistory = () => {
                   }}
                 >
                   <Box>
-                    <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                    <Typography
+                      variant="body1"
+                      sx={{ fontWeight: 600 }}
+                      color={inFocus(i) ? "GrayText" : "inherit"}
+                    >
                       {`${
                         op.actor
                           ? `Edited by ${op.actor?.firstName} ${op.actor?.lastName}`
                           : `Created flow`
                       }`}
                     </Typography>
-                    <Typography variant="body2">
+                    <Typography
+                      variant="body2"
+                      color={inFocus(i) ? "GrayText" : "inherit"}
+                    >
                       {formatLastEditDate(op.createdAt)}
                     </Typography>
                   </Box>
-                  {
+                  {i > 0 && op.actor && (
                     <IconButton
-                      title="Undo"
-                      aria-label="Undo"
+                      title="Restore to this point"
+                      aria-label="Restore to this point"
                       onClick={() => handleUndo(i)}
                       onMouseEnter={() => setFocusedOpIndex(i)}
                       onMouseLeave={() => setFocusedOpIndex(undefined)}
-                      disabled={!canUserEditTeam}
-                      color="primary"
                     >
-                      <UndoOutlined />
+                      <RestoreOutlined
+                        fontSize="large"
+                        color={inFocus(i) ? "inherit" : "primary"}
+                      />
                     </IconButton>
-                  }
+                  )}
                 </Box>
                 {op.data && (
-                  <Typography variant="body2" component="ul" padding={2}>
+                  <Typography
+                    variant="body2"
+                    component="ul"
+                    padding={2}
+                    color={inFocus(i) ? "GrayText" : "inherit"}
+                  >
                     {[...new Set(formatOps(flow, op.data))].map(
                       (formattedOp, i) => (
                         <li key={i}>{formattedOp}</li>

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -3,6 +3,12 @@ import "./floweditor.scss";
 
 import { gql, useSubscription } from "@apollo/client";
 import UndoOutlined from "@mui/icons-material/UndoOutlined";
+import Timeline from "@mui/lab/Timeline";
+import TimelineConnector from "@mui/lab/TimelineConnector";
+import TimelineContent from "@mui/lab/TimelineContent";
+import TimelineDot from "@mui/lab/TimelineDot";
+import TimelineItem, { timelineItemClasses } from "@mui/lab/TimelineItem";
+import TimelineSeparator from "@mui/lab/TimelineSeparator";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
@@ -174,63 +180,82 @@ export const EditHistory = () => {
       {loading && !data ? (
         <DelayedLoadingIndicator />
       ) : (
-        data?.operations?.map((op: Operation, i: number) => (
-          <Box
-            key={`container-${op.id}`}
-            marginBottom={2}
-            padding={2}
-            sx={{
-              background: (theme) => theme.palette.grey[200],
-              borderLeft: (theme) =>
-                focusedOpIndex !== undefined && i <= focusedOpIndex
-                  ? `5px solid ${theme.palette.primary.main}`
-                  : `5px solid ${theme.palette.grey[200]}`, // looks like 'none', but avoids content shifting on focus
-            }}
-          >
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "row",
-                justifyContent: "space-between",
-              }}
-            >
-              <Box>
-                <Typography variant="body1" sx={{ fontWeight: 600 }}>
-                  {`${
-                    op.actor
-                      ? `Edited by ${op.actor?.firstName} ${op.actor?.lastName}`
-                      : `Created flow`
-                  }`}
-                </Typography>
-                <Typography variant="body2">
-                  {formatLastEditDate(op.createdAt)}
-                </Typography>
-              </Box>
-              {
-                <IconButton
-                  title="Undo"
-                  aria-label="Undo"
-                  onClick={() => handleUndo(i)}
-                  onMouseEnter={() => setFocusedOpIndex(i)}
-                  onMouseLeave={() => setFocusedOpIndex(undefined)}
-                  disabled={!canUserEditTeam}
-                  color="primary"
-                >
-                  <UndoOutlined />
-                </IconButton>
-              }
-            </Box>
-            {op.data && (
-              <Typography variant="body2" component="ul" padding={2}>
-                {[...new Set(formatOps(flow, op.data))].map(
-                  (formattedOp, i) => (
-                    <li key={i}>{formattedOp}</li>
-                  ),
+        <Timeline
+          sx={{
+            [`& .${timelineItemClasses.root}:before`]: {
+              flex: 0,
+              padding: 0,
+            },
+          }}
+        >
+          {data?.operations?.map((op: Operation, i: number) => (
+            <TimelineItem key={op.id}>
+              <TimelineSeparator>
+                <TimelineDot
+                  color={
+                    focusedOpIndex !== undefined && i <= focusedOpIndex
+                      ? "primary"
+                      : undefined
+                  }
+                />
+                {i < data.operations.length - 1 && (
+                  <TimelineConnector
+                    sx={{
+                      bgcolor: (theme) =>
+                        focusedOpIndex !== undefined && i <= focusedOpIndex
+                          ? theme.palette.primary.main
+                          : undefined,
+                    }}
+                  />
                 )}
-              </Typography>
-            )}
-          </Box>
-        ))
+              </TimelineSeparator>
+              <TimelineContent>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <Box>
+                    <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                      {`${
+                        op.actor
+                          ? `Edited by ${op.actor?.firstName} ${op.actor?.lastName}`
+                          : `Created flow`
+                      }`}
+                    </Typography>
+                    <Typography variant="body2">
+                      {formatLastEditDate(op.createdAt)}
+                    </Typography>
+                  </Box>
+                  {
+                    <IconButton
+                      title="Undo"
+                      aria-label="Undo"
+                      onClick={() => handleUndo(i)}
+                      onMouseEnter={() => setFocusedOpIndex(i)}
+                      onMouseLeave={() => setFocusedOpIndex(undefined)}
+                      disabled={!canUserEditTeam}
+                      color="primary"
+                    >
+                      <UndoOutlined />
+                    </IconButton>
+                  }
+                </Box>
+                {op.data && (
+                  <Typography variant="body2" component="ul" padding={2}>
+                    {[...new Set(formatOps(flow, op.data))].map(
+                      (formattedOp, i) => (
+                        <li key={i}>{formattedOp}</li>
+                      ),
+                    )}
+                  </Typography>
+                )}
+              </TimelineContent>
+            </TimelineItem>
+          ))}
+        </Timeline>
       )}
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -184,7 +184,7 @@ export const EditHistory = () => {
               borderLeft: (theme) =>
                 focusedOpIndex !== undefined && i <= focusedOpIndex
                   ? `5px solid ${theme.palette.primary.main}`
-                  : `none`,
+                  : `5px solid ${theme.palette.grey[200]}`, // looks like 'none', but avoids content shifting on focus
             }}
           >
             <Box

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -111,7 +111,9 @@ export const LastEdited = () => {
 };
 
 export const EditHistory = () => {
-  const [focusedOpIndex, setFocusedOpIndex] = useState<number | undefined>();
+  const [focusedOpIndex, setFocusedOpIndex] = useState<number | undefined>(
+    undefined,
+  );
 
   const [flowId, flow, canUserEditTeam, undoOperation] = useStore((state) => [
     state.id,
@@ -180,7 +182,7 @@ export const EditHistory = () => {
             sx={{
               background: (theme) => theme.palette.grey[200],
               borderLeft: (theme) =>
-                focusedOpIndex && i <= focusedOpIndex
+                focusedOpIndex !== undefined && i <= focusedOpIndex
                   ? `5px solid ${theme.palette.primary.main}`
                   : `none`,
             }}


### PR DESCRIPTION
Builds on #3056 - up for discussion & testing ! 

Rather than only being able to undo the most recent operation, now I can undo any of the operations shown - but I need to understand that it will also reverse each more recent change above it (we can't cherry pick out of this list because graph structure may have changed).