### PR TITLE
feat: Styling for set component in graph

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -12,6 +12,8 @@ $padding: 10px;
 $editorPadding: 30px;
 $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADElEQVQImWO4cOECAATkAnFXdNPtAAAAAElFTkSuQmCC);
 
+$fontMonospace: "Source Code Pro", monospace;
+
 // Import custom typeface for data inputs
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap");
 
@@ -161,6 +163,11 @@ $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAA
     > span:not(:nth-child(1)) {
       margin-left: 6px;
     }
+  }
+
+  &.type-SetValue > a {
+    background: #f0f0f0;
+    font-family: $fontMonospace;
   }
 
   &.type-Section {


### PR DESCRIPTION
# What does this PR do?

Adds subtle 'data' styling to the Set Component, inheriting font family (monospace) and background from editor data input.

Before:
<img width="287" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/b6166171-5a24-434b-a657-189839d9aae0">

After:
<img width="287" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/7b2493e4-8f4f-44f8-a107-2c36326c45f5">

**Example:**
https://3066.planx.pizza/testing/set-value-append-replace