### PR TITLE
fix: Autocomplete reset/re-render on keyboard events

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -19,6 +19,7 @@ import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import React, { forwardRef, PropsWithChildren, useMemo, useState } from "react";
 import { borderedFocusStyle } from "theme";
+import Checkbox from "ui/shared/Checkbox";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import {
@@ -28,7 +29,6 @@ import {
   removeSlots,
   UserFile,
 } from "./model";
-import Checkbox from "ui/shared/Checkbox";
 
 interface SelectMultipleProps {
   uploadedFile: FileUploadSlot;
@@ -123,7 +123,12 @@ const renderGroup: AutocompleteProps<
   false,
   "div"
 >["renderGroup"] = ({ group, key, children }) => (
-  <List key={`group-${key}`} role="group" sx={{ paddingY: 0 }} aria-labelledby={`${group}-label`}>
+  <List
+    key={`group-${key}`}
+    role="group"
+    sx={{ paddingY: 0 }}
+    aria-labelledby={`${group}-label`}
+  >
     <ListSubheader
       id={`${group}-label`}
       role="presentation"
@@ -156,7 +161,7 @@ const renderOption: AutocompleteProps<
       data-testid="select-checkbox"
       checked={selected}
       inputProps={{
-        "aria-label": option.name
+        "aria-label": option.name,
       }}
     />
     <ListItemText sx={{ ml: 2 }}>{option.name}</ListItemText>
@@ -165,11 +170,37 @@ const renderOption: AutocompleteProps<
 
 const PopupIcon = <ArrowIcon sx={{ color: "primary.main" }} fontSize="large" />;
 
+/**
+ * Custom Listbox component
+ * Used to wrap options within the autocomplete and append a custom element above the option list
+ */
+const ListboxComponent = forwardRef<typeof Box, PropsWithChildren>(
+  ({ children, ...props }, ref) => (
+    <>
+      <Box>
+        <ListHeader>
+          <Typography variant="h4" component="h3" pr={3}>
+            Select all that apply
+          </Typography>
+          <Button variant="contained" color="prompt" aria-label="Close list">
+            Done
+          </Button>
+        </ListHeader>
+      </Box>
+      <Box
+        ref={ref}
+        {...props}
+        role="listbox"
+        sx={{ paddingY: "0px !important" }}
+      >
+        {children}
+      </Box>
+    </>
+  ),
+);
+
 export const SelectMultiple = (props: SelectMultipleProps) => {
   const { uploadedFile, fileList, setFileList } = props;
-  const [open, setOpen] = useState(false);
-  const closePopper = () => setOpen(false);
-  const openPopper = () => setOpen(true);
 
   const initialTags = getTagsForSlot(uploadedFile.id, fileList);
 
@@ -234,42 +265,6 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
     }
   };
 
-  /**
-   * Custom Listbox component
-   * Used to wrap options within the autocomplete and append a custom element above the option list
-   */
-  const ListboxComponent = forwardRef<typeof Box, PropsWithChildren>(
-    ({ children, ...props }, ref) => {
-      return (
-        <>
-          <Box>
-            <ListHeader>
-              <Typography variant="h4" component="h3" pr={3}>
-                Select all that apply
-              </Typography>
-              <Button
-                variant="contained"
-                color="prompt"
-                onClick={closePopper}
-                aria-label="Close list"
-              >
-                Done
-              </Button>
-            </ListHeader>
-          </Box>
-          <Box
-            ref={ref}
-            {...props}
-            role="listbox"
-            sx={{ paddingY: "0px !important" }}
-          >
-            {children}
-          </Box>
-        </>
-      );
-    },
-  );
-
   return (
     <FormControl
       key={`form-${uploadedFile.id}`}
@@ -288,9 +283,6 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
         ListboxComponent={ListboxComponent}
         multiple
         onChange={handleChange}
-        onClose={closePopper}
-        onOpen={openPopper}
-        open={open}
         options={options}
         popupIcon={PopupIcon}
         renderGroup={renderGroup}


### PR DESCRIPTION
## What does this PR do?
 - Stops drop down list "resetting" to the top when an option is selected via keyboard

## Context
Please see https://github.com/theopensystemslab/planx-new/pull/2993#discussion_r1559815505

Originally I had to nest `ListboxComponent ` this within `SelectMultiple` in order to access functions related to the state of the popper. 

What I _think_ is happening is that selecting an item with they keyboard was causing a re-render of the popper and effectively resetting the view to the top of the list.

I've actually removed these here as currently clicking "Done" counts as a clickaway as it's outside of the scope of the popper (`ref` and `props` are applied to the `role="listbox"` child element within `ListboxComponent`). This actually in effect matches the current behaviour -
 - there's no custom action being triggered by "Done" (just a close)
 - it's already not keyboard navigable as a button

### Before
After selecting an item, the focus shifts back to the first item
https://github.com/theopensystemslab/planx-new/assets/20502206/9f960cbf-6ff0-4007-a0fb-8597fe68f8ef

### After
After selecting an item, the focus remains in place
https://github.com/theopensystemslab/planx-new/assets/20502206/6e890a66-cf08-4b43-96c4-b6bc0e78a03c 