### PR TITLE
chore: finalise in-editor publishing routes

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -26,7 +26,7 @@ const SendComponent: React.FC<Props> = ({
   const fullProps = { destinations: destinations, ...props };
   if (
     window.location.pathname.endsWith("/draft") ||
-    window.location.pathname.endsWith("/amber")
+    window.location.pathname.endsWith("/preview")
   ) {
     return <SkipSendWarning {...fullProps} />;
   } else {

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -106,7 +106,7 @@ describe("Header Component - Editor Route", () => {
   });
 });
 
-for (const route of ["/published", "/amber", "/draft", "/pay", "/invite"]) {
+for (const route of ["/published", "/preview", "/draft", "/pay", "/invite"]) {
   describe(`Header Component - ${route} Routes`, () => {
     beforeAll(() => {
       jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -214,7 +214,7 @@ export const client = new ApolloClient({
 
 /**
  * Client used to make requests in all public interface
- * e.g. /published, /amber, /draft, /pay
+ * e.g. /published, /preview, /draft, /pay
  */
 export const publicClient = new ApolloClient({
   link: from([retryLink, errorLink, publicHttpLink]),

--- a/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/PreviewBrowser.tsx
@@ -352,7 +352,7 @@ const AlteredNodesSummaryContent = (props: {
       <Box pt={2}>
         <Typography variant="body2">
           {`Preview these content changes in-service before publishing `}
-          <Link href={url.replace("/published", "/amber")} target="_blank">
+          <Link href={url.replace("/published", "/preview")} target="_blank">
             {`here (opens in a new tab).`}
           </Link>
         </Typography>
@@ -426,7 +426,7 @@ const PreviewBrowser: React.FC<{
           <input
             type="text"
             disabled
-            value={props.url.replace("/published", "/amber")}
+            value={props.url.replace("/published", "/preview")}
           />
 
           <Tooltip arrow title="Refresh preview">
@@ -480,7 +480,7 @@ const PreviewBrowser: React.FC<{
 
           <Tooltip arrow title="Open preview of changes to publish">
             <Link
-              href={props.url.replace("/published", "/amber")}
+              href={props.url.replace("/published", "/preview")}
               target="_blank"
               rel="noopener noreferrer"
               color="inherit"

--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -66,26 +66,13 @@ export default isPreviewOnlyDomain
       "/:team/:flow/published": lazy(() => import("./published")), // XXX: keeps old URL working, but only for the team listed in the domain.
       "/:flow": lazy(() => import("./published")),
       "/:flow/pay": mountPayRoutes(),
-      "/:team/:flow/preview": map(async (req) =>
-        redirect(
-          `/${req.params.team}/${req.params.flow}/published${req?.search}`,
-        ),
-      ),
       // XXX: We're not sure where to redirect `/` to so for now we'll just return the default 404
       // "/": redirect("somewhere?"),
     })
   : mount({
       "/:team/:flow/published": lazy(() => import("./published")), // loads current published flow if exists, or throws Not Found if unpublished
-      "/:team/:flow/amber": lazy(() => import("./preview")), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
+      "/:team/:flow/preview": lazy(() => import("./preview")), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
       "/:team/:flow/draft": lazy(() => import("./draft")), // loads current draft flow and draft external portals
       "/:team/:flow/pay": mountPayRoutes(),
-      "/:team/:flow/preview": map(async (req) =>
-        redirect(
-          `/${req.params.team}/${req.params.flow}/published${req?.search}`,
-        ),
-      ),
-      "/:team/:flow/unpublished": map(async (req) =>
-        redirect(`/${req.params.team}/${req.params.flow}/amber`),
-      ),
       "*": editorRoutes,
     });

--- a/editor.planx.uk/src/routes/views/preview.tsx
+++ b/editor.planx.uk/src/routes/views/preview.tsx
@@ -10,7 +10,7 @@ import { getTeamFromDomain } from "routes/utils";
 import { fetchSettingsForPublishedView } from "./published";
 
 /**
- * View wrapper for /amber (in future /preview)
+ * View wrapper for /preview
  * Does not display Save & Return layout as progress is not persisted on this route
  */
 export const previewView = async (req: NaviRequest) => {
@@ -18,13 +18,13 @@ export const previewView = async (req: NaviRequest) => {
   const teamSlug =
     req.params.team || (await getTeamFromDomain(window.location.hostname));
 
-  // /amber uses the same theme & global settings as /published
+  // /preview uses the same theme & global settings as /published
   const data = await fetchSettingsForPublishedView(flowSlug, teamSlug);
   const flow = data.flows[0];
   if (!flow)
     throw new NotFoundError(`Flow ${flowSlug} not found for ${teamSlug}`);
 
-  // /amber fetches draft data of this flow and the latest published version of each external portal
+  // /preview fetches draft data of this flow and the latest published version of each external portal
   const flowData = await fetchFlattenedFlowData(flow.id);
 
   const state = useStore.getState();


### PR DESCRIPTION
- Removes temporary redirects from `/preview` to `/published` - see confirmation thread from councils that this should be updated throughout all local sites now https://opensystemslab.slack.com/archives/C5Q59R3HB/p1713872123361579
- Temporary `/amber` route is renamed to `/preview` as originally intended (note that I am _not_ redirecting `/amber` &rarr; `/preview`; since this route is only navigable to from within editor, it shouldn't really be saved/advertised anywhere!)