### PR TITLE
fix: `<fieldset>` element overflows

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -146,7 +146,6 @@ const ChecklistComponent: React.FC<Props> = ({
             container
             spacing={layout === ChecklistLayout.Images ? 2 : 0}
             component="fieldset"
-            sx={{ border: "none", padding: 0 }}
           >
             <legend style={visuallyHidden}>{text}</legend>
             {options ? (

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -35,7 +35,6 @@ const DateInputPublic: React.FC<Props> = (props) => {
     <Card handleSubmit={formik.handleSubmit}>
       <Box
         component="fieldset"
-        sx={{ p: 0, border: 0 }}
         role="group"
         aria-describedby={[
           props.description ? DESCRIPTION_TEXT : "",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -255,6 +255,11 @@ const getThemeOptions = ({
           hr: {
             marginLeft: 0,
           },
+          fieldset: {
+            minInlineSize: "unset",
+            padding: 0,
+            border: 0,
+          },
         },
       },
       MuiButtonBase: {


### PR DESCRIPTION
I think this is the route of the problem causing the recent layout quirks we've been encountering.

Regression originally introduced here - https://github.com/theopensystemslab/planx-new/pull/2976

It turns out `<fieldset>` elements have [`min-inline-size: min-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) applied by default ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#styling_with_css)). This means that child content was overflowing and affecting layouts in a number of ways.

**Broken layout on staging**
https://editor.planx.dev/opensystemslab/listed-building-consent-files

https://github.com/theopensystemslab/planx-new/assets/20502206/d49727a9-3c9c-443e-ab41-83729c015f40

**Fixed layout on pizza**
https://3072.editor.planx.pizza/opensystemslab/listed-building-consent-files