### PR TITLE
fix: Long string wrapping in filenames

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -111,7 +111,11 @@ export const UploadedFileCard: React.FC<Props> = ({
         sx={{ display: "flex", justifyContent: "space-between", width: "100%" }}
       >
         <Box mr={2}>
-          <Typography variant="body1" pb="0.25em">
+          <Typography
+            variant="body1"
+            pb="0.25em"
+            sx={{ overflowWrap: "break-word", wordBreak: "break-all" }}
+          >
             {file.path}
           </Typography>
           <FileSize variant="body2">{formatBytes(file.size)}</FileSize>


### PR DESCRIPTION
# What does this PR do?

Fixes issue where long filenames are causing layout overflow on smaller screens.

**Before:**
<img width="391" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/203fe1c0-0e4d-42ae-b698-d36e0f33f064">

**After:**
<img width="391" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/e6858d4f-e1ff-478c-adc7-cbd4e89f1125">