### PR TITLE
fix: Max out modal on smaller screens -- no margin

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -65,6 +65,11 @@ export const FileTaggingModal = ({
           borderTop: (theme) => `20px solid ${theme.palette.primary.main}`,
           background: "#FFF",
           margin: (theme) => theme.spacing(2),
+          height: "100%",
+          "@media screen and (max-width: 500px)": {
+            margin: 0,
+            maxHeight: "none",
+          },
         },
       }}
     >

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -58,7 +58,7 @@ export const FileTaggingModal = ({
       maxWidth="xl"
       aria-labelledby="dialog-heading"
       PaperProps={{
-        sx: {
+        sx: (theme) => ({
           width: "100%",
           maxWidth: (theme) => theme.breakpoints.values.md,
           borderRadius: 0,
@@ -66,11 +66,11 @@ export const FileTaggingModal = ({
           background: "#FFF",
           margin: (theme) => theme.spacing(2),
           height: "100%",
-          "@media screen and (max-width: 500px)": {
+          [theme.breakpoints.down("sm")]: {
             margin: 0,
             maxHeight: "none",
           },
-        },
+        }),
       }}
     >
       <DialogContent>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -355,7 +355,7 @@ export const SelectMultiple = (props: SelectMultipleProps) => {
           },
           popper: {
             sx: {
-              boxShadow: 10,
+              boxShadow: "0 0 10px 4px rgba(0, 0, 0, 0.5)",
             },
           },
         }}

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -223,14 +223,6 @@ const getThemeOptions = ({
           },
         },
       },
-      MuiPopper: {
-        styleOverrides: {
-          root: {
-            // Override default popover box-shadow to increase visual separation
-            boxShadow: "0 0 10px 4px rgba(0, 0, 0, 0.5) !important",
-          },
-        },
-      },
       MuiContainer: {
         styleOverrides: {
           root: {
@@ -492,7 +484,7 @@ const generateTeamTheme = (
     linkColour: DEFAULT_PRIMARY_COLOR,
     logo: null,
     favicon: null,
-  }
+  },
 ): MUITheme => {
   const themeOptions = getThemeOptions(teamTheme);
   const theme = responsiveFontSizes(createTheme(themeOptions), { factor: 3 });


### PR DESCRIPTION
# What does this PR do?

Removes margins around modal windows on smaller screens, allowing the full screen area for interactions.