### PR TITLE
chore: Bump `actions/cache` to v4 (Node 20)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Cache build assets
         id: cache-react-build-assets
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**') }}
@@ -255,7 +255,7 @@ jobs:
         working-directory: infrastructure/application
       - name: Download React build assets
         id: cache-react-build-assets
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}
@@ -377,7 +377,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download React build assets
         id: cache-react-build-assets
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
       # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
       - name: NPM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-npm
         with:
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: PNPM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-pnpm
         with:

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
       # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
       - name: NPM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-npm
         with:
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: PNPM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-pnpm
         with:


### PR DESCRIPTION
Resolves this issue currently raised under GitHub actions, possibly addresses recent caching issues we believe we've been facing.

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/eb85bc7f-18f5-41e2-bf0b-e9735a8f2a9b)
