### PR TITLE
chore: Bump `pulumi/action` to v5 (Node 20)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -259,7 +259,7 @@ jobs:
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles('editor.planx.uk/**', '!editor.planx/build/**') }}
-      - uses: pulumi/actions@v4
+      - uses: pulumi/actions@v5
         with:
           command: preview
           stack-name: staging

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           name: build
           path: ./editor.planx.uk/build
-      - uses: pulumi/actions@v4
+      - uses: pulumi/actions@v5
         with:
           command: up
           stack-name: staging

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           name: build
           path: ./editor.planx.uk/build
-      - uses: pulumi/actions@v4
+      - uses: pulumi/actions@v5
         with:
           command: up
           stack-name: production


### PR DESCRIPTION
![image](https://github.com/theopensystemslab/planx-new/assets/20502206/b6a9c56f-4c79-4a0b-84ba-17316b8302dc)
