### PR TITLE
fix: Conditionally set test env header

### DIFF
--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -6,7 +6,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useState } from "react";
+import React from "react";
 
 const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
@@ -17,7 +17,10 @@ const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
 }));
 
 const TestEnvironmentBanner: React.FC = () => {
-  const [isTestEnvBannerVisible, hideTestEnvBanner] = useStore(state => [state.isTestEnvBannerVisible, state.hideTestEnvBanner]);
+  const [isTestEnvBannerVisible, hideTestEnvBanner] = useStore((state) => [
+    state.isTestEnvBannerVisible,
+    state.hideTestEnvBanner,
+  ]);
 
   if (!isTestEnvBannerVisible) return null;
 
@@ -34,13 +37,15 @@ const TestEnvironmentBanner: React.FC = () => {
         <Box display="flex" alignItems="center">
           <ReportIcon color="error" />
           <Typography variant="body2" ml={1}>
-            This is a <strong>testing environment</strong> for new features.
-            Do not use it to make permanent content changes.
+            This is a <strong>testing environment</strong> for new features. Do
+            not use it to make permanent content changes.
           </Typography>
         </Box>
         <Button size="small" onClick={hideTestEnvBanner}>
           Hide
-          <Box sx={visuallyHidden} component="span">the test environment banner</Box>
+          <Box sx={visuallyHidden} component="span">
+            the test environment banner
+          </Box>
         </Button>
       </Container>
     </TestEnvironmentWarning>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -55,7 +55,7 @@ export const editorUIStore: StateCreator<
     set({ showPreview: !get().showPreview });
   },
 
-  isTestEnvBannerVisible: true,
+  isTestEnvBannerVisible: !window.location.href.includes(".uk"),
 
   hideTestEnvBanner: () => set({ isTestEnvBannerVisible: false }),
 });


### PR DESCRIPTION
Regression introduced here - https://github.com/theopensystemslab/planx-new/pull/3028

Variable hardcoded to `true` for testing and never spotted sorry 🤦‍♂️ 

Original conditional logic now restored, see here for reference - https://github.com/theopensystemslab/planx-new/pull/3028/files#diff-9bc006127599ede1eeba7b86caa661cc41ccd88a25bbccb5fbce32f9aad0ba49L22