### PR TITLE
feat: Setup query and placeholder components for "Team members" page

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -539,9 +539,16 @@ const EditorToolbar: React.FC<{
 
             {/* Only show team settings link if inside a team route  */}
             {isTeamSettingsVisible && (
-              <MenuItem onClick={() => navigate(`${rootTeamPath()}/settings`)}>
-                Team Settings
-              </MenuItem>
+              <>
+                <MenuItem
+                  onClick={() => navigate(`${rootTeamPath()}/settings`)}
+                >
+                  Team Settings
+                </MenuItem>
+                <MenuItem onClick={() => navigate(`${rootTeamPath()}/members`)}>
+                  Team Members
+                </MenuItem>
+              </>
             )}
 
             {/* Only show flow settings link if inside a flow route  */}

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -545,9 +545,10 @@ const EditorToolbar: React.FC<{
                 >
                   Team Settings
                 </MenuItem>
-                <MenuItem onClick={() => navigate(`${rootTeamPath()}/members`)}>
+                {/* Hidden until feature complete */}
+                {/* <MenuItem onClick={() => navigate(`${rootTeamPath()}/members`)}>
                   Team Members
-                </MenuItem>
+                </MenuItem> */}
               </>
             )}
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -1,0 +1,19 @@
+import Box from "@mui/material/Box";
+import { Role, User } from "@opensystemslab/planx-core/types";
+import React from "react";
+
+export type TeamMember = Omit<User, "teams" | "isPlatformAdmin"> & {
+  role: Role;
+};
+
+interface Props {
+  teamMembersByRole: Record<Role, TeamMember[]>;
+}
+
+export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
+  return (
+    <Box component="pre" sx={{ fontSize: 12 }}>
+      {JSON.stringify(teamMembersByRole, null, 4)}
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -71,6 +71,8 @@ const routes = compose(
 
       return import("./flow");
     }),
+
+    "/members": lazy(() => import("./teamMembers")),
   }),
 );
 

--- a/editor.planx.uk/src/routes/teamMembers.tsx
+++ b/editor.planx.uk/src/routes/teamMembers.tsx
@@ -1,0 +1,76 @@
+import { Role, User } from "@opensystemslab/planx-core/types";
+import gql from "graphql-tag";
+import { groupBy } from "lodash";
+import { compose, mount, route, withData } from "navi";
+import {
+  TeamMember,
+  TeamMembers,
+} from "pages/FlowEditor/components/Team/TeamMembers";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+import { client } from "../lib/graphql";
+import { makeTitle } from "./utils";
+
+interface GetUsersForTeam {
+  users: User[];
+}
+
+const teamMembersRoutes = compose(
+  withData((req) => ({
+    mountpath: req.mountpath,
+  })),
+
+  mount({
+    "/": route(async () => {
+      const teamSlug = useStore.getState().teamSlug;
+
+      const {
+        data: { users },
+      } = await client.query<GetUsersForTeam>({
+        query: gql`
+          query GetUsersForTeam($teamSlug: String!) {
+            users(
+              where: {
+                _or: [
+                  { is_platform_admin: { _eq: true } }
+                  { teams: { team: { slug: { _eq: $teamSlug } } } }
+                ]
+              }
+            ) {
+              id
+              firstName: first_name
+              lastName: last_name
+              isPlatformAdmin: is_platform_admin
+              email
+              teams(where: { team: { slug: { _eq: $teamSlug } } }) {
+                role
+              }
+            }
+          }
+        `,
+        variables: { teamSlug },
+      });
+
+      const teamMembers: TeamMember[] = users.map((user) => ({
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        id: user.id,
+        role: user.isPlatformAdmin ? "platformAdmin" : user.teams[0].role,
+      }));
+
+      const teamMembersByRole = groupBy(teamMembers, "role") as Record<
+        Role,
+        TeamMember[]
+      >;
+
+      return {
+        title: makeTitle("Team Members"),
+        view: <TeamMembers teamMembersByRole={teamMembersByRole} />,
+      };
+    }),
+  }),
+);
+
+export default teamMembersRoutes;

--- a/editor.planx.uk/src/routes/teamMembers.tsx
+++ b/editor.planx.uk/src/routes/teamMembers.tsx
@@ -37,6 +37,7 @@ const teamMembersRoutes = compose(
                   { teams: { team: { slug: { _eq: $teamSlug } } } }
                 ]
               }
+              order_by: { first_name: asc }
             ) {
               id
               firstName: first_name


### PR DESCRIPTION
## What does this PR do?
 - Makes new page `/:team/members`
 - Sets up query to get team members, and to group by role
 - No styling, no feature flags!
 - Ready for handover to @ianjon3s!

Would be good to have a handover here to talk about how routes, queries, and components are lining up here 👍 

## Questions
 - "Inactive" users have an email address of `null` - should they be grouped by this, or are they fine within their previous roles?
 - We can add sorting to the query if we want to, that should then carry over into the `groupBy()`