### PR TITLE
wip: store every selected value in passport, regardless of granularity

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -222,17 +222,16 @@ export const previewStore: StateCreator<
           if (passportValue.length > 0) {
             const existingValue = acc.data?.[key] ?? [];
 
-            const combined = existingValue
-              .concat(passportValue)
-              .reduce(
-                (acc: string[], curr: string, _i: number, arr: string[]) => {
-                  if (!arr.some((x) => x !== curr && x.startsWith(curr))) {
-                    acc.push(curr);
-                  }
-                  return acc;
-                },
-                [],
-              );
+            const combined = existingValue.concat(passportValue);
+            // .reduce(
+            //   (acc: string[], curr: string, _i: number, arr: string[]) => {
+            //     if (!arr.some((x) => x !== curr && x.startsWith(curr))) {
+            //       acc.push(curr);
+            //     }
+            //     return acc;
+            //   },
+            //   [],
+            // );
 
             passportData[key] = uniq(combined);
           }


### PR DESCRIPTION
See thread https://opensystemslab.slack.com/archives/C5Q59R3HB/p1715070535334409

Previously, if you have a checklist with options: `new`, `new.agriculture`, `new.agriculture.glasshouse` and you select options 2 & 3 - your passport would only store 3 `new.agriculture.glasshouse` because it is the _most granular_ and any less granular future automations for `new` or `new.agriculture` could be handled based on this value alone.

On this pizza, we'll store _every_ selection you make regardless of relative granularity or duplication with pre-existing passport values. Just spinning this up as a demo to wrap our minds around scope of "problem" / possible routes to solving (code or schema heirarchy changes)