### PR TITLE
feat: Layout for undo history

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/EditHistory.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/EditHistory.tsx
@@ -8,15 +8,35 @@ import TimelineItem, { timelineItemClasses } from "@mui/lab/TimelineItem";
 import TimelineSeparator from "@mui/lab/TimelineSeparator";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import Tooltip, { tooltipClasses, TooltipProps } from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
 import { formatOps } from "@planx/graph";
 import { OT } from "@planx/graph/types";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import React, { useState } from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { formatLastEditDate, Operation } from "..";
 import { useStore } from "../lib/store";
+
+const TooltipWrap = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} placement="left-start" classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: theme.palette.background.dark,
+    fontSize: "0.8em",
+    borderRadius: 0,
+    fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  },
+}));
+
+const HistoryListItem = styled("li")(() => ({
+  listStyleType: "square",
+  overflowWrap: "break-word",
+  wordWrap: "break-word",
+}));
 
 const EditHistory = () => {
   const OPS_TO_DISPLAY = 5;
@@ -94,6 +114,7 @@ const EditHistory = () => {
       ) : (
         <Timeline
           sx={{
+            padding: 0,
             [`& .${timelineItemClasses.root}:before`]: {
               flex: 0,
               padding: 0,
@@ -122,18 +143,25 @@ const EditHistory = () => {
                   />
                 )}
               </TimelineSeparator>
-              <TimelineContent>
+              <TimelineContent
+                sx={{
+                  paddingRight: 0,
+                  minWidth: "100%",
+                  maxWidth: "100%",
+                }}
+              >
                 <Box
                   sx={{
                     display: "flex",
                     flexDirection: "row",
                     justifyContent: "space-between",
+                    alignItems: "center",
                   }}
                 >
                   <Box>
                     <Typography
                       variant="body1"
-                      sx={{ fontWeight: 600 }}
+                      sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
                       color={inUndoScope(i) ? "GrayText" : "inherit"}
                     >
                       {`${
@@ -150,18 +178,19 @@ const EditHistory = () => {
                     </Typography>
                   </Box>
                   {i > 0 && op.actor && canUserEditTeam(teamSlug) && (
-                    <IconButton
-                      title="Restore to this point"
-                      aria-label="Restore to this point"
-                      onClick={() => handleUndo(i)}
-                      onMouseEnter={() => setFocusedOpIndex(i)}
-                      onMouseLeave={() => setFocusedOpIndex(undefined)}
-                    >
-                      <RestoreOutlined
-                        fontSize="large"
-                        color={inUndoScope(i) ? "inherit" : "primary"}
-                      />
-                    </IconButton>
+                    <TooltipWrap title="Restore to this point">
+                      <IconButton
+                        aria-label="Restore to this point"
+                        onClick={() => handleUndo(i)}
+                        onMouseEnter={() => setFocusedOpIndex(i)}
+                        onMouseLeave={() => setFocusedOpIndex(undefined)}
+                      >
+                        <RestoreOutlined
+                          fontSize="large"
+                          color={inUndoScope(i) ? "inherit" : "primary"}
+                        />
+                      </IconButton>
+                    </TooltipWrap>
                   )}
                 </Box>
                 {op.data && (
@@ -171,13 +200,14 @@ const EditHistory = () => {
                       component="ul"
                       padding={2}
                       color={inUndoScope(i) ? "GrayText" : "inherit"}
+                      style={{ paddingRight: "50px" }}
                     >
                       {[...new Set(formatOps(flow, op.data))]
                         .slice(0, OPS_TO_DISPLAY)
                         .map((formattedOp, i) => (
-                          <li key={i} style={{ listStyleType: "disc" }}>
+                          <HistoryListItem key={i}>
                             {formattedOp}
-                          </li>
+                          </HistoryListItem>
                         ))}
                     </Typography>
                     {[...new Set(formatOps(flow, op.data))].length >
@@ -198,13 +228,14 @@ const EditHistory = () => {
                           component="ul"
                           padding={2}
                           color={inUndoScope(i) ? "GrayText" : "inherit"}
+                          style={{ paddingRight: "50px" }}
                         >
                           {[...new Set(formatOps(flow, op.data))]
                             .slice(OPS_TO_DISPLAY)
                             .map((formattedOp, i) => (
-                              <li key={i} style={{ listStyleType: "disc" }}>
+                              <HistoryListItem key={i}>
                                 {formattedOp}
-                              </li>
+                              </HistoryListItem>
                             ))}
                         </Typography>
                       </SimpleExpand>


### PR DESCRIPTION
# What does this PR do?

- Updates layout of undo history to make best use of available space
- Prevents layout overflow caused by long strings (urls)
- Adds MUI Tooltip to give immediate feedback on restore button
- Changes history list bullet style to square to create a subtle difference from the timeline bullet