### PR TITLE
feat: build pizzas on alpine

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -17,7 +17,7 @@ jobs:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
-          os_type: ubuntu
+          os_type: alpine
           plan: vc2-1c-1gb
           pull_request_id: ${{ env.PULLREQUEST_ID }}
           region: lhr

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -307,7 +307,7 @@ jobs:
           action: create
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
-          os_type: ubuntu
+          os_type: alpine
           plan: vc2-1c-1gb
           pull_request_id: ${{ env.PULLREQUEST_ID }}
           region: lhr
@@ -324,13 +324,19 @@ jobs:
           password: ${{ steps.create.outputs.default_password }}
           command_timeout: 20m
           script: |
-            apt-get update -y
+            apk update
+            apk add docker
+            addgroup root docker
+            rc-update add docker default
+            service docker start
+            apk add docker-cli-compose
 
+            apk add git
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
             cd planx-new
             git fetch origin "pull/${{ env.PULLREQUEST_ID }}/head" && git checkout FETCH_HEAD
 
-            apt-get install awscli -y
+            apk add aws-cli
             export AWS_ACCESS_KEY_ID=${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
             export AWS_SECRET_ACCESS_KEY=${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
             export AWS_REGION=eu-west-2
@@ -352,15 +358,21 @@ jobs:
           username: root
           password: ${{ secrets.SSH_PASSWORD }}
           command_timeout: 10m
+          # TODO: some of below script might be superfluous for server update (rather than create)
           script: |
-            apt-get update -y
+            apk update
+            apk add docker
+            addgroup root docker
+            rc-update add docker default
+            service docker start
+            apk add docker-cli-compose
 
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
             cd planx-new
             git add . && git stash
             git fetch origin "pull/${{ env.PULLREQUEST_ID }}/head" && git checkout FETCH_HEAD
 
-            apt-get install awscli -y
+            apk add aws-cli
             export AWS_ACCESS_KEY_ID=${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
             export AWS_SECRET_ACCESS_KEY=${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
             export AWS_REGION=eu-west-2

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -10,15 +10,6 @@ echo "root:$SSH_PASSWORD" | chpasswd
 # https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-22-04
 swapon --show
 
-# install docker
-apt-get install apt-transport-https ca-certificates curl gnupg lsb-release -y
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update -y
-apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
-
 # set env for this shell
 set -o allexport
 source .env.pizza


### PR DESCRIPTION
As per title - use Alpine OS instead of Ubuntu 22.04 as the base OS for our Vultr pizzas. This seems to provide some substantial time savings, according to some tests I ran (see below). In particular, the work of updating the server, ensuring docker and aws-cli are installed, and actually doing the `docker compose` command to build the container stack, all of which are encapsulated in the `Create commands` step, is reduced from an average of 10:42 to 8:05, a saving of `157s`!

I didn't compare the `Update commands` step across the different operating systems, but there may also be gains there (I think unlikely that there would be losses).

Note that Vultr now provides an OS for the new Ubuntu LTS release (24.04, Noble Numbat). This is only just released as of this PR. Once it's more mature (e.g. at least 24.04.1 is released), it may in turn provide benefits compared to Alpine (or not). We can test that theory at a later date.

## Alpine

![image](https://github.com/theopensystemslab/planx-new/assets/29084012/88b6f4ac-d6e4-4b97-82ab-eb74ae018ceb)

## Ubuntu 22.04

![image](https://github.com/theopensystemslab/planx-new/assets/29084012/42cd05f7-c567-4e6a-889a-7018281ec5b7)
