### PR TITLE
fix: add required inputs to pizza teardown workflow

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -17,7 +17,11 @@ jobs:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
+          os_type: ubuntu
+          plan: vc2-1c-1gb
           pull_request_id: ${{ env.PULLREQUEST_ID }}
+          region: lhr
+          tag: pullrequest
 
       - uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
[v2](https://github.com/theopensystemslab/vultr-action/pull/2) of vultr-action is stricter about requiring all inputs, leading to a [failed teardown](https://github.com/theopensystemslab/planx-new/actions/runs/9003898131/job/24735601568) of the pizza for #2963 - this PR should resolve this by supplying a full set of inputs in the teardown workflow.