### PR TITLE
fix(a11y): Update notice component title to h1

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -196,7 +196,7 @@ test.describe("Navigation", () => {
     await answerQuestion({ page, title: "Is this a test?", answer: "Yes" });
     await clickContinue({ page });
     await expect(
-      page.locator("h3", { hasText: "Yes! this is a test" }),
+      page.locator("h1", { hasText: "Yes! this is a test" }),
     ).toBeVisible();
 
     await page.getByTestId("backButton").click();
@@ -204,7 +204,7 @@ test.describe("Navigation", () => {
     await answerQuestion({ page, title: "Is this a test?", answer: "No" });
     await clickContinue({ page });
     await expect(
-      page.locator("h3", { hasText: "Sorry, this is a test" }),
+      page.locator("h1", { hasText: "Sorry, this is a test" }),
     ).toBeVisible();
   });
 });

--- a/e2e/tests/ui-driven/src/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/globalHelpers.ts
@@ -204,7 +204,7 @@ export async function expectNotice({
   page: Page;
   text: string;
 }) {
-  const notice = page.locator("h3", { hasText: text });
+  const notice = page.locator("h1", { hasText: text });
   await expect(notice).toBeVisible();
 }
 

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -103,7 +103,9 @@ const NoticeComponent: React.FC<Props> = (props) => {
           <Content>
             <TitleWrap>
               <ErrorOutline sx={{ width: 34, height: 34 }} />
-              <Title variant="h3">{props.title}</Title>
+              <Title variant="h3" component="h1">
+                {props.title}
+              </Title>
             </TitleWrap>
             <Box mt={2}>
               <ReactMarkdownOrHtml

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -111,6 +111,7 @@ const NoticeComponent: React.FC<Props> = (props) => {
               <ReactMarkdownOrHtml
                 textColor={textColor}
                 source={props.description}
+                openLinksOnNewTab
               />
             </Box>
           </Content>


### PR DESCRIPTION
# What does this PR do?

Quick one - updates title of the notice component to be a `<h1>` element, as recommend in DAC audit p.67.