### PR TITLE
fix(a11y): Feedback link as <a> element

### DIFF
--- a/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
@@ -23,6 +23,7 @@ const Inner = styled(Box)(({ theme }) => ({
   justifyContent: "space-between",
   alignItems: "center",
   flexWrap: "wrap",
+  gap: theme.spacing(1),
   padding: theme.spacing(0.75, 0),
 }));
 
@@ -30,7 +31,14 @@ const PhaseWrap = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "start",
   alignItems: "start",
+  flexDirection: "column",
+  textWrap: "balance",
   padding: theme.spacing(0.5, 1, 0.5, 0),
+  gap: theme.spacing(0.5),
+  [theme.breakpoints.up("sm")]: {
+    flexDirection: "row",
+    gap: theme.spacing(1),
+  },
 }));
 
 const BetaFlag = styled(Box)(({ theme }) => ({
@@ -49,6 +57,11 @@ interface Props {
 }
 
 export default function PhaseBanner(props: Props): FCReturn {
+  const handleFeedbackClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    props.handleFeedbackClick();
+  };
+
   return (
     <Root>
       <Container maxWidth="contentWrap">
@@ -61,7 +74,6 @@ export default function PhaseBanner(props: Props): FCReturn {
               alignItems="flex-start"
               flexBasis={0}
               px={1}
-              mr={1}
               py={0.5}
               fontSize={14}
               textAlign="center"
@@ -78,9 +90,9 @@ export default function PhaseBanner(props: Props): FCReturn {
             >
               This is a new service. Your{" "}
               <Link
-                component={"button"}
+                href="#"
                 sx={{ verticalAlign: "top" }}
-                onClick={() => props.handleFeedbackClick()}
+                onClick={handleFeedbackClick}
               >
                 feedback
               </Link>{" "}


### PR DESCRIPTION
# What does this PR do?

Fixes issue highlighted by DAC report p.88 (DAC_Buttons_Styled_As_Links_Usability_01) in that the feedback link is a button with the appearance of a link.

To fix this I've added a hash link (href="#") and used `preventDefault` to remove link functionality. This works similar to how GOV.UK use it here: https://design-system.service.gov.uk/components/phase-banner/

Also, the layout has been tidied up for smaller screens.