### PR TITLE
feat: Inline loading indicator for address lookup

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import Card from "@planx/components/shared/Preview/Card";
 import QuestionHeader from "@planx/components/shared/Preview/QuestionHeader";
@@ -37,6 +38,18 @@ export const FETCH_BLPU_CODES = gql`
 `;
 
 type Props = PublicProps<FindProperty>;
+
+const AddressLoadingWrap = styled(Box)(({ theme }) => ({
+  marginBottom: theme.spacing(-2.5),
+  minHeight: theme.spacing(3),
+  pointerEvents: "none",
+  [theme.breakpoints.up("md")]: {
+    position: "absolute",
+    bottom: theme.spacing(1),
+    margin: 0,
+    paddingRight: theme.spacing(14),
+  },
+}));
 
 export default Component;
 
@@ -236,12 +249,15 @@ function Component(props: Props) {
               </Link>
             </Box>
           )}
-          {Boolean(address) && isValidating && (
-            <DelayedLoadingIndicator
-              msDelayBeforeVisible={50}
-              text="Fetching data..."
-            />
-          )}
+          <AddressLoadingWrap>
+            {Boolean(address) && isValidating && (
+              <DelayedLoadingIndicator
+                msDelayBeforeVisible={50}
+                text="Fetching address data..."
+                inline
+              />
+            )}
+          </AddressLoadingWrap>
         </>
       );
     }

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -47,6 +47,10 @@ const AddressLoadingWrap = styled(Box)(({ theme }) => ({
     position: "absolute",
     bottom: theme.spacing(1),
     margin: 0,
+    "& > div": {
+      justifyContent: "flex-start",
+      paddingLeft: theme.spacing(16),
+    },
   },
 }));
 

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -47,7 +47,6 @@ const AddressLoadingWrap = styled(Box)(({ theme }) => ({
     position: "absolute",
     bottom: theme.spacing(1),
     margin: 0,
-    paddingRight: theme.spacing(14),
   },
 }));
 

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -17,10 +17,6 @@ const Root = styled(Box, {
   justifyContent: "center",
   ...(inline && {
     padding: 0,
-    [theme.breakpoints.up("md")]: {
-      justifyContent: "flex-start",
-      paddingLeft: theme.spacing(16),
-    },
   }),
 }));
 

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -10,13 +10,17 @@ export interface Props {
 
 const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== "inline",
-})<Props>(({ inline }) => ({
+})<Props>(({ inline, theme }) => ({
   padding: 60,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
   ...(inline && {
     padding: 0,
+    [theme.breakpoints.up("md")]: {
+      justifyContent: "flex-start",
+      paddingLeft: theme.spacing(16),
+    },
   }),
 }));
 

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -4,17 +4,27 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React, { useEffect, useState } from "react";
 
-const Root = styled(Box)(() => ({
+export interface Props {
+  inline?: boolean;
+}
+
+const Root = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "inline",
+})<Props>(({ inline }) => ({
   padding: 60,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+  ...(inline && {
+    padding: 0,
+  }),
 }));
 
 const DelayedLoadingIndicator: React.FC<{
   msDelayBeforeVisible?: number;
   text?: string;
-}> = ({ msDelayBeforeVisible = 0, text }) => {
+  inline?: boolean;
+}> = ({ msDelayBeforeVisible = 0, text, inline }) => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -30,8 +40,9 @@ const DelayedLoadingIndicator: React.FC<{
       aria-busy="true"
       aria-live="assertive"
       data-testid="delayed-loading-indicator"
+      inline={inline}
     >
-      <CircularProgress aria-label="Loading" />
+      <CircularProgress size={inline ? 30 : 40} aria-label="Loading" />
       <Typography variant="body2" sx={{ ml: "1rem" }}>
         {text ?? "Loading..."}
       </Typography>


### PR DESCRIPTION
## What does this PR do?

To both build on the work in progress here: https://github.com/theopensystemslab/planx-new/pull/3022,
and also as an improvement to the current setup — updates the progress indicator to be inline with the continue button.

**Changes:**
- Progress indicator given a wrapper that is omnipresent (absolute positioning on desktop), eliminates layout shift on both desktop and small screens
- `inline` prop added to `DelayedLoadingIndicator`, making it easier to use either as a full screen takeover or as part of page content
- Text updated to "Fetching address data" to be more descriptive to users

**Preview:**
<img width="886" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/98881ebc-6a43-4ff0-9c18-e36916ca74ce">

**Test:**
https://3136.planx.pizza/testing/address-lookup/published
