### PR TITLE
fix(a11y): always enable continue button on FileUpload and DrawBoundary upload page

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -139,7 +139,13 @@ test("shows the file upload option by default and requires user data to continue
   // Navigate to upload a file screen
   await user.click(screen.getByTestId("upload-file-button"));
   expect(screen.getByText("Upload a file")).toBeInTheDocument();
-  expect(screen.getByTestId("continue-button")).toBeDisabled();
+
+  // Continue is enabled by default, but requires data to proceed
+  expect(screen.getByTestId("continue-button")).toBeEnabled();
+  await user.click(screen.getByTestId("continue-button"));
+  expect(
+    screen.getByTestId("error-message-upload-location-plan"),
+  ).toBeInTheDocument();
 });
 
 test("hides the upload option and allows user to continue without drawing if editor specifies", async () => {

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -6,13 +6,27 @@ import { axe, setup } from "testUtils";
 import { PASSPORT_REQUESTED_FILES_KEY } from "../FileUploadAndLabel/model";
 import FileUpload from "./Public";
 
-test("renders correctly and blocks submit if there are no files added", async () => {
+test("renders correctly", async () => {
   const handleSubmit = jest.fn();
 
   setup(<FileUpload fn="someKey" handleSubmit={handleSubmit} />);
 
-  expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
 
+  expect(handleSubmit).toHaveBeenCalledTimes(0);
+});
+
+test("shows error if user tries to continue before adding files", async () => {
+  const handleSubmit = jest.fn();
+
+  const { user } = setup(
+    <FileUpload fn="elevations" id="elevations" handleSubmit={handleSubmit} />,
+  );
+
+  await user.click(screen.getByTestId("continue-button"));
+  expect(screen.getByText("Upload at least one file.")).toBeInTheDocument();
+
+  // Blocked by validation error
   expect(handleSubmit).toHaveBeenCalledTimes(0);
 });
 

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -115,13 +115,7 @@ const FileUpload: React.FC<Props> = (props) => {
   }, [slots]);
 
   return (
-    <Card
-      isValid={
-        slots.length > 0 &&
-        slots.every((slot) => slot.url && slot.status === "success")
-      }
-      handleSubmit={handleSubmit}
-    >
+    <Card isValid={true} handleSubmit={handleSubmit}>
       <QuestionHeader
         title={props.title}
         description={props.description}


### PR DESCRIPTION
We currently have three components that don't enable the "Continue" button by default which is flagged as a bad pattern in the "usability" feedback section of our Accessbility report: 
1. FindProperty (two pages - select & map)
2. DrawBoundary (two pages - map & upload)
3. FileUpload

These changes address enabling the continue button for all "upload" instances. I'll continue to address the map & select instances in a followup PR (see #3022).

**Testing:**
- DrawBoundary 
  - When you switch to the upload page the "continue" button should always be enabled now
  - If you click it before uploading, you should see an error wrapper around the upload preventing you from proceeding
  - If you upload a file, you can proceed successfully
- FileUpload
  -  "Continue" should be enabled by defualt
  - If you click before uploading, or while a large file is still loading, you should see an error wrapper preventing you from proceeding
  - If you upload a file, you can proceed successfully