### PR TITLE
fix(a11y): Add support for Windows high contrast mode

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -260,6 +260,13 @@ const getThemeOptions = ({
             padding: 0,
             border: 0,
           },
+          img: {
+            // a11y: Ensure images are visible in Windows high contrast mode
+            "@media (forced-colors: active)": {
+              forcedColorAdjust: "none",
+              backgroundColor: "white",
+            },
+          },
         },
       },
       MuiButtonBase: {


### PR DESCRIPTION
## What does this PR do?
- Ignores the `forced-colors` media query on `img` elements to ensure we always have high enough contrast on our images

## Context
We've been unable to recreate the issue `DAC_Inverted_Colours_Usability_01` (page 89) from the accessability report. We asked for further feedback and got the following response - 

Response from DAC -

> _I tested the inverted colours by using the windows settings and applying the ‘night sky’ preset. I was able to replicate the issue on Journey 1 step 14, however I could not replicate the issue again on Journey 1 step 34. It is frequent that <img> elements do not contrast appropriately when these settings are applied, however if these images are implemented as <svg> elements, then the CSS property ‘forced-color-adjust: auto;’ can be applied. This CSS property is used to override the default colour adjustments made by the user agent (typically the web browser) for elements that have their colour adjusted automatically to improve readability or contrast, such as in high contrast mode._

## To test
This can be tested in the browser via the Dev Tools > Rendering command panel in Chrome, where we can emulate [the forced colors media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) - 

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/fd9d7050-8b6f-47b5-8acb-c30c9823aed3)


## Questions
- Does this work on Windows "night sky" mode? I'll message on Slack to see if we can manually test once the Pizza is up
  - Tested and working as expected on Windows ✅ 
  - Please see https://opensystemslab.slack.com/archives/C5Q59R3HB/p1715608880552959 (OSL Slack)
- Is applying this at the theme level too broad? Would it better to repeat this for multiple image elements throughout the codebase?

