### PR TITLE
feat: create `submission_services_log` view

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1361,6 +1361,9 @@
                 _is_null: true
         check: null
 - table:
+    name: submission_services_log
+    schema: public
+- table:
     name: submission_services_summary
     schema: public
   select_permissions:

--- a/hasura.planx.uk/migrations/1715689232003_create view submission services log /down.sql
+++ b/hasura.planx.uk/migrations/1715689232003_create view submission services log /down.sql
@@ -1,0 +1,1 @@
+drop view if exists public.submission_services_log cascade;

--- a/hasura.planx.uk/migrations/1715689232003_create view submission services log /up.sql
+++ b/hasura.planx.uk/migrations/1715689232003_create view submission services log /up.sql
@@ -1,0 +1,45 @@
+create or replace view public.submission_services_log as 
+with payments as (
+    select 
+      session_id,
+      payment_id::text as event_id,
+      'Pay' as event_type,
+      initcap(status) as status,
+      '{}'::jsonb as response,
+      created_at
+    from payment_status
+    where status != 'created'
+      and created_at >= '2024-01-01'
+), submissions as (
+    select 
+      (seil.request -> 'payload' -> 'payload' ->> 'sessionId')::uuid as session_id,
+      se.id as event_id,
+      case 
+        when se.webhook_conf::text like '%bops%' then 'Submit to BOPS'
+        when se.webhook_conf::text like '%uniform%' then 'Submit to Uniform'
+        when se.webhook_conf::text like '%email-submission%' then 'Send to email'
+        when se.webhook_conf::text like '%upload-submission%' then 'Upload to AWS S3'
+        else se.webhook_conf::text
+      end as event_type,
+      case 
+        when seil.status = 200 then 'Success'
+        else format('Failed (%s)', seil.status)
+      end as status,
+      seil.response::jsonb,
+      seil.created_at
+    from hdb_catalog.hdb_scheduled_events se
+      left join hdb_catalog.hdb_scheduled_event_invocation_logs seil on seil.event_id = se.id
+    where se.webhook_conf::text not like '%email/%'
+      and seil.created_at >= '2024-01-01'
+), all_events as (
+    select * from payments 
+    union all
+    select * from submissions
+)
+SELECT
+  ls.flow_id,
+  ae.*
+FROM all_events ae
+  left join public.lowcal_sessions ls on ls.id = ae.session_id
+WHERE ls.flow_id is not null
+order by ae.created_at desc;


### PR DESCRIPTION
Creates a new view of submission & pay events - now exposing successful _and failed_ events - more similar to what we log in `#planx-notifications`.  

Here's a snippet of what this looks like running against an environment with submissions:
![Screenshot from 2024-05-14 14-31-46](https://github.com/theopensystemslab/planx-new/assets/5132349/52265a05-a182-4030-966a-556635ab93d0)

Next steps:
- Query via frontend and update visual display in submissions log tab
- Remove any views or outdated data structures associated with current implementation

