### PR TITLE
feat: Submissions log styles update

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -1,3 +1,4 @@
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
 import Payment from "@mui/icons-material/Payment";
@@ -54,7 +55,7 @@ const EventsLog: React.FC<GetSubmissionsResponse> = ({
 
   return (
     <TableContainer>
-      <Table>
+      <Table sx={{ tableLayout: "fixed" }}>
         <TableHead>
           <TableRow>
             <TableCell sx={{ width: 300 }}>
@@ -85,30 +86,32 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
   return (
     <React.Fragment key={submission.eventId}>
       <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
-        <TableCell
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-          }}
-        >
-          <Avatar
+        <TableCell>
+          <Box
             sx={{
-              background: "none",
-              marginRight: (theme) => theme.spacing(1),
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
             }}
           >
-            {submission.eventType === "Pay" ? (
-              <Payment
-                color={submission.status === "Success" ? "success" : "error"}
-              />
-            ) : (
-              <Send
-                color={submission.status === "Success" ? "success" : "error"}
-              />
-            )}
-          </Avatar>
-          {submission.eventType}
+            <Avatar
+              sx={{
+                background: "none",
+                marginRight: (theme) => theme.spacing(1),
+              }}
+            >
+              {submission.eventType === "Pay" ? (
+                <Payment
+                  color={submission.status === "Success" ? "success" : "error"}
+                />
+              ) : (
+                <Send
+                  color={submission.status === "Success" ? "success" : "error"}
+                />
+              )}
+            </Avatar>
+            {submission.eventType}
+          </Box>
         </TableCell>
         <TableCell>
           {format(new Date(submission.createdAt), "dd/MM/yy hh:mm:ss")}
@@ -153,6 +156,7 @@ const FormattedResponse: React.FC<Submission> = (submission) => {
           margin: 1,
           maxWidth: "contentWrap",
           overflowWrap: "break-word",
+          whiteSpace: "pre-wrap",
         }}
       >
         {submission.status === "Success"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -1,11 +1,9 @@
-import CancelIcon from "@mui/icons-material/Cancel";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
 import Payment from "@mui/icons-material/Payment";
 import Send from "@mui/icons-material/Send";
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
 import Collapse from "@mui/material/Collapse";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
@@ -59,16 +57,19 @@ const EventsLog: React.FC<GetSubmissionsResponse> = ({
       <Table sx={{ tableLayout: "fixed" }}>
         <TableHead>
           <TableRow>
-            <TableCell sx={{ width: 300 }}>
+            <TableCell sx={{ width: 240 }}>
               <strong>Event</strong>
             </TableCell>
-            <TableCell sx={{ width: 200 }}>
+            <TableCell sx={{ width: 110 }}>
+              <strong>Status</strong>
+            </TableCell>
+            <TableCell sx={{ width: 120 }}>
               <strong>Date</strong>
             </TableCell>
             <TableCell sx={{ width: 380 }}>
               <strong>Session ID</strong>
             </TableCell>
-            <TableCell sx={{ width: 70 }}></TableCell>
+            <TableCell sx={{ width: 60 }}></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -95,24 +96,18 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
               alignItems: "center",
             }}
           >
-            <Avatar
-              sx={{
-                background: "none",
-                marginRight: (theme) => theme.spacing(1.5),
-              }}
-            >
-              {submission.status === "Success" ? (
-                <CheckCircleIcon color="success" />
-              ) : (
-                <CancelIcon color="error" />
-              )}
-            </Avatar>
-
             {submission.eventType === "Pay" ? <Payment /> : <Send />}
-            <Typography variant="body2" ml={0.5}>
+            <Typography variant="body2" ml={1}>
               {submission.eventType}
             </Typography>
           </Box>
+        </TableCell>
+        <TableCell>
+          {submission.status === "Success" ? (
+            <Chip label="Success" size="small" color="success" />
+          ) : (
+            <Chip label="Error" size="small" color="error" />
+          )}
         </TableCell>
         <TableCell>
           {format(new Date(submission.createdAt), "dd/MM/yy hh:mm:ss")}
@@ -129,7 +124,7 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
         </TableCell>
       </TableRow>
       <TableRow sx={{ background: (theme) => theme.palette.background.paper }}>
-        <TableCell sx={{ padding: 0, border: "none" }} colSpan={4}>
+        <TableCell sx={{ padding: 0, border: "none" }} colSpan={5}>
           <Collapse
             in={open}
             timeout="auto"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -129,8 +129,17 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
         </TableCell>
       </TableRow>
       <TableRow sx={{ background: (theme) => theme.palette.background.paper }}>
-        <TableCell sx={{ paddingBottom: 0, paddingTop: 0 }} colSpan={4}>
-          <Collapse in={open} timeout="auto" unmountOnExit>
+        <TableCell sx={{ padding: 0, border: "none" }} colSpan={4}>
+          <Collapse
+            in={open}
+            timeout="auto"
+            unmountOnExit
+            sx={{
+              borderBottom: (theme) =>
+                `1px solid ${theme.palette.border.light}`,
+              padding: (theme) => theme.spacing(0, 1.5),
+            }}
+          >
             <FormattedResponse {...submission} />
           </Collapse>
         </TableCell>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -1,3 +1,4 @@
+import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
@@ -64,10 +65,10 @@ const EventsLog: React.FC<GetSubmissionsResponse> = ({
             <TableCell sx={{ width: 200 }}>
               <strong>Date</strong>
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ width: 380 }}>
               <strong>Session ID</strong>
             </TableCell>
-            <TableCell></TableCell>
+            <TableCell sx={{ width: 70 }}></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -97,20 +98,20 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
             <Avatar
               sx={{
                 background: "none",
-                marginRight: (theme) => theme.spacing(1),
+                marginRight: (theme) => theme.spacing(1.5),
               }}
             >
-              {submission.eventType === "Pay" ? (
-                <Payment
-                  color={submission.status === "Success" ? "success" : "error"}
-                />
+              {submission.status === "Success" ? (
+                <CheckCircleIcon color="success" />
               ) : (
-                <Send
-                  color={submission.status === "Success" ? "success" : "error"}
-                />
+                <CancelIcon color="error" />
               )}
             </Avatar>
-            {submission.eventType}
+
+            {submission.eventType === "Pay" ? <Payment /> : <Send />}
+            <Typography variant="body2" ml={0.5}>
+              {submission.eventType}
+            </Typography>
           </Box>
         </TableCell>
         <TableCell>


### PR DESCRIPTION
## What does this PR do?

Builds on the submissions log work:
https://github.com/theopensystemslab/planx-new/pull/3153

Summary of changes:
- Move border to collapsable element to prevent double border
- Prevent overflow by setting explicit column widths and wrapping code
- Use separate icons for success/error, so that it not communicated by colour only
- Wrap cell inner contents in a div with `flex` to allow cells to expand vertically

**Preview:**
https://3155.planx.pizza/testing/test-submissions/settings/submissions