### PR TITLE
feat: Capture `node_data` directly alongside feeback

### DIFF
--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -17,6 +17,7 @@ export type FeedbackMetadata = {
   nodeType?: string | null;
   device: Bowser.Parser.ParsedResult;
   userData: UserData;
+  nodeData: Store.node["data"];
 };
 
 export async function getInternalFeedbackMetadata(): Promise<FeedbackMetadata> {
@@ -40,6 +41,7 @@ export async function getInternalFeedbackMetadata(): Promise<FeedbackMetadata> {
     nodeType: node?.type ? TYPES[node.type] : null,
     device: Bowser.parse(window.navigator.userAgent),
     userData: userData,
+    nodeData: node?.data
   };
 
   return metadata;
@@ -55,6 +57,7 @@ export async function insertFeedbackMutation(data: {
   userContext?: string;
   userComment: string;
   feedbackType: string;
+  nodeData?: Store.node["data"];
 }) {
   const result = await publicClient.mutate({
     mutation: gql`
@@ -68,6 +71,7 @@ export async function insertFeedbackMutation(data: {
         $userContext: String
         $userComment: String!
         $feedbackType: feedback_type_enum_enum!
+        $nodeData: jsonb
       ) {
         insert_feedback(
           objects: {
@@ -80,6 +84,7 @@ export async function insertFeedbackMutation(data: {
             user_context: $userContext
             user_comment: $userComment
             feedback_type: $feedbackType
+            node_data: $nodeData
           }
         ) {
           affected_rows

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -239,6 +239,7 @@
           - feedback_type
           - flow_id
           - id
+          - node_data
           - node_id
           - node_type
           - status

--- a/hasura.planx.uk/migrations/1715867685564_alter_table_public_feedback_add_column_node_data/down.sql
+++ b/hasura.planx.uk/migrations/1715867685564_alter_table_public_feedback_add_column_node_data/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."feedback"."node_data" is NULL;
+
+ALTER TABLE feedback DROP COLUMN node_data;

--- a/hasura.planx.uk/migrations/1715867685564_alter_table_public_feedback_add_column_node_data/up.sql
+++ b/hasura.planx.uk/migrations/1715867685564_alter_table_public_feedback_add_column_node_data/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."feedback" add column "node_data" jsonb
+ null;
+
+comment on column "public"."feedback"."node_data" is E'The data of the node the user was on when their feedback was left';

--- a/hasura.planx.uk/migrations/1715868696352_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1715868696352_run_sql_migration/down.sql
@@ -1,0 +1,54 @@
+DROP VIEW "public"."feedback_summary";
+
+-- Most recent version of view from planx-new/hasura.planx.uk/migrations/1715784133713_run_sql_migration/up.sql
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS
+SELECT 
+    fb.id AS feedback_id,
+    t.slug AS team,
+    f.slug AS service_slug,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    COALESCE(
+        published_flow_node.data ->> 'title', 
+        published_flow_node.data ->> 'text', 
+        published_flow_node.data ->> 'flagSet'
+    ) AS node_title,
+    published_flow_node.data ->> 'description' AS node_text,
+    published_flow_node.data ->> 'info' AS help_text,
+    published_flow_node.data ->> 'policyRef' AS help_sources,
+    published_flow_node.data ->> 'howMeasured' AS help_definition,
+    COALESCE(
+        fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'single_line_address',
+        fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'title'
+    ) AS address,
+    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'uprn') AS uprn,
+    (fb.user_data -> 'passport' -> 'data' ->> 'proposal.projectType') AS project_type,
+    (fb.user_data -> 'passport' -> 'data' ->> 'property.constraints.planning') AS intersecting_constraints,
+    published_flow_node.data AS node_data
+FROM 
+    feedback fb
+LEFT JOIN 
+    flows f ON f.id = fb.flow_id
+LEFT JOIN 
+    teams t ON t.id = fb.team_id
+LEFT JOIN LATERAL 
+    ( 
+        SELECT 
+            (published_flows.data -> fb.node_id) -> 'data' AS data
+        FROM 
+            published_flows
+        WHERE 
+            published_flows.flow_id = fb.flow_id 
+            AND published_flows.created_at < fb.created_at
+        ORDER BY 
+            published_flows.created_at DESC
+        LIMIT 1
+    ) AS published_flow_node ON true;
+
+GRANT SELECT ON public.feedback_summary TO metabase_read_only;

--- a/hasura.planx.uk/migrations/1715868696352_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1715868696352_run_sql_migration/up.sql
@@ -1,0 +1,40 @@
+DROP VIEW "public"."feedback_summary";
+
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS
+SELECT 
+    fb.id AS feedback_id,
+    t.slug AS team,
+    f.slug AS service_slug,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,
+    COALESCE(
+        fb.node_data ->> 'title', 
+        fb.node_data ->> 'text', 
+        fb.node_data ->> 'flagSet'
+    ) AS node_title,
+    fb.node_data ->> 'description' AS node_text,
+    fb.node_data ->> 'info' AS help_text,
+    fb.node_data ->> 'policyRef' AS help_sources,
+    fb.node_data ->> 'howMeasured' AS help_definition,
+    COALESCE(
+        fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'single_line_address',
+        fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'title'
+    ) AS address,
+    (fb.user_data -> 'passport' -> 'data' -> '_address' ->> 'uprn') AS uprn,
+    (fb.user_data -> 'passport' -> 'data' ->> 'proposal.projectType') AS project_type,
+    (fb.user_data -> 'passport' -> 'data' ->> 'property.constraints.planning') AS intersecting_constraints
+FROM 
+    feedback fb
+LEFT JOIN 
+    flows f ON f.id = fb.flow_id
+LEFT JOIN 
+    teams t ON t.id = fb.team_id;
+    
+GRANT SELECT ON public.feedback_summary TO metabase_read_only;


### PR DESCRIPTION
## What does this PR do?
 - Adds new `node_data` column to `feedback` table
 - Writes to the `node_data` column when feedback is logged
 - Rebuilds `feedback_summary` view to read from this column

## Context
The current `feedback_summary` view in pretty slow running, likely due to the filtered join per-row to the `published_flows` table. This solution stores the node data directly alongside the feedback, thus mitigating this issue (hopefully!).

Local testing is good - significantly faster to query the view now.

## Next steps...
Once the following changes are live on production, I'm proposing to run the following SQL to populate the new column. I'm opting to do this manually instead of as a Hasura migration as it will be slightly easier to manage and monitor, and it's pretty low-risk (we're just populating a new column).
 
```sql
UPDATE feedback
SET node_data = (
    SELECT 
        (published_flows.data -> feedback.node_id) -> 'data'
    FROM 
        published_flows
    WHERE 
        published_flows.flow_id = feedback.flow_id 
        AND published_flows.created_at < feedback.created_at
    ORDER BY 
        published_flows.created_at DESC
    LIMIT 1
);
```
I've tested this locally with a copy of feedback data, however the sync script just copies a single published flow so it only populates a few records.

This matches the current join on the flow, as seen here - https://github.com/theopensystemslab/planx-new/blob/4eeea8f6f460c3997a6f62e729e735c32d5833b4/hasura.planx.uk/migrations/1715784133713_run_sql_migration/up.sql#L37-L49
