### PR TITLE
chore: Feedback sync script (example)

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -18,7 +18,19 @@ mkdir -p /tmp
 # Create sync.sql file for all our comnands which will be executed in a single transaction
 touch '/tmp/sync.sql'
 
-tables=(flows users teams flow_document_templates team_members team_themes)
+tables=(
+  # Mandatory tables
+  flows 
+  users 
+  teams 
+  flow_document_templates 
+  team_members 
+  team_themes
+  # Optional tables
+  # Please comment in if working on a feature and you require example data locally
+  # You will need to manually grant select permissions to the github_actions on production, and update main.sql
+  # feedback
+)
 
 # run copy commands on remote  db
 for table in "${tables[@]}"; do

--- a/scripts/seed-database/write/feedback.sql
+++ b/scripts/seed-database/write/feedback.sql
@@ -1,0 +1,70 @@
+-- insert feedback overwriting conflicts
+CREATE TEMPORARY TABLE sync_feedback (
+  id integer,
+  team_id integer,
+  flow_id uuid,
+  created_at timestamptz,
+  node_id text,
+  device jsonb,
+  user_data jsonb,
+  user_context text,
+  user_comment text,
+  feedback_type text,
+  status text,
+  node_type text,
+  node_data jsonb
+);
+
+\copy sync_feedback FROM '/tmp/feedback.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  feedback (
+    id,
+    team_id,
+    flow_id,
+    created_at,
+    node_id,
+    device,
+    user_data,
+    user_context,
+    user_comment,
+    feedback_type,
+    status,
+    node_type,
+    node_data
+  )
+SELECT
+  id,
+  team_id,
+  flow_id,
+  created_at,
+  node_id,
+  device,
+  user_data,
+  user_context,
+  user_comment,
+  feedback_type,
+  status,
+  node_type,
+  node_data
+FROM
+  sync_feedback ON CONFLICT (id) DO
+UPDATE
+SET
+  id = EXCLUDED.id,
+  team_id = EXCLUDED.team_id,
+  flow_id = EXCLUDED.flow_id,
+  created_at = EXCLUDED.created_at,
+  node_id = EXCLUDED.node_id,
+  device = EXCLUDED.device,
+  user_data = EXCLUDED.user_data,
+  user_context = EXCLUDED.user_context,
+  user_comment = EXCLUDED.user_comment,
+  feedback_type = EXCLUDED.feedback_type,
+  status = EXCLUDED.status,
+  node_type = EXCLUDED.node_type,
+  node_data = EXCLUDED.node_data;
+SELECT
+  setval('feedback_id_seq', max(id))
+FROM
+  feedback;

--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -1,3 +1,4 @@
+-- Mandatory tables
 \include write/users.sql
 \include write/teams.sql
 \include write/flows.sql
@@ -6,3 +7,6 @@
 \include write/team_members.sql
 \include write/team_integrations.sql
 \include write/team_themes.sql
+
+-- Optional tables
+-- \include write/feedback.sql


### PR DESCRIPTION
Not really advocating for this to be merged, but I wanted some sort of history here and it may prove to be helpful for others.

I added a `feedback.sql` so I could get a copy of production data locally.

Commenting out an item in the list seemed a nicer pattern than a flag per table or some other optional inputs to the script. A bit quick and dirty but worked well for me.