### PR TITLE
fix: Remove popper shadow placed at theme level

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -228,14 +228,6 @@ const getThemeOptions = ({
           },
         },
       },
-      MuiPopper: {
-        styleOverrides: {
-          root: {
-            // Override default popover box-shadow to increase visual separation
-            boxShadow: "0 0 10px 4px rgba(0, 0, 0, 0.5) !important",
-          },
-        },
-      },
       MuiContainer: {
         styleOverrides: {
           root: {


### PR DESCRIPTION
## What does this PR do?

Removes a visual regression introduced by placing popper shadow property at theme level.

Preview of issue:
<img width="392" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/51156018/e8db42bc-7c44-4e49-894f-465e219b7356">
