### PR TITLE
fix: Position of address loading with save and return

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -44,10 +44,13 @@ const AddressLoadingWrap = styled(Box)(({ theme }) => ({
   minHeight: theme.spacing(3),
   pointerEvents: "none",
   [theme.breakpoints.up("md")]: {
-    position: "absolute",
-    bottom: theme.spacing(1),
+    position: "relative",
     margin: 0,
+    height: 0,
+    minHeight: 0,
     "& > div": {
+      position: "absolute",
+      top: theme.spacing(5.5),
       justifyContent: "flex-start",
       paddingLeft: theme.spacing(16),
     },

--- a/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
+++ b/editor.planx.uk/src/components/DelayedLoadingIndicator.tsx
@@ -10,7 +10,7 @@ export interface Props {
 
 const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== "inline",
-})<Props>(({ inline, theme }) => ({
+})<Props>(({ inline }) => ({
   padding: 60,
   display: "flex",
   alignItems: "center",


### PR DESCRIPTION
## What does this PR do?

The updated loading indicator for address lookup is positioned `absolute` with a unit reference to `bottom`. This fails on when save & return is enabled as the button is no longer the last element in the container.

This PR adjusts so that the indicator is positioned with reference to the `top` of the container.