### PR TITLE
fix: Remove input checkbox elements and replace with spans

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -10,7 +10,6 @@ import FormControl from "@mui/material/FormControl";
 import { inputLabelClasses } from "@mui/material/InputLabel";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 import { styled } from "@mui/material/styles";
@@ -92,6 +91,31 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
   },
 }));
 
+const CustomCheckbox = styled("span")(({ theme }) => ({
+  display: "inline-flex",
+  flexShrink: 0,
+  position: "relative",
+  width: 40,
+  height: 40,
+  borderColor: theme.palette.text.primary,
+  border: "2px solid",
+  background: "transparent",
+  marginRight: theme.spacing(1.5),
+  "&.selected::after": {
+    content: "''",
+    position: "absolute",
+    height: 24,
+    width: 12,
+    borderColor: theme.palette.text.primary,
+    borderBottom: "5px solid",
+    borderRight: "5px solid",
+    left: "50%",
+    top: "42%",
+    transform: "translate(-50%, -50%) rotate(45deg)",
+    cursor: "pointer",
+  },
+}));
+
 /**
  * Function which returns the Input component used by Autocomplete
  */
@@ -108,7 +132,7 @@ const renderInput: AutocompleteProps<
       ...params.InputProps,
       notched: false,
     }}
-    label="What does this file show?"
+    label="What does this file show? (select all that apply)"
   />
 );
 
@@ -156,10 +180,8 @@ const renderOption: AutocompleteProps<
   "div"
 >["renderOption"] = (props, option, { selected }) => (
   <ListItem {...props}>
-    <Box component="span" aria-hidden="true">
-      {selected ? "✅" : "❎"}
-    </Box>
-    <ListItemText sx={{ ml: 2 }}>{option.name}</ListItemText>
+    <CustomCheckbox aria-hidden="true" className={selected ? "selected" : ""} />
+    {option.name}
   </ListItem>
 );
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -19,7 +19,6 @@ import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
 import React, { forwardRef, PropsWithChildren, useMemo } from "react";
 import { borderedFocusStyle } from "theme";
-import Checkbox from "ui/shared/Checkbox";
 
 import { FileUploadSlot } from "../FileUpload/Public";
 import {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -17,7 +17,7 @@ import { styled } from "@mui/material/styles";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import capitalize from "lodash/capitalize";
-import React, { forwardRef, PropsWithChildren, useMemo, useState } from "react";
+import React, { forwardRef, PropsWithChildren, useMemo } from "react";
 import { borderedFocusStyle } from "theme";
 import Checkbox from "ui/shared/Checkbox";
 
@@ -157,13 +157,9 @@ const renderOption: AutocompleteProps<
   "div"
 >["renderOption"] = (props, option, { selected }) => (
   <ListItem {...props}>
-    <Checkbox
-      data-testid="select-checkbox"
-      checked={selected}
-      inputProps={{
-        "aria-label": option.name,
-      }}
-    />
+    <Box component="span" aria-hidden="true">
+      {selected ? "✅" : "❎"}
+    </Box>
     <ListItemText sx={{ ml: 2 }}>{option.name}</ListItemText>
   </ListItem>
 );

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultiple.tsx
@@ -50,6 +50,10 @@ const StyledAutocomplete = styled(
   Autocomplete<Option, true, true, false, "div">,
 )(({ theme }) => ({
   marginTop: theme.spacing(2),
+  // Prevent label from overlapping expand icon
+  "& > div > label": {
+    paddingRight: theme.spacing(3),
+  },
   // Vertically center "large" size caret icon
   [`& .${autocompleteClasses.endAdornment}`]: {
     top: "unset",
@@ -86,7 +90,7 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
       textDecoration: "none",
       color: theme.palette.text.primary,
       paddingY: 0,
-      transform: "translate(14px, -22px) scale(0.85)",
+      transform: "translate(0px, -22px) scale(0.85)",
     },
   },
 }));


### PR DESCRIPTION
Quick proof of concept, we can now replace ✅ and ❎ with CSS, svgs, other elements to get a PlanX looking "checkbox".

Ian: Updated with CSS spans, matching the structure of the ARIA authoring guide exactly (no wrapper element on the label)