### PR TITLE
fix: check if council has A4 schema set via GIS API and display in admin panel

### DIFF
--- a/api.planx.uk/modules/gis/routes.ts
+++ b/api.planx.uk/modules/gis/routes.ts
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import { locationSearch } from "./service";
+import { hasArticle4Schema } from "./service/article4Schema";
 import { classifiedRoadsSearch } from "./service/classifiedRoads";
 
 const router = Router();
 
 router.get("/gis/:localAuthority", locationSearch);
+router.get("/gis/:localAuthority/article4-schema", hasArticle4Schema);
 router.get("/roads", classifiedRoadsSearch);
 
 export default router;

--- a/api.planx.uk/modules/gis/service/article4Schema.ts
+++ b/api.planx.uk/modules/gis/service/article4Schema.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from "express";
+
+import { localAuthorityMetadata } from "./digitalLand";
+
+/**
+ * @swagger
+ * /gis/{localAuthority}/article4-schema:
+ *  get:
+ *    summary: Returns whether Article 4 schema variables are configured for this local authority
+ *    description: Returns whether Article 4 schema variables are configured for this local authority. A positive "status" from this endpoint is a proxy for marking this PlanX onboarding step "complete".
+ *    tags:
+ *      - gis
+ *    parameters:
+ *      - $ref: '#/components/parameters/localAuthority'
+ *        description: Name of the Local Authority, usually the same as Planx `team`. Required until Planning Data is available for any council o article 4 variables are generalised based on permitted development rights removed rather than council
+ */
+export async function hasArticle4Schema(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    if (!req.params.localAuthority) {
+      return next({
+        status: 401,
+        message: "Missing param local authority",
+      });
+    }
+
+    const status = Object.keys(localAuthorityMetadata).includes(
+      req.params.localAuthority,
+    );
+    res.status(200).send({
+      message: `${status ? "Found" : "Did not find"} Article 4 schema for ${req.params.localAuthority}`,
+      status: status,
+    });
+  } catch (error) {
+    next({
+      status: 500,
+      message: `Error getting Article 4 schema for ${req.params.localAuthority}: ${error}`,
+    });
+  }
+}

--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -18,7 +18,7 @@ export interface LocalAuthorityMetadata {
 }
 
 /** When a team publishes their granular Article 4 data, add them to this list. Key must match team slug */
-const localAuthorityMetadata: Record<string, LocalAuthorityMetadata> = {
+export const localAuthorityMetadata: Record<string, LocalAuthorityMetadata> = {
   "barking-and-dagenham": require("./local_authorities/metadata/barkingAndDagenham"),
   barnet: require("./local_authorities/metadata/barnet"),
   birmingham: require("./local_authorities/metadata/birmingham"),

--- a/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
@@ -10,6 +10,7 @@ import Typography from "@mui/material/Typography";
 import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import useSWR from "swr";
 import { AdminPanelData } from "types";
 import Caret from "ui/icons/Caret";
 
@@ -54,6 +55,13 @@ const NotConfigured: React.FC = () => <Close color="error" fontSize="small" />;
 const Configured: React.FC = () => <Done color="success" fontSize="small" />;
 
 const TeamData: React.FC<TeamData> = ({ data }) => {
+  const a4Endpoint = `${process.env.REACT_APP_API_URL}/gis/${data.slug}/article4-schema`;
+  const fetcher = (url: string) => fetch(url).then((r) => r.json());
+  const { data: a4Check, isValidating } = useSWR(
+    () => data.slug ? a4Endpoint : null,
+    fetcher,
+  );
+
   return (
     <StyledTeamAccordion primaryColour={data.primaryColour} elevation={0}>
       <AccordionSummary
@@ -114,8 +122,8 @@ const TeamData: React.FC<TeamData> = ({ data }) => {
                 </Box>
               </>
               <>
-                <Box component="dt">{"Article 4s"}</Box>
-                <Box component="dd">{"?"}</Box>
+                <Box component="dt">{"Article 4s (API)"}</Box>
+                <Box component="dd">{!isValidating && a4Check?.status ? <Configured /> : <NotConfigured />}</Box>
               </>
               <>
                 <Box component="dt">{"Reference code"}</Box>


### PR DESCRIPTION
Currently the Editor's admin panel will display a static "?" for Article 4 status because A4s are a tricky three-part onboarding process: spreadsheet, flow content, and GIS API.  

This introduces a quick API endpoint we can use to correctly set "Configured" or "Not configured" for a more meaningful reflection of the status of the final step of the onboarding process (GIS API).

![Screenshot from 2024-05-20 20-11-31](https://github.com/theopensystemslab/planx-new/assets/5132349/12d743f7-0ec1-4eee-84e7-8dc6104c7d0b)
