### PR TITLE
fix: Fetch flow settings in new views

### DIFF
--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -28,6 +28,7 @@ import FormModal from "../pages/FlowEditor/components/forms/FormModal";
 import { SLUGS } from "../pages/FlowEditor/data/types";
 import { useStore } from "../pages/FlowEditor/lib/store";
 import type { Flow } from "../types";
+import { getFlowSettings } from "./flowSettings";
 import { makeTitle } from "./utils";
 import { flowEditorView } from "./views/flowEditor";
 
@@ -223,6 +224,7 @@ const routes = compose(
       withView(SettingsContainer),
 
       route(async (req) => ({
+        getData: getFlowSettings,
         title: makeTitle(
           [req.params.team, req.params.flow, "service"].join("/"),
         ),
@@ -234,6 +236,7 @@ const routes = compose(
       withView(SettingsContainer),
 
       route(async (req) => ({
+        getData: getFlowSettings,
         title: makeTitle(
           [req.params.team, req.params.flow, "service-flags"].join("/"),
         ),


### PR DESCRIPTION
## Context
This is a small fix / refactor I noticed when working on https://github.com/theopensystemslab/planx-new/pull/3183. It was introduced in https://github.com/theopensystemslab/planx-new/pull/3028. 

This work in also included in the WIP PR #3183 - once this PR is merged I'll rebase that one to pick up the changes. I've pulled it out into its own PR to make it easier to test & review. 

### Problem
The new pages (e.g. `/:flow/service`) aren't correctly fetching team settings - this was only being done in `/:flow/settings/:tab`).

### Solution
A shared function, `getFlowSettings()`, to handle this across routes in a consistent manner.

## Testing
To test this works as expected, you should be able to view and edit settings for a flow via both routes. You'll need the `EDITOR_NAVIGATION` feature flag to do this (`window.featureFlags.toggle("EDITOR_NAVIGATION")`)

- Old "settings" route - https://3182.planx.pizza/barking-and-dagenham/article4-barkinganddagenham/settings/service
- New "sidebar" route - https://3182.planx.pizza/barking-and-dagenham/article4-barkinganddagenham/service


