### PR TITLE
feat: generate JSON payloads for discretionary services

### DIFF
--- a/api.planx.uk/modules/pay/controller.ts
+++ b/api.planx.uk/modules/pay/controller.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { Request } from "express";
 import { responseInterceptor } from "http-proxy-middleware";
-import { logPaymentStatus } from "../send/utils/helpers";
+import { logPaymentStatus } from "./helpers";
 import { usePayProxy } from "./proxy";
 import { $api } from "../../client";
 import { ServerError } from "../../errors";

--- a/api.planx.uk/modules/pay/helpers.ts
+++ b/api.planx.uk/modules/pay/helpers.ts
@@ -1,0 +1,112 @@
+import { gql } from "graphql-request";
+import airbrake from "../../airbrake";
+import { $api } from "../../client";
+
+export async function logPaymentStatus({
+  sessionId,
+  flowId,
+  teamSlug,
+  govUkResponse,
+}: {
+  sessionId: string | undefined;
+  flowId: string | undefined;
+  teamSlug: string;
+  govUkResponse: {
+    amount: number;
+    payment_id: string;
+    state: {
+      status: string;
+    };
+  };
+}): Promise<void> {
+  if (!flowId || !sessionId) {
+    reportError({
+      error: "Could not log the payment status due to missing context value(s)",
+      context: { sessionId, flowId, teamSlug },
+    });
+  } else {
+    // log payment status response
+    try {
+      await insertPaymentStatus({
+        sessionId,
+        flowId,
+        teamSlug,
+        paymentId: govUkResponse.payment_id,
+        status: govUkResponse.state?.status || "unknown",
+        amount: govUkResponse.amount,
+      });
+    } catch (e) {
+      reportError({
+        error: `Failed to insert a payment status: ${e}`,
+        context: { govUkResponse },
+      });
+    }
+  }
+}
+
+// TODO: this would ideally live in planx-client
+async function insertPaymentStatus({
+  flowId,
+  sessionId,
+  paymentId,
+  teamSlug,
+  status,
+  amount,
+}: {
+  flowId: string;
+  sessionId: string;
+  paymentId: string;
+  teamSlug: string;
+  status: string;
+  amount: number;
+}): Promise<void> {
+  const _response = await $api.client.request(
+    gql`
+      mutation InsertPaymentStatus(
+        $flowId: uuid!
+        $sessionId: uuid!
+        $paymentId: String!
+        $teamSlug: String!
+        $status: payment_status_enum_enum
+        $amount: Int!
+      ) {
+        insert_payment_status(
+          objects: {
+            flow_id: $flowId
+            session_id: $sessionId
+            payment_id: $paymentId
+            team_slug: $teamSlug
+            status: $status
+            amount: $amount
+          }
+        ) {
+          affected_rows
+        }
+      }
+    `,
+    {
+      flowId,
+      sessionId,
+      teamSlug,
+      paymentId,
+      status,
+      amount,
+    },
+  );
+}
+
+// tmp explicit error handling
+export function reportError(report: { error: any; context: object }) {
+  if (airbrake) {
+    airbrake.notify(report);
+    return;
+  }
+  log(report);
+}
+
+// tmp logger
+function log(event: object | string) {
+  if (!process.env.SUPPRESS_LOGS) {
+    console.log(event);
+  }
+}

--- a/api.planx.uk/modules/send/utils/exportZip.test.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.test.ts
@@ -232,7 +232,7 @@ describe("buildSubmissionExportZip", () => {
       );
     });
 
-    test("ODP schema json is excluded if unsupported application type", async () => {
+    test("ODP schema json is included, but not validated, if unsupported application type", async () => {
       // set-up mock session passport overwriting "application.type"
       const lowcalSessionUnsupportedAppType: Partial<LowCalSession> = {
         ...mockLowcalSession,
@@ -243,7 +243,7 @@ describe("buildSubmissionExportZip", () => {
           passport: {
             data: {
               ...mockLowcalSession.data!.passport.data,
-              "application.type": ["listedBuildingConsent"],
+              "application.type": ["reportAPlanningBreach"],
             },
           },
         },
@@ -255,13 +255,13 @@ describe("buildSubmissionExportZip", () => {
         includeDigitalPlanningJSON: true,
       });
 
-      expect(mockAddFile).not.toHaveBeenCalledWith(
+      expect(mockAddFile).toHaveBeenCalledWith(
         "application.json",
         expect.anything(),
       );
     });
 
-    test("ODP schema json is excluded if no application type", async () => {
+    test("ODP schema json is included, but not validated, if no application type", async () => {
       // set-up mock session passport overwriting "application.type"
       const lowcalSessionUnsupportedAppType: Partial<LowCalSession> = {
         ...mockLowcalSession,
@@ -284,7 +284,7 @@ describe("buildSubmissionExportZip", () => {
         includeDigitalPlanningJSON: true,
       });
 
-      expect(mockAddFile).not.toHaveBeenCalledWith(
+      expect(mockAddFile).toHaveBeenCalledWith(
         "application.json",
         expect.anything(),
       );

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -60,7 +60,7 @@ export async function buildSubmissionExportZip({
   if (includeDigitalPlanningJSON) {
     try {
       const doValidation = isApplicationTypeSupported(passport);
-      const schema = doValidation 
+      const schema = doValidation
         ? await $api.export.digitalPlanningDataPayload(sessionId)
         : await $api.export.digitalPlanningDataPayload(sessionId, true);
       const schemaBuff = Buffer.from(JSON.stringify(schema, null, 2));

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -16,6 +16,7 @@ import { Passport } from "@opensystemslab/planx-core";
 import type { Passport as IPassport } from "../../../types";
 import type { Stream } from "node:stream";
 import type { PlanXExportData } from "@opensystemslab/planx-core/types";
+import { isApplicationTypeSupported } from "./helpers";
 
 export async function buildSubmissionExportZip({
   sessionId,
@@ -30,7 +31,7 @@ export async function buildSubmissionExportZip({
   const sessionData = await $api.session.find(sessionId);
   if (!sessionData) {
     throw new Error(
-      `session ${sessionId} not found so could not create Uniform submission zip`,
+      `session ${sessionId} not found so could not create submission zip`,
     );
   }
   const passport = sessionData.data?.passport as IPassport;
@@ -50,21 +51,18 @@ export async function buildSubmissionExportZip({
       });
     } catch (error) {
       throw new Error(
-        `Failed to generate OneApp XML for ${sessionId}. Error - ${error}`,
+        `Failed to generate OneApp XML for ${sessionId} zip. Error - ${error}`,
       );
     }
   }
 
-  // add ODP Schema JSON to the zip for supported application types
-  const supportedApplicationPrefixes = ["ldc", "pa", "pp"];
-  const applicationType = passport.data?.["application.type"]?.[0];
-  if (
-    includeDigitalPlanningJSON &&
-    applicationType &&
-    supportedApplicationPrefixes.includes(applicationType.split(".")?.[0])
-  ) {
+  // add ODP Schema JSON to the zip, skipping validation if an unsupported application type
+  if (includeDigitalPlanningJSON) {
     try {
-      const schema = await $api.export.digitalPlanningDataPayload(sessionId);
+      const doValidation = isApplicationTypeSupported(passport);
+      const schema = doValidation 
+        ? await $api.export.digitalPlanningDataPayload(sessionId)
+        : await $api.export.digitalPlanningDataPayload(sessionId, true);
       const schemaBuff = Buffer.from(JSON.stringify(schema, null, 2));
       zip.addFile({
         name: "application.json",

--- a/api.planx.uk/modules/send/utils/helpers.ts
+++ b/api.planx.uk/modules/send/utils/helpers.ts
@@ -1,112 +1,17 @@
-import { gql } from "graphql-request";
-import airbrake from "../../../airbrake";
-import { $api } from "../../../client";
+import { Passport } from "../../../types";
 
-export async function logPaymentStatus({
-  sessionId,
-  flowId,
-  teamSlug,
-  govUkResponse,
-}: {
-  sessionId: string | undefined;
-  flowId: string | undefined;
-  teamSlug: string;
-  govUkResponse: {
-    amount: number;
-    payment_id: string;
-    state: {
-      status: string;
-    };
-  };
-}): Promise<void> {
-  if (!flowId || !sessionId) {
-    reportError({
-      error: "Could not log the payment status due to missing context value(s)",
-      context: { sessionId, flowId, teamSlug },
-    });
-  } else {
-    // log payment status response
-    try {
-      await insertPaymentStatus({
-        sessionId,
-        flowId,
-        teamSlug,
-        paymentId: govUkResponse.payment_id,
-        status: govUkResponse.state?.status || "unknown",
-        amount: govUkResponse.amount,
-      });
-    } catch (e) {
-      reportError({
-        error: `Failed to insert a payment status: ${e}`,
-        context: { govUkResponse },
-      });
-    }
-  }
-}
+/**
+ * Checks whether a session's passport data includes an application type supported by the ODP Schema
+ * @param passport
+ * @returns boolean
+ */
+export function isApplicationTypeSupported(passport: Passport): boolean {
+  // Prefixes of application types that are supported by the ODP Schema
+  //   TODO in future look up via schema type definitions
+  const supportedAppTypes = ["ldc", "listed", "pa", "pp"];
+    
+  const appType = passport.data?.["application.type"]?.[0];
+  const appTypePrefix = appType?.split(".")?.[0];
 
-// tmp explicit error handling
-export function reportError(report: { error: any; context: object }) {
-  if (airbrake) {
-    airbrake.notify(report);
-    return;
-  }
-  log(report);
-}
-
-// tmp logger
-function log(event: object | string) {
-  if (!process.env.SUPPRESS_LOGS) {
-    console.log(event);
-  }
-}
-
-// TODO: this would ideally live in planx-client
-async function insertPaymentStatus({
-  flowId,
-  sessionId,
-  paymentId,
-  teamSlug,
-  status,
-  amount,
-}: {
-  flowId: string;
-  sessionId: string;
-  paymentId: string;
-  teamSlug: string;
-  status: string;
-  amount: number;
-}): Promise<void> {
-  const _response = await $api.client.request(
-    gql`
-      mutation InsertPaymentStatus(
-        $flowId: uuid!
-        $sessionId: uuid!
-        $paymentId: String!
-        $teamSlug: String!
-        $status: payment_status_enum_enum
-        $amount: Int!
-      ) {
-        insert_payment_status(
-          objects: {
-            flow_id: $flowId
-            session_id: $sessionId
-            payment_id: $paymentId
-            team_slug: $teamSlug
-            status: $status
-            amount: $amount
-          }
-        ) {
-          affected_rows
-        }
-      }
-    `,
-    {
-      flowId,
-      sessionId,
-      teamSlug,
-      paymentId,
-      status,
-      amount,
-    },
-  );
+  return supportedAppTypes.includes(appTypePrefix);
 }

--- a/api.planx.uk/modules/send/utils/helpers.ts
+++ b/api.planx.uk/modules/send/utils/helpers.ts
@@ -9,7 +9,7 @@ export function isApplicationTypeSupported(passport: Passport): boolean {
   // Prefixes of application types that are supported by the ODP Schema
   //   TODO in future look up via schema type definitions
   const supportedAppTypes = ["ldc", "listed", "pa", "pp"];
-    
+
   const appType = passport.data?.["application.type"]?.[0];
   const appTypePrefix = appType?.split(".")?.[0];
 

--- a/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -1,8 +1,8 @@
 import { isObject } from "lodash";
 import { JSDOM } from "jsdom";
 import createDOMPurify from "dompurify";
-import { reportError } from "../../../send/utils/helpers";
 import { decode } from "he";
+import { reportError } from "../../../pay/helpers";
 
 // Setup JSDOM and DOMPurify
 const window = new JSDOM("").window;


### PR DESCRIPTION
**Changes:**
- Generates & includes a Digital Planning Application JSON for _every_ "Send to email" or "Upload to S3" submission, skipping validation if not a supported application type
  - For example, this should be sufficient for Barnet to begin testing "Report a Planning Breach" with Power Automate
- Does not change anything about current BOPS or Uniform payloads
  - BOPS currently rejects invalid payloads, they may accept discretionary services in future
  - Uniform zip can't contain JSON files at all currently
- Moved pay helpers out of send module into pay!

**Open questions:** 
- What's a "generic" or "discretionary" payload to begin with? I've decided it's simply the ODP Schema shape, but without any validation for a couple of reasons:
  - We have existing methods to generate this
  - `data` already has defined representations for some of our most common component types (FindProperty, ContactInput) & `responses` is already generic enough to support a service that literally sets zero data fields
  - We can focus our dev time & energy on maintaining a single set of passport mappings going forward, benefiting _both_ validated statutory service and discretionary service payloads
  - I imagine a slightly more complex future (but we don't have to get there yet) that is maybe like: 
    - Applications types within "DigitalPlanningApplication" schema definition
    - Application type(s) within "DigitalPlanningPreApplication" schema definition
    - Then all (invalid) discretionary things
- What's the best way to consume ODP Schema type definitions in planx-new? See this thread with initial ideas: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1716279436365409
  - Is this implementation in or out of scope of this initial piece of work?
  
**Testing:**
- Sent through a Report a Breach via Barnet successfully end-to-end with Kev :heavy_check_mark: https://3184.planx.pizza/barnet/report-a-planning-breach-template-v1-test/settings/submissions
  - This highlights where we should improve our schema passport mappings (eg default to undefined rather than 0/false more often), but that's something we can address as a follow-up in planx-core https://api.3184.planx.pizza/admin/session/d7896b95-ca38-4a82-ad5c-4815c07953eb/digital-planning-application?skipValidation=true