### PR TITLE
refactor: Last edit placement in flow breadcrumbs

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -40,6 +40,7 @@ import {
 import { ApplicationPath } from "types";
 import Reset from "ui/icons/Reset";
 
+import { LastEdited } from "../pages/FlowEditor/components/LastEdited";
 import { useStore } from "../pages/FlowEditor/lib/store";
 import { rootFlowPath, rootTeamPath } from "../routes/utils";
 import AnalyticsDisabledBanner from "./AnalyticsDisabledBanner";
@@ -53,7 +54,6 @@ const Root = styled(AppBar)(() => ({
 }));
 
 const BreadcrumbsRoot = styled(Box)(() => ({
-  cursor: "pointer",
   fontSize: 20,
   display: "flex",
   columnGap: 10,
@@ -257,6 +257,7 @@ const Breadcrumbs: React.FC = () => {
           )}
         </>
       )}
+      <LastEdited />
     </BreadcrumbsRoot>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/EditorMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/EditorMenu.tsx
@@ -23,7 +23,7 @@ const Root = styled(Box)(({ theme }) => ({
 const MenuWrap = styled("ul")(({ theme }) => ({
   listStyle: "none",
   margin: 0,
-  padding: theme.spacing(4, 0, 0, 0),
+  padding: theme.spacing(2, 0, 0, 0),
 }));
 
 const MenuItem = styled("li")(({ theme }) => ({

--- a/editor.planx.uk/src/pages/FlowEditor/components/LastEdited.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/LastEdited.tsx
@@ -1,0 +1,59 @@
+import { gql, useSubscription } from "@apollo/client";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { Operation } from "types";
+
+import { useStore } from "../lib/store";
+import { formatLastEditMessage } from "../utils";
+
+export const LastEdited = () => {
+  const [flowId] = useStore((state) => [state.id]);
+
+  const { data, loading, error } = useSubscription<{ operations: Operation[] }>(
+    gql`
+      subscription GetMostRecentOperation($flow_id: uuid = "") {
+        operations(
+          limit: 1
+          where: { flow_id: { _eq: $flow_id } }
+          order_by: { created_at: desc }
+        ) {
+          id
+          createdAt: created_at
+          actor {
+            firstName: first_name
+            lastName: last_name
+          }
+        }
+      }
+    `,
+    {
+      variables: {
+        flow_id: flowId,
+      },
+    },
+  );
+
+  if (error) {
+    console.log(error.message);
+    return null;
+  }
+
+  // Handle missing operations (e.g. non-production data)
+  if (data && !data.operations[0].actor) return null;
+
+  let message: string;
+  if (loading || !data) {
+    message = "Loading...";
+  } else {
+    const {
+      operations: [operation],
+    } = data;
+    message = formatLastEditMessage(operation?.createdAt, operation?.actor);
+  }
+
+  return (
+    <Typography variant="body2" fontSize="small">
+      {message}
+    </Typography>
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -1,22 +1,15 @@
 import "./components/Settings";
 import "./floweditor.scss";
 
-import { gql, useSubscription } from "@apollo/client";
-import EditNoteIcon from "@mui/icons-material/EditNote";
 import Box from "@mui/material/Box";
-import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
-import Typography from "@mui/material/Typography";
 import React, { useRef } from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import { Operation } from "types";
 
 import { rootFlowPath } from "../../routes/utils";
 import Flow from "./components/Flow";
 import Sidebar from "./components/Sidebar";
 import { useStore } from "./lib/store";
 import useScrollControlsAndRememberPosition from "./lib/useScrollControlsAndRememberPosition";
-import { formatLastEditMessage } from "./utils";
 
 const EditorContainer = styled(Box)(() => ({
   display: "flex",
@@ -24,81 +17,6 @@ const EditorContainer = styled(Box)(() => ({
   overflow: "hidden",
   flexGrow: 1,
 }));
-
-export const LastEdited = () => {
-  const [flowId] = useStore((state) => [state.id]);
-
-  const { data, loading, error } = useSubscription<{ operations: Operation[] }>(
-    gql`
-      subscription GetMostRecentOperation($flow_id: uuid = "") {
-        operations(
-          limit: 1
-          where: { flow_id: { _eq: $flow_id } }
-          order_by: { created_at: desc }
-        ) {
-          id
-          createdAt: created_at
-          actor {
-            firstName: first_name
-            lastName: last_name
-          }
-        }
-      }
-    `,
-    {
-      variables: {
-        flow_id: flowId,
-      },
-    },
-  );
-
-  if (error) {
-    console.log(error.message);
-    return null;
-  }
-
-  // Handle missing operations (e.g. non-production data)
-  if (data && !data.operations[0].actor) return null;
-
-  let message: string;
-  if (loading || !data) {
-    message = "Loading...";
-  } else {
-    const {
-      operations: [operation],
-    } = data;
-    message = formatLastEditMessage(operation?.createdAt, operation?.actor);
-  }
-
-  return (
-    <Box
-      sx={(theme) => ({
-        backgroundColor: theme.palette.grey[200],
-        borderBottom: `1px solid ${theme.palette.border.main}`,
-        padding: theme.spacing(0.5, 1),
-        paddingLeft: theme.spacing(2),
-        display: "flex",
-        alignItems: "center",
-        [theme.breakpoints.up("md")]: {
-          paddingLeft: theme.spacing(2),
-        },
-      })}
-    >
-      <Typography variant="body2" fontSize="small">
-        {message}
-      </Typography>
-      <Link
-        variant="body2"
-        fontSize="small"
-        fontWeight={FONT_WEIGHT_SEMI_BOLD}
-        ml={2}
-        sx={{ display: "flex", alignItems: "center" }}
-      >
-        <EditNoteIcon /> View edit history
-      </Link>
-    </Box>
-  );
-};
 
 const FlowEditor: React.FC<any> = ({ flow, breadcrumbs }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -115,7 +33,6 @@ const FlowEditor: React.FC<any> = ({ flow, breadcrumbs }) => {
           overflowX: "auto",
         }}
       >
-        <LastEdited />
         <Box id="editor" ref={scrollContainerRef} sx={{ position: "relative" }}>
           <Flow flow={flow} breadcrumbs={breadcrumbs} />
         </Box>


### PR DESCRIPTION
## What does this PR do?

Moves the "last edit" text to sit within the flow breadcrumbs in the header, removing the need for a dedicated bar on the graph.

Still to do:

- [ ] Exclude last edit from showing on team page