### PR TITLE
wip: Editor layout and style updates

### DIFF
--- a/e2e/tests/ui-driven/src/login.spec.ts
+++ b/e2e/tests/ui-driven/src/login.spec.ts
@@ -67,7 +67,7 @@ test.describe("Login", () => {
       route.continue();
     });
     await expect(
-      page.locator("h1").filter({ hasText: "My services" }),
+      page.locator("h1").filter({ hasText: "Services" }),
     ).toBeVisible();
     await expect(page.getByText(toastText)).toBeHidden();
   });

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -467,19 +467,7 @@ const EditorToolbar: React.FC<{
                       <MenuOpenIcon />
                     </IconButton>
                   )}
-                  <Box mr={1}>
-                    <Avatar
-                      sx={{
-                        bgcolor: grey[200],
-                        color: "text.primary",
-                        fontSize: "1em",
-                        fontWeight: "600",
-                      }}
-                    >
-                      {user.firstName[0]}
-                      {user.lastName[0]}
-                    </Avatar>
-                  </Box>
+                  <Box mr={1}></Box>
                   <IconButton
                     edge="end"
                     color="inherit"
@@ -487,6 +475,24 @@ const EditorToolbar: React.FC<{
                     onClick={handleMenuToggle}
                     size="large"
                   >
+                    <Avatar
+                      component="span"
+                      sx={{
+                        bgcolor: grey[200],
+                        color: "text.primary",
+                        fontSize: "1rem",
+                        fontWeight: "600",
+                        width: 33,
+                        height: 33,
+                        marginRight: "0.5rem",
+                      }}
+                    >
+                      {user.firstName[0]}
+                      {user.lastName[0]}
+                    </Avatar>
+                    <Typography variant="body2" fontSize="small">
+                      Account
+                    </Typography>
                     <KeyboardArrowDown />
                   </IconButton>
                 </ProfileSection>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -48,8 +48,8 @@ import TestEnvironmentBanner from "./TestEnvironmentBanner";
 
 export const HEADER_HEIGHT = 74;
 
-const Root = styled(AppBar)(() => ({
-  color: "#fff",
+const Root = styled(AppBar)(({ theme }) => ({
+  color: theme.palette.common.white,
 }));
 
 const BreadcrumbsRoot = styled(Box)(() => ({
@@ -59,6 +59,12 @@ const BreadcrumbsRoot = styled(Box)(() => ({
   columnGap: 10,
   alignItems: "center",
 }));
+
+const BreadcrumbsLink = styled(Link)(({ theme }) => ({
+  color: theme.palette.common.white,
+  textDecoration: "none",
+  borderBottom: "1px solid currentColor",
+})) as typeof Link;
 
 const StyledToolbar = styled(MuiToolbar)(() => ({
   height: HEADER_HEIGHT,
@@ -103,7 +109,7 @@ const StyledPopover = styled(Popover)(({ theme }) => ({
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+  color: theme.palette.common.white,
   borderRadius: 0,
   boxShadow: "none",
   minWidth: 180,
@@ -131,7 +137,7 @@ const SkipLink = styled("a")(({ theme }) => ({
   width: "100vw",
   height: HEADER_HEIGHT / 2,
   backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+  color: theme.palette.common.white,
   textDecoration: "underline",
   padding: theme.spacing(1),
   paddingLeft: theme.spacing(3),
@@ -203,33 +209,25 @@ const Breadcrumbs: React.FC = () => {
 
   return (
     <BreadcrumbsRoot>
-      <Link
-        style={{
-          color: "#fff",
-          textDecoration: "none",
-        }}
+      <BreadcrumbsLink
         component={ReactNaviLink}
         href={"/"}
         prefetch={false}
         {...(isStandalone && { target: "_blank" })}
       >
         Plan✕
-      </Link>
+      </BreadcrumbsLink>
       {team.slug && (
         <>
           {" / "}
-          <Link
-            style={{
-              color: "#fff",
-              textDecoration: "none",
-            }}
+          <BreadcrumbsLink
             component={ReactNaviLink}
             href={`/${team.slug}`}
             prefetch={false}
             {...(isStandalone && { target: "_blank" })}
           >
             {team.slug}
-          </Link>
+          </BreadcrumbsLink>
         </>
       )}
       {route.data.flow && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/EditorMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/EditorMenu.tsx
@@ -11,19 +11,19 @@ import { rootFlowPath } from "routes/utils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import EditorIcon from "ui/icons/Editor";
 
-const MENU_WIDTH = "46px";
+const MENU_WIDTH = "54px";
 
 const Root = styled(Box)(({ theme }) => ({
   width: MENU_WIDTH,
   flexShrink: 0,
   background: theme.palette.background.paper,
-  borderRight: `1px solid ${theme.palette.border.main}`,
+  borderRight: `1px solid ${theme.palette.border.light}`,
 }));
 
 const MenuWrap = styled("ul")(({ theme }) => ({
   listStyle: "none",
   margin: 0,
-  padding: theme.spacing(4, 0, 0, 0),
+  padding: theme.spacing(4, 0.5, 0, 0.5),
 }));
 
 const MenuItem = styled("li")(({ theme }) => ({
@@ -49,21 +49,19 @@ const TooltipWrap = styled(({ className, ...props }: TooltipProps) => (
 const MenuButton = styled(IconButton, {
   shouldForwardProp: (prop) => prop !== "isActive",
 })<{ isActive: boolean }>(({ theme, isActive }) => ({
-  color: theme.palette.primary.main,
-  width: MENU_WIDTH,
-  height: MENU_WIDTH,
+  color: theme.palette.text.primary,
+  width: "100%",
   border: "1px solid transparent",
-  borderRightColor: theme.palette.border.main,
+  justifyContent: "flex-start",
+  borderRadius: "3px",
   "&:hover": {
     background: "white",
-    borderTopColor: theme.palette.border.light,
-    borderBottomColor: theme.palette.border.light,
+    borderColor: theme.palette.border.light,
   },
   ...(isActive && {
     background: theme.palette.common.white,
     color: theme.palette.text.primary,
-    border: `1px solid ${theme.palette.border.main}`,
-    borderRightColor: "transparent",
+    border: `1px solid ${theme.palette.border.light}`,
   }),
 }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
@@ -77,12 +77,12 @@ function GlobalMenu() {
     {
       title: "Admin panel",
       Icon: AdminPanelSettingsIcon,
-      route: "/admin-panel",
+      route: "admin-panel",
     },
     {
       title: "Global settings",
       Icon: TuneIcon,
-      route: "/global-settings",
+      route: "global-settings",
     },
   ];
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
@@ -10,19 +10,19 @@ import { useCurrentRoute, useNavigation } from "react-navi";
 import { rootFlowPath } from "routes/utils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-const MENU_WIDTH = "180px";
+const MENU_WIDTH = "185px";
 
 const Root = styled(Box)(({ theme }) => ({
   width: MENU_WIDTH,
   flexShrink: 0,
   background: theme.palette.background.paper,
-  borderRight: `1px solid ${theme.palette.border.main}`,
+  borderRight: `1px solid ${theme.palette.border.light}`,
 }));
 
 const MenuWrap = styled("ul")(({ theme }) => ({
   listStyle: "none",
   margin: 0,
-  padding: theme.spacing(2.5, 0, 0, 0),
+  padding: theme.spacing(2.5, 0.5, 0, 0.5),
   position: "sticky",
   top: 0,
 }));
@@ -41,21 +41,19 @@ const MenuTitle = styled(Typography)(({ theme }) => ({
 const MenuButton = styled(IconButton, {
   shouldForwardProp: (prop) => prop !== "isActive",
 })<{ isActive: boolean }>(({ theme, isActive }) => ({
-  color: theme.palette.primary.main,
-  width: MENU_WIDTH,
+  color: theme.palette.text.primary,
+  width: "100%",
   border: "1px solid transparent",
-  borderRightColor: theme.palette.border.main,
   justifyContent: "flex-start",
+  borderRadius: "3px",
   "&:hover": {
     background: "white",
-    borderTopColor: theme.palette.border.light,
-    borderBottomColor: theme.palette.border.light,
+    borderColor: theme.palette.border.light,
   },
   ...(isActive && {
     background: theme.palette.common.white,
     color: theme.palette.text.primary,
-    border: `1px solid ${theme.palette.border.main}`,
-    borderRightColor: "transparent",
+    border: `1px solid ${theme.palette.border.light}`,
   }),
 }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
@@ -1,0 +1,105 @@
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import TuneIcon from "@mui/icons-material/Tune";
+import ViewListIcon from "@mui/icons-material/ViewList";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { useCurrentRoute, useNavigation } from "react-navi";
+import { rootFlowPath } from "routes/utils";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+const MENU_WIDTH = "180px";
+
+const Root = styled(Box)(({ theme }) => ({
+  width: MENU_WIDTH,
+  flexShrink: 0,
+  background: theme.palette.background.paper,
+  borderRight: `1px solid ${theme.palette.border.main}`,
+}));
+
+const MenuWrap = styled("ul")(({ theme }) => ({
+  listStyle: "none",
+  margin: 0,
+  padding: theme.spacing(2.5, 0, 0, 0),
+  position: "sticky",
+  top: 0,
+}));
+
+const MenuItem = styled("li")(({ theme }) => ({
+  margin: theme.spacing(0.75, 0),
+  padding: 0,
+}));
+
+const MenuTitle = styled(Typography)(({ theme }) => ({
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  paddingLeft: theme.spacing(0.5),
+  textAlign: "left",
+})) as typeof Typography;
+
+const MenuButton = styled(IconButton, {
+  shouldForwardProp: (prop) => prop !== "isActive",
+})<{ isActive: boolean }>(({ theme, isActive }) => ({
+  color: theme.palette.primary.main,
+  width: MENU_WIDTH,
+  border: "1px solid transparent",
+  borderRightColor: theme.palette.border.main,
+  justifyContent: "flex-start",
+  "&:hover": {
+    background: "white",
+    borderTopColor: theme.palette.border.light,
+    borderBottomColor: theme.palette.border.light,
+  },
+  ...(isActive && {
+    background: theme.palette.common.white,
+    color: theme.palette.text.primary,
+    border: `1px solid ${theme.palette.border.main}`,
+    borderRightColor: "transparent",
+  }),
+}));
+
+function GlobalMenu() {
+  const { navigate } = useNavigation();
+  const { url } = useCurrentRoute();
+  const rootPath = rootFlowPath();
+
+  const isActive = (route: string) => url.pathname.endsWith(route);
+  const handleClick = (route: string) =>
+    !isActive(route) && navigate(rootPath + route);
+
+  const routes = [
+    {
+      title: "Select a team",
+      Icon: ViewListIcon,
+      route: "/",
+    },
+    {
+      title: "Admin panel",
+      Icon: AdminPanelSettingsIcon,
+      route: "/admin-panel",
+    },
+    {
+      title: "Global settings",
+      Icon: TuneIcon,
+      route: "/global-settings",
+    },
+  ];
+
+  return (
+    <Root>
+      <MenuWrap>
+        {routes.map(({ title, Icon, route }) => (
+          <MenuItem onClick={() => handleClick(route)} key={title}>
+            <MenuButton isActive={isActive(route)} disableRipple>
+              <Icon />
+              <MenuTitle variant="body2">{title}</MenuTitle>
+            </MenuButton>
+          </MenuItem>
+        ))}
+      </MenuWrap>
+    </Root>
+  );
+}
+
+export default GlobalMenu;

--- a/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/GlobalMenu.tsx
@@ -1,6 +1,6 @@
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import TuneIcon from "@mui/icons-material/Tune";
-import ViewListIcon from "@mui/icons-material/ViewList";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
@@ -34,7 +34,7 @@ const MenuItem = styled("li")(({ theme }) => ({
 
 const MenuTitle = styled(Typography)(({ theme }) => ({
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  paddingLeft: theme.spacing(0.5),
+  paddingLeft: theme.spacing(0.75),
   textAlign: "left",
 })) as typeof Typography;
 
@@ -55,6 +55,9 @@ const MenuButton = styled(IconButton, {
     color: theme.palette.text.primary,
     border: `1px solid ${theme.palette.border.light}`,
   }),
+  "& > svg": {
+    width: "20px",
+  },
 }));
 
 function GlobalMenu() {
@@ -69,7 +72,7 @@ function GlobalMenu() {
   const routes = [
     {
       title: "Select a team",
-      Icon: ViewListIcon,
+      Icon: FormatListBulletedIcon,
       route: "/",
     },
     {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -11,9 +11,12 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import { Role, User } from "@opensystemslab/planx-core/types";
+import { Dashboard, DashboardWrap } from "pages/Teams";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import EditorRow from "ui/editor/EditorRow";
+
+import TeamMenu from "../TeamMenu";
 
 const StyledAvatar = styled(Avatar)(({ theme }) => ({
   background: theme.palette.background.dark,
@@ -127,39 +130,44 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
   );
 
   return (
-    <Container maxWidth="contentWrap">
-      <Box py={7}>
-        <EditorRow>
-          <Typography variant="h2" component="h3" gutterBottom>
-            Team editors
-          </Typography>
-          <Typography variant="body1">
-            Editors have access to edit your services.
-          </Typography>
-          <MembersTable members={activeMembers} />
-        </EditorRow>
-        <EditorRow>
-          <Typography variant="h2" component="h3" gutterBottom>
-            Admins
-          </Typography>
-          <Typography variant="body1">
-            Admins have editor access across all teams.
-          </Typography>
-          <MembersTable members={platformAdmins} />
-        </EditorRow>
-        {archivedMembers.length > 0 && (
-          <EditorRow>
-            <Typography variant="h2" component="h3" gutterBottom>
-              Archived team editors
-            </Typography>
-            <Typography variant="body1">
-              Past team members who no longer have access to the Editor, but may
-              be part of the edit history of your services.
-            </Typography>
-            <MembersTable members={archivedMembers} />
-          </EditorRow>
-        )}
-      </Box>
-    </Container>
+    <DashboardWrap>
+      <Dashboard>
+        <TeamMenu />
+        <Container maxWidth="contentWrap">
+          <Box py={3}>
+            <EditorRow>
+              <Typography variant="h2" component="h3" gutterBottom>
+                Team editors
+              </Typography>
+              <Typography variant="body1">
+                Editors have access to edit your services.
+              </Typography>
+              <MembersTable members={activeMembers} />
+            </EditorRow>
+            <EditorRow>
+              <Typography variant="h2" component="h3" gutterBottom>
+                Admins
+              </Typography>
+              <Typography variant="body1">
+                Admins have editor access across all teams.
+              </Typography>
+              <MembersTable members={platformAdmins} />
+            </EditorRow>
+            {archivedMembers.length > 0 && (
+              <EditorRow>
+                <Typography variant="h2" component="h3" gutterBottom>
+                  Archived team editors
+                </Typography>
+                <Typography variant="body1">
+                  Past team members who no longer have access to the Editor, but
+                  may be part of the edit history of your services.
+                </Typography>
+                <MembersTable members={archivedMembers} />
+              </EditorRow>
+            )}
+          </Box>
+        </Container>
+      </Dashboard>
+    </DashboardWrap>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
@@ -55,6 +55,9 @@ const MenuButton = styled(IconButton, {
     color: theme.palette.text.primary,
     border: `1px solid ${theme.palette.border.light}`,
   }),
+  "& > svg": {
+    width: "20px",
+  },
 }));
 
 function TeamMenu() {

--- a/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
@@ -1,6 +1,6 @@
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
 import PaletteIcon from "@mui/icons-material/Palette";
-import ViewListIcon from "@mui/icons-material/ViewList";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
@@ -72,7 +72,7 @@ function TeamMenu() {
   const routes = [
     {
       title: "Services",
-      Icon: ViewListIcon,
+      Icon: FormatListBulletedIcon,
       route: "/",
     },
     {

--- a/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
@@ -10,19 +10,19 @@ import { useCurrentRoute, useNavigation } from "react-navi";
 import { rootFlowPath } from "routes/utils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-const MENU_WIDTH = "180px";
+const MENU_WIDTH = "185px";
 
 const Root = styled(Box)(({ theme }) => ({
   width: MENU_WIDTH,
   flexShrink: 0,
   background: theme.palette.background.paper,
-  borderRight: `1px solid ${theme.palette.border.main}`,
+  borderRight: `1px solid ${theme.palette.border.light}`,
 }));
 
 const MenuWrap = styled("ul")(({ theme }) => ({
   listStyle: "none",
   margin: 0,
-  padding: theme.spacing(2.5, 0, 0, 0),
+  padding: theme.spacing(2.5, 0.5, 0, 0.5),
   position: "sticky",
   top: 0,
 }));
@@ -41,21 +41,19 @@ const MenuTitle = styled(Typography)(({ theme }) => ({
 const MenuButton = styled(IconButton, {
   shouldForwardProp: (prop) => prop !== "isActive",
 })<{ isActive: boolean }>(({ theme, isActive }) => ({
-  color: theme.palette.primary.main,
-  width: MENU_WIDTH,
+  color: theme.palette.text.primary,
+  width: "100%",
   border: "1px solid transparent",
-  borderRightColor: theme.palette.border.main,
   justifyContent: "flex-start",
+  borderRadius: "3px",
   "&:hover": {
     background: "white",
-    borderTopColor: theme.palette.border.light,
-    borderBottomColor: theme.palette.border.light,
+    borderColor: theme.palette.border.light,
   },
   ...(isActive && {
     background: theme.palette.common.white,
     color: theme.palette.text.primary,
-    border: `1px solid ${theme.palette.border.main}`,
-    borderRightColor: "transparent",
+    border: `1px solid ${theme.palette.border.light}`,
   }),
 }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/TeamMenu.tsx
@@ -1,0 +1,105 @@
+import GroupIcon from "@mui/icons-material/Group";
+import PaletteIcon from "@mui/icons-material/Palette";
+import ViewListIcon from "@mui/icons-material/ViewList";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { useCurrentRoute, useNavigation } from "react-navi";
+import { rootFlowPath } from "routes/utils";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+const MENU_WIDTH = "180px";
+
+const Root = styled(Box)(({ theme }) => ({
+  width: MENU_WIDTH,
+  flexShrink: 0,
+  background: theme.palette.background.paper,
+  borderRight: `1px solid ${theme.palette.border.main}`,
+}));
+
+const MenuWrap = styled("ul")(({ theme }) => ({
+  listStyle: "none",
+  margin: 0,
+  padding: theme.spacing(2.5, 0, 0, 0),
+  position: "sticky",
+  top: 0,
+}));
+
+const MenuItem = styled("li")(({ theme }) => ({
+  margin: theme.spacing(0.75, 0),
+  padding: 0,
+}));
+
+const MenuTitle = styled(Typography)(({ theme }) => ({
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  paddingLeft: theme.spacing(0.5),
+  textAlign: "left",
+})) as typeof Typography;
+
+const MenuButton = styled(IconButton, {
+  shouldForwardProp: (prop) => prop !== "isActive",
+})<{ isActive: boolean }>(({ theme, isActive }) => ({
+  color: theme.palette.primary.main,
+  width: MENU_WIDTH,
+  border: "1px solid transparent",
+  borderRightColor: theme.palette.border.main,
+  justifyContent: "flex-start",
+  "&:hover": {
+    background: "white",
+    borderTopColor: theme.palette.border.light,
+    borderBottomColor: theme.palette.border.light,
+  },
+  ...(isActive && {
+    background: theme.palette.common.white,
+    color: theme.palette.text.primary,
+    border: `1px solid ${theme.palette.border.main}`,
+    borderRightColor: "transparent",
+  }),
+}));
+
+function TeamMenu() {
+  const { navigate } = useNavigation();
+  const { url } = useCurrentRoute();
+  const rootPath = rootFlowPath();
+
+  const isActive = (route: string) => url.pathname.endsWith(route);
+  const handleClick = (route: string) =>
+    !isActive(route) && navigate(rootPath + route);
+
+  const routes = [
+    {
+      title: "Services",
+      Icon: ViewListIcon,
+      route: "/",
+    },
+    {
+      title: "Team members",
+      Icon: GroupIcon,
+      route: "/members",
+    },
+    {
+      title: "Design",
+      Icon: PaletteIcon,
+      route: "/settings/design",
+    },
+  ];
+
+  return (
+    <Root>
+      <MenuWrap>
+        {routes.map(({ title, Icon, route }) => (
+          <MenuItem onClick={() => handleClick(route)} key={title}>
+            <MenuButton isActive={isActive(route)} disableRipple>
+              <Icon />
+              <MenuTitle variant="body2">{title}</MenuTitle>
+            </MenuButton>
+          </MenuItem>
+        ))}
+      </MenuWrap>
+    </Root>
+  );
+}
+
+export default TeamMenu;

--- a/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
@@ -4,11 +4,14 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
+import GlobalMenu from "pages/FlowEditor/components/GlobalMenu";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { Dashboard, DashboardWrap } from "pages/Teams";
 import React from "react";
 import useSWR from "swr";
 import { AdminPanelData } from "types";
@@ -34,15 +37,24 @@ function Component() {
   const adminPanelData = useStore((state) => state.adminPanelData);
 
   return (
-    <Box p={3}>
-      <Typography variant="h1">Platform Admin Panel</Typography>
-      <Typography variant="body1" mb={3}>
-        {`This is an overview of each team's integrations and settings for the `}
-        <strong>{process.env.REACT_APP_ENV}</strong>
-        {` environment`}
-      </Typography>
-      {adminPanelData?.map((team) => <TeamData key={team.id} data={team} />)}
-    </Box>
+    <DashboardWrap>
+      <Dashboard>
+        <GlobalMenu />
+        <Container maxWidth={false}>
+          <Box py={3}>
+            <Typography variant="h1">Platform Admin Panel</Typography>
+            <Typography variant="body1" mb={3}>
+              {`This is an overview of each team's integrations and settings for the `}
+              <strong>{process.env.REACT_APP_ENV}</strong>
+              {` environment`}
+            </Typography>
+            {adminPanelData?.map((team) => (
+              <TeamData key={team.id} data={team} />
+            ))}
+          </Box>
+        </Container>
+      </Dashboard>
+    </DashboardWrap>
   );
 }
 
@@ -58,7 +70,7 @@ const TeamData: React.FC<TeamData> = ({ data }) => {
   const a4Endpoint = `${process.env.REACT_APP_API_URL}/gis/${data.slug}/article4-schema`;
   const fetcher = (url: string) => fetch(url).then((r) => r.json());
   const { data: a4Check, isValidating } = useSWR(
-    () => data.slug ? a4Endpoint : null,
+    () => (data.slug ? a4Endpoint : null),
     fetcher,
   );
 
@@ -123,7 +135,13 @@ const TeamData: React.FC<TeamData> = ({ data }) => {
               </>
               <>
                 <Box component="dt">{"Article 4s (API)"}</Box>
-                <Box component="dd">{!isValidating && a4Check?.status ? <Configured /> : <NotConfigured />}</Box>
+                <Box component="dd">
+                  {!isValidating && a4Check?.status ? (
+                    <Configured />
+                  ) : (
+                    <NotConfigured />
+                  )}
+                </Box>
               </>
               <>
                 <Box component="dt">{"Reference code"}</Box>

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -71,9 +71,9 @@ const DashboardLink = styled(Link)(({ theme }) => ({
   textDecoration: "none",
   color: "currentColor",
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  marginBottom: theme.spacing(1.5),
   padding: theme.spacing(2),
   margin: 0,
+  width: "100%",
 }));
 
 const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -14,8 +14,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { HEADER_HEIGHT } from "components/Header";
-import formatDistanceToNow from "date-fns/formatDistanceToNow";
-import orderBy from "lodash/orderBy";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -27,11 +27,6 @@ import TeamMenu from "./FlowEditor/components/TeamMenu";
 import { useStore } from "./FlowEditor/lib/store";
 import { formatLastEditMessage } from "./FlowEditor/utils";
 
-interface TeamTheme {
-  slug: string;
-  primaryColour: string;
-}
-
 const Root = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
   width: "100%",

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -1,10 +1,11 @@
 import { gql } from "@apollo/client";
-import Add from "@mui/icons-material/Add";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import Edit from "@mui/icons-material/Edit";
 import Visibility from "@mui/icons-material/Visibility";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonBase from "@mui/material/ButtonBase";
+import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -12,6 +13,8 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { HEADER_HEIGHT } from "components/Header";
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import orderBy from "lodash/orderBy";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
@@ -20,25 +23,29 @@ import { slugify } from "utils";
 
 import { client } from "../lib/graphql";
 import SimpleMenu from "../ui/editor/SimpleMenu";
+import TeamMenu from "./FlowEditor/components/TeamMenu";
 import { useStore } from "./FlowEditor/lib/store";
 import { formatLastEditMessage } from "./FlowEditor/utils";
 
+interface TeamTheme {
+  slug: string;
+  primaryColour: string;
+}
+
 const Root = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+  backgroundColor: theme.palette.background.default,
   width: "100%",
-  flex: 1,
+  display: "flex",
   justifyContent: "flex-start",
-  alignItems: "center",
+  alignItems: "flex-start",
+  flexGrow: 1,
 }));
 
-const Dashboard = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+const Dashboard = styled(Box)(() => ({
   width: "100%",
-  maxWidth: 600,
-  margin: "auto",
-  padding: theme.spacing(8, 0, 4, 0),
+  display: "flex",
+  flexDirection: "row",
+  minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
 }));
 
 const DashboardList = styled("ul")(({ theme }) => ({
@@ -50,7 +57,12 @@ const DashboardList = styled("ul")(({ theme }) => ({
 const DashboardListItem = styled("li")(({ theme }) => ({
   listStyle: "none",
   position: "relative",
-  padding: theme.spacing(2.5, 2),
+  color: theme.palette.common.white,
+  margin: theme.spacing(1.5, 0),
+  background: theme.palette.text.primary,
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "stretch",
 }));
 
 const DashboardLink = styled(Link)(({ theme }) => ({
@@ -60,20 +72,19 @@ const DashboardLink = styled(Link)(({ theme }) => ({
   color: "currentColor",
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
   marginBottom: theme.spacing(1.5),
-  marginTop: 0,
+  padding: theme.spacing(2),
+  margin: 0,
 }));
 
 const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({
-  position: "absolute",
-  top: theme.spacing(2),
-  right: theme.spacing(1),
+  display: "flex",
+  borderLeft: `1px solid ${theme.palette.border.main}`,
 }));
 
 const LinkSubText = styled(Box)(() => ({
   color: "#aaa",
-  "& a": {
-    color: "#fff",
-  },
+  fontWeight: "normal",
+  paddingTop: "0.5em",
 }));
 
 const Confirm = ({
@@ -113,13 +124,12 @@ const Confirm = ({
 );
 
 const AddButtonRoot = styled(ButtonBase)(({ theme }) => ({
-  width: "100%",
-  padding: theme.spacing(4),
   fontSize: 20,
-  backgroundColor: "rgba(255,255,255,0.25)",
-  display: "block",
+  display: "flex",
+  alignItems: "center",
   textAlign: "left",
-  marginTop: theme.spacing(2),
+  color: theme.palette.primary.main,
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
 }));
 
 function AddButton({
@@ -131,7 +141,7 @@ function AddButton({
 }): FCReturn {
   return (
     <AddButtonRoot onClick={onClick}>
-      <Add sx={{ mr: 3, verticalAlign: "middle" }} /> {children}
+      <AddCircleOutlineIcon sx={{ mr: 1 }} /> {children}
     </AddButtonRoot>
   );
 }
@@ -191,17 +201,15 @@ const FlowItem: React.FC<FlowItemProps> = ({
         />
       )}
       <DashboardListItem>
-        <Box pr={4}>
-          <DashboardLink href={`./${flow.slug}`} prefetch={false}>
-            {flow.slug}
-          </DashboardLink>
+        <DashboardLink href={`./${flow.slug}`} prefetch={false}>
+          {flow.slug}
           <LinkSubText>
             {formatLastEditMessage(
               flow.operations[0].createdAt,
               flow.operations[0]?.actor,
             )}
           </LinkSubText>
-        </Box>
+        </DashboardLink>
         {useStore.getState().canUserEditTeam(teamSlug) && (
           <StyledSimpleMenu
             items={[
@@ -302,57 +310,70 @@ const Team: React.FC = () => {
   return (
     <Root>
       <Dashboard>
-        <Box
-          pl={2}
-          pb={2}
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
-          <Typography variant="h2" component="h1">
-            My services
-          </Typography>
-          {useStore.getState().canUserEditTeam(slug) ? (
-            <Edit />
-          ) : (
-            <Visibility />
-          )}
-        </Box>
-        {useStore.getState().canUserEditTeam(slug) && (
-          <AddButton
-            onClick={() => {
-              const newFlowName = prompt("Service name");
-              if (newFlowName) {
-                const newFlowSlug = slugify(newFlowName);
-                useStore
-                  .getState()
-                  .createFlow(teamId, newFlowSlug)
-                  .then((newId: string) => {
-                    navigation.navigate(`/${slug}/${newId}`);
-                  });
-              }
-            }}
-          >
-            Add a new service
-          </AddButton>
-        )}
-        {flows && (
-          <DashboardList>
-            {flows.map((flow: any) => (
-              <FlowItem
-                flow={flow}
-                key={flow.slug}
-                teamId={teamId}
-                teamSlug={slug}
-                refreshFlows={() => {
-                  fetchFlows();
+        <TeamMenu />
+        <Container maxWidth="formWrap">
+          <Box py={4}>
+            <Box
+              pb={1}
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
                 }}
-              />
-            ))}
-          </DashboardList>
-        )}
+              >
+                <Typography variant="h2" component="h1" pr={1}>
+                  Services
+                </Typography>
+                {useStore.getState().canUserEditTeam(slug) ? (
+                  <Edit />
+                ) : (
+                  <Visibility />
+                )}
+              </Box>
+              {useStore.getState().canUserEditTeam(slug) && (
+                <AddButton
+                  onClick={() => {
+                    const newFlowName = prompt("Service name");
+                    if (newFlowName) {
+                      const newFlowSlug = slugify(newFlowName);
+                      useStore
+                        .getState()
+                        .createFlow(teamId, newFlowSlug)
+                        .then((newId: string) => {
+                          navigation.navigate(`/${slug}/${newId}`);
+                        });
+                    }
+                  }}
+                >
+                  Add a new service
+                </AddButton>
+              )}
+            </Box>
+            {flows && (
+              <DashboardList>
+                {flows.map((flow: any) => (
+                  <FlowItem
+                    flow={flow}
+                    key={flow.slug}
+                    teamId={teamId}
+                    teamSlug={slug}
+                    refreshFlows={() => {
+                      fetchFlows();
+                    }}
+                  />
+                ))}
+              </DashboardList>
+            )}
+          </Box>
+        </Container>
       </Dashboard>
     </Root>
   );

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -14,7 +14,6 @@ import { useStore } from "./FlowEditor/lib/store";
 interface TeamTheme {
   slug: string;
   primaryColour: string;
-  logo: string;
 }
 
 interface Props {
@@ -42,18 +41,22 @@ const StyledLink = styled(Link)(() => ({
   textDecoration: "none",
 }));
 
-const LogoWrap = styled(Box)(() => ({
-  width: "90px",
-  height: "50px",
+const TeamCard = styled(Card)(({ theme }) => ({
   display: "flex",
-  justifyContent: "center",
+  justifyContent: "flex-start",
   alignItems: "center",
+  marginBottom: theme.spacing(2),
+  color: theme.palette.text.primary,
+  outline: `1px solid ${theme.palette.border.light}`,
+  outlineOffset: "-1px",
+  borderRadius: "1px",
 }));
 
-const TeamLogo = styled("img")(() => ({
-  width: "100%",
-  height: "100%",
-  objectFit: "contain",
+const TeamColourBand = styled(Box)(({ theme }) => ({
+  display: "flex",
+  alignSelf: "stretch",
+  width: theme.spacing(1.5),
+  zIndex: 1,
 }));
 
 const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
@@ -66,30 +69,15 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
     teamsToRender.map(({ name, slug }) => {
       const theme = teamTheme.find((t) => t.slug === slug);
       const primaryColour = theme ? theme.primaryColour : "#000";
-      const logo = theme ? theme.logo : "";
 
       return (
         <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
-          <Box
-            mb={1}
-            px={2}
-            py={2}
-            bgcolor={primaryColour}
-            component={Card}
-            color="common.white"
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-            }}
-          >
-            <Typography variant="h4" component="h2">
+          <TeamCard>
+            <TeamColourBand bgcolor={primaryColour} />
+            <Typography p={2} variant="h3" component="h2">
               {name}
             </Typography>
-            <LogoWrap>
-              {logo && <TeamLogo src={logo} alt={`${name} logo`} />}
-            </LogoWrap>
-          </Box>
+          </TeamCard>
         </StyledLink>
       );
     });

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -22,15 +22,16 @@ interface Props {
   teamTheme: Array<TeamTheme>;
 }
 
-const Root = styled(Box)(({ theme }) => ({
+export const DashboardWrap = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
   width: "100%",
-  flex: 1,
+  display: "flex",
   justifyContent: "flex-start",
-  alignItems: "center",
+  alignItems: "flex-start",
 }));
 
-const Dashboard = styled(Box)(() => ({
+export const Dashboard = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
   width: "100%",
   display: "flex",
   flexDirection: "row",
@@ -94,7 +95,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
     });
 
   return (
-    <Root>
+    <DashboardWrap>
       <Dashboard>
         <GlobalMenu />
         <Container maxWidth="formWrap">
@@ -122,7 +123,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
           </Box>
         </Container>
       </Dashboard>
-    </Root>
+    </DashboardWrap>
   );
 };
 

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -1,71 +1,126 @@
-import Edit from "@mui/icons-material/Edit";
-import Visibility from "@mui/icons-material/Visibility";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
+import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
+import { HEADER_HEIGHT } from "components/Header";
+import GlobalMenu from "pages/FlowEditor/components/GlobalMenu";
 import React from "react";
 import { Link } from "react-navi";
 
 import { useStore } from "./FlowEditor/lib/store";
 
+interface TeamTheme {
+  slug: string;
+  primaryColour: string;
+  logo: string;
+}
+
 interface Props {
   teams: Array<Team>;
+  teamTheme: Array<TeamTheme>;
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+  backgroundColor: theme.palette.background.default,
   width: "100%",
   flex: 1,
   justifyContent: "flex-start",
   alignItems: "center",
 }));
 
-const Dashboard = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+const Dashboard = styled(Box)(() => ({
   width: "100%",
-  maxWidth: 600,
-  margin: "auto",
-  padding: theme.spacing(8, 0, 4, 0),
+  display: "flex",
+  flexDirection: "row",
+  minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
 }));
 
 const StyledLink = styled(Link)(() => ({
   textDecoration: "none",
 }));
 
-const Teams: React.FC<Props> = ({ teams }) => {
+const LogoWrap = styled(Box)(() => ({
+  width: "90px",
+  height: "50px",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+}));
+
+const TeamLogo = styled("img")(() => ({
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+}));
+
+const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
+  const canUserEditTeam = useStore.getState().canUserEditTeam;
+
+  const editableTeams = teams.filter((team) => canUserEditTeam(team.slug));
+  const viewOnlyTeams = teams.filter((team) => !canUserEditTeam(team.slug));
+
+  const renderTeams = (teamsToRender: Array<Team>) =>
+    teamsToRender.map(({ name, slug }) => {
+      const theme = teamTheme.find((t) => t.slug === slug);
+      const primaryColour = theme ? theme.primaryColour : "#000";
+      const logo = theme ? theme.logo : "";
+
+      return (
+        <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
+          <Box
+            mb={1}
+            px={2}
+            py={2}
+            bgcolor={primaryColour}
+            component={Card}
+            color="common.white"
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <Typography variant="h4" component="h2">
+              {name}
+            </Typography>
+            <LogoWrap>
+              {logo && <TeamLogo src={logo} alt={`${name} logo`} />}
+            </LogoWrap>
+          </Box>
+        </StyledLink>
+      );
+    });
+
   return (
     <Root>
       <Dashboard>
-        <Box pl={2} pb={2}>
-          <Typography variant="h2" component="h1" gutterBottom>
-            Select a team
-          </Typography>
-        </Box>
-        {teams.map(({ name, slug }) => (
-          <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
-            <Box
-              mb={2.5}
-              px={2.5}
-              py={3}
-              mx={2}
-              component={Card}
-              style={{ display: "flex", justifyContent: "space-between" }}
-            >
-              <Typography variant="h4" component="h2">
-                {name}
-              </Typography>
-              {useStore.getState().canUserEditTeam(slug) ? (
-                <Edit />
-              ) : (
-                <Visibility />
-              )}
-            </Box>
-          </StyledLink>
-        ))}
+        <GlobalMenu />
+        <Container maxWidth="formWrap">
+          <Box py={4}>
+            <Typography variant="h2" component="h1" mb={4}>
+              Select a team
+            </Typography>
+            {editableTeams.length > 0 && (
+              <>
+                <Typography variant="h3" component="h2" mb={2}>
+                  My teams
+                </Typography>
+                {renderTeams(editableTeams)}
+              </>
+            )}
+
+            {viewOnlyTeams.length > 0 && (
+              <>
+                <Typography variant="h4" component="h2" mt={4} mb={2}>
+                  Other teams (view only)
+                </Typography>
+                {renderTeams(viewOnlyTeams)}
+              </>
+            )}
+          </Box>
+        </Container>
       </Dashboard>
     </Root>
   );

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -31,6 +31,11 @@ const editorRoutes = compose(
               name
               slug
             }
+            teamThemes: teams_summary {
+              slug
+              primaryColour: primary_colour
+              logo
+            }
           }
         `,
       });
@@ -39,7 +44,7 @@ const editorRoutes = compose(
 
       return {
         title: makeTitle("Teams"),
-        view: <Teams teams={data.teams} />,
+        view: <Teams teams={data.teams} teamTheme={data.teamThemes} />,
       };
     }),
 


### PR DESCRIPTION
## What does this PR do?

Restructuring and styling of the editor interface
- Team cards restyled, separated into teams a user can edit ("My teams"), and read only teams ("Other teams, view only")
- Service cards restyled to inherit portal styling
- Settings pages moved into navigation menus