### PR TITLE
test: try building vultr with ubuntu

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -17,7 +17,7 @@ jobs:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
-          os_type: alpine
+          os_type: ubuntu
           plan: vc2-1c-1gb
           pull_request_id: ${{ env.PULLREQUEST_ID }}
           region: lhr

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -307,7 +307,7 @@ jobs:
           action: create
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
-          os_type: alpine
+          os_type: ubuntu
           plan: vc2-1c-1gb
           pull_request_id: ${{ env.PULLREQUEST_ID }}
           region: lhr


### PR DESCRIPTION
Latest Alpine release (3.20) seems to have dropped `aws-cli` and we don't have option via Vultr to specify 3.19, so let's just try going back to Ubuntu builds temporarily until next Alpine release or fix 

See https://www.reddit.com/r/AlpineLinux/comments/1cyd3ws/am_i_tripping_or_was_awscli_removed_from_the/