### PR TITLE
fix: GIS API should return geometry

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -119,14 +119,14 @@ async function go(
       );
       // because there can be many digital land datasets per planx variable, check if this key is already in our result
       if (key && Object.keys(formattedResult).includes(key)) {
-        formattedResult[key]["data"]?.push(omitGeometry(entity));
+        formattedResult[key]["data"]?.push(entity);
       } else {
         if (key) {
           formattedResult[key] = {
             fn: key,
             value: true,
             text: baseSchema[key].pos,
-            data: [omitGeometry(entity)],
+            data: [entity],
             category: baseSchema[key].category,
           };
         }

--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -5,7 +5,7 @@ import type {
 } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
 import fetch from "isomorphic-fetch";
-import { addDesignatedVariable, omitGeometry } from "./helpers";
+import { addDesignatedVariable } from "./helpers";
 import { baseSchema } from "./local_authorities/metadata/base";
 import { $api } from "../../../client";
 


### PR DESCRIPTION
Quick adjustment to start returning the WKT `geometry` & `point` fields from the raw Planning Data "entity" response in our own formatted response for any intersecting entities. 

We used to filter these out for simplicity, but now we want to start prototyping displaying maps of intersecting constraints on the frontend so we need the geometry! (We already have a WKT library in the editor to handle the GeoJSON conversion).