### PR TITLE
feat: Basic CRUD for `userData` structure, setup `ListContext`

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -1,6 +1,6 @@
-import React, { createContext, ReactNode,useContext, useState } from "react";
+import React, { createContext, ReactNode, useContext, useState } from "react";
 
-import { generateNewItem,Schema, UserData } from "../model";
+import { generateNewItem, Schema, UserData } from "../model";
 
 interface ListContextValue {
   schema: Schema;
@@ -43,7 +43,16 @@ export const ListProvider: React.FC<ListProviderProps> = ({
   const editItem = (index: number) => setActiveIndex(index);
 
   const removeItem = (index: number) => {
-    if (index === activeIndex || index === 0) cancelEditItem();
+    // If item is currently in Edit mode, exit Edit mode
+    if (index === activeIndex || index === 0) {
+      cancelEditItem();
+    }
+    // If item is before currently active card, retain active card
+    if (activeIndex && index < activeIndex) {
+      setActiveIndex((prev) => (prev === undefined ? 0 : prev - 1));
+    }
+
+    // Remove item from userData
     setUserData((prev) => prev.filter((_, i) => i !== index));
   };
 

--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -43,13 +43,12 @@ export const ListProvider: React.FC<ListProviderProps> = ({
   const editItem = (index: number) => setActiveIndex(index);
 
   const removeItem = (index: number) => {
-    // If item is currently in Edit mode, exit Edit mode
-    if (index === activeIndex || index === 0) {
-      cancelEditItem();
-    }
-    // If item is before currently active card, retain active card
     if (activeIndex && index < activeIndex) {
+      // If item is before currently active card, retain active card
       setActiveIndex((prev) => (prev === undefined ? 0 : prev - 1));
+    } else if (index === activeIndex || index === 0) {
+      // If item is currently in Edit mode, exit Edit mode
+      cancelEditItem();
     }
 
     // Remove item from userData

--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, ReactNode,useContext, useState } from "react";
+
+import { generateNewItem,Schema, UserData } from "../model";
+
+interface ListContextValue {
+  schema: Schema;
+  activeIndex: number | undefined;
+  userData: UserData;
+  addNewItem: () => void;
+  saveItem: (index: number, updatedItem: UserData[0]) => void;
+  removeItem: (index: number) => void;
+  editItem: (index: number) => void;
+  cancelEditItem: () => void;
+}
+
+interface ListProviderProps {
+  children: ReactNode;
+  schema: Schema;
+}
+
+const ListContext = createContext<ListContextValue | undefined>(undefined);
+
+export const ListProvider: React.FC<ListProviderProps> = ({
+  children,
+  schema,
+}) => {
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(0);
+  const [userData, setUserData] = useState<UserData>(
+    schema.min === 0 ? [] : [generateNewItem(schema)],
+  );
+
+  const addNewItem = () => {
+    setUserData([...userData, generateNewItem(schema)]);
+    setActiveIndex((prev) => (prev === undefined ? 0 : prev + 1));
+  };
+
+  const saveItem = (index: number, updatedItem: UserData[0]) => {
+    setUserData((prev) =>
+      prev.map((item, i) => (i === index ? updatedItem : item)),
+    );
+  };
+
+  const editItem = (index: number) => setActiveIndex(index);
+
+  const removeItem = (index: number) => {
+    if (index === activeIndex || index === 0) cancelEditItem();
+    setUserData((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const cancelEditItem = () => setActiveIndex(undefined);
+
+  return (
+    <ListContext.Provider
+      value={{
+        activeIndex,
+        userData,
+        addNewItem,
+        saveItem,
+        schema,
+        editItem,
+        removeItem,
+        cancelEditItem,
+      }}
+    >
+      {children}
+    </ListContext.Provider>
+  );
+};
+
+export const useListContext = (): ListContextValue => {
+  const context = useContext(ListContext);
+  if (!context) {
+    throw new Error("useListContext must be used within a ListProvider");
+  }
+  return context;
+};

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -1,3 +1,5 @@
+import { within } from "@testing-library/react";
+import { cloneDeep, merge } from "lodash";
 import React from "react";
 import { axe, setup } from "testUtils";
 
@@ -99,9 +101,269 @@ describe("Navigating back", () => {
 });
 
 describe("Building a list", () => {
-  test.todo("Adding an item");
-  test.todo("Editing an item");
-  test.todo("Removing an item");
+  it("does not display a default item if the schema has no required minimum", () => {
+    const mockWithMinZero = merge(cloneDeep(mockProps), { schema: { min: 0 } });
+    const { queryByRole, getByRole } = setup(
+      <ListComponent {...mockWithMinZero} />,
+    );
+
+    // No card present
+    const activeListHeading = queryByRole("heading", {
+      level: 2,
+      name: "Animal 1",
+    });
+    expect(activeListHeading).toBeNull();
+
+    // Button is present allow additional items to be added
+    const addItemButton = getByRole("button", {
+      name: /Add a new animal type/,
+    });
+    expect(addItemButton).toBeInTheDocument();
+    expect(addItemButton).not.toBeDisabled();
+  });
+
+  it("displays a default item if the schema has a required minimum", () => {
+    const { getByRole, queryByLabelText } = setup(
+      <ListComponent {...mockProps} />,
+    );
+
+    // Card present...
+    const activeListHeading = getByRole("heading", {
+      level: 2,
+      name: "Animal 1",
+    });
+    expect(activeListHeading).toBeInTheDocument();
+
+    // ...with active fields
+    const inputField = queryByLabelText(/What's their name?/);
+    expect(inputField).toBeInTheDocument();
+    expect(inputField).not.toBeDisabled();
+  });
+
+  test("Adding an item", async () => {
+    const { getAllByRole, getByRole, user } = setup(
+      <ListComponent {...mockProps} />,
+    );
+
+    let cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(1);
+
+    const addItemButton = getByRole("button", {
+      name: /Add a new animal type/,
+    });
+    await user.click(addItemButton);
+
+    // Item successfully added
+    cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(2);
+
+    // Old item is inactive
+    const [firstCard, secondCard] = cards;
+    expect(firstCard).not.toBeNull();
+    expect(
+      within(firstCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+
+    // New item is active
+    expect(secondCard).not.toBeNull();
+    expect(
+      within(secondCard!).getByLabelText(/What's their name?/),
+    ).toBeInTheDocument();
+  });
+
+  test("Editing an item", async () => {
+    // Setup three cards
+    const { getAllByRole, getByRole, user, findByLabelText } = setup(
+      <ListComponent {...mockProps} />,
+    );
+
+    const addItemButton = getByRole("button", {
+      name: /Add a new animal type/,
+    });
+    await user.click(addItemButton);
+    await user.click(addItemButton);
+
+    let cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(3);
+
+    let [firstCard, secondCard, thirdCard] = cards;
+
+    // Final card is currently active
+    expect(thirdCard).not.toBeNull();
+    expect(
+      within(thirdCard!).getByLabelText(/What's their name?/),
+    ).toBeInTheDocument();
+
+    // Hitting "cancel" takes us out of Edit mode
+    const thirdCardCancelButton = within(thirdCard!).getByRole("button", {
+      name: /Cancel/,
+    });
+    await user.click(thirdCardCancelButton);
+
+    cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    [firstCard, secondCard, thirdCard] = cards;
+
+    // No cards currently active
+    expect(
+      within(firstCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+    expect(
+      within(secondCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+    expect(
+      within(thirdCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+
+    // All card in view only / summary mode
+    expect(within(firstCard!).getByText(/What's their name?/)).toBeVisible();
+    expect(within(secondCard!).getByText(/What's their name?/)).toBeVisible();
+    expect(within(thirdCard!).getByText(/What's their name?/)).toBeVisible();
+
+    // Hit "Edit" on second card
+    const secondCardEditButton = within(secondCard!).getByRole("button", {
+      name: /Edit/,
+    });
+    await user.click(secondCardEditButton);
+
+    cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    [firstCard, secondCard, thirdCard] = cards;
+
+    // Second card now editable
+    expect(
+      within(secondCard!).getByLabelText(/What's their name?/),
+    ).toBeInTheDocument();
+  });
+
+  test("Removing an item when all cards are inactive", async () => {
+    // Setup three cards
+    const { getAllByRole, getByRole, user, getByLabelText, queryAllByRole } =
+      setup(<ListComponent {...mockProps} />);
+
+    const addItemButton = getByRole("button", {
+      name: /Add a new animal type/,
+    });
+    await user.click(addItemButton);
+    await user.click(addItemButton);
+
+    let cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(3);
+
+    let [firstCard, secondCard, thirdCard] = cards;
+
+    const thirdCardCancelButton = within(thirdCard!).getByRole("button", {
+      name: /Cancel/,
+    });
+    await user.click(thirdCardCancelButton);
+
+    [firstCard, secondCard, thirdCard] = getAllByRole("heading", {
+      level: 2,
+    }).map((el) => el.closest("div"));
+
+    // Remove third card
+    const thirdCardRemoveButton = within(thirdCard!).getByRole("button", {
+      name: /Remove/,
+    });
+    await user.click(thirdCardRemoveButton);
+    cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(2);
+
+    [firstCard, secondCard] = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+
+    // Previous items remain inactive
+    expect(
+      within(firstCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+    expect(
+      within(secondCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+
+    // Remove second card
+    const secondCardRemoveButton = within(secondCard!).getByRole("button", {
+      name: /Remove/,
+    });
+    await user.click(secondCardRemoveButton);
+    cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(1);
+
+    [firstCard] = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+
+    // Previous items remain inactive
+    expect(
+      within(firstCard!).queryByLabelText(/What's their name?/),
+    ).toBeNull();
+
+    // Remove first card
+    const firstCardRemoveButton = within(firstCard!).getByRole("button", {
+      name: /Remove/,
+    });
+    await user.click(firstCardRemoveButton);
+    cards = queryAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(0);
+
+    // Add item back
+    await user.click(addItemButton);
+
+    // This is now editable and active
+    const newFirstCardInput = getByLabelText(/What's their name?/);
+    expect(newFirstCardInput).toBeInTheDocument();
+  });
+
+  test("Removing an item when another card is active", async () => {
+    // Setup two cards
+    const { getAllByRole, getByRole, user, getByLabelText, queryAllByRole } =
+      setup(<ListComponent {...mockProps} />);
+
+    const addItemButton = getByRole("button", {
+      name: /Add a new animal type/,
+    });
+    await user.click(addItemButton);
+
+    const [firstCard, secondCard] = getAllByRole("heading", { level: 2 }).map(
+      (el) => el.closest("div"),
+    );
+
+    // Second card is active
+    expect(
+      within(secondCard!).getByLabelText(/What's their name?/),
+    ).toBeInTheDocument();
+
+    // Remove first
+    const firstCardRemoveButton = within(firstCard!).getByRole("button", {
+      name: /Remove/,
+    });
+    await user.click(firstCardRemoveButton);
+    const cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+    expect(cards).toHaveLength(1);
+
+    // First card is active
+    expect(
+      within(cards[0]!).getByLabelText(/What's their name?/),
+    ).toBeInTheDocument();
+  });
 });
 
 describe("Form validation and error handling", () => {

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
 import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
@@ -100,23 +101,25 @@ const InactiveListCard: React.FC<{
         {schema.type} {index + 1}
       </Typography>
       <Table>
-        {schema.fields.map((field, i) => (
-          <TableRow>
-            <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
-              {field.data.title}
-            </TableCell>
-            <TableCell>{userData[index][i]?.val}</TableCell>
-          </TableRow>
-        ))}
+        <TableBody>
+          {schema.fields.map((field, i) => (
+            <TableRow key={`tableRow-${i}`}>
+              <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+                {field.data.title}
+              </TableCell>
+              <TableCell>{userData[index][i]?.val}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
       </Table>
       <Box display="flex" gap={2}>
         <CardButton onClick={() => removeItem(index)}>
-          <DeleteIcon titleAccess="Remove" color="warning" fontSize="medium" />
+          <DeleteIcon color="warning" fontSize="medium" />
           Remove
         </CardButton>
         <CardButton onClick={() => editItem(index)}>
           {/* TODO: Is primary colour really right here? */}
-          <EditIcon titleAccess="Edit" color="primary" fontSize="medium" />
+          <EditIcon color="primary" fontSize="medium" />
           Edit
         </CardButton>
       </Box>

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -1,14 +1,21 @@
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
+import Table from "@mui/material/Table";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/ui";
 import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import InputRow from "ui/shared/InputRow";
 
 import Card from "../../shared/Preview/Card";
 import CardHeader from "../../shared/Preview/CardHeader";
 import type { Field, List } from "../model";
+import { ListProvider, useListContext } from "./Context";
 import {
   NumberFieldInput,
   RadioFieldInput,
@@ -26,6 +33,11 @@ const ListCard = styled(Box)(({ theme }) => ({
   flexDirection: "column",
   gap: theme.spacing(2),
   marginBottom: theme.spacing(2),
+}));
+
+const CardButton = styled(Button)(({ theme }) => ({
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  gap: theme.spacing(2),
 }));
 
 /**
@@ -47,23 +59,76 @@ const InputField: React.FC<Field & { index: number }> = (props) => {
   }
 };
 
-function ListComponent({
-  info,
-  policyRef,
-  howMeasured,
-  schema,
-  handleSubmit,
-  title,
-  description,
-}: Props) {
-  // TODO: Track user state, allow items to be added and removed
-  // TODO: Track "active" index
-  // TODO: Validate min / max
-  // TODO: Validate user input against schema fields, track errors
-  // TODO: On submit generate a payload
+const ActiveListCard: React.FC<{
+  index: number;
+}> = ({ index }) => {
+  const { schema, saveItem, cancelEditItem } = useListContext();
 
   return (
-    <Card handleSubmit={handleSubmit} isValid>
+    // TODO: This should be a HTML form
+    <ListCard>
+      <Typography component="h2" variant="h3">
+        {schema.type} {index + 1}
+      </Typography>
+      {schema.fields.map((field, i) => (
+        <InputRow key={i}>
+          <InputField {...field} index={i} />
+        </InputRow>
+      ))}
+      <Box display="flex" gap={2}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => saveItem(index, [])}
+        >
+          Save
+        </Button>
+        <Button onClick={cancelEditItem}>Cancel</Button>
+      </Box>
+    </ListCard>
+  );
+};
+
+const InactiveListCard: React.FC<{
+  index: number;
+}> = ({ index }) => {
+  const { schema, userData, removeItem, editItem } = useListContext();
+
+  return (
+    <ListCard>
+      <Typography component="h2" variant="h3">
+        {schema.type} {index + 1}
+      </Typography>
+      <Table>
+        {schema.fields.map((field, i) => (
+          <TableRow>
+            <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+              {field.data.title}
+            </TableCell>
+            <TableCell>{userData[index][i]?.val}</TableCell>
+          </TableRow>
+        ))}
+      </Table>
+      <Box display="flex" gap={2}>
+        <CardButton onClick={() => removeItem(index)}>
+          <DeleteIcon titleAccess="Remove" color="warning" fontSize="medium" />
+          Remove
+        </CardButton>
+        <CardButton onClick={() => editItem(index)}>
+          {/* TODO: Is primary colour really right here? */}
+          <EditIcon titleAccess="Edit" color="primary" fontSize="medium" />
+          Edit
+        </CardButton>
+      </Box>
+    </ListCard>
+  );
+};
+
+const Root = ({ title, description, info, policyRef, howMeasured }: Props) => {
+  const { userData, activeIndex, schema, addNewItem } = useListContext();
+
+  return (
+    <Card handleSubmit={() => console.log({ userData })} isValid>
       <CardHeader
         title={title}
         description={description}
@@ -71,26 +136,29 @@ function ListComponent({
         policyRef={policyRef}
         howMeasured={howMeasured}
       />
-      <ListCard>
-        <Typography component="h2" variant="h3">
-          {schema.type} index
-        </Typography>
-        {schema.fields.map((field, i) => (
-          <InputRow key={i}>
-            <InputField {...field} index={i} />
-          </InputRow>
-        ))}
-        <Box display="flex" gap={2}>
-          <Button variant="contained" color="primary">
-            Save
-          </Button>
-          <Button>Cancel</Button>
-        </Box>
-      </ListCard>
-      <Button variant="contained" color="secondary">
+      {userData.map((_, i) =>
+        i === activeIndex ? (
+          <ActiveListCard key={`card-${i}`} index={i} />
+        ) : (
+          <InactiveListCard key={`card-${i}`} index={i} />
+        ),
+      )}
+      <Button variant="contained" color="secondary" onClick={addNewItem}>
         + Add a new {schema.type.toLowerCase()} type
       </Button>
     </Card>
+  );
+};
+
+function ListComponent(props: Props) {
+  // TODO: Validate min / max
+  // TODO: Validate user input against schema fields, track errors
+  // TODO: On submit generate a payload
+
+  return (
+    <ListProvider schema={props.schema}>
+      <Root {...props} />
+    </ListProvider>
   );
 }
 

--- a/editor.planx.uk/src/@planx/components/List/model.ts
+++ b/editor.planx.uk/src/@planx/components/List/model.ts
@@ -10,20 +10,24 @@ import { SCHEMAS } from "./Editor";
 interface QuestionInput {
   title: string;
   description?: string;
-  fn?: string;
   options: Option[];
 }
 
-export type TextField = { type: "text"; required?: boolean; data: TextInput };
+// TODO: Add summary fields for inactive view?
+export type TextField = {
+  type: "text";
+  required?: boolean;
+  data: TextInput & { fn: string };
+};
 export type NumberField = {
   type: "number";
   required?: boolean;
-  data: NumberInput;
+  data: NumberInput & { fn: string };
 };
 export type QuestionField = {
   type: "question";
   required?: boolean;
-  data: QuestionInput;
+  data: QuestionInput & { fn: string };
 };
 
 /**
@@ -38,7 +42,7 @@ export type Field = TextField | NumberField | QuestionField;
 export interface Schema {
   type: string;
   fields: Field[];
-  min?: number;
+  min: number;
   max?: number;
 }
 
@@ -58,3 +62,21 @@ export const parseContent = (data: Record<string, any> | undefined): List => ({
   schema: data?.schema || SCHEMAS[0].schema,
   ...parseMoreInformation(data),
 });
+
+interface Response {
+  type: Field["type"];
+  val: string;
+  fn: string;
+}
+
+export type UserData = Response[][];
+
+export const generateNewItem = (schema: Schema): Response[] => {
+  const item = schema.fields.map((field) => ({
+    type: field.type,
+    val: "",
+    fn: field.data.fn,
+  }));
+
+  return item;
+};


### PR DESCRIPTION
## What does this PR do?
- Follows on from https://github.com/theopensystemslab/planx-new/pull/3197
- Sets up `ListContext` to wrap components and share state and logic
- List items can be added, edited and removed
- Tests to describe this behaviour

https://github.com/theopensystemslab/planx-new/assets/20502206/5cf251de-6cff-458c-9651-22eabe40a1d9


## What's not in this PR?
- No form state / form validation - any values typed into inputs is not persisted
- Logic to stop new items being added when there's still an active/incomplete item
- UI polish, e.g. scroll to new item, scrol on delete or edit

## Context / Design
I feel like one of the main pain points with the `FileUploadAndLabel` component was having a group of interdependent components which relied on a shared state in the "root" component. This wasn't a problem initially, but as things grew it got harder and harder to manage, and there's a lot of prop-drilling and derived state there. I've tried to anticipate this a little by setting up a `React.Context` to wrap these components. This also means co-location of logic, and separation from style/structure which is nice.

Again, a lot of unfinished work and outstanding `TODO`s in this PR!
