### PR TITLE
chore: Run React tests with `--silent` flag

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -172,7 +172,7 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
         working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm test
+      - run: pnpm test:silent
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   build_react_app:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -119,7 +119,7 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
         working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm test
+      - run: pnpm test:silent
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   end_to_end_tests:


### PR DESCRIPTION
It's currently tricky to parse the logs from the React tests in the GitHub UI as they're massive! Over 50mb of logs on each run means a lot of endless scrolling and frustration.

Almost all the warnings are either - 
 - `console.alert()` and `console.error()` messages such as Zustand deprecation warnings, CSS warnings (`:nth-child` alert)
 - `console.log()` called by tests or components
 - `not wrapped in act(...)` warning (see https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning)

This should not affect test runs, or failure messages, it just stops the console working during test runs (docs: https://jestjs.io/docs/cli#--silent)

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/a9059c02-a83d-4971-b4a6-0f2aa6681dd8)
