### PR TITLE
fix: Flow status migration script

### DIFF
--- a/hasura.planx.uk/migrations/1715954131936_create_table_public_flow_status_enum/up.sql
+++ b/hasura.planx.uk/migrations/1715954131936_create_table_public_flow_status_enum/up.sql
@@ -10,12 +10,15 @@ COMMENT ON TABLE "public"."flow_status_enum" IS E'An enum for tracking the statu
 INSERT INTO "public"."flow_status_enum"("value", "comment") VALUES (E'online', null);
 INSERT INTO "public"."flow_status_enum"("value", "comment") VALUES (E'offline', null);
 
--- Add flow.status column
+-- Add new flow.status column without default value
 alter table "public"."flows" add column "status" text
- not null default 'offline';
+ not null;
 
  -- Populate flows.status for all existing flows
 UPDATE "public"."flows" SET status = 'online';
+
+-- Set the default value for new rows
+ALTER TABLE "public"."flows" ALTER COLUMN "status" SET DEFAULT 'offline';
 
 alter table "public"."flows"
   add constraint "flows_status_fkey"


### PR DESCRIPTION
Please see https://github.com/theopensystemslab/planx-new/pull/3183#discussion_r1617191040 for context.

Despite reading as being correct (to me!) I didn't get the expected results on staging after merging to `main`. All `flow.status` columns were set to `"offline"` despite the command `UPDATE "public"."flows" SET status = 'online';` in the migration script.

I'm guessing this may be an issue a race condition, or some sort of issue with how Hasura handles transactions as part of migrations?

I manually fixed this on staging but as there's an associated trigger and audit table, it was a bit of a hassle. This change in this PR won't get run on staging but the updated migration will get run when it hits production.