### PR TITLE
fix(a11y): Non-text contrast (3:1)

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -57,13 +57,13 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   action: {
     selected: "#F8F8F8",
     focus: "#FFDD00",
-    disabled: "#B4B4B4",
+    disabled: "#949494",
   },
   error: {
     main: "#D4351C",
   },
   success: {
-    main: "#4CAF50",
+    main: "#49A74C",
     dark: "#265A26",
   },
   info: {


### PR DESCRIPTION
<img width="457" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/5f6f3c10-2c07-4307-be8d-8e15352fd7ee">

<img width="511" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/6fac2aaf-a533-4309-8c8b-2ea0f030dfbf">


Colour are derived from current colours, darkened to hit 3:1 ratio.