### PR TITLE
fix: Incorrect status in `flow_status_history`

### DIFF
--- a/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
@@ -94,8 +94,8 @@ Then("a new flow_status_history record is created", async function () {
   assert.ok(flowStatusHistory[1], "flow_status_history record not created");
   assert.equal(
     flowStatusHistory[1].status,
-    "offline",
-    `Flow status is ${flowStatusHistory[1].status} - it should be "offline"`,
+    "online",
+    `Flow status is ${flowStatusHistory[1].status} - it should be "online"`,
   );
   assert.notEqual(
     flowStatusHistory[1].eventStart,

--- a/hasura.planx.uk/migrations/1715954131936_create_table_public_flow_status_enum/up.sql
+++ b/hasura.planx.uk/migrations/1715954131936_create_table_public_flow_status_enum/up.sql
@@ -60,7 +60,7 @@ BEGIN
 
         -- Start new event
         INSERT INTO flow_status_history (flow_id, status, event_start)
-        VALUES (NEW.id, OLD.status, NOW());
+        VALUES (NEW.id, NEW.status, NOW());
 
     ELSIF (TG_OP = 'INSERT') THEN
         -- Start new event


### PR DESCRIPTION
Apologies - just spotted this issue now when testing. This must have been missed when changing the model to offline by default here - https://github.com/theopensystemslab/planx-new/pull/3170/commits/81d7c7be64566b770ca5abb98b1b429e00a01a6f

I've actually just updated the _existing_ migration file here, with proposal to be to update the trigger directly on staging and production as a more immediate fix.

✅ Regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/9289391705