### PR TITLE
feat: Add restart text label to restart button

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -366,16 +366,16 @@ const PublicToolbar: React.FC<{
                   size="large"
                   aria-describedby="restart-application-description"
                 >
+                  <Reset color="secondary" />
                   <Typography
                     id="restart-application-description"
                     variant="body2"
                     fontSize="small"
                     fontWeight={FONT_WEIGHT_SEMI_BOLD}
-                    pr={0.5}
+                    pl={0.5}
                   >
                     Restart
                   </Typography>
-                  <Reset color="secondary" />
                 </IconButton>
               )}
             </RightBox>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -368,11 +368,12 @@ const PublicToolbar: React.FC<{
                 >
                   <Typography
                     id="restart-application-description"
-                    style={visuallyHidden}
+                    variant="body2"
+                    fontSize="small"
+                    fontWeight={FONT_WEIGHT_SEMI_BOLD}
+                    pr={0.5}
                   >
-                    Open a dialog with the option to restart your application.
-                    If you chose to restart your application, this will delete
-                    your previous answers
+                    Restart
                   </Typography>
                   <Reset color="secondary" />
                 </IconButton>


### PR DESCRIPTION
## What does this PR do?

Adds a "restart" text label to the restart button in the page header.

Highlighted as a usability suggestion in the DAC audit.

**Example:**
https://3211.planx.pizza/camden/apply-for-prior-approval/published