### PR TITLE
Production deploy

### DIFF
--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/base.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/base.ts
@@ -14,8 +14,8 @@ type PlanningConstraintsBaseSchema = Record<string, PlanningConstraintConfig>;
 const baseSchema: PlanningConstraintsBaseSchema = {
   article4: {
     active: true,
-    neg: "is not subject to local permitted development restrictions (known as Article 4 directions)",
-    pos: "is subject to local permitted development restrictions (known as Article 4 directions)",
+    neg: "is not in an Article 4 direction area",
+    pos: "is in an Article 4 direction area",
     "digital-land-datasets": ["article-4-direction-area"],
     category: "General policy",
   },

--- a/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
@@ -94,8 +94,8 @@ Then("a new flow_status_history record is created", async function () {
   assert.ok(flowStatusHistory[1], "flow_status_history record not created");
   assert.equal(
     flowStatusHistory[1].status,
-    "offline",
-    `Flow status is ${flowStatusHistory[1].status} - it should be "offline"`,
+    "online",
+    `Flow status is ${flowStatusHistory[1].status} - it should be "online"`,
   );
   assert.notEqual(
     flowStatusHistory[1].eventStart,

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -366,15 +366,16 @@ const PublicToolbar: React.FC<{
                   size="large"
                   aria-describedby="restart-application-description"
                 >
+                  <Reset color="secondary" />
                   <Typography
                     id="restart-application-description"
-                    style={visuallyHidden}
+                    variant="body2"
+                    fontSize="small"
+                    fontWeight={FONT_WEIGHT_SEMI_BOLD}
+                    pl={0.5}
                   >
-                    Open a dialog with the option to restart your application.
-                    If you chose to restart your application, this will delete
-                    your previous answers
+                    Restart
                   </Typography>
-                  <Reset color="secondary" />
                 </IconButton>
               )}
             </RightBox>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -129,9 +129,13 @@ const ServiceSettings: React.FC = () => {
     initialValues: {
       status: flowStatus || "online",
     },
-    onSubmit: async ({ status }) => {
-      await updateFlowStatus(status);
-      setIsAlertOpen(true);
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await updateFlowStatus(values.status);
+      if (isSuccess) {
+        setIsAlertOpen(true);
+        // Reset "dirty" status to disable Save & Reset buttons
+        resetForm({ values });
+      }
     },
   });
 

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -418,6 +418,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - team_id
@@ -441,6 +442,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - team_id
@@ -471,6 +473,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - team_id
@@ -494,6 +497,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - status
@@ -512,6 +516,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - status
@@ -529,6 +534,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - status
@@ -547,6 +553,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - status
@@ -566,6 +573,7 @@
           - creator_id
           - data
           - id
+          - name
           - settings
           - slug
           - status
@@ -587,6 +595,7 @@
       permission:
         columns:
           - data
+          - name
           - settings
           - slug
           - status
@@ -606,6 +615,7 @@
       permission:
         columns:
           - data
+          - name
           - settings
           - slug
           - status

--- a/hasura.planx.uk/migrations/1715954131936_create_table_public_flow_status_enum/up.sql
+++ b/hasura.planx.uk/migrations/1715954131936_create_table_public_flow_status_enum/up.sql
@@ -60,7 +60,7 @@ BEGIN
 
         -- Start new event
         INSERT INTO flow_status_history (flow_id, status, event_start)
-        VALUES (NEW.id, OLD.status, NOW());
+        VALUES (NEW.id, NEW.status, NOW());
 
     ELSIF (TG_OP = 'INSERT') THEN
         -- Start new event

--- a/hasura.planx.uk/migrations/1716902907392_alter_table_public_flows_add_column_name/down.sql
+++ b/hasura.planx.uk/migrations/1716902907392_alter_table_public_flows_add_column_name/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."flows"."name" is NULL;
+
+ALTER TABLE flows DROP COLUMN name;

--- a/hasura.planx.uk/migrations/1716902907392_alter_table_public_flows_add_column_name/up.sql
+++ b/hasura.planx.uk/migrations/1716902907392_alter_table_public_flows_add_column_name/up.sql
@@ -1,0 +1,9 @@
+alter table "public"."flows" add column "name" text
+ null;
+ comment on column "public"."flows"."name" is 'The name of the flow, entered by the user and used to generate the "slug"';
+
+UPDATE flows
+SET name = replace(concat(upper(substring(slug,1,1)),right(slug,-1)),'-',' ')
+WHERE name IS NULL
+
+

--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -11,7 +11,8 @@ CREATE TEMPORARY TABLE sync_flows (
   settings jsonb,
   copied_from uuid,
   analytics_link text,
-  status text
+  status text,
+  name text
 );
 
 \copy sync_flows FROM '/tmp/flows.csv' WITH (FORMAT csv, DELIMITER ';');
@@ -26,7 +27,8 @@ INSERT INTO flows (
   settings,
   copied_from,
   analytics_link,
-  status
+  status,
+  name
 )
 SELECT
   id,
@@ -38,7 +40,8 @@ SELECT
   settings,
   copied_from,
   NULL,
-  status
+  status,
+  name
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -50,7 +53,8 @@ SET
   settings = EXCLUDED.settings,
   copied_from = EXCLUDED.copied_from,
   analytics_link = NULL,
-  status = EXCLUDED.status;
+  status = EXCLUDED.status,
+  name = EXCLUDED.name;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;


### PR DESCRIPTION
So our nightly database sync doesn't fail on the new `flows.name` column :slightly_smiling_face: 