### PR TITLE
fix: spell "metres" not "meters" in NumberInput modal

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
@@ -7,6 +7,9 @@ import { setup } from "testUtils";
 
 import DateInputComponent from "./Editor";
 
+// double regular timeout for tests in this file, as they regularly timeout on CI
+jest.setTimeout(10000);
+
 const minError = "Min must be less than max";
 const maxError = "Max must be greater than min";
 const invalidError = "Enter a valid date in DD.MM.YYYY format";

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -70,7 +70,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
               <Input
                 name="units"
                 value={formik.values.units}
-                placeholder="e.g. square meters"
+                placeholder="eg square metres"
                 onChange={formik.handleChange}
               />
             </InputRowItem>


### PR DESCRIPTION
:gb: 