### PR TITLE
feat: List component - submission and back navigation

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -1,9 +1,17 @@
+import { makeData } from "@planx/components/shared/utils";
+import { PublicProps } from "@planx/components/ui";
 import { FormikProps, useFormik } from "formik";
-import React, { createContext, ReactNode, useContext, useState } from "react";
+import React, {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useState,
+} from "react";
 
 import {
   generateInitialValues,
   generateValidationSchema,
+  List,
   Schema,
   UserData,
 } from "../model";
@@ -17,7 +25,8 @@ interface ListContextValue {
   editItem: (index: number) => void;
   cancelEditItem: () => void;
   formik: FormikProps<UserData>;
-  handleSubmit: () => void;
+  validateAndSubmitForm: () => void;
+  listProps: PublicProps<List>;
   errors: {
     addItem: boolean;
     unsavedItem: boolean;
@@ -26,17 +35,13 @@ interface ListContextValue {
   };
 }
 
-interface ListProviderProps {
-  children: ReactNode;
-  schema: Schema;
-}
+type ListProviderProps = PropsWithChildren<PublicProps<List>>;
 
 const ListContext = createContext<ListContextValue | undefined>(undefined);
 
-export const ListProvider: React.FC<ListProviderProps> = ({
-  children,
-  schema,
-}) => {
+export const ListProvider: React.FC<ListProviderProps> = (props) => {
+  const { schema, children, handleSubmit } = props;
+
   const [activeIndex, setActiveIndex] = useState<number>(0);
 
   const [addItemError, setAddItemError] = useState<boolean>(false);
@@ -91,7 +96,7 @@ export const ListProvider: React.FC<ListProviderProps> = ({
     );
   };
 
-  const handleSubmit = () => {
+  const validateAndSubmitForm = () => {
     // Do not allow submissions with an unsaved item
     if (activeIndex !== -1) return setUnsavedItemError(true);
 
@@ -113,8 +118,7 @@ export const ListProvider: React.FC<ListProviderProps> = ({
       userData: schema.min ? [generateInitialValues(schema)] : [],
     },
     onSubmit: (values) => {
-      console.log("Submit!");
-      console.log({ values });
+      handleSubmit?.(makeData(props, values.userData));
     },
     validateOnBlur: false,
     validateOnChange: false,
@@ -128,11 +132,12 @@ export const ListProvider: React.FC<ListProviderProps> = ({
         addNewItem,
         saveItem,
         schema,
+        listProps: props,
         editItem,
         removeItem,
         cancelEditItem,
         formik,
-        handleSubmit,
+        validateAndSubmitForm,
         errors: {
           addItem: addItemError,
           unsavedItem: unsavedItemError,

--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -1,4 +1,7 @@
-import { makeData } from "@planx/components/shared/utils";
+import {
+  getPreviouslySubmittedData,
+  makeData,
+} from "@planx/components/shared/utils";
 import { PublicProps } from "@planx/components/ui";
 import { FormikProps, useFormik } from "formik";
 import React, {
@@ -42,7 +45,9 @@ const ListContext = createContext<ListContextValue | undefined>(undefined);
 export const ListProvider: React.FC<ListProviderProps> = (props) => {
   const { schema, children, handleSubmit } = props;
 
-  const [activeIndex, setActiveIndex] = useState<number>(0);
+  const [activeIndex, setActiveIndex] = useState<number>(
+    props.previouslySubmittedData ? -1 : 0,
+  );
 
   const [addItemError, setAddItemError] = useState<boolean>(false);
   const [unsavedItemError, setUnsavedItemError] = useState<boolean>(false);
@@ -111,11 +116,19 @@ export const ListProvider: React.FC<ListProviderProps> = (props) => {
   };
 
   const cancelEditItem = () => setActiveIndex(-1);
+
   const editItem = (index: number) => setActiveIndex(index);
+
+  const getInitialValues = () => {
+    const previousValues = getPreviouslySubmittedData(props);
+    if (previousValues) return previousValues;
+
+    return schema.min ? [generateInitialValues(schema)] : [];
+  };
 
   const formik = useFormik<UserData>({
     initialValues: {
-      userData: schema.min ? [generateInitialValues(schema)] : [],
+      userData: getInitialValues(),
     },
     onSubmit: (values) => {
       handleSubmit?.(makeData(props, values.userData));

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -15,6 +15,27 @@ const mockProps: Props = {
   description: "Mock description",
 };
 
+const mockPayload = {
+  data: {
+    mockFn: [
+      {
+        age: 10,
+        cuteness: "Very",
+        email: "richard.parker@pi.com",
+        name: "Richard Parker",
+        size: "Medium",
+      },
+      {
+        age: 10,
+        cuteness: "Very",
+        email: "richard.parker@pi.com",
+        name: "Richard Parker",
+        size: "Medium",
+      },
+    ],
+  },
+};
+
 jest.setTimeout(20_000);
 
 describe("Basic UI", () => {
@@ -393,31 +414,30 @@ describe("Payload generation", () => {
     await user.click(screen.getByTestId("continue-button"));
 
     expect(handleSubmit).toHaveBeenCalled();
-    expect(handleSubmit.mock.calls[0][0]).toMatchObject({
-      data: {
-        mockFn: [
-          {
-            age: 10,
-            cuteness: "Very",
-            email: "richard.parker@pi.com",
-            name: "Richard Parker",
-            size: "Medium",
-          },
-          {
-            age: 10,
-            cuteness: "Very",
-            email: "richard.parker@pi.com",
-            name: "Richard Parker",
-            size: "Medium",
-          },
-        ],
-      },
-    });
+    expect(handleSubmit.mock.calls[0][0]).toMatchObject(mockPayload);
   });
 });
 
 describe("Navigating back", () => {
-  test.todo("it pre-populates list correctly");
+  test("it pre-populates list correctly", async () => {
+    const { getAllByText, queryByLabelText, getAllByRole } = setup(
+      <ListComponent {...mockProps} previouslySubmittedData={mockPayload} />,
+    );
+
+    const cards = getAllByRole("heading", { level: 2 }).map((el) =>
+      el.closest("div"),
+    );
+
+    // Two cards
+    expect(cards).toHaveLength(2);
+
+    // Both inactive
+    expect(queryByLabelText(/What's their name?/)).toBeNull();
+    expect(getAllByText(/What's their name?/)).toHaveLength(2);
+
+    // With the correct previous data
+    expect(getAllByText(/Richard Parker/)).toHaveLength(2);
+  });
 });
 
 /**

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -8,7 +8,7 @@ import ListComponent, { Props } from "../Public";
 import { Zoo } from "../schemas/Zoo";
 
 const mockProps: Props = {
-  fn: "mock",
+  fn: "mockFn",
   schema: Zoo,
   schemaName: "Zoo",
   title: "Mock Title",
@@ -376,7 +376,44 @@ describe("Form validation and error handling", () => {
 });
 
 describe("Payload generation", () => {
-  it.todo("generates a valid payload on submission");
+  it("generates a valid payload on submission", async () => {
+    const handleSubmit = jest.fn();
+    const { getByRole, user } = setup(
+      <ListComponent {...mockProps} handleSubmit={handleSubmit} />,
+    );
+    const addItemButton = getByRole("button", {
+      name: /Add a new animal type/,
+    });
+
+    await fillInResponse(user);
+
+    await user.click(addItemButton);
+    await fillInResponse(user);
+
+    await user.click(screen.getByTestId("continue-button"));
+
+    expect(handleSubmit).toHaveBeenCalled();
+    expect(handleSubmit.mock.calls[0][0]).toMatchObject({
+      data: {
+        mockFn: [
+          {
+            age: 10,
+            cuteness: "Very",
+            email: "richard.parker@pi.com",
+            name: "Richard Parker",
+            size: "Medium",
+          },
+          {
+            age: 10,
+            cuteness: "Very",
+            email: "richard.parker@pi.com",
+            name: "Richard Parker",
+            size: "Medium",
+          },
+        ],
+      },
+    });
+  });
 });
 
 describe("Navigating back", () => {

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -123,7 +123,7 @@ describe("Basic UI", () => {
 describe("Building a list", () => {
   it("does not display a default item if the schema has no required minimum", () => {
     const mockWithMinZero = merge(cloneDeep(mockProps), { schema: { min: 0 } });
-    const { queryByRole, getByRole } = setup(
+    const { queryByRole, getByTestId } = setup(
       <ListComponent {...mockWithMinZero} />,
     );
 
@@ -135,9 +135,7 @@ describe("Building a list", () => {
     expect(activeListHeading).toBeNull();
 
     // Button is present allow additional items to be added
-    const addItemButton = getByRole("button", {
-      name: /Add a new animal type/,
-    });
+    const addItemButton = getByTestId("list-add-button");
     expect(addItemButton).toBeInTheDocument();
     expect(addItemButton).not.toBeDisabled();
   });
@@ -161,26 +159,20 @@ describe("Building a list", () => {
   });
 
   test("Adding an item", async () => {
-    const { getAllByRole, getByRole, user } = setup(
+    const { getAllByTestId, getByTestId, user } = setup(
       <ListComponent {...mockProps} />,
     );
 
-    let cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    let cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(1);
 
     await fillInResponse(user);
 
-    const addItemButton = getByRole("button", {
-      name: /Add a new animal type/,
-    });
+    const addItemButton = getByTestId("list-add-button");
     await user.click(addItemButton);
 
     // Item successfully added
-    cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(2);
 
     // Old item is inactive
@@ -199,15 +191,13 @@ describe("Building a list", () => {
 
   test("Editing an item", async () => {
     // Setup three cards
-    const { getAllByRole, getByRole, user } = setup(
+    const { getAllByTestId, getByTestId, user } = setup(
       <ListComponent {...mockProps} />,
     );
 
     await fillInResponse(user);
 
-    const addItemButton = getByRole("button", {
-      name: /Add a new animal type/,
-    });
+    const addItemButton = getByTestId("list-add-button");
 
     await user.click(addItemButton);
     await fillInResponse(user);
@@ -215,9 +205,7 @@ describe("Building a list", () => {
     await user.click(addItemButton);
     await fillInResponse(user);
 
-    let cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    const cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(3);
 
     let [firstCard, secondCard, thirdCard] = cards;
@@ -244,10 +232,7 @@ describe("Building a list", () => {
     });
     await user.click(secondCardEditButton);
 
-    cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
-    [firstCard, secondCard, thirdCard] = cards;
+    [firstCard, secondCard, thirdCard] = getAllByTestId(/list-card/);
 
     // Second card now editable
     expect(
@@ -257,14 +242,17 @@ describe("Building a list", () => {
 
   test("Removing an item when all cards are inactive", async () => {
     // Setup three cards
-    const { getAllByRole, getByRole, user, getByLabelText, queryAllByRole } =
-      setup(<ListComponent {...mockProps} />);
+    const {
+      getByTestId,
+      getAllByTestId,
+      user,
+      getByLabelText,
+      queryAllByTestId,
+    } = setup(<ListComponent {...mockProps} />);
 
     await fillInResponse(user);
 
-    const addItemButton = getByRole("button", {
-      name: /Add a new animal type/,
-    });
+    const addItemButton = getByTestId("list-add-button");
 
     await user.click(addItemButton);
     await fillInResponse(user);
@@ -272,13 +260,10 @@ describe("Building a list", () => {
     await user.click(addItemButton);
     await fillInResponse(user);
 
-    let cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    let cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(3);
 
-    let [firstCard, secondCard] = cards;
-    const thirdCard = cards[2];
+    let [firstCard, secondCard, thirdCard] = cards;
 
     // Remove third card
     const thirdCardRemoveButton = within(thirdCard!).getByRole("button", {
@@ -286,14 +271,10 @@ describe("Building a list", () => {
     });
 
     await user.click(thirdCardRemoveButton);
-    cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(2);
 
-    [firstCard, secondCard] = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    [firstCard, secondCard, thirdCard] = getAllByTestId(/list-card/);
 
     // Previous items remain inactive
     expect(
@@ -308,14 +289,10 @@ describe("Building a list", () => {
       name: /Remove/,
     });
     await user.click(secondCardRemoveButton);
-    cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(1);
 
-    [firstCard] = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    [firstCard] = getAllByTestId(/list-card/);
 
     // Previous items remain inactive
     expect(
@@ -327,9 +304,7 @@ describe("Building a list", () => {
       name: /Remove/,
     });
     await user.click(firstCardRemoveButton);
-    cards = queryAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    cards = queryAllByTestId(/list-card/);
     expect(cards).toHaveLength(0);
 
     // Add item back
@@ -342,21 +317,17 @@ describe("Building a list", () => {
 
   test("Removing an item when another card is active", async () => {
     // Setup two cards
-    const { getAllByRole, getByRole, user } = setup(
+    const { getAllByTestId, getByTestId, user } = setup(
       <ListComponent {...mockProps} />,
     );
 
     await fillInResponse(user);
 
-    const addItemButton = getByRole("button", {
-      name: /Add a new animal type/,
-    });
+    const addItemButton = getByTestId("list-add-button");
 
     await user.click(addItemButton);
 
-    const [firstCard, secondCard] = getAllByRole("heading", { level: 2 }).map(
-      (el) => el.closest("div"),
-    );
+    const [firstCard, secondCard] = getAllByTestId(/list-card/);
 
     // Second card is active
     expect(
@@ -368,9 +339,7 @@ describe("Building a list", () => {
       name: /Remove/,
     });
     await user.click(firstCardRemoveButton);
-    const cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    const cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(1);
 
     // First card is active
@@ -399,12 +368,10 @@ describe("Form validation and error handling", () => {
 describe("Payload generation", () => {
   it("generates a valid payload on submission", async () => {
     const handleSubmit = jest.fn();
-    const { getByRole, user } = setup(
+    const { getByTestId, user } = setup(
       <ListComponent {...mockProps} handleSubmit={handleSubmit} />,
     );
-    const addItemButton = getByRole("button", {
-      name: /Add a new animal type/,
-    });
+    const addItemButton = getByTestId("list-add-button");
 
     await fillInResponse(user);
 
@@ -420,13 +387,11 @@ describe("Payload generation", () => {
 
 describe("Navigating back", () => {
   test("it pre-populates list correctly", async () => {
-    const { getAllByText, queryByLabelText, getAllByRole } = setup(
+    const { getAllByText, queryByLabelText, getAllByTestId } = setup(
       <ListComponent {...mockProps} previouslySubmittedData={mockPayload} />,
     );
 
-    const cards = getAllByRole("heading", { level: 2 }).map((el) =>
-      el.closest("div"),
-    );
+    const cards = getAllByTestId(/list-card/);
 
     // Two cards
     expect(cards).toHaveLength(2);

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -131,9 +131,18 @@ const InactiveListCard: React.FC<{
   );
 };
 
-const Root = ({ title, description, info, policyRef, howMeasured }: Props) => {
-  const { formik, handleSubmit, activeIndex, schema, addNewItem, errors } =
-    useListContext();
+const Root = () => {
+  const {
+    formik,
+    validateAndSubmitForm,
+    activeIndex,
+    schema,
+    addNewItem,
+    errors,
+    listProps,
+  } = useListContext();
+
+  const { title, description, info, policyRef, howMeasured } = listProps;
 
   const rootError: string =
     (errors.min && `You must provide at least ${schema.min} response(s)`) ||
@@ -141,7 +150,7 @@ const Root = ({ title, description, info, policyRef, howMeasured }: Props) => {
     "";
 
   return (
-    <Card handleSubmit={handleSubmit} isValid>
+    <Card handleSubmit={validateAndSubmitForm} isValid>
       <CardHeader
         title={title}
         description={description}
@@ -181,11 +190,9 @@ const Root = ({ title, description, info, policyRef, howMeasured }: Props) => {
 };
 
 function ListComponent(props: Props) {
-  // TODO: On submit generate a payload
-
   return (
-    <ListProvider schema={props.schema}>
-      <Root {...props} />
+    <ListProvider {...props}>
+      <Root />
     </ListProvider>
   );
 }

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -70,7 +70,7 @@ const ActiveListCard: React.FC<{
     <ErrorWrapper
       error={errors.unsavedItem ? "Please save in order to continue" : ""}
     >
-      <ListCard>
+      <ListCard data-testid={`list-card-${index}`}>
         <Typography component="h2" variant="h3">
           {schema.type} {index + 1}
         </Typography>
@@ -100,7 +100,7 @@ const InactiveListCard: React.FC<{
   const { schema, formik, removeItem, editItem } = useListContext();
 
   return (
-    <ListCard>
+    <ListCard data-testid={`list-card-${i}`}>
       <Typography component="h2" variant="h3">
         {schema.type} {i + 1}
       </Typography>
@@ -179,6 +179,7 @@ const Root = () => {
               color="secondary"
               onClick={addNewItem}
               sx={{ width: "100%" }}
+              data-testid="list-add-button"
             >
               + Add a new {schema.type.toLowerCase()} type
             </Button>


### PR DESCRIPTION
## What does this PR do?
 - Submits validated form values via `handleSubmit()`
   - This adds the values to the passport and breadcrumbs
   - I don't think that what's in this PR is necessarily the right or final shape of this data, but this just serves to complete the wiring up of this component
 - Pre-populate form values on "back" navigation
 - Replaces brittle and repetitive test selectors with `data-testid` values (see https://github.com/theopensystemslab/planx-new/pull/3198#discussion_r1617316748)