### PR TITLE
fix: remove "real" council email extensions in tests

### DIFF
--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -49,7 +49,7 @@ describe(`sending an application by email to a planning office`, () => {
       data: {
         teams: [
           {
-            sendToEmail: "planners@southwark.gov.uk",
+            sendToEmail: "planning.office.example@council.gov.uk",
             notifyPersonalisation: { emailReplyToId: "abc123" },
           },
         ],
@@ -96,7 +96,7 @@ describe(`sending an application by email to a planning office`, () => {
       variables: {
         sessionId: "123",
         teamSlug: "southwark",
-        recipient: "planning.office.example@southwark.gov.uk",
+        recipient: "planning.office.example@council.gov.uk",
         request: {
           personalisation: {
             serviceName: "Apply for something",
@@ -119,7 +119,7 @@ describe(`sending an application by email to a planning office`, () => {
       .then((res) => {
         expect(res.body).toEqual({
           message: `Successfully sent to email`,
-          inbox: "planners@southwark.gov.uk",
+          inbox: "planning.office.example@council.gov.uk",
           govuk_notify_template: "Submit",
         });
       });
@@ -200,7 +200,7 @@ describe(`downloading application data received by email`, () => {
       name: "GetTeamEmailSettings",
       matchOnVariables: false,
       data: {
-        teams: [{ sendToEmail: "planners@southwark.gov.uk" }],
+        teams: [{ sendToEmail: "planning.office.example@council.gov.uk" }],
       },
       variables: { slug: "southwark" },
     });
@@ -229,7 +229,7 @@ describe(`downloading application data received by email`, () => {
   it("errors if email query param does not match the stored database value for this team", async () => {
     await supertest(app)
       .get(
-        "/download-application-files/123?email=wrong@southwark.gov.uk&localAuthority=southwark",
+        "/download-application-files/123?email=wrong@council.gov.uk&localAuthority=southwark",
       )
       .expect(403)
       .then((res) => {
@@ -251,7 +251,7 @@ describe(`downloading application data received by email`, () => {
 
     await supertest(app)
       .get(
-        "/download-application-files/456?email=planners@southwark.gov.uk&localAuthority=southwark",
+        "/download-application-files/456?email=planning.office.example@council.gov.uk&localAuthority=southwark",
       )
       .expect(400)
       .then((res) => {
@@ -264,7 +264,7 @@ describe(`downloading application data received by email`, () => {
   it("calls addTemplateFilesToZip()", async () => {
     await supertest(app)
       .get(
-        "/download-application-files/123?email=planners@southwark.gov.uk&localAuthority=southwark",
+        "/download-application-files/123?email=planning.office.example@council.gov.uk&localAuthority=southwark",
       )
       .expect(200)
       .then((_res) => {


### PR DESCRIPTION
Sam reported this in help-issues: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1717490595516369

My best guess is that `planners@southwark.gov.uk` might actually be a real email now & got forwarded to `rs@southwark.gov.uk` per her screenshot ?? Not sure why this happened for the first time last Friday, but this should hopefully prevent in future :crossed_fingers: 
