### PR TITLE
fix: list of flows should display and be sorted by most recent operations, not `flows.updated_at`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -25,12 +25,12 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { AxiosError } from "axios";
-import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import React, { useState } from "react";
 import { useAsync } from "react-use";
 import Caret from "ui/icons/Caret";
 import Input from "ui/shared/Input";
 
+import { formatLastPublishMessage } from "pages/FlowEditor/utils";
 import Questions from "../../../Preview/Questions";
 import { useStore } from "../../lib/store";
 import EditHistory from "./EditHistory";
@@ -124,9 +124,6 @@ const StyledTab = styled(Tab)(({ theme }) => ({
   },
 })) as typeof Tab;
 
-const formatLastPublish = (date: string, user: string) =>
-  `Last published ${formatDistanceToNow(new Date(date))} ago by ${user}`;
-
 const DebugConsole = () => {
   const [passport, breadcrumbs, flowId, cachedBreadcrumbs] = useStore(
     (state) => [
@@ -203,7 +200,7 @@ const AlteredNestedFlowListItem = (props: Portal) => {
 
   const _nestedFlowLastPublishedRequest = useAsync(async () => {
     const user = await lastPublisher(flowId);
-    setNestedFlowLastPublishedTitle(formatLastPublish(publishedAt, user));
+    setNestedFlowLastPublishedTitle(formatLastPublishMessage(publishedAt, user));
   });
 
   return (
@@ -402,7 +399,7 @@ const Sidebar: React.FC<{
     const date = await lastPublished(flowId);
     const user = await lastPublisher(flowId);
 
-    setLastPublishedTitle(formatLastPublish(date, user));
+    setLastPublishedTitle(formatLastPublishMessage(date, user));
   });
 
   const _validateAndDiffRequest = useAsync(async () => {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -278,11 +278,15 @@ export const editorStore: StateCreator<
           ) {
             id
             slug
-            updated_at
-            operations(limit: 1, order_by: { id: desc }) {
+            updatedAt: updated_at
+            operations (
+              limit: 1,
+              order_by: { created_at: desc }
+            ) {
+              createdAt: created_at
               actor {
-                first_name
-                last_name
+                firstName: first_name
+                lastName: last_name
               }
             }
           }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -272,17 +272,11 @@ export const editorStore: StateCreator<
     const { data } = await client.query({
       query: gql`
         query GetFlow($teamId: Int!) {
-          flows(
-            order_by: { updated_at: desc }
-            where: { team: { id: { _eq: $teamId } } }
-          ) {
+          flows(where: { team: { id: { _eq: $teamId } } }) {
             id
             slug
             updatedAt: updated_at
-            operations (
-              limit: 1,
-              order_by: { created_at: desc }
-            ) {
+            operations(limit: 1, order_by: { created_at: desc }) {
               createdAt: created_at
               actor {
                 firstName: first_name

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -18,3 +18,6 @@ export const formatLastEditMessage = (
   const name = `${actor.firstName} ${actor.lastName}`;
   return `Last edited ${formatLastEditDate(date)} by ${name}`;
 };
+
+export const formatLastPublishMessage = (date: string, user: string): string =>
+  `Last published ${formatLastEditDate(date)} ago by ${user}`;

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -12,6 +12,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import orderBy from "lodash/orderBy";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -195,7 +196,10 @@ const FlowItem: React.FC<FlowItemProps> = ({
             {flow.slug}
           </DashboardLink>
           <LinkSubText>
-            {formatLastEditMessage(flow.operations[0].createdAt, flow.operations[0]?.actor)}
+            {formatLastEditMessage(
+              flow.operations[0].createdAt,
+              flow.operations[0]?.actor,
+            )}
           </LinkSubText>
         </Box>
         {useStore.getState().canUserEditTeam(teamSlug) && (
@@ -281,7 +285,15 @@ const Team: React.FC = () => {
       .getState()
       .getFlows(teamId)
       .then((res: { flows: any[] }) => {
-        setFlows(res.flows);
+        // Copy the array and sort by most recently edited desc using last associated operation.createdAt, not flow.updatedAt
+        const sortedFlows = res.flows
+          .slice()
+          .sort((a, b) =>
+            b.operations[0]["createdAt"].localeCompare(
+              a.operations[0]["createdAt"],
+            ),
+          );
+        setFlows(sortedFlows);
       });
   }, [teamId, setFlows]);
 

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -12,7 +12,6 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -21,6 +20,7 @@ import { slugify } from "utils";
 import { client } from "../lib/graphql";
 import SimpleMenu from "../ui/editor/SimpleMenu";
 import { useStore } from "./FlowEditor/lib/store";
+import { formatLastEditMessage } from "./FlowEditor/utils";
 
 const Root = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.dark,
@@ -74,17 +74,6 @@ const LinkSubText = styled(Box)(() => ({
     color: "#fff",
   },
 }));
-
-const flowInfoHelper = (time: any, operations: any[] = []) => {
-  let str = `Edited ${formatDistanceToNow(new Date(time))} ago`;
-  // there will always be an user attached to every sharedb
-  // operation soon, so the if statement won't be necessary
-  if (operations[0]?.actor) {
-    const { first_name, last_name } = operations[0].actor;
-    str += ` by ${first_name} ${last_name}`;
-  }
-  return str;
-};
 
 const Confirm = ({
   title,
@@ -206,7 +195,7 @@ const FlowItem: React.FC<FlowItemProps> = ({
             {flow.slug}
           </DashboardLink>
           <LinkSubText>
-            {flowInfoHelper(flow.updated_at, flow.operations)}
+            {formatLastEditMessage(flow.operations[0].createdAt, flow.operations[0]?.actor)}
           </LinkSubText>
         </Box>
         {useStore.getState().canUserEditTeam(teamSlug) && (
@@ -286,6 +275,7 @@ const Team: React.FC = () => {
   const { id: teamId, slug } = useStore((state) => state.getTeam());
   const [flows, setFlows] = useState<any[] | null>(null);
   const navigation = useNavigation();
+
   const fetchFlows = useCallback(() => {
     useStore
       .getState()
@@ -294,9 +284,11 @@ const Team: React.FC = () => {
         setFlows(res.flows);
       });
   }, [teamId, setFlows]);
+
   useEffect(() => {
     fetchFlows();
   }, [fetchFlows]);
+
   return (
     <Root>
       <Dashboard>


### PR DESCRIPTION
**Changes:**
August mentioned that it's really disorienting that all the flows within a team now show the same "Edited 5 days ago" timestamp - this is because this message was referencing `flows.updated_at` which changed when `flows.status` merged and is updated, whereas we really think about "edits" to a flow coming from the associated `operations`. 

Now updated to display based on `operations`, sharing the same formatting as in-graph view of "Last edited..." too. This means that both the list & graph timestamps will now match (previously they didn't :see_no_evil:), and that the list timestamps now ignore bulk flow migrations or non-data changes like renaming, toggling status, etc. 

See thread: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1717571853477949

**Testing:**
Click into a flow, edit the graph data, click back out to the list of services within the team and confirm it's at the top of the list with a correct "Last edited {at} by {user}" message. 

Note that real `operations` are _not_ synced from production to other environments (staging, local, pizza), so you won't see a first and last name associated with the timestamp on the pizza until new edits are made. Only production has a full history!