### PR TITLE
chore: split residential unit List component schemas into six options

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -7,7 +7,6 @@ import Card from "@planx/components/shared/Preview/Card";
 import CardHeader from "@planx/components/shared/Preview/CardHeader";
 import { getIn, useFormik } from "formik";
 import React, { useState } from "react";
-import InputLegend from "ui/editor/InputLegend";
 import { ExpandableList, ExpandableListItem } from "ui/public/ExpandableList";
 import FormWrapper from "ui/public/FormWrapper";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";

--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -13,15 +13,33 @@ import InputRowLabel from "ui/shared/InputRowLabel";
 
 import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
 import { List, parseContent } from "./model";
-import { ResidentialUnits } from "./schemas/ResidentialUnits";
+import { ResidentialUnitsExisting } from "./schemas/ResidentialUnits/Existing";
+import { ResidentialUnitsGLANew } from "./schemas/ResidentialUnits/GLA/New";
+import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebuilt";
+import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Removed";
+import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
+import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
 import { Zoo } from "./schemas/Zoo";
 
 type Props = EditorProps<TYPES.List, List>;
 
 export const SCHEMAS = [
-  { name: "Residential Units (alpha)", schema: ResidentialUnits },
+  { name: "Residential units - Existing", schema: ResidentialUnitsExisting },
+  { name: "Residential units - Proposed", schema: ResidentialUnitsProposed },
+  { name: "Residential units (GLA) - New", schema: ResidentialUnitsGLANew },
+  {
+    name: "Residential units (GLA) - Rebuilt",
+    schema: ResidentialUnitsGLARebuilt,
+  },
+  {
+    name: "Residentail units (GLA) - Removed",
+    schema: ResidentialUnitsGLARemoved,
+  },
+  {
+    name: "Residential units (GLA) - Retained",
+    schema: ResidentialUnitsGLARetained,
+  },
   { name: "Zoo (test)", schema: Zoo },
-  // TODO: Residential units (GLA)
 ];
 
 function ListComponent(props: Props) {

--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -141,12 +141,14 @@ export const ListProvider: React.FC<ListProviderProps> = (props) => {
       // basic example of general summary stats we can add onSubmit
       let sumIdenticalUnits = 0;
       defaultPassportData[`${props.fn}`].map(
-        (item) => (sumIdenticalUnits += parseInt(item.identicalUnits)),
+        (item) => (sumIdenticalUnits += parseInt(item?.identicalUnits)),
       );
       const summaries = {
         [`${props.fn}.total.listItems`]:
           defaultPassportData[`${props.fn}`].length,
-        [`${props.fn}.total.units`]: sumIdenticalUnits,
+        ...(sumIdenticalUnits > 0 && {
+          [`${props.fn}.total.units`]: sumIdenticalUnits,
+        }),
       };
 
       handleSubmit?.({

--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -139,8 +139,14 @@ export const ListProvider: React.FC<ListProviderProps> = (props) => {
       const flattenedPassportData = flatten(defaultPassportData);
 
       // basic example of general summary stats we can add onSubmit
+      let sumIdenticalUnits = 0;
+      defaultPassportData[`${props.fn}`].map(
+        (item) => (sumIdenticalUnits += parseInt(item.identicalUnits)),
+      );
       const summaries = {
-        [`${props.fn}.count`]: defaultPassportData[`${props.fn}`].length,
+        [`${props.fn}.total.listItems`]:
+          defaultPassportData[`${props.fn}`].length,
+        [`${props.fn}.total.units`]: sumIdenticalUnits,
       };
 
       handleSubmit?.({

--- a/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
-import Grid from "@mui/material/Grid";
 import MenuItem from "@mui/material/MenuItem";
 import RadioGroup from "@mui/material/RadioGroup";
 import { Option } from "@planx/components/shared";
@@ -9,19 +8,13 @@ import { getIn } from "formik";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput";
 import InputLabel from "ui/public/InputLabel";
-import ChecklistItem from "ui/shared/ChecklistItem";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../shared/constants";
 import BasicRadio from "../../shared/Radio/BasicRadio";
-import type {
-  ChecklistField,
-  NumberField,
-  QuestionField,
-  TextField,
-} from "../model";
+import type { NumberField, QuestionField, TextField } from "../model";
 import { useListContext } from "./Context";
 
 type Props<T> = T & { id: string };
@@ -201,50 +194,5 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
         </SelectInput>
       </ErrorWrapper>
     </InputLabel>
-  );
-};
-
-export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
-  const { formik, activeIndex } = useListContext();
-  const { id, data, required } = props;
-
-  return (
-    <FormControl sx={{ width: "100%" }} component="fieldset">
-      <FormLabel
-        component="legend"
-        id={`checklist-group-label-${id}`}
-        sx={(theme) => ({
-          color: theme.palette.text.primary,
-          "&.Mui-focused": {
-            color: theme.palette.text.primary,
-          },
-        })}
-      >
-        {required === false ? data.title + " (optional)" : data.title}
-      </FormLabel>
-      <ErrorWrapper
-        id={`${id}-error`}
-        error={getIn(formik.errors, `userData[${activeIndex}][${data.fn}]`)}
-      >
-        <RadioGroup
-          aria-labelledby={`checklist-group-label-${id}`}
-          name={`userData[${activeIndex}][${[data.fn]}]`}
-          sx={{ p: 1 }}
-          value={formik.values.userData[activeIndex][data.fn]}
-        >
-          {data.options.map(({ id, data }) => (
-            <Grid item xs={12} key={data.text}>
-              <ChecklistItem
-                id={id}
-                label={data.text}
-                checked={false}
-                // checked={formik.values.userData[activeIndex][`${data.val}`].includes(id)}
-                onChange={formik.handleChange}
-              />
-            </Grid>
-          ))}
-        </RadioGroup>
-      </ErrorWrapper>
-    </FormControl>
   );
 };

--- a/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
+import Grid from "@mui/material/Grid";
 import MenuItem from "@mui/material/MenuItem";
 import RadioGroup from "@mui/material/RadioGroup";
 import { Option } from "@planx/components/shared";
@@ -8,13 +9,19 @@ import { getIn } from "formik";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput";
 import InputLabel from "ui/public/InputLabel";
+import ChecklistItem from "ui/shared/ChecklistItem";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../shared/constants";
 import BasicRadio from "../../shared/Radio/BasicRadio";
-import type { NumberField, QuestionField, TextField } from "../model";
+import type {
+  ChecklistField,
+  NumberField,
+  QuestionField,
+  TextField,
+} from "../model";
 import { useListContext } from "./Context";
 
 type Props<T> = T & { id: string };
@@ -108,12 +115,9 @@ export const NumberFieldInput: React.FC<Props<NumberField>> = ({
   );
 };
 
-export const RadioFieldInput: React.FC<Props<QuestionField>> = ({
-  id,
-  data,
-  required,
-}) => {
+export const RadioFieldInput: React.FC<Props<QuestionField>> = (props) => {
   const { formik, activeIndex } = useListContext();
+  const { id, data, required } = props;
 
   return (
     <FormControl sx={{ width: "100%" }} component="fieldset">
@@ -197,5 +201,50 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
         </SelectInput>
       </ErrorWrapper>
     </InputLabel>
+  );
+};
+
+export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
+  const { formik, activeIndex } = useListContext();
+  const { id, data, required } = props;
+
+  return (
+    <FormControl sx={{ width: "100%" }} component="fieldset">
+      <FormLabel
+        component="legend"
+        id={`checklist-group-label-${id}`}
+        sx={(theme) => ({
+          color: theme.palette.text.primary,
+          "&.Mui-focused": {
+            color: theme.palette.text.primary,
+          },
+        })}
+      >
+        {required === false ? data.title + " (optional)" : data.title}
+      </FormLabel>
+      <ErrorWrapper
+        id={`${id}-error`}
+        error={getIn(formik.errors, `userData[${activeIndex}][${data.fn}]`)}
+      >
+        <RadioGroup
+          aria-labelledby={`checklist-group-label-${id}`}
+          name={`userData[${activeIndex}][${[data.fn]}]`}
+          sx={{ p: 1 }}
+          value={formik.values.userData[activeIndex][data.fn]}
+        >
+          {data.options.map(({ id, data }) => (
+            <Grid item xs={12} key={data.text}>
+              <ChecklistItem
+                id={id}
+                label={data.text}
+                checked={false}
+                // checked={formik.values.userData[activeIndex][`${data.val}`].includes(id)}
+                onChange={formik.handleChange}
+              />
+            </Grid>
+          ))}
+        </RadioGroup>
+      </ErrorWrapper>
+    </FormControl>
   );
 };

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -43,7 +43,7 @@ const mockPayload = {
     "mockFn.two.email": "richard.parker@pi.com",
     "mockFn.two.name": "Richard Parker",
     "mockFn.two.size": "Medium",
-    "mockFn.count": 2,
+    "mockFn.total.listItems": 2,
   },
 };
 

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -19,7 +19,6 @@ import CardHeader from "../../shared/Preview/CardHeader";
 import type { Field, List } from "../model";
 import { ListProvider, useListContext } from "./Context";
 import {
-  ChecklistFieldInput,
   NumberFieldInput,
   RadioFieldInput,
   SelectFieldInput,
@@ -59,8 +58,6 @@ const InputField: React.FC<Field> = (props) => {
         return <RadioFieldInput id={inputFieldId} {...props} />;
       }
       return <SelectFieldInput id={inputFieldId} {...props} />;
-    case "checklist":
-      return <ChecklistFieldInput id={inputFieldId} {...props} />;
   }
 };
 
@@ -173,7 +170,7 @@ const Root = () => {
           <ErrorWrapper
             error={
               errors.addItem
-                ? `Please save all responses before adding a new ${schema.type.toLowerCase()}`
+                ? `Please save all responses before adding another ${schema.type.toLowerCase()}`
                 : ""
             }
           >
@@ -184,7 +181,7 @@ const Root = () => {
               sx={{ width: "100%" }}
               data-testid="list-add-button"
             >
-              + Add a new {schema.type.toLowerCase()} description
+              + Add another {schema.type.toLowerCase()} description
             </Button>
           </ErrorWrapper>
         </>

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -19,6 +19,7 @@ import CardHeader from "../../shared/Preview/CardHeader";
 import type { Field, List } from "../model";
 import { ListProvider, useListContext } from "./Context";
 import {
+  ChecklistFieldInput,
   NumberFieldInput,
   RadioFieldInput,
   SelectFieldInput,
@@ -58,6 +59,8 @@ const InputField: React.FC<Field> = (props) => {
         return <RadioFieldInput id={inputFieldId} {...props} />;
       }
       return <SelectFieldInput id={inputFieldId} {...props} />;
+    case "checklist":
+      return <ChecklistFieldInput id={inputFieldId} {...props} />;
   }
 };
 

--- a/editor.planx.uk/src/@planx/components/List/model.ts
+++ b/editor.planx.uk/src/@planx/components/List/model.ts
@@ -10,11 +10,16 @@ import {
 import { SCHEMAS } from "./Editor";
 
 /**
- * Simplified custom QuestionInput
+ * Simplified custom QuestionInput & ChecklistInput
  * Existing model is too complex for our needs currently
  * If adding more properties here, check if re-using existing model could be an option
  */
 interface QuestionInput {
+  title: string;
+  description?: string;
+  options: Option[];
+}
+interface ChecklistInput {
   title: string;
   description?: string;
   options: Option[];
@@ -45,12 +50,17 @@ export type QuestionField = {
   unique?: boolean;
   data: QuestionInput & { fn: string };
 };
+export type ChecklistField = {
+  type: "checklist";
+  required?: boolean;
+  data: ChecklistInput & { fn: string };
+};
 
 /**
  * Represents the input types available in the List component
  * Existing models are used to allow to us to re-use existing components, maintaining consistend UX/UI
  */
-export type Field = TextField | NumberField | QuestionField;
+export type Field = TextField | NumberField | QuestionField | ChecklistField;
 
 /**
  * Models the form displayed to the user

--- a/editor.planx.uk/src/@planx/components/List/model.ts
+++ b/editor.planx.uk/src/@planx/components/List/model.ts
@@ -10,16 +10,11 @@ import {
 import { SCHEMAS } from "./Editor";
 
 /**
- * Simplified custom QuestionInput & ChecklistInput
+ * Simplified custom QuestionInput
  * Existing model is too complex for our needs currently
  * If adding more properties here, check if re-using existing model could be an option
  */
 interface QuestionInput {
-  title: string;
-  description?: string;
-  options: Option[];
-}
-interface ChecklistInput {
   title: string;
   description?: string;
   options: Option[];
@@ -50,17 +45,12 @@ export type QuestionField = {
   unique?: boolean;
   data: QuestionInput & { fn: string };
 };
-export type ChecklistField = {
-  type: "checklist";
-  required?: boolean;
-  data: ChecklistInput & { fn: string };
-};
 
 /**
  * Represents the input types available in the List component
  * Existing models are used to allow to us to re-use existing components, maintaining consistend UX/UI
  */
-export type Field = TextField | NumberField | QuestionField | ChecklistField;
+export type Field = TextField | NumberField | QuestionField;
 
 /**
  * Models the form displayed to the user

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
@@ -1,0 +1,62 @@
+import { Schema } from "../../model";
+
+export const ResidentialUnitsExisting: Schema = {
+  type: "Existing residential unit",
+  fields: [
+    {
+      type: "question",
+      unique: true,
+      data: {
+        title: "What is the tenure type?",
+        fn: "tenureType",
+        options: [
+          { id: "marketHousing", data: { text: "Market housing" } },
+          {
+            id: "socialAffordableRent",
+            data: { text: "Social and affordable rent" },
+          },
+          {
+            id: "affordableHomeOwnership",
+            data: { text: "Affordable home ownership" },
+          },
+          { id: "starterHome", data: { text: "Starter homes" } },
+          { id: "selfBuild", data: { text: "Self build" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What is the unit type?",
+        fn: "unitType",
+        options: [
+          { id: "houses", data: { text: "Houses" } },
+          { id: "flats", data: { text: "Flats" } },
+          { id: "bedsits", data: { text: "Bedsits" } },
+          { id: "starterHome", data: { text: "Starter homes" } },
+          { id: "shelteredHousing", data: { text: "Sheltered housing" } },
+          { id: "clusteredFlats", data: { text: "Clustered flats" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many bedrooms are there?",
+        fn: "numberBedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title:
+          "How many residential units does the description above apply to?",
+        fn: "numberIdenticalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
@@ -7,35 +7,32 @@ export const ResidentialUnitsExisting: Schema = {
       type: "question",
       unique: true,
       data: {
-        title: "What is the tenure type?",
-        fn: "tenureType",
+        title: "What best describes the tenure of this unit?",
+        fn: "tenure",
         options: [
-          { id: "marketHousing", data: { text: "Market housing" } },
+          { id: "MH", data: { text: "Market housing" } },
+          { id: "SAIR", data: { text: "Social, affordable or interim rent" } },
+          { id: "AHO", data: { text: "Affordable home ownership" } },
+          { id: "SH", data: { text: "Starter homes" } },
           {
-            id: "socialAffordableRent",
-            data: { text: "Social and affordable rent" },
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
           },
-          {
-            id: "affordableHomeOwnership",
-            data: { text: "Affordable home ownership" },
-          },
-          { id: "starterHome", data: { text: "Starter homes" } },
-          { id: "selfBuild", data: { text: "Self build" } },
+          { id: "other", data: { text: "Other" } },
         ],
       },
     },
     {
       type: "question",
       data: {
-        title: "What is the unit type?",
-        fn: "unitType",
+        title: "What best describes the type of this unit?",
+        fn: "type",
         options: [
-          { id: "houses", data: { text: "Houses" } },
-          { id: "flats", data: { text: "Flats" } },
-          { id: "bedsits", data: { text: "Bedsits" } },
-          { id: "starterHome", data: { text: "Starter homes" } },
-          { id: "shelteredHousing", data: { text: "Sheltered housing" } },
-          { id: "clusteredFlats", data: { text: "Clustered flats" } },
+          { id: "house", data: { text: "House" } },
+          { id: "flat", data: { text: "Flat, apartment or maisonette" } },
+          { id: "sheltered", data: { text: "Sheltered housing" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
           { id: "other", data: { text: "Other" } },
         ],
       },
@@ -43,17 +40,16 @@ export const ResidentialUnitsExisting: Schema = {
     {
       type: "number",
       data: {
-        title: "How many bedrooms are there?",
-        fn: "numberBedrooms",
+        title: "How many bedrooms does this existing unit have?",
+        fn: "bedrooms",
         allowNegatives: false,
       },
     },
     {
       type: "number",
       data: {
-        title:
-          "How many residential units does the description above apply to?",
-        fn: "numberIdenticalUnits",
+        title: "How many identical units will the description above apply to?",
+        fn: "identicalUnits",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
@@ -5,20 +5,28 @@ export const ResidentialUnitsExisting: Schema = {
   fields: [
     {
       type: "question",
-      unique: true,
       data: {
         title: "What best describes the tenure of this unit?",
         fn: "tenure",
         options: [
-          { id: "MH", data: { text: "Market housing" } },
-          { id: "SAIR", data: { text: "Social, affordable or interim rent" } },
-          { id: "AHO", data: { text: "Affordable home ownership" } },
-          { id: "SH", data: { text: "Starter homes" } },
+          { id: "MH", data: { text: "Market housing", val: "MH" } },
+          {
+            id: "SAIR",
+            data: { text: "Social, affordable or interim rent", val: "SAIR" },
+          },
+          {
+            id: "AHO",
+            data: { text: "Affordable home ownership", val: "AHO" },
+          },
+          { id: "SH", data: { text: "Starter homes", val: "SH" } },
           {
             id: "selfCustomBuild",
-            data: { text: "Self-build and custom build" },
+            data: {
+              text: "Self-build and custom build",
+              val: "selfCustomBuild",
+            },
           },
-          { id: "other", data: { text: "Other" } },
+          { id: "other", data: { text: "Other", val: "other" } },
         ],
       },
     },
@@ -28,19 +36,25 @@ export const ResidentialUnitsExisting: Schema = {
         title: "What best describes the type of this unit?",
         fn: "type",
         options: [
-          { id: "house", data: { text: "House" } },
-          { id: "flat", data: { text: "Flat, apartment or maisonette" } },
-          { id: "sheltered", data: { text: "Sheltered housing" } },
-          { id: "studio", data: { text: "Studio or bedsit" } },
-          { id: "cluster", data: { text: "Cluster flat" } },
-          { id: "other", data: { text: "Other" } },
+          { id: "house", data: { text: "House", val: "house" } },
+          {
+            id: "flat",
+            data: { text: "Flat, apartment or maisonette", val: "flat" },
+          },
+          {
+            id: "sheltered",
+            data: { text: "Sheltered housing", val: "sheltered" },
+          },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "other", data: { text: "Other", val: "other" } },
         ],
       },
     },
     {
       type: "number",
       data: {
-        title: "How many bedrooms does this existing unit have?",
+        title: "How many bedrooms does this unit have?",
         fn: "bedrooms",
         allowNegatives: false,
       },
@@ -48,7 +62,7 @@ export const ResidentialUnitsExisting: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units will the description above apply to?",
+        title: "How many identical units does the description above apply to?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
@@ -80,7 +80,7 @@ export const ResidentialUnitsGLANew: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
-        fn: "compliance.m42",
+        fn: "complianceM42", // compliance.m42
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -92,7 +92,7 @@ export const ResidentialUnitsGLANew: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
-        fn: "compliance.m432a",
+        fn: "complianceM432a", // compliance.m432a
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -104,7 +104,7 @@ export const ResidentialUnitsGLANew: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
-        fn: "compliance.m432b",
+        fn: "complianceM432b", // compliance.m432b
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
@@ -53,61 +53,64 @@ export const ResidentialUnitsGLANew: Schema = {
         ],
       },
     },
+    // {
+    //   type: "checklist", // @todo
+    //   data: {
+    //     title: "Is this unit compliant with any of the following?",
+    //     fn: "compliance",
+    //     options: [
+    //       {
+    //         id: "m42",
+    //         data: { text: "Part M4(2) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432a",
+    //         data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432b",
+    //         data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+    //       },
+    //       { id: "none", data: { text: "None of these" } },
+    //     ],
+    //   },
+    // },
     {
-      type: "checklist",
+      type: "question",
       data: {
-        title: "Is this unit compliant with any of the following?",
-        fn: "compliance",
+        title:
+          "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
+        fn: "compliance.m42",
         options: [
-          {
-            id: "m42",
-            data: { text: "Part M4(2) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432a",
-            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432b",
-            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
-          },
-          { id: "none", data: { text: "None of these" } },
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
         ],
       },
     },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(2)?",
-    //     fn: "m42Compliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2a)?",
-    //     fn: "m432aCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2b)?",
-    //     fn: "m432bCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
+        fn: "compliance.m432a",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
+        fn: "compliance.m432b",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
     {
       type: "question",
       data: {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
@@ -1,0 +1,17 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ResidentialUnitsGLANew: Schema = {
+  type: "New residential unit",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title:
+          "How many residential units does the description above apply to?",
+        fn: "numberIdenticalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
@@ -1,14 +1,205 @@
 import { Schema } from "@planx/components/List/model";
 
 export const ResidentialUnitsGLANew: Schema = {
-  type: "New residential unit",
+  type: "New built residential unit",
   fields: [
     {
       type: "number",
       data: {
-        title:
-          "How many residential units does the description above apply to?",
-        fn: "numberIdenticalUnits",
+        title: "What is the number of habitable rooms of this unit?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of bedrooms of this unit?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent" } },
+          {
+            id: "AR",
+            data: { text: "Affordable rent (not at LAR benchmark rents)" },
+          },
+          { id: "SR", data: { text: "Social rent" } },
+          { id: "LRR", data: { text: "London Living Rent" } },
+          { id: "sharedEquity", data: { text: "Shared equity" } },
+          { id: "LSO", data: { text: "London Shared Ownership" } },
+          { id: "DMS", data: { text: "Discount market sale" } },
+          { id: "DMR", data: { text: "Discount market rent" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+            },
+          },
+          { id: "marketForRent", data: { text: "Market for rent" } },
+          { id: "SH", data: { text: "Starter homes" } },
+          {
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
+          },
+          { id: "marketForSale", data: { text: "Market for sale" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "checklist",
+      data: {
+        title: "Is this unit compliant with any of the following?",
+        fn: "compliance",
+        options: [
+          {
+            id: "m42",
+            data: { text: "Part M4(2) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432a",
+            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432b",
+            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+          },
+          { id: "none", data: { text: "None of these" } },
+        ],
+      },
+    },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(2)?",
+    //     fn: "m42Compliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2a)?",
+    //     fn: "m432aCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2b)?",
+    //     fn: "m432bCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home" } },
+          { id: "semiDetached", data: { text: "Semi detached home" } },
+          { id: "detached", data: { text: "Detached home" } },
+          { id: "flat", data: { text: "Flat/apartment or maisonette" } },
+          { id: "LW", data: { text: "Live/work unit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "coLiving", data: { text: "Co living unit" } },
+          { id: "hostel", data: { text: "Hostel room" } },
+          { id: "HMO", data: { text: "HMO" } },
+          { id: "student", data: { text: "Student accomodation" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private" } },
+          { id: "privateRented", data: { text: "Private rented sector" } },
+          { id: "HA", data: { text: "Housing association" } },
+          { id: "LA", data: { text: "Local authority" } },
+          { id: "publicAuthority", data: { text: "Other public authority" } },
+          { id: "councilDelivery", data: { text: "Council delivery company" } },
+          {
+            id: "councilBuildToRent",
+            data: { text: "Council delivered build to rent" },
+          },
+          {
+            id: "affordableHousing",
+            data: { text: "Other affordable housing provider" },
+          },
+          { id: "selfBuild", data: { text: "Self-build" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit built on garden land?",
+        fn: "garden",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
@@ -80,7 +80,7 @@ export const ResidentialUnitsGLARebuilt: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
-        fn: "compliance.m42",
+        fn: "complianceM42", // compliance.m42
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -92,7 +92,7 @@ export const ResidentialUnitsGLARebuilt: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
-        fn: "compliance.m432a",
+        fn: "complianceM432a", // compliance.m432a
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -104,7 +104,7 @@ export const ResidentialUnitsGLARebuilt: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
-        fn: "compliance.m432b",
+        fn: "complianceM432b", // compliance.m432b
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
@@ -6,9 +6,200 @@ export const ResidentialUnitsGLARebuilt: Schema = {
     {
       type: "number",
       data: {
-        title:
-          "How many residential units does the description above apply to?",
-        fn: "numberIdenticalUnits",
+        title: "What is the number of habitable rooms of this unit?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of bedrooms of this unit?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent" } },
+          {
+            id: "AR",
+            data: { text: "Affordable rent (not at LAR benchmark rents)" },
+          },
+          { id: "SR", data: { text: "Social rent" } },
+          { id: "LRR", data: { text: "London Living Rent" } },
+          { id: "sharedEquity", data: { text: "Shared equity" } },
+          { id: "LSO", data: { text: "London Shared Ownership" } },
+          { id: "DMS", data: { text: "Discount market sale" } },
+          { id: "DMR", data: { text: "Discount market rent" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+            },
+          },
+          { id: "marketForRent", data: { text: "Market for rent" } },
+          { id: "SH", data: { text: "Starter homes" } },
+          {
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
+          },
+          { id: "marketForSale", data: { text: "Market for sale" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "checklist",
+      data: {
+        title: "Is this unit compliant with any of the following?",
+        fn: "compliance",
+        options: [
+          {
+            id: "m42",
+            data: { text: "Part M4(2) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432a",
+            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432b",
+            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+          },
+          { id: "none", data: { text: "None of these" } },
+        ],
+      },
+    },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(2)?",
+    //     fn: "m42Compliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2a)?",
+    //     fn: "m432aCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2b)?",
+    //     fn: "m432bCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home" } },
+          { id: "semiDetached", data: { text: "Semi detached home" } },
+          { id: "detached", data: { text: "Detached home" } },
+          { id: "flat", data: { text: "Flat/apartment or maisonette" } },
+          { id: "LW", data: { text: "Live/work unit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "coLiving", data: { text: "Co living unit" } },
+          { id: "hostel", data: { text: "Hostel room" } },
+          { id: "HMO", data: { text: "HMO" } },
+          { id: "student", data: { text: "Student accomodation" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private" } },
+          { id: "privateRented", data: { text: "Private rented sector" } },
+          { id: "HA", data: { text: "Housing association" } },
+          { id: "LA", data: { text: "Local authority" } },
+          { id: "publicAuthority", data: { text: "Other public authority" } },
+          { id: "councilDelivery", data: { text: "Council delivery company" } },
+          {
+            id: "councilBuildToRent",
+            data: { text: "Council delivered build to rent" },
+          },
+          {
+            id: "affordableHousing",
+            data: { text: "Other affordable housing provider" },
+          },
+          { id: "selfBuild", data: { text: "Self-build" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit built on garden land?",
+        fn: "garden",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
@@ -53,61 +53,64 @@ export const ResidentialUnitsGLARebuilt: Schema = {
         ],
       },
     },
+    // {
+    //   type: "checklist", // @todo
+    //   data: {
+    //     title: "Is this unit compliant with any of the following?",
+    //     fn: "compliance",
+    //     options: [
+    //       {
+    //         id: "m42",
+    //         data: { text: "Part M4(2) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432a",
+    //         data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432b",
+    //         data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+    //       },
+    //       { id: "none", data: { text: "None of these" } },
+    //     ],
+    //   },
+    // },
     {
-      type: "checklist",
+      type: "question",
       data: {
-        title: "Is this unit compliant with any of the following?",
-        fn: "compliance",
+        title:
+          "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
+        fn: "compliance.m42",
         options: [
-          {
-            id: "m42",
-            data: { text: "Part M4(2) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432a",
-            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432b",
-            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
-          },
-          { id: "none", data: { text: "None of these" } },
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
         ],
       },
     },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(2)?",
-    //     fn: "m42Compliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2a)?",
-    //     fn: "m432aCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2b)?",
-    //     fn: "m432bCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
+        fn: "compliance.m432a",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
+        fn: "compliance.m432b",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
     {
       type: "question",
       data: {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
@@ -1,0 +1,17 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ResidentialUnitsGLARebuilt: Schema = {
+  type: "Rebuilt residential unit",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title:
+          "How many residential units does the description above apply to?",
+        fn: "numberIdenticalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
@@ -80,7 +80,7 @@ export const ResidentialUnitsGLARemoved: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
-        fn: "compliance.m42",
+        fn: "complianceM42", // compliance.m42
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -92,7 +92,7 @@ export const ResidentialUnitsGLARemoved: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
-        fn: "compliance.m432a",
+        fn: "complianceM432a", // compliance.m432a
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -104,7 +104,7 @@ export const ResidentialUnitsGLARemoved: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
-        fn: "compliance.m432b",
+        fn: "complianceM432b", // compliance.m432b
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
@@ -1,0 +1,17 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ResidentialUnitsGLARemoved: Schema = {
+  type: "Removed residential unit",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title:
+          "How many residential units does the description above apply to?",
+        fn: "numberIdenticalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
@@ -6,9 +6,189 @@ export const ResidentialUnitsGLARemoved: Schema = {
     {
       type: "number",
       data: {
-        title:
-          "How many residential units does the description above apply to?",
-        fn: "numberIdenticalUnits",
+        title: "What is the number of habitable rooms of this unit?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of bedrooms of this unit?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent" } },
+          {
+            id: "AR",
+            data: { text: "Affordable rent (not at LAR benchmark rents)" },
+          },
+          { id: "SR", data: { text: "Social rent" } },
+          { id: "LRR", data: { text: "London Living Rent" } },
+          { id: "sharedEquity", data: { text: "Shared equity" } },
+          { id: "LSO", data: { text: "London Shared Ownership" } },
+          { id: "DMS", data: { text: "Discount market sale" } },
+          { id: "DMR", data: { text: "Discount market rent" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+            },
+          },
+          { id: "marketForRent", data: { text: "Market for rent" } },
+          { id: "SH", data: { text: "Starter homes" } },
+          {
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
+          },
+          { id: "marketForSale", data: { text: "Market for sale" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "checklist",
+      data: {
+        title: "Is this unit compliant with any of the following?",
+        fn: "compliance",
+        options: [
+          {
+            id: "m42",
+            data: { text: "Part M4(2) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432a",
+            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432b",
+            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+          },
+          { id: "none", data: { text: "None of these" } },
+        ],
+      },
+    },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(2)?",
+    //     fn: "m42Compliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2a)?",
+    //     fn: "m432aCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2b)?",
+    //     fn: "m432bCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home" } },
+          { id: "semiDetached", data: { text: "Semi detached home" } },
+          { id: "detached", data: { text: "Detached home" } },
+          { id: "flat", data: { text: "Flat/apartment or maisonette" } },
+          { id: "LW", data: { text: "Live/work unit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "coLiving", data: { text: "Co living unit" } },
+          { id: "hostel", data: { text: "Hostel room" } },
+          { id: "HMO", data: { text: "HMO" } },
+          { id: "student", data: { text: "Student accomodation" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private" } },
+          { id: "privateRented", data: { text: "Private rented sector" } },
+          { id: "HA", data: { text: "Housing association" } },
+          { id: "LA", data: { text: "Local authority" } },
+          { id: "publicAuthority", data: { text: "Other public authority" } },
+          { id: "councilDelivery", data: { text: "Council delivery company" } },
+          {
+            id: "councilBuildToRent",
+            data: { text: "Council delivered build to rent" },
+          },
+          {
+            id: "affordableHousing",
+            data: { text: "Other affordable housing provider" },
+          },
+          { id: "selfBuild", data: { text: "Self-build" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
@@ -53,61 +53,64 @@ export const ResidentialUnitsGLARemoved: Schema = {
         ],
       },
     },
+    // {
+    //   type: "checklist", // @todo
+    //   data: {
+    //     title: "Is this unit compliant with any of the following?",
+    //     fn: "compliance",
+    //     options: [
+    //       {
+    //         id: "m42",
+    //         data: { text: "Part M4(2) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432a",
+    //         data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432b",
+    //         data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+    //       },
+    //       { id: "none", data: { text: "None of these" } },
+    //     ],
+    //   },
+    // },
     {
-      type: "checklist",
+      type: "question",
       data: {
-        title: "Is this unit compliant with any of the following?",
-        fn: "compliance",
+        title:
+          "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
+        fn: "compliance.m42",
         options: [
-          {
-            id: "m42",
-            data: { text: "Part M4(2) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432a",
-            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432b",
-            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
-          },
-          { id: "none", data: { text: "None of these" } },
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
         ],
       },
     },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(2)?",
-    //     fn: "m42Compliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2a)?",
-    //     fn: "m432aCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2b)?",
-    //     fn: "m432bCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
+        fn: "compliance.m432a",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
+        fn: "compliance.m432b",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
     {
       type: "question",
       data: {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
@@ -53,61 +53,64 @@ export const ResidentialUnitsGLARetained: Schema = {
         ],
       },
     },
+    // {
+    //   type: "checklist", // @todo
+    //   data: {
+    //     title: "Is this unit compliant with any of the following?",
+    //     fn: "compliance",
+    //     options: [
+    //       {
+    //         id: "m42",
+    //         data: { text: "Part M4(2) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432a",
+    //         data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432b",
+    //         data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+    //       },
+    //       { id: "none", data: { text: "None of these" } },
+    //     ],
+    //   },
+    // },
     {
-      type: "checklist",
+      type: "question",
       data: {
-        title: "Is this unit compliant with any of the following?",
-        fn: "compliance",
+        title:
+          "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
+        fn: "compliance.m42",
         options: [
-          {
-            id: "m42",
-            data: { text: "Part M4(2) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432a",
-            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
-          },
-          {
-            id: "m432b",
-            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
-          },
-          { id: "none", data: { text: "None of these" } },
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
         ],
       },
     },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(2)?",
-    //     fn: "m42Compliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2a)?",
-    //     fn: "m432aCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
-    // {
-    //   type: "question", // checklist
-    //   data: {
-    //     title: "Will this unit comply with M4(3)(2b)?",
-    //     fn: "m432bCompliance",
-    //     options: [
-    //       { id: "yes", data: { text: "Yes" } },
-    //       { id: "no", data: { text: "No" } },
-    //     ],
-    //   },
-    // },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
+        fn: "compliance.m432a",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
+        fn: "compliance.m432b",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
     {
       type: "question",
       data: {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
@@ -1,0 +1,17 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ResidentialUnitsGLARetained: Schema = {
+  type: "Retained residential unit",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title:
+          "How many residential units does the description above apply to?",
+        fn: "numberIdenticalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
@@ -80,7 +80,7 @@ export const ResidentialUnitsGLARetained: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
-        fn: "compliance.m42",
+        fn: "complianceM42", // compliance.m42
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -92,7 +92,7 @@ export const ResidentialUnitsGLARetained: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
-        fn: "compliance.m432a",
+        fn: "complianceM432a", // compliance.m432a
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },
@@ -104,7 +104,7 @@ export const ResidentialUnitsGLARetained: Schema = {
       data: {
         title:
           "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
-        fn: "compliance.m432b",
+        fn: "complianceM432b", // compliance.m432b
         options: [
           { id: "true", data: { text: "Yes" } },
           { id: "false", data: { text: "No" } },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
@@ -6,9 +6,189 @@ export const ResidentialUnitsGLARetained: Schema = {
     {
       type: "number",
       data: {
-        title:
-          "How many residential units does the description above apply to?",
-        fn: "numberIdenticalUnits",
+        title: "What is the number of habitable rooms of this unit?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of bedrooms of this unit?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent" } },
+          {
+            id: "AR",
+            data: { text: "Affordable rent (not at LAR benchmark rents)" },
+          },
+          { id: "SR", data: { text: "Social rent" } },
+          { id: "LRR", data: { text: "London Living Rent" } },
+          { id: "sharedEquity", data: { text: "Shared equity" } },
+          { id: "LSO", data: { text: "London Shared Ownership" } },
+          { id: "DMS", data: { text: "Discount market sale" } },
+          { id: "DMR", data: { text: "Discount market rent" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+            },
+          },
+          { id: "marketForRent", data: { text: "Market for rent" } },
+          { id: "SH", data: { text: "Starter homes" } },
+          {
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
+          },
+          { id: "marketForSale", data: { text: "Market for sale" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "checklist",
+      data: {
+        title: "Is this unit compliant with any of the following?",
+        fn: "compliance",
+        options: [
+          {
+            id: "m42",
+            data: { text: "Part M4(2) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432a",
+            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432b",
+            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+          },
+          { id: "none", data: { text: "None of these" } },
+        ],
+      },
+    },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(2)?",
+    //     fn: "m42Compliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2a)?",
+    //     fn: "m432aCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    // {
+    //   type: "question", // checklist
+    //   data: {
+    //     title: "Will this unit comply with M4(3)(2b)?",
+    //     fn: "m432bCompliance",
+    //     options: [
+    //       { id: "yes", data: { text: "Yes" } },
+    //       { id: "no", data: { text: "No" } },
+    //     ],
+    //   },
+    // },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home" } },
+          { id: "semiDetached", data: { text: "Semi detached home" } },
+          { id: "detached", data: { text: "Detached home" } },
+          { id: "flat", data: { text: "Flat/apartment or maisonette" } },
+          { id: "LW", data: { text: "Live/work unit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "coLiving", data: { text: "Co living unit" } },
+          { id: "hostel", data: { text: "Hostel room" } },
+          { id: "HMO", data: { text: "HMO" } },
+          { id: "student", data: { text: "Student accomodation" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private" } },
+          { id: "privateRented", data: { text: "Private rented sector" } },
+          { id: "HA", data: { text: "Housing association" } },
+          { id: "LA", data: { text: "Local authority" } },
+          { id: "publicAuthority", data: { text: "Other public authority" } },
+          { id: "councilDelivery", data: { text: "Council delivery company" } },
+          {
+            id: "councilBuildToRent",
+            data: { text: "Council delivered build to rent" },
+          },
+          {
+            id: "affordableHousing",
+            data: { text: "Other affordable housing provider" },
+          },
+          { id: "selfBuild", data: { text: "Self-build" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
@@ -7,35 +7,32 @@ export const ResidentialUnitsProposed: Schema = {
       type: "question",
       unique: true,
       data: {
-        title: "What is the tenure type?",
-        fn: "tenureType",
+        title: "What best describes the tenure of this unit?",
+        fn: "tenure",
         options: [
-          { id: "marketHousing", data: { text: "Market housing" } },
+          { id: "MH", data: { text: "Market housing" } },
+          { id: "SAIR", data: { text: "Social, affordable or interim rent" } },
+          { id: "AHO", data: { text: "Affordable home ownership" } },
+          { id: "SH", data: { text: "Starter homes" } },
           {
-            id: "socialAffordableRent",
-            data: { text: "Social and affordable rent" },
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
           },
-          {
-            id: "affordableHomeOwnership",
-            data: { text: "Affordable home ownership" },
-          },
-          { id: "starterHome", data: { text: "Starter homes" } },
-          { id: "selfBuild", data: { text: "Self build" } },
+          { id: "other", data: { text: "Other" } },
         ],
       },
     },
     {
       type: "question",
       data: {
-        title: "What is the unit type?",
-        fn: "unitType",
+        title: "What best describes the type of this unit?",
+        fn: "type",
         options: [
-          { id: "houses", data: { text: "Houses" } },
-          { id: "flats", data: { text: "Flats" } },
-          { id: "bedsits", data: { text: "Bedsits" } },
-          { id: "starterHome", data: { text: "Starter homes" } },
-          { id: "shelteredHousing", data: { text: "Sheltered housing" } },
-          { id: "clusteredFlats", data: { text: "Clustered flats" } },
+          { id: "house", data: { text: "House" } },
+          { id: "flat", data: { text: "Flat, apartment or maisonette" } },
+          { id: "sheltered", data: { text: "Sheltered housing" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
           { id: "other", data: { text: "Other" } },
         ],
       },
@@ -43,17 +40,16 @@ export const ResidentialUnitsProposed: Schema = {
     {
       type: "number",
       data: {
-        title: "How many bedrooms are there?",
-        fn: "numberBedrooms",
+        title: "How many bedrooms will this proposed unit have?",
+        fn: "bedrooms",
         allowNegatives: false,
       },
     },
     {
       type: "number",
       data: {
-        title:
-          "How many residential units does the description above apply to?",
-        fn: "numberIdenticalUnits",
+        title: "How many identical units will the description above apply to?",
+        fn: "identicalUnits",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
@@ -5,20 +5,28 @@ export const ResidentialUnitsProposed: Schema = {
   fields: [
     {
       type: "question",
-      unique: true,
       data: {
         title: "What best describes the tenure of this unit?",
         fn: "tenure",
         options: [
-          { id: "MH", data: { text: "Market housing" } },
-          { id: "SAIR", data: { text: "Social, affordable or interim rent" } },
-          { id: "AHO", data: { text: "Affordable home ownership" } },
-          { id: "SH", data: { text: "Starter homes" } },
+          { id: "MH", data: { text: "Market housing", val: "MH" } },
+          {
+            id: "SAIR",
+            data: { text: "Social, affordable or interim rent", val: "SAIR" },
+          },
+          {
+            id: "AHO",
+            data: { text: "Affordable home ownership", val: "AHO" },
+          },
+          { id: "SH", data: { text: "Starter homes", val: "SH" } },
           {
             id: "selfCustomBuild",
-            data: { text: "Self-build and custom build" },
+            data: {
+              text: "Self-build and custom build",
+              val: "selfCustomBuild",
+            },
           },
-          { id: "other", data: { text: "Other" } },
+          { id: "other", data: { text: "Other", val: "other" } },
         ],
       },
     },
@@ -28,19 +36,25 @@ export const ResidentialUnitsProposed: Schema = {
         title: "What best describes the type of this unit?",
         fn: "type",
         options: [
-          { id: "house", data: { text: "House" } },
-          { id: "flat", data: { text: "Flat, apartment or maisonette" } },
-          { id: "sheltered", data: { text: "Sheltered housing" } },
-          { id: "studio", data: { text: "Studio or bedsit" } },
-          { id: "cluster", data: { text: "Cluster flat" } },
-          { id: "other", data: { text: "Other" } },
+          { id: "house", data: { text: "House", val: "house" } },
+          {
+            id: "flat",
+            data: { text: "Flat, apartment or maisonette", val: "flat" },
+          },
+          {
+            id: "sheltered",
+            data: { text: "Sheltered housing", val: "sheltered" },
+          },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "other", data: { text: "Other", val: "other" } },
         ],
       },
     },
     {
       type: "number",
       data: {
-        title: "How many bedrooms will this proposed unit have?",
+        title: "How many bedrooms will this unit have?",
         fn: "bedrooms",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
@@ -1,19 +1,8 @@
-import { Schema } from "../model";
+import { Schema } from "../../model";
 
-export const ResidentialUnits: Schema = {
-  type: "Residential Units",
+export const ResidentialUnitsProposed: Schema = {
+  type: "Proposed residential unit",
   fields: [
-    {
-      type: "question",
-      data: {
-        title: "What type of change are you making?",
-        fn: "changeType",
-        options: [
-          { id: "proposed", data: { text: "Proposed" } },
-          { id: "existing", data: { text: "Existing" } },
-        ],
-      },
-    },
     {
       type: "question",
       unique: true,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -65,7 +65,7 @@ const Node: React.FC<any> = (props) => {
     case TYPES.FindProperty:
       return <Question {...allProps} text="Find property" />;
     case TYPES.List:
-      return <Question {...allProps} text="List" />;
+      return <Question {...allProps} text={node?.data?.title ?? "List"} />;
     case TYPES.NextSteps:
       return <Question {...allProps} text="Next steps" />;
     case TYPES.Notice:


### PR DESCRIPTION
Schemas based on this flow: https://editor.planx.uk/opensystemslab/residential-units

See thread here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1717676834944659?thread_ts=1717416055.509189&cid=C5Q59R3HB

Also adjusts summary totals calculated `onSubmit` to include both count of list items _and_ sum of all units.

Eventually, we'll want to calculate totals by tenure and unit type - but we should consider capturing the `val`, rather than `text` in the passport first.