### PR TITLE
feat: basic summary of List component on Review page

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -64,6 +64,7 @@ function ListComponent(props: Props) {
               value={formik.values.title}
               placeholder="Title"
               onChange={formik.handleChange}
+              required
             />
           </InputRow>
           <InputRow>
@@ -81,6 +82,7 @@ function ListComponent(props: Props) {
               value={formik.values.fn}
               placeholder="Data Field"
               onChange={formik.handleChange}
+              required
             />
           </InputRow>
           <InputRow>

--- a/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Context.tsx
@@ -138,7 +138,9 @@ export const ListProvider: React.FC<ListProviderProps> = (props) => {
       // flattenedPassportData makes individual list items compatible with Calculate components
       const flattenedPassportData = flatten(defaultPassportData);
 
-      // basic example of general summary stats we can add onSubmit
+      // basic example of general summary stats we can add onSubmit:
+      //   1. count of items/responses
+      //   2. if the schema includes a field that sets fn = "identicalUnits", sum of total units
       let sumIdenticalUnits = 0;
       defaultPassportData[`${props.fn}`].map(
         (item) => (sumIdenticalUnits += parseInt(item?.identicalUnits)),

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -181,7 +181,7 @@ const Root = () => {
               sx={{ width: "100%" }}
               data-testid="list-add-button"
             >
-              + Add another {schema.type.toLowerCase()} description
+              + Add another {schema.type.toLowerCase()}
             </Button>
           </ErrorWrapper>
         </>

--- a/editor.planx.uk/src/@planx/components/List/model.ts
+++ b/editor.planx.uk/src/@planx/components/List/model.ts
@@ -75,7 +75,7 @@ export interface List extends MoreInformation {
 }
 
 export const parseContent = (data: Record<string, any> | undefined): List => ({
-  fn: data?.fn || "",
+  fn: data?.fn,
   title: data?.title,
   description: data?.description,
   schemaName: data?.schemaName || SCHEMAS[0].name,

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -338,12 +338,15 @@ interface ComponentProps {
 }
 
 function List(props: ComponentProps) {
+  // `...total.units` is only set when the schema includes a field with fn = `identicalUnits`
   const totalUnits = props.passport.data?.[`${props.node.data.fn}.total.units`];
+  // `...total.listItems` is always set for any schema
   const totalListItems =
     props.passport.data?.[`${props.node.data.fn}.total.listItems`];
+
   const summary = totalUnits
-    ? `${totalUnits} units total`
-    : `${totalListItems} items total`;
+    ? `${totalUnits} ${totalUnits > 1 ? `units` : `unit`} total`
+    : `${totalListItems} ${totalListItems > 1 ? `items` : `item`} total`;
 
   return (
     <>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -100,7 +100,7 @@ const presentationalComponents: {
   [TYPES.Flow]: undefined,
   [TYPES.InternalPortal]: undefined,
   [TYPES.FileUploadAndLabel]: FileUploadAndLabel,
-  [TYPES.List]: undefined,
+  [TYPES.List]: List,
   [TYPES.Notice]: undefined,
   [TYPES.NextSteps]: undefined,
   [TYPES.NumberInput]: NumberInput,
@@ -335,6 +335,22 @@ interface ComponentProps {
   flow: Store.flow;
   passport: Store.passport;
   nodeId: Store.nodeId;
+}
+
+function List(props: ComponentProps) {
+  const totalUnits = props.passport.data?.[`${props.node.data.fn}.total.units`];
+  const totalListItems =
+    props.passport.data?.[`${props.node.data.fn}.total.listItems`];
+  const summary = totalUnits
+    ? `${totalUnits} units total`
+    : `${totalListItems} items total`;
+
+  return (
+    <>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">{summary}</Box>
+    </>
+  );
 }
 
 function Question(props: ComponentProps) {


### PR DESCRIPTION
**Changes:**
- Adds basic `List` component representation to existing `SummaryList` Review page 
  - Makes "title" & "fn" required in Editor to ensure necessary info is consistently available
- Displays one row _per_ List component
  - If that List's schema includes a field that sets `identicalUnits`, then summary is "X units total"
    - Else default to how many items/responses were provided, eg "X items total"
  - "Change" link takes you back to the List component where you can edit your responses one-by-one

![Screenshot from 2024-06-07 13-10-32](https://github.com/theopensystemslab/planx-new/assets/5132349/39c55cda-e0af-4ef9-b447-8e0a7ed8589f)
