### PR TITLE
feat: Add new GLA schemas for residential units and existing and proposed uses

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -22,6 +22,7 @@ import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
 import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained";
 import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
 import { ExistingAndProposedUsesGLA } from "./schemas/GLA/ExistingAndProposedUses";
+import { CommunalSpaceGLA } from "./schemas/GLA/CommunalSpace";
 import { Zoo } from "./schemas/Zoo";
 import { ProposedAdvertisements } from "./schemas/Adverts";
 
@@ -33,6 +34,7 @@ export const SCHEMAS = [
   { name: "Residential units (GLA) - Gained", schema: ResidentialUnitsGLAGained },
   { name: "Residential units (GLA) - Lost", schema: ResidentialUnitsGLALost },
   { name: "Existing and proposed uses (GLA)", schema: ExistingAndProposedUsesGLA },
+  { name: "Communal spaces", schema: CommunalSpaceGLA },
 //  { name: "Residential units (GLA) - New", schema: ResidentialUnitsGLANew },
 //  {
 //    name: "Residential units (GLA) - Rebuilt",

--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -23,6 +23,7 @@ import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained
 import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
 import { ExistingAndProposedUsesGLA } from "./schemas/GLA/ExistingAndProposedUses";
 import { CommunalSpaceGLA } from "./schemas/GLA/CommunalSpace";
+import { BuildingDetailsGLA } from "./schemas/GLA/BuildingDetails";
 import { Zoo } from "./schemas/Zoo";
 import { ProposedAdvertisements } from "./schemas/Adverts";
 
@@ -34,7 +35,8 @@ export const SCHEMAS = [
   { name: "Residential units (GLA) - Gained", schema: ResidentialUnitsGLAGained },
   { name: "Residential units (GLA) - Lost", schema: ResidentialUnitsGLALost },
   { name: "Existing and proposed uses (GLA)", schema: ExistingAndProposedUsesGLA },
-  { name: "Communal spaces", schema: CommunalSpaceGLA },
+  { name: "Communal spaces (GLA)", schema: CommunalSpaceGLA },
+  { name: "Building details (GLA)", schema: BuildingDetailsGLA },
 //  { name: "Residential units (GLA) - New", schema: ResidentialUnitsGLANew },
 //  {
 //    name: "Residential units (GLA) - Rebuilt",

--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -14,11 +14,14 @@ import InputRowLabel from "ui/shared/InputRowLabel";
 import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
 import { List, parseContent } from "./model";
 import { ResidentialUnitsExisting } from "./schemas/ResidentialUnits/Existing";
-import { ResidentialUnitsGLANew } from "./schemas/ResidentialUnits/GLA/New";
-import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebuilt";
-import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Removed";
-import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
+// import { ResidentialUnitsGLANew } from "./schemas/ResidentialUnits/GLA/New";
+// import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebuilt";
+// import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Removed";
+// import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
+import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained";
+import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
+import { ExistingAndProposedUsesGLA } from "./schemas/GLA/ExistingAndProposedUses";
 import { Zoo } from "./schemas/Zoo";
 import { ProposedAdvertisements } from "./schemas/Adverts";
 
@@ -27,19 +30,22 @@ type Props = EditorProps<TYPES.List, List>;
 export const SCHEMAS = [
   { name: "Residential units - Existing", schema: ResidentialUnitsExisting },
   { name: "Residential units - Proposed", schema: ResidentialUnitsProposed },
-  { name: "Residential units (GLA) - New", schema: ResidentialUnitsGLANew },
-  {
-    name: "Residential units (GLA) - Rebuilt",
-    schema: ResidentialUnitsGLARebuilt,
-  },
-  {
-    name: "Residentail units (GLA) - Removed",
-    schema: ResidentialUnitsGLARemoved,
-  },
-  {
-    name: "Residential units (GLA) - Retained",
-    schema: ResidentialUnitsGLARetained,
-  },
+  { name: "Residential units (GLA) - Gained", schema: ResidentialUnitsGLAGained },
+  { name: "Residential units (GLA) - Lost", schema: ResidentialUnitsGLALost },
+  { name: "Existing and proposed uses (GLA)", schema: ExistingAndProposedUsesGLA },
+//  { name: "Residential units (GLA) - New", schema: ResidentialUnitsGLANew },
+//  {
+//    name: "Residential units (GLA) - Rebuilt",
+//    schema: ResidentialUnitsGLARebuilt,
+//  },
+//  {
+//    name: "Residentail units (GLA) - Removed",
+//    schema: ResidentialUnitsGLARemoved,
+//  },
+//  {
+//    name: "Residential units (GLA) - Retained",
+//    schema: ResidentialUnitsGLARetained,
+//  },
   { name: "Zoo (test)", schema: Zoo },
   { name: "Proposed advertisements", schema: ProposedAdvertisements },
 ];

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/BuildingDetails.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/BuildingDetails.ts
@@ -9,7 +9,6 @@ export const BuildingDetailsGLA: Schema = {
         title: "Building reference",
         fn: "reference",
         type: TextInputType.Short,
-        ],
       },
     },
     {

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/BuildingDetails.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/BuildingDetails.ts
@@ -1,3 +1,4 @@
+import { TextInputType } from "@planx/components/TextInput/model";
 import { Schema } from "@planx/components/List/model";
 
 export const BuildingDetailsGLA: Schema = {

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/BuildingDetails.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/BuildingDetails.ts
@@ -1,0 +1,34 @@
+import { Schema } from "@planx/components/List/model";
+
+export const BuildingDetailsGLA: Schema = {
+  type: "Building detail",
+  fields: [
+    {
+      type: "text",
+      data: {
+        title: "Building reference",
+        fn: "reference",
+        type: TextInputType.Short,
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the maximum height of the building?",
+        units: "m",
+        fn: "height",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many storeys does the building have?",
+        fn: "storeys",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/CommunalSpace.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/CommunalSpace.ts
@@ -1,0 +1,36 @@
+import { Schema } from "@planx/components/List/model";
+
+export const CommunalSpaceGLA: Schema = {
+  type: "Unit of communal space",
+  fields: [
+    {
+      type: "question",
+      data: {
+        title: "Is this unit of communal space lost or gained?",
+        fn: "development",
+        options: [
+          { id: "gained", data: { text: "Gained", val: "gained" } },
+          { id: "lost", data: { text: "Lost", val: "lost" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/ExistingAndProposedUses.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/ExistingAndProposedUses.ts
@@ -29,7 +29,7 @@ export const ExistingAndProposedUsesGLA: Schema = {
       data: {
         title: "What is the existing gross internal floor area?",
         units: "m²",
-        fn: "GIAExisting",
+        fn: "area.existing",
         allowNegatives: false,
       },
     },
@@ -38,7 +38,7 @@ export const ExistingAndProposedUsesGLA: Schema = {
       data: {
         title: "What is the gross internal floor area lost?",
         units: "m²",
-        fn: "GIALost",
+        fn: "area.lost",
         allowNegatives: false,
       },
     },
@@ -47,7 +47,7 @@ export const ExistingAndProposedUsesGLA: Schema = {
       data: {
         title: "What is the gross internal floor area gained?",
         units: "m²",
-        fn: "GIAGained",
+        fn: "area.gained",
         allowNegatives: false,
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/ExistingAndProposedUses.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/ExistingAndProposedUses.ts
@@ -1,0 +1,53 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ExistingAndProposedUsesGLA: Schema = {
+  type: "Existing and proposed uses",
+  fields: [
+    {
+      type: "question",
+      data: {
+        title: "What is the use class?",
+        fn: "useClass",
+        options: [
+          { id: "bTwo", data: { text: "B2 - General industry", val: "bTwo" } },
+          { id: "bEight", data: { text: "B8 - Storage and distribution", val: "bEight" } },
+          { id: "cOne", data: { text: "C1 - Hotels", val: "cOne" } },
+          { id: "cTwo", data: { text: "C2 - Residential institutions", val: "cTwo" } },
+          { id: "cTwoA", data: { text: "C2a - Secure residential institutions", val: "cTwoA" } },
+          { id: "cThree", data: { text: "C3 - Dwellinghouses", val: "cThree" } },
+          { id: "cFour", data: { text: "C4 - Houses in multiple occupation", val: "cFour" } },
+          { id: "e", data: { text: "E - Commercial, business and service", val: "e" } },
+          { id: "fOne", data: { text: "Learning and non-residential institutions", val: "fOne" } },
+          { id: "fTwo", data: { text: "Local community uses", val: "fTwo" } },
+          { id: "SG", data: { text: "Sui generis", val: "SG" } },
+          { id: "unknown", data: { text: "Unknown", val: "unknown" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the existing gross internal floor area (in square metres)?",
+        fn: "GIAExisting",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the gross internal floor area lost (in square metres)?",
+        fn: "GIALost",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the gross internal floor area gained (in square metres)?",
+        fn: "GIAGained",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/ExistingAndProposedUses.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/ExistingAndProposedUses.ts
@@ -17,8 +17,8 @@ export const ExistingAndProposedUsesGLA: Schema = {
           { id: "cThree", data: { text: "C3 - Dwellinghouses", val: "cThree" } },
           { id: "cFour", data: { text: "C4 - Houses in multiple occupation", val: "cFour" } },
           { id: "e", data: { text: "E - Commercial, business and service", val: "e" } },
-          { id: "fOne", data: { text: "Learning and non-residential institutions", val: "fOne" } },
-          { id: "fTwo", data: { text: "Local community uses", val: "fTwo" } },
+          { id: "fOne", data: { text: "F1 - Learning and non-residential institutions", val: "fOne" } },
+          { id: "fTwo", data: { text: "F2 - Local community uses", val: "fTwo" } },
           { id: "SG", data: { text: "Sui generis", val: "SG" } },
           { id: "unknown", data: { text: "Unknown", val: "unknown" } },
         ],
@@ -27,7 +27,8 @@ export const ExistingAndProposedUsesGLA: Schema = {
     {
       type: "number",
       data: {
-        title: "What is the existing gross internal floor area (in square metres)?",
+        title: "What is the existing gross internal floor area?",
+        units: "m²",
         fn: "GIAExisting",
         allowNegatives: false,
       },
@@ -35,7 +36,8 @@ export const ExistingAndProposedUsesGLA: Schema = {
     {
       type: "number",
       data: {
-        title: "What is the gross internal floor area lost (in square metres)?",
+        title: "What is the gross internal floor area lost?",
+        units: "m²",
         fn: "GIALost",
         allowNegatives: false,
       },
@@ -43,7 +45,8 @@ export const ExistingAndProposedUsesGLA: Schema = {
     {
       type: "number",
       data: {
-        title: "What is the gross internal floor area gained (in square metres)?",
+        title: "What is the gross internal floor area gained?",
+        units: "m²",
         fn: "GIAGained",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
@@ -1,0 +1,225 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ResidentialUnitsGLAGained: Schema = {
+  type: "Gained residential unit",
+  fields: [
+    {
+      type: "question",
+      data: {
+        title: "What development does this unit result from?",
+        fn: "development",
+        options: [
+          { id: "newBuild", data: { text: "New build", val: "newBuild" } },
+          { id: "conversion", data: { text: "Conversion", val: "conversion" } },
+          { id: "changeOfUse", data: { text: "Change of use", val: "changeOfUse" } },
+          { id: "extension", data: { text: "Extension", val: "extension" } },
+          { id: "notKnown", data: { text: "Not known", val: "notKnown" } },    
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of habitable rooms of this unit?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of bedrooms of this unit?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent" } },
+          {
+            id: "AR",
+            data: { text: "Affordable rent (not at LAR benchmark rents)" },
+          },
+          { id: "SR", data: { text: "Social rent" } },
+          { id: "LRR", data: { text: "London Living Rent" } },
+          { id: "sharedEquity", data: { text: "Shared equity" } },
+          { id: "LSO", data: { text: "London Shared Ownership" } },
+          { id: "DMS", data: { text: "Discount market sale" } },
+          { id: "DMR", data: { text: "Discount market rent" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+            },
+          },
+          { id: "marketForRent", data: { text: "Market for rent" } },
+          { id: "SH", data: { text: "Starter homes" } },
+          {
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
+          },
+          { id: "marketForSale", data: { text: "Market for sale" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    // {
+    //   type: "checklist", // @todo
+    //   data: {
+    //     title: "Is this unit compliant with any of the following?",
+    //     fn: "compliance",
+    //     options: [
+    //       {
+    //         id: "m42",
+    //         data: { text: "Part M4(2) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432a",
+    //         data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432b",
+    //         data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+    //       },
+    //       { id: "none", data: { text: "None of these" } },
+    //     ],
+    //   },
+    // },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
+        fn: "complianceM42", // compliance.m42
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
+        fn: "complianceM432a", // compliance.m432a
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
+        fn: "complianceM432b", // compliance.m432b
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home" } },
+          { id: "semiDetached", data: { text: "Semi detached home" } },
+          { id: "detached", data: { text: "Detached home" } },
+          { id: "flat", data: { text: "Flat/apartment or maisonette" } },
+          { id: "LW", data: { text: "Live/work unit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "coLiving", data: { text: "Co living unit" } },
+          { id: "hostel", data: { text: "Hostel room" } },
+          { id: "HMO", data: { text: "HMO" } },
+          { id: "student", data: { text: "Student accomodation" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private" } },
+          { id: "privateRented", data: { text: "Private rented sector" } },
+          { id: "HA", data: { text: "Housing association" } },
+          { id: "LA", data: { text: "Local authority" } },
+          { id: "publicAuthority", data: { text: "Other public authority" } },
+          { id: "councilDelivery", data: { text: "Council delivery company" } },
+          {
+            id: "councilBuildToRent",
+            data: { text: "Council delivered build to rent" },
+          },
+          {
+            id: "affordableHousing",
+            data: { text: "Other affordable housing provider" },
+          },
+          { id: "selfBuild", data: { text: "Self-build" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit built on garden land?",
+        fn: "garden",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
@@ -1,0 +1,200 @@
+import { Schema } from "@planx/components/List/model";
+
+export const ResidentialUnitsGLALost: Schema = {
+  type: "Lost or replaced residential unit",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title: "What is the number of habitable rooms of this unit?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the number of bedrooms of this unit?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent" } },
+          {
+            id: "AR",
+            data: { text: "Affordable rent (not at LAR benchmark rents)" },
+          },
+          { id: "SR", data: { text: "Social rent" } },
+          { id: "LRR", data: { text: "London Living Rent" } },
+          { id: "sharedEquity", data: { text: "Shared equity" } },
+          { id: "LSO", data: { text: "London Shared Ownership" } },
+          { id: "DMS", data: { text: "Discount market sale" } },
+          { id: "DMR", data: { text: "Discount market rent" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+            },
+          },
+          { id: "marketForRent", data: { text: "Market for rent" } },
+          { id: "SH", data: { text: "Starter homes" } },
+          {
+            id: "selfCustomBuild",
+            data: { text: "Self-build and custom build" },
+          },
+          { id: "marketForSale", data: { text: "Market for sale" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    // {
+    //   type: "checklist", // @todo
+    //   data: {
+    //     title: "Is this unit compliant with any of the following?",
+    //     fn: "compliance",
+    //     options: [
+    //       {
+    //         id: "m42",
+    //         data: { text: "Part M4(2) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432a",
+    //         data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+    //       },
+    //       {
+    //         id: "m432b",
+    //         data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+    //       },
+    //       { id: "none", data: { text: "None of these" } },
+    //     ],
+    //   },
+    // },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(2) of the Building Regulations 2010?",
+        fn: "complianceM42", // compliance.m42
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2a) of the Building Regulations 2010?",
+        fn: "complianceM432a", // compliance.m432a
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this unit compliant with Part M4(3)(2b) of the Building Regulations 2010?",
+        fn: "complianceM432b", // compliance.m432b
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home" } },
+          { id: "semiDetached", data: { text: "Semi detached home" } },
+          { id: "detached", data: { text: "Detached home" } },
+          { id: "flat", data: { text: "Flat/apartment or maisonette" } },
+          { id: "LW", data: { text: "Live/work unit" } },
+          { id: "cluster", data: { text: "Cluster flat" } },
+          { id: "studio", data: { text: "Studio or bedsit" } },
+          { id: "coLiving", data: { text: "Co living unit" } },
+          { id: "hostel", data: { text: "Hostel room" } },
+          { id: "HMO", data: { text: "HMO" } },
+          { id: "student", data: { text: "Student accomodation" } },
+          { id: "other", data: { text: "Other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private" } },
+          { id: "privateRented", data: { text: "Private rented sector" } },
+          { id: "HA", data: { text: "Housing association" } },
+          { id: "LA", data: { text: "Local authority" } },
+          { id: "publicAuthority", data: { text: "Other public authority" } },
+          { id: "councilDelivery", data: { text: "Council delivery company" } },
+          {
+            id: "councilBuildToRent",
+            data: { text: "Council delivered build to rent" },
+          },
+          {
+            id: "affordableHousing",
+            data: { text: "Other affordable housing provider" },
+          },
+          { id: "selfBuild", data: { text: "Self-build" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes" } },
+          { id: "false", data: { text: "No" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many identical units does the description above apply to?",
+        fn: "identicalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
Changed GLA schemas from new/rebuild/retained/lost to gained/lost structure. Added existing and proposed uses schema.

Need to check subsequently as to new summary/count total requirements or if they can be created manually.