### PR TITLE
fix: make flow name required and update all contexts for passing e2e tests

### DIFF
--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -25,7 +25,7 @@ export interface Context {
     id?: string;
     publishedId?: number;
     slug: string;
-    name?: string;
+    name: string;
     data?: object;
   };
   sessionIds?: string[];

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -21,6 +21,7 @@ let context: Context = {
   ...contextDefaults,
   flow: {
     slug: "invite-to-pay-test",
+    name: "Invite to pay test",
     data: inviteToPayFlow,
   },
   sessionIds: [], // used to collect and clean up sessions

--- a/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
@@ -18,6 +18,7 @@ let context: Context = {
   ...contextDefaults,
   flow: {
     slug: "invite-to-pay-test",
+    name: "Invite to pay test",
     data: inviteToPayFlow,
   },
   sessionIds: [], // used to collect and clean up sessions

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -23,6 +23,7 @@ let context: Context = {
   ...contextDefaults,
   flow: {
     slug: "pay-test",
+    name: "Pay test",
     data: payFlow,
   },
   sessionIds: [], // used to collect and clean up sessions

--- a/e2e/tests/ui-driven/src/save-and-return.spec.ts
+++ b/e2e/tests/ui-driven/src/save-and-return.spec.ts
@@ -24,6 +24,7 @@ test.describe("Save and return", () => {
     ...contextDefaults,
     flow: {
       slug: "e2e-save-and-return-test-flow",
+      name: "E2E Save and Return test flow",
       data: simpleSendFlow,
     },
   };

--- a/e2e/tests/ui-driven/src/sections.spec.ts
+++ b/e2e/tests/ui-driven/src/sections.spec.ts
@@ -38,6 +38,7 @@ test.describe("Section statuses", () => {
     ...contextDefaults,
     flow: {
       slug: "sections-test-flow",
+      name: "Sections test flow",
       data: flow,
     },
   };


### PR DESCRIPTION
These changes work locally for me, hopefully will pass on CI too :crossed_fingers: 