### PR TITLE
feat: Updating Email Templates with Flow Name

### DIFF
--- a/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.test.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.test.ts
@@ -34,6 +34,7 @@ describe("Create payment send events webhook", () => {
           flow: {
             id: "flow-123",
             slug: "apply-for-something",
+            name: "Apply for Something",
           },
         },
       },

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
@@ -31,6 +31,7 @@ describe("sendAgentAndPayeeConfirmationEmail", () => {
             email: agentEmail,
             flow: {
               slug: "some-flow",
+              name: "Some Flow",
               team: {
                 notifyPersonalisation: {
                   emailReplyToId: "123",

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
@@ -87,7 +87,7 @@ describe("sendAgentAndPayeeConfirmationEmail", () => {
         helpEmail: "help@email.com",
         helpOpeningHours: "9-5",
         helpPhone: "123",
-        serviceName: "Some flow",
+        serviceName: "Some Flow",
       },
     };
     await sendAgentAndPayeeConfirmationEmail("mockSessionId");

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -38,7 +38,7 @@ type PayeeAndAgentEmailData = {
 };
 
 async function getDataForPayeeAndAgentEmails(
-  sessionId: string
+  sessionId: string,
 ): Promise<PayeeAndAgentEmailData> {
   const query = gql`
     query GetDataForPayeeAndAgentEmails($sessionId: uuid!) {

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -38,7 +38,7 @@ type PayeeAndAgentEmailData = {
 };
 
 async function getDataForPayeeAndAgentEmails(
-  sessionId: string,
+  sessionId: string
 ): Promise<PayeeAndAgentEmailData> {
   const query = gql`
     query GetDataForPayeeAndAgentEmails($sessionId: uuid!) {
@@ -68,6 +68,7 @@ async function getDataForPayeeAndAgentEmails(
       email: string;
       flow: {
         slug: string;
+        name: string;
         team: {
           notifyPersonalisation: {
             emailReplyToId: string;
@@ -89,7 +90,7 @@ async function getDataForPayeeAndAgentEmails(
   const data = response.lowcal_sessions[0];
   const { emailReplyToId, helpEmail, helpOpeningHours, helpPhone } =
     data.flow.team.notifyPersonalisation;
-  const serviceName = convertSlugToName(data.flow.slug);
+  const serviceName = data.flow.name;
   const applicantEmail = data.email;
   const { payeeEmail, payeeName, address, projectTypes, applicantName } =
     data.paymentRequests[0];

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -18,6 +18,7 @@ interface SessionDetails {
   email: string;
   flow: {
     slug: string;
+    name: string;
     team: Team;
   };
 }
@@ -36,7 +37,7 @@ const sendSinglePaymentEmail = async ({
   try {
     const { session, paymentRequest } = await validatePaymentRequest(
       paymentRequestId,
-      template,
+      template
     );
     const config = await getInviteToPayNotifyConfig(session, paymentRequest);
     const recipient = template.includes("-agent")
@@ -50,7 +51,7 @@ const sendSinglePaymentEmail = async ({
 
 const validatePaymentRequest = async (
   paymentRequestId: string,
-  template: Template,
+  template: Template
 ): Promise<{ session: SessionDetails; paymentRequest: PaymentRequest }> => {
   try {
     const query = gql`
@@ -69,6 +70,7 @@ const validatePaymentRequest = async (
             email
             flow {
               slug
+              name
               team {
                 id
                 name
@@ -88,7 +90,7 @@ const validatePaymentRequest = async (
     } = await client.request<ValidatePaymentRequest>(
       query,
       { paymentRequestId },
-      headers,
+      headers
     );
 
     if (!paymentRequest)
@@ -99,14 +101,14 @@ const validatePaymentRequest = async (
     return { session, paymentRequest };
   } catch (error) {
     throw Error(
-      `Unable to validate payment request. ${(error as Error).message}`,
+      `Unable to validate payment request. ${(error as Error).message}`
     );
   }
 };
 
 const getInviteToPayNotifyConfig = async (
   session: SessionDetails,
-  paymentRequest: PaymentRequest,
+  paymentRequest: PaymentRequest
 ): Promise<InviteToPayNotifyConfig> => ({
   personalisation: {
     ...session.flow.team.notifyPersonalisation,
@@ -121,9 +123,9 @@ const getInviteToPayNotifyConfig = async (
     fee: getFee(paymentRequest),
     projectType:
       (await $public.formatRawProjectTypes(
-        paymentRequest.sessionPreviewData?.["proposal.projectType"] as string[],
+        paymentRequest.sessionPreviewData?.["proposal.projectType"] as string[]
       )) || "Project type not submitted",
-    serviceName: convertSlugToName(session.flow.slug),
+    serviceName: session.flow.name,
     serviceLink: getServiceLink(session.flow.team, session.flow.slug),
     expiryDate: calculateExpiryDate(paymentRequest.createdAt),
     paymentLink: getPaymentLink(session, paymentRequest),
@@ -141,7 +143,7 @@ const getFee = (paymentRequest: PaymentRequest) => {
 
 const getPaymentLink = (
   session: SessionDetails,
-  paymentRequest: PaymentRequest,
+  paymentRequest: PaymentRequest
 ) => {
   const {
     flow: {

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -37,7 +37,7 @@ const sendSinglePaymentEmail = async ({
   try {
     const { session, paymentRequest } = await validatePaymentRequest(
       paymentRequestId,
-      template
+      template,
     );
     const config = await getInviteToPayNotifyConfig(session, paymentRequest);
     const recipient = template.includes("-agent")
@@ -51,7 +51,7 @@ const sendSinglePaymentEmail = async ({
 
 const validatePaymentRequest = async (
   paymentRequestId: string,
-  template: Template
+  template: Template,
 ): Promise<{ session: SessionDetails; paymentRequest: PaymentRequest }> => {
   try {
     const query = gql`
@@ -90,7 +90,7 @@ const validatePaymentRequest = async (
     } = await client.request<ValidatePaymentRequest>(
       query,
       { paymentRequestId },
-      headers
+      headers,
     );
 
     if (!paymentRequest)
@@ -101,14 +101,14 @@ const validatePaymentRequest = async (
     return { session, paymentRequest };
   } catch (error) {
     throw Error(
-      `Unable to validate payment request. ${(error as Error).message}`
+      `Unable to validate payment request. ${(error as Error).message}`,
     );
   }
 };
 
 const getInviteToPayNotifyConfig = async (
   session: SessionDetails,
-  paymentRequest: PaymentRequest
+  paymentRequest: PaymentRequest,
 ): Promise<InviteToPayNotifyConfig> => ({
   personalisation: {
     ...session.flow.team.notifyPersonalisation,
@@ -123,7 +123,7 @@ const getInviteToPayNotifyConfig = async (
     fee: getFee(paymentRequest),
     projectType:
       (await $public.formatRawProjectTypes(
-        paymentRequest.sessionPreviewData?.["proposal.projectType"] as string[]
+        paymentRequest.sessionPreviewData?.["proposal.projectType"] as string[],
       )) || "Project type not submitted",
     serviceName: session.flow.name,
     serviceLink: getServiceLink(session.flow.team, session.flow.slug),
@@ -143,7 +143,7 @@ const getFee = (paymentRequest: PaymentRequest) => {
 
 const getPaymentLink = (
   session: SessionDetails,
-  paymentRequest: PaymentRequest
+  paymentRequest: PaymentRequest,
 ) => {
   const {
     flow: {

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
@@ -49,6 +49,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
     ];
@@ -83,6 +84,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
       {
@@ -100,6 +102,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
       {
@@ -117,6 +120,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
     ];
@@ -158,6 +162,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
       {
@@ -175,6 +180,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2022-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
     ];
@@ -206,6 +212,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
     ];
@@ -240,6 +247,7 @@ describe("buildContentFromSessions function", () => {
         created_at: "2026-05-01T01:02:03.865452+00:00",
         flow: {
           slug: "apply-for-a-lawful-development-certificate",
+          name: "Apply for a Lawful Development Certificate",
         },
       },
     ];

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -23,7 +23,7 @@ const getResumeLink = (
     id: string;
   },
   team: Team,
-  flowSlug: string
+  flowSlug: string,
 ) => {
   const serviceLink = getServiceLink(team, flowSlug);
   return `${serviceLink}?sessionId=${session.id}`;
@@ -84,7 +84,7 @@ const sendSingleApplicationEmail = async ({
 const validateSingleSessionRequest = async (
   email: string,
   sessionId: string,
-  template: Template
+  template: Template,
 ) => {
   try {
     const query = gql`
@@ -118,7 +118,7 @@ const validateSingleSessionRequest = async (
     } = await client.request<{ lowcalSessions: LowCalSession[] }>(
       query,
       { sessionId },
-      headers
+      headers,
     );
 
     if (!session) throw Error(`Unable to find session: ${sessionId}`);
@@ -147,7 +147,7 @@ interface SessionDetails {
  * Parse session details into an object which will be read by email template
  */
 export const getSessionDetails = async (
-  session: LowCalSession
+  session: LowCalSession,
 ): Promise<SessionDetails> => {
   const passportProtectTypes =
     session.data.passport?.data?.["proposal.projectType"];
@@ -175,7 +175,7 @@ const getPersonalisation = (
   session: SessionDetails,
   flowSlug: string,
   flowName: string,
-  team: Team
+  team: Team,
 ) => {
   return {
     resumeLink: getResumeLink(session, team, flowSlug),
@@ -269,7 +269,7 @@ export const setupEmailEventTriggers = async (sessionId: string) => {
     return hasUserSaved;
   } catch (error) {
     throw new Error(
-      `Error setting up email notifications for session ${sessionId}. Error: ${error}`
+      `Error setting up email notifications for session ${sessionId}. Error: ${error}`,
     );
   }
 };

--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -72,7 +72,7 @@ describe(`sending an application by email to a planning office`, () => {
       data: {
         session: {
           email: "simulate-delivered@notifications.service.gov.uk",
-          flow: { slug: "test-flow" },
+          flow: { slug: "test-flow", name: "Test Flow" },
         },
       },
       variables: { id: "123" },

--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -12,7 +12,7 @@ import {
 export async function sendToEmail(
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ) {
   req.setTimeout(120 * 1000); // Temporary bump to address submission timeouts
 
@@ -65,7 +65,7 @@ export async function sendToEmail(
       localAuthority,
       sendToEmail,
       config,
-      response
+      response,
     );
 
     return res.status(200).send({

--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -12,7 +12,7 @@ import {
 export async function sendToEmail(
   req: Request,
   res: Response,
-  next: NextFunction,
+  next: NextFunction
 ) {
   req.setTimeout(120 * 1000); // Temporary bump to address submission timeouts
 
@@ -40,7 +40,7 @@ export async function sendToEmail(
 
     // Get the applicant email and flow slug associated with the session
     const { email, flow } = await getSessionEmailDetailsById(payload.sessionId);
-    const flowName = capitalize(flow?.slug?.replaceAll("-", " "));
+    const flowName = flow.name;
 
     // Prepare email template
     const config: EmailSubmissionNotifyConfig = {
@@ -65,7 +65,7 @@ export async function sendToEmail(
       localAuthority,
       sendToEmail,
       config,
-      response,
+      response
     );
 
     return res.status(200).send({

--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -23,7 +23,7 @@ export async function getTeamEmailSettings(localAuthority: string) {
     `,
     {
       slug: localAuthority,
-    },
+    }
   );
 
   return response?.teams[0];
@@ -44,7 +44,7 @@ export async function getSessionData(sessionId: string) {
     `,
     {
       id: sessionId,
-    },
+    }
   );
 
   return response?.session?.data;
@@ -55,6 +55,7 @@ interface GetSessionEmailDetailsById {
     email: string;
     flow: {
       slug: string;
+      name: string;
     };
   } | null;
 }
@@ -67,18 +68,19 @@ export async function getSessionEmailDetailsById(sessionId: string) {
           email
           flow {
             slug
+            name
           }
         }
       }
     `,
     {
       id: sessionId,
-    },
+    }
   );
 
   if (!response.session)
     throw Error(
-      `Cannot find session ${sessionId} in GetSessionEmailDetails query`,
+      `Cannot find session ${sessionId} in GetSessionEmailDetails query`
     );
 
   return response.session;
@@ -98,7 +100,7 @@ export async function insertAuditEntry(
   sendEmailResponse: {
     message: string;
     expiryDate?: string;
-  },
+  }
 ) {
   const response = await $api.client.request<CreateEmailApplication>(
     gql`
@@ -128,7 +130,7 @@ export async function insertAuditEntry(
       recipient: recipient,
       request: notifyRequest,
       response: sendEmailResponse,
-    },
+    }
   );
 
   return response?.application?.id;

--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -23,7 +23,7 @@ export async function getTeamEmailSettings(localAuthority: string) {
     `,
     {
       slug: localAuthority,
-    }
+    },
   );
 
   return response?.teams[0];
@@ -44,7 +44,7 @@ export async function getSessionData(sessionId: string) {
     `,
     {
       id: sessionId,
-    }
+    },
   );
 
   return response?.session?.data;
@@ -75,12 +75,12 @@ export async function getSessionEmailDetailsById(sessionId: string) {
     `,
     {
       id: sessionId,
-    }
+    },
   );
 
   if (!response.session)
     throw Error(
-      `Cannot find session ${sessionId} in GetSessionEmailDetails query`
+      `Cannot find session ${sessionId} in GetSessionEmailDetails query`,
     );
 
   return response.session;
@@ -100,7 +100,7 @@ export async function insertAuditEntry(
   sendEmailResponse: {
     message: string;
     expiryDate?: string;
-  }
+  },
 ) {
   const response = await $api.client.request<CreateEmailApplication>(
     gql`
@@ -130,7 +130,7 @@ export async function insertAuditEntry(
       recipient: recipient,
       request: notifyRequest,
       response: sendEmailResponse,
-    }
+    },
   );
 
   return response?.application?.id;

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5b8c840",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccca2ac",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#5b8c840
-    version: github.com/theopensystemslab/planx-core/5b8c840
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccca2ac
+    version: github.com/theopensystemslab/planx-core/ccca2ac
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8301,8 +8301,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/5b8c840:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5b8c840}
+  github.com/theopensystemslab/planx-core/ccca2ac:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccca2ac}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -50,6 +50,7 @@ export const validSession: Session = {
   flow: {
     id: "741a2372-b0b4-4f30-98a8-7c98c6464954",
     slug: "apply-for-a-lawful-development-certificate",
+    name: "Apply for a Lawful Development Certificate",
   },
 };
 
@@ -77,6 +78,7 @@ export const validPaymentRequest = {
     email: "the-agent@opensystemslab.io",
     flow: {
       slug: "apply-for-a-lawful-development-certificate",
+      name: "Apply for a Lawful Development Certificate",
       team: {
         name: "Buckinghamshire",
         slug: "buckinghamshire",

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -19,6 +19,7 @@ export const validSessionQueryMock = {
       flow: {
         id: validSession.flow.id,
         slug: validSession.flow.slug,
+        name: validSession.flow.name,
       },
     },
   },
@@ -37,6 +38,7 @@ export const detailedValidSessionQueryMock = {
       flow: {
         id: validSession.flow.id,
         slug: validSession.flow.slug,
+        name: validSession.flow.name,
       },
     },
   },

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -16,6 +16,7 @@ export const mockTeam = {
 export const mockFlow: Flow = {
   id: "dcfd4f07-76da-4b67-9822-2aca92b27551",
   slug: "slug",
+  name: "Flow Name",
   team_id: mockTeam.id,
   data: {
     _root: {
@@ -63,6 +64,7 @@ export const mockLowcalSession: LowCalSession = {
   },
   flow: {
     slug: "apply-for-a-lawful-development-certificate",
+    name: "Apply for a Lawful Development Certificate",
     team: mockTeam,
   },
   flow_id: mockFlow.id,

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -85,6 +85,7 @@ export interface LowCalSession {
   has_user_saved: boolean;
   flow: {
     slug: string;
+    name: string;
     team: Team;
   };
   lockedAt?: string;

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -17,6 +17,7 @@ export interface Node {
 export interface Flow {
   id: string;
   slug: string;
+  name: string;
   data: {
     [key: string]: Node;
   };

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5b8c840",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccca2ac",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#5b8c840
-    version: github.com/theopensystemslab/planx-core/5b8c840
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccca2ac
+    version: github.com/theopensystemslab/planx-core/ccca2ac
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -446,6 +446,7 @@ packages:
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.3.4(supports-color@8.1.1)
@@ -461,6 +462,7 @@ packages:
 
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
     dev: false
 
   /@isaacs/cliui@8.0.2:
@@ -2936,8 +2938,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/5b8c840:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5b8c840}
+  github.com/theopensystemslab/planx-core/ccca2ac:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccca2ac}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5b8c840",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccca2ac",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#5b8c840
-    version: github.com/theopensystemslab/planx-core/5b8c840
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccca2ac
+    version: github.com/theopensystemslab/planx-core/ccca2ac
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2684,8 +2684,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/5b8c840:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5b8c840}
+  github.com/theopensystemslab/planx-core/ccca2ac:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccca2ac}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@mui/material": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.2",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5b8c840",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccca2ac",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -41,8 +41,8 @@ dependencies:
     specifier: ^0.8.2
     version: 0.8.2
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#5b8c840
-    version: github.com/theopensystemslab/planx-core/5b8c840(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccca2ac
+    version: github.com/theopensystemslab/planx-core/ccca2ac(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -6544,11 +6544,11 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-manager@8.1.5(prettier@3.3.0):
+  /@storybook/builder-manager@8.1.5(prettier@3.3.1):
     resolution: {integrity: sha512-wDiHLV+UPaUN+765WwXkocVRB2QnJ61CjLHbpWaLiJvryFJt+JQ6nAvgSalCRnZxI046ztbS9T6okhpFI011IA==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.5(prettier@3.3.0)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/manager': 8.1.5
       '@storybook/node-logger': 8.1.5
       '@types/ejs': 3.1.5
@@ -6652,12 +6652,12 @@ packages:
       '@babel/types': 7.24.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.3.0)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/core-events': 8.1.5
-      '@storybook/core-server': 8.1.5(prettier@3.3.0)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-server': 8.1.5(prettier@3.3.1)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-tools': 8.1.5
       '@storybook/node-logger': 8.1.5
-      '@storybook/telemetry': 8.1.5(prettier@3.3.0)
+      '@storybook/telemetry': 8.1.5(prettier@3.3.1)
       '@storybook/types': 8.1.5
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -6796,7 +6796,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/core-common@8.1.5(prettier@3.3.0):
+  /@storybook/core-common@8.1.5(prettier@3.3.1):
     resolution: {integrity: sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==}
     peerDependencies:
       prettier: ^2 || ^3
@@ -6825,8 +6825,8 @@ packages:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier: 3.3.0
-      prettier-fallback: /prettier@3.3.0
+      prettier: 3.3.1
+      prettier-fallback: /prettier@3.3.1
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.2
@@ -6858,16 +6858,16 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/core-server@8.1.5(prettier@3.3.0)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/core-server@8.1.5(prettier@3.3.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-y16W2sg5KIHG6qgbd+a0nBUYHAgiUpPDFF7cdcIpbeOIoqFn+6ECp93MVefukumiSj3sQiJFU/tSm2A8apGltw==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.5(prettier@3.3.0)
+      '@storybook/builder-manager': 8.1.5(prettier@3.3.1)
       '@storybook/channels': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.3.0)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/core-events': 8.1.5
       '@storybook/csf': 0.1.7
       '@storybook/csf-tools': 8.1.5
@@ -6877,7 +6877,7 @@ packages:
       '@storybook/manager-api': 8.1.5(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 8.1.5
       '@storybook/preview-api': 8.1.5
-      '@storybook/telemetry': 8.1.5(prettier@3.3.0)
+      '@storybook/telemetry': 8.1.5(prettier@3.3.1)
       '@storybook/types': 8.1.5
       '@types/detect-port': 1.3.5
       '@types/diff': 5.2.1
@@ -7320,11 +7320,11 @@ packages:
       qs: 6.12.1
     dev: true
 
-  /@storybook/telemetry@8.1.5(prettier@3.3.0):
+  /@storybook/telemetry@8.1.5(prettier@3.3.1):
     resolution: {integrity: sha512-QbB1Ox7oBaCvIF2TacFjPLi1XYeHxSPeZUuFXeE+tSMdvvWZzYLnXfj/oISmV6Q+X5VZfyJVMrZ2LfeW9CuFNg==}
     dependencies:
       '@storybook/client-logger': 8.1.5
-      '@storybook/core-common': 8.1.5(prettier@3.3.0)
+      '@storybook/core-common': 8.1.5(prettier@3.3.1)
       '@storybook/csf-tools': 8.1.5
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -17468,7 +17468,6 @@ packages:
     resolution: {integrity: sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: false
 
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -21632,9 +21631,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/5b8c840(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5b8c840}
-    id: github.com/theopensystemslab/planx-core/5b8c840
+  github.com/theopensystemslab/planx-core/ccca2ac(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccca2ac}
+    id: github.com/theopensystemslab/planx-core/ccca2ac
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
# What does this PR do?

This PR follows on from other PRs which have added the ``name`` column to the ``flows`` table and created functionality for users to add a flow name to their team's flows. 

The final part of this work is to update email templates so the ``Session Name`` is the user generated ``name`` rather than the augmented ``flowSlug``