### PR TITLE
fix: preserve editor redirects when logging in

### DIFF
--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -111,7 +111,13 @@ export const useJWT = expressjwt({
 });
 
 export const useGoogleAuth: RequestHandler = (req, res, next) => {
-  req.session!.returnTo = req.get("Referrer");
+  // Ensure returnTo maintains `?redirectTo=` param if provided
+  let returnToURL = req.get("Referrer");
+  if (req.query.redirectTo) {
+    returnToURL += `?redirectTo=${encodeURIComponent(req.query.redirectTo as string)}`;
+  }
+
+  req.session!.returnTo = returnToURL;
   return passport.authenticate("google", {
     scope: ["profile", "email"],
   })(req, res, next);

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -40,15 +40,17 @@ const hasJWT = (): boolean | void => {
   if (authCookie) return true;
 
   // If JWT not set via cookie, check search params
-  const jwtSearchParams = new URLSearchParams(window.location.search).get(
-    "jwt",
-  );
+  const searchParams = new URLSearchParams(window.location.search);
+  const jwtSearchParams = searchParams.get("jwt",);
   if (!jwtSearchParams) return false;
 
   // Remove JWT from URL, and re-run this function
   setCookie("jwt", jwtSearchParams);
   setCookie("auth", { loggedIn: true });
-  window.location.href = "/";
+  // Strip leading "/" from redirectTo URL
+  const redirectTo = (searchParams.get("redirectTo") || "/").substring(1);
+
+  window.location.replace(encodeURIComponent(redirectTo));
 };
 
 const Layout: React.FC<{

--- a/editor.planx.uk/src/pages/Login.tsx
+++ b/editor.planx.uk/src/pages/Login.tsx
@@ -27,7 +27,7 @@ const PhaseText = styled("span")(() => ({
   color: "rgba(255, 255, 255, 0.49);",
 }));
 
-const Login: React.FC = () => {
+const Login: React.FC = () => { 
   return (
     <Wrapper>
       <LoginContainer>
@@ -41,7 +41,7 @@ const Login: React.FC = () => {
           href={`${
             process.env.REACT_APP_GOOGLE_OAUTH_OVERRIDE ??
             process.env.REACT_APP_API_URL
-          }/auth/google`}
+          }/auth/google${window.location.search}`}
         >
           Login with Google
         </Link>


### PR DESCRIPTION
At first, I suspected this might be at the react-navi level, but our editor routes look consistent with docs [here](https://frontarm.com/navi/en/reference/matchers/#examples-1) & [here](https://www.tabnine.com/code/javascript/classes/navi/NaviRequest).

When we handle the request to `/auth/google`, we were previously setting the `req.session!.returnTo` URL as the referrer which comes through _without_ the `?redirectTo=` param so this explicitly preserves it.

Doesn't seem to break anything in local testing, but wasn't fixing the issue yet either? Opening a pizza to see if any different.

To test, try to open this editor url directly before you're logged in: https://3275.planx.pizza/opensystemslab
- Prior behavior was to login and land on `/`, without being redirected
- Ideal behavior it to login and then be properly redirected to intended path