### PR TITLE
feat: display existing validation checks in publish dialog

### DIFF
--- a/api.planx.uk/modules/flows/validate/helpers.ts
+++ b/api.planx.uk/modules/flows/validate/helpers.ts
@@ -1,0 +1,51 @@
+import {
+  ComponentType,
+  FlowGraph,
+  Node,
+} from "@opensystemslab/planx-core/types";
+import { Entry } from "type-fest";
+
+export const isComponentType = (
+  entry: Entry<FlowGraph>,
+  type: ComponentType,
+): entry is [string, Node] => {
+  const [nodeId, node] = entry;
+  if (nodeId === "_root") return false;
+  return Boolean(node?.type === type);
+};
+
+export const hasComponentType = (
+  flowGraph: FlowGraph,
+  type: ComponentType,
+  fn?: string,
+): boolean => {
+  const nodeIds = Object.entries(flowGraph).filter(
+    (entry): entry is [string, Node] => isComponentType(entry, type),
+  );
+  if (fn) {
+    nodeIds
+      ?.filter(([_nodeId, nodeData]) => nodeData?.data?.fn === fn)
+      ?.map(([nodeId, _nodeData]) => nodeId);
+  } else {
+    nodeIds?.map(([nodeId, _nodeData]) => nodeId);
+  }
+  return Boolean(nodeIds?.length);
+};
+
+export const numberOfComponentType = (
+  flowGraph: FlowGraph,
+  type: ComponentType,
+  fn?: string,
+): number => {
+  const nodeIds = Object.entries(flowGraph).filter(
+    (entry): entry is [string, Node] => isComponentType(entry, type),
+  );
+  if (fn) {
+    nodeIds
+      ?.filter(([_nodeId, nodeData]) => nodeData?.data?.fn === fn)
+      ?.map(([nodeId, _nodeData]) => nodeId);
+  } else {
+    nodeIds?.map(([nodeId, _nodeData]) => nodeId);
+  }
+  return nodeIds?.length;
+};

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -107,12 +107,20 @@ describe("sections validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body).toEqual({
-          alteredNodes: null,
-          message: "Cannot publish an invalid flow",
-          description:
-            "Found Sections in one or more External Portals, but Sections are only allowed in main flow",
-        });
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Sections",
+            status: "Fail",
+            message:
+              "Found Sections in one or more External Portals, but Sections are only allowed in main flow",
+          },
+          {
+            title: "Invite to Pay",
+            status: "Not applicable",
+            message: "Your flow is not using Invite to Pay",
+          },
+        ]);
       });
   });
 
@@ -148,12 +156,19 @@ describe("sections validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body).toEqual({
-          alteredNodes: null,
-          message: "Cannot publish an invalid flow",
-          description:
-            "When using Sections, your flow must start with a Section",
-        });
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Sections",
+            status: "Fail",
+            message: "When using Sections, your flow must start with a Section",
+          },
+          {
+            title: "Invite to Pay",
+            status: "Not applicable",
+            message: "Your flow is not using Invite to Pay",
+          },
+        ]);
       });
   });
 });
@@ -180,10 +195,19 @@ describe("invite to pay validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual(
-          "When using Invite to Pay, your flow must have a Send",
-        );
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Invite to Pay",
+            status: "Fail",
+            message: "When using Invite to Pay, your flow must have a Send",
+          },
+          {
+            title: "Sections",
+            status: "Not applicable",
+            message: "Your flow is not using Sections",
+          },
+        ]);
       });
   });
 
@@ -219,10 +243,20 @@ describe("invite to pay validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual(
-          "When using Invite to Pay, your flow must have exactly ONE Send. It can select many destinations",
-        );
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Invite to Pay",
+            status: "Fail",
+            message:
+              "When using Invite to Pay, your flow must have exactly ONE Send. It can select many destinations",
+          },
+          {
+            title: "Sections",
+            status: "Not applicable",
+            message: "Your flow is not using Sections",
+          },
+        ]);
       });
   });
 
@@ -254,10 +288,20 @@ describe("invite to pay validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual(
-          "When using Invite to Pay, your flow must have a FindProperty",
-        );
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Invite to Pay",
+            status: "Fail",
+            message:
+              "When using Invite to Pay, your flow must have a FindProperty",
+          },
+          {
+            title: "Sections",
+            status: "Not applicable",
+            message: "Your flow is not using Sections",
+          },
+        ]);
       });
   });
 
@@ -291,10 +335,20 @@ describe("invite to pay validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual(
-          "When using Invite to Pay, your flow must have exactly ONE Pay",
-        );
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Invite to Pay",
+            status: "Fail",
+            message:
+              "When using Invite to Pay, your flow must have exactly ONE Pay",
+          },
+          {
+            title: "Sections",
+            status: "Not applicable",
+            message: "Your flow is not using Sections",
+          },
+        ]);
       });
   });
 
@@ -330,10 +384,20 @@ describe("invite to pay validation on diff", () => {
       .set(auth)
       .expect(200)
       .then((res) => {
-        expect(res.body.message).toEqual("Cannot publish an invalid flow");
-        expect(res.body.description).toEqual(
-          "When using Invite to Pay, your flow must have a Checklist that sets the passport variable `proposal.projectType`",
-        );
+        expect(res.body.message).toEqual("Changes queued to publish");
+        expect(res.body.validationChecks).toEqual([
+          {
+            title: "Invite to Pay",
+            status: "Fail",
+            message:
+              "When using Invite to Pay, your flow must have a Checklist that sets `proposal.projectType`",
+          },
+          {
+            title: "Sections",
+            status: "Not applicable",
+            message: "Your flow is not using Sections",
+          },
+        ]);
       });
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PublishDialog.tsx
@@ -1,0 +1,246 @@
+import Close from "@mui/icons-material/Close";
+import Done from "@mui/icons-material/Done";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Collapse from "@mui/material/Collapse";
+import Divider from "@mui/material/Divider";
+import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import React, { useState } from "react";
+import { useAsync } from "react-use";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import Caret from "ui/icons/Caret";
+
+import { formatLastPublishMessage } from "pages/FlowEditor/utils";
+import { useStore } from "../../lib/store";
+
+export interface AlteredNode {
+  id: string;
+  type: TYPES;
+  data?: any;
+}
+
+const AlteredNodeListItem = (props: { node: AlteredNode }) => {
+  const { node } = props;
+  let text, data;
+
+  if (node.id === "_root") {
+    text = "Changed _root service by adding, deleting or re-ordering nodes";
+  } else if (node.id === "0") {
+    text = `The entire _root service will be published for the first time`;
+  } else if (node.id && Object.keys(node).length === 1) {
+    text = `Deleted node ${node.id}`;
+  } else if (node.type && node.data) {
+    text = `Added/edited ${TYPES[node.type]}`;
+    data = JSON.stringify(node.data, null, 2);
+  } else {
+    text = `Added/edited ${TYPES[node.type]}`;
+  }
+
+  return (
+    <li key={node.id}>
+      <Typography variant="body2">{text}</Typography>
+      {data && <pre style={{ fontSize: ".8em" }}>{data}</pre>}
+    </li>
+  );
+};
+
+interface Portal {
+  text: string;
+  flowId: string;
+  publishedFlowId: number;
+  summary: string;
+  publishedBy: number;
+  publishedAt: string;
+}
+
+const AlteredNestedFlowListItem = (props: Portal) => {
+  const { text, flowId, publishedFlowId, summary, publishedAt } = props;
+
+  const [nestedFlowLastPublishedTitle, setNestedFlowLastPublishedTitle] =
+    useState<string>();
+  const lastPublisher = useStore((state) => state.lastPublisher);
+
+  const _nestedFlowLastPublishedRequest = useAsync(async () => {
+    const user = await lastPublisher(flowId);
+    setNestedFlowLastPublishedTitle(formatLastPublishMessage(publishedAt, user));
+  });
+
+  return (
+    <ListItem
+      key={publishedFlowId}
+      disablePadding
+      sx={{ display: "list-item" }}
+    >
+      <ListItemText
+        primary={
+          useStore.getState().canUserEditTeam(text.split("/")[0]) ? (
+            <Link href={`../${text}`} target="_blank">
+              <Typography variant="body2">{text}</Typography>
+            </Link>
+          ) : (
+            <Typography variant="body2">{text}</Typography>
+          )
+        }
+        secondary={
+          <>
+            <Typography variant="body2" fontSize="small">
+              {nestedFlowLastPublishedTitle}
+            </Typography>
+            {summary && (
+              <Typography variant="body2" fontSize="small">
+                {summary}
+              </Typography>
+            )}
+          </>
+        }
+      />
+    </ListItem>
+  );
+};
+
+interface AlteredNodesSummary {
+  title: string;
+  portals: Portal[];
+  updated: number;
+  deleted: number;
+}
+
+export const AlteredNodesSummaryContent = (props: {
+  alteredNodes: AlteredNode[];
+}) => {
+  const { alteredNodes } = props;
+  const [expandNodes, setExpandNodes] = useState<boolean>(false);
+
+  const changeSummary: AlteredNodesSummary = {
+    title: "",
+    portals: [],
+    updated: 0,
+    deleted: 0,
+  };
+
+  alteredNodes.map((node) => {
+    if (node.id === "0") {
+      changeSummary["title"] =
+        "You are publishing the main service for the first time.";
+    } else if (node.id && Object.keys(node).length === 1) {
+      changeSummary["deleted"] += 1;
+    } else if (node.type === TYPES.InternalPortal) {
+      if (node.data?.text?.includes("/")) {
+        changeSummary["portals"].push({ ...node.data, flowId: node.id });
+      }
+    } else if (node.type) {
+      changeSummary["updated"] += 1;
+    }
+
+    return changeSummary;
+  });
+
+  return (
+    <Box pb={2}>
+      {changeSummary["title"] && (
+        <Typography variant="body2" pb={2}>
+          {changeSummary["title"]}
+        </Typography>
+      )}
+      {(changeSummary["updated"] > 0 || changeSummary["deleted"] > 0) && (
+        <Box pb={2}>
+          <ul>
+            <li key={"updated"}>
+              <Typography variant="body2">{`${changeSummary["updated"]} nodes have been updated or added`}</Typography>
+            </li>
+            <li key={"deleted"}>
+              <Typography variant="body2">{`${changeSummary["deleted"]} nodes have been deleted`}</Typography>
+            </li>
+          </ul>
+          <Box
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              marginBottom: 2,
+            }}
+          >
+            <Box
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+              }}
+            >
+              <Typography variant="body2">{`See detailed changelog `}</Typography>
+              <Button
+                onClick={() => setExpandNodes((expandNodes) => !expandNodes)}
+                size="small"
+                disableRipple
+              >
+                <Caret
+                  expanded={expandNodes}
+                  color="primary"
+                  titleAccess={
+                    expandNodes ? "Less information" : "More information"
+                  }
+                />
+              </Button>
+            </Box>
+            <Collapse in={expandNodes}>
+              <Box pb={1}>
+                <ul>
+                  {alteredNodes.map((node) => (
+                    <AlteredNodeListItem node={node} />
+                  ))}
+                </ul>
+              </Box>
+            </Collapse>
+          </Box>
+        </Box>
+      )}
+      <Divider />
+      {changeSummary["portals"].length > 0 && (
+        <>
+          <Box pt={2}>
+            <Typography variant="body2">{`This includes recently published changes in the following nested services:`}</Typography>
+            <List sx={{ listStyleType: "disc", marginLeft: 4 }}>
+              {changeSummary["portals"].map((portal) => (
+                <AlteredNestedFlowListItem {...portal} />
+              ))}
+            </List>
+          </Box>
+          <Divider />
+        </>
+      )}
+    </Box>
+  );
+};
+
+export const ValidationChecks = (props: {
+  validationChecks: { title: string; isValid: boolean; message: string; }[]
+}) => {
+  const { validationChecks } = props;
+
+  return (
+    <Box pb={2}>
+      <Typography variant="body2" fontWeight={FONT_WEIGHT_SEMI_BOLD}>
+        Validation checks
+      </Typography>
+      <List sx={{ pb: 2 }}>
+        {validationChecks.map((check, i) => (
+          <ListItem key={i} disablePadding>
+            <ListItemIcon>
+              {check.isValid ? <Done color="success" /> : <Close color="error" />}
+            </ListItemIcon>
+            <ListItemText
+              primary={<Typography variant="body2">{check.title}</Typography>}
+              secondary={<Typography variant="body2" fontSize="small">{check.message}</Typography>}
+            />
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+    </Box>
+  )
+}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PublishDialog.tsx
@@ -232,15 +232,11 @@ export const ValidationChecks = (props: {
 }) => {
   const { validationChecks } = props;
 
-  const getIcon = (status: ValidationCheck["status"]) => {
-    if (status === "Pass") {
-      return <Done color="success" />;
-    } else if (status === "Fail") {
-      return <Close color="error" />;
-    } else if (status === "Not applicable") {
-      return <NotInterested color="disabled" />;
-    }
-  }
+  const Icon: Record<ValidationCheck["status"], React.ReactElement> = {
+    "Pass": <Done color="success" />,
+    "Fail": <Close color="error" />,
+    "Not applicable": <NotInterested color="disabled" />
+  };
 
   return (
     <Box pb={2}>
@@ -251,7 +247,7 @@ export const ValidationChecks = (props: {
         {validationChecks.map((check, i) => (
           <ListItem key={i} disablePadding>
             <ListItemIcon sx={{ minWidth: (theme) => theme.spacing(3) }}>
-              {getIcon(check.status)}
+              {Icon[check.status]}
             </ListItemIcon>
             <ListItemText
               primary={<Typography variant="body2" color={check.status === "Not applicable" ? "GrayText" : "inherit"}>{check.title}</Typography>}
@@ -262,5 +258,5 @@ export const ValidationChecks = (props: {
       </List>
       <Divider />
     </Box>
-  )
+  );
 }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PublishDialog.tsx
@@ -1,5 +1,6 @@
 import Close from "@mui/icons-material/Close";
 import Done from "@mui/icons-material/Done";
+import NotInterested from "@mui/icons-material/NotInterested";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
@@ -13,7 +14,6 @@ import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import React, { useState } from "react";
 import { useAsync } from "react-use";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import Caret from "ui/icons/Caret";
 
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
@@ -113,12 +113,13 @@ interface AlteredNodesSummary {
 
 export const AlteredNodesSummaryContent = (props: {
   alteredNodes: AlteredNode[];
+  lastPublishedTitle: string;
 }) => {
-  const { alteredNodes } = props;
+  const { alteredNodes, lastPublishedTitle } = props;
   const [expandNodes, setExpandNodes] = useState<boolean>(false);
 
   const changeSummary: AlteredNodesSummary = {
-    title: "",
+    title: lastPublishedTitle,
     portals: [],
     updated: 0,
     deleted: 0,
@@ -143,21 +144,24 @@ export const AlteredNodesSummaryContent = (props: {
 
   return (
     <Box pb={2}>
+      <Typography variant="h4" component="h3" pb={2}>
+        {`Changes`}
+      </Typography>
       {changeSummary["title"] && (
-        <Typography variant="body2" pb={2}>
+        <Typography variant="body2">
           {changeSummary["title"]}
         </Typography>
       )}
       {(changeSummary["updated"] > 0 || changeSummary["deleted"] > 0) && (
         <Box pb={2}>
-          <ul>
-            <li key={"updated"}>
+          <List sx={{ listStyleType: "disc", marginLeft: 3 }}>
+            <ListItem key={"updated"} disablePadding sx={{ display: "list-item" }}>
               <Typography variant="body2">{`${changeSummary["updated"]} nodes have been updated or added`}</Typography>
-            </li>
-            <li key={"deleted"}>
+            </ListItem>
+            <ListItem key={"deleted"} disablePadding sx={{ display: "list-item" }}>
               <Typography variant="body2">{`${changeSummary["deleted"]} nodes have been deleted`}</Typography>
-            </li>
-          </ul>
+            </ListItem>
+          </List>
           <Box
             style={{
               display: "flex",
@@ -204,7 +208,7 @@ export const AlteredNodesSummaryContent = (props: {
         <>
           <Box pt={2}>
             <Typography variant="body2">{`This includes recently published changes in the following nested services:`}</Typography>
-            <List sx={{ listStyleType: "disc", marginLeft: 4 }}>
+            <List sx={{ listStyleType: "disc", marginLeft: 3 }}>
               {changeSummary["portals"].map((portal) => (
                 <AlteredNestedFlowListItem {...portal} />
               ))}
@@ -217,25 +221,41 @@ export const AlteredNodesSummaryContent = (props: {
   );
 };
 
+export interface ValidationCheck {
+  title: string;
+  status: "Pass" | "Fail" | "Not applicable";
+  message: string;
+}
+
 export const ValidationChecks = (props: {
-  validationChecks: { title: string; isValid: boolean; message: string; }[]
+  validationChecks: ValidationCheck[]
 }) => {
   const { validationChecks } = props;
 
+  const getIcon = (status: ValidationCheck["status"]) => {
+    if (status === "Pass") {
+      return <Done color="success" />;
+    } else if (status === "Fail") {
+      return <Close color="error" />;
+    } else if (status === "Not applicable") {
+      return <NotInterested color="disabled" />;
+    }
+  }
+
   return (
     <Box pb={2}>
-      <Typography variant="body2" fontWeight={FONT_WEIGHT_SEMI_BOLD}>
+      <Typography variant="h4" component="h3">
         Validation checks
       </Typography>
       <List sx={{ pb: 2 }}>
         {validationChecks.map((check, i) => (
           <ListItem key={i} disablePadding>
-            <ListItemIcon>
-              {check.isValid ? <Done color="success" /> : <Close color="error" />}
+            <ListItemIcon sx={{ minWidth: (theme) => theme.spacing(3) }}>
+              {getIcon(check.status)}
             </ListItemIcon>
             <ListItemText
-              primary={<Typography variant="body2">{check.title}</Typography>}
-              secondary={<Typography variant="body2" fontSize="small">{check.message}</Typography>}
+              primary={<Typography variant="body2" color={check.status === "Not applicable" ? "GrayText" : "inherit"}>{check.title}</Typography>}
+              secondary={<Typography variant="body2" fontSize="small" color={check.status === "Not applicable" ? "GrayText" : "inherit"}>{check.message}</Typography>}
             />
           </ListItem>
         ))}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -7,33 +7,27 @@ import SignalCellularAltIcon from "@mui/icons-material/SignalCellularAlt";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Collapse from "@mui/material/Collapse";
 import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
-import { styled } from "@mui/material/styles";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { styled } from "@mui/material/styles";
 import { AxiosError } from "axios";
 import React, { useState } from "react";
 import { useAsync } from "react-use";
-import Caret from "ui/icons/Caret";
 import Input from "ui/shared/Input";
 
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
 import Questions from "../../../Preview/Questions";
 import { useStore } from "../../lib/store";
 import EditHistory from "./EditHistory";
+import { AlteredNode, AlteredNodesSummaryContent, ValidationChecks } from "./PublishDialog";
 
 type SidebarTabs = "PreviewBrowser" | "History";
 
@@ -151,211 +145,6 @@ const DebugConsole = () => {
   );
 };
 
-interface AlteredNode {
-  id: string;
-  type: TYPES;
-  data?: any;
-}
-
-const AlteredNodeListItem = (props: { node: AlteredNode }) => {
-  const { node } = props;
-  let text, data;
-
-  if (node.id === "_root") {
-    text = "Changed _root service by adding, deleting or re-ordering nodes";
-  } else if (node.id === "0") {
-    text = `The entire _root service will be published for the first time`;
-  } else if (node.id && Object.keys(node).length === 1) {
-    text = `Deleted node ${node.id}`;
-  } else if (node.type && node.data) {
-    text = `Added/edited ${TYPES[node.type]}`;
-    data = JSON.stringify(node.data, null, 2);
-  } else {
-    text = `Added/edited ${TYPES[node.type]}`;
-  }
-
-  return (
-    <li key={node.id}>
-      <Typography variant="body2">{text}</Typography>
-      {data && <pre style={{ fontSize: ".8em" }}>{data}</pre>}
-    </li>
-  );
-};
-
-interface Portal {
-  text: string;
-  flowId: string;
-  publishedFlowId: number;
-  summary: string;
-  publishedBy: number;
-  publishedAt: string;
-}
-
-const AlteredNestedFlowListItem = (props: Portal) => {
-  const { text, flowId, publishedFlowId, summary, publishedAt } = props;
-
-  const [nestedFlowLastPublishedTitle, setNestedFlowLastPublishedTitle] =
-    useState<string>();
-  const lastPublisher = useStore((state) => state.lastPublisher);
-
-  const _nestedFlowLastPublishedRequest = useAsync(async () => {
-    const user = await lastPublisher(flowId);
-    setNestedFlowLastPublishedTitle(formatLastPublishMessage(publishedAt, user));
-  });
-
-  return (
-    <ListItem
-      key={publishedFlowId}
-      disablePadding
-      sx={{ display: "list-item" }}
-    >
-      <ListItemText
-        primary={
-          useStore.getState().canUserEditTeam(text.split("/")[0]) ? (
-            <Link href={`../${text}`} target="_blank">
-              <Typography variant="body2">{text}</Typography>
-            </Link>
-          ) : (
-            <Typography variant="body2">{text}</Typography>
-          )
-        }
-        secondary={
-          <>
-            <Typography variant="body2" fontSize="small">
-              {nestedFlowLastPublishedTitle}
-            </Typography>
-            {summary && (
-              <Typography variant="body2" fontSize="small">
-                {summary}
-              </Typography>
-            )}
-          </>
-        }
-      />
-    </ListItem>
-  );
-};
-
-interface AlteredNodesSummary {
-  title: string;
-  portals: Portal[];
-  updated: number;
-  deleted: number;
-}
-
-const AlteredNodesSummaryContent = (props: {
-  alteredNodes: AlteredNode[];
-  url: string;
-}) => {
-  const { alteredNodes, url } = props;
-  const [expandNodes, setExpandNodes] = useState<boolean>(false);
-
-  const changeSummary: AlteredNodesSummary = {
-    title: "",
-    portals: [],
-    updated: 0,
-    deleted: 0,
-  };
-
-  alteredNodes.map((node) => {
-    if (node.id === "0") {
-      changeSummary["title"] =
-        "You are publishing the main service for the first time.";
-    } else if (node.id && Object.keys(node).length === 1) {
-      changeSummary["deleted"] += 1;
-    } else if (node.type === TYPES.InternalPortal) {
-      if (node.data?.text?.includes("/")) {
-        changeSummary["portals"].push({ ...node.data, flowId: node.id });
-      }
-    } else if (node.type) {
-      changeSummary["updated"] += 1;
-    }
-
-    return changeSummary;
-  });
-
-  return (
-    <Box pb={2}>
-      {changeSummary["title"] && (
-        <Typography variant="body2" pb={2}>
-          {changeSummary["title"]}
-        </Typography>
-      )}
-      {(changeSummary["updated"] > 0 || changeSummary["deleted"] > 0) && (
-        <Box pb={2}>
-          <ul>
-            <li key={"updated"}>
-              <Typography variant="body2">{`${changeSummary["updated"]} nodes have been updated or added`}</Typography>
-            </li>
-            <li key={"deleted"}>
-              <Typography variant="body2">{`${changeSummary["deleted"]} nodes have been deleted`}</Typography>
-            </li>
-          </ul>
-          <Box
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              marginBottom: 2,
-            }}
-          >
-            <Box
-              style={{
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-              }}
-            >
-              <Typography variant="body2">{`See detailed changelog `}</Typography>
-              <Button
-                onClick={() => setExpandNodes((expandNodes) => !expandNodes)}
-                size="small"
-                disableRipple
-              >
-                <Caret
-                  expanded={expandNodes}
-                  color="primary"
-                  titleAccess={
-                    expandNodes ? "Less information" : "More information"
-                  }
-                />
-              </Button>
-            </Box>
-            <Collapse in={expandNodes}>
-              <Box pb={1}>
-                <ul>
-                  {alteredNodes.map((node) => (
-                    <AlteredNodeListItem node={node} />
-                  ))}
-                </ul>
-              </Box>
-            </Collapse>
-          </Box>
-        </Box>
-      )}
-      <Divider />
-      {changeSummary["portals"].length > 0 && (
-        <Box pt={2}>
-          <Typography variant="body2">{`This includes recently published changes in the following nested services:`}</Typography>
-          <List sx={{ listStyleType: "disc", marginLeft: 4 }}>
-            {changeSummary["portals"].map((portal) => (
-              <AlteredNestedFlowListItem {...portal} />
-            ))}
-          </List>
-        </Box>
-      )}
-      <Divider />
-      <Box pt={2}>
-        <Typography variant="body2">
-          {`Preview these content changes in-service before publishing `}
-          <Link href={url.replace("/published", "/preview")} target="_blank">
-            {`here (opens in a new tab).`}
-          </Link>
-        </Typography>
-      </Box>
-    </Box>
-  );
-};
-
 const Sidebar: React.FC<{
   url: string;
 }> = React.memo((props) => {
@@ -385,7 +174,7 @@ const Sidebar: React.FC<{
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
     "This flow is not published yet",
   );
-  const [validationMessage, setValidationMessage] = useState<string>();
+  const [validationChecks, setValidationChecks] = useState<{ title: string; isValid: boolean; message: string; }[]>([]);
   const [alteredNodes, setAlteredNodes] = useState<AlteredNode[]>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
@@ -535,7 +324,7 @@ const Sidebar: React.FC<{
                         ? `Found changes to ${alteredFlow.data.alteredNodes.length} node(s)`
                         : alteredFlow?.data.message,
                     );
-                    setValidationMessage(alteredFlow?.data.description);
+                    setValidationChecks(alteredFlow?.data?.validationChecks);
                     setDialogOpen(true);
                   } catch (error) {
                     setLastPublishedTitle(
@@ -569,8 +358,16 @@ const Sidebar: React.FC<{
                   <>
                     <AlteredNodesSummaryContent
                       alteredNodes={alteredNodes}
-                      url={props.url}
                     />
+                    <ValidationChecks validationChecks={validationChecks} />
+                    <Box pb={2}>
+                      <Typography variant="body2">
+                        {`Preview these content changes in-service before publishing `}
+                        <Link href={props.url.replace("/published", "/preview")} target="_blank">
+                          {`here (opens in a new tab).`}
+                        </Link>
+                      </Typography>
+                    </Box>
                     <Input
                       bordered
                       type="text"
@@ -580,8 +377,6 @@ const Sidebar: React.FC<{
                       onChange={(e) => setSummary(e.target.value)}
                     />
                   </>
-                ) : validationMessage ? (
-                  validationMessage
                 ) : (
                   lastPublishedTitle
                 )}
@@ -611,7 +406,7 @@ const Sidebar: React.FC<{
                       console.log(error);
                     }
                   }}
-                  disabled={!alteredNodes || alteredNodes.length === 0}
+                  disabled={!alteredNodes || alteredNodes.length === 0 || validationChecks.filter((v) => !v.isValid).length > 0}
                 >
                   PUBLISH
                 </Button>

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -20,4 +20,4 @@ export const formatLastEditMessage = (
 };
 
 export const formatLastPublishMessage = (date: string, user: string): string =>
-  `Last published ${formatLastEditDate(date)} ago by ${user}`;
+  `Last published ${formatLastEditDate(date)} by ${user}`;


### PR DESCRIPTION
As a first step towards the attached ticket for adding _more_ validation checks on Publish, I'm refactoring a bit how our existing validation checks are organised and displayed.

**Changes:**
- [API] The `/flows/:flowId/diff` endpoint will now always return a list of `validationChecks` when `alteredNodes` is not null (meaning anytime there are changes queued to publish) independent of the status of each validation check
  - Previously, the whole endpoint would return an error for the first failed validation check it found
- [Editor] The "Check for changes to publish" dialog now displays each validation check. If any check has "failed", the "Publish" button will be disabled.
  - Currently, the same validation checks are run across _all flows_, so some checks may appear as "Not applicable" depending on the types of components found in the flow
  - I'm going for a sort of "continuous integration" feel here (green tick dopamine?) - hopefully adding re-assurance to the publishing process
  
Here's how the dialog will display for various validation states (the whole dialog has also been bumped from size "sm" to "md"): 
![Screenshot from 2024-06-14 12-51-13](https://github.com/theopensystemslab/planx-new/assets/5132349/1df40b51-1efc-4448-90f6-9a9c4d00a50b)

![Screenshot from 2024-06-14 12-52-04](https://github.com/theopensystemslab/planx-new/assets/5132349/d87d222d-b919-4eb3-9478-f15fffbb203f)

![Screenshot from 2024-06-14 13-01-10](https://github.com/theopensystemslab/planx-new/assets/5132349/cfd6f3d2-6514-476e-9b5e-221eaf4e34a4)

**Next steps:** 
- Tidy up dialog styling, it's pretty info dense & spacing/margins are definitely a bit misaligned right now
- [Followup PR] Determine which additional validation steps we want to add - see attached ticket for ideas
  - Should all 'failed' validation checks always block ability to Publish or just be a warning? We may want to consider extending the type with another field like `blocking: boolean` that could be used in combination with `status` to determine if Publish button is enabled/disabled? 