### PR TITLE
chore: Make `flow.name` column required

### DIFF
--- a/e2e/tests/api-driven/src/permissions/queries/flows.ts
+++ b/e2e/tests/api-driven/src/permissions/queries/flows.ts
@@ -3,7 +3,11 @@ import { gql } from "graphql-tag";
 export const INSERT_FLOW_QUERY = gql`
   mutation InsertFlowE2E($team1Id: Int) {
     result: insert_flows(
-      objects: { slug: "e2e-test-flow", team_id: $team1Id }
+      objects: {
+        slug: "e2e-test-flow"
+        team_id: $team1Id
+        name: "E2E Test Flow"
+      }
     ) {
       returning {
         id

--- a/hasura.planx.uk/migrations/1718705200477_alter_table_public_flows_alter_column_name/down.sql
+++ b/hasura.planx.uk/migrations/1718705200477_alter_table_public_flows_alter_column_name/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."flows" alter column "name" drop not null;

--- a/hasura.planx.uk/migrations/1718705200477_alter_table_public_flows_alter_column_name/up.sql
+++ b/hasura.planx.uk/migrations/1718705200477_alter_table_public_flows_alter_column_name/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."flows" alter column "name" set not null;

--- a/hasura.planx.uk/tests/portals.test.js
+++ b/hasura.planx.uk/tests/portals.test.js
@@ -9,9 +9,9 @@ describe("portals", () => {
     let res = await gqlAdmin(`
       mutation {
         insert_flows(objects: [
-          {slug: "TEST_root"},
-          {slug: "TEST_portal"},
-          {slug: "TEST_subportal"}
+          {slug: "TEST_root", name: "Test root"},
+          {slug: "TEST_portal", name: "Test portal"},
+          {slug: "TEST_subportal", name: "Test subportal"}
         ]) {
           returning {
             id

--- a/hasura.planx.uk/tests/sessions.test.js
+++ b/hasura.planx.uk/tests/sessions.test.js
@@ -80,13 +80,15 @@ describe("sessions", () => {
         `mutation InsertFlow(
         $data: jsonb!,
         $slug: String!,
+        $name: String!,
         $teamId: Int!,
       ) {
         insert_flows_one(
           object: {
             data: $data
             slug: $slug
-            team_id: $teamId,
+            name: $name
+            team_id: $teamId
             version: 1
           }
         ) {
@@ -97,6 +99,7 @@ describe("sessions", () => {
           data: { x: 1 },
           slug: "flow1",
           teamId: teamId,
+          name: "flow 1",
         }
       );
       flowId = res2.data.insert_flows_one.id;

--- a/sharedb.planx.uk/sharedb-postgresql.js
+++ b/sharedb.planx.uk/sharedb-postgresql.js
@@ -81,8 +81,8 @@ PostgresDB.prototype.commit = function (
 
         client.query("BEGIN", (err) => {
           client.query(
-            "INSERT INTO flows (id, slug) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-            [id, id],
+            "INSERT INTO flows (id, slug, name) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+            [id, id, id],
             (err, _res) => {
               if (err) {
                 rollback(client, done);
@@ -156,7 +156,7 @@ PostgresDB.prototype.commit = function (
 };
 
 // Get the named document from the database. The callback is called with (err,
-// snapshot). A snapshot with a version of zero is returned if the docuemnt
+// snapshot). A snapshot with a version of zero is returned if the document
 // has never been created in the database.
 PostgresDB.prototype.getSnapshot = function (
   _collection,


### PR DESCRIPTION
## What does this PR do?
- Following on from @RODO94's work to add the `flow.name` column, this has now been updated to be a required field in the DB, which matches the associated types and expected behaviour
- Updates a number of tests and functions which required a value for `flow.name`

## Next steps (?)
The reason there's so much "whack-a-mole" with some of these tests is that `flow.name` and `flow.team_id` are now really the compound primary key / unique constraints, not `flow.slug` and `flow.team_id`. A more robust solution may be to make this change in reality in the database, and to correspondingly update mocks to just have a `flow.name` value.

Regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/9565438594 ✅ 