### PR TITLE
fix: Trim URLs to avoid sanitation errors

### DIFF
--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -281,11 +281,12 @@ const initialUrlValue = "https://";
 
 // Makes sure that if the user pastes a full URL into the input, the pre-populated `https://` is removed
 // e.g. https://https://something.com -> https://something.com
+// Also trim whitespace from links which flag sanitation errors
 const trimUrlValue = (url: string) => {
   if (url.startsWith(`${initialUrlValue}${initialUrlValue}`)) {
     return url.slice(initialUrlValue.length);
   }
-  return url;
+  return url.trim();
 };
 
 const getContentHierarchyError = (doc: JSONContent): string | null => {


### PR DESCRIPTION
## What's the problem?
 - URLs with whitespace at the end trigger sanitation errors. This means that these flows cannot be copied or moved to other teams.
 - Please see https://opensystemslab.slack.com/archives/C5Q59R3HB/p1718717945966979 (OSL Slack) for context
 
 ## What's the solution
 - Calling `.trim()` on the draft URL means this cannot happen, even on copy/paste of a link