### PR TITLE
chore: Bump Hasura Fargate task CPU and memory (production)

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -21,6 +21,8 @@ config:
     secure: AAABADo05EPv/HWj7Rkf19nBeTcPJd4pEcRi2/uhyB3agraFODpLvNMx2bXfISf5pZ4HA41GYCE4f7OLcJN6hIV6ZMWUlEriPzvkoUAixbLlz1LIERiyk73R8E4F2bV65/9aFqi4l7caLS5c8iDJrE+JAvu2i7oS
   application:hasura-admin-secret:
     secure: AAABAHfDtVpAD8w32yINWTjgvuRQixWXYFf3/rEcyh59/pRSz+J4ZYCXNq5jqBiIXM2emB+7zOY=
+  application:hasura-cpu: "512"
+  application:hasura-memory: "2048"
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
   application:jwt-secret:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -22,6 +22,8 @@ config:
     secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
   application:hasura-admin-secret:
     secure: AAABAHsoh7ZNkr6ep3xXsUZpp/JIjshBX+tJ0KOFgGnJ4wxR0oIcB6VewVDuwSyFJRVix72YahM=
+  application:hasura-cpu: "256"
+  application:hasura-memory: "1024"
   application:hasura-planx-api-key:
     secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
   application:jwt-secret:

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -68,8 +68,8 @@ export const createHasuraService = async ({
         },
         hasura: {
           image: repo.buildAndPushImage("../../hasura.planx.uk"),
-          cpu: 2048,
-          memory: 2048 /*MB*/,
+          cpu: config.requireNumber("hasura-cpu"),
+          memory: config.requireNumber("hasura-memory"),
           environment: [
             { name: "HASURA_GRAPHQL_ENABLE_CONSOLE", value: "true" },
             {

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -68,7 +68,8 @@ export const createHasuraService = async ({
         },
         hasura: {
           image: repo.buildAndPushImage("../../hasura.planx.uk"),
-          memory: 1024 /*MB*/,
+          cpu: 2048,
+          memory: 2048 /*MB*/,
           environment: [
             { name: "HASURA_GRAPHQL_ENABLE_CONSOLE", value: "true" },
             {
@@ -106,7 +107,7 @@ export const createHasuraService = async ({
             },
           ],
         },
-      } 
+      },
     },
     desiredCount: 1,
   });


### PR DESCRIPTION
## What's the problem?
- There's been an increase in downtime for Hasura recently
- A quick look at the service health on AWS suggests this may be due to hitting max CPU, which may lead to timeouts (see screenshots for overview of past two weeks below)

## What's the solution?
- Double CPU and memory, and monitor going forward
- CPU and memory are inline with task sizes outlined here - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/3bf85f36-166b-4023-8c31-6d68b43f3c78)
