### PR TITLE
fix: Maintain redirect on login

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -48,7 +48,7 @@ const hasJWT = (): boolean | void => {
   // Remove JWT from URL, and re-run this function
   setCookie("jwt", jwtSearchParams);
   setCookie("auth", { loggedIn: true });
-  window.location.href = "/";
+  window.history.go(-1);
 };
 
 const Layout: React.FC<{


### PR DESCRIPTION
Alternate approach to https://github.com/theopensystemslab/planx-new/pull/3275 where I'm running afoul of https://github.com/theopensystemslab/planx-new/security/code-scanning/17 

Here's we're simply navigating back after a login to pickup the previous `redirectTo` params 👍 