### PR TITLE
feat: Updated editor teams and team selection pages

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow/helpers.ts
+++ b/e2e/tests/ui-driven/src/create-flow/helpers.ts
@@ -29,6 +29,6 @@ export async function getTeamPage({
   teamName: string;
 }): Promise<Page> {
   const page = await getAdminPage({ browser, userId });
-  await page.locator("h2", { hasText: teamName }).click();
+  await page.locator("h3", { hasText: teamName }).click();
   return page;
 }

--- a/e2e/tests/ui-driven/src/login.spec.ts
+++ b/e2e/tests/ui-driven/src/login.spec.ts
@@ -67,7 +67,7 @@ test.describe("Login", () => {
       route.continue();
     });
     await expect(
-      page.locator("h1").filter({ hasText: "My services" }),
+      page.locator("h1").filter({ hasText: "Services" }),
     ).toBeVisible();
     await expect(page.getByText(toastText)).toBeHidden();
   });

--- a/e2e/tests/ui-driven/src/login.spec.ts
+++ b/e2e/tests/ui-driven/src/login.spec.ts
@@ -37,7 +37,7 @@ test.describe("Login", () => {
       return response.url().includes("/graphql");
     });
 
-    const team = page.locator("h2", { hasText: context.team.name });
+    const team = page.locator("h3", { hasText: context.team.name });
     await expect(team).toBeVisible();
   });
 
@@ -50,7 +50,7 @@ test.describe("Login", () => {
     });
     await page.goto("/");
 
-    const teamLink = page.locator("h2").filter({ hasText: context.team.name });
+    const teamLink = page.locator("h3").filter({ hasText: context.team.name });
     await teamLink.waitFor(); // wait for this to be visible
 
     // drop graphql requests

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -16,6 +16,7 @@ import Typography from "@mui/material/Typography";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { borderedFocusStyle } from "theme";
 import Dashboard from "ui/editor/Dashboard";
 import { slugify } from "utils";
 
@@ -59,6 +60,9 @@ const DashboardLink = styled(Link)(({ theme }) => ({
   padding: theme.spacing(2),
   margin: 0,
   width: "100%",
+  "&:focus-within": {
+    ...borderedFocusStyle,
+  },
 }));
 
 const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({
@@ -70,21 +74,6 @@ const LinkSubText = styled(Box)(({ theme }) => ({
   color: theme.palette.grey[400],
   fontWeight: "normal",
   paddingTop: "0.5em",
-}));
-
-const HiddenText = styled(Box)(() => ({
-  color: "transparent",
-  position: "absolute",
-  height: "100%",
-  width: "100%",
-  top: 0,
-  left: 0,
-  display: "flex",
-  "&::selection": {
-    background: "hotpink",
-    color: "black",
-    padding: "1em",
-  },
 }));
 
 const Confirm = ({
@@ -205,7 +194,6 @@ const FlowItem: React.FC<FlowItemProps> = ({
           <Typography variant="h4" component="h2">
             {flow.name}
           </Typography>
-          <HiddenText aria-hidden="true">{flow.slug}</HiddenText>
           <LinkSubText>
             {formatLastEditMessage(
               flow.operations[0].createdAt,

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -1,10 +1,11 @@
 import { gql } from "@apollo/client";
-import Add from "@mui/icons-material/Add";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import Edit from "@mui/icons-material/Edit";
 import Visibility from "@mui/icons-material/Visibility";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonBase from "@mui/material/ButtonBase";
+import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -12,10 +13,10 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import orderBy from "lodash/orderBy";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import Dashboard from "ui/editor/Dashboard";
 import { slugify } from "utils";
 
 import { client } from "../lib/graphql";
@@ -24,21 +25,11 @@ import { useStore } from "./FlowEditor/lib/store";
 import { formatLastEditMessage } from "./FlowEditor/utils";
 
 const Root = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+  backgroundColor: theme.palette.background.default,
   width: "100%",
-  flex: 1,
-  justifyContent: "flex-start",
-  alignItems: "center",
-}));
-
-const Dashboard = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
-  width: "100%",
-  maxWidth: 600,
-  margin: "auto",
-  padding: theme.spacing(8, 0, 4, 0),
+  display: "flex",
+  alignItems: "flex-start",
+  flexGrow: 1,
 }));
 
 const DashboardList = styled("ul")(({ theme }) => ({
@@ -50,7 +41,13 @@ const DashboardList = styled("ul")(({ theme }) => ({
 const DashboardListItem = styled("li")(({ theme }) => ({
   listStyle: "none",
   position: "relative",
-  padding: theme.spacing(2.5, 2),
+  color: theme.palette.common.white,
+  margin: theme.spacing(1, 0),
+  background: theme.palette.text.primary,
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "stretch",
+  borderRadius: "2px",
 }));
 
 const DashboardLink = styled(Link)(({ theme }) => ({
@@ -59,20 +56,34 @@ const DashboardLink = styled(Link)(({ theme }) => ({
   textDecoration: "none",
   color: "currentColor",
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  marginBottom: theme.spacing(1.5),
-  marginTop: 0,
+  padding: theme.spacing(2),
+  margin: 0,
+  width: "100%",
 }));
 
 const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({
-  position: "absolute",
-  top: theme.spacing(2),
-  right: theme.spacing(1),
+  display: "flex",
+  borderLeft: `1px solid ${theme.palette.border.main}`,
 }));
 
-const LinkSubText = styled(Box)(() => ({
-  color: "#aaa",
-  "& a": {
-    color: "#fff",
+const LinkSubText = styled(Box)(({ theme }) => ({
+  color: theme.palette.grey[400],
+  fontWeight: "normal",
+  paddingTop: "0.5em",
+}));
+
+const HiddenText = styled(Box)(() => ({
+  color: "transparent",
+  position: "absolute",
+  height: "100%",
+  width: "100%",
+  top: 0,
+  left: 0,
+  display: "flex",
+  "&::selection": {
+    background: "hotpink",
+    color: "black",
+    padding: "1em",
   },
 }));
 
@@ -113,13 +124,12 @@ const Confirm = ({
 );
 
 const AddButtonRoot = styled(ButtonBase)(({ theme }) => ({
-  width: "100%",
-  padding: theme.spacing(4),
   fontSize: 20,
-  backgroundColor: "rgba(255,255,255,0.25)",
-  display: "block",
+  display: "flex",
+  alignItems: "center",
   textAlign: "left",
-  marginTop: theme.spacing(2),
+  color: theme.palette.primary.main,
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
 }));
 
 function AddButton({
@@ -131,7 +141,7 @@ function AddButton({
 }): FCReturn {
   return (
     <AddButtonRoot onClick={onClick}>
-      <Add sx={{ mr: 3, verticalAlign: "middle" }} /> {children}
+      <AddCircleOutlineIcon sx={{ mr: 1 }} /> {children}
     </AddButtonRoot>
   );
 }
@@ -191,17 +201,18 @@ const FlowItem: React.FC<FlowItemProps> = ({
         />
       )}
       <DashboardListItem>
-        <Box pr={4}>
-          <DashboardLink href={`./${flow.slug}`} prefetch={false}>
+        <DashboardLink href={`./${flow.slug}`} prefetch={false}>
+          <Typography variant="h4" component="h2">
             {flow.name}
-          </DashboardLink>
+          </Typography>
+          <HiddenText aria-hidden="true">{flow.slug}</HiddenText>
           <LinkSubText>
             {formatLastEditMessage(
               flow.operations[0].createdAt,
               flow.operations[0]?.actor,
             )}
           </LinkSubText>
-        </Box>
+        </DashboardLink>
         {useStore.getState().canUserEditTeam(teamSlug) && (
           <StyledSimpleMenu
             items={[
@@ -305,57 +316,67 @@ const Team: React.FC = () => {
   return (
     <Root>
       <Dashboard>
-        <Box
-          pl={2}
-          pb={2}
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
-          <Typography variant="h2" component="h1">
-            My services
-          </Typography>
-          {useStore.getState().canUserEditTeam(slug) ? (
-            <Edit />
-          ) : (
-            <Visibility />
-          )}
-        </Box>
-        {useStore.getState().canUserEditTeam(slug) && (
-          <AddButton
-            onClick={() => {
-              const newFlowName = prompt("Service name");
-              if (newFlowName) {
-                const newFlowSlug = slugify(newFlowName);
-                useStore
-                  .getState()
-                  .createFlow(teamId, newFlowSlug, newFlowName)
-                  .then((newId: string) => {
-                    navigation.navigate(`/${slug}/${newId}`);
-                  });
-              }
+        <Container maxWidth="formWrap">
+          <Box
+            pb={1}
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
             }}
           >
-            Add a new service
-          </AddButton>
-        )}
-        {flows && (
-          <DashboardList>
-            {flows.map((flow: any) => (
-              <FlowItem
-                flow={flow}
-                key={flow.slug}
-                teamId={teamId}
-                teamSlug={slug}
-                refreshFlows={() => {
-                  fetchFlows();
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+              }}
+            >
+              <Typography variant="h2" component="h1" pr={1}>
+                Services
+              </Typography>
+              {useStore.getState().canUserEditTeam(slug) ? (
+                <Edit />
+              ) : (
+                <Visibility />
+              )}
+            </Box>
+            {useStore.getState().canUserEditTeam(slug) && (
+              <AddButton
+                onClick={() => {
+                  const newFlowName = prompt("Service name");
+                  if (newFlowName) {
+                    const newFlowSlug = slugify(newFlowName);
+                    useStore
+                      .getState()
+                      .createFlow(teamId, newFlowSlug, newFlowName)
+                      .then((newId: string) => {
+                        navigation.navigate(`/${slug}/${newId}`);
+                      });
+                  }
                 }}
-              />
-            ))}
-          </DashboardList>
-        )}
+              >
+                Add a new service
+              </AddButton>
+            )}
+          </Box>
+          {flows && (
+            <DashboardList>
+              {flows.map((flow: any) => (
+                <FlowItem
+                  flow={flow}
+                  key={flow.slug}
+                  teamId={teamId}
+                  teamSlug={slug}
+                  refreshFlows={() => {
+                    fetchFlows();
+                  }}
+                />
+              ))}
+            </DashboardList>
+          )}
+        </Container>
       </Dashboard>
     </Root>
   );

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { Link } from "react-navi";
+import { borderedFocusStyle } from "theme";
 import Dashboard from "ui/editor/Dashboard";
 
 import { useStore } from "./FlowEditor/lib/store";
@@ -30,6 +31,9 @@ export const Root = styled(Box)(({ theme }) => ({
 
 const StyledLink = styled(Link)(() => ({
   textDecoration: "none",
+  "&:focus-within > div": {
+    ...borderedFocusStyle,
+  },
 }));
 
 const TeamCard = styled(Card)(({ theme }) => ({
@@ -53,20 +57,23 @@ const TeamColourBand = styled(Box)(({ theme }) => ({
 const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
   const canUserEditTeam = useStore.getState().canUserEditTeam;
 
-  const editableTeams = teams.filter((team) => canUserEditTeam(team.slug));
-  const viewOnlyTeams = teams.filter((team) => !canUserEditTeam(team.slug));
+  const editableTeams: Team[] = [];
+  const viewOnlyTeams: Team[] = [];
+
+  teams.forEach((team) =>
+    canUserEditTeam(team.slug)
+      ? editableTeams.push(team)
+      : viewOnlyTeams.push(team),
+  );
 
   const renderTeams = (teamsToRender: Array<Team>) =>
-    teamsToRender.map(({ name, slug }) => {
-      const theme = teamTheme.find((t) => t.slug === slug);
-      const primaryColour = theme ? theme.primaryColour : "#000";
-
+    teamsToRender.map((team) => {
       return (
-        <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
+        <StyledLink href={`/${team.slug}`} key={team.slug} prefetch={false}>
           <TeamCard>
-            <TeamColourBand bgcolor={primaryColour} />
+            <TeamColourBand bgcolor={team.theme.primaryColour} />
             <Typography p={2} variant="h3">
-              {name}
+              {team.name}
             </Typography>
           </TeamCard>
         </StyledLink>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -65,7 +65,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
         <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
           <TeamCard>
             <TeamColourBand bgcolor={primaryColour} />
-            <Typography p={2} variant="h3" component="h2">
+            <Typography p={2} variant="h3">
               {name}
             </Typography>
           </TeamCard>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -1,71 +1,102 @@
-import Edit from "@mui/icons-material/Edit";
-import Visibility from "@mui/icons-material/Visibility";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
+import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { Link } from "react-navi";
+import Dashboard from "ui/editor/Dashboard";
 
 import { useStore } from "./FlowEditor/lib/store";
 
-interface Props {
-  teams: Array<Team>;
+interface TeamTheme {
+  slug: string;
+  primaryColour: string;
 }
 
-const Root = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
-  width: "100%",
-  flex: 1,
-  justifyContent: "flex-start",
-  alignItems: "center",
-}));
+interface Props {
+  teams: Array<Team>;
+  teamTheme: Array<TeamTheme>;
+}
 
-const Dashboard = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.dark,
-  color: "#fff",
+export const Root = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
   width: "100%",
-  maxWidth: 600,
-  margin: "auto",
-  padding: theme.spacing(8, 0, 4, 0),
+  display: "flex",
+  alignItems: "flex-start",
+  flexGrow: 1,
 }));
 
 const StyledLink = styled(Link)(() => ({
   textDecoration: "none",
 }));
 
-const Teams: React.FC<Props> = ({ teams }) => {
+const TeamCard = styled(Card)(({ theme }) => ({
+  display: "flex",
+  justifyContent: "flex-start",
+  alignItems: "center",
+  marginBottom: theme.spacing(2),
+  color: theme.palette.text.primary,
+  outline: `1px solid ${theme.palette.border.light}`,
+  outlineOffset: "-1px",
+  borderRadius: "1px",
+}));
+
+const TeamColourBand = styled(Box)(({ theme }) => ({
+  display: "flex",
+  alignSelf: "stretch",
+  width: theme.spacing(1.5),
+  zIndex: 1,
+}));
+
+const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
+  const canUserEditTeam = useStore.getState().canUserEditTeam;
+
+  const editableTeams = teams.filter((team) => canUserEditTeam(team.slug));
+  const viewOnlyTeams = teams.filter((team) => !canUserEditTeam(team.slug));
+
+  const renderTeams = (teamsToRender: Array<Team>) =>
+    teamsToRender.map(({ name, slug }) => {
+      const theme = teamTheme.find((t) => t.slug === slug);
+      const primaryColour = theme ? theme.primaryColour : "#000";
+
+      return (
+        <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
+          <TeamCard>
+            <TeamColourBand bgcolor={primaryColour} />
+            <Typography p={2} variant="h3" component="h2">
+              {name}
+            </Typography>
+          </TeamCard>
+        </StyledLink>
+      );
+    });
   return (
     <Root>
       <Dashboard>
-        <Box pl={2} pb={2}>
-          <Typography variant="h2" component="h1" gutterBottom>
+        <Container maxWidth="formWrap">
+          <Typography variant="h2" component="h1" mb={4}>
             Select a team
           </Typography>
-        </Box>
-        {teams.map(({ name, slug }) => (
-          <StyledLink href={`/${slug}`} key={slug} prefetch={false}>
-            <Box
-              mb={2.5}
-              px={2.5}
-              py={3}
-              mx={2}
-              component={Card}
-              style={{ display: "flex", justifyContent: "space-between" }}
-            >
-              <Typography variant="h4" component="h2">
-                {name}
+          {editableTeams.length > 0 && (
+            <>
+              <Typography variant="h3" component="h2" mb={2}>
+                My teams
               </Typography>
-              {useStore.getState().canUserEditTeam(slug) ? (
-                <Edit />
-              ) : (
-                <Visibility />
-              )}
-            </Box>
-          </StyledLink>
-        ))}
+              {renderTeams(editableTeams)}
+            </>
+          )}
+
+          {viewOnlyTeams.length > 0 && (
+            <>
+              <Typography variant="h3" component="h2" mt={4} mb={2}>
+                Other teams (view only)
+              </Typography>
+              {renderTeams(viewOnlyTeams)}
+            </>
+          )}
+        </Container>
       </Dashboard>
     </Root>
   );

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -30,11 +30,10 @@ const editorRoutes = compose(
               id
               name
               slug
-            }
-            teamThemes: teams_summary {
-              slug
-              primaryColour: primary_colour
-              logo
+              theme {
+                primaryColour: primary_colour
+                logo
+              }
             }
           }
         `,

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -31,6 +31,11 @@ const editorRoutes = compose(
               name
               slug
             }
+            teamThemes: teams_summary {
+              slug
+              primaryColour: primary_colour
+              logo
+            }
           }
         `,
       });
@@ -39,7 +44,7 @@ const editorRoutes = compose(
 
       return {
         title: makeTitle("Teams"),
-        view: <Teams teams={data.teams} />,
+        view: <Teams teams={data.teams} teamTheme={data.teamThemes} />,
       };
     }),
 

--- a/editor.planx.uk/src/ui/editor/Dashboard.tsx
+++ b/editor.planx.uk/src/ui/editor/Dashboard.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import { containerClasses } from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import { HEADER_HEIGHT } from "components/Header";
 import React, { PropsWithChildren } from "react";
@@ -10,7 +11,7 @@ const Root = styled(Box)(({ theme }) => ({
   flexDirection: "row",
   width: "100%",
   minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
-  "& > .MuiContainer-root": {
+  [`& > .${containerClasses.root}`]: {
     paddingTop: theme.spacing(6),
     paddingBottom: theme.spacing(6),
   },

--- a/editor.planx.uk/src/ui/editor/Dashboard.tsx
+++ b/editor.planx.uk/src/ui/editor/Dashboard.tsx
@@ -1,0 +1,21 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import { HEADER_HEIGHT } from "components/Header";
+import React, { PropsWithChildren } from "react";
+
+const Root = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+  color: theme.palette.text.primary,
+  display: "flex",
+  flexDirection: "row",
+  width: "100%",
+  minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
+  "& > .MuiContainer-root": {
+    paddingTop: theme.spacing(6),
+    paddingBottom: theme.spacing(6),
+  },
+}));
+
+export default function Dashboard(props: PropsWithChildren) {
+  return <Root>{props.children}</Root>;
+}


### PR DESCRIPTION
## What does this PR do?

Introduces style and minor structural changes across Teams and Team pages.

Summary of changes:

- Background changed to light
- Council branding added to teams list
- Teams list separated into separate lists based on permissions, teams which a user has editing permissions to will appear first
- Services styled similar to editor portals

In addition to this a `<Dashboard>` component has been created to standardise layout and spacing across editor pages (applied to only these two pages for now). This also contains layout styles that make it ready to drop in the editor in-page navigation elements.