### PR TITLE
fix: Image upload stretch and design settings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
@@ -22,6 +22,8 @@ export const DesignPreview = styled(Box)(({ theme }) => ({
   border: `2px solid ${theme.palette.border.input}`,
   padding: theme.spacing(2),
   boxShadow: "4px 4px 0px rgba(150, 150, 150, 0.5)",
+  display: "flex",
+  justifyContent: "center",
 }));
 
 export const EXAMPLE_COLOUR = "#007078";

--- a/editor.planx.uk/src/ui/editor/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/editor/ImgInput.tsx
@@ -27,6 +27,14 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
   marginLeft: theme.spacing(0.5),
 }));
 
+const ImageWrapper = styled(Box)(() => ({
+  width: 50,
+  height: 50,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+}));
+
 /** Uploads an image and returns corresponding URL */
 export default function ImgInput({
   img,
@@ -86,13 +94,15 @@ export default function ImgInput({
           Remove
         </MenuItem>
       </Menu>
-      <img
-        width={50}
-        height={50}
-        src={img}
-        alt="embedded img"
-        style={{ display: "block", backgroundColor: backgroundColor }}
-      />
+      <ImageWrapper sx={{ backgroundColor: backgroundColor }}>
+        <img
+          width={44}
+          height={44}
+          src={img}
+          alt="embedded img"
+          style={{ display: "block", height: "auto" }}
+        />
+      </ImageWrapper>
     </ImageUploadContainer>
   ) : (
     <Tooltip title="Drop file here">


### PR DESCRIPTION
## What does this PR do?

Quick one, addresses small issues with image upload and design settings layout.

### Image upload

Previously the uploaded image was being stretched which makes it hard to decipher the image if it is not square:

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/60538b5c-d3a3-4e69-9ad4-ee94d89b249d)

### Design settings

Having the preview left-aligned means you can't preview what is being applied when the colour picker is open, centering helps with this:

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/20164316-d12f-4d4f-8254-5ede9cc82945)
