### PR TITLE
chore: Remove ``has_planning_data`` from team_settings table

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -15,9 +15,6 @@ export interface GeneralSettings {
   helpPhone: string;
   helpOpeningHours: string;
   homepage: string;
-  isPlanningDataCollected: boolean;
-  portalName: string;
-  portalUrl: string;
 }
 
 export interface FormProps {
@@ -36,9 +33,6 @@ const GeneralSettings: React.FC = () => {
     helpPhone: "",
     helpOpeningHours: "",
     homepage: "",
-    isPlanningDataCollected: true,
-    portalName: "",
-    portalUrl: "",
   };
 
   useEffect(() => {

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1660,9 +1660,6 @@
     - role: api
       permission:
         columns:
-          - has_planning_data
-          - id
-          - team_id
           - boundary_json
           - boundary_url
           - email_reply_to_id
@@ -1672,15 +1669,14 @@
           - help_opening_hours
           - help_phone
           - homepage
+          - id
           - reference_code
+          - team_id
         filter: {}
       comment: ""
     - role: platformAdmin
       permission:
         columns:
-          - has_planning_data
-          - id
-          - team_id
           - boundary_json
           - boundary_url
           - email_reply_to_id
@@ -1690,7 +1686,9 @@
           - help_opening_hours
           - help_phone
           - homepage
+          - id
           - reference_code
+          - team_id
         filter: {}
       comment: ""
     - role: public
@@ -1700,7 +1698,6 @@
           - boundary_url
           - external_planning_site_name
           - external_planning_site_url
-          - has_planning_data
           - homepage
           - id
           - reference_code
@@ -1710,9 +1707,6 @@
     - role: teamEditor
       permission:
         columns:
-          - has_planning_data
-          - id
-          - team_id
           - boundary_json
           - boundary_url
           - email_reply_to_id
@@ -1722,7 +1716,9 @@
           - help_opening_hours
           - help_phone
           - homepage
+          - id
           - reference_code
+          - team_id
         filter: {}
       comment: ""
   update_permissions:
@@ -1733,7 +1729,6 @@
           - email_reply_to_id
           - external_planning_site_name
           - external_planning_site_url
-          - has_planning_data
           - help_email
           - help_opening_hours
           - help_phone
@@ -1749,7 +1744,6 @@
           - email_reply_to_id
           - external_planning_site_name
           - external_planning_site_url
-          - has_planning_data
           - help_email
           - help_opening_hours
           - help_phone

--- a/hasura.planx.uk/migrations/1719307850258_alter_table_public_team_settings_drop_column_has_planning_data/down.sql
+++ b/hasura.planx.uk/migrations/1719307850258_alter_table_public_team_settings_drop_column_has_planning_data/down.sql
@@ -1,0 +1,4 @@
+alter table "public"."team_settings" add column "has_planning_data" bool;
+comment on column "public"."team_settings"."has_planning_data" is E'Global settings for boundary and contact details';
+alter table "public"."team_settings" alter column "has_planning_data" set default false;
+alter table "public"."team_settings" alter column "has_planning_data" drop not null;

--- a/hasura.planx.uk/migrations/1719307850258_alter_table_public_team_settings_drop_column_has_planning_data/up.sql
+++ b/hasura.planx.uk/migrations/1719307850258_alter_table_public_team_settings_drop_column_has_planning_data/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."team_settings" drop column "has_planning_data" cascade;


### PR DESCRIPTION
## What does this PR do?

Following #3305, it was found that the ``has_planning_data`` column of the "team_settings" table is redundant and should be removed.

This PR creates the necessary migrations and table permission changes to remove the column