### PR TITLE
feat: add scripts for pulling ``team_settings`` data from production

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1862,6 +1862,13 @@
           table:
             name: team_integrations
             schema: public
+    - name: team_settings
+      using:
+        foreign_key_constraint_on:
+          column: team_id
+          table:
+            name: team_settings
+            schema: public
     - name: theme
       using:
         foreign_key_constraint_on:

--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -26,6 +26,7 @@ tables=(
   flow_document_templates 
   team_members 
   team_themes
+  team_settings
   # Optional tables
   # Please comment in if working on a feature and you require example data locally
   # You will need to manually grant select permissions to the github_actions on production, and update main.sql

--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -7,6 +7,7 @@
 \include write/team_members.sql
 \include write/team_integrations.sql
 \include write/team_themes.sql
+\include write/team_settings.sql
 
 -- Optional tables
 -- \include write/feedback.sql

--- a/scripts/seed-database/write/team_settings.sql
+++ b/scripts/seed-database/write/team_settings.sql
@@ -1,0 +1,65 @@
+-- insert teams_settings overwriting conflicts
+CREATE TEMPORARY TABLE sync_team_settings (
+  id integer,
+  team_id integer,
+  reference_code text,
+  homepage text,
+  help_email text,
+  help_phone text,
+  help_opening_hours text,
+  email_reply_to_id text,
+  external_planning_site_url text,
+  external_planning_site_name text,
+  boundary_json jsonb,
+  boundary_url text
+);
+
+\copy sync_team_settings FROM '/tmp/team_settings.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  team_themes (
+    id,
+    team_id,
+    reference_code,
+    homepage,
+    help_email,
+    help_phone,
+    help_opening_hours,
+    email_reply_to_id,
+    external_planning_site_url,
+    external_planning_site_name,
+    boundary_json,
+    boundary_url
+  )
+SELECT
+    id,
+    team_id,
+    reference_code,
+    homepage,
+    help_email,
+    help_phone,
+    help_opening_hours,
+    email_reply_to_id,
+    external_planning_site_url,
+    external_planning_site_name,
+    boundary_json,
+    boundary_url
+FROM
+  sync_team_settings ON CONFLICT (id) DO
+UPDATE
+SET
+    team_id = EXCLUDED.team_id,
+    reference_code = EXCLUDED.reference_code,
+    homepage = EXCLUDED.homepage,
+    help_email = EXCLUDED.help_email,
+    help_phone = EXCLUDED.help_phone,
+    help_opening_hours = EXCLUDED.help_opening_hours,
+    email_reply_to_id = EXCLUDED.email_reply_to_id,
+    external_planning_site_url = EXCLUDED.external_planning_site_url,
+    external_planning_site_name = EXCLUDED.external_planning_site_name,
+    boundary_json = EXCLUDED.boundary_json,
+    boundary_url = EXCLUDED.boundary_url;
+SELECT
+  setval('team_settings_id_seq', max(id))
+FROM
+  team_settings;

--- a/scripts/seed-database/write/team_settings.sql
+++ b/scripts/seed-database/write/team_settings.sql
@@ -10,14 +10,14 @@ CREATE TEMPORARY TABLE sync_team_settings (
   email_reply_to_id text,
   external_planning_site_url text,
   external_planning_site_name text,
-  boundary_json jsonb,
-  boundary_url text
+  boundary_url text,
+  boundary_json jsonb
 );
 
 \copy sync_team_settings FROM '/tmp/team_settings.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
-  team_themes (
+  team_settings (
     id,
     team_id,
     reference_code,
@@ -28,8 +28,8 @@ INSERT INTO
     email_reply_to_id,
     external_planning_site_url,
     external_planning_site_name,
-    boundary_json,
-    boundary_url
+    boundary_url,
+    boundary_json
   )
 SELECT
     id,
@@ -42,8 +42,8 @@ SELECT
     email_reply_to_id,
     external_planning_site_url,
     external_planning_site_name,
-    boundary_json,
-    boundary_url
+    boundary_url,
+    boundary_json
 FROM
   sync_team_settings ON CONFLICT (id) DO
 UPDATE
@@ -57,8 +57,8 @@ SET
     email_reply_to_id = EXCLUDED.email_reply_to_id,
     external_planning_site_url = EXCLUDED.external_planning_site_url,
     external_planning_site_name = EXCLUDED.external_planning_site_name,
-    boundary_json = EXCLUDED.boundary_json,
-    boundary_url = EXCLUDED.boundary_url;
+    boundary_url = EXCLUDED.boundary_url,
+    boundary_json = EXCLUDED.boundary_json;
 SELECT
   setval('team_settings_id_seq', max(id))
 FROM


### PR DESCRIPTION
## What does this PR do?

This PR follows #3289 and #3314 which have added the new ``team_settings`` table to the database. With the new table, there is a need to create scripts to pull data from the production database when new, local databases are created for containers. 

This PR will enable this pulling of production ``team_settings`` data

In addition, I have added a relationship between the `teams` table and the `team_settings` table to enable a link when creating queries.