### PR TITLE
fix: Prevent event bubbling on click of checkbox

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.test.tsx
@@ -173,6 +173,7 @@ describe("Checklist Component - Grouped Layout", () => {
       answers: ["S1_Option1", "S3_Option1"],
     });
   });
+
   it("should not have any accessibility violations", async () => {
     const { container } = setup(
       <Checklist
@@ -185,6 +186,7 @@ describe("Checklist Component - Grouped Layout", () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
   it("should be navigable by keyboard", async () => {
     const handleSubmit = jest.fn();
 
@@ -218,13 +220,11 @@ describe("Checklist Component - Grouped Layout", () => {
     expect(screen.getByTestId("S2_Option1")).toHaveFocus();
     // Select option using keyboard
     await user.keyboard("[Space]");
-    expect(screen.getByTestId("S2_Option1")).toBeChecked();
     // Tab to Section 2, Option 2
     await user.tab();
     expect(screen.getByTestId("S2_Option2")).toHaveFocus();
     // Select option using keyboard
     await user.keyboard("[Space]");
-    expect(screen.getByTestId("S2_Option2")).toBeChecked();
     // Tab to Section 3, and navigate through to "Continue" without selecting anything
     await user.tab();
     expect(section3Button).toHaveFocus();
@@ -279,6 +279,7 @@ describe("Checklist Component - Basic & Images Layout", () => {
         answers: ["flat_id", "house_id", "spaceship_id"],
       });
     });
+
     it(`recovers checkboxes state when clicking the back button (${ChecklistLayout[type]} layout)`, async () => {
       const handleSubmit = jest.fn();
 

--- a/editor.planx.uk/src/ui/shared/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox.tsx
@@ -56,14 +56,18 @@ export default function Checkbox({
   onChange,
   inputProps,
 }: Props): FCReturn {
+  const handleChange = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault()
+    onChange && onChange();
+  }
+
   return (
-    <Root onClick={() => onChange && onChange()}>
+    <Root onClick={handleChange}>
       <Input
         defaultChecked={checked}
         type="checkbox"
         id={id}
         data-testid={id}
-        onChange={() => onChange && onChange()}
         {...inputProps}
       />
       <Icon checked={checked} />


### PR DESCRIPTION
## What's the problem?
I hit some strange checkbox behaviour when working on https://github.com/theopensystemslab/planx-new/pull/3304 which sidetracked me somewhat! See video below for demo - 

https://github.com/theopensystemslab/planx-new/assets/20502206/47b90a82-ebf6-477d-9a63-184fb7879cd6

What's happening is - 
 - Clicking labels behaves as expected
 - Clicking checkbox fires event (`onChange()` function) twice, resulting in nondeterministic updates when combined with async state updates (via Formik)

We can check this out by using a `console.log()` inside our `onChange()` function and seeing that it fires multiple times (event outside the scope of React's strict mode). Another good example of this, which is now fixed in this PR, is that selecting checkboxes in the Editor's send component triggers an alert twice on staging, but only once on this PR.


## What's the solution?
Use `event.preventDefault()` to stop the event bubbling up further. Docs: https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault

## To test...
Let's make sure this hasn't broken anything!

 - I can check public facing checklists via...
   - Click on checkbox
   - Click on label
   - Keyboard navigation

 - I can check Editor facing checklists (e.g. Send components) via...
   - Click on checkbox
   - Click on label
   - Keyboard navigation
   - And events only fire once (single alert popup)