### PR TITLE
feat: fetching team_settings data from database and populating forms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       - "theopensystemslab/planx"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
 
   # Hasura
   - package-ecosystem: "npm"
@@ -38,7 +38,7 @@ updates:
       - "theopensystemslab/planx"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/hasura.planx.uk"
@@ -76,7 +76,7 @@ updates:
       - "theopensystemslab/planx"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   
   # ShareDB
   - package-ecosystem: "npm"
@@ -90,7 +90,7 @@ updates:
       - "theopensystemslab/planx"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/sharedb.planx.uk"
@@ -115,7 +115,7 @@ updates:
       - "theopensystemslab/planx"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/api.planx.uk"
@@ -142,7 +142,7 @@ updates:
       - "theopensystemslab/planx"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   
   # Infrastructure
   # - package-ecosystem: "npm"

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -85,7 +85,7 @@ describe("Header Component - Editor Route", () => {
           id: 123,
           email: "test@example.com",
         },
-      }),
+      })
     );
 
     jest.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
@@ -98,7 +98,7 @@ describe("Header Component - Editor Route", () => {
           data: {
             flow: "test-flow",
           },
-        }) as any,
+        }) as any
     );
   });
 
@@ -139,7 +139,7 @@ for (const route of ["/published", "/preview", "/draft", "/pay", "/invite"]) {
             data: {
               flow: "test-flow",
             },
-          }) as any,
+          }) as any
       );
     });
 
@@ -148,7 +148,7 @@ for (const route of ["/published", "/preview", "/draft", "/pay", "/invite"]) {
       expect(screen.queryByText("Plan✕")).not.toBeInTheDocument();
       expect(screen.getByAltText(`${mockTeam1.name} Logo`)).toHaveAttribute(
         "src",
-        "logo.jpg",
+        "logo.jpg"
       );
     });
 
@@ -156,7 +156,7 @@ for (const route of ["/published", "/preview", "/draft", "/pay", "/invite"]) {
       act(() => setState({ teamTheme: mockTeam2.theme }));
       setup(<Header />);
       expect(
-        screen.queryByAltText(`${mockTeam2.name} Logo`),
+        screen.queryByAltText(`${mockTeam2.name} Logo`)
       ).not.toBeInTheDocument();
       expect(screen.getByText("Plan✕")).toBeInTheDocument();
       act(() => setState({ teamTheme: mockTeam1.theme }));
@@ -190,7 +190,7 @@ describe("Section navigation bar", () => {
           data: {
             flow: "test-flow",
           },
-        }) as any,
+        }) as any
     );
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
@@ -42,7 +42,6 @@ const DesignSettings: React.FC = () => {
       try {
         const fetchedTeam = await useStore.getState().fetchCurrentTeam();
         if (!fetchedTeam) throw Error("Unable to find team");
-
         setFormikConfig({
           initialValues: fetchedTeam.theme,
           // This value will be set per form section

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -11,7 +11,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   const formik = useFormik({
     ...formikConfig,
     onSubmit: async (values, { resetForm }) => {
-      const isSuccess = await useStore.getState().updateTeamSettings({
+      const isSuccess = await useStore.getState().updateGeneralSettings({
         boundaryUrl: values.boundaryUrl,
       });
       console.log("button pressed");

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -1,4 +1,5 @@
 import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
@@ -9,9 +10,16 @@ import { FormProps } from ".";
 export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   const formik = useFormik({
     ...formikConfig,
-    onSubmit(values, { resetForm }) {
-      onSuccess();
-      resetForm({ values });
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await useStore.getState().updateGeneralSettings({
+        boundaryUrl: values.boundaryUrl,
+      });
+      console.log("button pressed");
+      console.log({ successBool: isSuccess });
+      if (isSuccess) {
+        onSuccess();
+        resetForm({ values });
+      }
     },
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -11,7 +11,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   const formik = useFormik({
     ...formikConfig,
     onSubmit: async (values, { resetForm }) => {
-      const isSuccess = await useStore.getState().updateGeneralSettings({
+      const isSuccess = await useStore.getState().updateTeamSettings({
         boundaryUrl: values.boundaryUrl,
       });
       console.log("button pressed");

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -3,6 +3,8 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
+import InputRow from "ui/shared/InputRow";
+import InputRowLabel from "ui/shared/InputRowLabel";
 import * as Yup from "yup";
 
 import { SettingsForm } from "../shared/SettingsForm";

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -24,7 +24,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
     ...formikConfig,
     validationSchema: formSchema,
     onSubmit: async (values, { resetForm }) => {
-      const isSuccess = await useStore.getState().updateTeamSettings({
+      const isSuccess = await useStore.getState().updateGeneralSettings({
         homepage: values.homepage,
         helpEmail: values.helpEmail,
         helpPhone: values.helpPhone,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -24,7 +24,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
     ...formikConfig,
     validationSchema: formSchema,
     onSubmit: async (values, { resetForm }) => {
-      const isSuccess = await useStore.getState().updateGeneralSettings({
+      const isSuccess = await useStore.getState().updateTeamSettings({
         homepage: values.homepage,
         helpEmail: values.helpEmail,
         helpPhone: values.helpPhone,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
@@ -20,9 +21,17 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
   const formik = useFormik({
     ...formikConfig,
     validationSchema: formSchema,
-    onSubmit(values, { resetForm }) {
-      onSuccess();
-      resetForm({ values });
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await useStore.getState().updateGeneralSettings({
+        homepage: values.homepage,
+        helpEmail: values.helpEmail,
+        helpPhone: values.helpPhone,
+        helpOpeningHours: values.helpOpeningHours,
+      });
+      if (isSuccess) {
+        onSuccess();
+        resetForm({ values });
+      }
     },
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -41,43 +41,55 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
       }
       input={
         <>
-          <InputLabel label="Homepage URL" htmlFor="homepageUrl">
-            <Input
-              name="homepage"
-              onChange={(event) => {
-                onChangeFn("homepage", event);
-              }}
-              id="homepageUrl"
-            />
-          </InputLabel>
-          <InputLabel label="Contact email address" htmlFor="helpEmail">
-            <Input
-              name="helpEmail"
-              onChange={(event) => {
-                onChangeFn("helpEmail", event);
-              }}
-              id="helpEmail"
-            />
-          </InputLabel>
-          <InputLabel label="Phone number" htmlFor="helpPhone">
-            <Input
-              name="helpPhone"
-              onChange={(event) => {
-                onChangeFn("helpPhone", event);
-              }}
-              id="helpPhone"
-            />
-          </InputLabel>
-          <InputLabel label="Opening hours" htmlFor="helpOpeningHours">
-            <Input
-              multiline
-              name="helpOpeningHours"
-              onChange={(event) => {
-                onChangeFn("helpOpeningHours", event);
-              }}
-              id="helpOpeningHours"
-            />
-          </InputLabel>
+          <InputRow>
+            <InputRowLabel>
+              Homepage URL
+              <Input
+                name="homepage"
+                value={formik.values.homepage}
+                onChange={(event) => {
+                  onChangeFn("homepage", event);
+                }}
+              />
+            </InputRowLabel>
+          </InputRow>
+          <InputRow>
+            <InputRowLabel>
+              Contact email address
+              <Input
+                name="helpEmail"
+                value={formik.values.helpEmail}
+                onChange={(event) => {
+                  onChangeFn("helpEmail", event);
+                }}
+              />
+            </InputRowLabel>
+          </InputRow>
+          <InputRow>
+            <InputRowLabel>
+              Phone number
+              <Input
+                name="helpPhone"
+                value={formik.values.helpPhone}
+                onChange={(event) => {
+                  onChangeFn("helpPhone", event);
+                }}
+              />
+            </InputRowLabel>
+          </InputRow>
+          <InputRow>
+            <InputRowLabel>
+              Opening hours
+              <Input
+                multiline
+                name="helpOpeningHours"
+                value={formik.values.helpOpeningHours}
+                onChange={(event) => {
+                  onChangeFn("helpOpeningHours", event);
+                }}
+              />
+            </InputRowLabel>
+          </InputRow>
         </>
       }
     />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -2,7 +2,7 @@ import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
-import { TeamSettings } from "@opensystemslab/planx-core/types";
+import { GeneralTeamSettings } from "@opensystemslab/planx-core/types";
 import { FormikConfig } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
@@ -11,14 +11,22 @@ import SettingsSection from "ui/editor/SettingsSection";
 import BoundaryForm from "./BoundaryForm";
 import ContactForm from "./ContactForm";
 
+export interface GeneralSettings {
+  boundaryUrl: string;
+  helpEmail: string;
+  helpPhone: string;
+  helpOpeningHours: string;
+  homepage: string;
+}
+
 export interface FormProps {
-  formikConfig: FormikConfig<TeamSettings>;
+  formikConfig: FormikConfig<GeneralTeamSettings>;
   onSuccess: () => void;
 }
 
 const GeneralSettings: React.FC = () => {
   const [formikConfig, setFormikConfig] = useState<
-    FormikConfig<TeamSettings> | undefined
+    FormikConfig<GeneralTeamSettings> | undefined
   >(undefined);
 
   useEffect(() => {
@@ -28,7 +36,7 @@ const GeneralSettings: React.FC = () => {
         console.log(fetchedTeam);
         if (!fetchedTeam) throw Error("Unable to find team");
         setFormikConfig({
-          initialValues: fetchedTeam.teamSettings,
+          initialValues: fetchedTeam.team_settings,
           onSubmit: () => {},
           validateOnBlur: false,
           validateOnChange: false,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -2,7 +2,7 @@ import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
-import { GeneralTeamSettings } from "@opensystemslab/planx-core/types";
+import { TeamSettings } from "@opensystemslab/planx-core/types";
 import { FormikConfig } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
@@ -11,22 +11,14 @@ import SettingsSection from "ui/editor/SettingsSection";
 import BoundaryForm from "./BoundaryForm";
 import ContactForm from "./ContactForm";
 
-export interface GeneralSettings {
-  boundaryUrl: string;
-  helpEmail: string;
-  helpPhone: string;
-  helpOpeningHours: string;
-  homepage: string;
-}
-
 export interface FormProps {
-  formikConfig: FormikConfig<GeneralTeamSettings>;
+  formikConfig: FormikConfig<TeamSettings>;
   onSuccess: () => void;
 }
 
 const GeneralSettings: React.FC = () => {
   const [formikConfig, setFormikConfig] = useState<
-    FormikConfig<GeneralTeamSettings> | undefined
+    FormikConfig<TeamSettings> | undefined
   >(undefined);
 
   useEffect(() => {
@@ -36,7 +28,7 @@ const GeneralSettings: React.FC = () => {
         console.log(fetchedTeam);
         if (!fetchedTeam) throw Error("Unable to find team");
         setFormikConfig({
-          initialValues: fetchedTeam.team_settings,
+          initialValues: fetchedTeam.teamSettings,
           onSubmit: () => {},
           validateOnBlur: false,
           validateOnChange: false,
@@ -55,7 +47,7 @@ const GeneralSettings: React.FC = () => {
 
   const handleClose = (
     _event?: React.SyntheticEvent | Event,
-    reason?: string
+    reason?: string,
   ) => {
     if (reason === "clickaway") {
       return;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -2,7 +2,9 @@ import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
+import { GeneralTeamSettings } from "@opensystemslab/planx-core/types";
 import { FormikConfig } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import SettingsSection from "ui/editor/SettingsSection";
 
@@ -18,28 +20,23 @@ export interface GeneralSettings {
 }
 
 export interface FormProps {
-  formikConfig: FormikConfig<GeneralSettings>;
+  formikConfig: FormikConfig<GeneralTeamSettings>;
   onSuccess: () => void;
 }
 
 const GeneralSettings: React.FC = () => {
   const [formikConfig, setFormikConfig] = useState<
-    FormikConfig<GeneralSettings> | undefined
+    FormikConfig<GeneralTeamSettings> | undefined
   >(undefined);
-
-  const initialValues = {
-    boundaryUrl: "",
-    helpEmail: "",
-    helpPhone: "",
-    helpOpeningHours: "",
-    homepage: "",
-  };
 
   useEffect(() => {
     const fetchTeam = async () => {
       try {
+        const fetchedTeam = await useStore.getState().fetchCurrentTeam();
+        console.log(fetchedTeam);
+        if (!fetchedTeam) throw Error("Unable to find team");
         setFormikConfig({
-          initialValues: initialValues,
+          initialValues: fetchedTeam.team_settings,
           onSubmit: () => {},
           validateOnBlur: false,
           validateOnChange: false,
@@ -58,7 +55,7 @@ const GeneralSettings: React.FC = () => {
 
   const handleClose = (
     _event?: React.SyntheticEvent | Event,
-    reason?: string,
+    reason?: string
   ) => {
     if (reason === "clickaway") {
       return;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -15,9 +15,10 @@ export interface TeamStore {
   teamId: number;
   teamIntegrations: TeamIntegrations;
   teamName: string;
+  teamSettings: TeamSettings;
   teamSlug: string;
   teamTheme: TeamTheme;
-  teamSettings: TeamSettings;
+  teamGeneralSettings: GeneralTeamSettings;
 
   setTeam: (team: Team) => void;
   getTeam: () => Team;
@@ -25,7 +26,9 @@ export interface TeamStore {
   clearTeamStore: () => void;
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
-  updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
+  updateGeneralSettings: (
+    generalSettings: Partial<GeneralTeamSettings>,
+  ) => Promise<boolean>;
 }
 
 export const teamStore: StateCreator<
@@ -38,9 +41,10 @@ export const teamStore: StateCreator<
   teamId: 0,
   teamIntegrations: {} as TeamIntegrations,
   teamName: "",
+  teamSettings: {} as TeamSettings,
   teamSlug: "",
   teamTheme: {} as TeamTheme,
-  teamSettings: {} as TeamSettings,
+  teamGeneralSettings: {} as GeneralTeamSettings,
 
   setTeam: (team) => {
     set({
@@ -48,9 +52,10 @@ export const teamStore: StateCreator<
       teamId: team.id,
       teamIntegrations: team.integrations,
       teamName: team.name,
+      teamSettings: team.teamSettings,
       teamSlug: team.slug,
       teamTheme: team.theme,
-      teamSettings: team.teamSettings,
+      teamGeneralSettings: team.team_settings,
     });
 
     if (team.theme?.favicon) {
@@ -64,9 +69,10 @@ export const teamStore: StateCreator<
     id: get().teamId,
     integrations: get().teamIntegrations,
     name: get().teamName,
+    teamSettings: get().teamSettings,
     slug: get().teamSlug,
     theme: get().teamTheme,
-    teamSettings: get().teamSettings,
+    team_settings: get().teamGeneralSettings,
   }),
 
   initTeamStore: async (slug) => {
@@ -130,10 +136,12 @@ export const teamStore: StateCreator<
     return isSuccess;
   },
 
-  updateTeamSettings: async (generalSettings: Partial<TeamSettings>) => {
+  updateGeneralSettings: async (
+    generalSettings: Partial<GeneralTeamSettings>,
+  ) => {
     const { teamId, $client } = get();
     console.log(generalSettings);
-    const isSuccess = await $client.team.updateTeamSettings(
+    const isSuccess = await $client.team.updateGeneralSettings(
       teamId,
       generalSettings,
     );

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -15,10 +15,9 @@ export interface TeamStore {
   teamId: number;
   teamIntegrations: TeamIntegrations;
   teamName: string;
-  teamSettings: TeamSettings;
   teamSlug: string;
   teamTheme: TeamTheme;
-  teamGeneralSettings: GeneralTeamSettings;
+  teamSettings: TeamSettings;
 
   setTeam: (team: Team) => void;
   getTeam: () => Team;
@@ -26,9 +25,7 @@ export interface TeamStore {
   clearTeamStore: () => void;
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
-  updateGeneralSettings: (
-    generalSettings: Partial<GeneralTeamSettings>,
-  ) => Promise<boolean>;
+  updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
 }
 
 export const teamStore: StateCreator<
@@ -41,10 +38,9 @@ export const teamStore: StateCreator<
   teamId: 0,
   teamIntegrations: {} as TeamIntegrations,
   teamName: "",
-  teamSettings: {} as TeamSettings,
   teamSlug: "",
   teamTheme: {} as TeamTheme,
-  teamGeneralSettings: {} as GeneralTeamSettings,
+  teamSettings: {} as TeamSettings,
 
   setTeam: (team) => {
     set({
@@ -52,10 +48,9 @@ export const teamStore: StateCreator<
       teamId: team.id,
       teamIntegrations: team.integrations,
       teamName: team.name,
-      teamSettings: team.teamSettings,
       teamSlug: team.slug,
       teamTheme: team.theme,
-      teamGeneralSettings: team.team_settings,
+      teamSettings: team.teamSettings,
     });
 
     if (team.theme?.favicon) {
@@ -69,10 +64,9 @@ export const teamStore: StateCreator<
     id: get().teamId,
     integrations: get().teamIntegrations,
     name: get().teamName,
-    teamSettings: get().teamSettings,
     slug: get().teamSlug,
     theme: get().teamTheme,
-    team_settings: get().teamGeneralSettings,
+    teamSettings: get().teamSettings,
   }),
 
   initTeamStore: async (slug) => {
@@ -136,12 +130,10 @@ export const teamStore: StateCreator<
     return isSuccess;
   },
 
-  updateGeneralSettings: async (
-    generalSettings: Partial<GeneralTeamSettings>,
-  ) => {
+  updateTeamSettings: async (generalSettings: Partial<TeamSettings>) => {
     const { teamId, $client } = get();
     console.log(generalSettings);
-    const isSuccess = await $client.team.updateGeneralSettings(
+    const isSuccess = await $client.team.updateTeamSettings(
       teamId,
       generalSettings,
     );

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -26,6 +26,9 @@ export interface TeamStore {
   clearTeamStore: () => void;
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
+  updateGeneralSettings: (
+    generalSettings: Partial<GeneralTeamSettings>,
+  ) => Promise<boolean>;
 }
 
 export const teamStore: StateCreator<
@@ -130,6 +133,18 @@ export const teamStore: StateCreator<
   updateTeamTheme: async (theme: Partial<TeamTheme>) => {
     const { teamId, $client } = get();
     const isSuccess = await $client.team.updateTheme(teamId, theme);
+    return isSuccess;
+  },
+
+  updateGeneralSettings: async (
+    generalSettings: Partial<GeneralTeamSettings>,
+  ) => {
+    const { teamId, $client } = get();
+    console.log(generalSettings);
+    const isSuccess = await $client.team.updateGeneralSettings(
+      teamId,
+      generalSettings,
+    );
     return isSuccess;
   },
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -18,6 +18,7 @@ export interface TeamStore {
   teamSettings: TeamSettings;
   teamSlug: string;
   teamTheme: TeamTheme;
+  teamGeneralSettings: GeneralTeamSettings;
 
   setTeam: (team: Team) => void;
   getTeam: () => Team;
@@ -40,6 +41,7 @@ export const teamStore: StateCreator<
   teamSettings: {} as TeamSettings,
   teamSlug: "",
   teamTheme: {} as TeamTheme,
+  teamGeneralSettings: {} as GeneralTeamSettings,
 
   setTeam: (team) => {
     set({
@@ -50,6 +52,7 @@ export const teamStore: StateCreator<
       teamSettings: team.teamSettings,
       teamSlug: team.slug,
       teamTheme: team.theme,
+      teamGeneralSettings: team.team_settings,
     });
 
     if (team.theme?.favicon) {
@@ -66,6 +69,7 @@ export const teamStore: StateCreator<
     teamSettings: get().teamSettings,
     slug: get().teamSlug,
     theme: get().teamTheme,
+    team_settings: get().teamGeneralSettings,
   }),
 
   initTeamStore: async (slug) => {

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -28,7 +28,7 @@ const teamSettingsRoutes = compose(
 
       if (!isAuthorised)
         throw new NotFoundError(
-          `User does not have access to ${req.originalUrl}`,
+          `User does not have access to ${req.originalUrl}`
         );
 
       return route(async (req) => ({
@@ -47,17 +47,17 @@ const teamSettingsRoutes = compose(
                 route: "design",
                 Component: DesignSettings,
               },
-              // {
-              //   name: "General",
-              //   route: "general",
-              //   Component: GeneralSettings,
-              // },
+              {
+                name: "General",
+                route: "general",
+                Component: GeneralSettings,
+              },
             ]}
           />
         ),
       }));
     }),
-  }),
+  })
 );
 
 export default teamSettingsRoutes;


### PR DESCRIPTION
## What does this PR do?

Continuing work on the ``team_settings`` implementation, this PR pulls in data from the database with a graphQL query and populates the corresponding form inputs.

This PR also uses the update mutation, similar to `team_themes` to update the form fields and database. 

This PR aligns with a planx-core change where the requests and types for a Team were altered to incorporate the new ``team_settings`` table.

[Reference to the planx-core changes](https://github.com/theopensystemslab/planx-core/pull/424)

> Important to note that this PR has not deleted any functions, methods, or types related to previous versions of `notifyPersonalisation` or the original ``settings`` column of _"teams"_ table. Thinking is to do this clear out after changes have been made and tested using the new ``team_settings`` table