### PR TITLE
test: Fix skipped List component test

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -413,48 +413,62 @@ describe("Payload generation", () => {
     expect(handleSubmit.mock.calls[0][0]).toMatchObject(mockZooPayload);
   });
 
-  it.skip("generates a valid payload with summary stats on submission (Units)", async () => {
+  it("generates a valid payload with summary stats on submission (Units)", async () => {
     const handleSubmit = jest.fn();
-    const { getByTestId, user } = setup(
+    const { getByTestId, user, getByRole, getAllByRole, getByLabelText } = setup(
       <ListComponent {...mockUnitsProps} handleSubmit={handleSubmit} />,
     );
 
-    const saveButton = screen.getByRole("button", { name: /Save/ });
     const addItemButton = getByTestId("list-add-button");
-    const developmentSelect = screen.getByRole("combobox");
-    const gardenYesRadio = screen.getAllByRole("radio")[0];
-    const gardenNoRadio = screen.getAllByRole("radio")[1];
-    const unitsNumberInput = screen.getByLabelText(/identical units/);
 
     // Response 1
+    let saveButton = getByRole("button", { name: /Save/ });
+    let developmentSelect = getByRole("combobox");
+    let gardenYesRadio = getAllByRole("radio")[0];
+    let gardenNoRadio = getAllByRole("radio")[1];
+    let unitsNumberInput = getByLabelText(/identical units/);
+
     await user.click(developmentSelect);
-    await user.click(screen.getByRole("option", { name: /New build/ }));
+    await user.click(getByRole("option", { name: /New build/ }));
     await user.click(gardenYesRadio);
     await user.type(unitsNumberInput, "1");
     await user.click(saveButton);
 
     // Response 2
     await user.click(addItemButton);
+
+    saveButton = getByRole("button", { name: /Save/ });
+    developmentSelect = getByRole("combobox");
+    gardenYesRadio = getAllByRole("radio")[0];
+    gardenNoRadio = getAllByRole("radio")[1];
+    unitsNumberInput = getByLabelText(/identical units/);
+
     await user.click(developmentSelect);
-    await user.click(screen.getByRole("option", { name: /New build/ }));
+    await user.click(getByRole("option", { name: /New build/ }));
     await user.click(gardenNoRadio);
     await user.type(unitsNumberInput, "2");
     await user.click(saveButton);
 
     // Response 3
     await user.click(addItemButton);
+
+    saveButton = getByRole("button", { name: /Save/ });
+    developmentSelect = getByRole("combobox");
+    gardenYesRadio = getAllByRole("radio")[0];
+    gardenNoRadio = getAllByRole("radio")[1];
+    unitsNumberInput = getByLabelText(/identical units/);
+    
     await user.click(developmentSelect);
-    await user.click(
-      screen.getByRole("option", { name: /Change of use to a home/ }),
-    );
+    await user.click(getByRole("option", { name: /Change of use to a home/ }));
     await user.click(gardenNoRadio);
     await user.type(unitsNumberInput, "2");
     await user.click(saveButton);
 
-    await user.click(screen.getByTestId("continue-button"));
+    await user.click(getByTestId("continue-button"));
 
     expect(handleSubmit).toHaveBeenCalled();
-    expect(handleSubmit.mock.calls[0][0]).toMatchObject(mockUnitsPayload);
+    const output = handleSubmit.mock.calls[0][0]
+    expect(output).toMatchObject(mockUnitsPayload);
   });
 });
 

--- a/editor.planx.uk/src/@planx/components/List/schemas/mocks/GenericUnits.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/mocks/GenericUnits.ts
@@ -89,7 +89,7 @@ export const mockUnitsPayload = {
     "proposal.units.residential.three.identicalUnits": 2,
     "proposal.units.residential.total.listItems": 3,
     "proposal.units.residential.total.units": 5,
-    "proposal.units.residential.total.units.newBuid": 3,
-    "proposal.units.residential.total.units.changeOfUseTo": 2,
+    "proposal.units.residential.total.units.development.newBuild": 3,
+    "proposal.units.residential.total.units.development.changeOfUseTo": 2,
   },
 };


### PR DESCRIPTION
## What's the problem?
 - There was a skipped test introduced in #3263 
 - This was failing when un-skipped, as react-testing-library was unable to locate DOM elements to interact with

## What's the solution?
Variables need be be reinstated when a new list item is added, otherwise they hold onto their old references and are invalid.