### PR TITLE
fix: List component radio remove extra margin

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
@@ -133,7 +133,7 @@ export const RadioFieldInput: React.FC<Props<QuestionField>> = (props) => {
         <RadioGroup
           aria-labelledby={`radio-buttons-group-label-${id}`}
           name={`userData[${activeIndex}]['${data.fn}']`}
-          sx={{ p: 1 }}
+          sx={{ p: 1, mb: -2 }}
           value={formik.values.userData[activeIndex][data.fn]}
         >
           {data.options.map(({ id, data }) => (


### PR DESCRIPTION
## What does this PR do?

Quick one: adds a negative margin to `</RadioGroup>` in the List component to negate the extra margin caused by using this inline (radio button rows have margin-bottom to ensure layout spacing).

**Before vs after:**

![image](https://github.com/theopensystemslab/planx-new/assets/51156018/9131c714-5294-472a-9d6f-dc61b1acecea)
