### PR TITLE
refactor: Editor forms tidy up and unify

### DIFF
--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -31,6 +31,7 @@ import type { handleSubmit } from "pages/Preview/Node";
 import React, { ChangeEvent } from "react";
 import ImgInput from "ui/editor/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
+import InputLabel from "ui/editor/InputLabel";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -109,8 +110,8 @@ export const MoreInformation = ({
   return (
     <ModalSection>
       <ModalSectionContent title="More Information" Icon={InfoOutlined}>
-        <InputGroup label="Why it matters">
-          <InputRow>
+        <InputGroup flowSpacing>
+          <InputLabel label="Why it matters">
             <RichTextInput
               multiline
               name="info"
@@ -118,10 +119,8 @@ export const MoreInformation = ({
               onChange={changeField}
               placeholder="Why it matters"
             />
-          </InputRow>
-        </InputGroup>
-        <InputGroup label="Policy source">
-          <InputRow>
+          </InputLabel>
+          <InputLabel label="Policy source">
             <RichTextInput
               multiline
               name="policyRef"
@@ -129,26 +128,26 @@ export const MoreInformation = ({
               onChange={changeField}
               placeholder="Policy source"
             />
-          </InputRow>
-        </InputGroup>
-        <InputGroup label="How it is defined?">
-          <InputRow>
-            <RichTextInput
-              multiline
-              name="howMeasured"
-              value={howMeasured}
-              onChange={changeField}
-              placeholder="How it is defined?"
-            />
-            <ImgInput
-              img={definitionImg}
-              onChange={(newUrl) => {
-                changeField({
-                  target: { name: "definitionImg", value: newUrl },
-                });
-              }}
-            />
-          </InputRow>
+          </InputLabel>
+          <InputLabel label="How it is defined?">
+            <InputRow>
+              <RichTextInput
+                multiline
+                name="howMeasured"
+                value={howMeasured}
+                onChange={changeField}
+                placeholder="How it is defined?"
+              />
+              <ImgInput
+                img={definitionImg}
+                onChange={(newUrl) => {
+                  changeField({
+                    target: { name: "definitionImg", value: newUrl },
+                  });
+                }}
+              />
+            </InputRow>
+          </InputLabel>
         </InputGroup>
       </ModalSectionContent>
     </ModalSection>

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -117,7 +117,6 @@ export const MoreInformation = ({
               name="info"
               value={info}
               onChange={changeField}
-              placeholder="Why it matters"
             />
           </InputLabel>
           <InputLabel label="Policy source">
@@ -126,7 +125,6 @@ export const MoreInformation = ({
               name="policyRef"
               value={policyRef}
               onChange={changeField}
-              placeholder="Policy source"
             />
           </InputLabel>
           <InputLabel label="How it is defined?">
@@ -136,7 +134,6 @@ export const MoreInformation = ({
                 name="howMeasured"
                 value={howMeasured}
                 onChange={changeField}
-                placeholder="How it is defined?"
               />
               <ImgInput
                 img={definitionImg}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackPage.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackPage.tsx
@@ -24,7 +24,7 @@ import gql from "graphql-tag";
 import { client } from "lib/graphql";
 import React, { useState } from "react";
 import { Feedback } from "routes/feedback";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 import ErrorSummary from "ui/shared/ErrorSummary";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
@@ -156,15 +156,15 @@ export const FeedbackPage: React.FC<Props> = ({ feedback }) => {
   return (
     <Container maxWidth="contentWrap">
       <Box py={4}>
-        <SettingsRow>
+        <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
             Feedback log
           </Typography>
           <Typography variant="body1">
             Feedback from users about this service.
           </Typography>
-        </SettingsRow>
-        <SettingsRow>
+        </SettingsSection>
+        <SettingsSection>
           {feedback.length === 0 ? (
             <ErrorSummary
               format="info"
@@ -202,7 +202,7 @@ export const FeedbackPage: React.FC<Props> = ({ feedback }) => {
               </Table>
             </Feed>
           )}
-        </SettingsRow>
+        </SettingsSection>
       </Box>
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackPage.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackPage.tsx
@@ -24,7 +24,7 @@ import gql from "graphql-tag";
 import { client } from "lib/graphql";
 import React, { useState } from "react";
 import { Feedback } from "routes/feedback";
-import EditorRow from "ui/editor/EditorRow";
+import SettingsRow from "ui/editor/SettingsRow";
 import ErrorSummary from "ui/shared/ErrorSummary";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
@@ -156,15 +156,15 @@ export const FeedbackPage: React.FC<Props> = ({ feedback }) => {
   return (
     <Container maxWidth="contentWrap">
       <Box py={4}>
-        <EditorRow>
+        <SettingsRow>
           <Typography variant="h2" component="h3" gutterBottom>
             Feedback log
           </Typography>
           <Typography variant="body1">
             Feedback from users about this service.
           </Typography>
-        </EditorRow>
-        <EditorRow>
+        </SettingsRow>
+        <SettingsRow>
           {feedback.length === 0 ? (
             <ErrorSummary
               format="info"
@@ -202,7 +202,7 @@ export const FeedbackPage: React.FC<Props> = ({ feedback }) => {
               </Table>
             </Feed>
           )}
-        </EditorRow>
+        </SettingsRow>
       </Box>
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -2,12 +2,12 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 const DataManagerSettings: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <SettingsRow>
+      <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Data Manager
         </Typography>
@@ -15,10 +15,10 @@ const DataManagerSettings: React.FC = () => {
           Manage the data that your service uses and makes available via its
           API.
         </Typography>
-      </SettingsRow>
-      <SettingsRow>
+      </SettingsSection>
+      <SettingsSection>
         <FeaturePlaceholder title="Feature in development" />
-      </SettingsRow>
+      </SettingsSection>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DataManagerSettings.tsx
@@ -1,13 +1,13 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import EditorRow from "ui/editor/EditorRow";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+import SettingsRow from "ui/editor/SettingsRow";
 
 const DataManagerSettings: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <EditorRow>
+      <SettingsRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Data Manager
         </Typography>
@@ -15,10 +15,10 @@ const DataManagerSettings: React.FC = () => {
           Manage the data that your service uses and makes available via its
           API.
         </Typography>
-      </EditorRow>
-      <EditorRow>
+      </SettingsRow>
+      <SettingsRow>
         <FeaturePlaceholder title="Feature in development" />
-      </EditorRow>
+      </SettingsRow>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
@@ -7,7 +7,6 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import ColorPicker from "ui/editor/ColorPicker";
-import InputDescription from "ui/editor/InputDescription";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
@@ -39,12 +38,12 @@ export const ButtonForm: React.FC<FormProps> = ({
       legend="Button colour"
       description={
         <>
-          <InputDescription>
+          <p>
             The button background colour should be either a dark or light
             colour. The text will be programmatically selected to contrast with
             the selected colour (being either black or white).
-          </InputDescription>
-          <InputDescription>
+          </p>
+          <p>
             <Link
               href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
               target="_blank"
@@ -52,7 +51,7 @@ export const ButtonForm: React.FC<FormProps> = ({
             >
               See our guide for setting button colours
             </Link>
-          </InputDescription>
+          </p>
         </>
       }
       input={

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/FaviconForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/FaviconForm.tsx
@@ -5,7 +5,6 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import ImgInput from "ui/editor/ImgInput";
-import InputDescription from "ui/editor/InputDescription";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 import InputRowLabel from "ui/shared/InputRowLabel";
@@ -42,11 +41,11 @@ export const FaviconForm: React.FC<FormProps> = ({
       legend="Favicon"
       description={
         <>
-          <InputDescription>
+          <p>
             Set the favicon to be used in the browser tab. The favicon should be
             32x32px and in .ico or .png format.
-          </InputDescription>
-          <InputDescription>
+          </p>
+          <p>
             <Link
               href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
               target="_blank"
@@ -54,7 +53,7 @@ export const FaviconForm: React.FC<FormProps> = ({
             >
               See our guide for favicons
             </Link>
-          </InputDescription>
+          </p>
         </>
       }
       input={

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
@@ -5,7 +5,6 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import ColorPicker from "ui/editor/ColorPicker";
-import InputDescription from "ui/editor/InputDescription";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
@@ -49,11 +48,11 @@ export const TextLinkForm: React.FC<FormProps> = ({
       legend="Text link colour"
       description={
         <>
-          <InputDescription>
+          <p>
             The text link colour should be a dark colour that contrasts with
             white ("#ffffff").
-          </InputDescription>
-          <InputDescription>
+          </p>
+          <p>
             <Link
               href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
               target="_blank"
@@ -61,7 +60,7 @@ export const TextLinkForm: React.FC<FormProps> = ({
             >
               See our guide for setting text link colours
             </Link>
-          </InputDescription>
+          </p>
         </>
       }
       input={

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
@@ -7,7 +7,6 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import ColorPicker from "ui/editor/ColorPicker";
 import ImgInput from "ui/editor/ImgInput";
-import InputDescription from "ui/editor/InputDescription";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 import InputRowLabel from "ui/shared/InputRowLabel";
@@ -60,13 +59,13 @@ export const ThemeAndLogoForm: React.FC<FormProps> = ({
       legend="Theme colour & logo"
       description={
         <>
-          <InputDescription>
+          <p>
             The theme colour and logo, are used in the header of the service.
             The theme colour should be a dark colour that contrasts with white
             ("#ffffff"). The logo should contrast with a dark background colour
             (your theme colour) and have a transparent background.
-          </InputDescription>
-          <InputDescription>
+          </p>
+          <p>
             <Link
               href="https://opensystemslab.notion.site/10-Customise-the-appearance-of-your-services-3811fe9707534f6cbc0921fc44a2b193"
               target="_blank"
@@ -74,7 +73,7 @@ export const ThemeAndLogoForm: React.FC<FormProps> = ({
             >
               See our guide for setting theme colours and logos
             </Link>
-          </InputDescription>
+          </p>
         </>
       }
       input={

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
@@ -7,7 +7,7 @@ import { TeamTheme } from "@opensystemslab/planx-core/types";
 import { FormikConfig } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 import { ButtonForm } from "./ButtonForm";
 import { FaviconForm } from "./FaviconForm";
@@ -76,14 +76,14 @@ const DesignSettings: React.FC = () => {
 
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <SettingsRow>
+      <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Design
         </Typography>
         <Typography variant="body1">
           How your service appears to public users.
         </Typography>
-      </SettingsRow>
+      </SettingsSection>
       {formikConfig && (
         <>
           <ThemeAndLogoForm formikConfig={formikConfig} onSuccess={onSuccess} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/index.tsx
@@ -7,7 +7,7 @@ import { TeamTheme } from "@opensystemslab/planx-core/types";
 import { FormikConfig } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
-import EditorRow from "ui/editor/EditorRow";
+import SettingsRow from "ui/editor/SettingsRow";
 
 import { ButtonForm } from "./ButtonForm";
 import { FaviconForm } from "./FaviconForm";
@@ -76,14 +76,14 @@ const DesignSettings: React.FC = () => {
 
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <EditorRow>
+      <SettingsRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Design
         </Typography>
         <Typography variant="body1">
           How your service appears to public users.
         </Typography>
-      </EditorRow>
+      </SettingsRow>
       {formikConfig && (
         <>
           <ThemeAndLogoForm formikConfig={formikConfig} onSuccess={onSuccess} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -1,9 +1,7 @@
 import { useFormik } from "formik";
 import React, { ChangeEvent } from "react";
-import InputDescription from "ui/editor/InputDescription";
+import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
-import InputRow from "ui/shared/InputRow";
-import InputRowLabel from "ui/shared/InputRowLabel";
 
 import { SettingsForm } from "../shared/SettingsForm";
 import { FormProps } from ".";
@@ -22,37 +20,35 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
       formik={formik}
       legend="Boundary"
       description={
-        <InputDescription>
-          The boundary URL is used to retrieve the outer boundary of your
-          council area. This can then help users define whether they are within
-          your council area.
-          <br />
-          <br />
-          The boundary should be given as a link from:{" "}
-          <a
-            href="https://www.planning.data.gov.uk/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            https://www.planning.data.gov.uk/
-          </a>
-        </InputDescription>
+        <>
+          <p>
+            The boundary URL is used to retrieve the outer boundary of your
+            council area. This can then help users define whether they are
+            within your council area.
+          </p>
+          <p>
+            The boundary should be given as a link from:{" "}
+            <a
+              href="https://www.planning.data.gov.uk/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              https://www.planning.data.gov.uk/
+            </a>
+          </p>
+        </>
       }
       input={
-        <>
-          <InputRow>
-            <InputRowLabel>
-              Boundary URL
-              <Input
-                name="boundary"
-                value={formik.values.boundaryUrl}
-                onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-                  formik.setFieldValue("boundaryUrl", ev.target.value);
-                }}
-              />
-            </InputRowLabel>
-          </InputRow>
-        </>
+        <InputLabel label="Boundary URL" htmlFor="boundaryUrl">
+          <Input
+            name="boundary"
+            value={formik.values.boundaryUrl}
+            onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+              formik.setFieldValue("boundaryUrl", ev.target.value);
+            }}
+            id="boundaryUrl"
+          />
+        </InputLabel>
       }
     />
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -1,9 +1,7 @@
 import { useFormik } from "formik";
 import React, { ChangeEvent } from "react";
-import InputDescription from "ui/editor/InputDescription";
+import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
-import InputRow from "ui/shared/InputRow";
-import InputRowLabel from "ui/shared/InputRowLabel";
 import * as Yup from "yup";
 
 import { SettingsForm } from "../shared/SettingsForm";
@@ -36,58 +34,50 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
       legend="Contact Information"
       formik={formik}
       description={
-        <InputDescription>
+        <>
           Details to help direct different messages, feedback, and enquiries
           from users.
-        </InputDescription>
+        </>
       }
       input={
         <>
-          <InputRow>
-            <InputRowLabel>
-              Homepage URL
-              <Input
-                name="homepage"
-                onChange={(event) => {
-                  onChangeFn("homepage", event);
-                }}
-              />
-            </InputRowLabel>
-          </InputRow>
-          <InputRow>
-            <InputRowLabel>
-              Contact email address
-              <Input
-                name="helpEmail"
-                onChange={(event) => {
-                  onChangeFn("helpEmail", event);
-                }}
-              />
-            </InputRowLabel>
-          </InputRow>
-          <InputRow>
-            <InputRowLabel>
-              Phone number
-              <Input
-                name="helpPhone"
-                onChange={(event) => {
-                  onChangeFn("helpPhone", event);
-                }}
-              />
-            </InputRowLabel>
-          </InputRow>
-          <InputRow>
-            <InputRowLabel>
-              Opening hours
-              <Input
-                multiline
-                name="helpOpeningHours"
-                onChange={(event) => {
-                  onChangeFn("helpOpeningHours", event);
-                }}
-              />
-            </InputRowLabel>
-          </InputRow>
+          <InputLabel label="Homepage URL" htmlFor="homepageUrl">
+            <Input
+              name="homepage"
+              onChange={(event) => {
+                onChangeFn("homepage", event);
+              }}
+              id="homepageUrl"
+            />
+          </InputLabel>
+          <InputLabel label="Contact email address" htmlFor="helpEmail">
+            <Input
+              name="helpEmail"
+              onChange={(event) => {
+                onChangeFn("helpEmail", event);
+              }}
+              id="helpEmail"
+            />
+          </InputLabel>
+          <InputLabel label="Phone number" htmlFor="helpPhone">
+            <Input
+              name="helpPhone"
+              onChange={(event) => {
+                onChangeFn("helpPhone", event);
+              }}
+              id="helpPhone"
+            />
+          </InputLabel>
+          <InputLabel label="Opening hours" htmlFor="helpOpeningHours">
+            <Input
+              multiline
+              name="helpOpeningHours"
+              onChange={(event) => {
+                onChangeFn("helpOpeningHours", event);
+              }}
+              id="helpOpeningHours"
+            />
+          </InputLabel>
         </>
       }
     />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -4,7 +4,7 @@ import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
 import { FormikConfig } from "formik";
 import React, { useEffect, useState } from "react";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 import BoundaryForm from "./BoundaryForm";
 import ContactForm from "./ContactForm";
@@ -71,14 +71,14 @@ const GeneralSettings: React.FC = () => {
 
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <SettingsRow>
+      <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           General
         </Typography>
         <Typography variant="body1">
           Important links and settings for how your users connect with you
         </Typography>
-      </SettingsRow>
+      </SettingsSection>
       {formikConfig && (
         <>
           <ContactForm formikConfig={formikConfig} onSuccess={onSuccess} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -4,7 +4,7 @@ import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
 import { FormikConfig } from "formik";
 import React, { useEffect, useState } from "react";
-import EditorRow from "ui/editor/EditorRow";
+import SettingsRow from "ui/editor/SettingsRow";
 
 import BoundaryForm from "./BoundaryForm";
 import ContactForm from "./ContactForm";
@@ -71,14 +71,14 @@ const GeneralSettings: React.FC = () => {
 
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <EditorRow>
+      <SettingsRow>
         <Typography variant="h2" component="h3" gutterBottom>
           General
         </Typography>
         <Typography variant="body1">
           Important links and settings for how your users connect with you
         </Typography>
-      </EditorRow>
+      </SettingsRow>
       {formikConfig && (
         <>
           <ContactForm formikConfig={formikConfig} onSuccess={onSuccess} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -2,12 +2,12 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 const ServiceFlags: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <SettingsRow>
+      <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Service flags
         </Typography>
@@ -15,10 +15,10 @@ const ServiceFlags: React.FC = () => {
           Manage the flag sets that this service uses. Flags at the top of a set
           override flags below.
         </Typography>
-      </SettingsRow>
-      <SettingsRow>
+      </SettingsSection>
+      <SettingsSection>
         <FeaturePlaceholder title="Feature in development" />
-      </SettingsRow>
+      </SettingsSection>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceFlags.tsx
@@ -1,13 +1,13 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import EditorRow from "ui/editor/EditorRow";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+import SettingsRow from "ui/editor/SettingsRow";
 
 const ServiceFlags: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <EditorRow>
+      <SettingsRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Service flags
         </Typography>
@@ -15,10 +15,10 @@ const ServiceFlags: React.FC = () => {
           Manage the flag sets that this service uses. Flags at the top of a set
           override flags below.
         </Typography>
-      </EditorRow>
-      <EditorRow>
+      </SettingsRow>
+      <SettingsRow>
         <FeaturePlaceholder title="Feature in development" />
-      </EditorRow>
+      </SettingsRow>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -11,10 +11,11 @@ import { FlowStatus } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React, { useState } from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
-import EditorRow from "ui/editor/EditorRow";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import RichTextInput from "ui/editor/RichTextInput";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import SettingsRow from "ui/editor/SettingsRow";
 import Input, { Props as InputProps } from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
@@ -39,14 +40,16 @@ const TextInput: React.FC<{
 }) => {
   return (
     <Box width="100%">
-      <Box mb={2} display="flex" alignItems="center">
+      <Box mb={0.5} display="flex" alignItems="center">
         <Switch {...switchProps} color="primary" />
         <Typography variant="h4" component="h5">
           {title}
         </Typography>
       </Box>
-      <Box mb={2}>
-        {description && <Typography variant="body2">{description}</Typography>}
+      <Box mb={1}>
+        {description && (
+          <SettingsDescription>{description}</SettingsDescription>
+        )}
       </Box>
       <InputRow>
         <InputRowItem>
@@ -142,15 +145,15 @@ const ServiceSettings: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
       <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
-        <EditorRow>
+        <SettingsRow>
           <Typography variant="h2" component="h3" gutterBottom>
             Elements
           </Typography>
           <Typography variant="body1">
             Manage the features that users will be able to see.
           </Typography>
-        </EditorRow>
-        <EditorRow background>
+        </SettingsRow>
+        <SettingsRow background>
           <TextInput
             title="Legal Disclaimer"
             description="Displayed before a user submits their application"
@@ -170,8 +173,8 @@ const ServiceSettings: React.FC = () => {
               onChange: elementsForm.handleChange,
             }}
           />
-        </EditorRow>
-        <EditorRow background>
+        </SettingsRow>
+        <SettingsRow background>
           <InputGroup flowSpacing>
             <InputLegend>Footer Links</InputLegend>
             <InputRow>
@@ -219,8 +222,8 @@ const ServiceSettings: React.FC = () => {
               />
             </InputRow>
           </InputGroup>
-        </EditorRow>
-        <EditorRow>
+        </SettingsRow>
+        <SettingsRow>
           <Button
             type="submit"
             variant="contained"
@@ -229,22 +232,23 @@ const ServiceSettings: React.FC = () => {
           >
             Update elements
           </Button>
-        </EditorRow>
+        </SettingsRow>
       </Box>
       <Box component="form" onSubmit={statusForm.handleSubmit}>
-        <EditorRow>
+        <SettingsRow>
           <Typography variant="h2" component="h3" gutterBottom>
             Status
           </Typography>
           <Typography variant="body1">
             Manage the status of your service.
           </Typography>
-        </EditorRow>
-        <EditorRow background>
+        </SettingsRow>
+        <SettingsRow background>
           <FormControlLabel
             label={statusForm.values.status}
             sx={{
               margin: 0,
+              marginBottom: 0.5,
               [`& .${formControlLabelClasses.label}`]: {
                 fontWeight: FONT_WEIGHT_BOLD,
                 textTransform: "capitalize",
@@ -267,16 +271,14 @@ const ServiceSettings: React.FC = () => {
               />
             }
           />
-          <Typography variant="body1">
-            Toggle your service between "offline" and "online".
-          </Typography>
-          <Typography variant="body1">
-            A service must be online to be accessed by the public, and to enable
-            analytics gathering.
-          </Typography>
-          <Typography variant="body1">
-            Offline services can still be edited and published as normal.
-          </Typography>
+          <SettingsDescription>
+            <p>Toggle your service between "offline" and "online".</p>
+            <p>
+              A service must be online to be accessed by the public, and to
+              enable analytics gathering.
+            </p>
+            <p>Offline services can still be edited and published as normal.</p>
+          </SettingsDescription>
           <Box>
             <Button
               type="submit"
@@ -296,7 +298,7 @@ const ServiceSettings: React.FC = () => {
               Reset changes
             </Button>
           </Box>
-        </EditorRow>
+        </SettingsRow>
       </Box>
       <Snackbar
         open={isAlertOpen}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -15,7 +15,7 @@ import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import RichTextInput from "ui/editor/RichTextInput";
 import SettingsDescription from "ui/editor/SettingsDescription";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 import Input, { Props as InputProps } from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
@@ -145,15 +145,15 @@ const ServiceSettings: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
       <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
-        <SettingsRow>
+        <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
             Elements
           </Typography>
           <Typography variant="body1">
             Manage the features that users will be able to see.
           </Typography>
-        </SettingsRow>
-        <SettingsRow background>
+        </SettingsSection>
+        <SettingsSection background>
           <TextInput
             title="Legal Disclaimer"
             description="Displayed before a user submits their application"
@@ -173,8 +173,8 @@ const ServiceSettings: React.FC = () => {
               onChange: elementsForm.handleChange,
             }}
           />
-        </SettingsRow>
-        <SettingsRow background>
+        </SettingsSection>
+        <SettingsSection background>
           <InputGroup flowSpacing>
             <InputLegend>Footer Links</InputLegend>
             <InputRow>
@@ -222,8 +222,8 @@ const ServiceSettings: React.FC = () => {
               />
             </InputRow>
           </InputGroup>
-        </SettingsRow>
-        <SettingsRow>
+        </SettingsSection>
+        <SettingsSection>
           <Button
             type="submit"
             variant="contained"
@@ -232,18 +232,18 @@ const ServiceSettings: React.FC = () => {
           >
             Update elements
           </Button>
-        </SettingsRow>
+        </SettingsSection>
       </Box>
       <Box component="form" onSubmit={statusForm.handleSubmit}>
-        <SettingsRow>
+        <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
             Status
           </Typography>
           <Typography variant="body1">
             Manage the status of your service.
           </Typography>
-        </SettingsRow>
-        <SettingsRow background>
+        </SettingsSection>
+        <SettingsSection background>
           <FormControlLabel
             label={statusForm.values.status}
             sx={{
@@ -298,7 +298,7 @@ const ServiceSettings: React.FC = () => {
               Reset changes
             </Button>
           </Box>
-        </SettingsRow>
+        </SettingsSection>
       </Box>
       <Snackbar
         open={isAlertOpen}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -3,7 +3,7 @@ import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import React, { useMemo } from "react";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 import { useStore } from "../../../lib/store";
 import EventsLog from "./EventsLog";
@@ -75,21 +75,21 @@ const Submissions: React.FC = () => {
   return (
     <Container maxWidth="contentWrap">
       <Box>
-        <SettingsRow>
+        <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
             Submissions
           </Typography>
           <Typography variant="body1">
             Feed of payment and submission events for this service
           </Typography>
-        </SettingsRow>
-        <SettingsRow>
+        </SettingsSection>
+        <SettingsSection>
           <EventsLog
             submissions={submissions}
             loading={loading}
             error={error}
           />
-        </SettingsRow>
+        </SettingsSection>
       </Box>
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -3,7 +3,7 @@ import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import React, { useMemo } from "react";
-import EditorRow from "ui/editor/EditorRow";
+import SettingsRow from "ui/editor/SettingsRow";
 
 import { useStore } from "../../../lib/store";
 import EventsLog from "./EventsLog";
@@ -75,21 +75,21 @@ const Submissions: React.FC = () => {
   return (
     <Container maxWidth="contentWrap">
       <Box>
-        <EditorRow>
+        <SettingsRow>
           <Typography variant="h2" component="h3" gutterBottom>
             Submissions
           </Typography>
           <Typography variant="body1">
             Feed of payment and submission events for this service
           </Typography>
-        </EditorRow>
-        <EditorRow>
+        </SettingsRow>
+        <SettingsRow>
           <EventsLog
             submissions={submissions}
             loading={loading}
             error={error}
           />
-        </EditorRow>
+        </SettingsRow>
       </Box>
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -1,35 +1,35 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import EditorRow from "ui/editor/EditorRow";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+import SettingsRow from "ui/editor/SettingsRow";
 
 const Team: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <EditorRow>
+      <SettingsRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Team
         </Typography>
         <Typography variant="body1">
           Manage who has permission to edit this service.
         </Typography>
-      </EditorRow>
-      <EditorRow>
+      </SettingsRow>
+      <SettingsRow>
         <FeaturePlaceholder title="Feature in development" />
-      </EditorRow>
-      <hr />
-      <EditorRow>
+      </SettingsRow>
+      <hr style={{ margin: "40px 0" }} />
+      <SettingsRow>
         <Typography variant="h2" component="h3" gutterBottom>
           Sharing
         </Typography>
         <Typography variant="body1">
           Allow other teams on Plan✕ to find and use your service pattern.
         </Typography>
-      </EditorRow>
-      <EditorRow>
+      </SettingsRow>
+      <SettingsRow>
         <FeaturePlaceholder title="Feature in development" />
-      </EditorRow>
+      </SettingsRow>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/TeamSettings.tsx
@@ -2,34 +2,34 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 const Team: React.FC = () => {
   return (
     <Box maxWidth="formWrap" mx="auto">
-      <SettingsRow>
+      <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Team
         </Typography>
         <Typography variant="body1">
           Manage who has permission to edit this service.
         </Typography>
-      </SettingsRow>
-      <SettingsRow>
+      </SettingsSection>
+      <SettingsSection>
         <FeaturePlaceholder title="Feature in development" />
-      </SettingsRow>
+      </SettingsSection>
       <hr style={{ margin: "40px 0" }} />
-      <SettingsRow>
+      <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Sharing
         </Typography>
         <Typography variant="body1">
           Allow other teams on Plan✕ to find and use your service pattern.
         </Typography>
-      </SettingsRow>
-      <SettingsRow>
+      </SettingsSection>
+      <SettingsSection>
         <FeaturePlaceholder title="Feature in development" />
-      </SettingsRow>
+      </SettingsSection>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -3,9 +3,10 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import { FormikProps } from "formik";
 import React from "react";
-import EditorRow from "ui/editor/EditorRow";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import SettingsRow from "ui/editor/SettingsRow";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 type SettingsFormProps<TFormikValues> = {
@@ -24,11 +25,11 @@ export const SettingsForm = <TFormikValues,>({
   preview,
 }: SettingsFormProps<TFormikValues>) => {
   return (
-    <EditorRow background>
+    <SettingsRow background>
       <form onSubmit={formik.handleSubmit}>
         <InputGroup flowSpacing>
           <InputLegend>{legend}</InputLegend>
-          {description}
+          <SettingsDescription>{description}</SettingsDescription>
           {input}
         </InputGroup>
         {preview && (
@@ -60,6 +61,6 @@ export const SettingsForm = <TFormikValues,>({
           </Box>
         </ErrorWrapper>
       </form>
-    </EditorRow>
+    </SettingsRow>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import SettingsDescription from "ui/editor/SettingsDescription";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 type SettingsFormProps<TFormikValues> = {
@@ -25,7 +25,7 @@ export const SettingsForm = <TFormikValues,>({
   preview,
 }: SettingsFormProps<TFormikValues>) => {
   return (
-    <SettingsRow background>
+    <SettingsSection background>
       <form onSubmit={formik.handleSubmit}>
         <InputGroup flowSpacing>
           <InputLegend>{legend}</InputLegend>
@@ -61,6 +61,6 @@ export const SettingsForm = <TFormikValues,>({
           </Box>
         </ErrorWrapper>
       </form>
-    </SettingsRow>
+    </SettingsSection>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -13,7 +13,7 @@ import Typography from "@mui/material/Typography";
 import { Role, User } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import EditorRow from "ui/editor/EditorRow";
+import SettingsRow from "ui/editor/SettingsRow";
 
 const StyledAvatar = styled(Avatar)(({ theme }) => ({
   background: theme.palette.background.dark,
@@ -129,7 +129,7 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
   return (
     <Container maxWidth="contentWrap">
       <Box py={7}>
-        <EditorRow>
+        <SettingsRow>
           <Typography variant="h2" component="h3" gutterBottom>
             Team editors
           </Typography>
@@ -137,8 +137,8 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
             Editors have access to edit your services.
           </Typography>
           <MembersTable members={activeMembers} />
-        </EditorRow>
-        <EditorRow>
+        </SettingsRow>
+        <SettingsRow>
           <Typography variant="h2" component="h3" gutterBottom>
             Admins
           </Typography>
@@ -146,9 +146,9 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
             Admins have editor access across all teams.
           </Typography>
           <MembersTable members={platformAdmins} />
-        </EditorRow>
+        </SettingsRow>
         {archivedMembers.length > 0 && (
-          <EditorRow>
+          <SettingsRow>
             <Typography variant="h2" component="h3" gutterBottom>
               Archived team editors
             </Typography>
@@ -157,7 +157,7 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
               be part of the edit history of your services.
             </Typography>
             <MembersTable members={archivedMembers} />
-          </EditorRow>
+          </SettingsRow>
         )}
       </Box>
     </Container>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -13,7 +13,7 @@ import Typography from "@mui/material/Typography";
 import { Role, User } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 
 const StyledAvatar = styled(Avatar)(({ theme }) => ({
   background: theme.palette.background.dark,
@@ -129,7 +129,7 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
   return (
     <Container maxWidth="contentWrap">
       <Box py={7}>
-        <SettingsRow>
+        <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
             Team editors
           </Typography>
@@ -137,8 +137,8 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
             Editors have access to edit your services.
           </Typography>
           <MembersTable members={activeMembers} />
-        </SettingsRow>
-        <SettingsRow>
+        </SettingsSection>
+        <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
             Admins
           </Typography>
@@ -146,9 +146,9 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
             Admins have editor access across all teams.
           </Typography>
           <MembersTable members={platformAdmins} />
-        </SettingsRow>
+        </SettingsSection>
         {archivedMembers.length > 0 && (
-          <SettingsRow>
+          <SettingsSection>
             <Typography variant="h2" component="h3" gutterBottom>
               Archived team editors
             </Typography>
@@ -157,7 +157,7 @@ export const TeamMembers: React.FC<Props> = ({ teamMembersByRole }) => {
               be part of the edit history of your services.
             </Typography>
             <MembersTable members={archivedMembers} />
-          </SettingsRow>
+          </SettingsSection>
         )}
       </Box>
     </Container>

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -14,7 +14,7 @@ import InputLegend from "ui/editor/InputLegend";
 import ListManager from "ui/editor/ListManager";
 import RichTextInput from "ui/editor/RichTextInput";
 import SettingsDescription from "ui/editor/SettingsDescription";
-import SettingsRow from "ui/editor/SettingsRow";
+import SettingsSection from "ui/editor/SettingsSection";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
@@ -69,12 +69,12 @@ function Component() {
     <Dashboard>
       <Container maxWidth="contentWrap">
         <form onSubmit={formik.handleSubmit}>
-          <SettingsRow>
+          <SettingsSection>
             <Typography variant="h2" component="h3" gutterBottom>
               Global Settings
             </Typography>
-          </SettingsRow>
-          <SettingsRow background>
+          </SettingsSection>
+          <SettingsSection background>
             <InputGroup flowSpacing>
               <InputLegend>Footer Elements</InputLegend>
               <SettingsDescription>
@@ -104,7 +104,7 @@ function Component() {
             <Button type="submit" variant="contained" color="primary">
               Save
             </Button>
-          </SettingsRow>
+          </SettingsSection>
         </form>
       </Container>
       <Snackbar

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -18,6 +18,7 @@ import SettingsRow from "ui/editor/SettingsRow";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import InputRowLabel from "ui/shared/InputRowLabel";
 import { slugify } from "utils";
 
 function Component() {
@@ -50,7 +51,7 @@ function Component() {
       );
 
       updateGlobalSettings(formatted);
-      setIsAlertOpen(true); // Open the snackbar
+      setIsAlertOpen(true);
     },
   });
 
@@ -126,7 +127,7 @@ function ContentEditor(props: {
       <InputRow>
         <InputRowItem>
           <Input
-            placeholder="Heading"
+            placeholder="Page title"
             format="bold"
             value={props.value.heading}
             onChange={(ev) => {

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -18,7 +18,6 @@ import SettingsRow from "ui/editor/SettingsRow";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
-import InputRowLabel from "ui/shared/InputRowLabel";
 import { slugify } from "utils";
 
 function Component() {
@@ -68,7 +67,7 @@ function Component() {
 
   return (
     <Dashboard>
-      <Container maxWidth="formWrap">
+      <Container maxWidth="contentWrap">
         <form onSubmit={formik.handleSubmit}>
           <SettingsRow>
             <Typography variant="h2" component="h3" gutterBottom>
@@ -79,10 +78,13 @@ function Component() {
             <InputGroup flowSpacing>
               <InputLegend>Footer Elements</InputLegend>
               <SettingsDescription>
-                Manage the content that will appear in the footer. The heading
-                will appear as a footer link which will open a content page.
+                <p>Manage the content that will appear in the footer.</p>
+                <p>
+                  The heading will appear as a footer link which will open a
+                  content page.
+                </p>
               </SettingsDescription>
-              <Box width="100%" mb={4}>
+              <Box width="100%" mb={4} p={0}>
                 <ListManager
                   values={formik.values.footerContent}
                   onChange={(newOptions) => {

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -5,8 +5,12 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import type { TextContent } from "types";
+import InputGroup from "ui/editor/InputGroup";
+import InputLegend from "ui/editor/InputLegend";
 import ListManager from "ui/editor/ListManager";
 import RichTextInput from "ui/editor/RichTextInput";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import SettingsRow from "ui/editor/SettingsRow";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
@@ -45,36 +49,40 @@ function Component() {
 
   return (
     <form onSubmit={formik.handleSubmit}>
-      <Box p={3}>
-        <Typography variant="h1">Global Settings</Typography>
-        <Box mb={2}>
-          <Box py={3} borderBottom={1}>
-            <Typography variant="h2" component="h3" gutterBottom>
-              <strong>Footer Elements</strong>
-            </Typography>
-            <Typography variant="body1">
-              Manage the content that will appear in the footer
-            </Typography>
-          </Box>
-          <ListManager
-            values={formik.values.footerContent}
-            onChange={(newOptions) => {
-              formik.setFieldValue("footerContent", newOptions);
-            }}
-            newValue={() =>
-              ({
-                heading: "",
-                content: "",
-                show: true,
-              }) as TextContent
-            }
-            Editor={ContentEditor}
-          />
-        </Box>
-
-        <Button type="submit" variant="contained" color="primary">
-          Save
-        </Button>
+      <Box maxWidth="formWrap" mx="auto" my={7}>
+        <SettingsRow>
+          <Typography variant="h2" component="h3" gutterBottom>
+            Global Settings
+          </Typography>
+        </SettingsRow>
+        <SettingsRow background>
+          <InputGroup flowSpacing>
+            <InputLegend>Footer Elements</InputLegend>
+            <SettingsDescription>
+              Manage the content that will appear in the footer. The heading
+              will appear as a footer link which will open a content page.
+            </SettingsDescription>
+            <Box width="100%" mb={4} pl={{ md: 2 }}>
+              <ListManager
+                values={formik.values.footerContent}
+                onChange={(newOptions) => {
+                  formik.setFieldValue("footerContent", newOptions);
+                }}
+                newValue={() =>
+                  ({
+                    heading: "",
+                    content: "",
+                    show: true,
+                  }) as TextContent
+                }
+                Editor={ContentEditor}
+              />
+            </Box>
+          </InputGroup>
+          <Button type="submit" variant="contained" color="primary">
+            Save
+          </Button>
+        </SettingsRow>
       </Box>
     </form>
   );
@@ -86,39 +94,37 @@ function ContentEditor(props: {
 }) {
   return (
     <Box width="100%">
-      <Box my={3} width="80%">
-        <InputRow>
-          <InputRowItem>
-            <Input
-              placeholder="Heading"
-              format="bold"
-              value={props.value.heading}
-              onChange={(ev) => {
-                props.onChange({
-                  ...props.value,
-                  heading: ev.target.value,
-                });
-              }}
-            />
-          </InputRowItem>
-        </InputRow>
-        <InputRow>
-          <InputRowItem>
-            <RichTextInput
-              placeholder="Text"
-              multiline
-              rows={6}
-              value={props.value.content}
-              onChange={(ev) => {
-                props.onChange({
-                  ...props.value,
-                  content: ev.target.value,
-                });
-              }}
-            />
-          </InputRowItem>
-        </InputRow>
-      </Box>
+      <InputRow>
+        <InputRowItem>
+          <Input
+            placeholder="Heading"
+            format="bold"
+            value={props.value.heading}
+            onChange={(ev) => {
+              props.onChange({
+                ...props.value,
+                heading: ev.target.value,
+              });
+            }}
+          />
+        </InputRowItem>
+      </InputRow>
+      <InputRow>
+        <InputRowItem>
+          <RichTextInput
+            placeholder="Page content"
+            multiline
+            rows={6}
+            value={props.value.content}
+            onChange={(ev) => {
+              props.onChange({
+                ...props.value,
+                content: ev.target.value,
+              });
+            }}
+          />
+        </InputRowItem>
+      </InputRow>
     </Box>
   );
 }

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -1,10 +1,14 @@
+import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useState } from "react";
 import type { TextContent } from "types";
+import Dashboard from "ui/editor/Dashboard";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import ListManager from "ui/editor/ListManager";
@@ -21,6 +25,8 @@ function Component() {
     state.globalSettings,
     state.updateGlobalSettings,
   ]);
+
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
 
   const formik = useFormik({
     initialValues: {
@@ -44,47 +50,70 @@ function Component() {
       );
 
       updateGlobalSettings(formatted);
+      setIsAlertOpen(true); // Open the snackbar
     },
   });
 
+  const handleClose = (
+    _event?: React.SyntheticEvent | Event,
+    reason?: string,
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setIsAlertOpen(false);
+  };
+
   return (
-    <form onSubmit={formik.handleSubmit}>
-      <Box maxWidth="formWrap" mx="auto" my={7}>
-        <SettingsRow>
-          <Typography variant="h2" component="h3" gutterBottom>
-            Global Settings
-          </Typography>
-        </SettingsRow>
-        <SettingsRow background>
-          <InputGroup flowSpacing>
-            <InputLegend>Footer Elements</InputLegend>
-            <SettingsDescription>
-              Manage the content that will appear in the footer. The heading
-              will appear as a footer link which will open a content page.
-            </SettingsDescription>
-            <Box width="100%" mb={4} pl={{ md: 2 }}>
-              <ListManager
-                values={formik.values.footerContent}
-                onChange={(newOptions) => {
-                  formik.setFieldValue("footerContent", newOptions);
-                }}
-                newValue={() =>
-                  ({
-                    heading: "",
-                    content: "",
-                    show: true,
-                  }) as TextContent
-                }
-                Editor={ContentEditor}
-              />
-            </Box>
-          </InputGroup>
-          <Button type="submit" variant="contained" color="primary">
-            Save
-          </Button>
-        </SettingsRow>
-      </Box>
-    </form>
+    <Dashboard>
+      <Container maxWidth="formWrap">
+        <form onSubmit={formik.handleSubmit}>
+          <SettingsRow>
+            <Typography variant="h2" component="h3" gutterBottom>
+              Global Settings
+            </Typography>
+          </SettingsRow>
+          <SettingsRow background>
+            <InputGroup flowSpacing>
+              <InputLegend>Footer Elements</InputLegend>
+              <SettingsDescription>
+                Manage the content that will appear in the footer. The heading
+                will appear as a footer link which will open a content page.
+              </SettingsDescription>
+              <Box width="100%" mb={4}>
+                <ListManager
+                  values={formik.values.footerContent}
+                  onChange={(newOptions) => {
+                    formik.setFieldValue("footerContent", newOptions);
+                  }}
+                  newValue={() =>
+                    ({
+                      heading: "",
+                      content: "",
+                      show: true,
+                    }) as TextContent
+                  }
+                  Editor={ContentEditor}
+                />
+              </Box>
+            </InputGroup>
+            <Button type="submit" variant="contained" color="primary">
+              Save
+            </Button>
+          </SettingsRow>
+        </form>
+      </Container>
+      <Snackbar
+        open={isAlertOpen}
+        autoHideDuration={6000}
+        onClose={handleClose}
+      >
+        <Alert onClose={handleClose} severity="success" sx={{ width: "100%" }}>
+          Footer settings updated successfully
+        </Alert>
+      </Snackbar>
+    </Dashboard>
   );
 }
 

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -47,11 +47,11 @@ const teamSettingsRoutes = compose(
                 route: "design",
                 Component: DesignSettings,
               },
-              {
-                name: "General",
-                route: "general",
-                Component: GeneralSettings,
-              },
+              // {
+              //   name: "General",
+              //   route: "general",
+              //   Component: GeneralSettings,
+              // },
             ]}
           />
         ),

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -47,11 +47,11 @@ const teamSettingsRoutes = compose(
                 route: "design",
                 Component: DesignSettings,
               },
-              /*  {
+              {
                 name: "General",
                 route: "general",
                 Component: GeneralSettings,
-              },*/
+              },
             ]}
           />
         ),

--- a/editor.planx.uk/src/ui/editor/InputLabel.tsx
+++ b/editor.planx.uk/src/ui/editor/InputLabel.tsx
@@ -1,20 +1,21 @@
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
-import React, { ReactNode } from "react";
+import React, { PropsWithChildren } from "react";
 
 const Root = styled("label")(() => ({
   display: "block",
   width: "100%",
 }));
 
-export default function InputLabel(props: {
-  label: string;
-  children: ReactNode;
-  hidden?: boolean;
-  htmlFor?: string;
-  id?: string;
-}) {
+export default function InputLabel(
+  props: PropsWithChildren<{
+    label: string;
+    hidden?: boolean;
+    htmlFor?: string;
+    id?: string;
+  }>,
+) {
   return (
     <Root htmlFor={props.htmlFor} id={props.id}>
       <Typography

--- a/editor.planx.uk/src/ui/editor/InputLabel.tsx
+++ b/editor.planx.uk/src/ui/editor/InputLabel.tsx
@@ -1,0 +1,30 @@
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
+import React, { ReactNode } from "react";
+
+const Root = styled("label")(() => ({
+  display: "block",
+  width: "100%",
+}));
+
+export default function InputLabel(props: {
+  label: string;
+  children: ReactNode;
+  hidden?: boolean;
+  htmlFor?: string;
+  id?: string;
+}) {
+  return (
+    <Root htmlFor={props.htmlFor} id={props.id}>
+      <Typography
+        sx={{ pb: 0.5 }}
+        variant="body2"
+        style={props.hidden ? visuallyHidden : undefined}
+      >
+        {props.label}
+      </Typography>
+      {props.children}
+    </Root>
+  );
+}

--- a/editor.planx.uk/src/ui/editor/InputLegend.tsx
+++ b/editor.planx.uk/src/ui/editor/InputLegend.tsx
@@ -5,6 +5,7 @@ import React, { ReactNode } from "react";
 const Legend = styled(Typography)(() => ({
   display: "block",
   width: "100%",
+  padding: 0,
 })) as typeof Typography;
 
 export default function InputLegend({ children }: { children: ReactNode }) {

--- a/editor.planx.uk/src/ui/editor/SettingsDescription.tsx
+++ b/editor.planx.uk/src/ui/editor/SettingsDescription.tsx
@@ -6,12 +6,25 @@ const Description = styled(Typography)(({ theme }) => ({
   width: "100%",
   textAlign: "left",
   color: theme.palette.text.secondary,
+  paddingBottom: theme.spacing(1),
+  paddingTop: theme.spacing(0.5),
+  "& p, & a": {
+    fontSize: "inherit",
+    margin: 0,
+  },
+  "& p + p": {
+    marginTop: "1em",
+  },
 })) as typeof Typography;
 
-export default function InputDescription({
+export default function SettingsDescription({
   children,
 }: {
   children: ReactNode;
 }) {
-  return <Description variant="body2">{children}</Description>;
+  return (
+    <Description component="div" variant="body2">
+      {children}
+    </Description>
+  );
 }

--- a/editor.planx.uk/src/ui/editor/SettingsRow.tsx
+++ b/editor.planx.uk/src/ui/editor/SettingsRow.tsx
@@ -12,9 +12,10 @@ const Root = styled(Box, {
 })<RootProps>(({ background, theme }) => ({
   display: "block",
   width: "100%",
-  padding: theme.spacing(2.5, 0),
+  marginTop: theme.spacing(2),
+  paddingBottom: theme.spacing(1),
   "&:first-of-type": {
-    paddingTop: 0,
+    marginTop: 0,
   },
   "& > * + *, & > form > * + *": {
     ...contentFlowSpacing(theme),
@@ -27,7 +28,7 @@ const Root = styled(Box, {
   }),
 }));
 
-export default function EditorRow({
+export default function SettingsRow({
   children,
   background,
 }: {

--- a/editor.planx.uk/src/ui/editor/SettingsSection.tsx
+++ b/editor.planx.uk/src/ui/editor/SettingsSection.tsx
@@ -28,7 +28,7 @@ const Root = styled(Box, {
   }),
 }));
 
-export default function SettingsRow({
+export default function SettingsSection({
   children,
   background,
 }: {


### PR DESCRIPTION
## What does this PR do?

Refactors settings pages to use a simplified and unified structure.

Summary of changes:

- Introduces dedicated `<InputLabel>` for editor
- `<EditorRow>` renamed to `<SettingsSection>` to differentiate from `<ModalSection>` as used in the graph editor
- `<InputDescription>` renamed to `<SettingsDescription>`
- Changes applied to Team settings page: https://3324.planx.pizza/barking-and-dagenham/settings/general
- Changes applied to Design page: https://3324.planx.pizza/barking-and-dagenham/settings/design
- Changes applied to Global settings page: https://3324.planx.pizza/global-settings

**To do before merging**
- [x] Hide team settings page