### PR TITLE
chore: Log full error when building digital planning application

### DIFF
--- a/api.planx.uk/modules/admin/session/digitalPlanningData.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.ts
@@ -40,9 +40,8 @@ export const getDigitalPlanningApplicationPayload = async (
     return res.send(data);
   } catch (error) {
     return next({
-      message:
-        "Failed to make Digital Planning Application payload: " +
-        (error as Error).message,
+      message: `Failed to make Digital Planning Application payload:
+        ${JSON.stringify(error as Error, null, 2)}.`,
     });
   }
 };


### PR DESCRIPTION
Currently hitting issues with an invalid payload and the API is logging out just the following - 

```json
{
"error": "Failed to make Digital Planning Application payload: Cannot read properties of undefined (reading 'data')"
}
```

Logging out the full `Error` object should give us access to `Error.stack` to help narrow this issue down.