### PR TITLE
fix: Log raw error without `JSON.stringify()`

### DIFF
--- a/api.planx.uk/modules/admin/session/digitalPlanningData.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.ts
@@ -40,8 +40,7 @@ export const getDigitalPlanningApplicationPayload = async (
     return res.send(data);
   } catch (error) {
     return next({
-      message: `Failed to make Digital Planning Application payload:
-        ${JSON.stringify(error as Error, null, 2)}.`,
+      message: `Failed to make Digital Planning Application payload: ${error}`,
     });
   }
 };


### PR DESCRIPTION
Fix for #3325 - we need to just log the full error to get the trace.