### PR TITLE
fix: Log error stack explicitly on DPA failures

### DIFF
--- a/api.planx.uk/modules/admin/session/digitalPlanningData.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.ts
@@ -40,7 +40,7 @@ export const getDigitalPlanningApplicationPayload = async (
     return res.send(data);
   } catch (error) {
     return next({
-      message: `Failed to make Digital Planning Application payload: ${error}`,
+      message: `Failed to make Digital Planning Application payload: ${error}. Stack: ${(error as Error).stack}`,
     });
   }
 };


### PR DESCRIPTION
Another crack at #3325 and #3327 🤞 