### PR TITLE
fix: Trim all form values on node creation

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/index.test.ts
+++ b/editor.planx.uk/src/@planx/components/shared/index.test.ts
@@ -1,0 +1,20 @@
+import { parseFormValues } from ".";
+
+describe("parseFormValues util", () => {
+  it("trims nested strings", () => {
+    const input = {
+      type: 100,
+      data: {
+        description: "description      ",
+        fn: "my.data.field      ",
+        img: "",
+        text: "Question      ",
+      },
+    };
+    const output = parseFormValues(Object.entries(input));
+
+    expect(output.data.fn).toEqual("my.data.field");
+    expect(output.data.text).toEqual("Question");
+    expect(output.data.description).toEqual("description");
+  })
+});

--- a/editor.planx.uk/src/@planx/components/shared/index.ts
+++ b/editor.planx.uk/src/@planx/components/shared/index.ts
@@ -44,6 +44,9 @@ export const parseFormValues = (ob: any, defaultValues = {}) =>
         .map((o) => parseFormValues(Object.entries(o)))
         // don't store options with no values
         .filter((o) => Object.keys(o).length > 0);
+    } else if (v && typeof v === "object") {
+      // if it's a nested object
+      acc[k] = parseFormValues(Object.entries(v));
     } else {
       // it's a number or boolean etc
       acc[k] = v;

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -10,7 +10,6 @@ import { styled } from "@mui/material/styles";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { parseFormValues } from "@planx/components/shared";
 import ErrorFallback from "components/ErrorFallback";
-import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useNavigation } from "react-navi";


### PR DESCRIPTION
Raised as an issue here - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1719495568931289 (OSL Slack)

Currently, this works on node update via `sanitize()` within the `_update()` function which handled operations. `sanitise()` is not set up in quite the same way for add node, so I'm handling this at the `parseFormData()` level.