### PR TITLE
feat: Remove 'unique' property from List schema (`QuestionField`)

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
@@ -152,18 +152,6 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
   const { formik, activeIndex } = useListContext();
   const { id, data } = props;
 
-  const isDisabled = (option: Option) => {
-    if (!props.unique) return false;
-
-    const existingValues = formik.values.userData
-      .map((response) => response[data.fn])
-      .filter(
-        (value) => value === option.data.val || value === option.data.text,
-      );
-
-    return existingValues.includes(option.data.val || option.data.text);
-  };
-
   return (
     <InputLabel
       label={data.title}
@@ -186,7 +174,6 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
             <MenuItem
               key={option.id}
               value={option.data.val || option.data.text}
-              disabled={isDisabled(option)}
             >
               {option.data.text}
             </MenuItem>

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -383,7 +383,6 @@ describe("Form validation and error handling", () => {
   test.todo("text fields use existing validation schemas");
   test.todo("number fields use existing validation schemas");
   test.todo("question fields use validation schema");
-  test.todo("unique constraints are enforced on question where this is set");
   test.todo("an error displays if the minimum number of items is not met");
   test.todo("an error displays if the maximum number of items is exceeded");
   test.todo(

--- a/editor.planx.uk/src/@planx/components/List/model.ts
+++ b/editor.planx.uk/src/@planx/components/List/model.ts
@@ -40,7 +40,6 @@ export type NumberField = {
 
 export type QuestionField = {
   type: "question";
-  unique?: boolean;
   data: QuestionInput & { fn: string };
 };
 


### PR DESCRIPTION
## What does this PR do?
 - Removes the `QuestionField["unique"]` property
 - Please see https://github.com/theopensystemslab/planx-new/pull/3222 for further context

## Why this change?
 - It's not currently used or necessary for existing schemas
 - There's likely better ways of handling this (e.g. pre-populating forms, not putting the onus on the user to manage this)
 - It's only being enforced via the UI, and not in the schema currently