### PR TITLE
fix: Make `val` optional in SetValue component

### DIFF
--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -106,18 +106,20 @@ function SetValueComponent(props: Props) {
             />
           </InputRow>
         </ModalSectionContent>
-        <ModalSectionContent title="Field value">
-          <InputRow>
-            <Input
-              required
-              format="data"
-              name="val"
-              value={formik.values.val}
-              placeholder="value"
-              onChange={formik.handleChange}
-            />
-          </InputRow>
-        </ModalSectionContent>
+        {formik.values.operation !== "removeAll" &&
+          <ModalSectionContent title="Field value">
+            <InputRow>
+              <Input
+                required
+                format="data"
+                name="val"
+                value={formik.values.val}
+                placeholder="value"
+                onChange={formik.handleChange}
+              />
+            </InputRow>
+          </ModalSectionContent>
+        }
         <ModalSectionContent title="Operation">
           <DescriptionText {...formik.values} />
           <FormControl component="fieldset">

--- a/editor.planx.uk/src/@planx/components/SetValue/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/model.ts
@@ -1,10 +1,20 @@
 import { MoreInformation, parseMoreInformation } from "../shared";
 
-export interface SetValue extends MoreInformation {
+export interface BaseSetValue extends MoreInformation {
   fn: string;
-  val: string;
-  operation: "replace" | "append" | "removeOne" | "removeAll";
 }
+
+interface SetValueWithVal extends BaseSetValue {
+  val: string;
+  operation: "replace" | "append" | "removeOne";
+}
+
+interface SetValueWithoutVal extends BaseSetValue {
+  val?: string;
+  operation: "removeAll";
+}
+
+export type SetValue = SetValueWithVal | SetValueWithoutVal;
 
 export const parseSetValue = (
   data: Record<string, any> | undefined,

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.ts
@@ -15,7 +15,7 @@ type HandleSetValue = (params: {
  * Called by computePassport()
  */
 export const handleSetValue: HandleSetValue = ({
-  nodeData: { operation, fn, val: current },
+  nodeData,
   previousValues,
   passport,
 }) => {
@@ -31,31 +31,28 @@ export const handleSetValue: HandleSetValue = ({
   const previous = formatPreviousValues(previousValues);
 
   const newValues = calculateNewValues({
-    operation,
+    nodeData,
     previous,
-    current,
   });
 
   if (newValues) {
-    passport.data![fn] = newValues;
+    passport.data![nodeData.fn] = newValues;
 
     // Operation has cleared passport value
-    if (!newValues.length) delete passport.data![fn];
+    if (!newValues.length) delete passport.data![nodeData.fn];
   }
 
   return passport;
 };
 
 type CalculateNewValues = (params: {
-  operation: SetValue["operation"];
+  nodeData: SetValue;
   previous: string[];
-  current: string;
 }) => string | string[] | undefined;
 
 const calculateNewValues: CalculateNewValues = ({
-  operation,
+  nodeData: { operation, val: current },
   previous,
-  current,
 }) => {
   switch (operation) {
     case "replace":


### PR DESCRIPTION
## What does this PR do?
 - Makes `val` an optional field in the SetValue component if the operation is `removeAll`
 - Updates types
 - Conditionally hides form field

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/87595ef2-57a2-4a11-8dba-25e499759373)
