### PR TITLE
chore: Add `packageManager` field to all `package.json` files

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -2,6 +2,7 @@
   "name": "api.planx.uk",
   "license": "MPL-2.0",
   "private": true,
+  "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@airbrake/node": "^2.1.8",
     "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b975cf9",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,6 +20,7 @@
       "prettier -w ./tests"
     ]
   },
+  "packageManager": "pnpm@8.6.6",
   "devDependencies": {
     "@types/node": "18.16.1",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -4,6 +4,7 @@
     "test": "cucumber-js --tags 'not @regression'",
     "test:regression": "cucumber-js"
   },
+  "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
     "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b975cf9",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -19,6 +19,7 @@
     "serve": "^14.2.1",
     "uuid": "^9.0.1"
   },
+  "packageManager": "pnpm@8.6.6",
   "devDependencies": {
     "@playwright/test": "^1.40.1",
     "@types/node": "18.16.1",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -158,6 +158,7 @@
     "typescript": "^5.4.3",
     "webpack": "^5.91.0"
   },
+  "packageManager": "pnpm@8.6.6",
   "scripts": {
     "start": "craco start",
     "build": "CI=false && craco build",

--- a/hasura.planx.uk/package.json
+++ b/hasura.planx.uk/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "hasura console --envfile ./../.env"
   },
+  "packageManager": "pnpm@8.6.6",
   "pnpm": {
     "overrides": {
       "follow-redirects@<=1.15.5": ">=1.15.6"

--- a/infrastructure/application/package.json
+++ b/infrastructure/application/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build-editor": "cd ../../editor.planx.uk && pnpm build"
   },
+  "packageManager": "pnpm@8.6.6",
   "pnpm": {
     "overrides": {
       "protobufjs@>=7.0.0 <7.2.5": ">=7.2.5",

--- a/infrastructure/certificates/package.json
+++ b/infrastructure/certificates/package.json
@@ -10,6 +10,7 @@
     "@pulumi/pulumi": "^3.0.0",
     "tldjs": "^2.3.1"
   },
+  "packageManager": "pnpm@8.6.6",
   "pnpm": {
     "overrides": {
       "protobufjs": ">=7.2.4",

--- a/infrastructure/data/package.json
+++ b/infrastructure/data/package.json
@@ -7,6 +7,7 @@
     "@pulumi/awsx": "^0.30.0",
     "@pulumi/pulumi": "^3.74.0"
   },
+  "packageManager": "pnpm@8.6.6",
   "pnpm": {
     "overrides": {
       "protobufjs@>=7.0.0 <7.2.5": ">=7.2.5",

--- a/infrastructure/networking/package.json
+++ b/infrastructure/networking/package.json
@@ -7,6 +7,7 @@
     "@pulumi/awsx": "^0.30.0",
     "@pulumi/pulumi": "^3.74.0"
   },
+  "packageManager": "pnpm@8.6.6",
   "pnpm": {
     "overrides": {
       "protobufjs@>=7.0.0 <7.2.5": ">=7.2.5",

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -7,6 +7,7 @@
     "encrypt": "ts-node encrypt.ts",
     "decrypt": "ts-node decrypt.ts"
   },
+  "packageManager": "pnpm@8.6.6",
   "keywords": [],
   "dependencies": {
     "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#722e1c7",

--- a/sharedb.planx.uk/package.json
+++ b/sharedb.planx.uk/package.json
@@ -15,6 +15,7 @@
     "dev": "node-dev server.js",
     "start": "node server.js"
   },
+  "packageManager": "pnpm@8.6.6",
   "devDependencies": {
     "node-dev": "^8.0.0"
   },


### PR DESCRIPTION
## What's the problem?
 - Dependabot updates are not using the correct pnpm version following the release of pnpm v9, and associated GitHub action updates
 - This means that the incorrect lockfile versions are used (v9 instead of v6)
   - See example here - https://github.com/theopensystemslab/planx-new/pull/3357 (screenshot below)

## What's the solution?
- Add `"packageManager"` field to all `package.json` files
- Please see https://github.com/dependabot/dependabot-core/issues/9684
- We could (should?) also take a look at jumping to pnpm v9 sometime soon
 
![image](https://github.com/theopensystemslab/planx-new/assets/20502206/0e5f9ea6-68c1-4b34-99ed-22778a01214d)
