### PR TITLE
feat: Fetch `team_settings` data for Editor forms and adding Update fn

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -33,6 +33,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
     <SettingsForm
       formik={formik}
       legend="Boundary"
+      isErrors={false}
       description={
         <>
           <p>
@@ -53,16 +54,21 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
         </>
       }
       input={
-        <InputLabel label="Boundary URL" htmlFor="boundaryUrl">
-          <Input
-            name="boundary"
-            value={formik.values.boundaryUrl}
-            onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-              formik.setFieldValue("boundaryUrl", ev.target.value);
-            }}
-            id="boundaryUrl"
-          />
-        </InputLabel>
+        <ErrorWrapper
+          error={Object.values(formik.errors).join(", ")}
+          id="settings-error"
+        >
+          <InputLabel label="Boundary URL" htmlFor="boundaryUrl">
+            <Input
+              name="boundary"
+              value={formik.values.boundaryUrl}
+              onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+                formik.setFieldValue("boundaryUrl", ev.target.value);
+              }}
+              id="boundaryUrl"
+            />
+          </InputLabel>
+        </ErrorWrapper>
       }
     />
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -1,4 +1,5 @@
 import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
@@ -9,9 +10,14 @@ import { FormProps } from ".";
 export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   const formik = useFormik({
     ...formikConfig,
-    onSubmit(values, { resetForm }) {
-      onSuccess();
-      resetForm({ values });
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await useStore.getState().updateTeamSettings({
+        boundaryUrl: values.boundaryUrl,
+      });
+      if (isSuccess) {
+        onSuccess();
+        resetForm({ values });
+      }
     },
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -2,22 +2,14 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
-import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
-import * as Yup from "yup";
 
 import { SettingsForm } from "../shared/SettingsForm";
 import { FormProps } from ".";
 
 export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
-  const formSchema = Yup.object().shape({
-    boundaryUrl: Yup.string()
-      .url("URL's must look like the example given above")
-      .required("Enter a boundary URL"),
-  });
   const formik = useFormik({
     ...formikConfig,
-    validationSchema: formSchema,
     onSubmit: async (values, { resetForm }) => {
       const isSuccess = await useStore.getState().updateTeamSettings({
         boundaryUrl: values.boundaryUrl,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -2,14 +2,22 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
+import * as Yup from "yup";
 
 import { SettingsForm } from "../shared/SettingsForm";
 import { FormProps } from ".";
 
 export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
+  const formSchema = Yup.object().shape({
+    boundaryUrl: Yup.string()
+      .url("URL's must look like the example given above")
+      .required("Enter a boundary URL"),
+  });
   const formik = useFormik({
     ...formikConfig,
+    validationSchema: formSchema,
     onSubmit: async (values, { resetForm }) => {
       const isSuccess = await useStore.getState().updateTeamSettings({
         boundaryUrl: values.boundaryUrl,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -25,7 +25,6 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
     <SettingsForm
       formik={formik}
       legend="Boundary"
-      isErrors={false}
       description={
         <>
           <p>
@@ -46,21 +45,16 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
         </>
       }
       input={
-        <ErrorWrapper
-          error={Object.values(formik.errors).join(", ")}
-          id="settings-error"
-        >
-          <InputLabel label="Boundary URL" htmlFor="boundaryUrl">
-            <Input
-              name="boundary"
-              value={formik.values.boundaryUrl}
-              onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-                formik.setFieldValue("boundaryUrl", ev.target.value);
-              }}
-              id="boundaryUrl"
-            />
-          </InputLabel>
-        </ErrorWrapper>
+        <InputLabel label="Boundary URL" htmlFor="boundaryUrl">
+          <Input
+            name="boundary"
+            value={formik.values.boundaryUrl}
+            onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+              formik.setFieldValue("boundaryUrl", ev.target.value);
+            }}
+            id="boundaryUrl"
+          />
+        </InputLabel>
       }
     />
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -55,12 +55,14 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
               onChange={(event) => {
                 onChangeFn("homepage", event);
               }}
+              value={formik.values.homepage}
               id="homepageUrl"
             />
           </InputLabel>
           <InputLabel label="Contact email address" htmlFor="helpEmail">
             <Input
               name="helpEmail"
+              value={formik.values.helpEmail}
               onChange={(event) => {
                 onChangeFn("helpEmail", event);
               }}
@@ -70,6 +72,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
           <InputLabel label="Phone number" htmlFor="helpPhone">
             <Input
               name="helpPhone"
+              value={formik.values.helpPhone}
               onChange={(event) => {
                 onChangeFn("helpPhone", event);
               }}
@@ -80,6 +83,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
             <Input
               multiline
               name="helpOpeningHours"
+              value={formik.values.helpOpeningHours}
               onChange={(event) => {
                 onChangeFn("helpOpeningHours", event);
               }}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
@@ -20,9 +21,16 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
   const formik = useFormik({
     ...formikConfig,
     validationSchema: formSchema,
-    onSubmit(values, { resetForm }) {
-      onSuccess();
-      resetForm({ values });
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await useStore.getState().updateTeamSettings({
+        helpEmail: values.helpEmail,
+        helpOpeningHours: values.helpOpeningHours,
+        helpPhone: values.helpPhone,
+      });
+      if (isSuccess) {
+        onSuccess();
+        resetForm({ values });
+      }
     },
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -41,8 +41,6 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
   const onChangeFn = (type: string, event: ChangeEvent<HTMLInputElement>) =>
     formik.setFieldValue(type, event.target.value);
 
-  console.log(formik.errors);
-
   return (
     <SettingsForm
       legend="Contact Information"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -26,6 +26,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
         helpEmail: values.helpEmail,
         helpOpeningHours: values.helpOpeningHours,
         helpPhone: values.helpPhone,
+        homepage: values.homepage,
       });
       if (isSuccess) {
         onSuccess();

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -2,7 +2,6 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
-import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
 import * as Yup from "yup";
 
@@ -45,7 +44,6 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
     <SettingsForm
       legend="Contact Information"
       formik={formik}
-      isErrors={false}
       description={
         <>
           Details to help direct different messages, feedback, and enquiries
@@ -54,21 +52,16 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
       }
       input={
         <>
-          <ErrorWrapper
-            error={formik.errors.homepage || undefined}
-            id="settings-error"
-          >
-            <InputLabel label="Homepage URL" htmlFor="homepage">
-              <Input
-                name="homepage"
-                onChange={(event) => {
-                  onChangeFn("homepage", event);
-                }}
-                value={formik.values.homepage}
-                id="homepage"
-              />
-            </InputLabel>
-          </ErrorWrapper>
+          <InputLabel label="Homepage URL" htmlFor="homepage">
+            <Input
+              name="homepage"
+              onChange={(event) => {
+                onChangeFn("homepage", event);
+              }}
+              value={formik.values.homepage}
+              id="homepage"
+            />
+          </InputLabel>
           <InputLabel label="Contact email address" htmlFor="helpEmail">
             <Input
               name="helpEmail"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -2,6 +2,7 @@ import { useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
 import * as Yup from "yup";
 
@@ -14,8 +15,10 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
       .email("Please enter valid email")
       .required("Help Email is required"),
     helpPhone: Yup.string().required("Help Phone is required"),
-    helpOpeningHours: Yup.string(),
-    homepage: Yup.string().url("Please enter a valid URL for the homepage"),
+    helpOpeningHours: Yup.string().required(),
+    homepage: Yup.string()
+      .url("Please enter a valid URL for the homepage")
+      .required("Enter a homepage"),
   });
 
   const formik = useFormik({
@@ -38,10 +41,13 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
   const onChangeFn = (type: string, event: ChangeEvent<HTMLInputElement>) =>
     formik.setFieldValue(type, event.target.value);
 
+  console.log(formik.errors);
+
   return (
     <SettingsForm
       legend="Contact Information"
       formik={formik}
+      isErrors={false}
       description={
         <>
           Details to help direct different messages, feedback, and enquiries
@@ -50,16 +56,21 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
       }
       input={
         <>
-          <InputLabel label="Homepage URL" htmlFor="homepageUrl">
-            <Input
-              name="homepage"
-              onChange={(event) => {
-                onChangeFn("homepage", event);
-              }}
-              value={formik.values.homepage}
-              id="homepageUrl"
-            />
-          </InputLabel>
+          <ErrorWrapper
+            error={formik.errors.homepage || undefined}
+            id="settings-error"
+          >
+            <InputLabel label="Homepage URL" htmlFor="homepage">
+              <Input
+                name="homepage"
+                onChange={(event) => {
+                  onChangeFn("homepage", event);
+                }}
+                value={formik.values.homepage}
+                id="homepage"
+              />
+            </InputLabel>
+          </ErrorWrapper>
           <InputLabel label="Contact email address" htmlFor="helpEmail">
             <Input
               name="helpEmail"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -2,44 +2,33 @@ import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
+import { TeamSettings } from "@opensystemslab/planx-core/types";
 import { FormikConfig } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import SettingsSection from "ui/editor/SettingsSection";
 
 import BoundaryForm from "./BoundaryForm";
 import ContactForm from "./ContactForm";
 
-export interface GeneralSettings {
-  boundaryUrl: string;
-  helpEmail: string;
-  helpPhone: string;
-  helpOpeningHours: string;
-  homepage: string;
-}
-
 export interface FormProps {
-  formikConfig: FormikConfig<GeneralSettings>;
+  formikConfig: FormikConfig<TeamSettings>;
   onSuccess: () => void;
 }
 
 const GeneralSettings: React.FC = () => {
   const [formikConfig, setFormikConfig] = useState<
-    FormikConfig<GeneralSettings> | undefined
+    FormikConfig<TeamSettings> | undefined
   >(undefined);
-
-  const initialValues = {
-    boundaryUrl: "",
-    helpEmail: "",
-    helpPhone: "",
-    helpOpeningHours: "",
-    homepage: "",
-  };
 
   useEffect(() => {
     const fetchTeam = async () => {
       try {
+        const fetchedTeam = await useStore.getState().fetchCurrentTeam();
+        if (!fetchedTeam) throw Error("Unable to find team");
+
         setFormikConfig({
-          initialValues: initialValues,
+          initialValues: fetchedTeam.teamSettings,
           onSubmit: () => {},
           validateOnBlur: false,
           validateOnChange: false,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -15,7 +15,6 @@ type SettingsFormProps<TFormikValues> = {
   input: React.ReactElement;
   formik: FormikProps<TFormikValues>;
   preview?: React.ReactElement;
-  isErrors?: boolean;
 };
 
 export const SettingsForm = <TFormikValues,>({
@@ -24,10 +23,7 @@ export const SettingsForm = <TFormikValues,>({
   description,
   input,
   preview,
-  isErrors,
 }: SettingsFormProps<TFormikValues>) => {
-  // By default, errors is set to true
-  isErrors === undefined ? (isErrors = true) : false;
   return (
     <SettingsSection background>
       <form onSubmit={formik.handleSubmit}>
@@ -44,32 +40,11 @@ export const SettingsForm = <TFormikValues,>({
             {preview}
           </Box>
         )}
-        {isErrors ? (
-          <ErrorWrapper
-            error={Object.values(formik.errors).join(", ")}
-            id="settings-error"
-          >
-            <Box>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!formik.dirty}
-              >
-                Save
-              </Button>
-              <Button
-                onClick={() => formik.resetForm()}
-                type="reset"
-                variant="contained"
-                disabled={!formik.dirty}
-                color="secondary"
-                sx={{ ml: 1.5 }}
-              >
-                Reset changes
-              </Button>
-            </Box>
-          </ErrorWrapper>
-        ) : (
+
+        <ErrorWrapper
+          error={Object.values(formik.errors).join(", ")}
+          id="settings-error"
+        >
           <Box>
             <Button type="submit" variant="contained" disabled={!formik.dirty}>
               Save
@@ -85,7 +60,7 @@ export const SettingsForm = <TFormikValues,>({
               Reset changes
             </Button>
           </Box>
-        )}
+        </ErrorWrapper>
       </form>
     </SettingsSection>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -15,6 +15,7 @@ type SettingsFormProps<TFormikValues> = {
   input: React.ReactElement;
   formik: FormikProps<TFormikValues>;
   preview?: React.ReactElement;
+  isErrors?: boolean;
 };
 
 export const SettingsForm = <TFormikValues,>({
@@ -23,7 +24,10 @@ export const SettingsForm = <TFormikValues,>({
   description,
   input,
   preview,
+  isErrors,
 }: SettingsFormProps<TFormikValues>) => {
+  // By default, errors is set to true
+  isErrors === undefined ? (isErrors = true) : false;
   return (
     <SettingsSection background>
       <form onSubmit={formik.handleSubmit}>
@@ -40,10 +44,32 @@ export const SettingsForm = <TFormikValues,>({
             {preview}
           </Box>
         )}
-        <ErrorWrapper
-          error={Object.values(formik.errors).join(", ")}
-          id="settings-error"
-        >
+        {isErrors ? (
+          <ErrorWrapper
+            error={Object.values(formik.errors).join(", ")}
+            id="settings-error"
+          >
+            <Box>
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={!formik.dirty}
+              >
+                Save
+              </Button>
+              <Button
+                onClick={() => formik.resetForm()}
+                type="reset"
+                variant="contained"
+                disabled={!formik.dirty}
+                color="secondary"
+                sx={{ ml: 1.5 }}
+              >
+                Reset changes
+              </Button>
+            </Box>
+          </ErrorWrapper>
+        ) : (
           <Box>
             <Button type="submit" variant="contained" disabled={!formik.dirty}>
               Save
@@ -59,7 +85,7 @@ export const SettingsForm = <TFormikValues,>({
               Reset changes
             </Button>
           </Box>
-        </ErrorWrapper>
+        )}
       </form>
     </SettingsSection>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -25,6 +25,7 @@ export interface TeamStore {
   clearTeamStore: () => void;
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
+  updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
 }
 
 export const teamStore: StateCreator<
@@ -126,6 +127,15 @@ export const teamStore: StateCreator<
   updateTeamTheme: async (theme: Partial<TeamTheme>) => {
     const { teamId, $client } = get();
     const isSuccess = await $client.team.updateTheme(teamId, theme);
+    return isSuccess;
+  },
+
+  updateTeamSettings: async (teamSettings: Partial<TeamSettings>) => {
+    const { teamId, $client } = get();
+    const isSuccess = await $client.team.updateTeamSettings(
+      teamId,
+      teamSettings,
+    );
     return isSuccess;
   },
 });

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -47,11 +47,11 @@ const teamSettingsRoutes = compose(
                 route: "design",
                 Component: DesignSettings,
               },
-              // {
-              //   name: "General",
-              //   route: "general",
-              //   Component: GeneralSettings,
-              // },
+              {
+                name: "General",
+                route: "general",
+                Component: GeneralSettings,
+              },
             ]}
           />
         ),

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -38,6 +38,11 @@ const teamSettingsRoutes = compose(
             currentTab={req.params.tab}
             tabs={[
               {
+                name: "General",
+                route: "general",
+                Component: GeneralSettings,
+              },
+              {
                 name: "Team",
                 route: "team",
                 Component: TeamSettings,
@@ -46,11 +51,6 @@ const teamSettingsRoutes = compose(
                 name: "Design",
                 route: "design",
                 Component: DesignSettings,
-              },
-              {
-                name: "General",
-                route: "general",
-                Component: GeneralSettings,
               },
             ]}
           />


### PR DESCRIPTION
## What does this PR do?

_This is a cleaner branch from the work undertaken on this previous branch: #3319_ 

Continuing work on the ``team_settings`` implementation, this PR pulls in data from the database with a graphQL query and populates the corresponding form inputs.

This PR also uses the update mutation, similar to `team_themes` to update the form fields and database. 

This PR aligns with a planx-core change where the requests and types for a Team were altered to incorporate the new ``team_settings`` table.

[Reference to the planx-core changes](https://github.com/theopensystemslab/planx-core/pull/424)

> Important to note that this PR has not deleted any functions, methods, or types related to previous versions of `notifyPersonalisation` or the original ``settings`` column of _"teams"_ table. Thinking is to do this clear out after changes have been made and tested using the new ``team_settings`` table