### PR TITLE
feat: `team_settings` form error validation

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
@@ -61,6 +61,7 @@ export const ButtonForm: React.FC<FormProps> = ({
               color={formik.values.actionColour}
               onChange={(color) => formik.setFieldValue("actionColour", color)}
               label="Button colour"
+              errorMessage={formik.errors.actionColour}
             />
           </InputRowItem>
         </InputRow>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
@@ -70,6 +70,7 @@ export const TextLinkForm: React.FC<FormProps> = ({
               color={formik.values.linkColour}
               onChange={(color) => formik.setFieldValue("linkColour", color)}
               label="Text link colour"
+              errorMessage={formik.errors.linkColour}
             />
           </InputRowItem>
         </InputRow>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
@@ -86,6 +86,7 @@ export const ThemeAndLogoForm: React.FC<FormProps> = ({
                   formik.setFieldValue("primaryColour", color)
                 }
                 label="Theme colour"
+                errorMessage={formik.errors.primaryColour}
               />
             </InputRowItem>
           </InputRow>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -11,7 +11,9 @@ import { FormProps } from ".";
 export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   const formSchema = Yup.object().shape({
     boundaryUrl: Yup.string()
-      .url("The URL should be in the form shown above")
+      .url(
+        "Enter a boundary URL in the correct format, https://www.planning.data.gov.uk/",
+      )
       .required("Enter a boundary URL"),
   });
 
@@ -57,6 +59,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
           <Input
             name="boundary"
             value={formik.values.boundaryUrl}
+            errorMessage={formik.errors.boundaryUrl}
             onChange={(ev: ChangeEvent<HTMLInputElement>) => {
               formik.setFieldValue("boundaryUrl", ev.target.value);
             }}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -3,13 +3,21 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input";
+import * as Yup from "yup";
 
 import { SettingsForm } from "../shared/SettingsForm";
 import { FormProps } from ".";
 
 export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
+  const formSchema = Yup.object().shape({
+    boundaryUrl: Yup.string()
+      .url("The URL should be in the form shown above")
+      .required("Enter a boundary URL"),
+  });
+
   const formik = useFormik({
     ...formikConfig,
+    validationSchema: formSchema,
     onSubmit: async (values, { resetForm }) => {
       const isSuccess = await useStore.getState().updateTeamSettings({
         boundaryUrl: values.boundaryUrl,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -11,12 +11,16 @@ import { FormProps } from ".";
 export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
   const formSchema = Yup.object().shape({
     helpEmail: Yup.string()
-      .email("Enter a valid email address")
+      .email(
+        "Enter an email address in the correct format, like example@email.com",
+      )
       .required("Enter a help email address"),
     helpPhone: Yup.string().required("Enter a help phone number"),
     helpOpeningHours: Yup.string().required("Enter your opening hours"),
     homepage: Yup.string()
-      .url("Enter a valid URL")
+      .url(
+        "Enter a homepage URL in the correct format, like https://www.localauthority.gov.uk/",
+      )
       .required("Enter a homepage"),
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -14,7 +14,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
       .email("Enter a valid email address")
       .required("Enter a help email address"),
     helpPhone: Yup.string().required("Enter a help phone number"),
-    helpOpeningHours: Yup.string().required(),
+    helpOpeningHours: Yup.string().required("Enter your opening hours"),
     homepage: Yup.string()
       .url("Enter a valid URL")
       .required("Enter a homepage"),
@@ -59,6 +59,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
                 onChangeFn("homepage", event);
               }}
               value={formik.values.homepage}
+              errorMessage={formik.errors.homepage}
               id="homepage"
             />
           </InputLabel>
@@ -66,6 +67,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
             <Input
               name="helpEmail"
               value={formik.values.helpEmail}
+              errorMessage={formik.errors.helpEmail}
               onChange={(event) => {
                 onChangeFn("helpEmail", event);
               }}
@@ -76,6 +78,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
             <Input
               name="helpPhone"
               value={formik.values.helpPhone}
+              errorMessage={formik.errors.helpPhone}
               onChange={(event) => {
                 onChangeFn("helpPhone", event);
               }}
@@ -87,6 +90,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
               multiline
               name="helpOpeningHours"
               value={formik.values.helpOpeningHours}
+              errorMessage={formik.errors.helpOpeningHours}
               onChange={(event) => {
                 onChangeFn("helpOpeningHours", event);
               }}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -11,12 +11,12 @@ import { FormProps } from ".";
 export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
   const formSchema = Yup.object().shape({
     helpEmail: Yup.string()
-      .email("Please enter valid email")
-      .required("Help Email is required"),
-    helpPhone: Yup.string().required("Help Phone is required"),
+      .email("Enter a valid email address")
+      .required("Enter a help email address"),
+    helpPhone: Yup.string().required("Enter a help phone number"),
     helpOpeningHours: Yup.string().required(),
     homepage: Yup.string()
-      .url("Please enter a valid URL for the homepage")
+      .url("Enter a valid URL")
       .required("Enter a homepage"),
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -40,27 +40,6 @@ export const SettingsForm = <TFormikValues,>({
             {preview}
           </Box>
         )}
-
-        <ErrorWrapper
-          error={Object.values(formik.errors).join(", ")}
-          id="settings-error"
-        >
-          <Box>
-            <Button type="submit" variant="contained" disabled={!formik.dirty}>
-              Save
-            </Button>
-            <Button
-              onClick={() => formik.resetForm()}
-              type="reset"
-              variant="contained"
-              disabled={!formik.dirty}
-              color="secondary"
-              sx={{ ml: 1.5 }}
-            >
-              Reset changes
-            </Button>
-          </Box>
-        </ErrorWrapper>
       </form>
     </SettingsSection>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -40,6 +40,21 @@ export const SettingsForm = <TFormikValues,>({
             {preview}
           </Box>
         )}
+        <Box>
+          <Button type="submit" variant="contained" disabled={!formik.dirty}>
+            Save
+          </Button>
+          <Button
+            onClick={() => formik.resetForm()}
+            type="reset"
+            variant="contained"
+            disabled={!formik.dirty}
+            color="secondary"
+            sx={{ ml: 1.5 }}
+          >
+            Reset changes
+          </Button>
+        </Box>
       </form>
     </SettingsSection>
   );

--- a/editor.planx.uk/src/ui/editor/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/editor/ColorPicker.tsx
@@ -2,13 +2,16 @@ import Box, { BoxProps } from "@mui/material/Box";
 import ButtonBase, { ButtonBaseProps } from "@mui/material/ButtonBase";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { ErrorMessage } from "formik";
 import React, { useState } from "react";
 import { ChromePicker, ColorChangeHandler } from "react-color";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 export interface Props {
   label?: string;
   inline?: boolean;
   color?: string;
+  errorMessage?: string | undefined;
   onChange?: (newColor: string) => void;
 }
 
@@ -93,28 +96,30 @@ export default function ColorPicker(props: Props): FCReturn {
   };
 
   return (
-    <Root inline={props.inline}>
-      <Typography mr={2} variant="body2" component="label">
-        {props.label || "Background colour"}:{" "}
-      </Typography>
-      <StyledButtonBase show={show} onClick={handleClick} disableRipple>
-        <Swatch sx={{ backgroundColor: props.color }} className="swatch" />
-        {props.color}
-      </StyledButtonBase>
-      {show ? (
-        <Popover className="popover">
-          <Cover
-            onClick={handleClose}
-            aria-label="Close Colour Picker"
-            disableRipple
-          />
-          <ChromePicker
-            color={props.color}
-            disableAlpha={true}
-            onChange={handleChange}
-          />
-        </Popover>
-      ) : null}
-    </Root>
+    <ErrorWrapper error={props.errorMessage || undefined} id="settings-error">
+      <Root inline={props.inline}>
+        <Typography mr={2} variant="body2" component="label">
+          {props.label || "Background colour"}:{" "}
+        </Typography>
+        <StyledButtonBase show={show} onClick={handleClick} disableRipple>
+          <Swatch sx={{ backgroundColor: props.color }} className="swatch" />
+          {props.color}
+        </StyledButtonBase>
+        {show ? (
+          <Popover className="popover">
+            <Cover
+              onClick={handleClose}
+              aria-label="Close Colour Picker"
+              disableRipple
+            />
+            <ChromePicker
+              color={props.color}
+              disableAlpha={true}
+              onChange={handleChange}
+            />
+          </Popover>
+        ) : null}
+      </Root>
+    </ErrorWrapper>
   );
 }

--- a/editor.planx.uk/src/ui/editor/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/editor/ColorPicker.tsx
@@ -11,7 +11,7 @@ export interface Props {
   label?: string;
   inline?: boolean;
   color?: string;
-  errorMessage?: string | undefined;
+  errorMessage?: string;
   onChange?: (newColor: string) => void;
 }
 
@@ -96,7 +96,10 @@ export default function ColorPicker(props: Props): FCReturn {
   };
 
   return (
-    <ErrorWrapper error={props.errorMessage || undefined} id="settings-error">
+    <ErrorWrapper
+      error={props.errorMessage || undefined}
+      id="colour-picker-error"
+    >
       <Root inline={props.inline}>
         <Typography mr={2} variant="body2" component="label">
           {props.label || "Background colour"}:{" "}


### PR DESCRIPTION
# What does this PR do?

Following previous work done on `team_settings` form in the Editor: https://github.com/theopensystemslab/planx-new/pull/3366

This PR will introduce the Error Handling while making changes to shared `SettingsForm` to handle error messaging on an input level rather than form level.

The only change to an _Input Component_ will be to the ``<ColourPicker>`` which is used in the ``Theme`` settings forms. The prop ``errorMessage`` has been added to the ``<ColourPicker>`` component to enable this input level error messaging