### PR TITLE
feat: Add error handling for failed file uploads

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -42,6 +42,17 @@ const slotsSchema = array()
           !slots.some((slot) => slot.status === "uploading"),
       );
     },
+  })
+  .test({
+    name: "errorStatus",
+    message: "Remove files which failed to upload",
+    test: (slots?: Array<FileUploadSlot>) => {
+      return Boolean(
+        slots &&
+          slots.length > 0 &&
+          !slots.some((slot) => slot.status === "error"),
+      );
+    },
   });
 
 const FileUpload: React.FC<Props> = (props) => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -148,6 +148,7 @@ function Component(props: Props) {
             break;
           }
           case "allRequiredFilesUploaded":
+          case "errorStatus":
             setFileListError(err?.message);
             break;
         }
@@ -188,10 +189,6 @@ function Component(props: Props) {
   return (
     <Card
       handleSubmit={props.hideDropZone ? props.handleSubmit : validateAndSubmit}
-      isValid={
-        props.hideDropZone ||
-        slots.every((slot) => slot.url && slot.status === "success")
-      }
     >
       <FullWidthWrapper>
         <CardHeader {...props} />

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -91,10 +91,21 @@ export const slotsSchema = array()
     name: "nonUploading",
     message: "Please wait for upload to complete",
     test: (slots?: Array<FileUploadSlot>) => {
-      const isEveryUploadComplete = Boolean(
-        slots?.every((slot) => slot.status === "success"),
+      const isAnyUploadInProgress = Boolean(
+        slots?.some((slot) => slot.status === "uploading"),
       );
-      return isEveryUploadComplete;
+      return !isAnyUploadInProgress;
+    },
+  })
+  .test({
+    name: "errorStatus",
+    message: "Remove files which failed to upload",
+    test: (slots?: Array<FileUploadSlot>) => {
+      return Boolean(
+        slots &&
+          slots.length > 0 &&
+          !slots.some((slot) => slot.status === "error"),
+      );
     },
   });
 

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -11,6 +11,7 @@ import { visuallyHidden } from "@mui/utils";
 import { FileUploadSlot } from "@planx/components/FileUpload/Public";
 import ImagePreview from "components/ImagePreview";
 import React from "react";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 interface Props extends FileUploadSlot {
   removeFile: () => void;
@@ -19,12 +20,12 @@ interface Props extends FileUploadSlot {
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  border: `1px solid ${theme.palette.border.main}`,
   marginBottom: theme.spacing(0.5),
   marginTop: theme.spacing(5),
 }));
 
 const FileCard = styled(Box)(({ theme }) => ({
+  border: `1px solid ${theme.palette.border.main}`,
   position: "relative",
   height: "auto",
   display: "flex",
@@ -91,74 +92,89 @@ export const UploadedFileCard: React.FC<Props> = ({
   removeFile,
   onChange,
   tags,
+  status,
 }) => (
   <Root>
-    <FileCard>
-      <ProgressBar
-        width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
-        role="progressbar"
-        aria-valuenow={progress * 100 || 0}
-        aria-label={file.path}
-      />
-      <FilePreview>
-        {file instanceof File && file?.type?.includes("image") ? (
-          <ImagePreview file={file} url={url} />
-        ) : (
-          <FileIcon />
-        )}
-      </FilePreview>
-      <Box
-        sx={{ display: "flex", justifyContent: "space-between", width: "100%" }}
-      >
-        <Box mr={2}>
-          <Typography
-            variant="body1"
-            pb="0.25em"
-            sx={{ overflowWrap: "break-word", wordBreak: "break-all" }}
+    <ErrorWrapper
+      error={
+        status === "error"
+          ? "Upload failed, please remove file and try again"
+          : undefined
+      }
+    >
+      <>
+        <FileCard>
+          <ProgressBar
+            width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
+            role="progressbar"
+            aria-valuenow={progress * 100 || 0}
+            aria-label={file.path}
+          />
+          <FilePreview>
+            {file instanceof File && file?.type?.includes("image") ? (
+              <ImagePreview file={file} url={url} />
+            ) : (
+              <FileIcon />
+            )}
+          </FilePreview>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              width: "100%",
+            }}
           >
-            {file.path}
-          </Typography>
-          <FileSize variant="body2">{formatBytes(file.size)}</FileSize>
-        </Box>
-        {removeFile && (
-          <IconButton
-            size="small"
-            aria-label={`Delete ${file.path}`}
-            title={`Delete ${file.path}`}
-            onClick={removeFile}
-          >
-            <DeleteIcon />
-          </IconButton>
-        )}
-      </Box>
-    </FileCard>
-    {tags && (
-      <TagRoot>
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-          {tags.map((tag) => (
-            <ListItem key={tag} disablePadding sx={{ width: "auto" }}>
-              <Chip
-                label={tag}
-                variant="uploadedFileTag"
+            <Box mr={2}>
+              <Typography
+                variant="body1"
+                pb="0.25em"
+                sx={{ overflowWrap: "break-word", wordBreak: "break-all" }}
+              >
+                {file.path}
+              </Typography>
+              <FileSize variant="body2">{formatBytes(file.size)}</FileSize>
+            </Box>
+            {removeFile && (
+              <IconButton
                 size="small"
-                data-testid="uploaded-file-chip"
-              />
-            </ListItem>
-          ))}
-        </Box>
-        <Link
-          onClick={() => onChange && onChange()}
-          sx={{ fontFamily: "inherit", fontSize: "inherit" }}
-          component="button"
-          variant="body2"
-        >
-          Change
-          <Box sx={visuallyHidden} component="span">
-            the list of what file {file.path} shows
+                aria-label={`Delete ${file.path}`}
+                title={`Delete ${file.path}`}
+                onClick={removeFile}
+              >
+                <DeleteIcon />
+              </IconButton>
+            )}
           </Box>
-        </Link>
-      </TagRoot>
-    )}
+        </FileCard>
+        {tags && (
+          <TagRoot>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+              {tags.map((tag) => (
+                <ListItem key={tag} disablePadding sx={{ width: "auto" }}>
+                  <Chip
+                    label={tag}
+                    variant="uploadedFileTag"
+                    size="small"
+                    data-testid="uploaded-file-chip"
+                  />
+                </ListItem>
+              ))}
+            </Box>
+            <Link
+              onClick={() => onChange && onChange()}
+              sx={{ fontFamily: "inherit", fontSize: "inherit" }}
+              component="button"
+              variant="body2"
+            >
+              Change
+              <Box sx={visuallyHidden} component="span">
+                the list of what file {file.path} shows
+              </Box>
+            </Link>
+          </TagRoot>
+        )}
+      </>
+    </ErrorWrapper>
   </Root>
 );
 


### PR DESCRIPTION
## What does this PR do?
 - Follow up to https://github.com/theopensystemslab/planx-core/pull/434 - this PR now catches these errors client side and allows the user the opportunity to resolve them
 - Displays error if a file upload fails
 - Displays error if user tries to proceed with files with a status of `"error"`

## Future improvements
 - It could be nice to add a "retry" button on failed uploads, but this will be covering a edge case. To our knowledge, a user submitting files which have failed to upload has only happened twice.