### PR TITLE
chore: Bump `planx-core`

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ed7c187",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ed7c187
-    version: github.com/theopensystemslab/planx-core/ed7c187
+    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
+    version: github.com/theopensystemslab/planx-core/b43b268
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7777,8 +7777,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /type-fest@4.20.1:
-    resolution: {integrity: sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==}
+  /type-fest@4.21.0:
+    resolution: {integrity: sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==}
     engines: {node: '>=16'}
     dev: false
 
@@ -8203,8 +8203,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/ed7c187:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ed7c187}
+  github.com/theopensystemslab/planx-core/b43b268:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -8229,7 +8229,7 @@ packages:
       prettier: 3.3.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.20.1
+      type-fest: 4.21.0
       uuid: 10.0.0
       zod: 3.23.8
     transitivePeerDependencies:

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ed7c187",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ed7c187
-    version: github.com/theopensystemslab/planx-core/ed7c187
+    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
+    version: github.com/theopensystemslab/planx-core/b43b268
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2852,8 +2852,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /type-fest@4.20.1:
-    resolution: {integrity: sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==}
+  /type-fest@4.21.0:
+    resolution: {integrity: sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==}
     engines: {node: '>=16'}
     dev: false
 
@@ -3053,8 +3053,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/ed7c187:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ed7c187}
+  github.com/theopensystemslab/planx-core/b43b268:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -3079,7 +3079,7 @@ packages:
       prettier: 3.3.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.20.1
+      type-fest: 4.21.0
       uuid: 10.0.0
       zod: 3.23.8
     transitivePeerDependencies:

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ed7c187",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ed7c187
-    version: github.com/theopensystemslab/planx-core/ed7c187
+    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
+    version: github.com/theopensystemslab/planx-core/b43b268
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -1588,6 +1588,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -1684,6 +1685,7 @@ packages:
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -2622,8 +2624,8 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /type-fest@4.20.1:
-    resolution: {integrity: sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==}
+  /type-fest@4.21.0:
+    resolution: {integrity: sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2780,8 +2782,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/ed7c187:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ed7c187}
+  github.com/theopensystemslab/planx-core/b43b268:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2806,7 +2808,7 @@ packages:
       prettier: 3.3.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.20.1
+      type-fest: 4.21.0
       uuid: 10.0.0
       zod: 3.23.8
     transitivePeerDependencies:

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@mui/material": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ed7c187",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -42,8 +42,8 @@ dependencies:
     specifier: ^0.8.3
     version: 0.8.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ed7c187
-    version: github.com/theopensystemslab/planx-core/ed7c187(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
+    version: github.com/theopensystemslab/planx-core/b43b268(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15309,6 +15309,7 @@ packages:
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
     dependencies:
       js-tokens: 4.0.0
 
@@ -18723,6 +18724,7 @@ packages:
 
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+    hasBin: true
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
@@ -18730,6 +18732,7 @@ packages:
 
   /resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
+    hasBin: true
     dependencies:
       is-core-module: 2.13.1
       path-parse: 1.0.7
@@ -20360,6 +20363,11 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
+  /type-fest@4.21.0:
+    resolution: {integrity: sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==}
+    engines: {node: '>=16'}
+    dev: false
+
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -21523,9 +21531,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/ed7c187(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ed7c187}
-    id: github.com/theopensystemslab/planx-core/ed7c187
+  github.com/theopensystemslab/planx-core/b43b268(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
+    id: github.com/theopensystemslab/planx-core/b43b268
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -21550,7 +21558,7 @@ packages:
       prettier: 3.3.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.20.1
+      type-fest: 4.21.0
       uuid: 10.0.0
       zod: 3.23.8
     transitivePeerDependencies:


### PR DESCRIPTION
This should fix failing regression tests.

Currently running against this branch here - https://github.com/theopensystemslab/planx-new/actions/runs/9837286637

Update: Yep, this resolved it. The above regression tests are now passing ✅ 