### PR TITLE
fix: allow teamEditor to select all rows from users table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2155,9 +2155,7 @@
           - is_platform_admin
           - last_name
           - updated_at
-        filter:
-          id:
-            _eq: x-hasura-user-id
+        filter: {}
   update_permissions:
     - role: platformAdmin
       permission:


### PR DESCRIPTION
Reported via #help-issues, see thread here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1720455630197209

Reminder difficult to test this on pizzas & staging because data syncs (it correctly says "Created flow" here!) but we'll be able to fully test once on prod (by toggling platformAdmin to false and checking "History" tab)