### PR TITLE
feat: Read from new `team_settings` table

### DIFF
--- a/api.planx.uk/modules/admin/session/summary.ts
+++ b/api.planx.uk/modules/admin/session/summary.ts
@@ -2,17 +2,12 @@ import {
   GovUKPayment,
   PaymentRequest,
   Session,
+  Team,
 } from "@opensystemslab/planx-core/types";
 import { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 
-import {
-  Breadcrumb,
-  Flow,
-  LowCalSession,
-  Passport,
-  Team,
-} from "../../../types";
+import { Breadcrumb, Flow, LowCalSession, Passport } from "../../../types";
 import { $api } from "../../../client";
 
 /**

--- a/api.planx.uk/modules/flows/moveFlow/service.ts
+++ b/api.planx.uk/modules/flows/moveFlow/service.ts
@@ -1,6 +1,7 @@
 import { gql } from "graphql-request";
-import { Flow, Team } from "../../../types";
+import { Flow } from "../../../types";
 import { $public, getClient } from "../../../client";
+import { Team } from "@opensystemslab/planx-core/types";
 
 export const moveFlow = async (flowId: string, teamSlug: string) => {
   const team = await $public.team.getBySlug(teamSlug);

--- a/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from "@opensystemslab/planx-core/types";
+import { ComponentType, Team } from "@opensystemslab/planx-core/types";
 import { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 import {
@@ -7,7 +7,7 @@ import {
 } from "../../../../lib/hasura/metadata";
 import { $api, $public } from "../../../../client";
 import { getMostRecentPublishedFlow } from "../../../../helpers";
-import { Flow, Node, Team } from "../../../../types";
+import { Flow, Node } from "../../../../types";
 
 enum Destination {
   BOPS = "bops",

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -46,7 +46,12 @@ async function getDataForPayeeAndAgentEmails(
         flow {
           slug
           team {
-            notifyPersonalisation: notify_personalisation
+            notifyPersonalisation: team_settings {
+              helpEmail: help_email
+              helpPhone: help_phone
+              emailReplyToId: email_reply_to_id
+              helpOpeningHours: help_opening_hours
+            }
           }
         }
         paymentRequests: payment_requests(

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
@@ -1,4 +1,4 @@
-import { LowCalSession, Team } from "../../../types";
+import { LowCalSession } from "../../../types";
 import supertest from "supertest";
 import app from "../../../server";
 import { queryMock } from "../../../tests/graphqlQueryMock";
@@ -8,6 +8,7 @@ import {
 } from "../../../tests/mocks/saveAndReturnMocks";
 import { buildContentFromSessions } from "./resumeApplication";
 import { PartialDeep } from "type-fest";
+import { Team } from "@opensystemslab/planx-core/types";
 
 const ENDPOINT = "/resume-application";
 const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk";

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
@@ -1,9 +1,9 @@
-import type { SiteAddress } from "@opensystemslab/planx-core/types";
+import type { SiteAddress, Team } from "@opensystemslab/planx-core/types";
 import { differenceInDays } from "date-fns";
 import { gql } from "graphql-request";
 import { $api, $public } from "../../../client";
 import { sendEmail } from "../../../lib/notify";
-import { LowCalSession, Team } from "../../../types";
+import { LowCalSession } from "../../../types";
 import { DAYS_UNTIL_EXPIRY, calculateExpiryDate, getResumeLink } from "./utils";
 
 /**
@@ -17,7 +17,7 @@ const resumeApplication = async (teamSlug: string, email: string) => {
   const config = {
     personalisation: await getPersonalisation(sessions, team),
     reference: null,
-    emailReplyToId: team.notifyPersonalisation.emailReplyToId,
+    emailReplyToId: team.settings.emailReplyToId,
   };
   const response = await sendEmail("resume", email, config);
   return response;
@@ -64,7 +64,7 @@ const validateRequest = async (
         teams(where: { slug: { _eq: $teamSlug } }) {
           slug
           name
-          notifyPersonalisation: notify_personalisation
+          settings: team_settings
           domain
         }
       }
@@ -93,7 +93,10 @@ const getPersonalisation = async (sessions: LowCalSession[], team: Team) => {
   return {
     teamName: team.name,
     content: await buildContentFromSessions(sessions, team),
-    ...team.notifyPersonalisation,
+    helpEmail: team.settings.helpEmail,
+    helpPhone: team.settings.helpPhone,
+    helpOpeningHours: team.settings.helpOpeningHours,
+    emailReplyToId: team.settings.emailReplyToId,
   };
 };
 

--- a/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
@@ -1,5 +1,6 @@
+import { Team } from "@opensystemslab/planx-core/types";
 import { queryMock } from "../../../tests/graphqlQueryMock";
-import { LowCalSession, LowCalSessionData, Team } from "../../../types";
+import { LowCalSession, LowCalSessionData } from "../../../types";
 import {
   getResumeLink,
   getSessionDetails,

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -1,11 +1,7 @@
-import {
-  SiteAddress,
-  Team,
-  TeamSettings,
-} from "@opensystemslab/planx-core/types";
+import { SiteAddress, Team } from "@opensystemslab/planx-core/types";
 import { format, addDays } from "date-fns";
 import { gql } from "graphql-request";
-import { LowCalSession, NotifyConfig } from "../../../types";
+import { LowCalSession } from "../../../types";
 import { Template, getClientForTemplate, sendEmail } from "../../../lib/notify";
 import { $api, $public } from "../../../client";
 

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -1,7 +1,11 @@
-import { SiteAddress } from "@opensystemslab/planx-core/types";
+import {
+  SiteAddress,
+  Team,
+  TeamSettings,
+} from "@opensystemslab/planx-core/types";
 import { format, addDays } from "date-fns";
 import { gql } from "graphql-request";
-import { LowCalSession, Team } from "../../../types";
+import { LowCalSession, NotifyConfig } from "../../../types";
 import { Template, getClientForTemplate, sendEmail } from "../../../lib/notify";
 import { $api, $public } from "../../../client";
 
@@ -59,7 +63,7 @@ const sendSingleApplicationEmail = async ({
     const config = {
       personalisation: getPersonalisation(session, flowSlug, flowName, team),
       reference: null,
-      emailReplyToId: team.notifyPersonalisation.emailReplyToId,
+      emailReplyToId: team.settings.emailReplyToId,
     };
     const firstSave = !session.hasUserSaved;
     if (firstSave && !session.submittedAt)
@@ -97,7 +101,7 @@ const validateSingleSessionRequest = async (
             team {
               name
               slug
-              notifyPersonalisation: notify_personalisation
+              settings: team_settings
               domain
             }
           }
@@ -176,7 +180,10 @@ const getPersonalisation = (
     serviceName: flowName,
     teamName: team.name,
     sessionId: session.id,
-    ...team.notifyPersonalisation,
+    helpEmail: team.settings.helpEmail,
+    helpPhone: team.settings.helpPhone,
+    helpOpeningHours: team.settings.helpOpeningHours,
+    emailReplyToId: team.settings.emailReplyToId,
     ...session,
   };
 };

--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -50,7 +50,7 @@ describe(`sending an application by email to a planning office`, () => {
         teams: [
           {
             sendToEmail: "planning.office.example@council.gov.uk",
-            notifyPersonalisation: { emailReplyToId: "abc123" },
+            settings: { emailReplyToId: "abc123" },
           },
         ],
       },
@@ -153,7 +153,7 @@ describe(`sending an application by email to a planning office`, () => {
         teams: [
           {
             sendToEmail: null,
-            notifyPersonalisation: { emailReplyToId: "abc123" },
+            settings: { emailReplyToId: "abc123" },
           },
         ],
       },

--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -17,7 +17,12 @@ export async function getTeamEmailSettings(localAuthority: string) {
       query GetTeamEmailSettings($slug: String) {
         teams(where: { slug: { _eq: $slug } }) {
           sendToEmail: submission_email
-          notifyPersonalisation: notify_personalisation
+          notifyPersonalisation: team_settings {
+            helpEmail: help_email
+            helpPhone: help_phone
+            emailReplyToId: email_reply_to_id
+            helpOpeningHours: help_opening_hours
+          }
         }
       }
     `,

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#75127e6",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
-    version: github.com/theopensystemslab/planx-core/b43b268
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
+    version: github.com/theopensystemslab/planx-core/a7ad0ff
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8203,8 +8203,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b43b268:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
+  github.com/theopensystemslab/planx-core/a7ad0ff:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
-    version: github.com/theopensystemslab/planx-core/a7ad0ff
+    specifier: git+https://github.com/theopensystemslab/planx-core#75127e6
+    version: github.com/theopensystemslab/planx-core/75127e6
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -8203,8 +8203,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ad0ff:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
+  github.com/theopensystemslab/planx-core/75127e6:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/75127e6}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -83,7 +83,7 @@ export const validPaymentRequest = {
         name: "Buckinghamshire",
         slug: "buckinghamshire",
         domain: "planningservices.buckinghamshire.gov.uk",
-        notifyPersonalisation: {
+        settings: {
           helpEmail: "help@council.gov.uk",
           helpPhone: "123",
           helpOpeningHours: "9a-5p",

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -1,17 +1,18 @@
 import { v4 as uuidV4 } from "uuid";
 import type { LowCalSession, Flow } from "../../types";
+import { Team } from "@opensystemslab/planx-core/types";
 
 export const mockTeam = {
   id: 1,
   slug: "test-team",
   name: "Test Team",
-  notifyPersonalisation: {
+  settings: {
     helpEmail: "example@council.gov.uk",
     helpPhone: "(01234) 567890",
     helpOpeningHours: "Monday - Friday, 9am - 5pm",
     emailReplyToId: "727d48fa-cb8a-42f9-b8b2-55032f3bb451",
   },
-};
+} as Team;
 
 export const mockFlow: Flow = {
   id: "dcfd4f07-76da-4b67-9822-2aca92b27551",

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -1,5 +1,5 @@
 import { PaymentRequest } from "@opensystemslab/planx-core/dist/types";
-import { GovUKPayment } from "@opensystemslab/planx-core/types";
+import { GovUKPayment, Team } from "@opensystemslab/planx-core/types";
 
 /**
  * @deprecated Migrating to Node from planx-core
@@ -48,20 +48,6 @@ export interface UserData {
 }
 
 export type Breadcrumb = Record<string, UserData>;
-
-export interface Team {
-  id: number;
-  slug: string;
-  name: string;
-  domain?: string;
-  boundaryBBox?: object;
-  notifyPersonalisation: {
-    helpEmail: string;
-    helpPhone: string;
-    helpOpeningHours: string;
-    emailReplyToId: string;
-  };
-}
 
 export interface Passport {
   data: Record<string, any>;

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#75127e6",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
-    version: github.com/theopensystemslab/planx-core/a7ad0ff
+    specifier: git+https://github.com/theopensystemslab/planx-core#75127e6
+    version: github.com/theopensystemslab/planx-core/75127e6
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -3053,8 +3053,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ad0ff:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
+  github.com/theopensystemslab/planx-core/75127e6:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/75127e6}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
-    version: github.com/theopensystemslab/planx-core/b43b268
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
+    version: github.com/theopensystemslab/planx-core/a7ad0ff
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -3053,8 +3053,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b43b268:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
+  github.com/theopensystemslab/planx-core/a7ad0ff:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#75127e6",
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
-    version: github.com/theopensystemslab/planx-core/a7ad0ff
+    specifier: git+https://github.com/theopensystemslab/planx-core#75127e6
+    version: github.com/theopensystemslab/planx-core/75127e6
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2782,8 +2782,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ad0ff:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
+  github.com/theopensystemslab/planx-core/75127e6:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/75127e6}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
-    version: github.com/theopensystemslab/planx-core/b43b268
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
+    version: github.com/theopensystemslab/planx-core/a7ad0ff
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2782,8 +2782,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b43b268:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
+  github.com/theopensystemslab/planx-core/a7ad0ff:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@mui/material": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b43b268",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@mui/material": "^5.15.2",
     "@mui/utils": "^5.15.2",
     "@opensystemslab/map": "^0.8.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ad0ff",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#75127e6",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -43,8 +43,8 @@ dependencies:
     specifier: ^0.8.3
     version: 0.8.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b43b268
-    version: github.com/theopensystemslab/planx-core/b43b268(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
+    version: github.com/theopensystemslab/planx-core/a7ad0ff(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -6819,11 +6819,11 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-manager@8.1.10(prettier@3.0.0):
+  /@storybook/builder-manager@8.1.10(prettier@3.3.2):
     resolution: {integrity: sha512-dhg54zpaglR9XKNAiwMqm5/IONMCEG/hO/iTfNHJI1rAGeWhvM71cmhF+VlKUcjpTlIfHe7J19+TL+sWQJNgtg==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.2)
       '@storybook/manager': 8.1.10
       '@storybook/node-logger': 8.1.10
       '@types/ejs': 3.1.5
@@ -6927,12 +6927,12 @@ packages:
       '@babel/types': 7.24.7
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.10
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.2)
       '@storybook/core-events': 8.1.10
-      '@storybook/core-server': 8.1.10(prettier@3.0.0)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-server': 8.1.10(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-tools': 8.1.10
       '@storybook/node-logger': 8.1.10
-      '@storybook/telemetry': 8.1.10(prettier@3.0.0)
+      '@storybook/telemetry': 8.1.10(prettier@3.3.2)
       '@storybook/types': 8.1.10
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -7071,7 +7071,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/core-common@8.1.10(prettier@3.0.0):
+  /@storybook/core-common@8.1.10(prettier@3.3.2):
     resolution: {integrity: sha512-+0GhgDRQwUlXu1lY77NdLnVBVycCEW0DG7eu7rvLYYkTyNRxbdl2RWsQpjr/j4sxqT6u82l9/b+RWpmsl4MgMQ==}
     peerDependencies:
       prettier: ^2 || ^3
@@ -7100,8 +7100,8 @@ packages:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier: 3.0.0
-      prettier-fallback: /prettier@3.0.0
+      prettier: 3.3.2
+      prettier-fallback: /prettier@3.3.2
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.2
@@ -7133,16 +7133,16 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/core-server@8.1.10(prettier@3.0.0)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/core-server@8.1.10(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-jNL5/daNyo7Rcu+y/bOmSB1P65pmcaLwvpr31EUEIISaAqvgruaneS3GKHg2TR0wcxEoHaM4abqhW6iwkI/XYQ==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.7
       '@babel/parser': 7.24.7
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.10(prettier@3.0.0)
+      '@storybook/builder-manager': 8.1.10(prettier@3.3.2)
       '@storybook/channels': 8.1.10
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.2)
       '@storybook/core-events': 8.1.10
       '@storybook/csf': 0.1.11
       '@storybook/csf-tools': 8.1.10
@@ -7152,7 +7152,7 @@ packages:
       '@storybook/manager-api': 8.1.10(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 8.1.10
       '@storybook/preview-api': 8.1.10
-      '@storybook/telemetry': 8.1.10(prettier@3.0.0)
+      '@storybook/telemetry': 8.1.10(prettier@3.3.2)
       '@storybook/types': 8.1.10
       '@types/detect-port': 1.3.5
       '@types/diff': 5.2.1
@@ -7594,11 +7594,11 @@ packages:
       qs: 6.12.3
     dev: true
 
-  /@storybook/telemetry@8.1.10(prettier@3.0.0):
+  /@storybook/telemetry@8.1.10(prettier@3.3.2):
     resolution: {integrity: sha512-pwiMWrq85D0AnaAgYNfB2w2BDgqnetQ+tXwsUAw4fUEFwA4oPU6r0uqekRbNNE6wmSSYjiiFP3JgknBFqjd2hg==}
     dependencies:
       '@storybook/client-logger': 8.1.10
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.2)
       '@storybook/csf-tools': 8.1.10
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -7912,20 +7912,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/dom@8.20.1:
-    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/runtime': 7.24.7
-      '@types/aria-query': 5.0.4
-      aria-query: 5.1.3
-      chalk: 4.1.2
-      dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
-      pretty-format: 27.5.1
-    dev: true
-
   /@testing-library/dom@9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
@@ -7963,7 +7949,7 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
-      '@testing-library/dom': 8.20.1
+      '@testing-library/dom': 9.3.4
       '@types/react-dom': 18.2.18
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -21847,9 +21833,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/b43b268(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b43b268}
-    id: github.com/theopensystemslab/planx-core/b43b268
+  github.com/theopensystemslab/planx-core/a7ad0ff(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
+    id: github.com/theopensystemslab/planx-core/a7ad0ff
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -43,8 +43,8 @@ dependencies:
     specifier: ^0.8.3
     version: 0.8.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ad0ff
-    version: github.com/theopensystemslab/planx-core/a7ad0ff(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#75127e6
+    version: github.com/theopensystemslab/planx-core/75127e6(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -6798,7 +6798,7 @@ packages:
       '@storybook/preview-api': 7.6.7
       '@storybook/theming': 7.6.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.6.7
-      '@types/lodash': 4.14.202
+      '@types/lodash': 4.17.6
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
@@ -8556,7 +8556,6 @@ packages:
 
   /@types/lodash@4.17.6:
     resolution: {integrity: sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==}
-    dev: false
 
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -21833,9 +21832,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ad0ff(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ad0ff}
-    id: github.com/theopensystemslab/planx-core/a7ad0ff
+  github.com/theopensystemslab/planx-core/75127e6(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/75127e6}
+    id: github.com/theopensystemslab/planx-core/75127e6
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -63,7 +63,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
 
   const [environment, boundaryBBox] = useStore((state) => [
     state.previewEnvironment,
-    state.teamSettings.boundaryBbox,
+    state.teamSettings.boundaryBBox,
   ]);
 
   useEffect(() => {

--- a/editor.planx.uk/src/components/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header.test.tsx
@@ -26,7 +26,7 @@ const mockTeam1: Team = {
     linkColour: "#0010A4",
     favicon: null,
   },
-  teamSettings: {
+  settings: {
     boundaryUrl: "https://www.planning.data.gov.uk/",
     helpEmail: "example@council.co.uk",
     helpPhone: "(01234) 56789",
@@ -52,7 +52,7 @@ const mockTeam2: Team = {
     linkColour: "#0010A4",
     favicon: null,
   },
-  teamSettings: {
+  settings: {
     boundaryUrl: "https://www.planning.data.gov.uk/",
     helpEmail: "example@council.co.uk",
     helpPhone: "(01234) 56789",
@@ -74,7 +74,7 @@ describe("Header Component - Editor Route", () => {
       setState({
         previewEnvironment: "editor",
         teamName: mockTeam1.name,
-        teamSettings: mockTeam1.teamSettings,
+        teamSettings: mockTeam1.settings,
         teamTheme: mockTeam1.theme,
         teamSlug: mockTeam1.slug,
         user: {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -47,7 +47,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
 
         const isUpdateSuccess = await useStore.getState().updateTeamSettings({
           boundaryUrl: values.boundaryUrl,
-          boundaryBbox: convertToBoundingBox(data),
+          boundaryBBox: convertToBoundingBox(data),
         });
         if (isUpdateSuccess) {
           onSuccess();

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -28,7 +28,7 @@ const GeneralSettings: React.FC = () => {
         if (!fetchedTeam) throw Error("Unable to find team");
 
         setFormikConfig({
-          initialValues: fetchedTeam.teamSettings,
+          initialValues: fetchedTeam.settings,
           onSubmit: () => {},
           validateOnBlur: false,
           validateOnChange: false,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -45,7 +45,7 @@ export const teamStore: StateCreator<
       teamId: team.id,
       teamIntegrations: team.integrations,
       teamName: team.name,
-      teamSettings: team.teamSettings,
+      teamSettings: team.settings,
       teamSlug: team.slug,
       teamTheme: team.theme,
     });
@@ -60,7 +60,7 @@ export const teamStore: StateCreator<
     id: get().teamId,
     integrations: get().teamIntegrations,
     name: get().teamName,
-    teamSettings: get().teamSettings,
+    settings: get().teamSettings,
     slug: get().teamSlug,
     theme: get().teamTheme,
   }),

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -26,7 +26,9 @@ const FormInner = styled(Box)(({ theme }) => ({
 const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
   const theme = useTheme();
   const expiryDate = getExpiryDateForPaymentRequest(createdAt);
-  const team = useStore((state) => state.getTeam());
+  const { helpEmail, helpOpeningHours, helpPhone } = useStore(
+    (state) => state.teamSettings,
+  );
 
   return (
     <>
@@ -70,18 +72,14 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
           </List>
           <Box>
             <Typography variant="body2">
-              <strong>Telephone</strong> {team.notifyPersonalisation?.helpPhone}
+              <strong>Telephone</strong> {helpPhone}
             </Typography>
-            <Typography variant="body2">
-              {team.notifyPersonalisation?.helpOpeningHours}
-            </Typography>
+            <Typography variant="body2">{helpOpeningHours}</Typography>
           </Box>
           <Box>
             <Typography variant="body2">
               <strong>Email</strong>{" "}
-              <Link href={`mailto:${team.notifyPersonalisation?.helpEmail}`}>
-                {team.notifyPersonalisation?.helpEmail}
-              </Link>
+              <Link href={`mailto:${helpEmail}`}>{helpEmail}</Link>
             </Typography>
             <Typography variant="body2">
               We aim to respond within 2 working days.

--- a/editor.planx.uk/src/routes/teamSettings.tsx
+++ b/editor.planx.uk/src/routes/teamSettings.tsx
@@ -22,7 +22,7 @@ const teamSettingsRoutes = compose(
   })),
 
   mount({
-    "/": redirect("./team"),
+    "/": redirect("./general"),
     "/:tab": map(async (req) => {
       const isAuthorised = useStore.getState().canUserEditTeam(req.params.team);
 

--- a/editor.planx.uk/src/routes/views/draft.tsx
+++ b/editor.planx.uk/src/routes/views/draft.tsx
@@ -77,13 +77,13 @@ const fetchSettingsForDraftView = async (
                 helpPhone: help_phone
                 helpOpeningHours: help_opening_hours
                 emailReplyToId: email_reply_to_id
+                boundaryBBox: boundary_bbox
               }
               integrations {
                 hasPlanningData: has_planning_data
               }
               slug
             }
-            settings
             slug
             name
           }

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -103,13 +103,13 @@ export const fetchSettingsForPublishedView = async (
                 helpPhone: help_phone
                 helpOpeningHours: help_opening_hours
                 emailReplyToId: email_reply_to_id
+                boundaryBBox: boundary_bbox
               }
               integrations {
                 hasPlanningData: has_planning_data
               }
               slug
             }
-            settings
             status
             publishedFlows: published_flows(
               limit: 1

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -77,13 +77,13 @@ const fetchDataForStandaloneView = async (
                 helpPhone: help_phone
                 helpOpeningHours: help_opening_hours
                 emailReplyToId: email_reply_to_id
+                boundaryBBox: boundary_bbox
               }
               integrations {
                 hasPlanningData: has_planning_data
               }
               slug
             }
-            settings
           }
 
           globalSettings: global_settings {

--- a/hasura.planx.uk/migrations/1720511391883_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1720511391883_run_sql_migration/down.sql
@@ -1,0 +1,28 @@
+-- Previous version of teams_summary view from 1713084872473_create_view_teams_summary/up.sql
+
+CREATE OR REPLACE VIEW "public"."teams_summary" AS SELECT 
+    t.id,
+    t.name,
+    t.slug,
+    t.reference_code,
+    t.settings->>'homepage' as homepage,
+    t.domain as subdomain,
+    ti.has_planning_data as planning_data_enabled,
+    '@todo' as article_4s_enabled,   
+    t.notify_personalisation as govnotify_personalisation,
+    CASE 
+        WHEN coalesce(ti.production_govpay_secret, ti.staging_govpay_secret) is not null 
+        THEN true
+        ELSE false
+    END as govpay_enabled,
+    t.submission_email as send_to_email_address,
+    coalesce(ti.production_bops_submission_url, ti.staging_bops_submission_url) as bops_submission_url,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour
+FROM teams t
+    JOIN team_integrations ti on ti.team_id = t.id
+    JOIN team_themes tt on tt.team_id = t.id
+ORDER BY t.name ASC;

--- a/hasura.planx.uk/migrations/1720511391883_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1720511391883_run_sql_migration/up.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE VIEW "public"."teams_summary" AS SELECT 
+    t.id,
+    t.name,
+    t.slug,
+    t.reference_code,
+    t.settings->>'homepage' as homepage,
+    t.domain as subdomain,
+    ti.has_planning_data as planning_data_enabled,
+    '@todo' as article_4s_enabled,  
+    jsonb_build_object(
+        'helpEmail', ts.help_email,
+        'helpPhone', ts.help_phone,
+        'emailReplyToId', ts.email_reply_to_id,
+        'helpOpeningHours', ts.help_opening_hours
+        ) as govnotify_personalisation,
+    CASE 
+        WHEN coalesce(ti.production_govpay_secret, ti.staging_govpay_secret) is not null 
+        THEN true
+        ELSE false
+    END as govpay_enabled,
+    t.submission_email as send_to_email_address,
+    coalesce(ti.production_bops_submission_url, ti.staging_bops_submission_url) as bops_submission_url,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour
+FROM teams t
+    JOIN team_integrations ti on ti.team_id = t.id
+    JOIN team_themes tt on tt.team_id = t.id
+    JOIN team_settings ts on ts.team_id = t.id
+ORDER BY t.name ASC;


### PR DESCRIPTION
## What does this PR do?
 - Reads from new `team_settings` table instead of `team.settings` column throughout the application
 - Import `Team` type from planx-core in the API (and many associate type fixes)
 - Relies on https://github.com/theopensystemslab/planx-core/pull/444
 
 ## Next steps...
 - Write to new table in `team.create()` (planx-core)
 - Drop `team.settings` column