### PR TITLE
test: Remove redundant test following `teamEditor` permission update

### DIFF
--- a/e2e/tests/api-driven/src/permissions/teamAdmin.feature
+++ b/e2e/tests/api-driven/src/permissions/teamAdmin.feature
@@ -54,5 +54,4 @@ Feature: Testing Permissions for teamEditor Role
 
     Examples:
       | TABLE           | ACTION          |
-      | users           | select          |
       | team_members    | select          |


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/3390

🚀 Regression tests running against this branch here - https://github.com/theopensystemslab/planx-new/actions/runs/9853501058