### PR TITLE
chore: enable AWS S3 Send destination on production

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -55,18 +55,17 @@ const SendComponent: React.FC<Props> = (props) => {
       value: Destination.Email,
       label: "Email to planning office",
     },
-  ];
-
-  // Show S3 & Nexus options on staging only
-  if (process.env.REACT_APP_ENV !== "production") {
-    options.push({
+    {
       value: Destination.S3,
       label: "Upload to AWS S3 bucket",
-    });
+    },
+  ];
 
+  // Show Nexus option on staging only
+  if (process.env.REACT_APP_ENV !== "production") {
     options.push({
       value: Destination.Idox,
-      label: "Idox Nexus",
+      label: "Idox Nexus (testing only)",
     });
   }
 


### PR DESCRIPTION
Barnet is ready to go live with Report a Breach using S3 / Power Automate integration solution