### PR TITLE
fix: Use `teamSettings` instead of `settings` in query

### DIFF
--- a/editor.planx.uk/src/routes/views/draft.tsx
+++ b/editor.planx.uk/src/routes/views/draft.tsx
@@ -69,7 +69,7 @@ const fetchSettingsForDraftView = async (
                 favicon
               }
               name
-              settings: team_settings {
+              teamSettings: team_settings {
                 boundaryUrl: boundary_url
                 boundaryBBox: boundary_bbox
                 homepage

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -95,7 +95,7 @@ export const fetchSettingsForPublishedView = async (
                 favicon
               }
               name
-              settings: team_settings {
+              teamSettings: team_settings {
                 boundaryUrl: boundary_url
                 boundaryBBox: boundary_bbox
                 homepage

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -69,7 +69,7 @@ const fetchDataForStandaloneView = async (
                 favicon
               }
               name
-              settings: team_settings {
+              teamSettings: team_settings {
                 boundaryUrl: boundary_url
                 boundaryBBox: boundary_bbox
                 homepage


### PR DESCRIPTION
Quick fix for https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1720531966270509

This PR ensures that the queries for `/draft`, `/preview`, and `/published` request `teamSettings` - this matches the current type, as expected by the store function `setTeam()`.

A more comprehensive fix, which avoid the nested `team.teamSettings` syntax and fixed types is incoming here - https://github.com/theopensystemslab/planx-new/pull/3391