### PR TITLE
feat: add an audit table for applications submitted via S3 and Power Automate

### DIFF
--- a/api.planx.uk/modules/send/s3/index.test.ts
+++ b/api.planx.uk/modules/send/s3/index.test.ts
@@ -53,6 +53,14 @@ describe(`uploading an application to S3`, () => {
         slug: "unsupported-team",
       },
     });
+
+    queryMock.mockQuery({
+      name: "CreateS3Application",
+      matchOnVariables: false,
+      data: {
+        insertS3Application: { id: 1 },
+      },
+    });
   });
 
   it("requires auth", async () => {

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1415,6 +1415,46 @@
       permission:
         filter: {}
 - table:
+    name: s3_applications
+    schema: public
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - id
+          - webhook_request
+          - webhook_response
+          - session_id
+          - team_slug
+          - created_at
+      comment: ""
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - webhook_request
+          - webhook_response
+          - session_id
+          - team_slug
+          - created_at
+        filter: {}
+      comment: ""
+  update_permissions:
+    - role: api
+      permission:
+        columns:
+          - id
+          - webhook_request
+          - webhook_response
+          - session_id
+          - team_slug
+          - created_at
+        filter: {}
+        check: null
+      comment: ""
+- table:
     name: sessions
     schema: public
   computed_fields:

--- a/hasura.planx.uk/migrations/1720597665798_create_table_s3_applications/down.sql
+++ b/hasura.planx.uk/migrations/1720597665798_create_table_s3_applications/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public.s3_applications" CASCADE;

--- a/hasura.planx.uk/migrations/1720597665798_create_table_s3_applications/up.sql
+++ b/hasura.planx.uk/migrations/1720597665798_create_table_s3_applications/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "public"."s3_applications" (
+    "id" serial NOT NULL, 
+    "session_id" text NOT NULL,
+    "team_slug" text NOT NULL,
+    "webhook_request" JSONB NOT NULL,
+    "webhook_response" JSONB NOT NULL,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY ("id")
+);
+
+COMMENT ON TABLE "public"."s3_applications" IS 'Stores a receipt of applications submitted using the Upload to AWS S3 method with notifications via Power Automate webhook';

--- a/hasura.planx.uk/tests/s3_applications.test.js
+++ b/hasura.planx.uk/tests/s3_applications.test.js
@@ -69,7 +69,7 @@ describe("s3_applications", () => {
     test("can query and mutate s3 applications", () => {
       expect(i.queries).toContain("s3_applications");
       expect(i.mutations).toContain("insert_s3_applications");
-      expect(i.mutations).toContais("update_s3_applications_by_pk");
+      expect(i.mutations).toContain("update_s3_applications_by_pk");
     });
 
     test("cannot delete s3 applications", () => {

--- a/hasura.planx.uk/tests/s3_applications.test.js
+++ b/hasura.planx.uk/tests/s3_applications.test.js
@@ -1,0 +1,79 @@
+const { introspectAs } = require("./utils");
+
+describe("s3_applications", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query s3 applications", () => {
+      expect(i.queries).not.toContain("s3_applications");
+    });
+
+    test("cannot create, update, or delete s3 applications", () => {
+      expect(i).toHaveNoMutationsFor("s3_applications");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate s3 applications", () => {
+      expect(i.queries).toContain("s3_applications");
+      expect(i.mutations).toContain("insert_s3_applications");
+      expect(i.mutations).toContain("update_s3_applications_by_pk");
+      expect(i.mutations).toContain("delete_s3_applications");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query s3_applications", () => {
+      expect(i.queries).not.toContain("s3_applications");
+    });
+
+    test("cannot create, update, or delete s3_applications", () => {
+      expect(i).toHaveNoMutationsFor("s3_applications");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query s3_applications", () => {
+      expect(i.queries).not.toContain("s3_applications");
+    });
+
+    test("cannot create, update, or delete s3_applications", () => {
+      expect(i).toHaveNoMutationsFor("s3_applications");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query and mutate s3 applications", () => {
+      expect(i.queries).toContain("s3_applications");
+      expect(i.mutations).toContain("insert_s3_applications");
+      expect(i.mutations).toContais("update_s3_applications_by_pk");
+    });
+
+    test("cannot delete s3 applications", () => {
+      expect(i.mutations).not.toContain("delete_s3_applications");
+    });
+  });
+});


### PR DESCRIPTION
Quick final step in helping Barnet go live with S3/Power Automate submissions soon. 

Adds a basic audit table for tracking application data.