### PR TITLE
fix: Reduce React re-renders when checking `currentCard()`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -33,7 +33,7 @@ export default function Component(props: Props) {
     state.breadcrumbs,
     state.cachedBreadcrumbs,
     state.changeAnswer,
-    state.currentCard(),
+    state.currentCard,
     state.currentSectionIndex,
     state.flow,
     state.flowName,

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -48,7 +48,7 @@ const Card: React.FC<Props> = ({
   ...props
 }) => {
   const theme = useTheme();
-  const [path, currentCard] = useStore((state) => [
+  const [path, visibleNode] = useStore((state) => [
     state.path,
     state.currentCard,
   ]);
@@ -57,9 +57,7 @@ const Card: React.FC<Props> = ({
   const { track } = useAnalyticsTracking();
 
   useEffect(() => {
-    // The Card component is only rendered when there's content the user will
-    // see
-    const visibleNode = currentCard();
+    // The Card component is only rendered when there's content the user will see
     if (visibleNode?.id) track(visibleNode?.id);
   }, []);
 

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -259,20 +259,19 @@ const Breadcrumbs: React.FC = () => {
 };
 
 const NavBar: React.FC = () => {
-  const [index, sectionCount, title, hasSections, saveToEmail, path] = useStore(
-    (state) => [
+  const [index, sectionCount, title, hasSections, saveToEmail, path, node] =
+    useStore((state) => [
       state.currentSectionIndex,
       state.sectionCount,
       state.currentSectionTitle,
       state.hasSections,
       state.saveToEmail,
       state.path,
-    ],
-  );
+      state.currentCard,
+    ]);
   const isSaveAndReturnLandingPage =
     path !== ApplicationPath.SingleSession && !saveToEmail;
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
-  const { node } = useAnalyticsTracking();
   const isSectionCard = node?.type == TYPES.Section;
   const isVisible =
     hasSections &&

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -23,13 +23,12 @@ export type FeedbackMetadata = {
 export async function getInternalFeedbackMetadata(): Promise<FeedbackMetadata> {
   const {
     breadcrumbs,
-    currentCard,
+    currentCard: node,
     computePassport,
     fetchCurrentTeam,
     id: flowId,
   } = useStore.getState();
   const { id: teamId } = await fetchCurrentTeam();
-  const node = currentCard();
   const userData = {
     breadcrumbs: breadcrumbs,
     passport: computePassport(),

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/clones.test.ts
@@ -3,7 +3,7 @@ const { getState, setState } = vanillaStore;
 import forwardsFlow from "./mocks/flowWithClones.json";
 import reverseFlow from "./mocks/flowWithReverseClones.json";
 
-const { record, previousCard, currentCard, upcomingCardIds, resetPreview } =
+const { record, previousCard, getCurrentCard, upcomingCardIds, resetPreview } =
   getState();
 
 beforeEach(() => {
@@ -54,14 +54,14 @@ describe("Clone order in flow (backwards)", () => {
     // Traverse forward to final node
     record("question", { answers: ["leftChoice"] });
     record("clone", { answers: ["finalNode"] });
-    expect(currentCard()?.id).toBe("finalNode");
+    expect(getCurrentCard()?.id).toBe("finalNode");
 
     // Traverse back one-by-one to first node
-    let previous = previousCard(currentCard());
+    let previous = previousCard(getCurrentCard());
     expect(previous).toBe("clone");
     record(previous!);
 
-    previous = previousCard(currentCard());
+    previous = previousCard(getCurrentCard());
     expect(previous).toBe("question");
     record(previous!);
 
@@ -79,18 +79,18 @@ describe("Clone order in flow (backwards)", () => {
     record("question", { answers: ["rightChoice"] });
     record("rightNotice", { answers: ["clone"] });
     record("clone", { answers: ["finalNode"] });
-    expect(currentCard()?.id).toBe("finalNode");
+    expect(getCurrentCard()?.id).toBe("finalNode");
 
     // Traverse back one-by-one to first node
-    let previous = previousCard(currentCard());
+    let previous = previousCard(getCurrentCard());
     expect(previous).toBe("clone");
     record(previous!);
 
-    previous = previousCard(currentCard());
+    previous = previousCard(getCurrentCard());
     expect(previous).toBe("rightNotice");
     record(previous!);
 
-    previous = previousCard(currentCard());
+    previous = previousCard(getCurrentCard());
     expect(previous).toBe("question");
     record(previous!);
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -4,8 +4,13 @@ import flowWithBranchingFilters from "./mocks/flowWithBranchingFilters.json";
 import flowWithRootFilter from "./mocks/flowWithRootFilter.json";
 
 const { getState, setState } = vanillaStore;
-const { upcomingCardIds, resetPreview, record, currentCard, collectedFlags } =
-  getState();
+const {
+  upcomingCardIds,
+  resetPreview,
+  record,
+  getCurrentCard,
+  collectedFlags,
+} = getState();
 
 // https://i.imgur.com/k0kkKox.png
 describe("A filter on the root of the graph", () => {
@@ -74,9 +79,9 @@ describe("A filter on a branch", () => {
     record("fork", { answers: ["filter2"] });
 
     // XXX: Test fails here
-    // The currentCard returns as "immunityFlag2" which we should not land on -
+    // The getCurrentCard returns as "immunityFlag2" which we should not land on -
     // the flags on the first filter are skipped, we go direct from "immunityPath1" to "fork"
-    expect(currentCard()?.id).toBe("immunityPath2");
+    expect(getCurrentCard()?.id).toBe("immunityPath2");
   });
 });
 
@@ -97,7 +102,7 @@ describe("Nodes on a filter path should only be auto-answered when the path matc
     record("TiIuAVIXsV", { answers: ["hdaeOVIXsV"], auto: false });
 
     // land on the correct result component
-    expect(currentCard()?.id).toBe("seN42VIXsV");
+    expect(getCurrentCard()?.id).toBe("seN42VIXsV");
     expect(getState().resultData()["Planning permission"]).toHaveProperty(
       "flag.value",
       "PLANNING_PERMISSION_REQUIRED",
@@ -131,7 +136,7 @@ describe("Nodes on a filter path should only be auto-answered when the path matc
     upcomingCardIds();
 
     // land on the correct result component
-    expect(currentCard()?.id).toBe("seN42VIXsV");
+    expect(getCurrentCard()?.id).toBe("seN42VIXsV");
     expect(getState().resultData()["Planning permission"]).toHaveProperty(
       "flag.value",
       "PLANNING_PERMISSION_REQUIRED",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -79,7 +79,7 @@ describe("A filter on a branch", () => {
     record("fork", { answers: ["filter2"] });
 
     // XXX: Test fails here
-    // The getCurrentCard returns as "immunityFlag2" which we should not land on -
+    // getCurrentCard returns as "immunityFlag2" which we should not land on -
     // the flags on the first filter are skipped, we go direct from "immunityPath1" to "fork"
     expect(getCurrentCard()?.id).toBe("immunityPath2");
   });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
@@ -3,6 +3,7 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { Store, vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
+const { canGoBack, getCurrentCard, resetPreview } = getState();
 
 // https://imgur.com/VFV64ax
 const flow: Store.flow = {
@@ -58,7 +59,7 @@ const flow: Store.flow = {
 };
 
 beforeEach(() => {
-  getState().resetPreview();
+  resetPreview();
   setState({
     flow,
   });
@@ -74,7 +75,7 @@ describe("can go back if", () => {
         },
       },
     });
-    expect(getState().canGoBack(getState().currentCard())).toStrictEqual(true);
+    expect(canGoBack(getCurrentCard())).toStrictEqual(true);
   });
 
   test("the user skipped the payment component", () => {
@@ -89,13 +90,13 @@ describe("can go back if", () => {
         },
       },
     });
-    expect(getState().canGoBack(getState().currentCard())).toStrictEqual(true);
+    expect(canGoBack(getCurrentCard())).toStrictEqual(true);
   });
 });
 
 describe("cannot go back if", () => {
   test("it's the very first component", () => {
-    expect(getState().canGoBack(getState().currentCard())).toStrictEqual(false);
+    expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 
   test("the only previous component was auto-answered", () => {
@@ -107,7 +108,7 @@ describe("cannot go back if", () => {
         },
       },
     });
-    expect(getState().canGoBack(getState().currentCard())).toStrictEqual(false);
+    expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 
   test("the applicant made a payment", () => {
@@ -128,7 +129,7 @@ describe("cannot go back if", () => {
         },
       },
     });
-    expect(getState().canGoBack(getState().currentCard())).toStrictEqual(false);
+    expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 
   test("changing a component's answer", () => {
@@ -150,6 +151,6 @@ describe("cannot go back if", () => {
       },
       changedNode: "Confirmation",
     });
-    expect(getState().canGoBack(getState().currentCard())).toStrictEqual(false);
+    expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
@@ -3,7 +3,8 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { Store, vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
-const { canGoBack, getCurrentCard, resetPreview } = getState();
+const { canGoBack, getCurrentCard, resetPreview, record, changeAnswer } =
+  getState();
 
 // https://imgur.com/VFV64ax
 const flow: Store.flow = {
@@ -67,29 +68,21 @@ beforeEach(() => {
 
 describe("can go back if", () => {
   test("the previous component was manually answered", () => {
-    setState({
-      breadcrumbs: {
-        Question: {
-          auto: false,
-          answers: ["NoFeeAnswerPath"],
-        },
-      },
+    record("Question", {
+      auto: false,
+      answers: ["NoFeeAnswerPath"],
     });
+
     expect(canGoBack(getCurrentCard())).toStrictEqual(true);
   });
 
   test("the user skipped the payment component", () => {
-    setState({
-      breadcrumbs: {
-        Question: {
-          auto: false,
-          answers: ["NoFeeAnswerPath"],
-        },
-        Pay: {
-          auto: true,
-        },
-      },
+    record("Question", {
+      auto: false,
+      answers: ["NoFeeAnswerPath"],
     });
+    record("Pay", { auto: true });
+
     expect(canGoBack(getCurrentCard())).toStrictEqual(true);
   });
 });
@@ -100,57 +93,44 @@ describe("cannot go back if", () => {
   });
 
   test("the only previous component was auto-answered", () => {
-    setState({
-      breadcrumbs: {
-        Question: {
-          auto: true,
-          answers: ["NoFeeAnswerPath"],
-        },
-      },
+    record("Question", {
+      auto: true,
+      answers: ["NoFeeAnswerPath"],
     });
+
     expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 
   test("the applicant made a payment", () => {
-    setState({
-      breadcrumbs: {
-        Question: {
-          auto: false,
-          answers: ["FeeAnswerPath"],
-        },
-        Calculate: {
-          auto: true,
-          data: {
-            fee: 10,
-          },
-        },
-        Pay: {
-          auto: false,
-        },
+    record("Question", {
+      auto: false,
+      answers: ["NoFeeAnswerPath"],
+    });
+    record("Calculate", {
+      auto: true,
+      data: {
+        fee: 10,
       },
     });
+    record("Pay", { auto: false });
+
     expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 
   test("changing a component's answer", () => {
-    setState({
-      breadcrumbs: {
-        Question: {
-          auto: false,
-          answers: ["FeeAnswerPath"],
-        },
-        Calculate: {
-          auto: true,
-          data: {
-            fee: 10,
-          },
-        },
-        Pay: {
-          auto: false,
-        },
-      },
-      changedNode: "Confirmation",
+    record("Question", {
+      auto: false,
+      answers: ["FeeAnswerPath"],
     });
+    record("Calculate", {
+      auto: true,
+      data: {
+        fee: 10,
+      },
+    });
+    record("Pay", { auto: false });
+    changeAnswer("Confirmation");
+
     expect(canGoBack(getCurrentCard())).toStrictEqual(false);
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
@@ -2,7 +2,7 @@ import { vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
 
-const { overrideAnswer, currentCard, upcomingCardIds, record } = getState();
+const { overrideAnswer, getCurrentCard, upcomingCardIds, record } = getState();
 
 test("it clears the correct breadcrumb and navigates back to the right node", async () => {
   // set up initial state, confirm our passport computes as expected
@@ -38,7 +38,7 @@ test("it clears the correct breadcrumb and navigates back to the right node", as
   });
 
   // confirm we've navigated back to the right node, and that PropertyInformation is queued up again in upcoming cards
-  expect(currentCard()?.id).toEqual("FirstPropertyTypeQuestionNodeId");
+  expect(getCurrentCard()?.id).toEqual("FirstPropertyTypeQuestionNodeId");
   expect(upcomingCardIds()).toContain("PropertyInformationNodeId");
 
   // select a new answer, confirm our passport has updated

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/previousCard.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/previousCard.test.ts
@@ -2,7 +2,7 @@ import { vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
 
-const { resetPreview, previousCard, currentCard } = getState();
+const { resetPreview, previousCard, getCurrentCard } = getState();
 
 beforeEach(() => {
   resetPreview();
@@ -24,7 +24,7 @@ const setup = (args = {}) =>
 describe("store.previousCard is", () => {
   test("undefined when there are no breadcrumbs", () => {
     setup();
-    expect(previousCard(currentCard())).toBeUndefined();
+    expect(previousCard(getCurrentCard())).toBeUndefined();
   });
 
   test("undefined when cards were automatically answered", () => {
@@ -34,7 +34,7 @@ describe("store.previousCard is", () => {
         b: { auto: true },
       },
     });
-    expect(previousCard(currentCard())).toBeUndefined();
+    expect(previousCard(getCurrentCard())).toBeUndefined();
   });
 
   test("the most recent human-answered card id", () => {
@@ -45,6 +45,6 @@ describe("store.previousCard is", () => {
       },
     });
 
-    expect(previousCard(currentCard())).toEqual("a");
+    expect(previousCard(getCurrentCard())).toEqual("a");
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -15,8 +15,14 @@ let flowWithPassportComponents = cloneDeep(
   flowWithPassportComponentsMock,
 ) as Store.flow;
 
-const { record, resetPreview, previousCard, getCurrentCard, changeAnswer } =
-  getState();
+const {
+  record,
+  resetPreview,
+  previousCard,
+  getCurrentCard,
+  changeAnswer,
+  setCurrentCard,
+} = getState();
 
 beforeEach(() => {
   resetPreview();
@@ -61,7 +67,7 @@ describe("removeNodesDependentOnPassport", () => {
 });
 
 describe("nodesDependentOnPassport with record", () => {
-  test("should remove Draw Boundary and Planning contraints from cachedBreadcrumbs", () => {
+  test("should remove Draw Boundary and Planning constraints from cachedBreadcrumbs", () => {
     const cachedBreadcrumbs = {
       ...breadcrumbsDependentOnPassport,
     } as Store.cachedBreadcrumbs;
@@ -228,6 +234,9 @@ describe("nodesDependentOnPassport with previousCard", () => {
       flow,
       _nodesPendingEdit: [],
     });
+
+    // Manually call setCurrentCard() as we're not using record() as part of our setup
+    setCurrentCard();
 
     expect(getCurrentCard()?.id).toEqual("drawBoundary");
     expect(previousCard(getCurrentCard())).toEqual("text");

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -15,7 +15,7 @@ let flowWithPassportComponents = cloneDeep(
   flowWithPassportComponentsMock,
 ) as Store.flow;
 
-const { record, resetPreview, previousCard, currentCard, changeAnswer } =
+const { record, resetPreview, previousCard, getCurrentCard, changeAnswer } =
   getState();
 
 beforeEach(() => {
@@ -182,7 +182,7 @@ describe("nodesDependentOnPassport with record", () => {
       },
     });
 
-    expect(currentCard()?.id).toEqual("drawBoundary");
+    expect(getCurrentCard()?.id).toEqual("drawBoundary");
   });
 
   test("should clear _nodesPendingEdit after edition", () => {
@@ -229,8 +229,8 @@ describe("nodesDependentOnPassport with previousCard", () => {
       _nodesPendingEdit: [],
     });
 
-    expect(currentCard()?.id).toEqual("drawBoundary");
-    expect(previousCard(currentCard())).toEqual("text");
+    expect(getCurrentCard()?.id).toEqual("drawBoundary");
+    expect(previousCard(getCurrentCard())).toEqual("text");
   });
 
   test("To be last pushed to the breadcrumbs when changing answer", () => {
@@ -247,7 +247,7 @@ describe("nodesDependentOnPassport with previousCard", () => {
       _nodesPendingEdit,
     });
 
-    expect(previousCard(currentCard())).toEqual("findProperty");
+    expect(previousCard(getCurrentCard())).toEqual("findProperty");
   });
 });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
@@ -3,7 +3,7 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { Store, vanillaStore } from "../../store";
 
 const { getState, setState } = vanillaStore;
-const { upcomingCardIds, resetPreview, record, currentCard } = getState();
+const { upcomingCardIds, resetPreview, record, getCurrentCard } = getState();
 
 const flow: Store.flow = {
   _root: {
@@ -75,7 +75,7 @@ test.skip("A node is only auto-answered when it is the first upcomingCardId(), n
   record("SetValue", { data: { fruit: ["apple"] }, auto: true });
   clickContinue();
 
-  expect(currentCard()?.id).toBe("Content");
+  expect(getCurrentCard()?.id).toBe("Content");
 
   // "AutomatedQuestion" should still be queued up, not already answered based on SetValue
   expect(visitedNodes()).not.toContain("AutomatedQuestion");

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
@@ -4,7 +4,7 @@ import { cloneDeep, merge } from "lodash";
 import { Store, vanillaStore } from "../store";
 
 const { getState, setState } = vanillaStore;
-const { resetPreview, record, computePassport, currentCard } = getState();
+const { resetPreview, record, computePassport, getCurrentCard } = getState();
 
 const baseFlow: Store.flow = {
   _root: {
@@ -76,7 +76,7 @@ describe("SetValue component", () => {
       expect(breadcrumbKeys).toContain("setValue1");
 
       // Middle of flow reached
-      expect(currentCard()?.id).toEqual("middleOfService");
+      expect(getCurrentCard()?.id).toEqual("middleOfService");
 
       // Passport correctly populated
       expect(computePassport()?.data?.myKey).toHaveLength(1);
@@ -94,7 +94,7 @@ describe("SetValue component", () => {
       expect(breadcrumbKeys).toContain("setValue2");
 
       // End of flow reached
-      expect(currentCard()?.id).toEqual("endOfService");
+      expect(getCurrentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated
       expect(computePassport()?.data?.myKey).toHaveLength(1);
@@ -133,7 +133,7 @@ describe("SetValue component", () => {
       expect(breadcrumbKeys).toContain("setValue1");
 
       // Middle of flow reached
-      expect(currentCard()?.id).toEqual("middleOfService");
+      expect(getCurrentCard()?.id).toEqual("middleOfService");
 
       // Passport correctly populated
       expect(computePassport()?.data?.myKey).toHaveLength(1);
@@ -155,7 +155,7 @@ describe("SetValue component", () => {
       expect(breadcrumbKeys).toContain("setValue2");
 
       // End of flow reached
-      expect(currentCard()?.id).toEqual("endOfService");
+      expect(getCurrentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated
       expect(computePassport()?.data?.myKey).toHaveLength(2);
@@ -212,7 +212,7 @@ describe("SetValue component", () => {
       expect(breadcrumbKeys).toContain("setValue1");
 
       // Middle of flow reached
-      expect(currentCard()?.id).toEqual("middleOfService");
+      expect(getCurrentCard()?.id).toEqual("middleOfService");
 
       // Passport correctly populated - value not present
       expect(computePassport()?.data?.myKey).toBeUndefined();
@@ -236,7 +236,7 @@ describe("SetValue component", () => {
       record("setValue3", { data: { myKey: ["mySecondValue"] } });
 
       // End of flow reached
-      expect(currentCard()?.id).toEqual("endOfService");
+      expect(getCurrentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated - value no longer set
       expect(computePassport()?.data?.myKey).toBeUndefined();
@@ -265,7 +265,7 @@ describe("SetValue component", () => {
       record("setValue3", { data: { myKey: ["myUnsetValue"] } });
 
       // End of flow reached
-      expect(currentCard()?.id).toEqual("endOfService");
+      expect(getCurrentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated - passport variable not removed as values do not match
       expect(computePassport()?.data?.myKey).toEqual("mySecondValue");
@@ -320,7 +320,7 @@ describe("SetValue component", () => {
       expect(breadcrumbKeys).toContain("setValue1");
 
       // Middle of flow reached
-      expect(currentCard()?.id).toEqual("middleOfService");
+      expect(getCurrentCard()?.id).toEqual("middleOfService");
 
       // Passport correctly populated - value not present
       expect(computePassport()?.data?.myKey).toBeUndefined();
@@ -344,7 +344,7 @@ describe("SetValue component", () => {
       record("setValue3", { data: { myKey: ["mySecondValue"] } });
 
       // End of flow reached
-      expect(currentCard()?.id).toEqual("endOfService");
+      expect(getCurrentCard()?.id).toEqual("endOfService");
 
       // Passport correctly populated - key:value pair removed
       expect(computePassport()?.data).not.toHaveProperty("myKey");

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -51,7 +51,6 @@ let lastVisibleNodeAnalyticsLogId: number | undefined = undefined;
 const analyticsContext = createContext<{
   createAnalytics: (type: AnalyticsType) => Promise<void>;
   trackEvent: (eventData: EventData) => Promise<void>;
-  node: Store.node | null;
   track: (
     nodeId: string,
     direction?: AnalyticsLogDirection,
@@ -60,7 +59,6 @@ const analyticsContext = createContext<{
 }>({
   createAnalytics: () => Promise.resolve(),
   trackEvent: () => Promise.resolve(),
-  node: null,
   track: () => Promise.resolve(),
 });
 const { Provider } = analyticsContext;
@@ -90,7 +88,6 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     state.id,
     state.flow,
   ]);
-  const node = currentCard();
   const isAnalyticsEnabled =
     new URL(window.location.href).searchParams.get("analytics") !== "false";
   const shouldTrackAnalytics =
@@ -138,7 +135,6 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     <Provider
       value={{
         createAnalytics,
-        node,
         trackEvent,
         track,
       }}
@@ -314,7 +310,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     });
     const id = response.data.insert_analytics_one.id;
     setAnalyticsId(id);
-    const currentNodeId = currentCard()?.id;
+    const currentNodeId = currentCard?.id;
     if (currentNodeId) track(currentNodeId, type, id);
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -41,6 +41,7 @@ export interface PreviewStore extends Store.Store {
   ) => Array<string>;
   currentCard: ({ id: Store.nodeId } & Store.node) | null;
   setCurrentCard: () => void;
+  getCurrentCard: () => ({ id: Store.nodeId } & Store.node) | null;
   hasPaid: () => boolean;
   previousCard: (
     node: Store.node | null,
@@ -654,6 +655,8 @@ export const previewStore: StateCreator<
   },
 
   currentCard: null,
+
+  getCurrentCard: () => get().currentCard,
 });
 
 const knownNots = (

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -39,7 +39,8 @@ export interface PreviewStore extends Store.Store {
     upToNodeId: Store.nodeId,
     visited?: Array<string>,
   ) => Array<string>;
-  currentCard: () => Store.node | null;
+  currentCard: ({ id: Store.nodeId } & Store.node) | null;
+  setCurrentCard: () => void;
   hasPaid: () => boolean;
   previousCard: (
     node: Store.node | null,
@@ -136,18 +137,15 @@ export const previewStore: StateCreator<
     return res;
   },
 
-  currentCard() {
+  setCurrentCard() {
     const { upcomingCardIds, flow } = get();
     const upcoming = upcomingCardIds();
 
     if (upcoming.length > 0) {
       const id = upcoming[0];
-      return {
-        id,
-        ...flow[id],
-      };
+      set({ currentCard: { id, ...flow[id] } });
     } else {
-      return null;
+      set({ currentCard: null });
     }
   },
 
@@ -287,6 +285,7 @@ export const previewStore: StateCreator<
       _nodesPendingEdit,
       changedNode,
       updateSectionData,
+      setCurrentCard,
     } = get();
 
     if (!flow[id]) throw new Error(`id "${id}" not found`);
@@ -370,6 +369,7 @@ export const previewStore: StateCreator<
       }
     }
     updateSectionData();
+    setCurrentCard();
   },
 
   resultData(flagSet, overrides) {
@@ -652,6 +652,8 @@ export const previewStore: StateCreator<
 
     return currentRequestedFiles || emptyFileList;
   },
+
+  currentCard: null,
 });
 
 const knownNots = (

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -369,8 +369,8 @@ export const previewStore: StateCreator<
         });
       }
     }
-    updateSectionData();
     setCurrentCard();
+    updateSectionData();
   },
 
   resultData(flagSet, overrides) {
@@ -380,6 +380,7 @@ export const previewStore: StateCreator<
 
   resumeSession(session: Session) {
     set({ ...session });
+    get().setCurrentCard();
     get().updateSectionData();
   },
 

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -63,6 +63,8 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     canGoBack,
     setPreviewEnvironment,
     getType,
+    node,
+    setCurrentCard,
   ] = useStore((state) => [
     state.previousCard,
     state.record,
@@ -75,9 +77,11 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.canGoBack,
     state.setPreviewEnvironment,
     state.getType,
+    state.currentCard,
+    state.setCurrentCard,
   ]);
   const isStandalone = previewEnvironment === "standalone";
-  const { createAnalytics, node, trackEvent } = useAnalyticsTracking();
+  const { createAnalytics, trackEvent } = useAnalyticsTracking();
   const [gotFlow, setGotFlow] = useState(false);
   const isUsingLocalStorage =
     useStore((state) => state.path) === ApplicationPath.SingleSession;
@@ -89,6 +93,8 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   // Initial setup
   useEffect(() => {
+    setCurrentCard();
+
     if (!isStandalone) return;
 
     if (isUsingLocalStorage) {

--- a/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -38,7 +38,7 @@ const ReconciliationPage: React.FC<Props> = ({
     state.flow,
     state.hasSections,
     state.sectionNodes,
-    state.currentCard(),
+    state.currentCard,
     state.changeAnswer,
     state.record,
     state.computePassport(),


### PR DESCRIPTION
## What's the problem?
 - Navigating through a sufficiently large flow can crash PlanX
  - This generally happens when navigating backwards, and can be triggered consistently when navigating back to or from a section component (though not exclusively)
  - Chrome freezer / runs out of memory
  - Raised as an issue here (PlanX Slack) - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1720449876847459
  - Consistenly recreateable on this flow when reaching the first section marker - https://editor.planx.dev/buckinghamshire/apply-for-planning-permission/published

## What's the cause?
When running the application in dev mode, the following two errors generally coincide with the above occurrence - 

<img width="745" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/1c573e8f-c8d0-4dfc-a06a-238f1f2f4e52">

<img width="747" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/cffa40d1-93b2-4125-a56b-966a205ef161">

The stack traces of these errors point to the following lines of code respectively - 

https://github.com/theopensystemslab/planx-new/blob/20ce9d60c30d44092274e67620c45240bd6fc594/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts#L512

https://github.com/theopensystemslab/planx-new/blob/main/editor.planx.uk/src/@planx/components/Section/Public.tsx#L31


After a lot of trial and error debugging these sections it essentially appears that the problem is caused by `upcomingCardIds()` (called when hitting "back") clashing with the rendering of the `AnalyticsProvider` (which passed the updated `node` down to it's descendants).


## What's the solution?
- Refactor `currentCard()`
  - This is a function with side effects - it updates state in the Zustand store by calling `upcomingCards()` and is ultimately responsible for displaying a card to the user
  - This should only be called once, when the continue button or back button is hit (via `record()`)
  - Generally `currentCard()` is called as a shorthand to get the current node Id, so I've made a new property in the store to hold this variable
  - This has the (very helpful) side effect of reducing the number of re-renders as we're no longer frequently calling `upcomingCardIds()`, just referring to the stored `currentCard()` from the last call.
 - Remove `node` from the `AnalyticsProvider`, and just store in Zustand
   - This resolves the errors we've been seeing, as well as making sense from a hierarchy POV