### PR TITLE
fix: React warnings on `PlanningConstraints` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -78,7 +78,7 @@ export default function ConstraintsList({
     <Box mb={3}>
       {Object.keys(groupedConstraints).map(
         (category: string, index: number) => (
-          <>
+          <React.Fragment key={`${category}-wrapper`}>
             <ListSubheader
               component="div"
               disableGutters
@@ -118,7 +118,7 @@ export default function ConstraintsList({
                 </ConstraintListItem>
               ))}
             </List>
-          </>
+          </React.Fragment>
         ),
       )}
     </Box>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -147,7 +147,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
           expandIcon={<Caret />}
           sx={{ pr: 1.5, background: `rgba(255, 255, 255, 0.8)` }}
         >
-          <Typography variant="body2" pr={1.5}>
+          <Typography component="div" variant="body2" pr={1.5}>
             {children}
           </Typography>
         </AccordionSummary>
@@ -199,7 +199,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
               </List>
             )}
           </>
-          <Typography variant="body2">
+          <Typography component="div" variant="body2">
             <ReactMarkdownOrHtml
               source={props.metadata?.text?.replaceAll(
                 "(/",


### PR DESCRIPTION
## What does this PR do?
- Adds missing `key` prop
- Ensures we use correct semantic HTML hierarchy by not wrapping HTML in paragraph element

<img width="764" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/7aabea37-aaa1-42b1-a600-aaad715d0ebf">

<img width="759" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/a011a1b8-ff09-4f80-9563-a3fbef2b9d87">

<img width="765" alt="image" src="https://github.com/theopensystemslab/planx-new/assets/20502206/6e25269c-64bf-431c-8ea5-2851d301f27e">
