### PR TITLE
fix: Update Pizza Teardown (Manual) GitHub action variables

### DIFF
--- a/.github/workflows/pizza-teardown-manual.yml
+++ b/.github/workflows/pizza-teardown-manual.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       pull_request_id:
         required: true
-        type: integer
+        type: number
         description: Pull Request number which should have its pizza destroyed
 
 env:
@@ -20,4 +20,8 @@ jobs:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}
           domain: ${{ env.DOMAIN }}
-          pullrequest_id: ${{  github.event.inputs.pull_request_id  }}
+          os_type: alpine
+          plan: vc2-1c-1gb
+          pull_request_id: ${{  github.event.inputs.pull_request_id  }}
+          region: lhr
+          tag: manual-teardown


### PR DESCRIPTION
## What's the problem?
- The GitHub action "Pizza Teardown (Manual)" is currently failing with the following errors (see screenshot below)
- Link to recent failed run of this action here - https://github.com/theopensystemslab/planx-new/actions/runs/9873182798 

![image](https://github.com/theopensystemslab/planx-new/assets/20502206/71814725-7834-4cd9-a07c-d641550abee5)


## What's the solution?
- Update action to use variables from [vultr-action@v2.0 update](https://github.com/theopensystemslab/vultr-action/releases/tag/v2.0)


