### PR TITLE
fix: Associate label and input in `MoreInformation`

### DIFF
--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -127,7 +127,7 @@ export const MoreInformation = ({
               onChange={changeField}
             />
           </InputLabel>
-          <InputLabel label="How it is defined?">
+          <InputLabel label="How it is defined?" htmlFor="howMeasured">
             <InputRow>
               <RichTextInput
                 multiline


### PR DESCRIPTION
Addresses issue discussed here (OSL Slack) -https://opensystemslab.slack.com/archives/C01E3AC0C03/p1720190594916289