### PR TITLE
chore: Remove redundant `convertSlugToName` util

### DIFF
--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -1,7 +1,6 @@
 import { $public, $api } from "../../../../client";
 import { sendEmail } from "../../../../lib/notify";
 import { gql } from "graphql-request";
-import { convertSlugToName } from "../../../saveAndReturn/service/utils";
 import type { AgentAndPayeeSubmissionNotifyConfig } from "../../../../types";
 
 export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -1,7 +1,6 @@
 import { gql } from "graphql-request";
 import {
   calculateExpiryDate,
-  convertSlugToName,
   getServiceLink,
 } from "../../../saveAndReturn/service/utils";
 import {

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
@@ -54,7 +54,7 @@ describe("buildContentFromSessions function", () => {
       },
     ];
 
-    const result = `Service: Apply for a lawful development certificate
+    const result = `Service: Apply for a Lawful Development Certificate
       Address: 1 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
@@ -124,15 +124,15 @@ describe("buildContentFromSessions function", () => {
         },
       },
     ];
-    const result = `Service: Apply for a lawful development certificate
+    const result = `Service: Apply for a Lawful Development Certificate
       Address: 1 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123\n\nService: Apply for a lawful development certificate
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123\n\nService: Apply for a Lawful Development Certificate
       Address: 2 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=456\n\nService: Apply for a lawful development certificate
+      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=456\n\nService: Apply for a Lawful Development Certificate
       Address: 3 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
@@ -184,7 +184,7 @@ describe("buildContentFromSessions function", () => {
         },
       },
     ];
-    const result = `Service: Apply for a lawful development certificate
+    const result = `Service: Apply for a Lawful Development Certificate
       Address: 1 High Street
       Project type: New office premises
       Expiry Date: 29 May 2026
@@ -217,7 +217,7 @@ describe("buildContentFromSessions function", () => {
       },
     ];
 
-    const result = `Service: Apply for a lawful development certificate
+    const result = `Service: Apply for a Lawful Development Certificate
       Address: Address not submitted
       Project type: New office premises
       Expiry Date: 29 May 2026
@@ -252,7 +252,7 @@ describe("buildContentFromSessions function", () => {
       },
     ];
 
-    const result = `Service: Apply for a lawful development certificate
+    const result = `Service: Apply for a Lawful Development Certificate
       Address: 1 High Street
       Project type: Project type not submitted
       Expiry Date: 29 May 2026

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
@@ -4,12 +4,7 @@ import { gql } from "graphql-request";
 import { $api, $public } from "../../../client";
 import { sendEmail } from "../../../lib/notify";
 import { LowCalSession, Team } from "../../../types";
-import {
-  DAYS_UNTIL_EXPIRY,
-  calculateExpiryDate,
-  convertSlugToName,
-  getResumeLink,
-} from "./utils";
+import { DAYS_UNTIL_EXPIRY, calculateExpiryDate, getResumeLink } from "./utils";
 
 /**
  * Send a "Resume" email to an applicant which list all open applications for a given council (team)
@@ -111,7 +106,6 @@ const buildContentFromSessions = async (
   team: Team,
 ): Promise<string> => {
   const contentBuilder = async (session: LowCalSession) => {
-    const service = convertSlugToName(session.flow.slug);
     const address: SiteAddress | undefined =
       session.data?.passport?.data?._address;
     const addressLine = address?.single_line_address || address?.title;
@@ -126,7 +120,7 @@ const buildContentFromSessions = async (
     const sessionAge = differenceInDays(today, new Date(session.created_at));
 
     if (sessionAge < DAYS_UNTIL_EXPIRY)
-      return `Service: ${service}
+      return `Service: ${session.flow.name}
       Address: ${addressLine || "Address not submitted"}
       Project type: ${projectType || "Project type not submitted"}
       Expiry Date: ${expiryDate}

--- a/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
@@ -1,24 +1,10 @@
 import { queryMock } from "../../../tests/graphqlQueryMock";
 import { LowCalSession, LowCalSessionData, Team } from "../../../types";
 import {
-  convertSlugToName,
   getResumeLink,
   getSessionDetails,
   setupEmailEventTriggers,
 } from "./utils";
-
-describe("convertSlugToName util function", () => {
-  it("should return the correct value", () => {
-    const testData = [
-      ["open-systems-lab", "Open systems lab"],
-      ["lambeth", "Lambeth"],
-    ];
-
-    testData.forEach(([slug, name]) => {
-      expect(convertSlugToName(slug)).toEqual(name);
-    });
-  });
-});
 
 describe("getResumeLink util function", () => {
   it("should return the correct value for a custom domain", () => {

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -9,13 +9,6 @@ const DAYS_UNTIL_EXPIRY = 28;
 const REMINDER_DAYS_FROM_EXPIRY = [7, 1];
 
 /**
- * Converts a flow's slug to a pretty name
- * XXX: This relies on pretty names not having dashes in them, which may not always be true (e.g. Na h-Eileanan Siar, Stoke-on-Trent)
- */
-const convertSlugToName = (slug: string): string =>
-  slug[0].toUpperCase() + slug.substring(1).replaceAll("-", " ");
-
-/**
  * Build the magic link which will be sent to users via email to continue their application
  */
 const getResumeLink = (
@@ -276,7 +269,6 @@ export const setupEmailEventTriggers = async (sessionId: string) => {
 
 export {
   getSaveAndReturnPublicHeaders,
-  convertSlugToName,
   getResumeLink,
   sendSingleApplicationEmail,
   markSessionAsSubmitted,


### PR DESCRIPTION
Quick tidy up - this was missed when adding the `flow.name` column.