### PR TITLE
chore: Finalise Epsom and Ewell subdomain setup

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -13,6 +13,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.buckinghamshire.gov.uk":
     case "planningservices.camden.gov.uk":
     case "planningservices.doncaster.gov.uk":
+    case "planningservices.epsom-ewell.gov.uk":
     case "planningservices.gateshead.gov.uk":
     case "planningservices.gloucester.gov.uk":
     case "planningservices.lambeth.gov.uk":

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -49,6 +49,7 @@ export const setPath = (flowData: Store.flow, req: NaviRequest) => {
 //      So I've hard-coded these domain names until a better solution comes along.
 //
 const PREVIEW_ONLY_DOMAINS = [
+  "planningservices.epsom-ewell.gov.uk",
   "planningservices.barnet.gov.uk",
   "planningservices.buckinghamshire.gov.uk",
   "planningservices.camden.gov.uk",


### PR DESCRIPTION
The CNAME record is set up and stable despite no confirmation back from E&E directly - https://planningservices.epsom-ewell.gov.uk/

**To Do**
- [ ] Populate `team.domain` column (post prod deploy)
- [x] Setup Uptime Robot
- [x] Update PlanX CRM