### PR TITLE
fix: Correctly populate flow settings and status

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -282,7 +282,7 @@ export const editorStore: StateCreator<
     client.cache.reset();
     const { data } = await client.query({
       query: gql`
-        query GetFlow($teamId: Int!) {
+        query GetFlows($teamId: Int!) {
           flows(where: { team: { id: { _eq: $teamId } } }) {
             id
             name

--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -224,7 +224,7 @@ const routes = compose(
       withView(SettingsContainer),
 
       route(async (req) => ({
-        getData: getFlowSettings,
+        getData: await getFlowSettings(req),
         title: makeTitle(
           [req.params.team, req.params.flow, "service"].join("/"),
         ),
@@ -236,7 +236,7 @@ const routes = compose(
       withView(SettingsContainer),
 
       route(async (req) => ({
-        getData: getFlowSettings,
+        getData: await getFlowSettings(req),
         title: makeTitle(
           [req.params.team, req.params.flow, "service-flags"].join("/"),
         ),

--- a/editor.planx.uk/src/routes/flowSettings.tsx
+++ b/editor.planx.uk/src/routes/flowSettings.tsx
@@ -95,13 +95,13 @@ const flowSettingsRoutes = compose(
           `User does not have access to ${req.originalUrl}`,
         );
 
-      return route({
-        getData: getFlowSettings,
+      return route(async (req) => ({
+        getData: await getFlowSettings(req),
         title: makeTitle(
           [req.params.team, req.params.flow, "Flow Settings"].join("/"),
         ),
         view: <Settings currentTab={req.params.tab} tabs={tabs} />,
-      });
+      }));
     }),
   }),
 );

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -6,17 +6,14 @@ import { View } from "react-navi";
 
 import { client } from "../../lib/graphql";
 import { useStore } from "../../pages/FlowEditor/lib/store";
-import type { FlowSettings } from "../../types";
 
 interface FlowMetadata {
-  flowSettings: FlowSettings;
   flowAnalyticsLink: string;
   isFlowPublished: boolean;
 }
 
 interface GetFlowMetadata {
   flows: {
-    flowSettings: FlowSettings;
     flowAnalyticsLink: string;
     publishedFlowsAggregate: {
       aggregate: {
@@ -34,13 +31,12 @@ const getFlowMetadata = async (
     data: { flows },
   } = await client.query<GetFlowMetadata>({
     query: gql`
-      query GetFlow($slug: String!, $team_slug: String!) {
+      query GetFlowMetadata($slug: String!, $team_slug: String!) {
         flows(
           limit: 1
           where: { slug: { _eq: $slug }, team: { slug: { _eq: $team_slug } } }
         ) {
           id
-          flowSettings: settings
           flowAnalyticsLink: analytics_link
           publishedFlowsAggregate: published_flows_aggregate {
             aggregate {
@@ -60,7 +56,6 @@ const getFlowMetadata = async (
   if (!flows) throw new NotFoundError(`Flow ${flowSlug} not found for ${team}`);
 
   const metadata = {
-    flowSettings: flow.flowSettings,
     flowAnalyticsLink: flow.flowAnalyticsLink,
     isFlowPublished: flow.publishedFlowsAggregate?.aggregate.count > 0,
   };
@@ -72,9 +67,9 @@ const getFlowMetadata = async (
  */
 export const flowEditorView = async (req: NaviRequest) => {
   const [flow] = req.params.flow.split(",");
-  const { flowSettings, flowAnalyticsLink, isFlowPublished } =
+  const { flowAnalyticsLink, isFlowPublished } =
     await getFlowMetadata(flow, req.params.team);
-  useStore.setState({ flowSettings, flowAnalyticsLink, isFlowPublished });
+  useStore.setState({ flowAnalyticsLink, isFlowPublished });
 
   return (
     <FlowEditorLayout>


### PR DESCRIPTION
## What's the problem?
When creating a new flow, the status shows as "online" if accessed via the Editor Menu. If we check the database, this is set to "offline" (and all tests for triggers etc are passing) - it's just a frontend visual bug.

## What's the cause?
Somewhere in the Editor Menu work a regression has slipped in which changed the way data was fetched. When accessing it via the dropdown menu, there's no issues. When accessing via the Editor Menu, the correct data is not fetched.

This is what's causing E2E tests to fail in https://github.com/theopensystemslab/planx-new/pull/3408 & https://github.com/theopensystemslab/planx-new/pull/3409

## What's the solution?
 - Only fetch flow settings when navigating to flow/settings
 - Make this an async request
 - Make query names unique (made debugging this more tricky as we had multiple `GetFlow` queries)