### PR TITLE
revert: reintroduce redirect bug to be fixed later

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -48,7 +48,8 @@ const hasJWT = (): boolean | void => {
   // Remove JWT from URL, and re-run this function
   setCookie("jwt", jwtSearchParams);
   setCookie("auth", { loggedIn: true });
-  window.history.go(-1);
+  // TODO: observe any redirect in secure fashion
+  window.location.href = "/";
 };
 
 const Layout: React.FC<{


### PR DESCRIPTION
Reverts #3302 for purposes of pushing through with Microsoft SSO work ([ticket](https://trello.com/c/owvV9UZh)), since the fix applied there was actually introducing a different bug there (being bounced back to Microsoft auth portal after returning to PlanX app, resulting in a 'Confirm Resubmission' error page).

This is still to be resolved satisfactorily later - full explanation in [new Trello ticket](https://trello.com/c/047oaBJh).