### PR TITLE
feat: Make `EditorNavMenu` items permission based

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -114,7 +114,7 @@ function EditorNavMenu() {
       title: "Select a team",
       Icon: FormatListBulletedIcon,
       route: "/",
-      accessibleBy: ["platformAdmin"],
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Admin panel",
@@ -147,13 +147,13 @@ function EditorNavMenu() {
       title: "Design",
       Icon: PaletteIcon,
       route: `/${teamSlug}/design`,
-      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
+      accessibleBy: ["platformAdmin", "teamEditor"],
     },
     {
       title: "Settings",
       Icon: TuneIcon,
       route: `/${teamSlug}/general-settings`,
-      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
+      accessibleBy: ["platformAdmin", "teamEditor"],
     },
   ];
 
@@ -168,13 +168,13 @@ function EditorNavMenu() {
       title: "Service settings",
       Icon: TuneIcon,
       route: `/${teamSlug}/${flowSlug}/service`,
-      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
+      accessibleBy: ["platformAdmin", "teamEditor"],
     },
     {
       title: "Submissions log",
       Icon: FactCheckIcon,
       route: `/${teamSlug}/${flowSlug}/submissions-log`,
-      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
+      accessibleBy: ["platformAdmin", "teamEditor"],
     },
     {
       title: "Feedback",
@@ -202,8 +202,8 @@ function EditorNavMenu() {
     return accessibleBy.includes("teamViewer");
   });
 
-  // Hide menu if the user cannot access any options
-  if (!visibleRoutes.length) return null;
+  // Hide menu if the user does not have a selection of items
+  if (visibleRoutes.length < 2) return null;
 
   return (
     <Root compact={compact}>

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -10,6 +10,7 @@ import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Tooltip, { tooltipClasses, TooltipProps } from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import { Role } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { useCurrentRoute, useNavigation } from "react-navi";
@@ -20,6 +21,7 @@ interface Route {
   title: string;
   Icon: React.ElementType;
   route: string;
+  accessibleBy: Role[];
 }
 
 const MENU_WIDTH_COMPACT = "52px";
@@ -93,9 +95,11 @@ const MenuButton = styled(IconButton, {
 function EditorNavMenu() {
   const { navigate } = useNavigation();
   const { url } = useCurrentRoute();
-  const [teamSlug, flowSlug] = useStore((state) => [
+  const [teamSlug, flowSlug, user, canUserEditTeam] = useStore((state) => [
     state.teamSlug,
     state.flowSlug,
+    state.user,
+    state.canUserEditTeam,
   ]);
 
   const isActive = (route: string) => url.href.endsWith(route);
@@ -110,16 +114,19 @@ function EditorNavMenu() {
       title: "Select a team",
       Icon: FormatListBulletedIcon,
       route: "/",
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Admin panel",
       Icon: AdminPanelSettingsIcon,
       route: "admin-panel",
+      accessibleBy: ["platformAdmin"],
     },
     {
       title: "Global settings",
       Icon: TuneIcon,
       route: "global-settings",
+      accessibleBy: ["platformAdmin"],
     },
   ];
 
@@ -128,21 +135,25 @@ function EditorNavMenu() {
       title: "Services",
       Icon: FormatListBulletedIcon,
       route: `/${teamSlug}`,
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Team members",
       Icon: GroupIcon,
       route: `/${teamSlug}/members`,
+      accessibleBy: ["platformAdmin", "teamEditor"],
     },
     {
       title: "Design",
       Icon: PaletteIcon,
       route: `/${teamSlug}/design`,
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Settings",
       Icon: TuneIcon,
       route: `/${teamSlug}/general-settings`,
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
   ];
 
@@ -151,21 +162,25 @@ function EditorNavMenu() {
       title: "Editor",
       Icon: EditorIcon,
       route: `/${teamSlug}/${flowSlug}`,
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Service settings",
       Icon: TuneIcon,
       route: `/${teamSlug}/${flowSlug}/service`,
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Submissions log",
       Icon: FactCheckIcon,
       route: `/${teamSlug}/${flowSlug}/submissions-log`,
+      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
     },
     {
       title: "Feedback",
       Icon: RateReviewIcon,
       route: `/${teamSlug}/${flowSlug}/feedback`,
+      accessibleBy: ["platformAdmin", "teamEditor"],
     },
   ];
 
@@ -181,10 +196,16 @@ function EditorNavMenu() {
 
   const { routes, compact } = getRoutesForUrl(url.href);
 
+  const visibleRoutes = routes.filter(({ accessibleBy }) => {
+    if (user?.isPlatformAdmin) return accessibleBy.includes("platformAdmin");
+    if (canUserEditTeam(teamSlug)) return accessibleBy.includes("teamEditor");
+    return accessibleBy.includes("teamViewer");
+  });
+
   return (
     <Root compact={compact}>
       <MenuWrap>
-        {routes.map(({ title, Icon, route }) => (
+        {visibleRoutes.map(({ title, Icon, route }) => (
           <MenuItem onClick={() => handleClick(route)} key={title}>
             {compact ? (
               <TooltipWrap title={title}>

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -114,7 +114,7 @@ function EditorNavMenu() {
       title: "Select a team",
       Icon: FormatListBulletedIcon,
       route: "/",
-      accessibleBy: ["platformAdmin", "teamEditor", "teamViewer"],
+      accessibleBy: ["platformAdmin"],
     },
     {
       title: "Admin panel",
@@ -201,6 +201,9 @@ function EditorNavMenu() {
     if (canUserEditTeam(teamSlug)) return accessibleBy.includes("teamEditor");
     return accessibleBy.includes("teamViewer");
   });
+
+  // Hide menu if the user cannot access any options
+  if (!visibleRoutes.length) return null;
 
   return (
     <Root compact={compact}>


### PR DESCRIPTION
## What does this PR do?
- Only displays menu items which a user can access
- Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1720786056596119 (OSL Slack) for context

Ideally it would be nice to encode this in our routing system once and use it to also limit access, as opposed to keeping it in the menu and having to add wrappers to views. But this feels like a quick and pragmatic option for now 👍 