### PR TITLE
chore: Improve network error logging

### DIFF
--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -104,7 +104,9 @@ const errorLink = onError(({ graphQLErrors, operation }) => {
     handleHasuraGraphQLErrors(graphQLErrors, operation);
   } else {
     console.error(
-      `[Error]: Operation name: ${operation.operationName}. Details: ${operation}`,
+      `[Error]: Operation name: ${
+        operation.operationName
+      }. Details: ${JSON.stringify(operation)}`,
     );
     toast.error("Network error, attempting to reconnect…", {
       toastId,


### PR DESCRIPTION
Follow up to #3393 

Currently this is just (predictably!) `[object Object]` which isn't very helpful.

![image](https://github.com/user-attachments/assets/27107ce9-1320-4d69-b146-3038639a38aa)
