### PR TITLE
Revert "fix: GIS API should return geometry"

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -5,7 +5,7 @@ import type {
 } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
 import fetch from "isomorphic-fetch";
-import { addDesignatedVariable } from "./helpers";
+import { addDesignatedVariable, omitGeometry } from "./helpers";
 import { baseSchema } from "./local_authorities/metadata/base";
 import { $api } from "../../../client";
 
@@ -119,14 +119,14 @@ async function go(
       );
       // because there can be many digital land datasets per planx variable, check if this key is already in our result
       if (key && Object.keys(formattedResult).includes(key)) {
-        formattedResult[key]["data"]?.push(entity);
+        formattedResult[key]["data"]?.push(omitGeometry(entity));
       } else {
         if (key) {
           formattedResult[key] = {
             fn: key,
             value: true,
             text: baseSchema[key].pos,
-            data: [entity],
+            data: [omitGeometry(entity)],
             category: baseSchema[key].category,
           };
         }


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#3195

Geometries, especially for flood zones, are huge - let's ensure we're not unnecessarily saving them in our breadcrumbs. See issue thread from August about Chrome running out of memory: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1720449876847459