### PR TITLE
fix: temporary redirect for Canterbury FOI service

### DIFF
--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -71,6 +71,12 @@ export default isPreviewOnlyDomain
     })
   : mount({
       "/:team/:flow/published": lazy(() => import("./published")), // loads current published flow if exists, or throws Not Found if unpublished
+      "canterbury/find-out-if-you-need-planning-permission/preview": map(
+        async (req) =>
+          redirect(
+            `/canterbury-find-out-if-you-need-planning-permission/published${req?.search}`,
+          ),
+      ), // temporary redirect while Canterbury works with internal IT to update advertised service links
       "/:team/:flow/preview": lazy(() => import("./preview")), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
       "/:team/:flow/draft": lazy(() => import("./draft")), // loads current draft flow and draft external portals
       "/:team/:flow/pay": mountPayRoutes(),


### PR DESCRIPTION
See thread https://opensystemslab.slack.com/archives/C5Q59R3HB/p1721054184936579

Follows same pattern as #3147 so that the advertised `/preview` link redirects to the "offline" `/published` link.