### PR TITLE
fix: correct Canterbury redirect

### DIFF
--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -74,7 +74,7 @@ export default isPreviewOnlyDomain
       "canterbury/find-out-if-you-need-planning-permission/preview": map(
         async (req) =>
           redirect(
-            `/canterbury-find-out-if-you-need-planning-permission/published${req?.search}`,
+            `/canterbury/find-out-if-you-need-planning-permission/published${req?.search}`,
           ),
       ), // temporary redirect while Canterbury works with internal IT to update advertised service links
       "/:team/:flow/preview": lazy(() => import("./preview")), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished


### PR DESCRIPTION
There's a typo here that I didn't spot when copy+pasting from Slack :see_no_evil: 

Page is currently redirecting to "Not found" whereas we want it to go to "Offline" - so no immediate rush to prod deploy (preview is still technically unavailable as intended!), but we want this fixed later today ideally