### PR TITLE
feat: add Planning Data entity & filtered map view links to constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -22,6 +22,7 @@ import Caret from "ui/icons/Caret";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
 import { SiteAddress } from "../FindProperty/model";
+import { availableDatasets } from "./model";
 
 const CATEGORY_COLORS: Record<string, string> = {
   "General policy": "#99C1DE",
@@ -148,6 +149,17 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
   const isSourcedFromPlanningData =
     props.metadata?.plural !== "Classified roads";
 
+  // Some constraint categories search for entities amongst many PD datasets, but our `props.metadata.dataset` will only store reference to the last one
+  //   Cross reference with `availableDatasets` in Editor to ensure map URL is filtered to include each possible dataset
+  const matchingDatasets = availableDatasets.find(
+    (d) =>
+      props.metadata?.dataset && d.datasets.includes(props.metadata.dataset),
+  )?.datasets || [props?.metadata?.dataset];
+  const encodedMatchingDatasets = matchingDatasets
+    ?.map((d) => `dataset=${d}`)
+    .join("&");
+  const planningDataMapURL = `https://www.planning.data.gov.uk/map/?${encodedMatchingDatasets}#${latitude},${longitude},17.5z`;
+
   return (
     <ListItem key={props.key} disablePadding sx={{ backgroundColor: "white" }}>
       <StyledAccordion {...props} disableGutters>
@@ -215,10 +227,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
           {isSourcedFromPlanningData ? (
             <Typography component="div" variant="body2" my={2}>
               {`View on the `}
-              <Link
-                href={`https://www.planning.data.gov.uk/map/?dataset=${props.metadata?.dataset}#${latitude},${longitude},17.5z`}
-                target="_blank"
-              >
+              <Link href={planningDataMapURL} target="_blank">
                 Planning Data map
               </Link>
               {` (opens in a new tab).`}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -219,7 +219,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
             </Typography>
           ) : (
             <Typography component="div" variant="body2" my={2}>
-              {`We searched Ordnance Survey MasterMap Highways for the Unique Street Reference Number of your property`}
+              {`We searched Ordnance Survey MasterMap Highways using the Unique Street Reference Number of your property`}
               {usrn && ` (${usrn})`}
             </Typography>
           )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -140,7 +140,7 @@ interface ConstraintListItemProps {
 }
 
 function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
-  const { longitude, latitude } =
+  const { longitude, latitude, usrn } =
     (useStore(
       (state) => state.computePassport().data?._address,
     ) as SiteAddress) || {};
@@ -206,7 +206,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
               </List>
             )}
           </React.Fragment>
-          {isSourcedFromPlanningData && (
+          {isSourcedFromPlanningData ? (
             <Typography component="div" variant="body2" my={2}>
               {`View on the `}
               <Link
@@ -217,18 +217,23 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
               </Link>
               {` (opens in a new tab).`}
             </Typography>
-          )}
-          {isSourcedFromPlanningData && (
-            <Typography variant="h5" gutterBottom>
-              {`How is it defined`}
+          ) : (
+            <Typography component="div" variant="body2" my={2}>
+              {`We searched Ordnance Survey MasterMap Highways for the Unique Street Reference Number of your property`}
+              {usrn && ` (${usrn})`}
             </Typography>
           )}
+          <Typography variant="h5">{`How is it defined`}</Typography>
           <Typography component="div" variant="body2">
             <ReactMarkdownOrHtml
-              source={props.metadata?.text?.replaceAll(
-                "(/",
-                "(https://www.planning.data.gov.uk/",
-              )}
+              source={
+                isSourcedFromPlanningData
+                  ? props.metadata?.text?.replaceAll(
+                      "(/",
+                      "(https://www.planning.data.gov.uk/",
+                    )
+                  : props.metadata?.text
+              }
               openLinksOnNewTab
             />
           </Typography>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -189,17 +189,23 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                           disableGutters
                           sx={{ display: "list-item" }}
                         >
-                          <Typography variant="body2">
-                            <Link
-                              href={`https://www.planning.data.gov.uk/entity/${record.entity}`}
-                              target="_blank"
-                            >
-                              {record.name ||
-                                (record["flood-risk-level"] &&
-                                  `${props.metadata?.name} - Level ${record["flood-risk-level"]}`) ||
-                                `Planning Data entity #${record.entity}`}
-                            </Link>
-                          </Typography>
+                          {isSourcedFromPlanningData ? (
+                            <Typography variant="body2">
+                              <Link
+                                href={`https://www.planning.data.gov.uk/entity/${record.entity}`}
+                                target="_blank"
+                              >
+                                {record.name ||
+                                  (record["flood-risk-level"] &&
+                                    `${props.metadata?.name} - Level ${record["flood-risk-level"]}`) ||
+                                  `Planning Data entity #${record.entity}`}
+                              </Link>
+                            </Typography>
+                          ) : (
+                            <Typography variant="body2">
+                              {record.name}
+                            </Typography>
+                          )}
                         </ListItem>
                       ),
                   )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -88,7 +88,7 @@ export default function ConstraintsList({
               disableGutters
               disableSticky
               color="primary"
-              key={category}
+              key={`${category}-ls`}
               style={{
                 padding: 0,
                 backgroundColor: CATEGORY_COLORS[category],
@@ -161,7 +161,11 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
   const planningDataMapURL = `https://www.planning.data.gov.uk/map/?${encodedMatchingDatasets}#${latitude},${longitude},17.5z`;
 
   return (
-    <ListItem key={props.key} disablePadding sx={{ backgroundColor: "white" }}>
+    <ListItem
+      key={`${props.key}-li`}
+      disablePadding
+      sx={{ backgroundColor: "white" }}
+    >
       <StyledAccordion {...props} disableGutters>
         <AccordionSummary
           id={`${item}-header`}
@@ -192,35 +196,30 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                 sx={{ listStyleType: "disc", pl: 4, pt: 1 }}
               >
                 {props.data &&
-                  props.data.map(
-                    (record: any) =>
-                      record.name && (
-                        <ListItem
-                          key={record.entity}
-                          dense
-                          disableGutters
-                          sx={{ display: "list-item" }}
-                        >
-                          {isSourcedFromPlanningData ? (
-                            <Typography variant="body2">
-                              <Link
-                                href={`https://www.planning.data.gov.uk/entity/${record.entity}`}
-                                target="_blank"
-                              >
-                                {record.name ||
-                                  (record["flood-risk-level"] &&
-                                    `${props.metadata?.name} - Level ${record["flood-risk-level"]}`) ||
-                                  `Planning Data entity #${record.entity}`}
-                              </Link>
-                            </Typography>
-                          ) : (
-                            <Typography variant="body2">
-                              {record.name}
-                            </Typography>
-                          )}
-                        </ListItem>
-                      ),
-                  )}
+                  props.data.map((record: any) => (
+                    <ListItem
+                      key={`entity-${record.entity}-li`}
+                      dense
+                      disableGutters
+                      sx={{ display: "list-item" }}
+                    >
+                      {isSourcedFromPlanningData ? (
+                        <Typography variant="body2">
+                          <Link
+                            href={`https://www.planning.data.gov.uk/entity/${record.entity}`}
+                            target="_blank"
+                          >
+                            {record.name ||
+                              (record["flood-risk-level"] &&
+                                `${props.metadata?.name} - Level ${record["flood-risk-level"]}`) ||
+                              `Planning Data entity #${record.entity}`}
+                          </Link>
+                        </Typography>
+                      ) : (
+                        <Typography variant="body2">{record.name}</Typography>
+                      )}
+                    </ListItem>
+                  ))}
               </List>
             )}
           </React.Fragment>


### PR DESCRIPTION
A minor first step at working towards "overriding" constraints by providing the user more context about each constraint. 

Replaces #3216

**Changes:**
- For a constraint that does apply, each entity listed will link to it's entity page on Planning Data (much more reliable than "document-url" field previously used as "source" link)
  - In the case of roads, which are not sourced from Planning Data and therefore can't link there, show the plain text list item as before
- For a constraint that does apply, if it does NOT have a `name` property on Planning Data (eg flood zones), ensure we have smarter fallback text
- For _any_ constraint, show a filtered, centred link to the Planning Data map
  - The `dataset=` query param reflects multiple datasets where applicable (eg WHS)
  - In the case of roads, show a sentence describing how we checked and display the USRN
- Add a subheader "How is it defined" to visually separate metadata
- Improve types (remove explicit definitions where it's already correctly inferred etc)

**Testing:**
- [Addresses here now](https://docs.google.com/spreadsheets/d/1fHy952Ey-yOI5os_W9PxNR8l3qrAguXqWo_Dv-qrTEI/edit?usp=sharing) :slightly_smiling_face: 
- Please especially double check properties where flood zones & classified roads apply!
  
**Before:**
![Screenshot from 2024-07-17 10-29-03](https://github.com/user-attachments/assets/a9adbec9-b160-4fea-9233-79c5c03a0eb8)
![Screenshot from 2024-07-17 10-30-34](https://github.com/user-attachments/assets/e2bbeff5-637e-434e-a7ac-958d6a01d04e)

**After:**
![Screenshot from 2024-07-17 10-29-40](https://github.com/user-attachments/assets/9ae0fe53-087f-4b89-84fd-bf9f5a3c6c8c)
![Screenshot from 2024-07-17 10-30-19](https://github.com/user-attachments/assets/6899556e-7c07-4a34-beb1-2c02dbf38866)
