### PR TITLE
feat: Initial frontend search proof of concept with Fuse.js

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "^0.8.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dd24b0a",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0336fd4",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -51,6 +51,7 @@
     "dompurify": "^3.0.6",
     "dotenv": "^16.4.5",
     "formik": "^2.4.5",
+    "fuse.js": "^7.0.0",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",
     "immer": "^9.0.21",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -156,6 +156,9 @@ dependencies:
   formik:
     specifier: ^2.4.5
     version: 2.4.5(react@18.2.0)
+  fuse.js:
+    specifier: ^7.0.0
+    version: 7.0.0
   graphql:
     specifier: ^16.8.1
     version: 16.8.1
@@ -6846,7 +6849,7 @@ packages:
       '@storybook/preview-api': 7.6.7
       '@storybook/theming': 7.6.7(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.6.7
-      '@types/lodash': 4.14.202
+      '@types/lodash': 4.17.7
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
@@ -6867,11 +6870,11 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-manager@8.1.10(prettier@3.0.0):
+  /@storybook/builder-manager@8.1.10(prettier@3.3.3):
     resolution: {integrity: sha512-dhg54zpaglR9XKNAiwMqm5/IONMCEG/hO/iTfNHJI1rAGeWhvM71cmhF+VlKUcjpTlIfHe7J19+TL+sWQJNgtg==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.3)
       '@storybook/manager': 8.1.10
       '@storybook/node-logger': 8.1.10
       '@types/ejs': 3.1.5
@@ -6975,12 +6978,12 @@ packages:
       '@babel/types': 7.25.0
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.10
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.3)
       '@storybook/core-events': 8.1.10
-      '@storybook/core-server': 8.1.10(prettier@3.0.0)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-server': 8.1.10(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-tools': 8.1.10
       '@storybook/node-logger': 8.1.10
-      '@storybook/telemetry': 8.1.10(prettier@3.0.0)
+      '@storybook/telemetry': 8.1.10(prettier@3.3.3)
       '@storybook/types': 8.1.10
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -7119,7 +7122,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/core-common@8.1.10(prettier@3.0.0):
+  /@storybook/core-common@8.1.10(prettier@3.3.3):
     resolution: {integrity: sha512-+0GhgDRQwUlXu1lY77NdLnVBVycCEW0DG7eu7rvLYYkTyNRxbdl2RWsQpjr/j4sxqT6u82l9/b+RWpmsl4MgMQ==}
     peerDependencies:
       prettier: ^2 || ^3
@@ -7148,8 +7151,8 @@ packages:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier: 3.0.0
-      prettier-fallback: /prettier@3.0.0
+      prettier: 3.3.3
+      prettier-fallback: /prettier@3.3.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.3
@@ -7181,16 +7184,16 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/core-server@8.1.10(prettier@3.0.0)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/core-server@8.1.10(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-jNL5/daNyo7Rcu+y/bOmSB1P65pmcaLwvpr31EUEIISaAqvgruaneS3GKHg2TR0wcxEoHaM4abqhW6iwkI/XYQ==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.9
       '@babel/parser': 7.25.0
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.10(prettier@3.0.0)
+      '@storybook/builder-manager': 8.1.10(prettier@3.3.3)
       '@storybook/channels': 8.1.10
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.3)
       '@storybook/core-events': 8.1.10
       '@storybook/csf': 0.1.11
       '@storybook/csf-tools': 8.1.10
@@ -7200,7 +7203,7 @@ packages:
       '@storybook/manager-api': 8.1.10(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 8.1.10
       '@storybook/preview-api': 8.1.10
-      '@storybook/telemetry': 8.1.10(prettier@3.0.0)
+      '@storybook/telemetry': 8.1.10(prettier@3.3.3)
       '@storybook/types': 8.1.10
       '@types/detect-port': 1.3.5
       '@types/diff': 5.2.1
@@ -7642,11 +7645,11 @@ packages:
       qs: 6.12.3
     dev: true
 
-  /@storybook/telemetry@8.1.10(prettier@3.0.0):
+  /@storybook/telemetry@8.1.10(prettier@3.3.3):
     resolution: {integrity: sha512-pwiMWrq85D0AnaAgYNfB2w2BDgqnetQ+tXwsUAw4fUEFwA4oPU6r0uqekRbNNE6wmSSYjiiFP3JgknBFqjd2hg==}
     dependencies:
       '@storybook/client-logger': 8.1.10
-      '@storybook/core-common': 8.1.10(prettier@3.0.0)
+      '@storybook/core-common': 8.1.10(prettier@3.3.3)
       '@storybook/csf-tools': 8.1.10
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -8611,7 +8614,6 @@ packages:
 
   /@types/lodash@4.17.7:
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
-    dev: false
 
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -10701,7 +10703,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
@@ -13173,6 +13175,11 @@ packages:
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  /fuse.js@7.0.0:
+    resolution: {integrity: sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==}
+    engines: {node: '>=10'}
+    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.8.3
     version: 0.8.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dd24b0a
-    version: github.com/theopensystemslab/planx-core/dd24b0a(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#0336fd4
+    version: github.com/theopensystemslab/planx-core/0336fd4(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -21898,9 +21898,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/dd24b0a(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd24b0a}
-    id: github.com/theopensystemslab/planx-core/dd24b0a
+  github.com/theopensystemslab/planx-core/0336fd4(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0336fd4}
+    id: github.com/theopensystemslab/planx-core/0336fd4
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/hooks/useSearch.ts
+++ b/editor.planx.uk/src/hooks/useSearch.ts
@@ -1,0 +1,48 @@
+import Fuse, { IFuseOptions } from "fuse.js";
+import { useEffect, useMemo, useState } from "react";
+
+const DEFAULT_OPTIONS: Required<SearchOptions> = {
+  limit: 20,
+};
+
+interface SearchOptions {
+  limit?: number;
+}
+
+interface UseSearchProps<T extends Record<string, unknown>> {
+  list: T[];
+  keys: string[];
+  options?: SearchOptions;
+}
+
+export const useSearch = <T extends Record<string, unknown>>({
+  list,
+  keys,
+  options,
+}: UseSearchProps<T>) => {
+  const [pattern, setPattern] = useState("");
+  const [results, setResults] = useState<T[]>([]);
+
+  const fuseOptions: IFuseOptions<T> = useMemo(
+    () => ({
+      threshold: 0.3,
+      useExtendedSearch: true,
+      keys,
+    }),
+    [keys],
+  );
+
+  const fuse = useMemo(
+    () => new Fuse<T>(list, fuseOptions),
+    [list, fuseOptions],
+  );
+
+  useEffect(() => {
+    const fuseResults = fuse.search(pattern, {
+      limit: options?.limit || DEFAULT_OPTIONS.limit,
+    });
+    setResults(fuseResults.map((result) => result.item));
+  }, [pattern]);
+
+  return { results, search: setPattern };
+};

--- a/editor.planx.uk/src/hooks/useSearch.ts
+++ b/editor.planx.uk/src/hooks/useSearch.ts
@@ -6,16 +6,26 @@ interface UseSearchProps<T extends object> {
   keys: string[];
 }
 
+export interface SearchResult<T extends object> {
+  item: T;
+  key: string;
+  matchIndices?: [number, number][];
+}
+
+export type SearchResults<T extends object> = SearchResult<T>[];
+
 export const useSearch = <T extends object>({
   list,
   keys,
 }: UseSearchProps<T>) => {
   const [pattern, setPattern] = useState("");
-  const [results, setResults] = useState<T[]>([]);
+  const [results, setResults] = useState<SearchResults<T>>([]);
 
   const fuseOptions: IFuseOptions<T> = useMemo(
     () => ({
       useExtendedSearch: true,
+      includeMatches: true,
+      minMatchCharLength: 3,
       keys,
     }),
     [keys],
@@ -28,7 +38,15 @@ export const useSearch = <T extends object>({
 
   useEffect(() => {
     const fuseResults = fuse.search(pattern);
-    setResults(fuseResults.map((result) => result.item));
+    setResults(
+      fuseResults.map((result) => ({
+        item: result.item,
+        key: result.matches?.[0].key || "",
+        // We only display the first match
+        matchIndices:
+          (result.matches?.[0].indices as [number, number][]) || undefined,
+      })),
+    );
   }, [pattern]);
 
   return { results, search: setPattern };

--- a/editor.planx.uk/src/hooks/useSearch.ts
+++ b/editor.planx.uk/src/hooks/useSearch.ts
@@ -1,31 +1,20 @@
 import Fuse, { IFuseOptions } from "fuse.js";
 import { useEffect, useMemo, useState } from "react";
 
-const DEFAULT_OPTIONS: Required<SearchOptions> = {
-  limit: 20,
-};
-
-interface SearchOptions {
-  limit?: number;
-}
-
-interface UseSearchProps<T extends Record<string, unknown>> {
+interface UseSearchProps<T extends object> {
   list: T[];
   keys: string[];
-  options?: SearchOptions;
 }
 
-export const useSearch = <T extends Record<string, unknown>>({
+export const useSearch = <T extends object>({
   list,
   keys,
-  options,
 }: UseSearchProps<T>) => {
   const [pattern, setPattern] = useState("");
   const [results, setResults] = useState<T[]>([]);
 
   const fuseOptions: IFuseOptions<T> = useMemo(
     () => ({
-      threshold: 0.3,
       useExtendedSearch: true,
       keys,
     }),
@@ -38,9 +27,7 @@ export const useSearch = <T extends Record<string, unknown>>({
   );
 
   useEffect(() => {
-    const fuseResults = fuse.search(pattern, {
-      limit: options?.limit || DEFAULT_OPTIONS.limit,
-    });
+    const fuseResults = fuse.search(pattern);
     setResults(fuseResults.map((result) => result.item));
   }, [pattern]);
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -14,7 +14,10 @@ import Hanger from "./Hanger";
 import Question from "./Question";
 
 const ExternalPortal: React.FC<any> = (props) => {
-  const copyNode = useStore((state) => state.copyNode);
+  const [copyNode, addExternalPortal] = useStore((state) => [
+    state.copyNode,
+    state.addExternalPortal,
+  ]);
   const [href, setHref] = useState("Loading...");
 
   const { data, loading } = useQuery(
@@ -23,6 +26,7 @@ const ExternalPortal: React.FC<any> = (props) => {
         flows_by_pk(id: $id) {
           id
           slug
+          name
           team {
             slug
           }
@@ -31,8 +35,17 @@ const ExternalPortal: React.FC<any> = (props) => {
     `,
     {
       variables: { id: props.data.flowId },
-      onCompleted: (data) =>
-        setHref([data.flows_by_pk.team.slug, data.flows_by_pk.slug].join("/")),
+      onCompleted: (data) => {
+        const href = [data.flows_by_pk.team.slug, data.flows_by_pk.slug].join(
+          "/",
+        );
+        setHref(href);
+        addExternalPortal({
+          id: props.data.flowId,
+          name: data.flows_by_pk.name,
+          href,
+        });
+      },
     },
   );
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
@@ -29,7 +29,7 @@ const SearchResultRoot = styled(List)(({ theme }) => ({
 const SearchResultCardRoot = styled(ListItemButton)(({ theme }) => ({
   padding: theme.spacing(1),
   border: `1px solid ${theme.palette.common.black}`,
-  display: "block"
+  display: "block",
 }));
 
 const ExternalPortalCard = styled(ListItemButton)(({ theme }) => ({
@@ -39,8 +39,8 @@ const ExternalPortalCard = styled(ListItemButton)(({ theme }) => ({
     backgroundColor: "black",
     "& p:last-of-type": {
       textDecoration: "underline",
-    }
-  }
+    },
+  },
 }));
 
 const SearchResults: React.FC<{ results: SearchResults<IndexedNode> }> = ({
@@ -117,7 +117,7 @@ const SearchResultCard: React.FC<{ result: SearchResult<IndexedNode> }> = ({
       const parentNode = useStore.getState().flow[item.parentId];
       Icon = ICONS[ComponentType.Question];
       title = parentNode!.data.text!;
-      displayKey = "Answer (data)";
+      displayKey = "Option (data)";
     }
 
     return {
@@ -136,7 +136,7 @@ const SearchResultCard: React.FC<{ result: SearchResult<IndexedNode> }> = ({
 
   const handleClick = () => {
     console.log("todo!");
-    console.log({ nodeId: result.item.id })
+    console.log({ nodeId: result.item.id });
     // get path for node
     // generate url from path
     // navigate to url
@@ -193,7 +193,11 @@ const ExternalPortalList: React.FC = () => {
       </Typography>
       <List sx={{ gap: 2 }}>
         {Object.values(externalPortals).map(({ name, href }) => (
-          <ListItem key={`external-portal-card-${name}`} disablePadding sx={{ mb: 2 }}>
+          <ListItem
+            key={`external-portal-card-${name}`}
+            disablePadding
+            sx={{ mb: 2 }}
+          >
             <ExternalPortalCard onClick={() => navigate("../" + href)}>
               <Typography
                 variant="body2"
@@ -203,9 +207,7 @@ const ExternalPortalList: React.FC = () => {
               >
                 External portal •
               </Typography>
-              <Typography
-                variant="body2"
-              >
+              <Typography variant="body2">
                 {href.replaceAll("/", " / ")}
               </Typography>
             </ExternalPortalCard>
@@ -218,7 +220,7 @@ const ExternalPortalList: React.FC = () => {
 
 interface SearchNodes {
   input: string;
-  facets: ["data.fn", "data.val"],
+  facets: ["data.fn", "data.val"];
 }
 
 const Search: React.FC = () => {
@@ -233,12 +235,14 @@ const Search: React.FC = () => {
 
   const formik = useFormik<SearchNodes>({
     initialValues: { input: "", facets: ["data.fn", "data.val"] },
-    onSubmit: ({ input }) => { search(input) },
+    onSubmit: ({ input }) => {
+      search(input);
+    },
   });
 
   const { results, search } = useSearch({
     list: orderedFlow || [],
-    keys: formik.values.facets
+    keys: formik.values.facets,
   });
 
   return (
@@ -257,7 +261,7 @@ const Search: React.FC = () => {
           name="search"
           value={formik.values.input}
           onChange={(e) => {
-            formik.setFieldValue("input", e.target.value)
+            formik.setFieldValue("input", e.target.value);
             formik.handleSubmit();
           }}
           inputProps={{ spellCheck: false }}
@@ -267,7 +271,7 @@ const Search: React.FC = () => {
           id={"search-data-field-facet"}
           checked
           inputProps={{ disabled: true }}
-          onChange={() => { }}
+          onChange={() => {}}
         />
         <Box pt={3}>
           {formik.values.input && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -12,6 +13,7 @@ import { capitalize, get } from "lodash";
 import { SLUGS } from "pages/FlowEditor/data/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent, useEffect } from "react";
+import { useNavigation } from "react-navi";
 import { FONT_WEIGHT_BOLD, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import ChecklistItem from "ui/shared/ChecklistItem";
 import Input from "ui/shared/Input";
@@ -26,7 +28,18 @@ const SearchResultRoot = styled(List)(({ theme }) => ({
 const SearchResultCardRoot = styled(ListItemButton)(({ theme }) => ({
   padding: theme.spacing(1),
   border: `1px solid ${theme.palette.common.black}`,
-  display: "block",
+  display: "block"
+}));
+
+const ExternalPortalCard = styled(ListItemButton)(({ theme }) => ({
+  backgroundColor: "black",
+  color: theme.palette.common.white,
+  "&:hover": {
+    backgroundColor: "black",
+    "& p:last-of-type": {
+      textDecoration: "underline",
+    }
+  }
 }));
 
 const SearchResults: React.FC<{ results: SearchResults<IndexedNode> }> = ({
@@ -39,7 +52,9 @@ const SearchResults: React.FC<{ results: SearchResults<IndexedNode> }> = ({
       </Typography>
       <SearchResultRoot>
         {results.map((result) => (
-          <SearchResultCard key={result.item.id} result={result} />
+          <ListItem key={result.item.id} disablePadding>
+            <SearchResultCard result={result} />
+          </ListItem>
         ))}
       </SearchResultRoot>
     </>
@@ -160,6 +175,7 @@ const SearchResultCard: React.FC<{ result: SearchResult<IndexedNode> }> = ({
 const ExternalPortalList: React.FC = () => {
   const externalPortals = useStore((state) => state.externalPortals);
   const hasExternalPortals = Object.keys(externalPortals).length;
+  const { navigate } = useNavigation();
 
   if (!hasExternalPortals) return null;
 
@@ -169,38 +185,27 @@ const ExternalPortalList: React.FC = () => {
         Your service also contains the following external portals, which have
         not been searched:
       </Typography>
+      <List sx={{ gap: 2 }}>
       {Object.values(externalPortals).map(({ name, href }) => (
-        <Box
-          sx={(theme) => ({
-            backgroundColor: "black",
-            color: theme.palette.common.white,
-            mb: 2,
-            p: 1,
-          })}
-          key={`external-portal-card-${name}`}
-        >
-          <Typography
-            variant="body2"
-            fontWeight={FONT_WEIGHT_SEMI_BOLD}
-            display="inline-block"
-            mr={0.5}
-          >
-            External portal •
-          </Typography>
-          <Typography
-            variant="body2"
-            component="a"
-            href={"../" + href}
-            sx={(theme) => ({
-              color: theme.palette.common.white,
-              textDecoration: "none",
-              borderBottom: "1px solid rgba(255, 255, 255, 0.75)",
-            })}
-          >
-            {href}
-          </Typography>
-        </Box>
+        <ListItem key={`external-portal-card-${name}`} disablePadding sx={{ mb: 2 }}>
+          <ExternalPortalCard  onClick={() => navigate("../" + href)}>
+            <Typography
+              variant="body2"
+              fontWeight={FONT_WEIGHT_SEMI_BOLD}
+              mr={0.5}
+              whiteSpace="nowrap"
+            >
+              External portal •
+            </Typography>
+            <Typography
+              variant="body2"
+            >
+              {href.replaceAll("/", " / ")}
+            </Typography>
+          </ExternalPortalCard>
+        </ListItem>
       ))}
+      </List>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
@@ -1,47 +1,128 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { IndexedNode, OrderedFlow } from "@opensystemslab/planx-core/types";
+import { ComponentType, IndexedNode } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/ui";
+import type { SearchResult, SearchResults } from "hooks/useSearch";
 import { useSearch } from "hooks/useSearch";
+import { capitalize, get } from "lodash";
+import { SLUGS } from "pages/FlowEditor/data/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent, useEffect } from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import InputLabel from "ui/editor/InputLabel";
+import { FONT_WEIGHT_BOLD, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import ChecklistItem from "ui/shared/ChecklistItem";
 import Input from "ui/shared/Input";
 
-const SearchResults: React.FC<{ results: OrderedFlow }> = ({ results }) => {
+const SearchResultRoot = styled(List)(({ theme }) => ({
+  width: "100%",
+  gap: theme.spacing(2),
+  display: "flex",
+  flexDirection: "column",
+}));
+
+const SearchResultCardRoot = styled(ListItemButton)(({ theme }) => ({
+  padding: theme.spacing(1),
+  border: `1px solid ${theme.palette.common.black}`,
+  display: "block",
+}));
+
+const SearchResults: React.FC<{ results: SearchResults<IndexedNode> }> = ({
+  results,
+}) => {
   return (
-    <Box
-      sx={{ width: "100%", gap: 2, display: "flex", flexDirection: "column" }}
-    >
-      {results.map((result) => (
-        <SearchResultCard key={result.id} {...result} />
-      ))}
-    </Box>
+    <>
+      <Typography variant="h3" mb={1}>
+        {results.length} {results.length > 1 ? "results" : "result"}:
+      </Typography>
+      <SearchResultRoot>
+        {results.map((result) => (
+          <SearchResultCard key={result.item.id} result={result} />
+        ))}
+      </SearchResultRoot>
+    </>
   );
 };
 
-// TODO: This likely needs to be related to facets?
-const SearchResultCard: React.FC<IndexedNode> = ({ data, type }) => {
-  const Icon = ICONS[type!];
+interface HeadlineProps {
+  text: string;
+  matchIndices: [number, number][];
+  variant: "data";
+}
+
+const Headline: React.FC<HeadlineProps> = ({ text, matchIndices, variant }) => {
+  const isHighlighted = (index: number) =>
+    matchIndices.some(([start, end]) => index >= start && index <= end);
+
+  return (
+    <>
+      {text.split("").map((char, index) => (
+        <Typography
+          fontWeight={isHighlighted(index) ? FONT_WEIGHT_BOLD : "regular"}
+          component="span"
+          p={0}
+          key={`headline-character-${index}`}
+          fontFamily={
+            variant === "data" ? '"Source Code Pro", monospace' : "inherit"
+          }
+          variant="body2"
+        >
+          {char}
+        </Typography>
+      ))}
+    </>
+  );
+};
+
+const SearchResultCard: React.FC<{ result: SearchResult<IndexedNode> }> = ({
+  result,
+}) => {
+  const getDisplayDetailsForResult = ({
+    item,
+    key,
+  }: SearchResult<IndexedNode>) => {
+    const componentType = capitalize(
+      SLUGS[result.item.type].replaceAll("-", " "),
+    );
+    let title = (item.data?.title as string) || (item.data?.text as string);
+    let Icon = ICONS[item.type];
+    // TODO: Generate display key from key
+    let displayKey = "Data";
+    const headline = get(item, key).toString() || "";
+
+    // For Answer nodes, update display values to match the parent question
+    if (item.type === ComponentType.Answer) {
+      const parentNode = useStore.getState().flow[item.parentId];
+      Icon = ICONS[ComponentType.Question];
+      title = parentNode!.data.text!;
+      displayKey = "Answer (data)";
+    }
+
+    return {
+      Icon,
+      componentType,
+      title,
+      key: displayKey,
+      headline,
+    };
+  };
+
+  const { Icon, componentType, title, key, headline } =
+    getDisplayDetailsForResult(result);
+
+  // TODO - display portal wrapper
 
   const handleClick = () => {
-    console.log("todo!")
+    console.log("todo!");
     // get path for node
     // generate url from path
     // navigate to url
   };
 
   return (
-    <Box
-      sx={(theme) => ({
-        pb: 2,
-        borderBottom: `1px solid ${theme.palette.border.main}`,
-      })}
-      onClick={handleClick}
-    >
+    <SearchResultCardRoot onClick={handleClick}>
       <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
         {Icon && <Icon sx={{ mr: 1 }} />}
         <Typography
@@ -49,20 +130,77 @@ const SearchResultCard: React.FC<IndexedNode> = ({ data, type }) => {
           fontSize={14}
           fontWeight={FONT_WEIGHT_SEMI_BOLD}
         >
-          Question
-          {data?.text && ` - ${data.text}`}
+          {componentType}
         </Typography>
+        {title && (
+          <Typography
+            variant="body2"
+            fontSize={14}
+            ml={0.5}
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+          >
+            {` • ${title}`}
+          </Typography>
+        )}
       </Box>
-      <Typography
-        variant="body2"
-        sx={{
-          backgroundColor: "#f0f0f0",
-          borderColor: "#d3d3d3",
-          fontFamily: `"Source Code Pro", monospace;`,
-        }}
-      >
-        {(data?.fn as string) || (data?.val as string)}
+      <Typography variant="body2" display="inline-block" mr={0.5}>
+        {key} -
       </Typography>
+      <Headline
+        text={headline}
+        matchIndices={result.matchIndices!}
+        variant="data"
+      />
+    </SearchResultCardRoot>
+  );
+};
+
+const ExternalPortalList: React.FC = () => {
+  const externalPortals = useStore((state) => state.externalPortals);
+  const hasExternalPortals = Object.keys(externalPortals).length;
+
+  if (!hasExternalPortals) return null;
+
+  return (
+    <Box pt={4}>
+      <Typography variant="body1" mb={2}>
+        Your service also contains the following external portals, which have
+        not been searched:
+      </Typography>
+      {Object.values(externalPortals).map(({ name, href }) => (
+        <Box
+          sx={(theme) => ({
+            backgroundColor: "black",
+            color: theme.palette.common.white,
+            mb: 2,
+            p: 1,
+          })}
+          key={`external-portal-card-${name}`}
+        >
+          <Typography
+            variant="body2"
+            fontWeight={FONT_WEIGHT_SEMI_BOLD}
+            display="inline-block"
+            mr={0.5}
+          >
+            External portal •
+          </Typography>
+          <Typography
+            variant="body2"
+            component="a"
+            href={"../" + href}
+            sx={(theme) => ({
+              color: theme.palette.common.white,
+              textDecoration: "none",
+              borderBottom: "1px solid rgba(255, 255, 255, 0.75)",
+            })}
+          >
+            {href}
+          </Typography>
+        </Box>
+      ))}
     </Box>
   );
 };
@@ -74,7 +212,7 @@ const Search: React.FC = () => {
   ]);
 
   useEffect(() => {
-    if (!orderedFlow) setOrderedFlow()
+    if (!orderedFlow) setOrderedFlow();
   }, [setOrderedFlow]);
 
   /** Map of search facets to associated node keys */
@@ -89,27 +227,39 @@ const Search: React.FC = () => {
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value;
-    console.log({ input });
     search(input);
-    console.log(results);
   };
 
   return (
     <Container component={Box} p={3}>
-      <InputLabel label="Type to search" htmlFor="search">
-        <Input name="search" onChange={handleChange} id="boundaryUrl" />
-      </InputLabel>
+      <Typography
+        component={"label"}
+        htmlFor="search"
+        variant="h3"
+        mb={1}
+        display={"block"}
+      >
+        Search this flow and internal portals
+      </Typography>
+      <Input
+        name="search"
+        onChange={handleChange}
+        inputProps={{ spellCheck: false }}
+      />
       <ChecklistItem
         label="Search only data fields"
         id={"search-data-field-facet"}
         checked
-        inputProps={{
-          disabled: true,
-        }}
+        inputProps={{ disabled: true }}
         onChange={() => {}}
       />
-      <Box py={3}>
-        {results ? <SearchResults results={results} /> : "Loading..."}
+      <Box pt={3}>
+        {results.length > 0 && (
+          <>
+            <SearchResults results={results} />
+            <ExternalPortalList />
+          </>
+        )}
       </Box>
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search.tsx
@@ -3,7 +3,7 @@ import Container from "@mui/material/Container";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
-import { styled } from "@mui/material/styles";
+import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { ComponentType, IndexedNode } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/ui";
@@ -32,15 +32,11 @@ const SearchResultCardRoot = styled(ListItemButton)(({ theme }) => ({
   display: "block",
 }));
 
-const ExternalPortalCard = styled(ListItemButton)(({ theme }) => ({
-  backgroundColor: "black",
-  color: theme.palette.common.white,
-  "&:hover": {
-    backgroundColor: "black",
-    "& p:last-of-type": {
-      textDecoration: "underline",
-    },
-  },
+const PortalList = styled(List)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  padding: theme.spacing(0.5, 0),
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.border.light}`,
 }));
 
 const SearchResults: React.FC<{ results: SearchResults<IndexedNode> }> = ({
@@ -191,29 +187,17 @@ const ExternalPortalList: React.FC = () => {
         Your service also contains the following external portals, which have
         not been searched:
       </Typography>
-      <List sx={{ gap: 2 }}>
+      <PortalList>
         {Object.values(externalPortals).map(({ name, href }) => (
-          <ListItem
-            key={`external-portal-card-${name}`}
-            disablePadding
-            sx={{ mb: 2 }}
-          >
-            <ExternalPortalCard onClick={() => navigate("../" + href)}>
-              <Typography
-                variant="body2"
-                fontWeight={FONT_WEIGHT_SEMI_BOLD}
-                mr={0.5}
-                whiteSpace="nowrap"
-              >
-                External portal •
-              </Typography>
+          <ListItem key={`external-portal-card-${name}`} disablePadding>
+            <ListItemButton component="a" href={`../${href}`}>
               <Typography variant="body2">
                 {href.replaceAll("/", " / ")}
               </Typography>
-            </ExternalPortalCard>
+            </ListItemButton>
           </ListItem>
         ))}
-      </List>
+      </PortalList>
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -101,6 +101,12 @@ export interface EditorStore extends Store.Store {
   undoOperation: (ops: OT.Op[]) => void;
   orderedFlow?: OrderedFlow;
   setOrderedFlow: () => void;
+  externalPortals: Record<string, { name: string; href: string }>;
+  addExternalPortal: (portal: {
+    id: string;
+    name: string;
+    href: string;
+  }) => void;
 }
 
 export const editorStore: StateCreator<
@@ -472,5 +478,13 @@ export const editorStore: StateCreator<
     const flow = get().flow as FlowGraph;
     const orderedFlow = sortFlow(flow);
     set({ orderedFlow });
+  },
+
+  externalPortals: {},
+
+  addExternalPortal: ({ id, name, href }) => {
+    const externalPortals = get().externalPortals;
+    externalPortals[id] = { name, href };
+    set({ externalPortals });
   },
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -1,4 +1,6 @@
 import { gql } from "@apollo/client";
+import { sortFlow } from "@opensystemslab/planx-core";
+import { FlowGraph, OrderedFlow } from "@opensystemslab/planx-core/types";
 import {
   add,
   clone,
@@ -97,6 +99,8 @@ export interface EditorStore extends Store.Store {
   removeNode: (id: Store.nodeId, parent: Store.nodeId) => void;
   updateNode: (node: any, relationships?: any) => void;
   undoOperation: (ops: OT.Op[]) => void;
+  orderedFlow?: OrderedFlow;
+  setOrderedFlow: () => void;
 }
 
 export const editorStore: StateCreator<
@@ -460,5 +464,13 @@ export const editorStore: StateCreator<
   undoOperation: (ops: OT.Op[]) => {
     const inverseOps: OT.Op[] = type.invert(ops);
     send(inverseOps);
+  },
+
+  orderedFlow: undefined,
+
+  setOrderedFlow: () => {
+    const flow = get().flow as FlowGraph;
+    const orderedFlow = sortFlow(flow);
+    set({ orderedFlow });
   },
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -93,7 +93,7 @@ export const sharedStore: StateCreator<
   },
 
   setFlow({ id, flow, flowSlug, flowName, flowStatus }) {
-    set({ id, flow, flowSlug, flowName, flowStatus });
+    set({ id, flow, flowSlug, flowName, flowStatus, orderedFlow: undefined });
     get().initNavigationStore();
   },
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -93,7 +93,15 @@ export const sharedStore: StateCreator<
   },
 
   setFlow({ id, flow, flowSlug, flowName, flowStatus }) {
-    set({ id, flow, flowSlug, flowName, flowStatus, orderedFlow: undefined });
+    set({
+      id,
+      flow,
+      flowSlug,
+      flowName,
+      flowStatus,
+      orderedFlow: undefined,
+      externalPortals: {},
+    });
     get().initNavigationStore();
   },
 


### PR DESCRIPTION
## What does this PR do?
- Handles search in the frontend using [Fuse.js](https://www.fusejs.io/)
- Creates `useSearch()` hook as a facade for this library
  - This means we could search elsewhere fairly easily by re-using this hook (e.g. teams, flows)
  - We could also more easily swap out the search functionality in future (maybe with our own API or another library) 
- Displays list of external portals to contextualise search results ([see Figma designs here](https://www.figma.com/design/bnUUrsVRG6qPwDkTmVKACI/PlanX-Design?node-id=15558-12317&t=SjQkPvPMMYyjxwVa-4))

### Why search in the frontend?
 - We have all flow data already in the frontend and don't need to fetch this from the db, add parentIds etc (on each debounced search request)
 - Most flows aren't actually _that_ big, so handling this in the frontend isn't as intensive a task as I would have thought (I have some SQL queries for avg. number of nodes, flow size in kb etc I can share).
 - Initial testing indicates it's pretty performant
 - If we start hitting performance issues, the Fuse.js code could still run server side so there's not much "lost" work as such

### Why Fuse.js?
 - Docs and API are comprehensive - covers all our needs and then some
 - Well established and stable
 - Plenty of other options out there if we find it's either not performant or inaccurate

## Next steps...
I'll pick up the below as follow up PRs - 
- [ ] UI tests
- [x] Generate path for node
  - https://github.com/theopensystemslab/planx-core/pull/463
- [ ] Generate URL from path
  - https://github.com/theopensystemslab/planx-new/pull/3460
- [ ] Visual display of nodes within portals
- [ ] Handle data values for complex nodes (FileUploadAndLabel, List, etc)
    - https://github.com/theopensystemslab/planx-new/pull/3448
- [ ] Search all node data, not just `data.fn` and `data.val`


https://github.com/user-attachments/assets/1fe2b1bf-6309-4b3c-a0d8-74744f079862


