### PR TITLE
feat: modal form for reporting inaccurate Planning Constraints

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -15,13 +15,14 @@ import type {
 } from "@opensystemslab/planx-core/types";
 import groupBy from "lodash/groupBy";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useState } from "react";
 import ReactHtmlParser from "react-html-parser";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import Caret from "ui/icons/Caret";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
 import { SiteAddress } from "../FindProperty/model";
+import { OverrideEntitiesModal } from "./Modal";
 import { availableDatasets } from "./model";
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -141,6 +142,9 @@ interface ConstraintListItemProps {
 }
 
 function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [disputedEntities, setDisputedEntities] = useState<string[]>([]);
+
   const { longitude, latitude, usrn } =
     (useStore(
       (state) => state.computePassport().data?._address,
@@ -238,7 +242,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
             </Typography>
           )}
           <Typography variant="h5">{`How is it defined`}</Typography>
-          <Typography component="div" variant="body2">
+          <Typography component="div" variant="body2" my={2}>
             <ReactMarkdownOrHtml
               source={
                 isSourcedFromPlanningData
@@ -251,6 +255,27 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
               openLinksOnNewTab
             />
           </Typography>
+          {props.value && Boolean(props.data?.length) && (
+            <Typography variant="h5">
+              <Link
+                component="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setShowModal(true);
+                }}
+              >
+                Report an innaccuracy
+              </Link>
+            </Typography>
+          )}
+          <OverrideEntitiesModal
+            showModal={showModal}
+            setShowModal={setShowModal}
+            entities={props.data}
+            metadata={props.metadata}
+            disputedEntities={disputedEntities}
+            setDisputedEntities={setDisputedEntities}
+          />
         </AccordionDetails>
       </StyledAccordion>
     </ListItem>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -264,7 +264,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                   setShowModal(true);
                 }}
               >
-                This constraint doesn't apply to me
+                This constraint doesn't apply to my property
               </Link>
             </Typography>
           )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -309,7 +309,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                     setShowModal(true);
                   }}
                 >
-                  This constraint doesn't apply to this property
+                  I don't think this constraint applies to this property
                 </Link>
               </Typography>
             )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -2,6 +2,7 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Box, { BoxProps } from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
 import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -218,19 +219,40 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                       key={`entity-${record.entity}-li`}
                       dense
                       disableGutters
-                      sx={{ display: "list-item" }}
+                      sx={{
+                        display: "list-item",
+                        color: props.inaccurateConstraints?.[props.fn]?.[
+                          "entities"
+                        ]?.includes(`${record.entity}`)
+                          ? "GrayText"
+                          : "inherit",
+                      }}
                     >
                       {isSourcedFromPlanningData ? (
-                        <Typography variant="body2">
+                        <Typography variant="body2" component="span">
                           <Link
                             href={`https://www.planning.data.gov.uk/entity/${record.entity}`}
                             target="_blank"
+                            sx={{
+                              color: props.inaccurateConstraints?.[props.fn]?.[
+                                "entities"
+                              ]?.includes(`${record.entity}`)
+                                ? "GrayText"
+                                : "inherit",
+                            }}
                           >
                             {formatEntityName(record, props.metadata)}
                           </Link>
                         </Typography>
                       ) : (
                         <Typography variant="body2">{record.name}</Typography>
+                      )}
+                      {props.inaccurateConstraints?.[props.fn]?.[
+                        "entities"
+                      ]?.includes(`${record.entity}`) && (
+                        <Typography variant="body2" component="span">
+                          {` [Not applicable]`}
+                        </Typography>
                       )}
                     </ListItem>
                   ))}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -264,7 +264,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                   setShowModal(true);
                 }}
               >
-                This constraint doesn't apply to my property
+                This constraint doesn't apply to this property
               </Link>
             </Typography>
           )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -264,7 +264,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
                   setShowModal(true);
                 }}
               >
-                Report an innaccuracy
+                This constraint doesn't apply to me
               </Link>
             </Typography>
           )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -1,0 +1,156 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
+import { Constraint, Metadata } from "@opensystemslab/planx-core/types";
+import React from "react";
+import InputLabel from "ui/public/InputLabel";
+import ChecklistItem from "ui/shared/ChecklistItem";
+import Input from "ui/shared/Input";
+
+interface OverrideEntitiesModalProps {
+  showModal: boolean;
+  setShowModal: (value: React.SetStateAction<boolean>) => void;
+  entities: Constraint["data"] | null;
+  metadata?: Metadata;
+  disputedEntities: string[];
+  setDisputedEntities: (value: React.SetStateAction<string[]>) => void;
+}
+
+export const OverrideEntitiesModal = ({
+  showModal,
+  setShowModal,
+  entities,
+  metadata,
+  disputedEntities,
+  setDisputedEntities,
+}: OverrideEntitiesModalProps) => {
+  const handleValidation = () => {
+    console.log("todo");
+  };
+
+  const closeModal = (_event: any, reason?: string) => {
+    if (reason && reason == "backdropClick") {
+      return;
+    }
+    setShowModal(false);
+  };
+
+  return (
+    <Dialog
+      open={showModal}
+      onClose={closeModal}
+      data-testid="override-planning-constraint-entities-dialog"
+      maxWidth="xl"
+      aria-labelledby="dialog-heading"
+      PaperProps={{
+        sx: {
+          width: "100%",
+          maxWidth: (theme) => theme.breakpoints.values.md,
+          borderRadius: 0,
+          borderTop: (theme) => `20px solid ${theme.palette.primary.main}`,
+          background: "#FFF",
+          margin: (theme) => theme.spacing(2),
+        },
+      }}
+    >
+      <DialogContent>
+        <Box>
+          <Typography
+            variant="h3"
+            component="h2"
+            id="dialog-heading"
+            gutterBottom
+            mb={2}
+          >
+            Report an inaccuracy
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            Have we identified a planning constraint that you don't think
+            applies to your property?
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            We check constraints using a geospatial search, and minor
+            differences in boundaries can occassionally lead to adjacent
+            constraints being incorrectly returned.
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            Select any incorrect constraints to proceed with the rest of your
+            application as if they do not apply, and we'll relay your report and
+            the original search result with your submission. Your feedback will
+            help councils improve their public data.
+          </Typography>
+          <Divider sx={{ marginY: 2 }} />
+          <Typography id="entities-group" variant="body1">
+            {`Which ${
+              metadata?.plural?.toLowerCase() || "entities"
+            } are inaccurate?`}
+          </Typography>
+          <List
+            disablePadding
+            dense
+            sx={{ marginBottom: 2 }}
+            role="group"
+            aria-labelledby="entities-group"
+          >
+            {Boolean(entities?.length) &&
+              entities?.map((e) => (
+                <ListItem
+                  key={`${e.entity}-li`}
+                  dense
+                  disablePadding
+                  disableGutters
+                >
+                  <ChecklistItem
+                    label={
+                      (e.name as string) ||
+                      ((e["flood-risk-level"] &&
+                        `${metadata?.name} - Level ${e["flood-risk-level"]}`) as string) ||
+                      (`Planning Data entity #${e.entity}` as string)
+                    }
+                    checked={false}
+                    onChange={() => console.log("clicked this one")}
+                  />
+                </ListItem>
+              ))}
+          </List>
+          <InputLabel label="Tell us why" htmlFor="reason">
+            <Input name="reason" type="text" bordered required />
+          </InputLabel>
+        </Box>
+      </DialogContent>
+      <DialogActions
+        sx={{
+          display: "flex",
+          justifyContent: "flex-start",
+          padding: 2,
+        }}
+      >
+        <Box>
+          <Button
+            variant="contained"
+            color="prompt"
+            onClick={handleValidation}
+            data-testid="modal-done-button"
+          >
+            Done
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            sx={{ ml: 1.5 }}
+            onClick={closeModal}
+            data-testid="modal-cancel-button"
+          >
+            Cancel
+          </Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -8,6 +8,7 @@ import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import { Constraint, Metadata } from "@opensystemslab/planx-core/types";
+import omit from "lodash/omit";
 import React, { useState } from "react";
 import InputLabel from "ui/public/InputLabel";
 import ChecklistItem from "ui/shared/ChecklistItem";
@@ -60,9 +61,14 @@ export const OverrideEntitiesModal = ({
     if (reason && reason == "backdropClick") {
       return;
     }
-    // Clear any non-submitted inputs
+
+    // Clear any non-submitted inputs on cancel & sync parent state
     setCheckedOptions(undefined);
     setTextInput(undefined);
+    const newInaccurateConstraints = omit(inaccurateConstraints, fn);
+    setInaccurateConstraints(newInaccurateConstraints);
+
+    // Close modal
     setShowModal(false);
   };
 
@@ -103,7 +109,7 @@ export const OverrideEntitiesModal = ({
     } else if (invalidInput) {
       setShowInputError(true);
     } else {
-      // Update inaccurateConstraints in parent component state on valid Modal submit
+      // Update inaccurateConstraints in parent component state on valid submit
       const newInaccurateConstraints = {
         ...inaccurateConstraints,
         ...{ [fn]: { entities: checkedOptions, reason: textInput } },

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -68,7 +68,7 @@ export const OverrideEntitiesModal = ({
             gutterBottom
             mb={2}
           >
-            This constraint doesn't apply to me
+            This constraint doesn't apply to my property
           </Typography>
           <Typography variant="body2" gutterBottom>
             Have we identified a planning constraint that you don't think
@@ -80,9 +80,9 @@ export const OverrideEntitiesModal = ({
             constraint on an adjacent property.
           </Typography>
           <Typography variant="body2" gutterBottom>
-            Select any inaccurate constraints to proceed forward as if they do
-            not apply to your property. Your feedback will also help councils
-            improve their public data.
+            Select each inaccurate constraint below to proceed forward as if it
+            does not apply to your property. Your feedback will also help
+            councils improve their public data.
           </Typography>
           <Divider sx={{ marginY: 2 }} />
           <Typography id="entities-group" variant="body1">

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -68,11 +68,11 @@ export const OverrideEntitiesModal = ({
             gutterBottom
             mb={2}
           >
-            This constraint doesn't apply to my property
+            This constraint doesn't apply to this property
           </Typography>
           <Typography variant="body2" gutterBottom>
             Have we identified a planning constraint that you don't think
-            applies to your property?
+            applies to this property?
           </Typography>
           <Typography variant="body2" gutterBottom>
             We check constraints using a geospatial search, and minor
@@ -81,7 +81,7 @@ export const OverrideEntitiesModal = ({
           </Typography>
           <Typography variant="body2" gutterBottom>
             Select each inaccurate constraint below to proceed forward as if it
-            does not apply to your property. Your feedback will also help
+            does not apply to this property. Your feedback will also help
             councils improve their public data.
           </Typography>
           <Divider sx={{ marginY: 2 }} />

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -156,7 +156,7 @@ export const OverrideEntitiesModal = ({
             gutterBottom
             mb={2}
           >
-            This constraint doesn't apply to this property
+            I don't think this constraint applies to this property
           </Typography>
           <Typography variant="body2" gutterBottom>
             Have we identified a planning constraint that you don't think

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -68,7 +68,7 @@ export const OverrideEntitiesModal = ({
             gutterBottom
             mb={2}
           >
-            Report an inaccuracy
+            This constraint doesn't apply to me
           </Typography>
           <Typography variant="body2" gutterBottom>
             Have we identified a planning constraint that you don't think
@@ -76,14 +76,13 @@ export const OverrideEntitiesModal = ({
           </Typography>
           <Typography variant="body2" gutterBottom>
             We check constraints using a geospatial search, and minor
-            differences in boundaries can occassionally lead to adjacent
-            constraints being incorrectly returned.
+            differences in boundaries may lead to inaccurate results such as a
+            constraint on an adjacent property.
           </Typography>
           <Typography variant="body2" gutterBottom>
-            Select any incorrect constraints to proceed with the rest of your
-            application as if they do not apply, and we'll relay your report and
-            the original search result with your submission. Your feedback will
-            help councils improve their public data.
+            Select any inaccurate constraints to proceed forward as if they do
+            not apply to your property. Your feedback will also help councils
+            improve their public data.
           </Typography>
           <Divider sx={{ marginY: 2 }} />
           <Typography id="entities-group" variant="body1">

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/PlanningConstraints.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/PlanningConstraints.stories.tsx
@@ -44,6 +44,8 @@ const propsWithIntersections: PlanningConstraintsContentProps = {
   },
   handleSubmit: () => {},
   refreshConstraints: () => {},
+  inaccurateConstraints: {},
+  setInaccurateConstraints: () => {},
 };
 
 const propsWithoutIntersections: PlanningConstraintsContentProps = {
@@ -63,6 +65,8 @@ const propsWithoutIntersections: PlanningConstraintsContentProps = {
   },
   handleSubmit: () => {},
   refreshConstraints: () => {},
+  inaccurateConstraints: {},
+  setInaccurateConstraints: () => {},
 };
 
 export const WithIntersections = {

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -36,7 +36,7 @@ interface InaccurateConstraint {
 }
 
 export type InaccurateConstraints =
-  | Record<Constraint["fn"], InaccurateConstraint>
+  | Record<string, InaccurateConstraint>
   | undefined;
 
 export default Component;

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -12,7 +12,7 @@ import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import capitalize from "lodash/capitalize";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { handleSubmit } from "pages/Preview/Node";
-import React from "react";
+import React, { useState } from "react";
 import useSWR, { Fetcher } from "swr";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 import { stringify } from "wkt";
@@ -30,9 +30,22 @@ import {
 
 type Props = PublicProps<PlanningConstraints>;
 
+interface InaccurateConstraint {
+  entities: string[];
+  reason: string;
+}
+
+export type InaccurateConstraints =
+  | Record<Constraint["fn"], InaccurateConstraint>
+  | undefined;
+
 export default Component;
 
 function Component(props: Props) {
+  const [inaccurateConstraints, setInaccurateConstraints] =
+    useState<InaccurateConstraints>();
+  console.log(inaccurateConstraints);
+
   const siteBoundary = useStore(
     (state) => state.computePassport().data?.["property.boundary.site"],
   );
@@ -177,6 +190,8 @@ function Component(props: Props) {
             });
           }}
           refreshConstraints={() => mutate()}
+          inaccurateConstraints={inaccurateConstraints}
+          setInaccurateConstraints={setInaccurateConstraints}
         />
       ) : (
         <Card handleSubmit={props.handleSubmit} isValid>
@@ -200,6 +215,10 @@ export type PlanningConstraintsContentProps = {
   metadata: GISResponse["metadata"];
   handleSubmit: () => void;
   refreshConstraints: () => void;
+  inaccurateConstraints: InaccurateConstraints;
+  setInaccurateConstraints: (
+    value: React.SetStateAction<InaccurateConstraints>,
+  ) => void;
 };
 
 export function PlanningConstraintsContent(
@@ -212,6 +231,8 @@ export function PlanningConstraintsContent(
     metadata,
     refreshConstraints,
     disclaimer,
+    inaccurateConstraints,
+    setInaccurateConstraints,
   } = props;
   const error = constraints.error || undefined;
   const showError = error || !Object.values(constraints)?.length;
@@ -238,7 +259,12 @@ export function PlanningConstraintsContent(
           <Typography variant="h3" component="h2" mt={3}>
             These are the planning constraints we think apply to this property
           </Typography>
-          <ConstraintsList data={positiveConstraints} metadata={metadata} />
+          <ConstraintsList
+            data={positiveConstraints}
+            metadata={metadata}
+            inaccurateConstraints={inaccurateConstraints}
+            setInaccurateConstraints={setInaccurateConstraints}
+          />
           {negativeConstraints.length > 0 && (
             <SimpleExpand
               id="negative-constraints-list"
@@ -247,7 +273,12 @@ export function PlanningConstraintsContent(
                 closed: "Hide constraints that don't apply",
               }}
             >
-              <ConstraintsList data={negativeConstraints} metadata={metadata} />
+              <ConstraintsList
+                data={negativeConstraints}
+                metadata={metadata}
+                inaccurateConstraints={inaccurateConstraints}
+                setInaccurateConstraints={setInaccurateConstraints}
+              />
             </SimpleExpand>
           )}
           <Disclaimer text={disclaimer} />
@@ -275,7 +306,12 @@ export function PlanningConstraintsContent(
                 closed: "Hide constraints that don't apply",
               }}
             >
-              <ConstraintsList data={negativeConstraints} metadata={metadata} />
+              <ConstraintsList
+                data={negativeConstraints}
+                metadata={metadata}
+                inaccurateConstraints={inaccurateConstraints}
+                setInaccurateConstraints={setInaccurateConstraints}
+              />
             </SimpleExpand>
             <Disclaimer text={disclaimer} />
           </>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -44,7 +44,6 @@ export default Component;
 function Component(props: Props) {
   const [inaccurateConstraints, setInaccurateConstraints] =
     useState<InaccurateConstraints>();
-  console.log(inaccurateConstraints);
 
   const siteBoundary = useStore(
     (state) => state.computePassport().data?.["property.boundary.site"],
@@ -167,6 +166,8 @@ function Component(props: Props) {
               if (data) _constraints.push(data as GISResponse["constraints"]);
             }
 
+            const _overrides = inaccurateConstraints;
+
             const _nots: any = {};
             const intersectingConstraints: IntersectingConstraints = {};
             Object.entries(constraints).forEach(([key, data]) => {
@@ -181,6 +182,7 @@ function Component(props: Props) {
 
             const passportData = {
               _constraints,
+              _overrides,
               _nots,
               ...intersectingConstraints,
             };

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["SEARCH"] as const;
+const AVAILABLE_FEATURE_FLAGS = ["SEARCH", "OVERRIDE_CONSTRAINTS"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 


### PR DESCRIPTION
**Changes:**
- Adds a new feature flag `"OVERRIDE_CONSTRAINTS"` so we can work on followup PRs in parallel
- Adds a link & modal to capture user input about inaccurate constraints (on intersecting constraints _only_):
  - The modal has context text, a checklist of entities that we think apply, and a long text input to provide a reason why it's inaccurate
  - "Submit" button does validation and updates internal component state with valid input
  - "Cancel" button clears input and exits the modal
- Basic styling feedback if you've marked an entity as inaccurate: gray text and "[Not applicable]" tag next to entity, and overall gray text accordion title if _every_ entity within that category has been marked as inaccurate

**Followup PRs:**
- Styling questions for Ian:
  - There's a mix of internal & external links in each accordion drawer, how best to distinguish?
  - More polished visual feedback after marking a constraint as inaccurate
  - Modal accessibility (currently re-using a lot of configs of UploadAndLabel modal)
- Passport logic for overall component `onSubmit` & automations 
- TESTS !

**Testing thread here:** https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1721219483725279