### PR TITLE
fix: react-navi error for Canterbury redirect

### DIFF
--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -71,7 +71,7 @@ export default isPreviewOnlyDomain
     })
   : mount({
       "/:team/:flow/published": lazy(() => import("./published")), // loads current published flow if exists, or throws Not Found if unpublished
-      "canterbury/find-out-if-you-need-planning-permission/preview": map(
+      "/canterbury/find-out-if-you-need-planning-permission/preview": map(
         async (req) =>
           redirect(
             `/canterbury/find-out-if-you-need-planning-permission/published${req?.search}`,


### PR DESCRIPTION
Fixes small typo from https://github.com/theopensystemslab/planx-new/pull/3427 which is causing a react-navi warning.

<img width="501" alt="image" src="https://github.com/user-attachments/assets/35c9e46e-6e55-44a4-b242-78c09b72ee52">
