### PR TITLE
chore: fix audit entries and setup Slack notifications for production S3 + Power Automate submissions

### DIFF
--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -1,8 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
-import capitalize from "lodash/capitalize";
-import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils";
 import { sendEmail } from "../../../lib/notify";
 import { EmailSubmissionNotifyConfig } from "../../../types";
+import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils";
 import {
   getSessionEmailDetailsById,
   getTeamEmailSettings,

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -1,6 +1,7 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import type { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
+
 import { $api } from "../../../client";
 import { Passport } from "../../../types";
 import { uploadPrivateFile } from "../../file/service/uploadFile";
@@ -60,8 +61,8 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
       `${sessionId}.json`,
     );
 
-    // Send a notification with the file URL to the Power Automate webook
-    const webhookRequest = {
+    // Send a notification with the file URL to the Power Automate webhook
+    const webhookRequest: AxiosRequestConfig = {
       method: "POST",
       url: powerAutomateWebhookURL,
       adapter: "http",
@@ -76,11 +77,8 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
         payload: doValidation ? "Validated ODP Schema" : "Discretionary",
       },
     };
-    let webhookResponseStatus: number | undefined;
-    await axios(webhookRequest)
+    const webhookResponse = await axios(webhookRequest)
       .then(async (res) => {
-        webhookResponseStatus = res.status;
-
         // Mark session as submitted so that reminder and expiry emails are not triggered
         markSessionAsSubmitted(sessionId);
 
@@ -109,14 +107,13 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
             session_id: sessionId,
             team_slug: localAuthority,
             webhook_request: webhookRequest,
-            webhook_response: res,
+            webhook_response: res.headers,
           },
         );
 
         return {
-          application: {
-            ...applicationId.insertS3Application,
-          },
+          id: applicationId.insertS3Application?.id,
+          axiosResponse: res,
         };
       })
       .catch((error) => {
@@ -125,10 +122,11 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
         );
       });
 
-    return res.status(200).send({
+    res.status(200).send({
       message: `Successfully uploaded submission to S3: ${fileUrl}`,
       payload: doValidation ? "Validated ODP Schema" : "Discretionary",
-      webhookResponse: webhookResponseStatus,
+      webhookResponse: webhookResponse.axiosResponse.status,
+      auditEntryId: webhookResponse.id,
     });
   } catch (error) {
     return next({

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -107,7 +107,7 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
             session_id: sessionId,
             team_slug: localAuthority,
             webhook_request: webhookRequest,
-            webhook_response: res.headers,
+            webhook_response: res,
           },
         );
 

--- a/api.planx.uk/modules/webhooks/docs.yaml
+++ b/api.planx.uk/modules/webhooks/docs.yaml
@@ -94,8 +94,8 @@ components:
         - body
     S3Submission:
       type: object
-      properties: 
-        body: 
+      properties:
+        body:
           type: object
           properties:
             event:
@@ -107,7 +107,7 @@ components:
                     new:
                       type: object
                       properties:
-                        session_id: 
+                        session_id:
                           type: string
                         team_slug:
                           type: string

--- a/api.planx.uk/modules/webhooks/docs.yaml
+++ b/api.planx.uk/modules/webhooks/docs.yaml
@@ -92,11 +92,33 @@ components:
                                   type: string
       required:
         - body
+    S3Submission:
+      type: object
+      properties: 
+        body: 
+          type: object
+          properties:
+            event:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    new:
+                      type: object
+                      properties:
+                        session_id: 
+                          type: string
+                        team_slug:
+                          type: string
+      required:
+        - body
     SendSlackNotification:
       oneOf:
         - $ref: "#/components/schemas/BopsSubmission"
         - $ref: "#/components/schemas/UniformSubmission"
         - $ref: "#/components/schemas/EmailSubmission"
+        - $ref: "#/components/schemas/S3Submission"
     CreatePaymentEvent:
       type: object
       properties:

--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
@@ -1,7 +1,7 @@
 import supertest from "supertest";
 import app from "../../../../server";
 import SlackNotify from "slack-notify";
-import { BOPSBody, EmailBody, UniformBody } from "./types";
+import { BOPSBody, EmailBody, S3Body, UniformBody } from "./types";
 import { $api } from "../../../../client";
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 
@@ -331,6 +331,65 @@ describe("Send Slack notifications endpoint", () => {
 
       await post(ENDPOINT)
         .query({ type: "email-submission" })
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send(body)
+        .expect(500)
+        .then((response) => {
+          expect(mockSend).toHaveBeenCalledTimes(1);
+          expect(response.body.error).toMatch(/Failed to send/);
+        });
+    });
+  });
+
+  describe("S3 notifications", () => {
+    const body: S3Body = {
+      event: {
+        data: {
+          new: {
+            session_id: "s3-pa-123",
+            team_slug: "test-team",
+          },
+        },
+      },
+    };
+
+    it("skips the staging environment", async () => {
+      process.env.APP_ENVIRONMENT = "staging";
+      await post(ENDPOINT)
+        .query({ type: "s3-submission" })
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send(body)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.message).toMatch(/skipping Slack notification/);
+        });
+    });
+
+    it("posts to Slack on success", async () => {
+      process.env.APP_ENVIRONMENT = "production";
+
+      await post(ENDPOINT)
+        .query({ type: "s3-submission" })
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send(body)
+        .expect(200)
+        .then((response) => {
+          expect(SlackNotify).toHaveBeenCalledWith(
+            process.env.SLACK_WEBHOOK_URL,
+          );
+          expect(mockSend).toHaveBeenCalledTimes(1);
+          expect(response.body.message).toBe("Posted to Slack");
+          expect(response.body.data).toMatch(/s3-pa-123/);
+          expect(response.body.data).toMatch(/test-team/);
+        });
+    });
+
+    it("returns error when Slack fails", async () => {
+      process.env.APP_ENVIRONMENT = "production";
+      mockSend.mockRejectedValue("Fail!");
+
+      await post(ENDPOINT)
+        .query({ type: "s3-submission" })
         .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
         .send(body)
         .expect(500)

--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -5,6 +5,7 @@ import {
   EmailEventData,
   EventData,
   EventType,
+  S3EventData,
   UniformEventData,
 } from "./types";
 import { $api } from "../../../../client";
@@ -41,6 +42,11 @@ const getMessageForEventType = (data: EventData, type: EventType) => {
     const { request, session_id, team_slug } = data as EmailEventData;
     return `New email submission "${request.personalisation.serviceName}" *${session_id}* [${team_slug}]`;
   }
+
+  if (type === "s3-submission") {
+    const { session_id, team_slug } = data as S3EventData;
+    return `New S3 + Power Automate submission *${session_id}* [${team_slug}]`;
+  }
 };
 
 const getSessionIdFromEvent = (data: EventData, type: EventType) =>
@@ -48,6 +54,7 @@ const getSessionIdFromEvent = (data: EventData, type: EventType) =>
     "bops-submission": (data as BOPSEventData).session_id,
     "uniform-submission": (data as UniformEventData).payload?.sessionId,
     "email-submission": (data as EmailEventData).session_id,
+    "s3-submission": (data as S3EventData).session_id,
   })[type];
 
 const getExemptionStatusesForSession = async (sessionId: string) => {

--- a/api.planx.uk/modules/webhooks/service/sendNotification/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/schema.ts
@@ -59,8 +59,25 @@ export const emailSubmissionSchema = z.object({
   }),
 });
 
+export const s3SubmissionSchema = z.object({
+  body: z.object({
+    event: z.object({
+      data: z.object({
+        new: z.object({
+          session_id: z.string(),
+          team_slug: z.string(),
+        }),
+      }),
+    }),
+  }),
+  query: z.object({
+    type: z.literal("s3-submission"),
+  }),
+});
+
 export const sendSlackNotificationSchema = z.union([
   bopsSubmissionSchema,
   uniformSubmissionSchema,
   emailSubmissionSchema,
+  s3SubmissionSchema,
 ]);

--- a/api.planx.uk/modules/webhooks/service/sendNotification/types.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/types.ts
@@ -3,6 +3,7 @@ import { ValidatedRequestHandler } from "../../../../shared/middleware/validate"
 import {
   bopsSubmissionSchema,
   emailSubmissionSchema,
+  s3SubmissionSchema,
   sendSlackNotificationSchema,
   uniformSubmissionSchema,
 } from "./schema";
@@ -25,7 +26,14 @@ export type UniformEventData = UniformBody["event"]["data"]["new"];
 export type EmailBody = z.infer<typeof emailSubmissionSchema>["body"];
 export type EmailEventData = EmailBody["event"]["data"]["new"];
 
-export type EventData = BOPSEventData | UniformEventData | EmailEventData;
+export type S3Body = z.infer<typeof s3SubmissionSchema>["body"];
+export type S3EventData = S3Body["event"]["data"]["new"];
+
+export type EventData =
+  | BOPSEventData
+  | UniformEventData
+  | EmailEventData
+  | S3EventData;
 
 export type SendSlackNotification = ValidatedRequestHandler<
   typeof sendSlackNotificationSchema,

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1444,6 +1444,27 @@
         filter: {}
         check: null
       comment: ""
+  event_triggers:
+    - name: setup_s3_applications_notifications
+      definition:
+        enable_manual: false
+        insert:
+          columns: '*'
+      retry_conf:
+        interval_sec: 30
+        num_retries: 1
+        timeout_sec: 60
+      webhook: '{{HASURA_PLANX_API_URL}}'
+      headers:
+        - name: authorization
+          value_from_env: HASURA_PLANX_API_KEY
+      request_transform:
+        method: POST
+        query_params:
+          type: s3-submission
+        template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        version: 2
 - table:
     name: sessions
     schema: public


### PR DESCRIPTION
**Two key changes here:** 
- Fixes a previous error where the S3 send events were failing because of a circular async/await error (Kev was still getting webhook notification fine, but we were failing to populate our audit table). 
- Adds a Slack notification on new row insert to `s3_applications` audit table following existing pattern so we can keep a basic pulse on production integration activity

Notes on testing:
- The Slack notification is only called on prod, so the "correct" response in the Hasura event triggers tab here is "Skipping because not production" 
- As for the audit table entry, please note that the _all_ of our Planx environments are sending to the same Power Automate webhook URL on Barnet's side (eg Kev does _not_ have a staging versus production distinction in Power Automate).  
  - While the notification message will say which Planx env the application is coming from, I'm not entirely sure how Kev is handling these (eg if he's saving all tests to same S3 folder as prod apps or filtering/ignoring them etc?) - so trying to not test excessively, or at least flag to him when I am !