### PR TITLE
wip: set `property.attachment` instead where `property.type` is a granular "residential.dwelling.house" type

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -76,6 +76,7 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
           uprn: selectedAddress.UPRN.padStart(12, "0"),
           usrn: selectedAddress.USRN, // padStart(8, "0") will break /roads API request
           blpu_code: selectedAddress.BLPU_STATE_CODE,
+          classification_code: selectedAddress.CLASSIFICATION_CODE,
           latitude: selectedAddress.LAT,
           longitude: selectedAddress.LNG,
           organisation: selectedAddress.ORGANISATION || null,

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -37,6 +37,23 @@ export const FETCH_BLPU_CODES = gql`
   }
 `;
 
+// For automations, these CLASSIFICATION_CODES set `property.type` = `residential.dwelling.house` ONLY
+//   and the fourth segment is extracted to it's own variable `property.attachment`
+export const ATTACHMENT_CLASSIFICATION_CODES = [
+  {
+    code: "RD02",
+    value: "detached",
+  },
+  {
+    code: "RD03",
+    value: "semiDetached",
+  },
+  {
+    code: "RD04",
+    value: "terrace",
+  },
+];
+
 type Props = PublicProps<FindProperty>;
 
 const AddressLoadingWrap = styled(Box)(({ theme }) => ({
@@ -144,6 +161,18 @@ function Component(props: Props) {
       newPassportData["_address"] = address;
       if (address?.planx_value) {
         newPassportData["property.type"] = [address.planx_value];
+      }
+
+      if (
+        address?.classification_code &&
+        ATTACHMENT_CLASSIFICATION_CODES.map((c) => c.code).includes(
+          address.classification_code,
+        )
+      ) {
+        const attachmentValue = ATTACHMENT_CLASSIFICATION_CODES.find(
+          (c) => c.code === address.classification_code,
+        )?.value;
+        newPassportData["property.attachment"] = [attachmentValue];
       }
 
       if (localAuthorityDistricts) {

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -51,6 +51,7 @@ export interface SiteAddress extends MinimumSiteAddress {
   uprn?: string;
   usrn?: string;
   blpu_code?: string;
+  classification_code?: string;
   organisation?: string | null;
   sao?: string | null;
   pao?: string;

--- a/hasura.planx.uk/migrations/1721375965230_update house type blpu code values/down.sql
+++ b/hasura.planx.uk/migrations/1721375965230_update house type blpu code values/down.sql
@@ -1,0 +1,5 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- UPDATE "public"."blpu_codes"
+-- SET value = 'residential.dwelling.house'
+-- WHERE code IN ('RD02', 'RD03', 'RD04');

--- a/hasura.planx.uk/migrations/1721375965230_update house type blpu code values/up.sql
+++ b/hasura.planx.uk/migrations/1721375965230_update house type blpu code values/up.sql
@@ -1,0 +1,3 @@
+UPDATE "public"."blpu_codes"
+SET value = 'residential.dwelling.house'
+WHERE code IN ('RD02', 'RD03', 'RD04');


### PR DESCRIPTION
Per questions from Jonny here https://opensystemslab.slack.com/archives/C5Q59R3HB/p1721315847076159