### PR TITLE
feat: Add New Team for Platform Admins 

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -10,16 +10,6 @@ import type { StateCreator } from "zustand";
 
 import { SharedStore } from "./shared";
 
-interface NewTeam {
-  name: string;
-  slug: string;
-  domain?: string;
-  reference?: string;
-  submissionEmail?: string;
-  settings?: Partial<TeamSettings>;
-  theme?: Partial<TeamTheme>;
-}
-
 export interface TeamStore {
   teamId: number;
   teamIntegrations: TeamIntegrations;
@@ -35,7 +25,7 @@ export interface TeamStore {
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
   updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
-  create: (newTeam: NewTeam) => Promise<number>;
+  create: (newTeam: { name: string; slug: string }) => Promise<number>;
 }
 
 export const teamStore: StateCreator<

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -10,6 +10,16 @@ import type { StateCreator } from "zustand";
 
 import { SharedStore } from "./shared";
 
+interface NewTeam {
+  name: string;
+  slug: string;
+  domain?: string;
+  reference?: string;
+  submissionEmail?: string;
+  settings?: Partial<TeamSettings>;
+  theme?: Partial<TeamTheme>;
+}
+
 export interface TeamStore {
   teamId: number;
   teamIntegrations: TeamIntegrations;
@@ -25,6 +35,7 @@ export interface TeamStore {
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
   updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
+  create: (newTeam: NewTeam) => Promise<number>;
 }
 
 export const teamStore: StateCreator<
@@ -64,6 +75,13 @@ export const teamStore: StateCreator<
     slug: get().teamSlug,
     theme: get().teamTheme,
   }),
+
+  create: async (newTeam) => {
+    const { $client } = get();
+    console.log(newTeam);
+    const isSuccess = await $client.team.create(newTeam);
+    return isSuccess;
+  },
 
   initTeamStore: async (slug) => {
     const { data } = await client.query({

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -78,7 +78,6 @@ export const teamStore: StateCreator<
 
   create: async (newTeam) => {
     const { $client } = get();
-    console.log(newTeam);
     const isSuccess = await $client.team.create(newTeam);
     return isSuccess;
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -25,7 +25,7 @@ export interface TeamStore {
   fetchCurrentTeam: () => Promise<Team>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
   updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
-  create: (newTeam: { name: string; slug: string }) => Promise<number>;
+  createTeam: (newTeam: { name: string; slug: string }) => Promise<number>;
 }
 
 export const teamStore: StateCreator<
@@ -66,7 +66,7 @@ export const teamStore: StateCreator<
     theme: get().teamTheme,
   }),
 
-  create: async (newTeam) => {
+  createTeam: async (newTeam) => {
     const { $client } = get();
     const isSuccess = await $client.team.create(newTeam);
     return isSuccess;

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -112,7 +112,7 @@ const AddButtonRoot = styled(ButtonBase)(({ theme }) => ({
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
 }));
 
-function AddButton({
+export function AddButton({
   children,
   onClick,
 }: {

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -118,9 +118,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
           >
             Add a new Team
           </AddButton>
-        ) : (
-          <></>
-        )}
+        ) : null}
       </Box>
       {editableTeams.length > 0 && (
         <>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -83,7 +83,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
           display: "flex",
           flexDirection: "row",
           justifyContent: "space-between",
-          alignItems: "flex-end",
+          alignItems: "center",
           marginBottom: "40px",
         }}
       >

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -8,6 +8,7 @@ import navigation from "lib/navigation";
 import React from "react";
 import { Link } from "react-navi";
 import { borderedFocusStyle } from "theme";
+import Permission from "ui/editor/Permission";
 import { slugify } from "utils";
 
 import { useStore } from "./FlowEditor/lib/store";
@@ -93,7 +94,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
         <Typography variant="h2" component="h1">
           Select a team
         </Typography>
-        {isPlatformAdmin ? (
+        <Permission.IsPlatformAdmin>
           <AddButton
             onClick={async () => {
               const newTeamName = prompt("Team name");
@@ -118,7 +119,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
           >
             Add a new team
           </AddButton>
-        ) : null}
+        </Permission.IsPlatformAdmin>
       </Box>
       {editableTeams.length > 0 && (
         <>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -100,23 +100,19 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
 
               if (newTeamName) {
                 const newSlug = slugify(newTeamName);
-                return newSlug;
-              }
-              const teamNameDuplicate = teams.find(
-                (team) => team.slug === newSlug,
-              );
-              if (teamNameDuplicate === undefined) {
-                await useStore
-                  .getState()
-                  .create({
+                const teamSlugDuplicate = teams.find(
+                  (team) => team.slug === newSlug,
+                );
+                if (teamSlugDuplicate !== undefined) {
+                  alert(
+                    `A team with the name "${teamSlugDuplicate.name}" already exists. Enter a unique team name to continue.`,
+                  );
+                } else {
+                  await createTeam({
                     name: newTeamName,
                     slug: newSlug,
-                  })
-                  .then(() => navigation.navigate(`/${newSlug}`));
-              } else {
-                alert(
-                  `A team with the name "${teamNameDuplicate.name}" already exists. Enter a unique team name to continue.`,
-                );
+                  }).then(() => navigation.navigate(`/${newSlug}`));
+                }
               }
             }}
           >

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -51,6 +51,8 @@ const TeamColourBand = styled(Box)(({ theme }) => ({
 const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
   const canUserEditTeam = useStore.getState().canUserEditTeam;
 
+  const isPlatformAdmin = useStore.getState().getUser()?.isPlatformAdmin;
+
   const editableTeams: Team[] = [];
   const viewOnlyTeams: Team[] = [];
 
@@ -88,23 +90,27 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
         <Typography variant="h2" component="h1">
           Select a team
         </Typography>
-        <AddButton
-          onClick={async () => {
-            const newTeamName = prompt("Team name");
-            if (newTeamName) {
-              const newSlug = slugify(newTeamName);
-              const response = await useStore
-                .getState()
-                .create({
-                  name: newTeamName,
-                  slug: newSlug,
-                })
-                .then(() => navigation.navigate(`/${newSlug}`));
-            }
-          }}
-        >
-          Add a new Team
-        </AddButton>
+        {isPlatformAdmin ? (
+          <AddButton
+            onClick={async () => {
+              const newTeamName = prompt("Team name");
+              if (newTeamName) {
+                const newSlug = slugify(newTeamName);
+                const response = await useStore
+                  .getState()
+                  .create({
+                    name: newTeamName,
+                    slug: newSlug,
+                  })
+                  .then(() => navigation.navigate(`/${newSlug}`));
+              }
+            }}
+          >
+            Add a new Team
+          </AddButton>
+        ) : (
+          <></>
+        )}
       </Box>
       {editableTeams.length > 0 && (
         <>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -110,7 +110,7 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
                     .then(() => navigation.navigate(`/${newSlug}`));
                 } else {
                   alert(
-                    `A team with the name "${teamNameDuplicate.name}" already exists, enter a unique team name`,
+                    `A team with the name "${teamNameDuplicate.name}" already exists. Enter a unique team name to continue.`,
                   );
                 }
               }

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -55,8 +55,6 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
     state.createTeam,
   ]);
 
-  const isPlatformAdmin = useStore.getState().getUser()?.isPlatformAdmin;
-
   const editableTeams: Team[] = [];
   const viewOnlyTeams: Team[] = [];
 
@@ -112,7 +110,8 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
                   await createTeam({
                     name: newTeamName,
                     slug: newSlug,
-                  }).then(() => navigation.navigate(`/${newSlug}`));
+                  });
+                  navigation.navigate(`/${newSlug}`);
                 }
               }
             }}

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -94,15 +94,25 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
           <AddButton
             onClick={async () => {
               const newTeamName = prompt("Team name");
+
               if (newTeamName) {
                 const newSlug = slugify(newTeamName);
-                const response = await useStore
-                  .getState()
-                  .create({
-                    name: newTeamName,
-                    slug: newSlug,
-                  })
-                  .then(() => navigation.navigate(`/${newSlug}`));
+                const teamNameDuplicate = teams.find(
+                  (team) => team.slug === newSlug,
+                );
+                if (teamNameDuplicate === undefined) {
+                  await useStore
+                    .getState()
+                    .create({
+                      name: newTeamName,
+                      slug: newSlug,
+                    })
+                    .then(() => navigation.navigate(`/${newSlug}`));
+                } else {
+                  alert(
+                    `A team with the name "${teamNameDuplicate.name}" already exists, enter a unique team name`,
+                  );
+                }
               }
             }}
           >

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -49,7 +49,10 @@ const TeamColourBand = styled(Box)(({ theme }) => ({
 }));
 
 const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
-  const canUserEditTeam = useStore.getState().canUserEditTeam;
+  const [canUserEditTeam, createTeam] = useStore((state) => [
+    state.canUserEditTeam,
+    state.createTeam,
+  ]);
 
   const isPlatformAdmin = useStore.getState().getUser()?.isPlatformAdmin;
 
@@ -97,26 +100,27 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
 
               if (newTeamName) {
                 const newSlug = slugify(newTeamName);
-                const teamNameDuplicate = teams.find(
-                  (team) => team.slug === newSlug,
+                return newSlug;
+              }
+              const teamNameDuplicate = teams.find(
+                (team) => team.slug === newSlug,
+              );
+              if (teamNameDuplicate === undefined) {
+                await useStore
+                  .getState()
+                  .create({
+                    name: newTeamName,
+                    slug: newSlug,
+                  })
+                  .then(() => navigation.navigate(`/${newSlug}`));
+              } else {
+                alert(
+                  `A team with the name "${teamNameDuplicate.name}" already exists. Enter a unique team name to continue.`,
                 );
-                if (teamNameDuplicate === undefined) {
-                  await useStore
-                    .getState()
-                    .create({
-                      name: newTeamName,
-                      slug: newSlug,
-                    })
-                    .then(() => navigation.navigate(`/${newSlug}`));
-                } else {
-                  alert(
-                    `A team with the name "${teamNameDuplicate.name}" already exists. Enter a unique team name to continue.`,
-                  );
-                }
               }
             }}
           >
-            Add a new Team
+            Add a new team
           </AddButton>
         ) : null}
       </Box>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -4,11 +4,14 @@ import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
+import navigation from "lib/navigation";
 import React from "react";
 import { Link } from "react-navi";
 import { borderedFocusStyle } from "theme";
+import { slugify } from "utils";
 
 import { useStore } from "./FlowEditor/lib/store";
+import { AddButton } from "./Team";
 
 interface TeamTheme {
   slug: string;
@@ -72,9 +75,37 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
     });
   return (
     <Container maxWidth="formWrap">
-      <Typography variant="h2" component="h1" mb={4}>
-        Select a team
-      </Typography>
+      <Box
+        pb={1}
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "flex-end",
+          marginBottom: "40px",
+        }}
+      >
+        <Typography variant="h2" component="h1">
+          Select a team
+        </Typography>
+        <AddButton
+          onClick={async () => {
+            const newTeamName = prompt("Team name");
+            if (newTeamName) {
+              const newSlug = slugify(newTeamName);
+              const response = await useStore
+                .getState()
+                .create({
+                  name: newTeamName,
+                  slug: newSlug,
+                })
+                .then(() => navigation.navigate(`/${newSlug}`));
+            }
+          }}
+        >
+          Add a new Team
+        </AddButton>
+      </Box>
       {editableTeams.length > 0 && (
         <>
           <Typography variant="h3" component="h2" mb={2}>

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1633,6 +1633,26 @@
     - name: team
       using:
         foreign_key_constraint_on: team_id
+  insert_permissions:
+    - role: platformAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - team_id
+          - production_bops_submission_url
+          - staging_bops_submission_url
+          - production_power_automate_api_key
+          - staging_power_automate_api_key
+          - has_planning_data
+          - production_file_api_key
+          - staging_file_api_key
+          - production_bops_secret
+          - staging_bops_secret
+          - production_govpay_secret
+          - staging_govpay_secret
+          - power_automate_webhook_url
+      comment: ""
   select_permissions:
     - role: api
       permission:
@@ -1727,6 +1747,24 @@
     - name: team
       using:
         foreign_key_constraint_on: team_id
+  insert_permissions:
+    - role: platformAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - external_planning_site_name
+          - external_planning_site_url
+          - homepage
+          - help_email
+          - help_opening_hours
+          - help_phone
+          - email_reply_to_id
+          - team_id
+          - boundary_bbox
+          - reference_code
+          - boundary_url
+      comment: ""
   select_permissions:
     - role: api
       permission:
@@ -1843,6 +1881,19 @@
     - name: team
       using:
         foreign_key_constraint_on: team_id
+  insert_permissions:
+    - role: platformAdmin
+      permission:
+        check: {}
+        columns:
+          - id
+          - team_id
+          - favicon
+          - logo
+          - action_colour
+          - link_colour
+          - primary_colour
+      comment: ""
   select_permissions:
     - role: api
       permission:

--- a/hasura.planx.uk/tests/team_integrations.test.js
+++ b/hasura.planx.uk/tests/team_integrations.test.js
@@ -40,8 +40,10 @@ describe("team_integrations", () => {
       expect(i.queries).not.toContain("team_integrations");
     });
 
-    test("cannot create, update, or delete team_integrations", () => {
-      expect(i).toHaveNoMutationsFor("team_integrations");
+    test("can create but, cannot update, or delete team_integrations", () => {
+      expect(i.mutations).toContain("insert_team_integrations");
+      expect(i.mutations).not.toContain("update_team_integrations_by_pk");
+      expect(i.mutations).not.toContain("delete_team_integrations");
     });
   });
 

--- a/hasura.planx.uk/tests/team_themes.test.js
+++ b/hasura.planx.uk/tests/team_themes.test.js
@@ -37,12 +37,16 @@ describe("team_themes", () => {
       expect(i.queries).toContain("team_themes");
     });
 
-    test("can insert team_themes", () => {
-      expect(i.queries).toContain("insert_team_themes");
+    test("cannot query insert team_themes", () => {
+      expect(i.queries).not.toContain("insert_team_themes");
     });
 
     test("can query team_themes", async () => {
       expect(i.queries).toContain("team_themes");
+    });
+
+    test("can insert team_themes", () => {
+      expect(i.mutations).toContain("insert_team_themes");
     });
 
     test("can mutate team_themes", async () => {

--- a/hasura.planx.uk/tests/team_themes.test.js
+++ b/hasura.planx.uk/tests/team_themes.test.js
@@ -37,8 +37,8 @@ describe("team_themes", () => {
       expect(i.queries).toContain("team_themes");
     });
 
-    test("cannot insert team_themes", () => {
-      expect(i.queries).not.toContain("insert_team_themes");
+    test("can insert team_themes", () => {
+      expect(i.queries).toContain("insert_team_themes");
     });
 
     test("can query team_themes", async () => {


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new button on the **Teams** page of the **Editor** which allows a PlatformAdmin to add a new Team to the database.

> By adding a new Team to the database, only ``name`` and ``slug`` are user generated, other fields in the **teams**, **team_themes**, **team_settings**, and **team_integrations** tables all rely on default values for the user to add later

Validation has also been added to ensure all team names are unique in the database, with an alert being added to indicate to the user that the team has not been added, as shown below.

Validation has been set up to use the ``slug`` rather than the ``name`` to catch capitalisation similarities.

>Capitalisation similarities would be like _Newcastle-upon-tyne_ being the same as _Newcastle-Upon-Tyne_ 

![image](https://github.com/user-attachments/assets/aee6b924-f30b-4710-9132-7c9d442a8916)



