### PR TITLE
fix: fix insert to `s3_submisisons.response`

### DIFF
--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -108,11 +108,11 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
             team_slug: localAuthority,
             webhook_request: webhookRequest,
             webhook_response: {
-              status: res.status, 
-              statusText: res.statusText, 
+              status: res.status,
+              statusText: res.statusText,
               headers: res.headers,
               config: res.config,
-              data: res.data
+              data: res.data,
             },
           },
         );

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -107,7 +107,13 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
             session_id: sessionId,
             team_slug: localAuthority,
             webhook_request: webhookRequest,
-            webhook_response: res,
+            webhook_response: {
+              status: res.status, 
+              statusText: res.statusText, 
+              headers: res.headers,
+              config: res.config,
+              data: res.data
+            },
           },
         );
 


### PR DESCRIPTION
Followup to #3439 - I was too hasty updating this value & the audit entry is failing again: https://github.com/theopensystemslab/planx-new/pull/3439#discussion_r1684145611

I think we might be getting a slightly malformed response from Power Automate - if `res?.request` is included the `response` json we're trying to write to the audit table (it is by default with `res`) I'm getting this error consistently, but as long as it's omitted everything succeeds.
```
        "message": "{\"error\":\"Failed to upload submission to S3 (barnet): Converting circular structure to JSON\\n    --> starting at object with constructor 'ClientRequest'\\n    |     property 'socket' -> object with constructor 'TLSSocket'\\n    --- property '_httpMessage' closes the circle\"}"
```

We're capturing the request separately anyways so this should be fine :heavy_check_mark: 