### PR TITLE
feat: Flow Name Duplicate Validation

### DIFF
--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -329,7 +329,7 @@ const Team: React.FC = () => {
                   (flow) => flow.slug === newFlowSlug,
                 );
 
-                duplicateFlowName === undefined
+                !duplicateFlowName
                   ? useStore
                       .getState()
                       .createFlow(teamId, newFlowSlug, newFlowName)

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -337,7 +337,7 @@ const Team: React.FC = () => {
                         navigation.navigate(`/${slug}/${newId}`);
                       })
                   : alert(
-                      `The flow "${newFlowName}" already exits. Enter a unique flow name to continue`,
+                      `The flow "${newFlowName}" already exists. Enter a unique flow name to continue`,
                     );
               }
             }}

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -325,12 +325,20 @@ const Team: React.FC = () => {
               const newFlowName = prompt("Service name");
               if (newFlowName) {
                 const newFlowSlug = slugify(newFlowName);
-                useStore
-                  .getState()
-                  .createFlow(teamId, newFlowSlug, newFlowName)
-                  .then((newId: string) => {
-                    navigation.navigate(`/${slug}/${newId}`);
-                  });
+                const duplicateFlowName = flows?.find(
+                  (flow) => flow.slug === newFlowSlug,
+                );
+
+                duplicateFlowName === undefined
+                  ? useStore
+                      .getState()
+                      .createFlow(teamId, newFlowSlug, newFlowName)
+                      .then((newId: string) => {
+                        navigation.navigate(`/${slug}/${newId}`);
+                      })
+                  : alert(
+                      `The flow "${newFlowName}" already exits. Enter a unique flow name to continue`,
+                    );
               }
             }}
           >


### PR DESCRIPTION
## What does this PR do?

Following work done on Team Name in #3441 to validate duplicate team names, the same logic has been carried into Flow Name. 

Greater detail on the thinking behind the code is given in the previously mentioned PR, #3441.
