### PR TITLE
feat: Add Props to MapAndLabel Component

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -1,7 +1,10 @@
 import ColorLensIcon from "@mui/icons-material/ColorLens";
+import FormControl from "@mui/material/FormControl";
+import RadioGroup from "@mui/material/RadioGroup";
+import { getContrastRatio, useTheme } from "@mui/material/styles";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import ColorPicker from "ui/editor/ColorPicker";
 import InputGroup from "ui/editor/InputGroup";
 import ModalSection from "ui/editor/ModalSection";
@@ -11,7 +14,7 @@ import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
-import { MapContainer } from "../shared/Preview/MapContainer";
+import BasicRadio from "../shared/Radio/BasicRadio";
 import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
 import { MapAndLabel, parseContent } from "./model";
 
@@ -20,9 +23,22 @@ type Props = EditorProps<TYPES.MapAndLabel, MapAndLabel>;
 export default MapAndLabelComponent;
 
 function MapAndLabelComponent(props: Props) {
+  const theme = useTheme();
+
   const formik = useFormik({
     initialValues: parseContent(props.node?.data),
+    validate: ({ lineColour }) => {
+      const isContrastThresholdMet =
+        getContrastRatio("#FFF", lineColour) > theme.palette.contrastThreshold;
+      if (!isContrastThresholdMet) {
+        return {
+          lineColour:
+            "Theme colour does not meet accessibility contrast requirements (3:1)",
+        };
+      }
+    },
     onSubmit: (newValues) => {
+      console.log({ onSubmit: props });
       props.handleSubmit?.({
         type: TYPES.MapAndLabel,
         data: newValues,
@@ -62,34 +78,49 @@ function MapAndLabelComponent(props: Props) {
                 name="fn"
                 placeholder={"Data Field"}
                 value={formik.values.fn}
+                onChange={formik.handleChange}
                 required
               />
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
-      </ModalSection>
-      <ModalSection>
-        <ModalSectionContent title="Formatting" Icon={ColorLensIcon}>
+        <ModalSectionContent title="Map Formatting">
           <InputGroup>
             <InputRow>
               <InputRowItem>
-                <ColorPicker label="Line Colour" />
-              </InputRowItem>
-            </InputRow>
-            <InputRow>
-              <InputRowItem>
-                <ColorPicker label="Fill Colour" />
+                <ColorPicker
+                  label="Line Colour"
+                  color={formik.values.lineColour}
+                  onChange={(color) => {
+                    formik.setFieldValue("lineColour", color);
+                  }}
+                  errorMessage={formik.errors.lineColour}
+                />
               </InputRowItem>
             </InputRow>
           </InputGroup>
-          <MapContainer environment="standalone">
-            <my-map
-              drawMode
-              drawPointer="crosshair"
-              zoom={20}
-              showCentreMarker
-            />
-          </MapContainer>
+        </ModalSectionContent>
+        <ModalSectionContent title="Map Drawing Type">
+          <FormControl component="fieldset">
+            <RadioGroup defaultValue="default" value={formik.values.drawType}>
+              {[
+                { id: "Polygon", title: "Polygon" },
+                { id: "Point", title: "Point" },
+              ].map((type) => (
+                <BasicRadio
+                  key={type.id}
+                  id={type.id}
+                  title={type.title}
+                  variant="compact"
+                  value={type.id}
+                  onChange={(e: React.SyntheticEvent<Element, Event>) => {
+                    const target = e?.target as HTMLInputElement;
+                    formik.setFieldValue("drawType", target.value);
+                  }}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
         </ModalSectionContent>
       </ModalSection>
       <MoreInformation

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -80,11 +80,11 @@ function MapAndLabelComponent(props: Props) {
                 <ColorPicker
                   label="Drawing Colour"
                   inline={false}
-                  color={formik.values.drawColour}
+                  color={formik.values.drawColor}
                   onChange={(color) => {
-                    formik.setFieldValue("drawColour", color);
+                    formik.setFieldValue("drawColor", color);
                   }}
-                  errorMessage={formik.errors.drawColour}
+                  errorMessage={formik.errors.drawColor}
                 />
               </InputRowItem>
             </InputRow>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -33,7 +33,7 @@ function MapAndLabelComponent(props: Props) {
       if (!isContrastThresholdMet) {
         return {
           drawColour:
-            "Theme colour does not meet accessibility contrast requirements (3:1)",
+            "Drawing colour does not meet accessibility contrast requirements (3:1)",
         };
       }
     },
@@ -88,7 +88,7 @@ function MapAndLabelComponent(props: Props) {
             <InputRow>
               <InputRowItem>
                 <ColorPicker
-                  label="Line Colour"
+                  label="Drawing Colour"
                   color={formik.values.drawColour}
                   onChange={(color) => {
                     formik.setFieldValue("drawColour", color);

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -1,10 +1,9 @@
-import ColorLensIcon from "@mui/icons-material/ColorLens";
 import FormControl from "@mui/material/FormControl";
 import RadioGroup from "@mui/material/RadioGroup";
-import { getContrastRatio, useTheme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import ColorPicker from "ui/editor/ColorPicker";
 import InputGroup from "ui/editor/InputGroup";
 import ModalSection from "ui/editor/ModalSection";
@@ -28,16 +27,6 @@ function MapAndLabelComponent(props: Props) {
 
   const formik = useFormik({
     initialValues: parseContent(props.node?.data),
-    validate: ({ drawColour }) => {
-      const isContrastThresholdMet =
-        getContrastRatio("#FFF", drawColour) > theme.palette.contrastThreshold;
-      if (!isContrastThresholdMet) {
-        return {
-          drawColour:
-            "Drawing colour does not meet accessibility contrast requirements (3:1)",
-        };
-      }
-    },
     onSubmit: (newValues) => {
       props.handleSubmit?.({
         type: TYPES.MapAndLabel,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -10,6 +10,7 @@ import InputGroup from "ui/editor/InputGroup";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
+import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
@@ -89,6 +90,7 @@ function MapAndLabelComponent(props: Props) {
               <InputRowItem>
                 <ColorPicker
                   label="Drawing Colour"
+                  inline={false}
                   color={formik.values.drawColour}
                   onChange={(color) => {
                     formik.setFieldValue("drawColour", color);
@@ -99,26 +101,28 @@ function MapAndLabelComponent(props: Props) {
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
-        <ModalSectionContent title="Map Drawing Type">
+        <ModalSectionContent>
           <FormControl component="fieldset">
-            <RadioGroup defaultValue="Polygon" value={formik.values.drawType}>
-              {[
-                { id: "Polygon", title: "Polygon" },
-                { id: "Point", title: "Point" },
-              ].map((type) => (
-                <BasicRadio
-                  key={type.id}
-                  id={type.id}
-                  title={type.title}
-                  variant="compact"
-                  value={type.id}
-                  onChange={(e: React.SyntheticEvent<Element, Event>) => {
-                    const target = e?.target as HTMLInputElement;
-                    formik.setFieldValue("drawType", target.value);
-                  }}
-                />
-              ))}
-            </RadioGroup>
+            <InputLabel label="Map drawing type">
+              <RadioGroup defaultValue="Polygon" value={formik.values.drawType}>
+                {[
+                  { id: "Polygon", title: "Polygon" },
+                  { id: "Point", title: "Point" },
+                ].map((type) => (
+                  <BasicRadio
+                    key={type.id}
+                    id={type.id}
+                    title={type.title}
+                    variant="compact"
+                    value={type.id}
+                    onChange={(e: React.SyntheticEvent<Element, Event>) => {
+                      const target = e?.target as HTMLInputElement;
+                      formik.setFieldValue("drawType", target.value);
+                    }}
+                  />
+                ))}
+              </RadioGroup>
+            </InputLabel>
           </FormControl>
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -83,7 +83,7 @@ function MapAndLabelComponent(props: Props) {
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
-        <ModalSectionContent title="Map Formatting">
+        <ModalSectionContent title="Map formatting">
           <InputGroup>
             <InputRow>
               <InputRowItem>
@@ -101,7 +101,7 @@ function MapAndLabelComponent(props: Props) {
         </ModalSectionContent>
         <ModalSectionContent title="Map Drawing Type">
           <FormControl component="fieldset">
-            <RadioGroup defaultValue="default" value={formik.values.drawType}>
+            <RadioGroup defaultValue="Polygon" value={formik.values.drawType}>
               {[
                 { id: "Polygon", title: "Polygon" },
                 { id: "Point", title: "Point" },

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -1,13 +1,17 @@
+import ColorLensIcon from "@mui/icons-material/ColorLens";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React from "react";
+import ColorPicker from "ui/editor/ColorPicker";
 import InputGroup from "ui/editor/InputGroup";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
+import InputRowItem from "ui/shared/InputRowItem";
 
+import { MapContainer } from "../shared/Preview/MapContainer";
 import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
 import { MapAndLabel, parseContent } from "./model";
 
@@ -62,6 +66,30 @@ function MapAndLabelComponent(props: Props) {
               />
             </InputRow>
           </InputGroup>
+        </ModalSectionContent>
+      </ModalSection>
+      <ModalSection>
+        <ModalSectionContent title="Formatting" Icon={ColorLensIcon}>
+          <InputGroup>
+            <InputRow>
+              <InputRowItem>
+                <ColorPicker label="Line Colour" />
+              </InputRowItem>
+            </InputRow>
+            <InputRow>
+              <InputRowItem>
+                <ColorPicker label="Fill Colour" />
+              </InputRowItem>
+            </InputRow>
+          </InputGroup>
+          <MapContainer environment="standalone">
+            <my-map
+              drawMode
+              drawPointer="crosshair"
+              zoom={20}
+              showCentreMarker
+            />
+          </MapContainer>
         </ModalSectionContent>
       </ModalSection>
       <MoreInformation

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -27,18 +27,17 @@ function MapAndLabelComponent(props: Props) {
 
   const formik = useFormik({
     initialValues: parseContent(props.node?.data),
-    validate: ({ lineColour }) => {
+    validate: ({ drawColour }) => {
       const isContrastThresholdMet =
-        getContrastRatio("#FFF", lineColour) > theme.palette.contrastThreshold;
+        getContrastRatio("#FFF", drawColour) > theme.palette.contrastThreshold;
       if (!isContrastThresholdMet) {
         return {
-          lineColour:
+          drawColour:
             "Theme colour does not meet accessibility contrast requirements (3:1)",
         };
       }
     },
     onSubmit: (newValues) => {
-      console.log({ onSubmit: props });
       props.handleSubmit?.({
         type: TYPES.MapAndLabel,
         data: newValues,
@@ -90,11 +89,11 @@ function MapAndLabelComponent(props: Props) {
               <InputRowItem>
                 <ColorPicker
                   label="Line Colour"
-                  color={formik.values.lineColour}
+                  color={formik.values.drawColour}
                   onChange={(color) => {
-                    formik.setFieldValue("lineColour", color);
+                    formik.setFieldValue("drawColour", color);
                   }}
-                  errorMessage={formik.errors.lineColour}
+                  errorMessage={formik.errors.drawColour}
                 />
               </InputRowItem>
             </InputRow>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -27,7 +27,6 @@ function MapAndLabelComponent(props: Props) {
           drawFillColor={alpha(props.drawColour, 0.1)}
           drawColor={props.drawColour}
           drawPointColor={props.drawColour}
-          showCentreMarker
           drawType={props.drawType}
         />
       </MapContainer>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -24,9 +24,9 @@ function MapAndLabelComponent(props: Props) {
           drawMode
           drawPointer="crosshair"
           zoom={20}
-          drawFillColor={alpha(props.drawColour, 0.1)}
-          drawColor={props.drawColour}
-          drawPointColor={props.drawColour}
+          drawFillColor={alpha(props.drawColor, 0.1)}
+          drawColor={props.drawColor}
+          drawPointColor={props.drawColor}
           drawType={props.drawType}
         />
       </MapContainer>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -12,24 +12,6 @@ type Props = PublicProps<MapAndLabel>;
 
 function MapAndLabelComponent(props: Props) {
   const teamSettings = useStore.getState().teamSettings;
-
-  const defaultBboxJSON = {
-    type: "Feature",
-    geometry: {
-      type: "Polygon",
-      coordinates: [
-        [
-          [1.9134116, 49.528423],
-          [1.9134116, 61.331151],
-          [1.9134116, 61.331151],
-          [-10.76418, 61.331151],
-          [-10.76418, 49.528423],
-        ],
-      ],
-    },
-    properties: {},
-  };
-
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
       <CardHeader
@@ -49,9 +31,8 @@ function MapAndLabelComponent(props: Props) {
           drawPointColor={props.drawColor}
           drawType={props.drawType}
           clipGeojsonData={
-            teamSettings !== undefined
-              ? JSON.stringify(teamSettings.boundaryBBox)
-              : JSON.stringify(defaultBboxJSON)
+            teamSettings?.boundaryBBox &&
+            JSON.stringify(teamSettings?.boundaryBBox)
           }
         />
       </MapContainer>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -1,6 +1,6 @@
 import { alpha } from "@mui/material/styles";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useState } from "react";
+import React from "react";
 
 import Card from "../shared/Preview/Card";
 import CardHeader from "../shared/Preview/CardHeader";

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -31,8 +31,9 @@ function MapAndLabelComponent(props: Props) {
           drawPointColor={props.drawColor}
           drawType={props.drawType}
           clipGeojsonData={
-            teamSettings?.boundaryBBox &&
-            JSON.stringify(teamSettings?.boundaryBBox)
+            teamSettings?.boundaryBBox
+              ? JSON.stringify(teamSettings?.boundaryBBox)
+              : undefined
           }
         />
       </MapContainer>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -1,3 +1,4 @@
+import { alpha } from "@mui/material/styles";
 import React from "react";
 
 import Card from "../shared/Preview/Card";
@@ -23,8 +24,7 @@ function MapAndLabelComponent(props: Props) {
           drawMode
           drawPointer="crosshair"
           zoom={20}
-          // adding 1A to the hexcode string adds 10% opacity to the colour
-          drawFillColor={props.drawColour + "1A"}
+          drawFillColor={alpha(props.drawColour, 0.1)}
           drawColor={props.drawColour}
           drawPointColor={props.drawColour}
           showCentreMarker

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -2,12 +2,14 @@ import React from "react";
 
 import Card from "../shared/Preview/Card";
 import CardHeader from "../shared/Preview/CardHeader";
+import { MapContainer } from "../shared/Preview/MapContainer";
 import { PublicProps } from "../ui";
 import { MapAndLabel } from "./model";
 
 type Props = PublicProps<MapAndLabel>;
 
 function MapAndLabelComponent(props: Props) {
+  console.log({ public: props });
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
       <CardHeader
@@ -17,6 +19,18 @@ function MapAndLabelComponent(props: Props) {
         policyRef={props.policyRef}
         howMeasured={props.howMeasured}
       />
+      <MapContainer environment="standalone">
+        <my-map
+          drawMode
+          drawPointer="crosshair"
+          zoom={20}
+          drawFillColor={props.lineColour + "35"}
+          drawColor={props.lineColour}
+          drawPointColor={props.lineColour}
+          showCentreMarker
+          drawType={props.drawType}
+        />
+      </MapContainer>
     </Card>
   );
 }

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -9,7 +9,6 @@ import { MapAndLabel } from "./model";
 type Props = PublicProps<MapAndLabel>;
 
 function MapAndLabelComponent(props: Props) {
-  console.log({ public: props });
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
       <CardHeader
@@ -24,9 +23,9 @@ function MapAndLabelComponent(props: Props) {
           drawMode
           drawPointer="crosshair"
           zoom={20}
-          drawFillColor={props.lineColour + "35"}
-          drawColor={props.lineColour}
-          drawPointColor={props.lineColour}
+          drawFillColor={props.drawColour + "35"}
+          drawColor={props.drawColour}
+          drawPointColor={props.drawColour}
           showCentreMarker
           drawType={props.drawType}
         />

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -22,6 +22,7 @@ function MapAndLabelComponent(props: Props) {
         howMeasured={props.howMeasured}
       />
       <MapContainer environment="standalone">
+        {/* @ts-ignore */}
         <my-map
           drawMode
           drawPointer="crosshair"
@@ -31,9 +32,8 @@ function MapAndLabelComponent(props: Props) {
           drawPointColor={props.drawColor}
           drawType={props.drawType}
           clipGeojsonData={
-            teamSettings?.boundaryBBox
-              ? JSON.stringify(teamSettings?.boundaryBBox)
-              : undefined
+            teamSettings?.boundaryBBox &&
+            JSON.stringify(teamSettings?.boundaryBBox)
           }
         />
       </MapContainer>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -1,5 +1,6 @@
 import { alpha } from "@mui/material/styles";
-import React from "react";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
 
 import Card from "../shared/Preview/Card";
 import CardHeader from "../shared/Preview/CardHeader";
@@ -10,6 +11,25 @@ import { MapAndLabel } from "./model";
 type Props = PublicProps<MapAndLabel>;
 
 function MapAndLabelComponent(props: Props) {
+  const teamSettings = useStore.getState().teamSettings;
+
+  const defaultBboxJSON = {
+    type: "Feature",
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [1.9134116, 49.528423],
+          [1.9134116, 61.331151],
+          [1.9134116, 61.331151],
+          [-10.76418, 61.331151],
+          [-10.76418, 49.528423],
+        ],
+      ],
+    },
+    properties: {},
+  };
+
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
       <CardHeader
@@ -23,11 +43,16 @@ function MapAndLabelComponent(props: Props) {
         <my-map
           drawMode
           drawPointer="crosshair"
-          zoom={20}
+          zoom={16}
           drawFillColor={alpha(props.drawColor, 0.1)}
           drawColor={props.drawColor}
           drawPointColor={props.drawColor}
           drawType={props.drawType}
+          clipGeojsonData={
+            teamSettings !== undefined
+              ? JSON.stringify(teamSettings.boundaryBBox)
+              : JSON.stringify(defaultBboxJSON)
+          }
         />
       </MapContainer>
     </Card>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -23,7 +23,8 @@ function MapAndLabelComponent(props: Props) {
           drawMode
           drawPointer="crosshair"
           zoom={20}
-          drawFillColor={props.drawColour + "35"}
+          // adding 1A to the hexcode string adds 10% opacity to the colour
+          drawFillColor={props.drawColour + "1A"}
           drawColor={props.drawColour}
           drawPointColor={props.drawColour}
           showCentreMarker

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -4,7 +4,7 @@ export interface MapAndLabel extends MoreInformation {
   fn: string;
   title: string;
   description?: string;
-  drawColour: string;
+  drawColor: string;
   drawType: "Polygon" | "Point";
 }
 
@@ -14,7 +14,7 @@ export const parseContent = (
   fn: data?.fn || "",
   title: data?.title,
   description: data?.description,
-  drawColour: data?.drawColour || "#22194D",
+  drawColor: data?.drawColor || "#22194D",
   drawType: data?.drawType || "Polygon",
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -5,7 +5,7 @@ export interface MapAndLabel extends MoreInformation {
   title: string;
   description?: string;
   drawColour: string;
-  drawType?: "Polygon" | "Point";
+  drawType: "Polygon" | "Point";
 }
 
 export const parseContent = (

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -4,7 +4,7 @@ export interface MapAndLabel extends MoreInformation {
   fn: string;
   title: string;
   description?: string;
-  lineColour: string;
+  drawColour: string;
   drawType?: "Polygon" | "Point";
 }
 
@@ -14,7 +14,7 @@ export const parseContent = (
   fn: data?.fn || "",
   title: data?.title,
   description: data?.description,
-  lineColour: data?.lineColour || "#22194D",
+  drawColour: data?.drawColour || "#22194D",
   drawType: data?.drawType || "Polygon",
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -2,7 +2,7 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 
 export interface MapAndLabel extends MoreInformation {
   fn: string;
-  title?: string;
+  title: string;
   description?: string;
   lineColour: string;
   fillColour: string;

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -5,7 +5,7 @@ export interface MapAndLabel extends MoreInformation {
   title: string;
   description?: string;
   lineColour: string;
-  fillColour: string;
+  drawType?: "Polygon" | "Point";
 }
 
 export const parseContent = (
@@ -14,7 +14,7 @@ export const parseContent = (
   fn: data?.fn || "",
   title: data?.title,
   description: data?.description,
-  lineColour: data?.lineColour,
-  fillColour: data?.fillColour,
+  lineColour: data?.lineColour || "#22194D",
+  drawType: data?.drawType || "Polygon",
   ...parseMoreInformation(data),
 });

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -2,15 +2,19 @@ import { MoreInformation, parseMoreInformation } from "../shared";
 
 export interface MapAndLabel extends MoreInformation {
   fn: string;
-  title?:string;
-  description?:string;
+  title?: string;
+  description?: string;
+  lineColour: string;
+  fillColour: string;
 }
 
 export const parseContent = (
   data: Record<string, any> | undefined,
 ): MapAndLabel => ({
   fn: data?.fn || "",
+  title: data?.title,
+  description: data?.description,
+  lineColour: data?.lineColour,
+  fillColour: data?.fillColour,
   ...parseMoreInformation(data),
-  title:"",
-  description:""
 });


### PR DESCRIPTION
## What does this PR do?

This PR looks to extend the new ``MapAndLabel`` component by adding a ``my-map`` component to the Public file and introduce the passing of props from the Editor Modal version to the Public version to control how the map is formatted.

Two props have been tested

- drawColour
- drawType

drawColour is also used to dictate ``drawFillColour`` and ``drawPointColour`` which are built in props for the ``my-map`` component.

Following this PR, I will start to add more data interactivity with what is happening on the graph and how it updates other elements of the component as shown in the ``FindProperty`` component as an example then continue to integrate work being undertaken on the map repo.