### PR TITLE
fix: query `hasPlanningData` on `initTeamStore()` to see constraints in editor sidebar

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -94,6 +94,9 @@ export const teamStore: StateCreator<
                 }
               }
             }
+            integrations {
+              hasPlanningData: has_planning_data
+            }
           }
         }
       `,

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1672,7 +1672,23 @@
           - staging_govpay_secret
           - power_automate_webhook_url
         filter: {}
+    - role: platformAdmin
+      permission:
+        columns:
+          - has_planning_data
+          - id
+          - team_id
+        filter: {}
+      comment: ""
     - role: public
+      permission:
+        columns:
+          - has_planning_data
+          - id
+          - team_id
+        filter: {}
+      comment: ""
+    - role: teamEditor
       permission:
         columns:
           - has_planning_data

--- a/hasura.planx.uk/tests/team_integrations.test.js
+++ b/hasura.planx.uk/tests/team_integrations.test.js
@@ -7,7 +7,7 @@ describe("team_integrations", () => {
       i = await introspectAs("public");
     });
 
-    test("cannot query team_integrations", () => {
+    test("can query team_integrations", () => {
       expect(i.queries).toContain("team_integrations");
     });
 
@@ -36,8 +36,8 @@ describe("team_integrations", () => {
       i = await introspectAs("platformAdmin");
     });
 
-    test("cannot query team_integrations", () => {
-      expect(i.queries).not.toContain("team_integrations");
+    test("cann query team_integrations", () => {
+      expect(i.queries).toContain("team_integrations");
     });
 
     test("can create but, cannot update, or delete team_integrations", () => {
@@ -52,8 +52,8 @@ describe("team_integrations", () => {
       i = await introspectAs("teamEditor");
     });
 
-    test("cannot query team_integrations", () => {
-      expect(i.queries).not.toContain("team_integrations");
+    test("can query team_integrations", () => {
+      expect(i.queries).toContain("team_integrations");
     });
 
     test("cannot create, update, or delete team_integrations", () => {


### PR DESCRIPTION
Fixes bug described here! https://github.com/theopensystemslab/planx-new/pull/3449#discussion_r1690218020