### PR TITLE
feat: Reduced colour fill print css

### DIFF
--- a/editor.planx.uk/src/components/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer.tsx
@@ -14,6 +14,10 @@ const Root = styled("footer")(({ theme }) => ({
   [theme.breakpoints.up("md")]: {
     padding: theme.spacing(3, 0),
   },
+  "@media print": {
+    color: theme.palette.common.black,
+    backgroundColor: theme.palette.common.white,
+  },
 }));
 
 const ButtonGroup = styled(Box)(({ theme }) => ({

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -126,10 +126,14 @@ const Logo = styled("img")(() => ({
   objectFit: "contain",
 }));
 
-const LogoLink = styled(Link)(() => ({
+const LogoLink = styled(Link)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   "&:focus-visible": borderedFocusStyle,
+  "@media print": {
+    backgroundColor: theme.palette.common.black,
+    padding: "0.25em",
+  },
 }));
 
 const SkipLink = styled("a")(({ theme }) => ({
@@ -362,8 +366,9 @@ const PublicToolbar: React.FC<{
                   aria-label="Restart Application"
                   size="large"
                   aria-describedby="restart-application-description"
+                  sx={{ "@media print": { color: "black" } }}
                 >
-                  <Reset color="secondary" />
+                  <Reset color="inherit" />
                   <Typography
                     id="restart-application-description"
                     variant="body2"
@@ -563,7 +568,10 @@ const Header: React.FC = () => {
       elevation={0}
       color="transparent"
       ref={headerRef}
-      style={{ backgroundColor: theme?.primaryColour || "#2c2c2c" }}
+      sx={{
+        backgroundColor: theme?.primaryColour || "#2c2c2c",
+        "@media print": { backgroundColor: "white", color: "black" },
+      }}
     >
       <Toolbar headerRef={headerRef}></Toolbar>
     </Root>

--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -68,7 +68,17 @@ const PublicFooter: React.FC = () => {
       <Feedback />
       <Footer items={[...footerItems]}>
         <Box display="flex" alignItems="center">
-          <Box pr={2} display="flex">
+          <Box
+            pr={2}
+            display="flex"
+            sx={{
+              "@media print": {
+                backgroundColor: "black",
+                padding: "0.5em",
+                margin: "0.5em",
+              },
+            }}
+          >
             <img src={Logo} alt="Open Government License Logo" />
           </Box>
           <Typography variant="body2">


### PR DESCRIPTION
## What does this PR do?

Quick one — there has been a lot of talk about users printing from PlanX recently.

If someone does print from the public interface we can save them a lot of printer ink with a few lines of CSS. This PR uses the `@media print` media query to remove the largest blocks of solid colour from the header and footer.

**Before:**
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/c59e769e-595c-4b9a-9cdc-c705ba070b12">

**After:**
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/01a20019-0ef7-4010-a5b6-6c03801a1eb4">
