### PR TITLE
wip: require exact match of data field segments for automations

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -478,8 +478,9 @@ export const previewStore: StateCreator<
                     const responseValues = String(r.data.val).split(",").sort();
 
                     for (const responseValue of responseValues) {
-                      return passportValues.some((passportValue: any) =>
-                        String(passportValue).startsWith(responseValue),
+                      return passportValues.some(
+                        (passportValue: any) =>
+                          String(passportValue) === responseValue,
                       );
                     }
                   });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -223,17 +223,7 @@ export const previewStore: StateCreator<
           if (passportValue.length > 0) {
             const existingValue = acc.data?.[key] ?? [];
 
-            const combined = existingValue
-              .concat(passportValue)
-              .reduce(
-                (acc: string[], curr: string, _i: number, arr: string[]) => {
-                  if (!arr.some((x) => x !== curr && x.startsWith(curr))) {
-                    acc.push(curr);
-                  }
-                  return acc;
-                },
-                [],
-              );
+            const combined = existingValue.concat(passportValue);
 
             passportData[key] = uniq(combined);
           }


### PR DESCRIPTION
An experiment! 

Comes out of planning constraints testing: with current automations behavior, `listed.grade.II` incorrectly auto-answers `listed.grade.I` because each segment uses a "startsWith" match rather than exact. 

This one-line change now does what we want in this specific use case, but services team will have to determine if it unexpectedly breaks other areas of the schema ! 
![Screenshot from 2024-07-26 09-57-48](https://github.com/user-attachments/assets/290f1774-013a-40ae-95d0-8ed3adb80c39)

More context here from August https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1721902632687949?thread_ts=1721219483.725279&cid=C04DZ1NBUMR
> The way values match is matching-up-to, the `.` separator isn't material to that behaviour. `value.valueAndThenSome` matches to `value.value` or `value.valueAnd` etc. the same way that `value.value.AndThenSome` matches to `value.value`. So changing to `listed.gradeI` and `listed.gradeII` wouldn't change that behaviour, the former would still match to the latter. Counterintuitive to our use of `.` separators and something to be changed perhaps?