### PR TITLE
feat(proof-of-concept): Re-use `useSearch` hook

### DIFF
--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -4,7 +4,8 @@ import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
-import React from "react";
+import { useSearch } from "hooks/useSearch";
+import React, { useRef } from "react";
 import { Link } from "react-navi";
 import { borderedFocusStyle } from "theme";
 
@@ -51,7 +52,16 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
   const editableTeams: Team[] = [];
   const viewOnlyTeams: Team[] = [];
 
-  teams.forEach((team) =>
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { results, search } = useSearch({
+    list: teams,
+    keys: ["name", "slug"],
+  });
+  const displayTeams = inputRef.current?.value
+    ? results.map(({ item: team }) => team)
+    : teams;
+
+  displayTeams.forEach((team) =>
     canUserEditTeam(team.slug)
       ? editableTeams.push(team)
       : viewOnlyTeams.push(team),
@@ -75,6 +85,8 @@ const Teams: React.FC<Props> = ({ teams, teamTheme }) => {
       <Typography variant="h2" component="h1" mb={4}>
         Select a team
       </Typography>
+      <input onChange={(e) => search(e.target.value)} ref={inputRef}></input>
+
       {editableTeams.length > 0 && (
         <>
           <Typography variant="h3" component="h2" mb={2}>


### PR DESCRIPTION
Quick sense check before we make tickets for this and pursue it further - looks like this will be a viable option for other search bars in the frontend.

Don't intend to keep and use this code directly, just something for show and tell and to then make tickets for x2 (flows and teams).

If I get time before show and tell I'll add a bit of polish to at least make the input bar a MUI one 💅 


https://github.com/user-attachments/assets/e6600f3d-226e-4533-9774-debf2d44e741

