### PR TITLE
refactor: [skip pizza] Neaten service offline page

### DIFF
--- a/editor.planx.uk/src/pages/OfflinePage.tsx
+++ b/editor.planx.uk/src/pages/OfflinePage.tsx
@@ -3,14 +3,16 @@ import StatusPage from "pages/Preview/StatusPage";
 import React from "react";
 
 export const OfflinePage: React.FC = () => (
-  <StatusPage bannerHeading="Offline">
-    <Typography variant="body2">
-      This service is not currently available to new applicants. Please check
-      back later.
-    </Typography>
-    <Typography variant="body2">
-      If you're resuming an application you previously started, please use the
-      link sent to you via email.
+  <StatusPage bannerHeading="Service offline">
+    <Typography variant="body1">
+      <p>
+        This service is not currently available to new applicants. Please check
+        back later.
+      </p>
+      <p>
+        If you're resuming an application you previously started, please use the
+        link sent to you via email.
+      </p>
     </Typography>
   </StatusPage>
 );


### PR DESCRIPTION
## What does this PR do?

Quick one: update service offline page to have a more descriptive header and use the same text formatting as other service pages.

Before (left) vs after (right):

![image](https://github.com/user-attachments/assets/f7391c38-3e54-4178-b575-9eaae41a9bc7)
