### PR TITLE
feat: Add event listener trackers to Map and Label

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -54,9 +54,8 @@ function MapAndLabelComponent(props: Props) {
     return function cleanup() {
       map?.removeEventListener("areaChange", areaChangeHandler);
       map?.removeEventListener("geojsonChange", geojsonChangeHandler);
-      console.log("cleanup");
     };
-  }, [objectArray]);
+  }, [objectArray, boundary]);
 
   return (
     <Card handleSubmit={props.handleSubmit} isValid>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -20,28 +20,33 @@ function MapAndLabelComponent(props: Props) {
   const [boundary, setBoundary] = useState<Boundary>();
   const [area, setArea] = useState<number | undefined>(0);
 
-  const areaChangeHandler = ({ detail }: { detail: string }) => {
-    console.log(detail);
-    const numberString = detail.split(" ")[0];
-    const area = Number(numberString);
-    setArea(area);
-  };
+  useEffect(() => {
+    const areaChangeHandler = ({ detail }: { detail: string }) => {
+      const numberString = detail.split(" ")[0];
+      const area = Number(numberString);
+      setArea(area);
+    };
 
-  const geojsonChangeHandler = ({ detail: geojson }: any) => {
-    console.log(geojson);
-    if (geojson["EPSG:3857"]?.features) {
-      // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
-      setBoundary(geojson["EPSG:3857"].features);
-    } else {
-      // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined
-      setBoundary(undefined);
-    }
-  };
+    const geojsonChangeHandler = ({ detail: geojson }: any) => {
+      if (geojson["EPSG:3857"]?.features) {
+        // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
+        setBoundary(geojson["EPSG:3857"].features[0]);
+      } else {
+        // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined
+        setBoundary(undefined);
+      }
+    };
 
-  const map: any = document.getElementById("draw-boundary-map");
+    const map: any = document.getElementById("draw-boundary-map");
 
-  map?.addEventListener("areaChange", areaChangeHandler);
-  map?.addEventListener("geojsonChange", geojsonChangeHandler);
+    map?.addEventListener("areaChange", areaChangeHandler);
+    map?.addEventListener("geojsonChange", geojsonChangeHandler);
+
+    return function cleanup() {
+      map?.removeEventListener("areaChange", areaChangeHandler);
+      map?.removeEventListener("geojsonChange", geojsonChangeHandler);
+    };
+  }, []);
 
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
@@ -57,8 +62,8 @@ function MapAndLabelComponent(props: Props) {
         <my-map
           id="draw-boundary-map"
           drawMode
-          drawGeojsonData={JSON.stringify(boundary)}
           drawPointer="crosshair"
+          drawGeojsonData={JSON.stringify(boundary)}
           zoom={16}
           drawFillColor={alpha(props.drawColor, 0.1)}
           drawColor={props.drawColor}

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -1,17 +1,48 @@
 import { alpha } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { Feature } from "geojson";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import Card from "../shared/Preview/Card";
 import CardHeader from "../shared/Preview/CardHeader";
-import { MapContainer } from "../shared/Preview/MapContainer";
+import { MapContainer, MapFooter } from "../shared/Preview/MapContainer";
 import { PublicProps } from "../ui";
 import { MapAndLabel } from "./model";
 
 type Props = PublicProps<MapAndLabel>;
 
+export type Boundary = Feature | undefined;
+
 function MapAndLabelComponent(props: Props) {
   const teamSettings = useStore.getState().teamSettings;
+  const [boundary, setBoundary] = useState<Boundary>();
+  const [area, setArea] = useState<number | undefined>(0);
+
+  const areaChangeHandler = ({ detail }: { detail: string }) => {
+    console.log(detail);
+    const numberString = detail.split(" ")[0];
+    const area = Number(numberString);
+    setArea(area);
+  };
+
+  const geojsonChangeHandler = ({ detail: geojson }: any) => {
+    console.log(geojson);
+    if (geojson["EPSG:3857"]?.features) {
+      // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
+      setBoundary(geojson["EPSG:3857"].features);
+    } else {
+      // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined
+      setBoundary(undefined);
+    }
+  };
+
+  const map: any = document.getElementById("draw-boundary-map");
+
+  map?.addEventListener("areaChange", areaChangeHandler);
+  map?.addEventListener("geojsonChange", geojsonChangeHandler);
+
   return (
     <Card handleSubmit={props.handleSubmit} isValid>
       <CardHeader
@@ -24,7 +55,9 @@ function MapAndLabelComponent(props: Props) {
       <MapContainer environment="standalone">
         {/* @ts-ignore */}
         <my-map
+          id="draw-boundary-map"
           drawMode
+          drawGeojsonData={JSON.stringify(boundary)}
           drawPointer="crosshair"
           zoom={16}
           drawFillColor={alpha(props.drawColor, 0.1)}
@@ -36,6 +69,18 @@ function MapAndLabelComponent(props: Props) {
             JSON.stringify(teamSettings?.boundaryBBox)
           }
         />
+        <MapFooter>
+          <Typography variant="body1">
+            The property boundary you have drawn is{" "}
+            <Typography
+              component="span"
+              noWrap
+              sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            >
+              {area?.toLocaleString("en-GB") ?? 0} m²
+            </Typography>
+          </Typography>
+        </MapFooter>
       </MapContainer>
     </Card>
   );

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -19,6 +19,9 @@ function MapAndLabelComponent(props: Props) {
   const teamSettings = useStore.getState().teamSettings;
   const [boundary, setBoundary] = useState<Boundary>();
   const [area, setArea] = useState<number | undefined>(0);
+  const [objectArray, setObjectArray] = useState<any>([]);
+
+  let count = 0;
 
   useEffect(() => {
     const areaChangeHandler = ({ detail }: { detail: string }) => {
@@ -29,8 +32,14 @@ function MapAndLabelComponent(props: Props) {
 
     const geojsonChangeHandler = ({ detail: geojson }: any) => {
       if (geojson["EPSG:3857"]?.features) {
+        count++;
+
         // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
         setBoundary(geojson["EPSG:3857"].features[0]);
+        setObjectArray([
+          ...objectArray,
+          { number: count, feature: geojson["EPSG:3857"].features[0] },
+        ]);
       } else {
         // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined
         setBoundary(undefined);
@@ -45,8 +54,9 @@ function MapAndLabelComponent(props: Props) {
     return function cleanup() {
       map?.removeEventListener("areaChange", areaChangeHandler);
       map?.removeEventListener("geojsonChange", geojsonChangeHandler);
+      console.log("cleanup");
     };
-  }, []);
+  }, [objectArray]);
 
   return (
     <Card handleSubmit={props.handleSubmit} isValid>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -60,13 +60,13 @@ function MapAndLabelComponent(props: Props) {
   }, [objectArray, boundary]);
 
   useEffect(() => {
-    if (!boundary && objectArray.length > 1) {
+    if (!boundary && objectArray.length < 1) {
       setMapValidationError("Add a boundary to the map");
     }
   }, [boundary]);
 
   return (
-    <Card handleSubmit={props.handleSubmit} isValid>
+    <Card handleSubmit={props.handleSubmit} isValid={!mapValidationError}>
       <CardHeader
         title={props.title}
         description={props.description}


### PR DESCRIPTION
## What does this PR do?

This PR begins to add event listeners and map dispatches to the public component of ``MapAndLabel`` which can then lay the foundations for Work to Trees and drawing shapes on a map and tracking them with List components. 

- [x] Track Geometry and Area
- [x] Add light validation 
- [x] Generate a dummy card with Geo data