### PR TITLE
refactor: Make ``label`` conditional on ``<ColorPicker>``

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Editor.tsx
@@ -41,6 +41,7 @@ const ContentComponent: React.FC<Props> = (props) => {
           </InputRow>
           <ColorPicker
             inline
+            label="Background colour"
             color={formik.values.color}
             onChange={(color) => {
               formik.setFieldValue("color", color);

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -13,6 +13,7 @@ import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import InputRowLabel from "ui/shared/InputRowLabel";
 
 import BasicRadio from "../shared/Radio/BasicRadio";
 import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
@@ -76,17 +77,18 @@ function MapAndLabelComponent(props: Props) {
         <ModalSectionContent title="Map formatting">
           <InputGroup>
             <InputRow>
-              <InputRowItem>
-                <ColorPicker
-                  label="Drawing Colour"
-                  inline={false}
-                  color={formik.values.drawColor}
-                  onChange={(color) => {
-                    formik.setFieldValue("drawColor", color);
-                  }}
-                  errorMessage={formik.errors.drawColor}
-                />
-              </InputRowItem>
+              <InputLabel label="Drawing colour">
+                <InputRowItem>
+                  <ColorPicker
+                    inline={false}
+                    color={formik.values.drawColor}
+                    onChange={(color) => {
+                      formik.setFieldValue("drawColor", color);
+                    }}
+                    errorMessage={formik.errors.drawColor}
+                  />
+                </InputRowItem>
+              </InputLabel>
             </InputRow>
           </InputGroup>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -77,18 +77,16 @@ function MapAndLabelComponent(props: Props) {
         <ModalSectionContent title="Map formatting">
           <InputGroup>
             <InputRow>
-              <InputLabel label="Drawing colour">
-                <InputRowItem>
-                  <ColorPicker
-                    inline={false}
-                    color={formik.values.drawColor}
-                    onChange={(color) => {
-                      formik.setFieldValue("drawColor", color);
-                    }}
-                    errorMessage={formik.errors.drawColor}
-                  />
-                </InputRowItem>
-              </InputLabel>
+              <InputRowItem>
+                <ColorPicker
+                  label="Drawing colour"
+                  color={formik.values.drawColor}
+                  onChange={(color) => {
+                    formik.setFieldValue("drawColor", color);
+                  }}
+                  errorMessage={formik.errors.drawColor}
+                />
+              </InputRowItem>
             </InputRow>
           </InputGroup>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -56,6 +56,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
           </InputRow>
           <ColorPicker
             inline
+            label="Background colou"
             color={props.value.color}
             onChange={(color) => {
               props.onChange({

--- a/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -56,7 +56,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
           </InputRow>
           <ColorPicker
             inline
-            label="Background colou"
+            label="Background colour"
             color={props.value.color}
             onChange={(color) => {
               props.onChange({

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ButtonForm.tsx
@@ -59,6 +59,7 @@ export const ButtonForm: React.FC<FormProps> = ({
           <InputRowItem>
             <ColorPicker
               color={formik.values.actionColour}
+              inline
               onChange={(color) => formik.setFieldValue("actionColour", color)}
               label="Button colour"
               errorMessage={formik.errors.actionColour}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/TextLinkForm.tsx
@@ -68,6 +68,7 @@ export const TextLinkForm: React.FC<FormProps> = ({
           <InputRowItem>
             <ColorPicker
               color={formik.values.linkColour}
+              inline
               onChange={(color) => formik.setFieldValue("linkColour", color)}
               label="Text link colour"
               errorMessage={formik.errors.linkColour}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/DesignSettings/ThemeAndLogoForm.tsx
@@ -82,6 +82,7 @@ export const ThemeAndLogoForm: React.FC<FormProps> = ({
             <InputRowItem>
               <ColorPicker
                 color={formik.values.primaryColour}
+                inline
                 onChange={(color) =>
                   formik.setFieldValue("primaryColour", color)
                 }

--- a/editor.planx.uk/src/ui/editor/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/editor/ColorPicker.tsx
@@ -7,7 +7,7 @@ import { ChromePicker, ColorChangeHandler } from "react-color";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 export interface Props {
-  label?: string;
+  label: string;
   inline?: boolean;
   color?: string;
   errorMessage?: string;
@@ -24,7 +24,8 @@ const Root = styled(Box, {
   padding: 0,
   position: "relative",
   display: "flex",
-  alignItems: "center",
+  alignItems: inline ? "center" : "flex-start",
+  flexDirection: inline ? "row" : "column",
   ...(inline && {
     padding: theme.spacing(2, 0),
     "& .popover": {
@@ -100,9 +101,13 @@ export default function ColorPicker(props: Props): FCReturn {
       id="colour-picker-error"
     >
       <Root inline={props.inline}>
-        {props.label && (
+        {props.inline ? (
           <Typography mr={2} variant="body2" component="label">
-            {props.label || "Background colour"}:{" "}
+            {props.label}:{" "}
+          </Typography>
+        ) : (
+          <Typography sx={{ pb: 1 }} variant="body1" component="label">
+            {props.label}
           </Typography>
         )}
         <StyledButtonBase show={show} onClick={handleClick} disableRipple>

--- a/editor.planx.uk/src/ui/editor/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/editor/ColorPicker.tsx
@@ -100,9 +100,11 @@ export default function ColorPicker(props: Props): FCReturn {
       id="colour-picker-error"
     >
       <Root inline={props.inline}>
-        <Typography mr={2} variant="body2" component="label">
-          {props.label || "Background colour"}:{" "}
-        </Typography>
+        {props.label && (
+          <Typography mr={2} variant="body2" component="label">
+            {props.label || "Background colour"}:{" "}
+          </Typography>
+        )}
         <StyledButtonBase show={show} onClick={handleClick} disableRipple>
           <Swatch sx={{ backgroundColor: props.color }} className="swatch" />
           {props.color}

--- a/editor.planx.uk/src/ui/editor/ListManager.stories.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager.stories.tsx
@@ -33,6 +33,7 @@ const Editor = (props: { value: Item; onChange: (newVal: Item) => void }) => (
       placeholder="Title"
     />
     <ColorPicker
+      label="Colour"
       color={props.value.color}
       onChange={(color) => {
         props.onChange({


### PR DESCRIPTION
## What does this PR do?

This PR updates the ``ColorPicker`` component to conditionally add a `label` if provided it as a prop, and don't add any label if the `label` prop doesn't exist.

The previous behaviour was to add a label stating ``"background colour"`` if no `label` prop was provided. 

To ensure continuous behaviour, I have updated the two components using ``<ColorPicker>`` without the ``label`` prop and I have updated the `MapAndLabel` component to use the ``<ColorPicker>`` without the `label` prop, which was the catalyst for this change.