### PR TITLE
fix: Sections navigation bar padding

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -187,6 +187,8 @@ const ServiceTitleRoot = styled("span")(({ theme }) => ({
 const StyledNavBar = styled("nav")(({ theme }) => ({
   backgroundColor: theme.palette.primary.dark,
   fontSize: 16,
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
 }));
 
 const SectionName = styled(Typography)(() => ({


### PR DESCRIPTION
## What does this PR do?

Fixes a regression that has removed the vertical padding from the sections navigation bar.

Before:
<img width="641" alt="image" src="https://github.com/user-attachments/assets/1fc6de6c-bb6a-489f-baae-5ba1b33cac48">


After:
<img width="641" alt="image" src="https://github.com/user-attachments/assets/8669e7ca-d817-4186-a6f9-b5d717ec7862">
