### PR TITLE
fix: Add min-height to map container

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -18,6 +18,11 @@ export const MapContainer = styled(Box)<MapContainerProps>(
       // Only increase map size in Published, Preview, and Draft routes
       height:
         size === "large" && environment === "standalone" ? "70vh" : "50vh",
+      // Ensure map is not reduced to an unusable height
+      minHeight: "400px",
+      [theme.breakpoints.up("md")]: {
+        minHeight: "480px",
+      },
     },
   }),
 );


### PR DESCRIPTION
## What does this PR do?

Introduces a `min-height` property to maps to ensure the viewport scaling height property does not reduce it to an unusable height.

(a very short-height map was observed during this the internal demo this morning)