### PR TITLE
[WIP] feat: add share button for flow links

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "^0.8.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6b2fd26",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7c37fc3",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -46,8 +46,8 @@ dependencies:
     specifier: ^0.8.3
     version: 0.8.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6b2fd26
-    version: github.com/theopensystemslab/planx-core/6b2fd26(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#7c37fc3
+    version: github.com/theopensystemslab/planx-core/7c37fc3(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15182,8 +15182,8 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  /json-schema-to-typescript@14.1.0:
-    resolution: {integrity: sha512-VIeAFQkn88gFh26MSHWG4uX7TjK/arTw0NVLMZn6vX1WrSF+P6xu5MyEdovu+9PJ0uiS5gm0wzwQvYW9eSq1uw==}
+  /json-schema-to-typescript@15.0.0:
+    resolution: {integrity: sha512-gOX3cJB4eL1ztMc3WUh569ubRcKnr8MnYk++6+/WaaN4bufGHSR6EcbUbvLZgirPQOfvni5SSGkRx0pYloYU8A==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -21898,9 +21898,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/6b2fd26(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6b2fd26}
-    id: github.com/theopensystemslab/planx-core/6b2fd26
+  github.com/theopensystemslab/planx-core/7c37fc3(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7c37fc3}
+    id: github.com/theopensystemslab/planx-core/7c37fc3
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -21920,7 +21920,7 @@ packages:
       fast-xml-parser: 4.4.1
       graphql: 16.9.0
       graphql-request: 6.1.0(graphql@16.9.0)
-      json-schema-to-typescript: 14.1.0
+      json-schema-to-typescript: 15.0.0
       lodash: 4.17.21
       marked: 13.0.3
       prettier: 3.3.3

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -585,7 +585,8 @@ const Header: React.FC = () => {
 
   useEffect(() => {
     const findPathname =
-      pathnameArray.pop() === "preview" || pathnameArray.pop() === "draft";
+      pathnameArray.slice(-1)[0] === "preview" ||
+      pathnameArray.slice(-1)[0] === "draft";
 
     setIsOutsideEditor(Boolean(findPathname));
   }, pathnameArray);

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -584,9 +584,9 @@ const Header: React.FC = () => {
   const pathnameArray = window.location.pathname.split("/");
 
   useEffect(() => {
-    const findPathname = pathnameArray.find(
-      (pathname) => pathname === "preview" || pathname === "draft",
-    );
+    const findPathname =
+      pathnameArray.pop() === "preview" || pathnameArray.pop() === "draft";
+
     setIsOutsideEditor(Boolean(findPathname));
   }, pathnameArray);
 

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -24,7 +24,7 @@ import { clearLocalFlow } from "lib/local";
 import { capitalize } from "lodash";
 import { Route } from "navi";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import React, { RefObject, useRef, useState } from "react";
+import React, { RefObject, useEffect, useRef, useState } from "react";
 import {
   Link as ReactNaviLink,
   useCurrentRoute,
@@ -577,8 +577,19 @@ const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
 };
 
 const Header: React.FC = () => {
+  const [isOutsideEditor, setIsOutsideEditor] = useState<boolean>(false);
   const headerRef = useRef<HTMLDivElement>(null);
   const theme = useStore((state) => state.teamTheme);
+  const environment = useStore((state) => state.previewEnvironment);
+  const pathnameArray = window.location.pathname.split("/");
+
+  useEffect(() => {
+    const findPathname = pathnameArray.find(
+      (pathname) => pathname === "preview" || pathname === "draft",
+    );
+    setIsOutsideEditor(Boolean(findPathname));
+  }, pathnameArray);
+
   return (
     <Root
       position="static"
@@ -586,7 +597,10 @@ const Header: React.FC = () => {
       color="transparent"
       ref={headerRef}
       sx={{
-        backgroundColor: theme?.primaryColour || "#2c2c2c",
+        backgroundColor:
+          isOutsideEditor || environment === "standalone"
+            ? theme.primaryColour
+            : "#2c2c2c",
         "@media print": { backgroundColor: "white", color: "black" },
       }}
     >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -24,6 +24,8 @@ const Flow = ({ breadcrumbs = [] }: any) => {
     href: `${window.location.pathname.split(id)[0]}${id}`,
   }));
 
+  console.log(useStore.getState().flowStatus);
+
   return (
     <>
       <ol id="flow" data-layout={flowLayout} className="decisions">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -16,6 +16,7 @@ import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import gql from "graphql-tag";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 
 import { client } from "../../../../lib/graphql";
@@ -193,7 +194,10 @@ const LinkContainer = (props: LinkProps) => {
 };
 
 export default function LinkDialog(props: DialogBaseProps) {
-  const [flowStatus, setFlowStatus] = useState<string | undefined>();
+  const [setFlowStatus, flowStatus] = useStore((state) => [
+    state.setFlowStatus,
+    state.flowStatus,
+  ]);
   // Retrieving flow status to determine which links to show in View Links
   useEffect(() => {
     const fetchFlowStatus = async () => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -15,10 +15,7 @@ import { styled } from "@mui/material/styles";
 import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { link } from "fs";
-import { SetState } from "immer/dist/internal";
-import { intersectDependencies } from "mathjs";
-import React, { SetStateAction, useEffect, useState } from "react";
+import React, { useState } from "react";
 import Permission from "ui/editor/Permission";
 
 interface DialogTeamTheme {
@@ -51,6 +48,12 @@ const ImageWrapper = styled(Box)(() => ({
   padding: "2px",
 }));
 
+const InactiveLink = styled(Typography)(({ theme }) => ({
+  width: "100%",
+  textAlign: "left",
+  color: theme.palette.text.secondary,
+}));
+
 const LinkComponent = (props: {
   linkType: "published" | "draft" | "subdomain" | "preview";
   primaryColour?: string;
@@ -63,16 +66,7 @@ const LinkComponent = (props: {
   const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
 
   return (
-    <Box
-      sx={{
-        opacity:
-          props.isPublished || props.isPublished === undefined ? "100%" : "50%",
-      }}
-      display={"flex"}
-      flexDirection={"column"}
-      gap={"8px"}
-      mb={1}
-    >
+    <Box display={"flex"} flexDirection={"column"} gap={"8px"} mb={1}>
       <Box
         display={"flex"}
         flexDirection={"row"}
@@ -108,6 +102,7 @@ const LinkComponent = (props: {
               setCopyMessage("copied");
               navigator.clipboard.writeText(props.link);
             }}
+            disabled={props.linkType === "published" && !props.isPublished}
           >
             <Typography
               display={"flex"}
@@ -121,7 +116,11 @@ const LinkComponent = (props: {
           </Button>
         </Tooltip>
       </Box>
-      {
+      <Typography>{props.description}</Typography>
+      {}
+      {props.linkType === "published" && !props.isPublished ? (
+        <InactiveLink variant="body1">{props.link}</InactiveLink>
+      ) : (
         <Link
           href={props.link}
           target="_blank"
@@ -130,8 +129,7 @@ const LinkComponent = (props: {
         >
           {props.link}
         </Link>
-      }
-      <Typography>{props.description}</Typography>
+      )}
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -1,0 +1,197 @@
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import LanguageIcon from "@mui/icons-material/Language";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Divider from "@mui/material/Divider";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import { styled } from "@mui/material/styles";
+import { SvgIconProps } from "@mui/material/SvgIcon";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { intersectDependencies } from "mathjs";
+import React, { useState } from "react";
+import Permission from "ui/editor/Permission";
+
+interface DialogTeamTheme {
+  logo: string | null;
+  primaryColour: string;
+}
+
+interface DialogBaseProps {
+  linkDialogOpen: boolean;
+  flowSlug: string;
+  isFlowPublished: boolean;
+  url: string;
+}
+
+interface DialogPropsWithTheme {
+  containsTheme: true;
+  teamTheme: DialogTeamTheme;
+  teamDomain?: string;
+}
+
+type DialogProps = DialogBaseProps & DialogPropsWithTheme;
+
+const ImageWrapper = styled(Box)(() => ({
+  height: 24,
+  width: 24,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "2px",
+}));
+
+const LinkComponent = (props: {
+  primaryColour?: string;
+  titleIcon?: string | SvgIconProps;
+  title: string;
+  link: string;
+  description?: string;
+  isPublished?: boolean;
+}) => {
+  const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
+
+  return (
+    <Box
+      sx={{
+        opacity:
+          props.isPublished || props.isPublished === undefined ? "100%" : "50%",
+      }}
+      display={"flex"}
+      flexDirection={"column"}
+      gap={"8px"}
+      mb={1}
+    >
+      <Box
+        display={"flex"}
+        flexDirection={"row"}
+        alignItems={"center"}
+        gap={"7px"}
+      >
+        {typeof props.titleIcon === "string" ? (
+          <ImageWrapper sx={{ backgroundColor: props.primaryColour }}>
+            <img
+              height={"auto"}
+              width={20}
+              src={props.titleIcon || undefined}
+              alt="Local authority logo"
+            />
+          </ImageWrapper>
+        ) : (
+          <>{props.titleIcon}</>
+        )}
+
+        <Typography variant="h4" component={"h4"} mr={1}>
+          {props.title}
+        </Typography>
+        <Tooltip title={copyMessage}>
+          <Button
+            component={"button"}
+            variant="help"
+            onMouseLeave={() => {
+              setTimeout(() => {
+                setCopyMessage("copy");
+              }, 500);
+            }}
+            onClick={() => {
+              setCopyMessage("copied");
+              navigator.clipboard.writeText(props.link);
+            }}
+          >
+            <Typography
+              display={"flex"}
+              flexDirection={"row"}
+              gap={"4px"}
+              variant="body2"
+            >
+              <ContentCopyIcon />
+              {copyMessage}
+            </Typography>
+          </Button>
+        </Tooltip>
+      </Box>
+      <Link
+        href={props.link}
+        target="_blank"
+        rel="noopener noreferrer"
+        sx={{ "&:hover": { cursor: "pointer" } }}
+      >
+        {props.link}{" "}
+      </Link>
+      <Typography>{props.description}</Typography>
+    </Box>
+  );
+};
+
+export default function LinkDialog(props: DialogProps) {
+  const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(
+    props.linkDialogOpen,
+  );
+
+  return (
+    <Dialog
+      open={linkDialogOpen}
+      onClose={() => setLinkDialogOpen(false)}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      fullWidth
+      maxWidth="md"
+    >
+      <Box padding={1} mb={1} display={"block"} textAlign={"end"}>
+        <Button
+          variant="text"
+          style={{ boxShadow: "none" }}
+          onClick={() => {
+            setLinkDialogOpen(false);
+          }}
+        >
+          <CloseIcon color="action" />
+        </Button>
+        <Divider />
+      </Box>
+      <DialogTitle mb={"25px"} variant="h3" component="h3">
+        {`Share this flow`}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={"25px"} mb={"30px"}>
+          {props.teamDomain && props.teamTheme ? (
+            <LinkComponent
+              primaryColour={props.teamTheme.primaryColour}
+              titleIcon={props.teamTheme.logo || undefined}
+              title={"Published flow with subdomain"}
+              link={`${props.teamDomain}/${props.flowSlug}`}
+            />
+          ) : null}
+          <LinkComponent
+            titleIcon={<LanguageIcon />}
+            title={"Published flow"}
+            isPublished={props.isFlowPublished}
+            link={props.url}
+            description="View of the currently published version of this flow."
+          />
+          <LinkComponent
+            titleIcon={<OpenInNewIcon />}
+            title={"Preview flow"}
+            link={props.url.replace("/published", "/preview")}
+            description="View of the draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
+          />{" "}
+          <Permission.IsPlatformAdmin>
+            <LinkComponent
+              titleIcon={<OpenInNewOffIcon />}
+              title={"Draft flow"}
+              link={props.url.replace("/published", "/draft")}
+              description="View of the draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
+            />
+          </Permission.IsPlatformAdmin>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -265,7 +265,7 @@ export default function LinkDialog(props: DialogBaseProps) {
             type="published"
             isPublished={props.isFlowPublished}
             status={flowStatus}
-            subdomain={props.teamDomain}
+            subdomain={`${props.teamDomain}/${props.flowSlug}`}
           />
           <LinkContainer
             titleIcon={<OpenInNewIcon />}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -16,7 +16,7 @@ import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { intersectDependencies } from "mathjs";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Permission from "ui/editor/Permission";
 
 interface DialogTeamTheme {
@@ -135,6 +135,9 @@ export default function LinkDialog(props: DialogProps) {
     props.linkDialogOpen,
   );
 
+  useEffect(() => {
+    setLinkDialogOpen(props.linkDialogOpen);
+  }, [props.linkDialogOpen]);
   return (
     <Dialog
       open={linkDialogOpen}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -156,6 +156,14 @@ const LinkContainer = (props: LinkProps) => {
           {props.type !== "published" && <CopyButton link={props.link} />}
         </Box>
         <Typography pl={infoPadding}>{props.description}</Typography>
+        {props.status === "offline" && props.type === "published" && (
+          <Typography pl={infoPadding}>
+            You can switch it to “Online” in your{" "}
+            <Link href={props.link.replace("/published", "/service")}>
+              Service Settings
+            </Link>
+          </Typography>
+        )}
       </LinkBox>
       {props.type === "published" ? (
         <PublishedLink
@@ -203,6 +211,15 @@ export default function LinkDialog(props: DialogBaseProps) {
     fetchFlowStatus();
   }, []);
 
+  const unpublishedOfflineDescription =
+    "The flow is not yet published and is not yet viewable by the public.";
+
+  const publishedOfflineDescription =
+    "The published version of this flow. It is not yet viewable by the public.";
+
+  const publishedOnlineDescription =
+    "This flow has been published and is viewable by the public.";
+
   return (
     <Dialog
       open={props.linkDialogOpen}
@@ -233,7 +250,13 @@ export default function LinkDialog(props: DialogBaseProps) {
             titleIcon={<LanguageIcon />}
             title={"Published flow"}
             link={props.url}
-            description="View of the currently published version of this flow."
+            description={
+              !props.isFlowPublished && flowStatus !== "online"
+                ? unpublishedOfflineDescription
+                : props.isFlowPublished && flowStatus !== "online"
+                ? publishedOfflineDescription
+                : publishedOnlineDescription
+            }
             type="published"
             isPublished={props.isFlowPublished}
             status={flowStatus}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -109,7 +109,9 @@ const ActivePublishedLink = (props: any) => {
   return (
     <LinkBox>
       {" "}
-      <PaddedText variant="h4">{props.title}</PaddedText>
+      <PaddedText variant="h4">
+        {props.title} <CopyButton link={props.link} />
+      </PaddedText>
       <Link pl="31px" href={props.link}>
         {props.link}
       </Link>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -95,44 +95,45 @@ const CopyButton = (props: any) => {
   );
 };
 
-const PublishedLink = (props: PublishedLinkProps) => {
+const InactivePublishedLink = (props: any) => {
+  return (
+    <LinkBox>
+      {" "}
+      <PaddedText variant="h4">{props.title}</PaddedText>
+      <InactiveLink pl={"31px"}>{props.message}</InactiveLink>{" "}
+    </LinkBox>
+  );
+};
+
+const ActivePublishedLink = (props: any) => {
+  return (
+    <LinkBox>
+      {" "}
+      <PaddedText variant="h4">{props.title}</PaddedText>
+      <Link pl={"31px"}>{props.link}</Link>
+    </LinkBox>
+  );
+};
+
+const PublishedLinkContent = (props: PublishedLinkProps) => {
   return (
     <Stack spacing={"15px"}>
-      {props.subdomain && props.status === "online" ? (
-        <LinkBox>
-          {" "}
-          <PaddedText variant="h4">
-            {"Subdomain"}
-            <CopyButton link={props.link} />
-          </PaddedText>
-          <Link pl={"31px"} href={props.subdomain}>
-            {props.subdomain}
-          </Link>{" "}
-        </LinkBox>
+      {props.subdomain && props.status === "online" && props.isPublished ? (
+        <ActivePublishedLink title="Subdomain" link={props.subdomain} />
+      ) : props.subdomain && props.status === "online" && !props.isPublished ? (
+        <InactivePublishedLink title="Subdomain" message={props.subdomain} />
+      ) : props.subdomain && props.status === "offline" && props.isPublished ? (
+        <InactivePublishedLink title="Subdomain" message={props.subdomain} />
       ) : (
-        <LinkBox>
-          {" "}
-          <PaddedText variant="h4">{"Subdomain"}</PaddedText>
-          <InactiveLink pl={"31px"}>
-            {"There is not a subdomain configured for this team"}
-          </InactiveLink>{" "}
-        </LinkBox>
+        <InactivePublishedLink
+          title="Subdomain"
+          message={"There is not a domain configured for this team"}
+        />
       )}
       {props.isPublished && props.status === "online" ? (
-        <LinkBox>
-          <PaddedText variant="h4">
-            {"Published"}
-            <CopyButton link={props.link} />
-          </PaddedText>
-          <Link pl={"31px"} href={props.link}>
-            {props.link}
-          </Link>{" "}
-        </LinkBox>
+        <ActivePublishedLink title="PlanX link" link={props.link} />
       ) : (
-        <LinkBox>
-          <PaddedText variant="h4">{"Published"}</PaddedText>
-          <InactiveLink pl={"31px"}>{props.link}</InactiveLink>{" "}
-        </LinkBox>
+        <InactivePublishedLink title="PlanX link" message={props.link} />
       )}
     </Stack>
   );
@@ -166,7 +167,7 @@ const LinkContainer = (props: LinkProps) => {
         )}
       </LinkBox>
       {props.type === "published" ? (
-        <PublishedLink
+        <PublishedLinkContent
           status={props.status}
           subdomain={props.subdomain}
           link={props.link}
@@ -260,6 +261,7 @@ export default function LinkDialog(props: DialogBaseProps) {
             type="published"
             isPublished={props.isFlowPublished}
             status={flowStatus}
+            subdomain={props.teamDomain}
           />
           <LinkContainer
             titleIcon={<OpenInNewIcon />}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -265,7 +265,9 @@ export default function LinkDialog(props: DialogBaseProps) {
             type="published"
             isPublished={props.isFlowPublished}
             status={flowStatus}
-            subdomain={`${props.teamDomain}/${props.flowSlug}`}
+            subdomain={
+              props.teamDomain && `${props.teamDomain}/${props.flowSlug}`
+            }
           />
           <LinkContainer
             titleIcon={<OpenInNewIcon />}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -229,6 +229,9 @@ export default function LinkDialog(props: DialogBaseProps) {
   const unpublishedOfflineDescription =
     "The flow is not yet published and is not yet viewable by the public.";
 
+  const unpublishedOnlineDescription =
+    "The flow is not yet published and is not viewable by the public";
+
   const publishedOfflineDescription =
     "The published version of this flow. It is not yet viewable by the public.";
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -16,29 +16,19 @@ import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import gql from "graphql-tag";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { client } from "../../../../lib/graphql";
 import Permission from "../../../../ui/editor/Permission";
 
-interface DialogTeamTheme {
-  logo: string | null;
-  primaryColour: string;
-}
-
 interface DialogBaseProps {
   linkDialogOpen: boolean;
+  teamDomain?: string;
   teamSlug: string;
   flowSlug: string;
   isFlowPublished: boolean;
   url: string;
   setLinkDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-interface DialogPropsWithTheme {
-  containsTheme: true;
-  teamTheme: DialogTeamTheme;
-  teamDomain?: string;
 }
 
 interface LinkProps {
@@ -56,8 +46,6 @@ type PublishedLinkProps = Pick<
   LinkProps,
   "status" | "subdomain" | "link" | "isPublished"
 >;
-
-type DialogProps = DialogBaseProps & DialogPropsWithTheme;
 
 const InactiveLink = styled(Typography)(({ theme }) => ({
   width: "100%",
@@ -185,7 +173,7 @@ const LinkContainer = (props: LinkProps) => {
   );
 };
 
-export default function LinkDialog(props: DialogProps) {
+export default function LinkDialog(props: DialogBaseProps) {
   const [flowStatus, setFlowStatus] = useState<string | undefined>();
   // Retrieving flow status to determine which links to show in View Links
   useEffect(() => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -123,14 +123,20 @@ const PublishedLinkContent = (props: PublishedLinkProps) => {
   return (
     <Stack spacing={"15px"}>
       {props.subdomain && props.status === "online" && props.isPublished ? (
-        <ActivePublishedLink title="Subdomain" link={props.subdomain} />
+        <ActivePublishedLink title="With subdomain" link={props.subdomain} />
       ) : props.subdomain && props.status === "online" && !props.isPublished ? (
-        <InactivePublishedLink title="Subdomain" message={props.subdomain} />
+        <InactivePublishedLink
+          title="With subdomain"
+          message={props.subdomain}
+        />
       ) : props.subdomain && props.status === "offline" && props.isPublished ? (
-        <InactivePublishedLink title="Subdomain" message={props.subdomain} />
+        <InactivePublishedLink
+          title="With subdomain"
+          message={props.subdomain}
+        />
       ) : (
         <InactivePublishedLink
-          title="Subdomain"
+          title="With subdomain"
           message={"There is not a domain configured for this team"}
         />
       )}
@@ -223,7 +229,7 @@ export default function LinkDialog(props: DialogBaseProps) {
     "The published version of this flow. It is not yet viewable by the public.";
 
   const publishedOnlineDescription =
-    "This flow has been published and is viewable by the public.";
+    "The published version of the flow that is viewable by the public.";
 
   return (
     <Dialog
@@ -273,7 +279,7 @@ export default function LinkDialog(props: DialogBaseProps) {
             titleIcon={<OpenInNewIcon />}
             title={"Preview"}
             link={props.url.replace("/published", "/preview")}
-            description="The draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
+            description="This link is representative of what your next published version will look like. It contains the draft data of the main flow and the latest published version of nested flows. "
             type="preview"
           />{" "}
           <Permission.IsPlatformAdmin>
@@ -281,7 +287,7 @@ export default function LinkDialog(props: DialogBaseProps) {
               titleIcon={<OpenInNewOffIcon />}
               title={"Draft"}
               link={props.url.replace("/published", "/draft")}
-              description="The draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
+              description="This link is not representative of what your next published version will look like. It contains the draft data of the main flow and the draft data of nested flows."
               type="draft"
             />
           </Permission.IsPlatformAdmin>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -253,7 +253,7 @@ export default function LinkDialog(props: DialogBaseProps) {
         <Stack spacing={"25px"} mb={"30px"}>
           <LinkContainer
             titleIcon={<LanguageIcon />}
-            title={"Published flow"}
+            title={"Published"}
             link={props.url}
             description={
               !props.isFlowPublished && flowStatus !== "online"
@@ -271,17 +271,17 @@ export default function LinkDialog(props: DialogBaseProps) {
           />
           <LinkContainer
             titleIcon={<OpenInNewIcon />}
-            title={"Preview flow"}
+            title={"Preview"}
             link={props.url.replace("/published", "/preview")}
-            description="View of the draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
+            description="The draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
             type="preview"
           />{" "}
           <Permission.IsPlatformAdmin>
             <LinkContainer
               titleIcon={<OpenInNewOffIcon />}
-              title={"Draft flow"}
+              title={"Draft"}
               link={props.url.replace("/published", "/draft")}
-              description="View of the draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
+              description="The draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
               type="draft"
             />
           </Permission.IsPlatformAdmin>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -110,7 +110,9 @@ const ActivePublishedLink = (props: any) => {
     <LinkBox>
       {" "}
       <PaddedText variant="h4">{props.title}</PaddedText>
-      <Link pl={"31px"}>{props.link}</Link>
+      <Link pl="31px" href={props.link}>
+        {props.link}
+      </Link>
     </LinkBox>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -15,8 +15,10 @@ import { styled } from "@mui/material/styles";
 import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import { link } from "fs";
+import { SetState } from "immer/dist/internal";
 import { intersectDependencies } from "mathjs";
-import React, { useEffect, useState } from "react";
+import React, { SetStateAction, useEffect, useState } from "react";
 import Permission from "ui/editor/Permission";
 
 interface DialogTeamTheme {
@@ -29,6 +31,7 @@ interface DialogBaseProps {
   flowSlug: string;
   isFlowPublished: boolean;
   url: string;
+  setLinkDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 interface DialogPropsWithTheme {
@@ -49,6 +52,7 @@ const ImageWrapper = styled(Box)(() => ({
 }));
 
 const LinkComponent = (props: {
+  linkType: "published" | "draft" | "subdomain" | "preview";
   primaryColour?: string;
   titleIcon?: string | SvgIconProps;
   title: string;
@@ -117,31 +121,27 @@ const LinkComponent = (props: {
           </Button>
         </Tooltip>
       </Box>
-      <Link
-        href={props.link}
-        target="_blank"
-        rel="noopener noreferrer"
-        sx={{ "&:hover": { cursor: "pointer" } }}
-      >
-        {props.link}{" "}
-      </Link>
+      {
+        <Link
+          href={props.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{ "&:hover": { cursor: "pointer" } }}
+        >
+          {props.link}
+        </Link>
+      }
       <Typography>{props.description}</Typography>
     </Box>
   );
 };
 
 export default function LinkDialog(props: DialogProps) {
-  const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(
-    props.linkDialogOpen,
-  );
-
-  useEffect(() => {
-    setLinkDialogOpen(props.linkDialogOpen);
-  }, [props.linkDialogOpen]);
+  console.log(props.linkDialogOpen);
   return (
     <Dialog
-      open={linkDialogOpen}
-      onClose={() => setLinkDialogOpen(false)}
+      open={props.linkDialogOpen}
+      onClose={() => props.setLinkDialogOpen(false)}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
       fullWidth
@@ -152,7 +152,7 @@ export default function LinkDialog(props: DialogProps) {
           variant="text"
           style={{ boxShadow: "none" }}
           onClick={() => {
-            setLinkDialogOpen(false);
+            props.setLinkDialogOpen(false);
           }}
         >
           <CloseIcon color="action" />
@@ -166,6 +166,7 @@ export default function LinkDialog(props: DialogProps) {
         <Stack spacing={"25px"} mb={"30px"}>
           {props.teamDomain && props.teamTheme ? (
             <LinkComponent
+              linkType="subdomain"
               primaryColour={props.teamTheme.primaryColour}
               titleIcon={props.teamTheme.logo || undefined}
               title={"Published flow with subdomain"}
@@ -173,6 +174,7 @@ export default function LinkDialog(props: DialogProps) {
             />
           ) : null}
           <LinkComponent
+            linkType="published"
             titleIcon={<LanguageIcon />}
             title={"Published flow"}
             isPublished={props.isFlowPublished}
@@ -180,6 +182,7 @@ export default function LinkDialog(props: DialogProps) {
             description="View of the currently published version of this flow."
           />
           <LinkComponent
+            linkType="preview"
             titleIcon={<OpenInNewIcon />}
             title={"Preview flow"}
             link={props.url.replace("/published", "/preview")}
@@ -187,6 +190,7 @@ export default function LinkDialog(props: DialogProps) {
           />{" "}
           <Permission.IsPlatformAdmin>
             <LinkComponent
+              linkType="draft"
               titleIcon={<OpenInNewOffIcon />}
               title={"Draft flow"}
               link={props.url.replace("/published", "/draft")}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/LinkDialog.tsx
@@ -69,6 +69,12 @@ const PaddedText = styled(Typography)(({ theme }) => ({
   paddingLeft: "31px",
 }));
 
+const LinkBox = styled(Box)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "10px",
+}));
+
 const CopyButton = (props: any) => {
   const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
   return (
@@ -91,9 +97,9 @@ const CopyButton = (props: any) => {
           display={"flex"}
           flexDirection={"row"}
           gap={"4px"}
-          variant="body2"
+          variant="body3"
         >
-          <ContentCopyIcon />
+          <ContentCopyIcon style={{ width: "18px", height: "18px" }} />
           {copyMessage}
         </Typography>
       </Button>
@@ -103,9 +109,9 @@ const CopyButton = (props: any) => {
 
 const PublishedLink = (props: PublishedLinkProps) => {
   return (
-    <>
+    <Stack spacing={"15px"}>
       {props.subdomain && props.status === "online" ? (
-        <>
+        <LinkBox>
           {" "}
           <PaddedText variant="h4">
             {"Subdomain"}
@@ -114,18 +120,18 @@ const PublishedLink = (props: PublishedLinkProps) => {
           <Link pl={"31px"} href={props.subdomain}>
             {props.subdomain}
           </Link>{" "}
-        </>
+        </LinkBox>
       ) : (
-        <>
+        <LinkBox>
           {" "}
           <PaddedText variant="h4">{"Subdomain"}</PaddedText>
           <InactiveLink pl={"31px"}>
             {"There is not a subdomain configured for this team"}
           </InactiveLink>{" "}
-        </>
+        </LinkBox>
       )}
       {props.isPublished && props.status === "online" ? (
-        <>
+        <LinkBox>
           <PaddedText variant="h4">
             {"Published"}
             <CopyButton link={props.link} />
@@ -133,34 +139,36 @@ const PublishedLink = (props: PublishedLinkProps) => {
           <Link pl={"31px"} href={props.link}>
             {props.link}
           </Link>{" "}
-        </>
+        </LinkBox>
       ) : (
-        <>
+        <LinkBox>
           <PaddedText variant="h4">{"Published"}</PaddedText>
           <InactiveLink pl={"31px"}>{props.link}</InactiveLink>{" "}
-        </>
+        </LinkBox>
       )}
-    </>
+    </Stack>
   );
 };
 
 const LinkContainer = (props: LinkProps) => {
   const infoPadding = "31px";
   return (
-    <Box display={"flex"} flexDirection={"column"} gap={"8px"} mb={1}>
-      <Box
-        display={"flex"}
-        flexDirection={"row"}
-        alignItems={"center"}
-        gap={"7px"}
-      >
-        <>{props.titleIcon}</>
-        <Typography variant="h4" component={"h4"}>
-          {props.title}
-        </Typography>
-        {props.type !== "published" && <CopyButton link={props.link} />}
-      </Box>
-      <Typography pl={infoPadding}>{props.description}</Typography>
+    <Box display={"flex"} flexDirection={"column"} gap={"15px"} mb={1}>
+      <LinkBox>
+        <Box
+          display={"flex"}
+          flexDirection={"row"}
+          alignItems={"center"}
+          gap={"7px"}
+        >
+          <>{props.titleIcon}</>
+          <Typography variant="h4" component={"h4"}>
+            {props.title}
+          </Typography>
+          {props.type !== "published" && <CopyButton link={props.link} />}
+        </Box>
+        <Typography pl={infoPadding}>{props.description}</Typography>
+      </LinkBox>
       {props.type === "published" ? (
         <PublishedLink
           status={props.status}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -11,6 +11,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
@@ -316,55 +317,248 @@ const Sidebar: React.FC<{
               {`Links to Copy`}
             </DialogTitle>
             <DialogContent>
-              <Box display={"flex"} flexDirection={"column"} gap={"8px"}>
-                <Box display={"flex"} flexDirection={"row"}>
-                  <ImageWrapper
-                    sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
+              <Stack spacing={2} mb={"30px"}>
+                <Box
+                  display={"flex"}
+                  flexDirection={"column"}
+                  gap={"8px"}
+                  mb={1}
+                >
+                  <Box
+                    display={"flex"}
+                    flexDirection={"row"}
+                    alignItems={"center"}
+                    gap={"7px"}
                   >
-                    <img
-                      width={44}
-                      src={currentTeam?.theme.logo || undefined}
-                      alt="Local authority logo"
-                      sizes=""
-                    />
-                  </ImageWrapper>
-
-                  <Typography variant="h4" component={"h4"} mr={1}>
-                    {"Published flow with subdomain"}
-                  </Typography>
-                  <Tooltip title={copyMessage}>
-                    <Link
-                      component={"button"}
-                      style={{ textDecoration: "none" }}
-                      onMouseLeave={() => {
-                        setTimeout(() => {
-                          setCopyMessage("copy");
-                        }, 1000);
-                      }}
-                      onClick={() => {
-                        setCopyMessage("copied");
-                        navigator.clipboard.writeText(
-                          props.url.replace("/published", "/preview"),
-                        );
-                      }}
+                    <ImageWrapper
+                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
                     >
-                      <Typography
-                        display={"flex"}
-                        flexDirection={"row"}
-                        gap={"4px"}
-                        variant="body1"
+                      <img
+                        height={12}
+                        width={"auto"}
+                        src={currentTeam?.theme.logo || undefined}
+                        alt="Local authority logo"
+                        sizes=""
+                      />
+                    </ImageWrapper>
+
+                    <Typography variant="h4" component={"h4"} mr={1}>
+                      {"Published flow with subdomain"}
+                    </Typography>
+                    <Tooltip title={copyMessage}>
+                      <Link
+                        component={"button"}
+                        style={{ textDecoration: "none" }}
+                        onMouseLeave={() => {
+                          setTimeout(() => {
+                            setCopyMessage("copy");
+                          }, 1000);
+                        }}
+                        onClick={() => {
+                          setCopyMessage("copied");
+                          navigator.clipboard.writeText(
+                            props.url.replace("/published", "/preview"),
+                          );
+                        }}
                       >
-                        <ContentCopyIcon />
-                        {copyMessage}
-                      </Typography>
-                    </Link>
-                  </Tooltip>
+                        <Typography
+                          display={"flex"}
+                          flexDirection={"row"}
+                          gap={"4px"}
+                          variant="body2"
+                        >
+                          <ContentCopyIcon />
+                          {copyMessage}
+                        </Typography>
+                      </Link>
+                    </Tooltip>
+                  </Box>
+                  <Link>{props.url.replace("/published", "/preview")} </Link>
+                  <Typography>
+                    {"This is the description of the published link"}
+                  </Typography>
                 </Box>
-                <Link>{props.url.replace("/published", "/preview")} </Link>
-                <Typography>
-                  {"This is the description of the published link"}
-                </Typography>
-              </Box>
+                <Box
+                  display={"flex"}
+                  flexDirection={"column"}
+                  gap={"8px"}
+                  mb={1}
+                >
+                  <Box
+                    display={"flex"}
+                    flexDirection={"row"}
+                    alignItems={"center"}
+                    gap={"7px"}
+                  >
+                    <ImageWrapper
+                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
+                    >
+                      <img
+                        height={12}
+                        width={"auto"}
+                        src={currentTeam?.theme.logo || undefined}
+                        alt="Local authority logo"
+                        sizes=""
+                      />
+                    </ImageWrapper>
+
+                    <Typography variant="h4" component={"h4"} mr={1}>
+                      {"Published flow with subdomain"}
+                    </Typography>
+                    <Tooltip title={copyMessage}>
+                      <Link
+                        component={"button"}
+                        style={{ textDecoration: "none" }}
+                        onMouseLeave={() => {
+                          setTimeout(() => {
+                            setCopyMessage("copy");
+                          }, 1000);
+                        }}
+                        onClick={() => {
+                          setCopyMessage("copied");
+                          navigator.clipboard.writeText(
+                            props.url.replace("/published", "/preview"),
+                          );
+                        }}
+                      >
+                        <Typography
+                          display={"flex"}
+                          flexDirection={"row"}
+                          gap={"4px"}
+                          variant="body2"
+                        >
+                          <ContentCopyIcon />
+                          {copyMessage}
+                        </Typography>
+                      </Link>
+                    </Tooltip>
+                  </Box>
+                  <Link>{props.url.replace("/published", "/preview")} </Link>
+                  <Typography>
+                    {"This is the description of the published link"}
+                  </Typography>
+                </Box>
+                <Box
+                  display={"flex"}
+                  flexDirection={"column"}
+                  gap={"8px"}
+                  mb={1}
+                >
+                  <Box
+                    display={"flex"}
+                    flexDirection={"row"}
+                    alignItems={"center"}
+                    gap={"7px"}
+                  >
+                    <ImageWrapper
+                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
+                    >
+                      <img
+                        height={12}
+                        width={"auto"}
+                        src={currentTeam?.theme.logo || undefined}
+                        alt="Local authority logo"
+                        sizes=""
+                      />
+                    </ImageWrapper>
+
+                    <Typography variant="h4" component={"h4"} mr={1}>
+                      {"Published flow with subdomain"}
+                    </Typography>
+                    <Tooltip title={copyMessage}>
+                      <Link
+                        component={"button"}
+                        style={{ textDecoration: "none" }}
+                        onMouseLeave={() => {
+                          setTimeout(() => {
+                            setCopyMessage("copy");
+                          }, 1000);
+                        }}
+                        onClick={() => {
+                          setCopyMessage("copied");
+                          navigator.clipboard.writeText(
+                            props.url.replace("/published", "/preview"),
+                          );
+                        }}
+                      >
+                        <Typography
+                          display={"flex"}
+                          flexDirection={"row"}
+                          gap={"4px"}
+                          variant="body2"
+                        >
+                          <ContentCopyIcon />
+                          {copyMessage}
+                        </Typography>
+                      </Link>
+                    </Tooltip>
+                  </Box>
+                  <Link>{props.url.replace("/published", "/preview")} </Link>
+                  <Typography>
+                    {"This is the description of the published link"}
+                  </Typography>
+                </Box>
+                <Box
+                  display={"flex"}
+                  flexDirection={"column"}
+                  gap={"8px"}
+                  mb={1}
+                >
+                  <Box
+                    display={"flex"}
+                    flexDirection={"row"}
+                    alignItems={"center"}
+                    gap={"7px"}
+                  >
+                    <ImageWrapper
+                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
+                    >
+                      <img
+                        height={12}
+                        width={"auto"}
+                        src={currentTeam?.theme.logo || undefined}
+                        alt="Local authority logo"
+                        sizes=""
+                      />
+                    </ImageWrapper>
+
+                    <Typography variant="h4" component={"h4"} mr={1}>
+                      {"Published flow with subdomain"}
+                    </Typography>
+                    <Tooltip title={copyMessage}>
+                      <Link
+                        component={"button"}
+                        style={{ textDecoration: "none" }}
+                        onMouseLeave={() => {
+                          setTimeout(() => {
+                            setCopyMessage("copy");
+                          }, 1000);
+                        }}
+                        onClick={() => {
+                          setCopyMessage("copied");
+                          navigator.clipboard.writeText(
+                            props.url.replace("/published", "/preview"),
+                          );
+                        }}
+                      >
+                        <Typography
+                          display={"flex"}
+                          flexDirection={"row"}
+                          gap={"4px"}
+                          variant="body2"
+                        >
+                          <ContentCopyIcon />
+                          {copyMessage}
+                        </Typography>
+                      </Link>
+                    </Tooltip>
+                  </Box>
+                  <Link>{props.url.replace("/published", "/preview")} </Link>
+                  <Typography>
+                    {"This is the description of the published link"}
+                  </Typography>
+                </Box>
+              </Stack>
             </DialogContent>
           </Dialog>
           <Box

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -24,6 +24,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
 import { AxiosError } from "axios";
+import gql from "graphql-tag";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
 import React, { useCallback, useEffect, useState } from "react";
@@ -31,6 +32,7 @@ import { useAsync } from "react-use";
 import Permission from "ui/editor/Permission";
 import Input from "ui/shared/Input";
 
+import { client } from "../../../../lib/graphql";
 import Questions from "../../../Preview/Questions";
 import { useStore } from "../../lib/store";
 import EditHistory from "./EditHistory";
@@ -181,6 +183,7 @@ const Sidebar: React.FC<{
     fetchCurrentTeam,
     togglePreview,
     flowSlug,
+    flowStatus,
     teamSlug,
     teamTheme,
     teamDomain,
@@ -195,6 +198,7 @@ const Sidebar: React.FC<{
     state.fetchCurrentTeam,
     state.togglePreview,
     state.flowSlug,
+    state.flowStatus,
     state.teamSlug,
     state.teamTheme,
     state.teamDomain,
@@ -298,6 +302,7 @@ const Sidebar: React.FC<{
             linkDialogOpen={linkDialogOpen}
             teamTheme={teamTheme}
             teamDomain={teamDomain}
+            teamSlug={teamSlug}
             flowSlug={flowSlug}
             isFlowPublished={isFlowPublished}
             url={props.url}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,16 +1,7 @@
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import ContentCopyTwoToneIcon from "@mui/icons-material/ContentCopyTwoTone";
-import LanguageIcon from "@mui/icons-material/Language";
-import MenuOpenIcon from "@mui/icons-material/MenuOpen";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import SignalCellularAltIcon from "@mui/icons-material/SignalCellularAlt";
-import Alert from "@mui/material/Alert";
+import LinkIcon from "@mui/icons-material/Link";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Chip from "@mui/material/Chip";
 import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
@@ -80,12 +71,6 @@ const Header = styled("header")(({ theme }) => ({
     background: theme.palette.common.white,
     border: "1px solid rgba(0, 0, 0, 0.2)",
   },
-  "& svg": {
-    cursor: "pointer",
-    opacity: "0.7",
-    margin: "6px 4px 1px 4px",
-    fontSize: "1.2rem",
-  },
 }));
 
 const TabList = styled(Box)(({ theme }) => ({
@@ -137,7 +122,7 @@ const DebugConsole = () => {
       state.breadcrumbs,
       state.id,
       state.cachedBreadcrumbs,
-    ]
+    ],
   );
   return (
     <Console borderTop={2} borderColor="border.main" bgcolor="background.paper">
@@ -180,10 +165,10 @@ const Sidebar: React.FC<{
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
-    "This flow is not published yet"
+    "This flow is not published yet",
   );
   const [validationChecks, setValidationChecks] = useState<ValidationCheck[]>(
-    []
+    [],
   );
   const [alteredNodes, setAlteredNodes] = useState<AlteredNode[]>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
@@ -200,12 +185,12 @@ const Sidebar: React.FC<{
       setLastPublishedTitle("Checking for changes...");
       const alteredFlow = await validateAndDiffFlow(flowId);
       setAlteredNodes(
-        alteredFlow?.data.alteredNodes ? alteredFlow.data.alteredNodes : []
+        alteredFlow?.data.alteredNodes ? alteredFlow.data.alteredNodes : [],
       );
       setLastPublishedTitle(
         alteredFlow?.data.alteredNodes
           ? `Found changes to ${alteredFlow.data.alteredNodes.length} nodes`
-          : alteredFlow?.data.message
+          : alteredFlow?.data.message,
       );
       setValidationChecks(alteredFlow?.data?.validationChecks);
       setDialogOpen(true);
@@ -216,7 +201,7 @@ const Sidebar: React.FC<{
         alert(error.response?.data?.error);
       } else {
         alert(
-          `Error checking for changes to publish. Confirm that your graph does not have any corrupted nodes and that all external portals are valid. \n${error}`
+          `Error checking for changes to publish. Confirm that your graph does not have any corrupted nodes and that all external portals are valid. \n${error}`,
         );
       }
     }
@@ -230,7 +215,7 @@ const Sidebar: React.FC<{
       setLastPublishedTitle(
         alteredNodes
           ? `Successfully published changes to ${alteredNodes.length} nodes`
-          : `${message}` || "No new changes to publish"
+          : `${message}` || "No new changes to publish",
       );
     } catch (error) {
       setLastPublishedTitle("Error trying to publish");
@@ -248,7 +233,7 @@ const Sidebar: React.FC<{
   const _validateAndDiffRequest = useAsync(async () => {
     const newChanges = await validateAndDiffFlow(flowId);
     setAlteredNodes(
-      newChanges?.data.alteredNodes ? newChanges.data.alteredNodes : []
+      newChanges?.data.alteredNodes ? newChanges.data.alteredNodes : [],
     );
   });
 
@@ -266,294 +251,27 @@ const Sidebar: React.FC<{
   return (
     <Root>
       <Header>
-        <Box width="100%" display="flex">
-          <input
-            disabled
-            value={props.url.replace("/published", "/preview")}
-            onClick={handleClick}
-          />
-          <Tooltip
-            arrow
-            title={isCopied ? "Copied" : "Copy link"}
-            onClick={handleClick}
+        <Box
+          width="100%"
+          mt={2}
+          mb={2}
+          display="flex"
+          flexDirection="row"
+          gap={"24px"}
+        >
+          <Button
+            sx={{
+              width: "35%",
+              display: "flex",
+              flexDirection: "row",
+              gap: "8px",
+            }}
+            variant="contained"
+            color="secondary"
+            disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           >
-            {isCopied ? <ContentCopyTwoToneIcon /> : <ContentCopyIcon />}
-          </Tooltip>
-          <Tooltip arrow title="Refresh preview">
-            <RefreshIcon
-              onClick={() => {
-                resetPreview();
-                setKey((a) => !a);
-              }}
-            />
-          </Tooltip>
-
-          <Tooltip arrow title="Toggle debug console">
-            <MenuOpenIcon
-              onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
-            />
-          </Tooltip>
-
-          {flowAnalyticsLink ? (
-            <Tooltip arrow title="Open analytics page">
-              <Link
-                href={flowAnalyticsLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <SignalCellularAltIcon />
-              </Link>
-            </Tooltip>
-          ) : (
-            <Tooltip arrow title="Analytics page unavailable">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
-                  <SignalCellularAltIcon />
-                </Link>
-              </Box>
-            </Tooltip>
-          )}
-
-          <Permission.IsPlatformAdmin>
-            <Tooltip arrow title="Open draft service">
-              <Link
-                href={props.url.replace("/published", "/draft")}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <OpenInNewOffIcon />
-              </Link>
-            </Tooltip>
-          </Permission.IsPlatformAdmin>
-
-          <Tooltip arrow title="Open preview of changes to publish">
-            <Link
-              href={props.url.replace("/published", "/preview")}
-              target="_blank"
-              rel="noopener noreferrer"
-              color="inherit"
-            >
-              <OpenInNewIcon />
-            </Link>
-          </Tooltip>
-
-          {isFlowPublished ? (
-            <Tooltip arrow title="Open published service">
-              <Link
-                href={props.url + "?analytics=false"}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <LanguageIcon />
-              </Link>
-            </Tooltip>
-          ) : (
-            <Tooltip arrow title="Flow not yet published">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
-                  <LanguageIcon />
-                </Link>
-              </Box>
-            </Tooltip>
-          )}
-        </Box>
-        <Box mt={1} mb={1} width={"100%"} display={"flex"}>
-          <Tooltip arrow title={isCopied ? "Copied" : "Copy link"}>
-            <Chip
-              variant={isCopied ? "filled" : "outlined"}
-              color="primary"
-              label={props.url.replace("/published", "/preview")}
-              onClick={handleClick}
-            />
-          </Tooltip>
-        </Box>
-        <Box mt={1} mb={1} width={"100%"} display={"flex"}>
-          <Tooltip arrow title={isCopied ? "Copied" : "Copy link"}>
-            <Chip
-              variant={isCopied ? "filled" : "outlined"}
-              color="primary"
-              icon={<ContentCopyIcon />}
-              label={"Copy your published link"}
-              onClick={handleClick}
-              sx={{ padding: "12px" }}
-            />
-          </Tooltip>
-          <Tooltip arrow title="Refresh preview">
-            <RefreshIcon
-              onClick={() => {
-                resetPreview();
-                setKey((a) => !a);
-              }}
-            />
-          </Tooltip>
-
-          <Tooltip arrow title="Toggle debug console">
-            <MenuOpenIcon
-              onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
-            />
-          </Tooltip>
-
-          {flowAnalyticsLink ? (
-            <Tooltip arrow title="Open analytics page">
-              <Link
-                href={flowAnalyticsLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <SignalCellularAltIcon />
-              </Link>
-            </Tooltip>
-          ) : (
-            <Tooltip arrow title="Analytics page unavailable">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
-                  <SignalCellularAltIcon />
-                </Link>
-              </Box>
-            </Tooltip>
-          )}
-
-          <Permission.IsPlatformAdmin>
-            <Tooltip arrow title="Open draft service">
-              <Link
-                href={props.url.replace("/published", "/draft")}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <OpenInNewOffIcon />
-              </Link>
-            </Tooltip>
-          </Permission.IsPlatformAdmin>
-
-          <Tooltip arrow title="Open preview of changes to publish">
-            <Link
-              href={props.url.replace("/published", "/preview")}
-              target="_blank"
-              rel="noopener noreferrer"
-              color="inherit"
-            >
-              <OpenInNewIcon />
-            </Link>
-          </Tooltip>
-
-          {isFlowPublished ? (
-            <Tooltip arrow title="Open published service">
-              <Link
-                href={props.url + "?analytics=false"}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <LanguageIcon />
-              </Link>
-            </Tooltip>
-          ) : (
-            <Tooltip arrow title="Flow not yet published">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
-                  <LanguageIcon />
-                </Link>
-              </Box>
-            </Tooltip>
-          )}
-        </Box>
-        <Box width="100%" display="flex">
-          <Tooltip arrow title={isCopied ? "Copied" : "Copy link"}>
-            <Chip
-              variant={isCopied ? "filled" : "outlined"}
-              color="primary"
-              label={"Copy your published link"}
-              onClick={handleClick}
-            />
-          </Tooltip>
-          <Tooltip arrow title="Refresh preview">
-            <RefreshIcon
-              onClick={() => {
-                resetPreview();
-                setKey((a) => !a);
-              }}
-            />
-          </Tooltip>
-
-          <Tooltip arrow title="Toggle debug console">
-            <MenuOpenIcon
-              onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
-            />
-          </Tooltip>
-
-          {flowAnalyticsLink ? (
-            <Tooltip arrow title="Open analytics page">
-              <Link
-                href={flowAnalyticsLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <SignalCellularAltIcon />
-              </Link>
-            </Tooltip>
-          ) : (
-            <Tooltip arrow title="Analytics page unavailable">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
-                  <SignalCellularAltIcon />
-                </Link>
-              </Box>
-            </Tooltip>
-          )}
-
-          <Permission.IsPlatformAdmin>
-            <Tooltip arrow title="Open draft service">
-              <Link
-                href={props.url.replace("/published", "/draft")}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <OpenInNewOffIcon />
-              </Link>
-            </Tooltip>
-          </Permission.IsPlatformAdmin>
-
-          <Tooltip arrow title="Open preview of changes to publish">
-            <Link
-              href={props.url.replace("/published", "/preview")}
-              target="_blank"
-              rel="noopener noreferrer"
-              color="inherit"
-            >
-              <OpenInNewIcon />
-            </Link>
-          </Tooltip>
-
-          {isFlowPublished ? (
-            <Tooltip arrow title="Open published service">
-              <Link
-                href={props.url + "?analytics=false"}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <LanguageIcon />
-              </Link>
-            </Tooltip>
-          ) : (
-            <Tooltip arrow title="Flow not yet published">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
-                  <LanguageIcon />
-                </Link>
-              </Box>
-            </Tooltip>
-          )}
-        </Box>
-        <Box mb={1} width={"100%"} display={"flex"}></Box>
-        <Box width="100%" mt={2}>
+            <LinkIcon fontSize="medium" /> Copy link
+          </Button>
           <Box
             display="flex"
             flexDirection="column"
@@ -639,8 +357,13 @@ const Sidebar: React.FC<{
                 </Button>
               </DialogActions>
             </Dialog>
-            <Box mr={0}>
-              <Typography variant="caption">{lastPublishedTitle}</Typography>
+            <Box mr={0} sx={{ position: "relative", width: "100%" }}>
+              <Typography
+                sx={{ position: "absolute", width: "100%", left: 0 }}
+                variant="caption"
+              >
+                {lastPublishedTitle}
+              </Typography>
             </Box>
           </Box>
         </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -293,6 +293,7 @@ const Sidebar: React.FC<{
             <LinkIcon fontSize="medium" /> View links
           </ViewButton>
           <LinkDialog
+            setLinkDialogOpen={setLinkDialogOpen}
             containsTheme
             linkDialogOpen={linkDialogOpen}
             teamTheme={teamTheme}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -417,7 +417,7 @@ const Sidebar: React.FC<{
                   titleIcon={<LanguageIcon />}
                   title={"Published"}
                   isPublished={isFlowPublished}
-                  link={props.url.replace("/published", "/published")}
+                  link={props.url}
                   description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
                 />
                 <LinkComponent

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -354,8 +354,9 @@ const Sidebar: React.FC<{
                       {"Published flow with subdomain"}
                     </Typography>
                     <Tooltip title={copyMessage}>
-                      <Link
+                      <Button
                         component={"button"}
+                        variant="help"
                         style={{ textDecoration: "none" }}
                         onMouseLeave={() => {
                           setTimeout(() => {
@@ -378,7 +379,7 @@ const Sidebar: React.FC<{
                           <ContentCopyIcon />
                           {copyMessage}
                         </Typography>
-                      </Link>
+                      </Button>
                     </Tooltip>
                   </Box>
                   <Link>{props.url.replace("/published", "/preview")} </Link>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,4 +1,6 @@
 import LinkIcon from "@mui/icons-material/Link";
+import MenuOpenIcon from "@mui/icons-material/MenuOpen";
+import RefreshIcon from "@mui/icons-material/Refresh";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -7,10 +9,12 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { AxiosError } from "axios";
 import { hasFeatureFlag } from "lib/featureFlags";
@@ -70,6 +74,10 @@ const Header = styled("header")(({ theme }) => ({
 
     border: "1px solid rgba(0, 0, 0, 0.2)",
   },
+}));
+
+const SecondaryButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.common.black,
 }));
 
 const ViewButton = styled(Button)(({ theme }) => ({
@@ -263,14 +271,41 @@ const Sidebar: React.FC<{
     <Root>
       <Header>
         <Box
+          display={"flex"}
+          flexDirection={"row"}
+          justifyContent={"flex-end"}
+          padding={"0px 20px"}
+          gap={"8px"}
+        >
+          <SecondaryButton color="primary">
+            <Tooltip arrow title="Refresh preview">
+              <RefreshIcon
+                onClick={() => {
+                  resetPreview();
+                  setKey((a) => !a);
+                }}
+              />
+            </Tooltip>
+          </SecondaryButton>
+          <SecondaryButton color="primary">
+            <Tooltip arrow title="Toggle debug console">
+              <MenuOpenIcon
+                onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
+              />
+            </Tooltip>
+          </SecondaryButton>
+        </Box>
+        <Box
           width="100%"
           mt={2}
           mb={4}
           pl={2}
+          pr={2}
           display="flex"
           flexDirection="row"
           gap={"24px"}
           style={{ position: "relative" }}
+          justifyContent={"space-between"}
         >
           <ViewButton
             onClick={() => setLinkDialogOpen(true)}
@@ -288,12 +323,7 @@ const Sidebar: React.FC<{
             url={props.url}
           />
 
-          <Box
-            display="flex"
-            flexDirection="column"
-            alignItems="flex-end"
-            marginRight={1}
-          >
+          <Box display="flex" flexDirection="column" alignItems="flex-end">
             <Badge
               sx={{ width: "100%" }}
               badgeContent={alteredNodes && alteredNodes.length}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -85,7 +85,7 @@ const ViewButton = styled(Button)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   boxShadow: "none",
   color: theme.palette.common.black,
-  width: "30%",
+  width: "33%",
   display: "flex",
   flexDirection: "row",
   gap: "8px",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -110,6 +110,7 @@ const CopyButton = styled(Button)(({ theme }) => ({
   flexDirection: "row",
   gap: "8px",
   borderRadius: "5px",
+  padding: "8px",
 }));
 
 const TabList = styled(Box)(({ theme }) => ({

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -405,7 +405,7 @@ const Sidebar: React.FC<{
             onClick={handleClick}
             disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           >
-            <LinkIcon fontSize="medium" /> Copy link
+            <LinkIcon fontSize="medium" /> View links
           </CopyButton>
 
           <Dialog
@@ -454,12 +454,14 @@ const Sidebar: React.FC<{
                   link={props.url.replace("/published", "/preview")}
                   description="View of the draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
                 />{" "}
-                <LinkComponent
-                  titleIcon={<OpenInNewOffIcon />}
-                  title={"Draft flow"}
-                  link={props.url.replace("/published", "/draft")}
-                  description="View of the draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
-                />
+                <Permission.IsPlatformAdmin>
+                  <LinkComponent
+                    titleIcon={<OpenInNewOffIcon />}
+                    title={"Draft flow"}
+                    link={props.url.replace("/published", "/draft")}
+                    description="View of the draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
+                  />
+                </Permission.IsPlatformAdmin>
               </Stack>
             </DialogContent>
           </Dialog>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,11 +1,16 @@
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ContentCopyTwoToneIcon from "@mui/icons-material/ContentCopyTwoTone";
 import LanguageIcon from "@mui/icons-material/Language";
 import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import SignalCellularAltIcon from "@mui/icons-material/SignalCellularAlt";
+import Alert from "@mui/material/Alert";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
 import Container from "@mui/material/Container";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
@@ -132,7 +137,7 @@ const DebugConsole = () => {
       state.breadcrumbs,
       state.id,
       state.cachedBreadcrumbs,
-    ],
+    ]
   );
   return (
     <Console borderTop={2} borderColor="border.main" bgcolor="background.paper">
@@ -175,15 +180,16 @@ const Sidebar: React.FC<{
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
-    "This flow is not published yet",
+    "This flow is not published yet"
   );
   const [validationChecks, setValidationChecks] = useState<ValidationCheck[]>(
-    [],
+    []
   );
   const [alteredNodes, setAlteredNodes] = useState<AlteredNode[]>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
+  const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
     setActiveTab(newValue);
@@ -194,12 +200,12 @@ const Sidebar: React.FC<{
       setLastPublishedTitle("Checking for changes...");
       const alteredFlow = await validateAndDiffFlow(flowId);
       setAlteredNodes(
-        alteredFlow?.data.alteredNodes ? alteredFlow.data.alteredNodes : [],
+        alteredFlow?.data.alteredNodes ? alteredFlow.data.alteredNodes : []
       );
       setLastPublishedTitle(
         alteredFlow?.data.alteredNodes
           ? `Found changes to ${alteredFlow.data.alteredNodes.length} nodes`
-          : alteredFlow?.data.message,
+          : alteredFlow?.data.message
       );
       setValidationChecks(alteredFlow?.data?.validationChecks);
       setDialogOpen(true);
@@ -210,7 +216,7 @@ const Sidebar: React.FC<{
         alert(error.response?.data?.error);
       } else {
         alert(
-          `Error checking for changes to publish. Confirm that your graph does not have any corrupted nodes and that all external portals are valid. \n${error}`,
+          `Error checking for changes to publish. Confirm that your graph does not have any corrupted nodes and that all external portals are valid. \n${error}`
         );
       }
     }
@@ -224,7 +230,7 @@ const Sidebar: React.FC<{
       setLastPublishedTitle(
         alteredNodes
           ? `Successfully published changes to ${alteredNodes.length} nodes`
-          : `${message}` || "No new changes to publish",
+          : `${message}` || "No new changes to publish"
       );
     } catch (error) {
       setLastPublishedTitle("Error trying to publish");
@@ -242,23 +248,37 @@ const Sidebar: React.FC<{
   const _validateAndDiffRequest = useAsync(async () => {
     const newChanges = await validateAndDiffFlow(flowId);
     setAlteredNodes(
-      newChanges?.data.alteredNodes ? newChanges.data.alteredNodes : [],
+      newChanges?.data.alteredNodes ? newChanges.data.alteredNodes : []
     );
   });
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
 
+  const handleClick = () => {
+    navigator.clipboard.writeText(props.url.replace("/published", "/preview"));
+    setIsCopied(true);
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
+  };
+
   return (
     <Root>
       <Header>
         <Box width="100%" display="flex">
           <input
-            type="text"
             disabled
             value={props.url.replace("/published", "/preview")}
+            onClick={handleClick}
           />
-
+          <Tooltip
+            arrow
+            title={isCopied ? "Copied" : "Copy link"}
+            onClick={handleClick}
+          >
+            {isCopied ? <ContentCopyTwoToneIcon /> : <ContentCopyIcon />}
+          </Tooltip>
           <Tooltip arrow title="Refresh preview">
             <RefreshIcon
               onClick={() => {
@@ -273,6 +293,27 @@ const Sidebar: React.FC<{
               onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
             />
           </Tooltip>
+
+          {flowAnalyticsLink ? (
+            <Tooltip arrow title="Open analytics page">
+              <Link
+                href={flowAnalyticsLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <SignalCellularAltIcon />
+              </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip arrow title="Analytics page unavailable">
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <SignalCellularAltIcon />
+                </Link>
+              </Box>
+            </Tooltip>
+          )}
 
           <Permission.IsPlatformAdmin>
             <Tooltip arrow title="Open draft service">
@@ -319,6 +360,199 @@ const Sidebar: React.FC<{
             </Tooltip>
           )}
         </Box>
+        <Box mt={1} mb={1} width={"100%"} display={"flex"}>
+          <Tooltip arrow title={isCopied ? "Copied" : "Copy link"}>
+            <Chip
+              variant={isCopied ? "filled" : "outlined"}
+              color="primary"
+              label={props.url.replace("/published", "/preview")}
+              onClick={handleClick}
+            />
+          </Tooltip>
+        </Box>
+        <Box mt={1} mb={1} width={"100%"} display={"flex"}>
+          <Tooltip arrow title={isCopied ? "Copied" : "Copy link"}>
+            <Chip
+              variant={isCopied ? "filled" : "outlined"}
+              color="primary"
+              icon={<ContentCopyIcon />}
+              label={"Copy your published link"}
+              onClick={handleClick}
+              sx={{ padding: "12px" }}
+            />
+          </Tooltip>
+          <Tooltip arrow title="Refresh preview">
+            <RefreshIcon
+              onClick={() => {
+                resetPreview();
+                setKey((a) => !a);
+              }}
+            />
+          </Tooltip>
+
+          <Tooltip arrow title="Toggle debug console">
+            <MenuOpenIcon
+              onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
+            />
+          </Tooltip>
+
+          {flowAnalyticsLink ? (
+            <Tooltip arrow title="Open analytics page">
+              <Link
+                href={flowAnalyticsLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <SignalCellularAltIcon />
+              </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip arrow title="Analytics page unavailable">
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <SignalCellularAltIcon />
+                </Link>
+              </Box>
+            </Tooltip>
+          )}
+
+          <Permission.IsPlatformAdmin>
+            <Tooltip arrow title="Open draft service">
+              <Link
+                href={props.url.replace("/published", "/draft")}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <OpenInNewOffIcon />
+              </Link>
+            </Tooltip>
+          </Permission.IsPlatformAdmin>
+
+          <Tooltip arrow title="Open preview of changes to publish">
+            <Link
+              href={props.url.replace("/published", "/preview")}
+              target="_blank"
+              rel="noopener noreferrer"
+              color="inherit"
+            >
+              <OpenInNewIcon />
+            </Link>
+          </Tooltip>
+
+          {isFlowPublished ? (
+            <Tooltip arrow title="Open published service">
+              <Link
+                href={props.url + "?analytics=false"}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <LanguageIcon />
+              </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip arrow title="Flow not yet published">
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <LanguageIcon />
+                </Link>
+              </Box>
+            </Tooltip>
+          )}
+        </Box>
+        <Box width="100%" display="flex">
+          <Tooltip arrow title={isCopied ? "Copied" : "Copy link"}>
+            <Chip
+              variant={isCopied ? "filled" : "outlined"}
+              color="primary"
+              label={"Copy your published link"}
+              onClick={handleClick}
+            />
+          </Tooltip>
+          <Tooltip arrow title="Refresh preview">
+            <RefreshIcon
+              onClick={() => {
+                resetPreview();
+                setKey((a) => !a);
+              }}
+            />
+          </Tooltip>
+
+          <Tooltip arrow title="Toggle debug console">
+            <MenuOpenIcon
+              onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
+            />
+          </Tooltip>
+
+          {flowAnalyticsLink ? (
+            <Tooltip arrow title="Open analytics page">
+              <Link
+                href={flowAnalyticsLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <SignalCellularAltIcon />
+              </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip arrow title="Analytics page unavailable">
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <SignalCellularAltIcon />
+                </Link>
+              </Box>
+            </Tooltip>
+          )}
+
+          <Permission.IsPlatformAdmin>
+            <Tooltip arrow title="Open draft service">
+              <Link
+                href={props.url.replace("/published", "/draft")}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <OpenInNewOffIcon />
+              </Link>
+            </Tooltip>
+          </Permission.IsPlatformAdmin>
+
+          <Tooltip arrow title="Open preview of changes to publish">
+            <Link
+              href={props.url.replace("/published", "/preview")}
+              target="_blank"
+              rel="noopener noreferrer"
+              color="inherit"
+            >
+              <OpenInNewIcon />
+            </Link>
+          </Tooltip>
+
+          {isFlowPublished ? (
+            <Tooltip arrow title="Open published service">
+              <Link
+                href={props.url + "?analytics=false"}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <LanguageIcon />
+              </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip arrow title="Flow not yet published">
+              <Box>
+                <Link component={"button"} disabled aria-disabled={true}>
+                  <LanguageIcon />
+                </Link>
+              </Box>
+            </Tooltip>
+          )}
+        </Box>
+        <Box mb={1} width={"100%"} display={"flex"}></Box>
         <Box width="100%" mt={2}>
           <Box
             display="flex"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -273,10 +273,6 @@ const Sidebar: React.FC<{
     );
   });
 
-  const handleClick = () => {
-    setLinkDialogOpen(true);
-  };
-
   return (
     <Root>
       <Header>
@@ -291,14 +287,14 @@ const Sidebar: React.FC<{
           style={{ position: "relative" }}
         >
           <ViewButton
-            onClick={handleClick}
+            onClick={() => setLinkDialogOpen(true)}
             disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           >
             <LinkIcon fontSize="medium" /> View links
           </ViewButton>
           <LinkDialog
             containsTheme
-            linkDialogOpen
+            linkDialogOpen={linkDialogOpen}
             teamTheme={teamTheme}
             teamDomain={teamDomain}
             flowSlug={flowSlug}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -390,7 +390,7 @@ const Sidebar: React.FC<{
         <Box
           width="100%"
           mt={2}
-          mb={2}
+          mb={4}
           pl={2}
           display="flex"
           flexDirection="row"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,6 +1,8 @@
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import LinkIcon from "@mui/icons-material/Link";
 import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import SchemaIcon from "@mui/icons-material/Schema";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -289,7 +291,7 @@ const Sidebar: React.FC<{
           </SecondaryButton>
           <SecondaryButton color="primary">
             <Tooltip arrow title="Toggle debug console">
-              <MenuOpenIcon
+              <AccountTreeIcon
                 onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
               />
             </Tooltip>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,6 +1,11 @@
 import CloseIcon from "@mui/icons-material/Close";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import LanguageIcon from "@mui/icons-material/Language";
 import LinkIcon from "@mui/icons-material/Link";
+import MenuOpenIcon from "@mui/icons-material/MenuOpen";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
+import RefreshIcon from "@mui/icons-material/Refresh";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -101,12 +106,12 @@ const TabList = styled(Box)(({ theme }) => ({
 }));
 
 const ImageWrapper = styled(Box)(() => ({
-  width: "auto",
   height: 24,
+  width: 24,
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  padding: "4px",
+  padding: "2px",
 }));
 
 const StyledTab = styled(Tab)(({ theme }) => ({
@@ -162,12 +167,22 @@ const LinkComponent = (props: {
   titleIcon?: string | SvgIconProps;
   title: string;
   link: string;
-  description: string;
+  description?: string;
+  isPublished?: boolean;
 }) => {
   const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
 
   return (
-    <Box display={"flex"} flexDirection={"column"} gap={"8px"} mb={1}>
+    <Box
+      sx={{
+        opacity:
+          props.isPublished || props.isPublished === undefined ? "100%" : "50%",
+      }}
+      display={"flex"}
+      flexDirection={"column"}
+      gap={"8px"}
+      mb={1}
+    >
       <Box
         display={"flex"}
         flexDirection={"row"}
@@ -177,8 +192,8 @@ const LinkComponent = (props: {
         {typeof props.titleIcon === "string" ? (
           <ImageWrapper sx={{ backgroundColor: props.primaryColour }}>
             <img
-              height={12}
-              width={"auto"}
+              height={"auto"}
+              width={20}
               src={props.titleIcon || undefined}
               alt="Local authority logo"
             />
@@ -198,7 +213,7 @@ const LinkComponent = (props: {
             onMouseLeave={() => {
               setTimeout(() => {
                 setCopyMessage("copy");
-              }, 1000);
+              }, 500);
             }}
             onClick={() => {
               setCopyMessage("copied");
@@ -373,6 +388,7 @@ const Sidebar: React.FC<{
             onClose={() => setLinkDialogOpen(false)}
             aria-labelledby="alert-dialog-title"
             aria-describedby="alert-dialog-description"
+            fullWidth
             maxWidth="md"
           >
             <Box padding={1} mb={1} display={"block"} textAlign={"end"}>
@@ -392,261 +408,33 @@ const Sidebar: React.FC<{
             </DialogTitle>
             <DialogContent>
               <Stack spacing={"25px"} mb={"30px"}>
-                <Box
-                  display={"flex"}
-                  flexDirection={"column"}
-                  gap={"8px"}
-                  mb={1}
-                >
-                  <LinkComponent
-                    primaryColour={currentTeam?.theme.primaryColour}
-                    titleIcon={currentTeam?.theme.logo || undefined}
-                    title={"Trial Link"}
-                    link={props.url.replace("/published", "/draft")}
-                    description="This is the description for a test link to trial a new component"
-                  />
-                  <LinkComponent
-                    primaryColour={currentTeam?.theme.primaryColour}
-                    titleIcon={<CloseIcon />}
-                    title={"Trial Link"}
-                    link={props.url.replace("/published", "/draft")}
-                    description="This is the description for a test link to trial a new component"
-                  />
-                  <Box
-                    display={"flex"}
-                    flexDirection={"row"}
-                    alignItems={"center"}
-                    gap={"7px"}
-                  >
-                    <ImageWrapper
-                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
-                    >
-                      <img
-                        height={12}
-                        width={"auto"}
-                        src={currentTeam?.theme.logo || undefined}
-                        alt="Local authority logo"
-                        sizes=""
-                      />
-                    </ImageWrapper>
-
-                    <Typography variant="h4" component={"h4"} mr={1}>
-                      {"Published flow with subdomain"}
-                    </Typography>
-                    <Tooltip title={copyMessage}>
-                      <Button
-                        component={"button"}
-                        variant="help"
-                        style={{ textDecoration: "none" }}
-                        onMouseLeave={() => {
-                          setTimeout(() => {
-                            setCopyMessage("copy");
-                          }, 1000);
-                        }}
-                        onClick={() => {
-                          setCopyMessage("copied");
-                          navigator.clipboard.writeText(
-                            props.url.replace("/published", "/preview"),
-                          );
-                        }}
-                      >
-                        <Typography
-                          display={"flex"}
-                          flexDirection={"row"}
-                          gap={"4px"}
-                          variant="body2"
-                        >
-                          <ContentCopyIcon />
-                          {copyMessage}
-                        </Typography>
-                      </Button>
-                    </Tooltip>
-                  </Box>
-                  <Link>{props.url.replace("/published", "/preview")} </Link>
-                  <Typography>
-                    {"This is the description of the published link"}
-                  </Typography>
-                </Box>
-                <Box
-                  display={"flex"}
-                  flexDirection={"column"}
-                  gap={"8px"}
-                  mb={1}
-                >
-                  <Box
-                    display={"flex"}
-                    flexDirection={"row"}
-                    alignItems={"center"}
-                    gap={"7px"}
-                  >
-                    <ImageWrapper
-                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
-                    >
-                      <img
-                        height={12}
-                        width={"auto"}
-                        src={currentTeam?.theme.logo || undefined}
-                        alt="Local authority logo"
-                        sizes=""
-                      />
-                    </ImageWrapper>
-
-                    <Typography variant="h4" component={"h4"} mr={1}>
-                      {"Published flow with subdomain"}
-                    </Typography>
-                    <Tooltip title={copyMessage}>
-                      <Link
-                        component={"button"}
-                        style={{ textDecoration: "none" }}
-                        onMouseLeave={() => {
-                          setTimeout(() => {
-                            setCopyMessage("copy");
-                          }, 1000);
-                        }}
-                        onClick={() => {
-                          setCopyMessage("copied");
-                          navigator.clipboard.writeText(
-                            props.url.replace("/published", "/preview"),
-                          );
-                        }}
-                      >
-                        <Typography
-                          display={"flex"}
-                          flexDirection={"row"}
-                          gap={"4px"}
-                          variant="body2"
-                        >
-                          <ContentCopyIcon />
-                          {copyMessage}
-                        </Typography>
-                      </Link>
-                    </Tooltip>
-                  </Box>
-                  <Link>{props.url.replace("/published", "/preview")} </Link>
-                  <Typography>
-                    {"This is the description of the published link"}
-                  </Typography>
-                </Box>
-                <Box
-                  display={"flex"}
-                  flexDirection={"column"}
-                  gap={"8px"}
-                  mb={1}
-                >
-                  <Box
-                    display={"flex"}
-                    flexDirection={"row"}
-                    alignItems={"center"}
-                    gap={"7px"}
-                  >
-                    <ImageWrapper
-                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
-                    >
-                      <img
-                        height={12}
-                        width={"auto"}
-                        src={currentTeam?.theme.logo || undefined}
-                        alt="Local authority logo"
-                        sizes=""
-                      />
-                    </ImageWrapper>
-
-                    <Typography variant="h4" component={"h4"} mr={1}>
-                      {"Published flow with subdomain"}
-                    </Typography>
-                    <Tooltip title={copyMessage}>
-                      <Link
-                        component={"button"}
-                        style={{ textDecoration: "none" }}
-                        onMouseLeave={() => {
-                          setTimeout(() => {
-                            setCopyMessage("copy");
-                          }, 1000);
-                        }}
-                        onClick={() => {
-                          setCopyMessage("copied");
-                          navigator.clipboard.writeText(
-                            props.url.replace("/published", "/preview"),
-                          );
-                        }}
-                      >
-                        <Typography
-                          display={"flex"}
-                          flexDirection={"row"}
-                          gap={"4px"}
-                          variant="body2"
-                        >
-                          <ContentCopyIcon />
-                          {copyMessage}
-                        </Typography>
-                      </Link>
-                    </Tooltip>
-                  </Box>
-                  <Link>{props.url.replace("/published", "/preview")} </Link>
-                  <Typography>
-                    {"This is the description of the published link"}
-                  </Typography>
-                </Box>
-                <Box
-                  display={"flex"}
-                  flexDirection={"column"}
-                  gap={"8px"}
-                  mb={1}
-                >
-                  <Box
-                    display={"flex"}
-                    flexDirection={"row"}
-                    alignItems={"center"}
-                    gap={"7px"}
-                  >
-                    <ImageWrapper
-                      sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
-                    >
-                      <img
-                        height={12}
-                        width={"auto"}
-                        src={currentTeam?.theme.logo || undefined}
-                        alt="Local authority logo"
-                        sizes=""
-                      />
-                    </ImageWrapper>
-
-                    <Typography variant="h4" component={"h4"} mr={1}>
-                      {"Published flow with subdomain"}
-                    </Typography>
-                    <Tooltip title={copyMessage}>
-                      <Link
-                        component={"button"}
-                        style={{ textDecoration: "none" }}
-                        onMouseLeave={() => {
-                          setTimeout(() => {
-                            setCopyMessage("copy");
-                          }, 1000);
-                        }}
-                        onClick={() => {
-                          setCopyMessage("copied");
-                          navigator.clipboard.writeText(
-                            props.url.replace("/published", "/preview"),
-                          );
-                        }}
-                      >
-                        <Typography
-                          display={"flex"}
-                          flexDirection={"row"}
-                          gap={"4px"}
-                          variant="body2"
-                        >
-                          <ContentCopyIcon />
-                          {copyMessage}
-                        </Typography>
-                      </Link>
-                    </Tooltip>
-                  </Box>
-                  <Link>{props.url.replace("/published", "/preview")} </Link>
-                  <Typography>
-                    {"This is the description of the published link"}
-                  </Typography>
-                </Box>
+                <LinkComponent
+                  primaryColour={currentTeam?.theme.primaryColour}
+                  titleIcon={currentTeam?.theme.logo || undefined}
+                  title={"Subdomain"}
+                  link={props.url.replace("/published", "/subdomain")}
+                />
+                <LinkComponent
+                  titleIcon={<LanguageIcon />}
+                  title={"Published"}
+                  isPublished={isFlowPublished}
+                  link={props.url.replace("/published", "/published")}
+                  description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                />
+                <LinkComponent
+                  primaryColour={currentTeam?.theme.primaryColour}
+                  titleIcon={<OpenInNewIcon />}
+                  title={"Preview"}
+                  link={props.url.replace("/published", "/preview")}
+                  description="Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                />{" "}
+                <LinkComponent
+                  primaryColour={currentTeam?.theme.primaryColour}
+                  titleIcon={<OpenInNewOffIcon />}
+                  title={"Draft"}
+                  link={props.url.replace("/published", "/draft")}
+                  description="Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                />
               </Stack>
             </DialogContent>
           </Dialog>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -13,6 +13,7 @@ import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
+import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
@@ -37,7 +38,6 @@ import {
   ValidationChecks,
 } from "./PublishDialog";
 import Search from "./Search";
-
 type SidebarTabs = "PreviewBrowser" | "History" | "Search";
 
 const Console = styled(Box)(() => ({
@@ -154,6 +154,72 @@ const DebugConsole = () => {
         {JSON.stringify({ passport, breadcrumbs, cachedBreadcrumbs }, null, 2)}
       </pre>
     </Console>
+  );
+};
+
+const LinkComponent = (props: {
+  primaryColour?: string;
+  titleIcon?: string | SvgIconProps;
+  title: string;
+  link: string;
+  description: string;
+}) => {
+  const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
+
+  return (
+    <Box display={"flex"} flexDirection={"column"} gap={"8px"} mb={1}>
+      <Box
+        display={"flex"}
+        flexDirection={"row"}
+        alignItems={"center"}
+        gap={"7px"}
+      >
+        {typeof props.titleIcon === "string" ? (
+          <ImageWrapper sx={{ backgroundColor: props.primaryColour }}>
+            <img
+              height={12}
+              width={"auto"}
+              src={props.titleIcon || undefined}
+              alt="Local authority logo"
+            />
+          </ImageWrapper>
+        ) : (
+          <>{props.titleIcon}</>
+        )}
+
+        <Typography variant="h4" component={"h4"} mr={1}>
+          {props.title}
+        </Typography>
+        <Tooltip title={copyMessage}>
+          <Button
+            component={"button"}
+            variant="help"
+            style={{ textDecoration: "none" }}
+            onMouseLeave={() => {
+              setTimeout(() => {
+                setCopyMessage("copy");
+              }, 1000);
+            }}
+            onClick={() => {
+              setCopyMessage("copied");
+              navigator.clipboard.writeText(props.link);
+            }}
+          >
+            <Typography
+              display={"flex"}
+              flexDirection={"row"}
+              gap={"4px"}
+              variant="body2"
+            >
+              <ContentCopyIcon />
+              {copyMessage}
+            </Typography>
+          </Button>
+        </Tooltip>
+      </Box>
+      <Link>{props.link} </Link>
+      <Typography>{props.description}</Typography>
+    </Box>
   );
 };
 
@@ -332,6 +398,20 @@ const Sidebar: React.FC<{
                   gap={"8px"}
                   mb={1}
                 >
+                  <LinkComponent
+                    primaryColour={currentTeam?.theme.primaryColour}
+                    titleIcon={currentTeam?.theme.logo || undefined}
+                    title={"Trial Link"}
+                    link={props.url.replace("/published", "/draft")}
+                    description="This is the description for a test link to trial a new component"
+                  />
+                  <LinkComponent
+                    primaryColour={currentTeam?.theme.primaryColour}
+                    titleIcon={<CloseIcon />}
+                    title={"Trial Link"}
+                    link={props.url.replace("/published", "/draft")}
+                    description="This is the description for a test link to trial a new component"
+                  />
                   <Box
                     display={"flex"}
                     flexDirection={"row"}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -175,6 +175,7 @@ const Sidebar: React.FC<{
   const [summary, setSummary] = useState<string>();
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
   const [isCopied, setIsCopied] = useState<boolean>(false);
+  const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(false);
 
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
     setActiveTab(newValue);
@@ -240,12 +241,9 @@ const Sidebar: React.FC<{
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
 
+  // navigator.clipboard.writeText(props.url.replace("/published", "/preview"));
   const handleClick = () => {
-    navigator.clipboard.writeText(props.url.replace("/published", "/preview"));
-    setIsCopied(true);
-    setTimeout(() => {
-      setIsCopied(false);
-    }, 1000);
+    setLinkDialogOpen(true);
   };
 
   return (
@@ -268,10 +266,23 @@ const Sidebar: React.FC<{
             }}
             variant="contained"
             color="secondary"
+            onClick={handleClick}
             disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           >
             <LinkIcon fontSize="medium" /> Copy link
           </Button>
+          <Dialog
+            open={linkDialogOpen}
+            onClose={() => setLinkDialogOpen(false)}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+            maxWidth="md"
+          >
+            <DialogTitle variant="h3" component="h1">
+              {`Links to Copy`}
+            </DialogTitle>
+            <DialogContent></DialogContent>
+          </Dialog>
           <Box
             display="flex"
             flexDirection="column"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -273,7 +273,6 @@ const Sidebar: React.FC<{
   const [summary, setSummary] = useState<string>();
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
   const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(false);
-  const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
   const [currentTeam, setCurrentTeam] = useState<Team | undefined>(undefined);
 
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -26,7 +26,7 @@ import { Team } from "@opensystemslab/planx-core/types";
 import { AxiosError } from "axios";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useAsync } from "react-use";
 import Permission from "ui/editor/Permission";
 import Input from "ui/shared/Input";
@@ -270,6 +270,10 @@ const Sidebar: React.FC<{
     isFlowPublished,
     fetchCurrentTeam,
     togglePreview,
+    flowSlug,
+    teamSlug,
+    teamTheme,
+    teamDomain,
   ] = useStore((state) => [
     state.id,
     state.resetPreview,
@@ -280,6 +284,10 @@ const Sidebar: React.FC<{
     state.isFlowPublished,
     state.fetchCurrentTeam,
     state.togglePreview,
+    state.flowSlug,
+    state.teamSlug,
+    state.teamTheme,
+    state.teamDomain,
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
@@ -295,19 +303,11 @@ const Sidebar: React.FC<{
   const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(false);
   const [currentTeam, setCurrentTeam] = useState<Team | undefined>(undefined);
 
+  console.log({ teamTheme, teamSlug, teamDomain });
+
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
     setActiveTab(newValue);
   };
-
-  useEffect(() => {
-    const getCurrentTeam = async () => {
-      const [response] = await Promise.all([fetchCurrentTeam()]);
-      setCurrentTeam(response);
-      return response;
-    };
-
-    getCurrentTeam();
-  }, []);
 
   const handleCheckForChangesToPublish = async () => {
     try {
@@ -366,10 +366,6 @@ const Sidebar: React.FC<{
     );
   });
 
-  // useStore.getState().getTeam().slug undefined here, use window instead
-  const teamSlug = window.location.pathname.split("/")[1];
-  const flowSlug = window.location.pathname.split("/")[2];
-
   const handleClick = () => {
     setLinkDialogOpen(true);
   };
@@ -419,12 +415,12 @@ const Sidebar: React.FC<{
             </DialogTitle>
             <DialogContent>
               <Stack spacing={"25px"} mb={"30px"}>
-                {currentTeam?.domain && (
+                {teamDomain && (
                   <LinkComponent
-                    primaryColour={currentTeam?.theme.primaryColour}
-                    titleIcon={currentTeam?.theme.logo || undefined}
+                    primaryColour={teamTheme.primaryColour}
+                    titleIcon={teamTheme.logo || undefined}
                     title={"Published flow with subdomain"}
-                    link={`${currentTeam?.domain}/${flowSlug}`}
+                    link={`${teamDomain}/${flowSlug}`}
                   />
                 )}
                 <LinkComponent

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -260,7 +260,14 @@ const LinkComponent = (props: {
           </Button>
         </Tooltip>
       </Box>
-      <Link sx={{ "&:hover": { cursor: "pointer" } }}>{props.link} </Link>
+      <Link
+        href={props.link}
+        target="_blank"
+        rel="noopener noreferrer"
+        sx={{ "&:hover": { cursor: "pointer" } }}
+      >
+        {props.link}{" "}
+      </Link>
       <Typography>{props.description}</Typography>
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -238,7 +238,6 @@ const LinkComponent = (props: {
           <Button
             component={"button"}
             variant="help"
-            style={{ textDecoration: "none" }}
             onMouseLeave={() => {
               setTimeout(() => {
                 setCopyMessage("copy");
@@ -254,7 +253,6 @@ const LinkComponent = (props: {
               flexDirection={"row"}
               gap={"4px"}
               variant="body2"
-              sx={{ textDecoration: "underline dotted" }}
             >
               <ContentCopyIcon />
               {copyMessage}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -100,7 +100,7 @@ const ToggleButton = styled(Button)(({ theme }) => ({
   },
 }));
 
-const CopyButton = styled(Button)(({ theme }) => ({
+const ViewButton = styled(Button)(({ theme }) => ({
   background: theme.palette.common.white,
   border: `1px solid ${theme.palette.border.main}`,
   boxShadow: "none",
@@ -402,12 +402,12 @@ const Sidebar: React.FC<{
           <ToggleButton onClick={togglePreview}>
             <ChevronRightRounded />
           </ToggleButton>
-          <CopyButton
+          <ViewButton
             onClick={handleClick}
             disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           >
             <LinkIcon fontSize="medium" /> View links
-          </CopyButton>
+          </ViewButton>
 
           <Dialog
             open={linkDialogOpen}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -57,7 +57,6 @@ const Root = styled(Box)(({ theme }) => ({
   width: "500px",
   display: "flex",
   flexShrink: 0,
-  zIndex: 1,
   flexDirection: "column",
   borderLeft: `1px solid ${theme.palette.border.main}`,
   background: theme.palette.background.paper,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,3 +1,5 @@
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import LinkIcon from "@mui/icons-material/Link";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
@@ -7,6 +9,7 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Tab, { tabClasses } from "@mui/material/Tab";
@@ -176,6 +179,7 @@ const Sidebar: React.FC<{
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(false);
+  const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
 
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
     setActiveTab(newValue);
@@ -271,6 +275,7 @@ const Sidebar: React.FC<{
           >
             <LinkIcon fontSize="medium" /> Copy link
           </Button>
+
           <Dialog
             open={linkDialogOpen}
             onClose={() => setLinkDialogOpen(false)}
@@ -278,10 +283,58 @@ const Sidebar: React.FC<{
             aria-describedby="alert-dialog-description"
             maxWidth="md"
           >
-            <DialogTitle variant="h3" component="h1">
+            <Box padding={1} mb={1} display={"block"} textAlign={"end"}>
+              <Button
+                variant="text"
+                onClick={() => {
+                  setLinkDialogOpen(false);
+                }}
+              >
+                <CloseIcon color="action" />
+              </Button>
+              <Divider />
+            </Box>
+            <DialogTitle variant="h3" component="h3">
               {`Links to Copy`}
             </DialogTitle>
-            <DialogContent></DialogContent>
+            <DialogContent>
+              <Box display={"flex"} flexDirection={"column"} gap={"8px"}>
+                <Box display={"flex"} flexDirection={"row"}>
+                  <Typography variant="h4" component={"h4"} mr={1}>
+                    {"Published flow with subdomain"}
+                  </Typography>
+                  <Tooltip title={copyMessage}>
+                    <Link
+                      component={"button"}
+                      style={{ textDecoration: "none" }}
+                      onMouseLeave={() => {
+                        setCopyMessage("copy");
+                      }}
+                      onClick={() => {
+                        setCopyMessage("copied");
+                        navigator.clipboard.writeText(
+                          props.url.replace("/published", "/preview"),
+                        );
+                      }}
+                    >
+                      <Typography
+                        display={"flex"}
+                        flexDirection={"row"}
+                        gap={"4px"}
+                        variant="body1"
+                      >
+                        <ContentCopyIcon />
+                        {"copy"}
+                      </Typography>
+                    </Link>
+                  </Tooltip>
+                </Box>
+                <Link>{props.url.replace("/published", "/preview")} </Link>
+                <Typography>
+                  {"This is the description of the published link"}
+                </Typography>
+              </Box>
+            </DialogContent>
           </Dialog>
           <Box
             display="flex"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,3 +1,4 @@
+import ChevronRightRounded from "@mui/icons-material/ChevronRightRounded";
 import CloseIcon from "@mui/icons-material/Close";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import LanguageIcon from "@mui/icons-material/Language";
@@ -18,6 +19,7 @@ import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
+import { darken } from "@mui/material/styles";
 import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
@@ -59,6 +61,7 @@ const Root = styled(Box)(({ theme }) => ({
   width: "500px",
   display: "flex",
   flexShrink: 0,
+  zIndex: 1,
   flexDirection: "column",
   borderLeft: `1px solid ${theme.palette.border.main}`,
   background: theme.palette.background.paper,
@@ -79,9 +82,38 @@ const Header = styled("header")(({ theme }) => ({
     flex: "1",
     padding: "5px",
     marginRight: "5px",
-    background: theme.palette.common.white,
+    background: theme.palette.background.paper,
+
     border: "1px solid rgba(0, 0, 0, 0.2)",
   },
+}));
+
+const ToggleButton = styled(Button)(({ theme }) => ({
+  background: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.border.main}`,
+  borderImage: `linear-gradient(to right, ${theme.palette.border.main} 50%, transparent 50%) 30% 1`,
+  position: "absolute",
+  left: "-35px",
+  height: "100%",
+  boxShadow: "none",
+  textAlign: "left",
+  paddingLeft: "4px",
+  "&:hover": {
+    background: theme.palette.background.paper,
+    boxShadow: "none",
+  },
+}));
+
+const CopyButton = styled(Button)(({ theme }) => ({
+  background: theme.palette.common.white,
+  border: `1px solid ${theme.palette.border.main}`,
+  boxShadow: "none",
+  color: theme.palette.common.black,
+  width: "35%",
+  display: "flex",
+  flexDirection: "row",
+  gap: "8px",
+  borderRadius: "5px",
 }));
 
 const TabList = styled(Box)(({ theme }) => ({
@@ -251,6 +283,7 @@ const Sidebar: React.FC<{
     validateAndDiffFlow,
     isFlowPublished,
     fetchCurrentTeam,
+    togglePreview,
   ] = useStore((state) => [
     state.id,
     state.resetPreview,
@@ -260,6 +293,7 @@ const Sidebar: React.FC<{
     state.validateAndDiffFlow,
     state.isFlowPublished,
     state.fetchCurrentTeam,
+    state.togglePreview,
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
@@ -361,24 +395,21 @@ const Sidebar: React.FC<{
           width="100%"
           mt={2}
           mb={2}
+          pl={2}
           display="flex"
           flexDirection="row"
           gap={"24px"}
+          style={{ position: "relative" }}
         >
-          <Button
-            sx={{
-              width: "35%",
-              display: "flex",
-              flexDirection: "row",
-              gap: "8px",
-            }}
-            variant="contained"
-            color="secondary"
+          <ToggleButton onClick={togglePreview}>
+            <ChevronRightRounded />
+          </ToggleButton>
+          <CopyButton
             onClick={handleClick}
             disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           >
             <LinkIcon fontSize="medium" /> Copy link
-          </Button>
+          </CopyButton>
 
           <Dialog
             open={linkDialogOpen}
@@ -400,8 +431,8 @@ const Sidebar: React.FC<{
               </Button>
               <Divider />
             </Box>
-            <DialogTitle variant="h3" component="h3">
-              {`Links to Copy`}
+            <DialogTitle mb={"25px"} variant="h3" component="h3">
+              {`Share this flow`}
             </DialogTitle>
             <DialogContent>
               <Stack spacing={"25px"} mb={"30px"}>
@@ -409,30 +440,28 @@ const Sidebar: React.FC<{
                   <LinkComponent
                     primaryColour={currentTeam?.theme.primaryColour}
                     titleIcon={currentTeam?.theme.logo || undefined}
-                    title={"Subdomain"}
+                    title={"Published flow with subdomain"}
                     link={`${currentTeam?.domain}/${flowSlug}`}
                   />
                 )}
                 <LinkComponent
                   titleIcon={<LanguageIcon />}
-                  title={"Published"}
+                  title={"Published flow"}
                   isPublished={isFlowPublished}
                   link={props.url}
-                  description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                  description="View of the currently published version of this flow."
                 />
                 <LinkComponent
-                  primaryColour={currentTeam?.theme.primaryColour}
                   titleIcon={<OpenInNewIcon />}
-                  title={"Preview"}
+                  title={"Preview flow"}
                   link={props.url.replace("/published", "/preview")}
-                  description="Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                  description="View of the draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
                 />{" "}
                 <LinkComponent
-                  primaryColour={currentTeam?.theme.primaryColour}
                   titleIcon={<OpenInNewOffIcon />}
-                  title={"Draft"}
+                  title={"Draft flow"}
                   link={props.url.replace("/published", "/draft")}
-                  description="Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                  description="View of the draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
                 />
               </Stack>
             </DialogContent>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -286,6 +286,7 @@ const Sidebar: React.FC<{
             <Box padding={1} mb={1} display={"block"} textAlign={"end"}>
               <Button
                 variant="text"
+                style={{ boxShadow: "none" }}
                 onClick={() => {
                   setLinkDialogOpen(false);
                 }}
@@ -308,7 +309,9 @@ const Sidebar: React.FC<{
                       component={"button"}
                       style={{ textDecoration: "none" }}
                       onMouseLeave={() => {
-                        setCopyMessage("copy");
+                        setTimeout(() => {
+                          setCopyMessage("copy");
+                        }, 1000);
                       }}
                       onClick={() => {
                         setCopyMessage("copied");
@@ -324,7 +327,7 @@ const Sidebar: React.FC<{
                         variant="body1"
                       >
                         <ContentCopyIcon />
-                        {"copy"}
+                        {copyMessage}
                       </Typography>
                     </Link>
                   </Tooltip>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -34,6 +34,7 @@ import Input from "ui/shared/Input";
 import Questions from "../../../Preview/Questions";
 import { useStore } from "../../lib/store";
 import EditHistory from "./EditHistory";
+import LinkDialog from "./LinkDialog";
 import {
   AlteredNode,
   AlteredNodesSummaryContent,
@@ -117,15 +118,6 @@ const TabList = styled(Box)(({ theme }) => ({
   },
 }));
 
-const ImageWrapper = styled(Box)(() => ({
-  height: 24,
-  width: 24,
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-  padding: "2px",
-}));
-
 const StyledTab = styled(Tab)(({ theme }) => ({
   position: "relative",
   zIndex: 1,
@@ -174,88 +166,6 @@ const DebugConsole = () => {
   );
 };
 
-const LinkComponent = (props: {
-  primaryColour?: string;
-  titleIcon?: string | SvgIconProps;
-  title: string;
-  link: string;
-  description?: string;
-  isPublished?: boolean;
-}) => {
-  const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
-
-  return (
-    <Box
-      sx={{
-        opacity:
-          props.isPublished || props.isPublished === undefined ? "100%" : "50%",
-      }}
-      display={"flex"}
-      flexDirection={"column"}
-      gap={"8px"}
-      mb={1}
-    >
-      <Box
-        display={"flex"}
-        flexDirection={"row"}
-        alignItems={"center"}
-        gap={"7px"}
-      >
-        {typeof props.titleIcon === "string" ? (
-          <ImageWrapper sx={{ backgroundColor: props.primaryColour }}>
-            <img
-              height={"auto"}
-              width={20}
-              src={props.titleIcon || undefined}
-              alt="Local authority logo"
-            />
-          </ImageWrapper>
-        ) : (
-          <>{props.titleIcon}</>
-        )}
-
-        <Typography variant="h4" component={"h4"} mr={1}>
-          {props.title}
-        </Typography>
-        <Tooltip title={copyMessage}>
-          <Button
-            component={"button"}
-            variant="help"
-            onMouseLeave={() => {
-              setTimeout(() => {
-                setCopyMessage("copy");
-              }, 500);
-            }}
-            onClick={() => {
-              setCopyMessage("copied");
-              navigator.clipboard.writeText(props.link);
-            }}
-          >
-            <Typography
-              display={"flex"}
-              flexDirection={"row"}
-              gap={"4px"}
-              variant="body2"
-            >
-              <ContentCopyIcon />
-              {copyMessage}
-            </Typography>
-          </Button>
-        </Tooltip>
-      </Box>
-      <Link
-        href={props.link}
-        target="_blank"
-        rel="noopener noreferrer"
-        sx={{ "&:hover": { cursor: "pointer" } }}
-      >
-        {props.link}{" "}
-      </Link>
-      <Typography>{props.description}</Typography>
-    </Box>
-  );
-};
-
 const Sidebar: React.FC<{
   url: string;
 }> = React.memo((props) => {
@@ -301,9 +211,6 @@ const Sidebar: React.FC<{
   const [summary, setSummary] = useState<string>();
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
   const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(false);
-  const [currentTeam, setCurrentTeam] = useState<Team | undefined>(undefined);
-
-  console.log({ teamTheme, teamSlug, teamDomain });
 
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
     setActiveTab(newValue);
@@ -389,64 +296,16 @@ const Sidebar: React.FC<{
           >
             <LinkIcon fontSize="medium" /> View links
           </ViewButton>
+          <LinkDialog
+            containsTheme
+            linkDialogOpen
+            teamTheme={teamTheme}
+            teamDomain={teamDomain}
+            flowSlug={flowSlug}
+            isFlowPublished={isFlowPublished}
+            url={props.url}
+          />
 
-          <Dialog
-            open={linkDialogOpen}
-            onClose={() => setLinkDialogOpen(false)}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-            fullWidth
-            maxWidth="md"
-          >
-            <Box padding={1} mb={1} display={"block"} textAlign={"end"}>
-              <Button
-                variant="text"
-                style={{ boxShadow: "none" }}
-                onClick={() => {
-                  setLinkDialogOpen(false);
-                }}
-              >
-                <CloseIcon color="action" />
-              </Button>
-              <Divider />
-            </Box>
-            <DialogTitle mb={"25px"} variant="h3" component="h3">
-              {`Share this flow`}
-            </DialogTitle>
-            <DialogContent>
-              <Stack spacing={"25px"} mb={"30px"}>
-                {teamDomain && (
-                  <LinkComponent
-                    primaryColour={teamTheme.primaryColour}
-                    titleIcon={teamTheme.logo || undefined}
-                    title={"Published flow with subdomain"}
-                    link={`${teamDomain}/${flowSlug}`}
-                  />
-                )}
-                <LinkComponent
-                  titleIcon={<LanguageIcon />}
-                  title={"Published flow"}
-                  isPublished={isFlowPublished}
-                  link={props.url}
-                  description="View of the currently published version of this flow."
-                />
-                <LinkComponent
-                  titleIcon={<OpenInNewIcon />}
-                  title={"Preview flow"}
-                  link={props.url.replace("/published", "/preview")}
-                  description="View of the draft data of the main flow and the latest published version of nested flows. This link is representative of what your next published version will look like."
-                />{" "}
-                <Permission.IsPlatformAdmin>
-                  <LinkComponent
-                    titleIcon={<OpenInNewOffIcon />}
-                    title={"Draft flow"}
-                    link={props.url.replace("/published", "/draft")}
-                    description="View of the draft data of the main flow and the draft data of nested flows.This link is not representative of what your next published version will look like."
-                  />
-                </Permission.IsPlatformAdmin>
-              </Stack>
-            </DialogContent>
-          </Dialog>
           <Box
             display="flex"
             flexDirection="column"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,10 +1,4 @@
-import ChevronRightRounded from "@mui/icons-material/ChevronRightRounded";
-import CloseIcon from "@mui/icons-material/Close";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import LanguageIcon from "@mui/icons-material/Language";
 import LinkIcon from "@mui/icons-material/Link";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -13,26 +7,18 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
-import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
-import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
-import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { Team } from "@opensystemslab/planx-core/types";
 import { AxiosError } from "axios";
-import gql from "graphql-tag";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useAsync } from "react-use";
-import Permission from "ui/editor/Permission";
 import Input from "ui/shared/Input";
 
-import { client } from "../../../../lib/graphql";
 import Questions from "../../../Preview/Questions";
 import { useStore } from "../../lib/store";
 import EditHistory from "./EditHistory";
@@ -183,9 +169,7 @@ const Sidebar: React.FC<{
     fetchCurrentTeam,
     togglePreview,
     flowSlug,
-    flowStatus,
     teamSlug,
-    teamTheme,
     teamDomain,
   ] = useStore((state) => [
     state.id,
@@ -198,9 +182,7 @@ const Sidebar: React.FC<{
     state.fetchCurrentTeam,
     state.togglePreview,
     state.flowSlug,
-    state.flowStatus,
     state.teamSlug,
-    state.teamTheme,
     state.teamDomain,
   ]);
   const [key, setKey] = useState<boolean>(false);
@@ -298,9 +280,7 @@ const Sidebar: React.FC<{
           </ViewButton>
           <LinkDialog
             setLinkDialogOpen={setLinkDialogOpen}
-            containsTheme
             linkDialogOpen={linkDialogOpen}
-            teamTheme={teamTheme}
             teamDomain={teamDomain}
             teamSlug={teamSlug}
             flowSlug={flowSlug}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -24,7 +24,6 @@ import { hasFeatureFlag } from "lib/featureFlags";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
 import React, { useEffect, useState } from "react";
 import { useAsync } from "react-use";
-import { ImageWrapper } from "ui/editor/ImgInput";
 import Permission from "ui/editor/Permission";
 import Input from "ui/shared/Input";
 
@@ -99,6 +98,15 @@ const TabList = styled(Box)(({ theme }) => ({
   "& .MuiTabs-indicator": {
     display: "none",
   },
+}));
+
+const ImageWrapper = styled(Box)(() => ({
+  width: "auto",
+  height: 24,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "4px",
 }));
 
 const StyledTab = styled(Tab)(({ theme }) => ({
@@ -317,7 +325,7 @@ const Sidebar: React.FC<{
               {`Links to Copy`}
             </DialogTitle>
             <DialogContent>
-              <Stack spacing={2} mb={"30px"}>
+              <Stack spacing={"25px"} mb={"30px"}>
                 <Box
                   display={"flex"}
                   flexDirection={"column"}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -16,11 +16,14 @@ import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import { Team } from "@opensystemslab/planx-core/types";
+import { Image } from "@planx/components/shared/Preview/CardHeader";
 import { AxiosError } from "axios";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAsync } from "react-use";
+import { ImageWrapper } from "ui/editor/ImgInput";
 import Permission from "ui/editor/Permission";
 import Input from "ui/shared/Input";
 
@@ -157,6 +160,7 @@ const Sidebar: React.FC<{
     lastPublisher,
     validateAndDiffFlow,
     isFlowPublished,
+    fetchCurrentTeam,
   ] = useStore((state) => [
     state.id,
     state.resetPreview,
@@ -165,6 +169,7 @@ const Sidebar: React.FC<{
     state.lastPublisher,
     state.validateAndDiffFlow,
     state.isFlowPublished,
+    state.fetchCurrentTeam,
   ]);
   const [key, setKey] = useState<boolean>(false);
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
@@ -177,13 +182,25 @@ const Sidebar: React.FC<{
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>();
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
-  const [isCopied, setIsCopied] = useState<boolean>(false);
   const [linkDialogOpen, setLinkDialogOpen] = useState<boolean>(false);
   const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
+  const [currentTeam, setCurrentTeam] = useState<Team | undefined>(undefined);
 
   const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
     setActiveTab(newValue);
   };
+
+  useEffect(() => {
+    const getCurrentTeam = async () => {
+      const [response] = await Promise.all([fetchCurrentTeam()]);
+      setCurrentTeam(response);
+      return response;
+    };
+
+    getCurrentTeam();
+  }, []);
+
+  console.log(currentTeam);
 
   const handleCheckForChangesToPublish = async () => {
     try {
@@ -301,6 +318,17 @@ const Sidebar: React.FC<{
             <DialogContent>
               <Box display={"flex"} flexDirection={"column"} gap={"8px"}>
                 <Box display={"flex"} flexDirection={"row"}>
+                  <ImageWrapper
+                    sx={{ backgroundColor: currentTeam?.theme.primaryColour }}
+                  >
+                    <img
+                      width={44}
+                      src={currentTeam?.theme.logo || undefined}
+                      alt="Local authority logo"
+                      sizes=""
+                    />
+                  </ImageWrapper>
+
                   <Typography variant="h4" component={"h4"} mr={1}>
                     {"Published flow with subdomain"}
                   </Typography>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -89,7 +89,7 @@ const ViewButton = styled(Button)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   boxShadow: "none",
   color: theme.palette.common.black,
-  width: "35%",
+  width: "30%",
   display: "flex",
   flexDirection: "row",
   gap: "8px",
@@ -321,7 +321,7 @@ const Sidebar: React.FC<{
                 disabled={!useStore.getState().canUserEditTeam(teamSlug)}
                 onClick={handleCheckForChangesToPublish}
               >
-                CHECK FOR CHANGES TO PUBLISH
+                Check for changes to publish
               </Button>
             </Badge>
             <Dialog

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -289,8 +289,6 @@ const Sidebar: React.FC<{
     getCurrentTeam();
   }, []);
 
-  console.log(currentTeam);
-
   const handleCheckForChangesToPublish = async () => {
     try {
       setLastPublishedTitle("Checking for changes...");
@@ -350,8 +348,8 @@ const Sidebar: React.FC<{
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
+  const flowSlug = window.location.pathname.split("/")[2];
 
-  // navigator.clipboard.writeText(props.url.replace("/published", "/preview"));
   const handleClick = () => {
     setLinkDialogOpen(true);
   };
@@ -407,12 +405,14 @@ const Sidebar: React.FC<{
             </DialogTitle>
             <DialogContent>
               <Stack spacing={"25px"} mb={"30px"}>
-                <LinkComponent
-                  primaryColour={currentTeam?.theme.primaryColour}
-                  titleIcon={currentTeam?.theme.logo || undefined}
-                  title={"Subdomain"}
-                  link={props.url.replace("/published", "/subdomain")}
-                />
+                {currentTeam?.domain && (
+                  <LinkComponent
+                    primaryColour={currentTeam?.theme.primaryColour}
+                    titleIcon={currentTeam?.theme.logo || undefined}
+                    title={"Subdomain"}
+                    link={`${currentTeam?.domain}/${flowSlug}`}
+                  />
+                )}
                 <LinkComponent
                   titleIcon={<LanguageIcon />}
                   title={"Published"}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -87,12 +87,15 @@ const ViewButton = styled(Button)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   boxShadow: "none",
   color: theme.palette.common.black,
-  width: "33%",
+  width: "30%",
   display: "flex",
   flexDirection: "row",
   gap: "8px",
-  borderRadius: "5px",
+  borderRadius: "3px",
   padding: "8px",
+  "&:hover": {
+    boxShadow: "none",
+  },
 }));
 
 const TabList = styled(Box)(({ theme }) => ({
@@ -305,9 +308,9 @@ const Sidebar: React.FC<{
           pr={2}
           display="flex"
           flexDirection="row"
-          gap={"24px"}
+          gap={"10px"}
           style={{ position: "relative" }}
-          justifyContent={"space-between"}
+          justifyContent={"space-around"}
         >
           <ViewButton
             onClick={() => setLinkDialogOpen(true)}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -3,10 +3,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import LanguageIcon from "@mui/icons-material/Language";
 import LinkIcon from "@mui/icons-material/Link";
-import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
-import RefreshIcon from "@mui/icons-material/Refresh";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -19,14 +17,12 @@ import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
-import { darken } from "@mui/material/styles";
 import { SvgIconProps } from "@mui/material/SvgIcon";
 import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
-import { Image } from "@planx/components/shared/Preview/CardHeader";
 import { AxiosError } from "axios";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
@@ -257,6 +253,7 @@ const LinkComponent = (props: {
               flexDirection={"row"}
               gap={"4px"}
               variant="body2"
+              sx={{ textDecoration: "underline dotted" }}
             >
               <ContentCopyIcon />
               {copyMessage}
@@ -264,7 +261,7 @@ const LinkComponent = (props: {
           </Button>
         </Tooltip>
       </Box>
-      <Link>{props.link} </Link>
+      <Link sx={{ "&:hover": { cursor: "pointer" } }}>{props.link} </Link>
       <Typography>{props.description}</Typography>
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -84,22 +84,6 @@ const Header = styled("header")(({ theme }) => ({
   },
 }));
 
-const ToggleButton = styled(Button)(({ theme }) => ({
-  background: theme.palette.background.paper,
-  border: `1px solid ${theme.palette.border.main}`,
-  borderImage: `linear-gradient(to right, ${theme.palette.border.main} 50%, transparent 50%) 30% 1`,
-  position: "absolute",
-  left: "-35px",
-  height: "100%",
-  boxShadow: "none",
-  textAlign: "left",
-  paddingLeft: "4px",
-  "&:hover": {
-    background: theme.palette.background.paper,
-    boxShadow: "none",
-  },
-}));
-
 const ViewButton = styled(Button)(({ theme }) => ({
   background: theme.palette.common.white,
   border: `1px solid ${theme.palette.border.main}`,
@@ -404,9 +388,6 @@ const Sidebar: React.FC<{
           gap={"24px"}
           style={{ position: "relative" }}
         >
-          <ToggleButton onClick={togglePreview}>
-            <ChevronRightRounded />
-          </ToggleButton>
           <ViewButton
             onClick={handleClick}
             disabled={!useStore.getState().canUserEditTeam(teamSlug)}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -89,6 +89,10 @@ export const teamStore: StateCreator<
             name
             slug
             domain
+            theme {
+              primary_colour
+              logo
+            }
             flows(order_by: { updated_at: desc }) {
               slug
               updated_at

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -14,6 +14,7 @@ export interface TeamStore {
   teamId: number;
   teamIntegrations: TeamIntegrations;
   teamName: string;
+  teamDomain?: string;
   teamSettings: TeamSettings;
   teamSlug: string;
   teamTheme: TeamTheme;
@@ -37,6 +38,7 @@ export const teamStore: StateCreator<
   teamId: 0,
   teamIntegrations: {} as TeamIntegrations,
   teamName: "",
+  teamDomain: "",
   teamSettings: {} as TeamSettings,
   teamSlug: "",
   teamTheme: {} as TeamTheme,
@@ -46,6 +48,7 @@ export const teamStore: StateCreator<
       teamId: team.id,
       teamIntegrations: team.integrations,
       teamName: team.name,
+      teamDomain: team.domain,
       teamSettings: team.settings,
       teamSlug: team.slug,
       teamTheme: team.theme,
@@ -61,6 +64,7 @@ export const teamStore: StateCreator<
     id: get().teamId,
     integrations: get().teamIntegrations,
     name: get().teamName,
+    domain: get().teamDomain,
     settings: get().teamSettings,
     slug: get().teamSlug,
     theme: get().teamTheme,
@@ -84,6 +88,7 @@ export const teamStore: StateCreator<
             id
             name
             slug
+            domain
             flows(order_by: { updated_at: desc }) {
               slug
               updated_at

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -90,7 +90,7 @@ export const teamStore: StateCreator<
             slug
             domain
             theme {
-              primary_colour
+              primaryColour: primary_colour
               logo
             }
             flows(order_by: { updated_at: desc }) {

--- a/editor.planx.uk/src/ui/editor/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/editor/ImgInput.tsx
@@ -27,7 +27,7 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
   marginLeft: theme.spacing(0.5),
 }));
 
-const ImageWrapper = styled(Box)(() => ({
+export const ImageWrapper = styled(Box)(() => ({
   width: 50,
   height: 50,
   display: "flex",

--- a/editor.planx.uk/src/ui/editor/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/editor/ImgInput.tsx
@@ -27,7 +27,7 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
   marginLeft: theme.spacing(0.5),
 }));
 
-export const ImageWrapper = styled(Box)(() => ({
+const ImageWrapper = styled(Box)(() => ({
   width: 50,
   height: 50,
   display: "flex",


### PR DESCRIPTION
## What does this PR do?

This PR comes from the Trello ticker: https://trello.com/c/k8cQojk7/2958-share-service-link-in-editor

The intention is to add a **share** link or **copy** link button to the FlowEditor page for users to easily see and share the right links for their flows.

From the Trello ticket:

> _As an Editor
I want to be able to copy/paste my service URL (with custom subdomain)
so that I can share the link_

I worked through the Figma designs given here: [Figma mock-ups](https://www.figma.com/design/bnUUrsVRG6qPwDkTmVKACI/PlanX-Design?node-id=15777-6403&t=Z9BAN3CGnRhbQZNB-4)

There has been a range of components added, created, and altered. From the new styled buttons, `CopyButton` and `ToggleButton`. 

The reuse of the `ImageWrapper` component used previously in Design Settings but customised to new sizes, I thought keeping the name consistent would point at similar use but different settings, since neither are exported from their origin.

A `LinkComponent` was made (naming may change to be more explicit) to harmonise styling across all the different links in the `Dialog` box, this includes the ability to add either an icon or image or neither to the Title of a link. 

The ``ToggleButton`` component was used to move the sidebar toggle from the top header to the Sidebar, in line with the other buttons for publishing and sharing links. This has been positioned ``absolute`` with a position ``relative`` set around the box containing the buttons so it can hang over the left edge of the siderbar.

Feedback requests:

_Feel free to give me feedback on anything, but these are the particular areas I found many options in._

1. Structure and use of ``<LinkComponent``
2. The way I have used MUI components and styled them
3. Closeness to the initial brief

To Do's 

- [x] Remove icon buttons from top of sidebar and replace with buttons
- [x] Create new dialog for seeing links
- [x] Make Published link opaque if the flow has not been published
- [x] Add previous buttons for `refresh` and `console`
- [ ] Create tests for new component
