### PR TITLE
[editor] serve microsoft-identity file

### DIFF
--- a/editor.planx.uk/public/.well-known/microsoft-identity-association.json
+++ b/editor.planx.uk/public/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "4469ee56-9275-47f3-b29d-e0df0991099a"
+    }
+  ]
+}


### PR DESCRIPTION
We want to demonstrate to Microsoft/Azure that we own `editor.planx.uk`, for the purpose of verifying it as a 'publisher domain', which will then be displayed to users attempting to sign on via a Microsoft account, for added trust.

NB. This can be reverted once the verification is complete.