### PR TITLE
[api] improve DX by overriding shell variables when running tests

### DIFF
--- a/api.planx.uk/.env.test.example
+++ b/api.planx.uk/.env.test.example
@@ -25,6 +25,9 @@ EDITOR_URL_EXT=example.com
 HASURA_GRAPHQL_URL=http://hasura:8080/v1/graphql
 HASURA_PLANX_API_KEY=👻
 
+# Minio object storage server port
+MINIO_PORT=1234
+
 # Integrations
 BOPS_API_TOKEN=👻
 BOPS_API_TOKEN=👻

--- a/api.planx.uk/jest.setup.js
+++ b/api.planx.uk/jest.setup.js
@@ -1,7 +1,10 @@
 import dotenv from "dotenv";
 import { queryMock } from "./tests/graphqlQueryMock";
 
-dotenv.config({ path: "./.env.test" });
+dotenv.config({
+  path: "./.env.test",
+  override: true,
+});
 
 beforeEach(() => {
   queryMock.setup(process.env.HASURA_GRAPHQL_URL);

--- a/api.planx.uk/modules/file/service/utils.test.ts
+++ b/api.planx.uk/modules/file/service/utils.test.ts
@@ -12,7 +12,7 @@ describe("s3 Factory", () => {
   });
 
   it("returns Minio config for local development", () => {
-    expect(s3Factory()).toHaveProperty("endpoint.host", "minio");
+    expect(s3Factory()).toHaveProperty("endpoint.host", "minio:1234");
   });
 
   ["pizza", "staging", "production"].forEach((env) => {


### PR DESCRIPTION
When working on #3464, I needed to make sure I could run all of `pnpm [check/test/build/start/dev]` reliably with any changes I was making. To run the latter 2 commands, I was loading the root `.env` into my shell, but this would then break the tests, because I'd carry the `MINIO_PORT` value over from my shell, and pollute the test environment.

To fix that I made the changes in this PR. It ensures that any environment variables already in your shell are overwritten by the values in `api.planx.uk/.env.test` for the purposes of testing.

Also adds demonstrative minio port value to `.env.test.example`, and adjusts test expectation accordingly.

NB. 1 API test will fail until we push up new secrets (i.e. add `MINIO_PORT=1234` to `.env.test`), but we should only do that when about to merge, since it will break CI for other PRs.