### PR TITLE
fix(e2e): Fix broken regression tests due to GovPay copy change

### DIFF
--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -313,10 +313,16 @@ test.describe("Gov Pay integration @regression", async () => {
     await expect(page.getByText("Application sent")).toBeVisible();
     await expect(page.getByText(actualPaymentId)).toBeVisible();
 
-    // try going back to the payment page
+    // Try going back to the GovPay payment page
     await page.goBack();
+    // Unable to make another payment - just get a status page...
     await expect(
-      page.locator("h1").getByText("Your payment session has expired"),
+      page.locator("h1").getByText("Your payment was successful"),
+    ).toBeVisible();
+    // ...with a link back to PlanX
+    await page.locator("a").getByText("View your payment summary").click();
+    await expect(
+      page.locator("h1").getByText("Application sent"),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## What does this PR do?
- Fixes failing regression test which relied on outdated copy on GovPay confirmation page
- Annotates test to be a little more descriptive
- Regression tests running passing against this branch here - https://github.com/theopensystemslab/planx-new/actions/runs/10252139211 ✅ 

<img width="1350" alt="image" src="https://github.com/user-attachments/assets/1820097b-b844-4982-8d75-37010f5b0b31">
