### PR TITLE
feat: Make external portals open in new tab when clicked

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -95,7 +95,13 @@ const ExternalPortal: React.FC<any> = (props) => {
         className={classNames("card", "portal", { isDragging })}
         onContextMenu={handleContext}
       >
-        <Link href={`/${href}`} prefetch={false} ref={drag}>
+        <Link
+          href={`/${href}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          prefetch={false}
+          ref={drag}
+        >
           <span>{href}</span>
         </Link>
         <Link href={editHref} prefetch={false} className="portalMenu">


### PR DESCRIPTION
## What does this PR do? 

This PR adds functionality to open external portals in new tabs when they are clicked in the flow editor. 

The work follows this Trello ticket: https://trello.com/c/MJ5VSADN/2960-could-external-portals-open-in-a-new-browser-tab-rather-than-in-window

I did think if it were better to enable right clicking to select what you'd like depending on your brower (new tab, new window etc...) but decided I'd follow the ticket explicitly first and see if more is required.