### PR TITLE
[chore] bump passport to 0.7.0

### DIFF
--- a/api.planx.uk/modules/test/controller.ts
+++ b/api.planx.uk/modules/test/controller.ts
@@ -1,0 +1,7 @@
+import { RequestHandler } from "express";
+
+export const testSessionMethods: RequestHandler = (req, res) => {
+  const hasRegenerate = typeof req.session?.regenerate === "function";
+  const hasSave = typeof req.session?.save === "function";
+  res.status(200).json({ hasRegenerate, hasSave });
+};

--- a/api.planx.uk/modules/test/docs.yaml
+++ b/api.planx.uk/modules/test/docs.yaml
@@ -1,0 +1,28 @@
+openapi: 3.1.0
+info:
+  title: Plan✕ API
+  version: 0.1.0
+tags:
+  - name: test
+    description: Requests for testing purposes
+paths:
+  /test-session:
+    get:
+      summary: Test req.session object
+      description: Confirms session has necessary dummy methods registered
+      tags: ["test"]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hasRegenerate:
+                    type: boolean
+                  hasSave:
+                    type: boolean
+                example:
+                  hasRegenerate: true
+                  hasSave: true

--- a/api.planx.uk/modules/test/routes.test.ts
+++ b/api.planx.uk/modules/test/routes.test.ts
@@ -1,0 +1,14 @@
+import supertest from "supertest";
+import app from "../../server";
+
+describe("Session setup", () => {
+  test("adds dummy methods to req.session to avoid passport/cookie-session incompatibility issue", async () => {
+    await supertest(app)
+      .get("/test-session")
+      .expect(200)
+      .then((res) => {
+        expect(res.body.hasRegenerate).toBe(true);
+        expect(res.body.hasSave).toBe(true);
+      });
+  });
+});

--- a/api.planx.uk/modules/test/routes.ts
+++ b/api.planx.uk/modules/test/routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { testSessionMethods } from "./controller";
+
+const router = Router();
+
+// in order to test the session setup, we need a dedicated test route
+router.get("/test-session", testSessionMethods);
+
+export default router;

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -39,7 +39,7 @@
     "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.7",
     "notifications-node-client": "^8.2.0",
-    "passport": "^0.5.3",
+    "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "pino-noir": "^2.2.1",
     "slack-notify": "^2.0.7",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -116,8 +116,8 @@ dependencies:
     specifier: ^8.2.0
     version: 8.2.0
   passport:
-    specifier: ^0.5.3
-    version: 0.5.3
+    specifier: ^0.7.0
+    version: 0.7.0
   passport-google-oauth20:
     specifier: ^2.0.0
     version: 2.0.0
@@ -315,8 +315,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@apidevtools/json-schema-ref-parser@11.6.4:
-    resolution: {integrity: sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==}
+  /@apidevtools/json-schema-ref-parser@11.7.0:
+    resolution: {integrity: sha512-pRrmXMCwnmrkS3MLgAIW5dXRzeTv6GLjkjb4HmxNnvAKXN1Nfzp4KmGADBQvlVUcqi+a5D+hfGDLLnd5NnYxog==}
     engines: {node: '>= 16'}
     dependencies:
       '@jsdevtools/ono': 7.1.3
@@ -1571,7 +1571,7 @@ packages:
       '@babel/runtime': 7.25.0
       '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1)(react@18.3.1)
       '@mui/types': 7.2.15
-      '@mui/utils': 5.16.5(react@18.3.1)
+      '@mui/utils': 5.16.6(react@18.3.1)
       '@popperjs/core': 2.11.8
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -1579,12 +1579,12 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@mui/core-downloads-tracker@5.16.5:
-    resolution: {integrity: sha512-ziFn1oPm6VjvHQcdGcAO+fXvOQEgieIj0BuSqcltFU+JXIxjPdVYNTdn2HU7/Ak5Gabk6k2u7+9PV7oZ6JT5sA==}
+  /@mui/core-downloads-tracker@5.16.6:
+    resolution: {integrity: sha512-kytg6LheUG42V8H/o/Ptz3olSO5kUXW9zF0ox18VnblX6bO2yif1FPItgc3ey1t5ansb1+gbe7SatntqusQupg==}
     dev: false
 
-  /@mui/material@5.16.5(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-eQrjjg4JeczXvh/+8yvJkxWIiKNHVptB/AqpsKfZBWp5mUD5U3VsjODMuUl1K2BSq0omV3CiO/mQmWSSMKSmaA==}
+  /@mui/material@5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-0LUIKBOIjiFfzzFNxXZBRAyr9UQfmTAFzbt6ziOU2FDXhorNN2o3N9/32mNJbCA8zJo2FqFU6d3dtoqUDyIEfA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -1607,10 +1607,10 @@ packages:
       '@babel/runtime': 7.25.0
       '@emotion/react': 11.13.0(react@18.3.1)
       '@emotion/styled': 11.13.0(@emotion/react@11.13.0)(react@18.3.1)
-      '@mui/core-downloads-tracker': 5.16.5
-      '@mui/system': 5.16.5(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1)
+      '@mui/core-downloads-tracker': 5.16.6
+      '@mui/system': 5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1)
       '@mui/types': 7.2.15
-      '@mui/utils': 5.16.5(react@18.3.1)
+      '@mui/utils': 5.16.6(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.1
@@ -1622,8 +1622,8 @@ packages:
       react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
     dev: false
 
-  /@mui/private-theming@5.16.5(react@18.3.1):
-    resolution: {integrity: sha512-CSLg0YkpDqg0aXOxtjo3oTMd3XWMxvNb5d0v4AYVqwOltU8q6GvnZjhWyCLjGSCrcgfwm6/VDjaKLPlR14wxIA==}
+  /@mui/private-theming@5.16.6(react@18.3.1):
+    resolution: {integrity: sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -1635,13 +1635,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.25.0
-      '@mui/utils': 5.16.5(react@18.3.1)
+      '@mui/utils': 5.16.6(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     dev: false
 
-  /@mui/styled-engine@5.16.4(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1):
-    resolution: {integrity: sha512-0+mnkf+UiAmTVB8PZFqOhqf729Yh0Cxq29/5cA3VAyDVTRIUUQ8FXQhiAhUIbijFmM72rY80ahFPXIm4WDbzcA==}
+  /@mui/styled-engine@5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1):
+    resolution: {integrity: sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -1664,8 +1664,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@mui/system@5.16.5(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1):
-    resolution: {integrity: sha512-uzIUGdrWddUx1HPxW4+B2o4vpgKyRxGe/8BxbfXVDPNPHX75c782TseoCnR/VyfnZJfqX87GcxDmnZEE1c031g==}
+  /@mui/system@5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1):
+    resolution: {integrity: sha512-5xgyJjBIMPw8HIaZpfbGAaFYPwImQn7Nyh+wwKWhvkoIeDosQ1ZMVrbTclefi7G8hNmqhip04duYwYpbBFnBgw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -1685,10 +1685,10 @@ packages:
       '@babel/runtime': 7.25.0
       '@emotion/react': 11.13.0(react@18.3.1)
       '@emotion/styled': 11.13.0(@emotion/react@11.13.0)(react@18.3.1)
-      '@mui/private-theming': 5.16.5(react@18.3.1)
-      '@mui/styled-engine': 5.16.4(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1)
+      '@mui/private-theming': 5.16.6(react@18.3.1)
+      '@mui/styled-engine': 5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.3.1)
       '@mui/types': 7.2.15
-      '@mui/utils': 5.16.5(react@18.3.1)
+      '@mui/utils': 5.16.6(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -1704,8 +1704,8 @@ packages:
         optional: true
     dev: false
 
-  /@mui/utils@5.16.5(react@18.3.1):
-    resolution: {integrity: sha512-CwhcA9y44XwK7k2joL3Y29mRUnoBt+gOZZdGyw7YihbEwEErJYBtDwbZwVgH68zAljGe/b+Kd5bzfl63Gi3R2A==}
+  /@mui/utils@5.16.6(react@18.3.1):
+    resolution: {integrity: sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -1978,8 +1978,8 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
-  /@types/node@20.14.13:
-    resolution: {integrity: sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==}
+  /@types/node@20.14.14:
+    resolution: {integrity: sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==}
     dependencies:
       undici-types: 5.26.5
     dev: false
@@ -3468,7 +3468,7 @@ packages:
     resolution: {integrity: sha512-4SbcbedPXTciySXiSnNNLuJXpvxFe5nqivbiEHXyL8P/w0wx2uW7YXNjnYgjW0e2e6vy+L/tMISU/oAiXCl57Q==}
     engines: {node: '>=10'}
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 20.14.14
       jszip: 3.10.1
       nanoid: 5.0.7
       xml: 1.0.1
@@ -5607,7 +5607,7 @@ packages:
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
-      '@apidevtools/json-schema-ref-parser': 11.6.4
+      '@apidevtools/json-schema-ref-parser': 11.7.0
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.0
       cli-color: 2.0.4
@@ -6491,12 +6491,13 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /passport@0.5.3:
-    resolution: {integrity: sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==}
+  /passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       passport-strategy: 1.0.0
       pause: 0.0.1
+      utils-merge: 1.0.1
     dev: false
 
   /path-exists@4.0.0:
@@ -8269,7 +8270,7 @@ packages:
       '@emotion/styled': 11.13.0(@emotion/react@11.13.0)(react@18.3.1)
       '@formatjs/intl-listformat': 7.5.7
       '@mui/base': 5.0.0-beta.40(react-dom@18.3.1)(react@18.3.1)
-      '@mui/material': 5.16.5(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/material': 5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react-dom@18.3.1)(react@18.3.1)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       cheerio: 1.0.0-rc.12

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -31,6 +31,7 @@ import fileRoutes from "./modules/file/routes";
 import gisRoutes from "./modules/gis/routes";
 import payRoutes from "./modules/pay/routes";
 import sendRoutes from "./modules/send/routes";
+import testRoutes from "./modules/test/routes";
 import { useSwaggerDocs } from "./docs";
 import { Role } from "@opensystemslab/planx-core/types";
 
@@ -149,6 +150,7 @@ app.use(sendRoutes);
 app.use(teamRoutes);
 app.use(userRoutes);
 app.use(webhookRoutes);
+app.use(testRoutes);
 
 const errorHandler: ErrorRequestHandler = (errorObject, _req, res, _next) => {
   const { status = 500, message = "Something went wrong" } = (() => {

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -14,6 +14,7 @@ import helmet from "helmet";
 import { ServerError } from "./errors";
 import airbrake from "./airbrake";
 import { apiLimiter } from "./rateLimit";
+import { registerSessionStubs } from "./session";
 import { googleStrategy } from "./modules/auth/strategy/google";
 import authRoutes from "./modules/auth/routes";
 import teamRoutes from "./modules/team/routes";
@@ -115,6 +116,9 @@ app.use(
     secret: process.env.SESSION_SECRET,
   }),
 );
+
+// register stubs after cookieSession middleware initialisation
+app.use(registerSessionStubs);
 
 passport.use("google", googleStrategy);
 

--- a/api.planx.uk/session.ts
+++ b/api.planx.uk/session.ts
@@ -1,0 +1,12 @@
+import { RequestHandler } from "http-proxy-middleware";
+
+// this middleware registers dummy methods on req.session to resolve passport/cookie-session incompatibility
+export const registerSessionStubs: RequestHandler = (req, _res, next): void => {
+  if (req.session && !req.session.regenerate) {
+    req.session.regenerate = (cb: (err?: Error) => void) => cb();
+  }
+  if (req.session && !req.session.save) {
+    req.session.save = (cb: (err?: Error) => void) => cb();
+  }
+  next();
+};


### PR DESCRIPTION
🔧   [Ticket in Trello](https://trello.com/c/BKP8MVAK).

We've wanted to bump the [passport](https://www.passportjs.org/) version in use for auth routes for some time, because `0.6.0` fixes a 'moderate' [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2022-25896) (as [flagged by dependabot](https://github.com/theopensystemslab/planx-new/security/dependabot/1) 2 years ago).

But this version throws up a bug related to our use of `cookie-session`, which `passport` does not commit to being compatible with (see [here](https://github.com/LinkedInLearning/node-authentication-2881188/issues/2)) (it only claims to support `express-session`). The issue is that passport used to implement the `req.session.regenerate` and `req.session.save` methods, which are called by `cookie-session`, but no longer does.

So in this PR we jump to `0.7.0` ([changelog](https://github.com/jaredhanson/passport/blob/master/CHANGELOG.md)), and implement a fix for this bug by stubbing out dummy methods on `req.session`. Credit to [this comment in passport#904](https://github.com/jaredhanson/passport/issues/904#issuecomment-1307558283) for the fix.

Supertest does not make the `request` objection available for testing - only the `response`. Therefore in order to test things about the request we are actually constructing, I added a new module with a dedicated test route. Very open to other ideas on how to test these dummy methods if that doesn't seem best practice :)