### PR TITLE
feat: add a "map" field to the List component

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -1,6 +1,7 @@
 import MenuItem from "@mui/material/MenuItem";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
+import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -27,6 +28,7 @@ import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebui
 import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Removed";
 import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
+import { Trees } from "./schemas/Trees";
 
 type Props = EditorProps<TYPES.List, List>;
 
@@ -60,6 +62,7 @@ export const SCHEMAS = [
   { name: "Protected spaces (GLA)", schema: ProtectedSpaceGLA },
   { name: "Open spaces (GLA)", schema: OpenSpaceGLA },
   { name: "Proposed advertisements", schema: ProposedAdvertisements },
+  ...(hasFeatureFlag("TREES") ? [{ name: "Trees", schema: Trees }] : []),
 ];
 
 function ListComponent(props: Props) {

--- a/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
@@ -5,9 +5,12 @@ import Grid from "@mui/material/Grid";
 import MenuItem from "@mui/material/MenuItem";
 import RadioGroup from "@mui/material/RadioGroup";
 import { visuallyHidden } from "@mui/utils";
+import { MapContainer } from "@planx/components/shared/Preview/MapContainer";
 import { getIn } from "formik";
+import { Feature } from "geojson";
 import { get } from "lodash";
-import React from "react";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useEffect, useState } from "react";
 import SelectInput from "ui/editor/SelectInput";
 import InputLabel from "ui/public/InputLabel";
 import ChecklistItem from "ui/shared/ChecklistItem";
@@ -19,6 +22,7 @@ import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../shared/constants";
 import BasicRadio from "../../shared/Radio/BasicRadio";
 import type {
   ChecklistField,
+  MapField,
   NumberField,
   QuestionField,
   TextField,
@@ -221,6 +225,80 @@ export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
             />
           ))}
         </Grid>
+      </ErrorWrapper>
+    </InputLabel>
+  );
+};
+
+export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
+  const { formik, activeIndex, schema } = useListContext();
+  const {
+    id,
+    data: { title, fn, drawType, drawColor, drawMany },
+  } = props;
+
+  const teamSettings = useStore.getState().teamSettings;
+  const passport = useStore((state) => state.computePassport());
+
+  const [features, setFeatures] = useState<Feature[] | undefined>(undefined);
+
+  useEffect(() => {
+    const geojsonChangeHandler = async ({ detail: geojson }: any) => {
+      if (geojson["EPSG:3857"]?.features) {
+        setFeatures(geojson["EPSG:3857"].features);
+        await formik.setFieldValue(
+          `userData[${activeIndex}]['${fn}']`,
+          features,
+        );
+        console.log(features, formik);
+      } else {
+        // if the user clicks 'reset' on the map, geojson will be empty object, so set features to undefined
+        setFeatures(undefined);
+        await formik.setFieldValue(
+          `userData[${activeIndex}]['${fn}']`,
+          features,
+        );
+      }
+    };
+
+    const map: any = document.getElementById(id);
+
+    map?.addEventListener("geojsonChange", geojsonChangeHandler);
+
+    return function cleanup() {
+      map?.removeEventListener("geojsonChange", geojsonChangeHandler);
+    };
+  }, [setFeatures]);
+
+  return (
+    <InputLabel label={title} id={`map-label-${id}`} htmlFor={id}>
+      <ErrorWrapper
+        error={getIn(formik.errors, `userData[${activeIndex}]['${fn}']`)}
+        id={id}
+      >
+        <MapContainer environment="standalone">
+          {/* @ts-ignore */}
+          <my-map
+            id={id}
+            ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
+            height={400}
+            drawMode
+            drawMany={drawMany}
+            drawColor={drawColor}
+            drawType={drawType}
+            drawPointer="crosshair"
+            zoom={20}
+            maxZoom={23}
+            latitude={Number(passport?.data?._address?.latitude)}
+            longitude={Number(passport?.data?._address?.longitude)}
+            osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
+            osCopyright={`Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
+            clipGeojsonData={
+              teamSettings?.boundaryBBox &&
+              JSON.stringify(teamSettings?.boundaryBBox)
+            }
+          />
+        </MapContainer>
       </ErrorWrapper>
     </InputLabel>
   );

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -21,6 +21,7 @@ import { formatSchemaDisplayValue } from "../utils";
 import { ListProvider, useListContext } from "./Context";
 import {
   ChecklistFieldInput,
+  MapFieldInput,
   NumberFieldInput,
   RadioFieldInput,
   SelectFieldInput,
@@ -62,6 +63,8 @@ const InputField: React.FC<Field> = (props) => {
       return <SelectFieldInput id={inputFieldId} {...props} />;
     case "checklist":
       return <ChecklistFieldInput id={inputFieldId} {...props} />;
+    case "map":
+      return <MapFieldInput id={inputFieldId} {...props} />;
   }
 };
 

--- a/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
@@ -1,0 +1,76 @@
+import { Schema } from "@planx/components/List/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const Trees: Schema = {
+  type: "Tree",
+  fields: [
+    {
+      type: "text",
+      data: {
+        title: "Species",
+        fn: "species",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Proposed work",
+        fn: "work",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Justification",
+        fn: "justification",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Urgency",
+        fn: "urgency",
+        options: [
+          {
+            id: "low",
+            data: { text: "Low", val: "low" },
+          },
+          {
+            id: "moderate",
+            data: { text: "Moderate", val: "moderate" },
+          },
+          {
+            id: "high",
+            data: { text: "High", val: "high" },
+          },
+          {
+            id: "urgent",
+            data: { text: "Urgent", val: "urgent" },
+          },
+        ],
+      },
+    },
+    {
+      type: "text", // @todo field type "date"
+      data: {
+        title: "Expected completion date",
+        fn: "completionDate",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "map",
+      data: {
+        title: "Where is it?",
+        fn: "features",
+        drawType: "Point",
+        drawColor: "#ff0000",
+        drawMany: true,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
After catching up about "Map & Label" design with Ian & Rory last Friday - there's still basically one big outstanding question: 
- Is the user's entry point a map _and then_ they annotate each feature they've plotted (eg #3501 & vertical tab design in Figma) 
- OR is the most accessible entry point a list/table _and then_ they spatially locate what they've already described

This PR prototypes the latter option - which I actually don't think requires a "new" component as our original instinct at all, rather we can add a new "map" field to the existing List component. 

![Screenshot from 2024-08-11 13-32-13](https://github.com/user-attachments/assets/18b7668b-ab1c-4e41-93f6-3eca5443d656)

Still outstanding:
- Fix formik & validation schema to record geojson features
- Inactive card for "map" field needs a bit of special handling - we want to render a static reference map similar to existing `SummaryList`
- Decide how to structure data `onSubmit` if a "map" field is present - do we want to collate into a singular GeoJSON `FeatureCollection` where other "fields" are reflected as `properties` of each individual feature?