### PR TITLE
fix: refactor uses of `__dirname` now that API is using `esnext`

### DIFF
--- a/api.planx.uk/jest.config.ts
+++ b/api.planx.uk/jest.config.ts
@@ -12,6 +12,16 @@ const config: JestConfigWithTsJest = {
         useESM: true,
         // we need a separate module/moduleResolution config for tests (jest v30 may fix this)
         tsconfig: "tsconfig.test.json",
+        diagnostics: {
+          ignoreCodes: [1343],
+        },
+        astTransformers: {
+          before: [
+            {
+              path: "node_modules/ts-jest-mock-import-meta",
+            },
+          ],
+        },
       },
     ],
   },

--- a/api.planx.uk/modules/file/service/utils.test.ts
+++ b/api.planx.uk/modules/file/service/utils.test.ts
@@ -12,7 +12,7 @@ describe("s3 Factory", () => {
   });
 
   it("returns Minio config for local development", () => {
-    expect(s3Factory()).toHaveProperty("endpoint.host", "minio:1234");
+    expect(s3Factory()).toHaveProperty("endpoint.host", "minio");
   });
 
   ["pizza", "staging", "production"].forEach((env) => {

--- a/api.planx.uk/modules/file/service/utils.test.ts
+++ b/api.planx.uk/modules/file/service/utils.test.ts
@@ -12,7 +12,7 @@ describe("s3 Factory", () => {
   });
 
   it("returns Minio config for local development", () => {
-    expect(s3Factory()).toHaveProperty("endpoint.host", "minio");
+    expect(s3Factory()).toHaveProperty("endpoint.host", "minio:1234");
   });
 
   ["pizza", "staging", "production"].forEach((env) => {

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -1,21 +1,22 @@
-import os from "os";
-import path from "path";
-import { $api } from "../../../client/index.js";
-import { stringify } from "csv-stringify";
-import fs from "fs";
-import str from "string-to-stream";
-import AdmZip from "adm-zip";
-import { getFileFromS3 } from "../../file/service/getFile.js";
 import {
-  hasRequiredDataForTemplate,
-  generateMapHTML,
   generateApplicationHTML,
   generateDocxTemplateStream,
+  generateMapHTML,
+  hasRequiredDataForTemplate,
+  Passport,
 } from "@opensystemslab/planx-core";
-import { Passport } from "@opensystemslab/planx-core";
-import type { Passport as IPassport } from "../../../types.js";
-import type { Stream } from "node:stream";
 import type { PlanXExportData } from "@opensystemslab/planx-core/types";
+import AdmZip from "adm-zip";
+import { stringify } from "csv-stringify";
+import fs from "fs";
+import type { Stream } from "node:stream";
+import os from "os";
+import path from "path";
+import str from "string-to-stream";
+import { fileURLToPath } from "url";
+import { $api } from "../../../client/index.js";
+import type { Passport as IPassport } from "../../../types.js";
+import { getFileFromS3 } from "../../file/service/getFile.js";
 import { isApplicationTypeSupported } from "./helpers.js";
 
 export async function buildSubmissionExportZip({
@@ -206,6 +207,11 @@ export class ExportZip {
     this.zip = new AdmZip();
     // make a tmp directory to avoid file name collisions if simultaneous applications
     this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), sessionId));
+
+    // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath
+    const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
+    const __dirname = path.dirname(__filename); // get the name of the directory
+
     this.filename = path.join(__dirname, `${flowSlug}-${sessionId}.zip`);
   }
 

--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -211,7 +211,6 @@ export class ExportZip {
     // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath
     const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
     const __dirname = path.dirname(__filename); // get the name of the directory
-
     this.filename = path.join(__dirname, `${flowSlug}-${sessionId}.zip`);
   }
 

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -116,6 +116,7 @@
     "rimraf": "^5.0.5",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.4",
+    "ts-jest-mock-import-meta": "^1.2.0",
     "tsx": "^4.16.2",
     "typescript": "^5.5.2",
     "uuid": "^10.0.0"

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -267,6 +267,9 @@ devDependencies:
   ts-jest:
     specifier: ^29.2.4
     version: 29.2.4(@babel/core@7.24.0)(esbuild@0.22.0)(jest@29.7.0)(typescript@5.5.2)
+  ts-jest-mock-import-meta:
+    specifier: ^1.2.0
+    version: 1.2.0(ts-jest@29.2.4)
   tsx:
     specifier: ^4.16.2
     version: 4.16.2
@@ -7801,6 +7804,14 @@ packages:
     dependencies:
       punycode: 2.3.1
     dev: false
+
+  /ts-jest-mock-import-meta@1.2.0(ts-jest@29.2.4):
+    resolution: {integrity: sha512-r2+TH6d8LHBXqLTXjJh1KfTZoMvGV0hdn9gwickNVcwS2Co2/mewGjj0XDVEPLg5MVfZVHUFQ9O09anURA3KCw==}
+    peerDependencies:
+      ts-jest: '>=20.0.0'
+    dependencies:
+      ts-jest: 29.2.4(@babel/core@7.24.0)(esbuild@0.22.0)(jest@29.7.0)(typescript@5.5.2)
+    dev: true
 
   /ts-jest@29.2.4(@babel/core@7.24.0)(esbuild@0.22.0)(jest@29.7.0)(typescript@5.5.2):
     resolution: {integrity: sha512-3d6tgDyhCI29HlpwIq87sNuI+3Q6GLTTCeYRHCs7vDz+/3GCMwEtV9jezLyl4ZtnBgx00I7hm8PCP8cTksMGrw==}

--- a/api.planx.uk/tests/loadOrRecordNockRequests.js
+++ b/api.planx.uk/tests/loadOrRecordNockRequests.js
@@ -1,8 +1,9 @@
 import { createHash } from "crypto";
 import { writeFileSync } from "fs";
+import stringify from "json-stringify-pretty-compact";
 import nock from "nock";
 import path from "path";
-import stringify from "json-stringify-pretty-compact";
+import { fileURLToPath } from "url";
 
 /**
  * Attempts to load HTTP requests that have been made in previous tests.
@@ -20,6 +21,9 @@ function loadOrRecordNockRequests(filename, hashKey) {
     .digest("hex")
     .slice(0, 8);
 
+  // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath
+  const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
+  const __dirname = path.dirname(__filename); // get the name of the directory
   const filePath = path.join(__dirname, "nocks", `${filename}.${hash}.json`);
 
   const records = [];


### PR DESCRIPTION
Should fix failing e2e regression tests on `main` :crossed_fingers: https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1723443286868999

Regression tests passing against this branch :white_check_mark: https://github.com/theopensystemslab/planx-new/actions/runs/10358321445

**Two part bug:** 
1.  `__dirname is not defined` error was being thrown when trying to generate zip folders for submissions (hence Uniform-related e2e failure) - we can now access this by using `fileURLToPath` as outlined in [this post](https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d)
2. BUT that solution throws the following error on `pnpm test` : `The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'` - which is a bit strange because these options do indeed match our API's `tsconfig` 
    - So then I spent some time working through various suggestions outlined in [this thread](https://github.com/kulshekhar/ts-jest/issues/3888) & ended up using the final solution to add an extra dev dependency `ts-jest-mock-import-meta`
    
**Manual testing notes:**
- For a valid session on staging, we can't successfully generate a zip and it throws the `__dirname` error: https://api.editor.planx.dev/admin/session/be215bcf-1acf-4d76-893c-3c319a00966a/zip (connect to Warp to access, open this GET endpoint in your browser, expect it to trigger a download but instead throws error)
- For the same valid session copied to this pizza, we can successfully generate a zip: https://api.3507.planx.pizza/admin/session/be215bcf-1acf-4d76-893c-3c319a00966a/zip (if you get token error, login to this pizza editor first then retry so you have a valid JWT in your browser - should see download start!)