### PR TITLE
fix: update ResidentialUnits list schemas based on feedback

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
@@ -1,7 +1,7 @@
 import { Schema } from "../../model";
 
 export const ResidentialUnitsExisting: Schema = {
-  type: "Existing residential unit",
+  type: "Existing residential unit type",
   fields: [
     {
       type: "question",
@@ -62,7 +62,7 @@ export const ResidentialUnitsExisting: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units does the description above apply to?",
+        title: "How many existing units fit the descriptions above?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/New.ts
@@ -1,29 +1,8 @@
 import { Schema } from "@planx/components/List/model";
 
 export const ResidentialUnitsGLANew: Schema = {
-  type: "New residential unit",
+  type: "New residential unit type",
   fields: [
-    {
-      type: "question",
-      data: {
-        title: "What development does this unit result from?",
-        fn: "development",
-        options: [
-          { id: "newBuild", data: { text: "New build", val: "newBuild" } },
-          {
-            id: "changeOfUseFrom",
-            data: {
-              text: "Change of use of existing single home",
-              val: "changeOfUseFrom",
-            },
-          },
-          {
-            id: "changeOfUseTo",
-            data: { text: "Change of use to a home", val: "changeOfUseTo" },
-          },
-        ],
-      },
-    },
     {
       type: "number",
       data: {
@@ -226,7 +205,7 @@ export const ResidentialUnitsGLANew: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units does the description above apply to?",
+        title: "How many new units fit the descriptions above?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Rebuilt.ts
@@ -1,7 +1,7 @@
 import { Schema } from "@planx/components/List/model";
 
 export const ResidentialUnitsGLARebuilt: Schema = {
-  type: "Rebuilt residential unit",
+  type: "Rebuilt residential unit type",
   fields: [
     {
       type: "question",
@@ -226,7 +226,7 @@ export const ResidentialUnitsGLARebuilt: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units does the description above apply to?",
+        title: "How many rebuilt units fit the descriptions above?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Removed.ts
@@ -1,7 +1,7 @@
 import { Schema } from "@planx/components/List/model";
 
 export const ResidentialUnitsGLARemoved: Schema = {
-  type: "Removed residential unit",
+  type: "Removed residential unit type",
   fields: [
     {
       type: "number",
@@ -172,7 +172,7 @@ export const ResidentialUnitsGLARemoved: Schema = {
     {
       type: "question",
       data: {
-        title: "Will this unit provide sheltered accommodation?",
+        title: "Is this unit providing sheltered accommodation?",
         fn: "sheltered",
         options: [
           { id: "true", data: { text: "Yes", val: "true" } },
@@ -194,7 +194,7 @@ export const ResidentialUnitsGLARemoved: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units does the description above apply to?",
+        title: "How many removed units fit the descriptions above?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Retained.ts
@@ -1,7 +1,7 @@
 import { Schema } from "@planx/components/List/model";
 
 export const ResidentialUnitsGLARetained: Schema = {
-  type: "Retained residential unit",
+  type: "Retained residential unit type",
   fields: [
     {
       type: "number",
@@ -94,7 +94,7 @@ export const ResidentialUnitsGLARetained: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units does the description above apply to?",
+        title: "How many retained units fit the descriptions above?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
@@ -83,7 +83,7 @@ export const ResidentialUnitsProposed: Schema = {
     {
       type: "number",
       data: {
-        title: "How many identical units will the description above apply to?",
+        title: "How many proposed units fit the descriptions above?",
         fn: "identicalUnits",
         allowNegatives: false,
       },


### PR DESCRIPTION
Add 'type' to title of all ResidentialUnits list schemas to better signify that the description can apply to multiple units.

Reword 'identical units' of all ResidentialUnits list schemas question to 'how many fit the description above' wording.

Remove development type question from ResidentialUnits GLA New list schema.