### PR TITLE
fix: Add missing `key` prop to `ChecklistItem`

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/Fields.tsx
@@ -212,6 +212,7 @@ export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
           <legend style={visuallyHidden}>{title}</legend>
           {options.map((option) => (
             <ChecklistItem
+              key={option.id}
               onChange={changeCheckbox(option.id)}
               label={option.data.text}
               id={option.id}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/da8aef73-64aa-4220-9b79-81c5fadf9e5a)
