### PR TITLE
fix: Display question values in `List` inactive card view

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -583,6 +583,40 @@ describe("Form validation and error handling", () => {
   });
 });
 
+test("Input data is displayed in the inactive card view", async () => {
+  const { getByText, user } = setup(
+    <ListComponent {...mockZooProps} />,
+  );
+
+  await fillInResponse(user);
+
+  // Text input
+  expect(getByText("What's their name?", { selector: "td" })).toBeVisible();
+  expect(getByText("Richard Parker", { selector: "td" })).toBeVisible();
+
+  // Email input
+  expect(getByText("What's their email address?", { selector: "td" })).toBeVisible();
+  expect(getByText("richard.parker@pi.com", { selector: "td" })).toBeVisible();
+  
+  // Number input
+  expect(getByText("How old are they?", { selector: "td" })).toBeVisible();
+  expect(getByText("10 years old", { selector: "td" })).toBeVisible();
+  
+  // Question input - select
+  expect(getByText("What size are they?", { selector: "td" })).toBeVisible();
+  expect(getByText("Medium", { selector: "td" })).toBeVisible();
+
+  // Question input - radio
+  expect(getByText("How cute are they?", { selector: "td" })).toBeVisible();
+  expect(getByText("Very", { selector: "td" })).toBeVisible();
+  
+  // Checklist input
+  expect(getByText("What do they eat?", { selector: "td" })).toBeVisible();
+  expect(getByText("Meat", { selector: "li" })).toBeVisible();
+  expect(getByText("Leaves", { selector: "li" })).toBeVisible();
+  expect(getByText("Bamboo", { selector: "li" })).toBeVisible();
+})
+
 describe("Payload generation", () => {
   it("generates a valid payload on submission (Zoo)", async () => {
     const handleSubmit = jest.fn();

--- a/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -38,7 +38,7 @@ export function formatSchemaDisplayValue(
     }
     case "question": {
       const matchingOption = field.data.options.find(
-        (option) => option.data.val === value,
+        (option) => option.data.text === value,
       );
       return matchingOption?.data.text;
     }


### PR DESCRIPTION
## What does this PR do?
- Displays responses for question inputs in the "inactive card" view
- Adds tests for "inactive card" view"

Not too sure where this regression slipped in - noticed it when working on other small `List` tickets for works to trees.

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/68c5cb7b-cddd-42a8-b31f-03a2718e824a)|![image](https://github.com/user-attachments/assets/c6c9ff2a-00a0-48cc-a257-e670d2e625aa)|