### PR TITLE
fix: Remove unused defaults from the `Calculate` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -43,9 +43,24 @@ export default function Component(props: Props) {
     },
   });
 
+  /**
+  * When the formula is updated, remove any defaults which are no longer used
+  */
+  const removeUnusedDefaults = (variables: Set<string>) => {
+    const defaultKeys = Object.keys(formik.values.defaults);
+
+    defaultKeys.forEach((key) => {
+      if (!variables.has(key)) {
+        formik.setFieldValue(`defaults[${key}]`, undefined);
+      }
+    });
+  };
+
   const variables = React.useMemo(() => {
     try {
-      return [...getVariables(formik.values.formula)];
+      const variables = getVariables(formik.values.formula)
+      removeUnusedDefaults(variables);
+      return [...variables];
     } catch (e) {
       return [];
     }


### PR DESCRIPTION
## What does this PR do?
 - Fixes a bug I hit when working on search
 - Current behaviour - when I update the formula of a calculate field, unused defaults are retained (these were showing up in search results)
 - New behaviour - when I update the formula of a calculate field, unused defaults are removed from the component's data

### Tests
I did spend a bit of time trying to get tests to work here, without much success.

The issues I was hitting was that both `user.type()` and `user.keyboard()` were having issues correctly populating the formula field. I'm not sure if this is a formik, mathjs or a react-testing-library issue (likely a combination!).

<img width="524" alt="image" src="https://github.com/user-attachments/assets/183051b3-389c-4b8e-a28e-2e43ea3099f8">
