### PR TITLE
chore: expose "Idox Nexus" Send destination on production for testing

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -52,6 +52,10 @@ const SendComponent: React.FC<Props> = (props) => {
       label: "Uniform",
     },
     {
+      value: Destination.Idox,
+      label: "Idox Nexus (TESTING ONLY)",
+    },
+    {
       value: Destination.Email,
       label: "Email to planning office",
     },
@@ -60,14 +64,6 @@ const SendComponent: React.FC<Props> = (props) => {
       label: "Upload to AWS S3 bucket",
     },
   ];
-
-  // Show Nexus option on staging only
-  if (process.env.REACT_APP_ENV !== "production") {
-    options.push({
-      value: Destination.Idox,
-      label: "Idox Nexus (testing only)",
-    });
-  }
 
   const changeCheckbox =
     (value: Destination) =>


### PR DESCRIPTION
Related to #3482 

I want to share `.dev` testing links with Idox instead of `.pizza` because of Vultr issues.

Staging content is overwritten nightly, so I need to create my test flows on production - including ability to set this "Send" destination! 

Production won't have Pulumi keys for new Idox changes coming in #3482, so if a council did attempt to use it too soon it would fail fast on our side :ok_hand: 