### PR TITLE
[api] implement verbatim module syntax in tsconfig

### DIFF
--- a/api.planx.uk/.eslintrc
+++ b/api.planx.uk/.eslintrc
@@ -18,6 +18,7 @@
       }
     ],
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/consistent-type-imports": "error",
     "no-nested-ternary": "error",
     "@vitest/expect-expect": [
       "error",

--- a/api.planx.uk/docs/index.ts
+++ b/api.planx.uk/docs/index.ts
@@ -1,4 +1,4 @@
-import { Express } from "express";
+import type { Express } from "express";
 import swaggerJSDoc from "swagger-jsdoc";
 import swaggerUi from "swagger-ui-express";
 

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -1,7 +1,8 @@
 import { gql } from "graphql-request";
 import capitalize from "lodash/capitalize.js";
-import { Flow, Node } from "./types.js";
-import { ComponentType, FlowGraph } from "@opensystemslab/planx-core/types";
+import type { Flow, Node } from "./types.js";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 import { $public, getClient } from "./client/index.js";
 
 export interface FlowData {

--- a/api.planx.uk/lib/hasura/metadata/index.test.ts
+++ b/api.planx.uk/lib/hasura/metadata/index.test.ts
@@ -1,10 +1,11 @@
-import { createScheduledEvent, RequiredScheduledEventArgs } from "./index.js";
+import type { RequiredScheduledEventArgs } from "./index.js";
+import { createScheduledEvent } from "./index.js";
 import axios from "axios";
 import type { Mocked } from "vitest";
 
 describe("Creation of scheduled event", () => {
   vi.mock("axios", async (importOriginal) => {
-    const actualAxios = await importOriginal<typeof import("axios")>();
+    const actualAxios = await importOriginal<typeof axios>();
     return {
       default: {
         ...actualAxios,

--- a/api.planx.uk/lib/hasura/metadata/index.ts
+++ b/api.planx.uk/lib/hasura/metadata/index.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosResponse, isAxiosError } from "axios";
+import type { AxiosResponse } from "axios";
+import axios, { isAxiosError } from "axios";
 
 /**
  * Body posted to Hasura Metadata API to create a scheduled event
@@ -46,7 +47,7 @@ const postToMetadataAPI = async (
   body: ScheduledEvent,
 ): Promise<AxiosResponse<ScheduledEventResponse>> => {
   try {
-    return await Axios.post(
+    return await axios.post(
       process.env.HASURA_METADATA_URL!,
       JSON.stringify(body),
       {

--- a/api.planx.uk/lib/hasura/schema/index.test.ts
+++ b/api.planx.uk/lib/hasura/schema/index.test.ts
@@ -4,7 +4,7 @@ import type { Mocked } from "vitest";
 
 describe("runSQL", () => {
   vi.mock("axios", async (importOriginal) => {
-    const actualAxios = await importOriginal<typeof import("axios")>();
+    const actualAxios = await importOriginal<typeof axios>();
     return {
       default: {
         ...actualAxios,

--- a/api.planx.uk/lib/hasura/schema/index.ts
+++ b/api.planx.uk/lib/hasura/schema/index.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosResponse, isAxiosError } from "axios";
+import type { AxiosResponse } from "axios";
+import axios, { isAxiosError } from "axios";
 
 export interface RunSQLArgs {
   source: "default";
@@ -18,7 +19,7 @@ const postToSchemaAPI = async <T>(
   query: SchemaAPIQuery,
 ): Promise<AxiosResponse<T>> => {
   try {
-    return await Axios.post(
+    return await axios.post(
       process.env.HASURA_SCHEMA_URL!,
       JSON.stringify(query),
       {

--- a/api.planx.uk/lib/notify/index.test.ts
+++ b/api.planx.uk/lib/notify/index.test.ts
@@ -1,6 +1,6 @@
 import { sendEmail } from "./index.js";
 import { NotifyClient } from "notifications-node-client";
-import { NotifyConfig } from "../../types.js";
+import type { NotifyConfig } from "../../types.js";
 
 vi.mock("notifications-node-client");
 

--- a/api.planx.uk/lib/notify/index.ts
+++ b/api.planx.uk/lib/notify/index.ts
@@ -1,6 +1,6 @@
 import { NotifyClient } from "notifications-node-client";
 import { softDeleteSession } from "../../modules/saveAndReturn/service/utils.js";
-import { NotifyConfig } from "../../types.js";
+import type { NotifyConfig } from "../../types.js";
 import { $api, $public } from "../../client/index.js";
 
 const notifyClient = new NotifyClient(process.env.GOVUK_NOTIFY_API_KEY);

--- a/api.planx.uk/modules/admin/session/csv.ts
+++ b/api.planx.uk/modules/admin/session/csv.ts
@@ -1,5 +1,5 @@
 import { stringify } from "csv-stringify";
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { $api } from "../../../client/index.js";
 
 /**

--- a/api.planx.uk/modules/admin/session/digitalPlanningData.ts
+++ b/api.planx.uk/modules/admin/session/digitalPlanningData.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { $api } from "../../../client/index.js";
 
 /**

--- a/api.planx.uk/modules/admin/session/oneAppXML.ts
+++ b/api.planx.uk/modules/admin/session/oneAppXML.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { $api } from "../../../client/index.js";
 
 /**

--- a/api.planx.uk/modules/admin/session/summary.ts
+++ b/api.planx.uk/modules/admin/session/summary.ts
@@ -1,13 +1,18 @@
-import {
+import type {
   GovUKPayment,
   PaymentRequest,
   Session,
   Team,
 } from "@opensystemslab/planx-core/types";
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 
-import { Breadcrumb, Flow, LowCalSession, Passport } from "../../../types.js";
+import type {
+  Breadcrumb,
+  Flow,
+  LowCalSession,
+  Passport,
+} from "../../../types.js";
 import { $api } from "../../../client/index.js";
 
 /**

--- a/api.planx.uk/modules/admin/session/zip.ts
+++ b/api.planx.uk/modules/admin/session/zip.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { buildSubmissionExportZip } from "../../send/utils/exportZip.js";
 
 /**

--- a/api.planx.uk/modules/analytics/controller.ts
+++ b/api.planx.uk/modules/analytics/controller.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { trackAnalyticsLogExit } from "./service.js";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 
 export const logAnalyticsSchema = z.object({
   query: z.object({

--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -1,5 +1,5 @@
-import { CookieOptions, RequestHandler, Response } from "express";
-import { Request } from "express-jwt";
+import type { CookieOptions, RequestHandler, Response } from "express";
+import type { Request } from "express-jwt";
 
 export const failedLogin: RequestHandler = (_req, _res, next) =>
   next({

--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -1,14 +1,14 @@
 import crypto from "crypto";
 import assert from "assert";
 import { ServerError } from "../../errors/index.js";
-import { Template } from "../../lib/notify/index.js";
+import type { Template } from "../../lib/notify/index.js";
 import { expressjwt } from "express-jwt";
 import { generators } from "openid-client";
-import { Authenticator } from "passport";
-import { RequestHandler } from "http-proxy-middleware";
-import { Role } from "@opensystemslab/planx-core/types";
+import type { Authenticator } from "passport";
+import type { RequestHandler } from "http-proxy-middleware";
+import type { Role } from "@opensystemslab/planx-core/types";
 import { AsyncLocalStorage } from "async_hooks";
-import { Request } from "express";
+import type { Request } from "express";
 
 export const userContext = new AsyncLocalStorage<{ user: Express.User }>();
 

--- a/api.planx.uk/modules/auth/passport.ts
+++ b/api.planx.uk/modules/auth/passport.ts
@@ -1,5 +1,6 @@
 import { Issuer } from "openid-client";
-import passport, { type Authenticator } from "passport";
+import type { Authenticator } from "passport";
+import passport from "passport";
 
 import { googleStrategy } from "./strategy/google.js";
 import {

--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -1,6 +1,6 @@
 import jwt from "jsonwebtoken";
 import { $api } from "../../client/index.js";
-import { User, Role } from "@opensystemslab/planx-core/types";
+import type { User, Role } from "@opensystemslab/planx-core/types";
 
 export const buildJWT = async (email: string): Promise<string | undefined> => {
   await checkUserCanAccessEnv(email, process.env.NODE_ENV);

--- a/api.planx.uk/modules/file/controller.ts
+++ b/api.planx.uk/modules/file/controller.ts
@@ -3,7 +3,7 @@ import { uploadPrivateFile, uploadPublicFile } from "./service/uploadFile.js";
 import { buildFilePath } from "./service/utils.js";
 import { getFileFromS3 } from "./service/getFile.js";
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 import { ServerError } from "../../errors/index.js";
 
 assert(process.env.AWS_S3_BUCKET);

--- a/api.planx.uk/modules/file/file.test.ts
+++ b/api.planx.uk/modules/file/file.test.ts
@@ -1,5 +1,5 @@
 import supertest from "supertest";
-import { Mocked } from "vitest";
+import type { Mocked } from "vitest";
 
 import app from "../../server.js";
 import { deleteFilesByURL } from "./service/deleteFile.js";

--- a/api.planx.uk/modules/file/service/deleteFile.ts
+++ b/api.planx.uk/modules/file/service/deleteFile.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectsRequest } from "aws-sdk/clients/s3.js";
+import type { DeleteObjectsRequest } from "aws-sdk/clients/s3.js";
 import { getS3KeyFromURL, s3Factory } from "./utils.js";
 
 export const deleteFilesByURL = async (

--- a/api.planx.uk/modules/file/service/getFile.ts
+++ b/api.planx.uk/modules/file/service/getFile.ts
@@ -1,4 +1,4 @@
-import S3 from "aws-sdk/clients/s3.js";
+import type S3 from "aws-sdk/clients/s3.js";
 import { s3Factory } from "./utils.js";
 
 export const getFileFromS3 = async (fileId: string) => {

--- a/api.planx.uk/modules/file/service/uploadFile.ts
+++ b/api.planx.uk/modules/file/service/uploadFile.ts
@@ -1,4 +1,4 @@
-import S3 from "aws-sdk/clients/s3.js";
+import type S3 from "aws-sdk/clients/s3.js";
 import { customAlphabet } from "nanoid";
 import mime from "mime";
 import { s3Factory } from "./utils.js";

--- a/api.planx.uk/modules/flows/copyFlow/controller.ts
+++ b/api.planx.uk/modules/flows/copyFlow/controller.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
-import { Flow } from "../../../types.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { Flow } from "../../../types.js";
 import { ServerError } from "../../../errors/index.js";
 import { copyFlow } from "./service.js";
 

--- a/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import { authHeader } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
-import { Flow } from "../../../types.js";
+import type { Flow } from "../../../types.js";
 import { userContext } from "../../auth/middleware.js";
 
 beforeEach(() => {

--- a/api.planx.uk/modules/flows/copyFlowAsPortal/controller.ts
+++ b/api.planx.uk/modules/flows/copyFlowAsPortal/controller.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { Flow } from "../../../types.js";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { Flow } from "../../../types.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { copyPortalAsFlow } from "./service.js";
 import { ServerError } from "../../../errors/index.js";
 

--- a/api.planx.uk/modules/flows/copyFlowAsPortal/copyPortalAsFlow.test.ts
+++ b/api.planx.uk/modules/flows/copyFlowAsPortal/copyPortalAsFlow.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import { authHeader } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
-import { Flow } from "../../../types.js";
+import type { Flow } from "../../../types.js";
 
 beforeEach(() => {
   queryMock.mockQuery({

--- a/api.planx.uk/modules/flows/copyFlowAsPortal/service.ts
+++ b/api.planx.uk/modules/flows/copyFlowAsPortal/service.ts
@@ -1,5 +1,5 @@
 import { getFlowData, getChildren, makeUniqueFlow } from "../../../helpers.js";
-import { Flow } from "../../../types.js";
+import type { Flow } from "../../../types.js";
 
 /**
  * Copies an internal portal and transforms it to be an independent flow

--- a/api.planx.uk/modules/flows/downloadSchema/controller.ts
+++ b/api.planx.uk/modules/flows/downloadSchema/controller.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { stringify } from "csv-stringify";
 import { getFlowSchema } from "./service.js";
 import { ServerError } from "../../../errors/index.js";

--- a/api.planx.uk/modules/flows/findReplace/controller.ts
+++ b/api.planx.uk/modules/flows/findReplace/controller.ts
@@ -1,9 +1,9 @@
-import { Flow } from "../../../types.js";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { Flow } from "../../../types.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { z } from "zod";
 import { ServerError } from "../../../errors/index.js";
 import { findAndReplaceInFlow } from "./service.js";
-import { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 
 interface FindAndReplaceResponse {
   message: string;

--- a/api.planx.uk/modules/flows/findReplace/findReplace.test.ts
+++ b/api.planx.uk/modules/flows/findReplace/findReplace.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import { authHeader } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
-import { Flow } from "../../../types.js";
+import type { Flow } from "../../../types.js";
 
 const auth = authHeader({ role: "platformAdmin" });
 

--- a/api.planx.uk/modules/flows/findReplace/service.ts
+++ b/api.planx.uk/modules/flows/findReplace/service.ts
@@ -1,8 +1,8 @@
 import { gql } from "graphql-request";
 import { getFlowData } from "../../../helpers.js";
 import { $api } from "../../../client/index.js";
-import { FlowGraph } from "@opensystemslab/planx-core/types";
-import { Flow } from "../../../types.js";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { Flow } from "../../../types.js";
 
 interface MatchResult {
   matches: Flow["data"];

--- a/api.planx.uk/modules/flows/flattenFlow/controller.ts
+++ b/api.planx.uk/modules/flows/flattenFlow/controller.ts
@@ -1,7 +1,7 @@
-import { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { z } from "zod";
 import { ServerError } from "../../../errors/index.js";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { dataMerged } from "../../../helpers.js";
 
 type FlattenFlowDataResponse = FlowGraph;

--- a/api.planx.uk/modules/flows/moveFlow/controller.ts
+++ b/api.planx.uk/modules/flows/moveFlow/controller.ts
@@ -1,4 +1,4 @@
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { z } from "zod";
 import { ServerError } from "../../../errors/index.js";
 import { moveFlow } from "./service.js";

--- a/api.planx.uk/modules/flows/moveFlow/service.ts
+++ b/api.planx.uk/modules/flows/moveFlow/service.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-request";
-import { Flow } from "../../../types.js";
+import type { Flow } from "../../../types.js";
 import { getClient } from "../../../client/index.js";
-import { Team } from "@opensystemslab/planx-core/types";
+import type { Team } from "@opensystemslab/planx-core/types";
 
 export const moveFlow = async (flowId: string, teamSlug: string) => {
   const $client = getClient();

--- a/api.planx.uk/modules/flows/publish/controller.ts
+++ b/api.planx.uk/modules/flows/publish/controller.ts
@@ -1,5 +1,5 @@
-import { Node } from "@opensystemslab/planx-core/types";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { Node } from "@opensystemslab/planx-core/types";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { z } from "zod";
 import { publishFlow } from "./service.js";
 import { ServerError } from "../../../errors/index.js";

--- a/api.planx.uk/modules/flows/publish/service.ts
+++ b/api.planx.uk/modules/flows/publish/service.ts
@@ -1,7 +1,7 @@
 import * as jsondiffpatch from "jsondiffpatch";
 import { dataMerged, getMostRecentPublishedFlow } from "../../../helpers.js";
 import { gql } from "graphql-request";
-import { FlowGraph, Node } from "@opensystemslab/planx-core/types";
+import type { FlowGraph, Node } from "@opensystemslab/planx-core/types";
 import { userContext } from "../../auth/middleware.js";
 import { getClient } from "../../../client/index.js";
 

--- a/api.planx.uk/modules/flows/validate/controller.ts
+++ b/api.planx.uk/modules/flows/validate/controller.ts
@@ -1,5 +1,5 @@
-import { Node } from "@opensystemslab/planx-core/types";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { Node } from "@opensystemslab/planx-core/types";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { z } from "zod";
 import { validateAndDiffFlow } from "./service/index.js";
 import { ServerError } from "../../../errors/index.js";

--- a/api.planx.uk/modules/flows/validate/helpers.ts
+++ b/api.planx.uk/modules/flows/validate/helpers.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   ComponentType,
   FlowGraph,
   Node,
 } from "@opensystemslab/planx-core/types";
-import { Entry } from "type-fest";
+import type { Entry } from "type-fest";
 
 export const isComponentType = (
   entry: Entry<FlowGraph>,

--- a/api.planx.uk/modules/flows/validate/service/fileTypes.ts
+++ b/api.planx.uk/modules/flows/validate/service/fileTypes.ts
@@ -1,13 +1,10 @@
 import { getValidSchemaValues } from "@opensystemslab/planx-core";
-import {
-  ComponentType,
-  FlowGraph,
-  Node,
-} from "@opensystemslab/planx-core/types";
+import type { FlowGraph, Node } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 import countBy from "lodash/countBy.js";
 
 import { isComponentType } from "../helpers.js";
-import { FlowValidationResponse } from "./index.js";
+import type { FlowValidationResponse } from "./index.js";
 
 const validateFileTypes = (flowGraph: FlowGraph): FlowValidationResponse => {
   // Get all passport variables set by FileUpload and/or FileUploadAndLabel

--- a/api.planx.uk/modules/flows/validate/service/index.ts
+++ b/api.planx.uk/modules/flows/validate/service/index.ts
@@ -1,4 +1,8 @@
-import { ComponentType, Edges, Node } from "@opensystemslab/planx-core/types";
+import type {
+  ComponentType,
+  Edges,
+  Node,
+} from "@opensystemslab/planx-core/types";
 import * as jsondiffpatch from "jsondiffpatch";
 
 import { dataMerged, getMostRecentPublishedFlow } from "../../../../helpers.js";

--- a/api.planx.uk/modules/flows/validate/service/inviteToPay.ts
+++ b/api.planx.uk/modules/flows/validate/service/inviteToPay.ts
@@ -1,11 +1,12 @@
-import { ComponentType, FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 
 import {
   hasComponentType,
   isComponentType,
   numberOfComponentType,
 } from "../helpers.js";
-import { FlowValidationResponse } from "./index.js";
+import type { FlowValidationResponse } from "./index.js";
 
 const validateInviteToPay = (flowGraph: FlowGraph): FlowValidationResponse => {
   if (inviteToPayEnabled(flowGraph)) {

--- a/api.planx.uk/modules/flows/validate/service/projectTypes.ts
+++ b/api.planx.uk/modules/flows/validate/service/projectTypes.ts
@@ -1,9 +1,10 @@
 import { getValidSchemaValues } from "@opensystemslab/planx-core";
-import { ComponentType, FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 import countBy from "lodash/countBy.js";
 
 import { isComponentType } from "../helpers.js";
-import { FlowValidationResponse } from "./index.js";
+import type { FlowValidationResponse } from "./index.js";
 
 const validateProjectTypes = (flowGraph: FlowGraph): FlowValidationResponse => {
   // Get all passport values set by Answers of Checklists that set fn "proposal.projectType"

--- a/api.planx.uk/modules/flows/validate/service/sections.ts
+++ b/api.planx.uk/modules/flows/validate/service/sections.ts
@@ -1,8 +1,9 @@
-import { ComponentType, FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 import intersection from "lodash/intersection.js";
 
 import { isComponentType } from "../helpers.js";
-import { FlowValidationResponse } from "./index.js";
+import type { FlowValidationResponse } from "./index.js";
 
 const validateSections = (flowGraph: FlowGraph): FlowValidationResponse => {
   if (getSectionNodeIds(flowGraph)?.length > 0) {

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -5,7 +5,7 @@ import { authHeader, getJWT } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
 import { flowWithInviteToPay } from "../../../tests/mocks/inviteToPayData.js";
 import { userContext } from "../../auth/middleware.js";
-import { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { mockFlowData } from "../../../tests/mocks/validateAndPublishMocks.js";
 
 beforeAll(() => {

--- a/api.planx.uk/modules/gis/service/article4Schema.ts
+++ b/api.planx.uk/modules/gis/service/article4Schema.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 import { localAuthorityMetadata } from "./digitalLand.js";
 

--- a/api.planx.uk/modules/gis/service/classifiedRoads.ts
+++ b/api.planx.uk/modules/gis/service/classifiedRoads.ts
@@ -1,5 +1,5 @@
-import { Constraint, GISResponse } from "@opensystemslab/planx-core/types";
-import { NextFunction, Request, Response } from "express";
+import type { Constraint, GISResponse } from "@opensystemslab/planx-core/types";
+import type { NextFunction, Request, Response } from "express";
 import fetch from "isomorphic-fetch";
 
 type OSFeatures = {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/barkingAndDagenham.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/barkingAndDagenham.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/1UmxQ95SjU72j0KaVIIkrIfhdE_k_lcFNhUWBc53GEIA/edit#gid=0
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/barnet.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/barnet.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/1ZjqYdC7upA8YS9rBoyRIQPT1sqCXJBaxQDrvUh1todU/edit#gid=0
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/birmingham.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/birmingham.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/19t4DKDvyWix1Vf5huuQPVf9L8e6jcq1W/edit#gid=207440632
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/buckinghamshire.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/buckinghamshire.ts
@@ -9,7 +9,7 @@ https://environment.data.gov.uk/arcgis/rest/services
 https://inspire.wycombe.gov.uk/ (legacy)
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/camden.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/camden.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/1pFzq0cv_cwDx33d8QgRPVfIXtiseSxgmwQb6cORCVYs/edit#gid=0
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/canterbury.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/canterbury.ts
@@ -9,7 +9,7 @@ https://mapping.canterbury.gov.uk/arcgis/rest/services/
 https://environment.data.gov.uk/arcgis/rest/services
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/doncaster.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/doncaster.ts
@@ -8,7 +8,7 @@ https://maps.doncaster.gov.uk/portal/apps/webappviewer/index.html?id=2435bce5ee1
 https://www.doncaster.gov.uk/services/planning/houses-in-multiple-occupation-article-4-direction
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/epsomAndEwell.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/epsomAndEwell.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/1BzYZ_YvJjOrY2afxPGWbPvV2g_FLBr0H/edit#gid=125611981
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/gateshead.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/gateshead.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/13RdEvCfydfSx6R6p4S742xubOhfea-tvR3n95sYUpvs/edit#gid=0
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/gloucester.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/gloucester.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction&dataset=art
 https://docs.google.com/spreadsheets/d/1ALSH4hiupdUlrA7Rq7jhfHnWr0-PcB-IzhsztPLl7FY/edit?gid=0#gid=0
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/lambeth.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/lambeth.ts
@@ -9,7 +9,7 @@ https://gis.lambeth.gov.uk/arcgis/rest/services
 https://environment.data.gov.uk/arcgis/rest/services
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/medway.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/medway.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://trello.com/c/cpNv0iyO/42-input-your-article-4-direction-information-into-this-spreadsheet
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/newcastle.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/newcastle.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/1GhxQEuKeSnrchZ_quxg6Rg7fHEWPDUr7/edit#gid=915271261
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/southwark.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/southwark.ts
@@ -8,7 +8,7 @@ https://geo.southwark.gov.uk/connect/analyst/mobile/#/main
 https://environment.data.gov.uk/arcgis/rest/services
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/stAlbans.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/stAlbans.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/17qaNhd7M-F90KZ34kVjyetTxfxECf1QUU8UI-aUiknU/edit#gid=0
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/tewkesbury.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/tewkesbury.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/19VMxVhzIt3z1CcvlhELuUxablfbw40Ri/edit#gid=1979469480
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/westBerkshire.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/westBerkshire.ts
@@ -8,7 +8,7 @@ https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geomet
 https://docs.google.com/spreadsheets/d/1dRTb8xhcJgsQB8zIFregenm5aEzrZGU_/edit#gid=322896440
 */
 
-import { LocalAuthorityMetadata } from "../../digitalLand.js";
+import type { LocalAuthorityMetadata } from "../../digitalLand.js";
 
 const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   article4: {

--- a/api.planx.uk/modules/misc/controller.ts
+++ b/api.planx.uk/modules/misc/controller.ts
@@ -1,7 +1,7 @@
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 import { stringify } from "csv-stringify";
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 
 export const healthCheck: RequestHandler = (_req, res) =>
   res.json({ hello: "world" });

--- a/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -1,6 +1,6 @@
 import { useProxy } from "../../shared/middleware/proxy.js";
-import { NextFunction, Request, Response } from "express";
-import { IncomingMessage } from "http";
+import type { NextFunction, Request, Response } from "express";
+import type { IncomingMessage } from "http";
 
 export const OS_DOMAIN = "https://api.os.uk";
 

--- a/api.planx.uk/modules/ordnanceSurvey/ordnanceSurvey.test.ts
+++ b/api.planx.uk/modules/ordnanceSurvey/ordnanceSurvey.test.ts
@@ -1,4 +1,4 @@
-import { Request } from "express";
+import type { Request } from "express";
 import nock from "nock";
 import supertest from "supertest";
 import app from "../../server.js";

--- a/api.planx.uk/modules/pay/controller.ts
+++ b/api.planx.uk/modules/pay/controller.ts
@@ -1,16 +1,19 @@
 import assert from "assert";
-import { Request } from "express";
+import type { Request } from "express";
 import { responseInterceptor } from "http-proxy-middleware";
 import { handleGovPayErrors, logPaymentStatus } from "./helpers.js";
 import { usePayProxy } from "./proxy.js";
 import { $api } from "../../client/index.js";
 import { ServerError } from "../../errors/index.js";
-import { GovUKPayment, PaymentRequest } from "@opensystemslab/planx-core/types";
+import type {
+  GovUKPayment,
+  PaymentRequest,
+} from "@opensystemslab/planx-core/types";
 import {
   addGovPayPaymentIdToPaymentRequest,
   postPaymentNotificationToSlack,
 } from "./service/utils.js";
-import {
+import type {
   InviteToPayController,
   PaymentProxyController,
   PaymentRequestProxyController,

--- a/api.planx.uk/modules/pay/middleware.ts
+++ b/api.planx.uk/modules/pay/middleware.ts
@@ -1,10 +1,10 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { gql } from "graphql-request";
 import { $api } from "../../client/index.js";
 import { ServerError } from "../../errors/index.js";
-import { GovPayMetadata } from "./types.js";
+import type { GovPayMetadata } from "./types.js";
 import { formatGovPayMetadata } from "@opensystemslab/planx-core";
-import {
+import type {
   GovPayMetadataValue,
   Passport,
 } from "@opensystemslab/planx-core/types";

--- a/api.planx.uk/modules/pay/proxy.ts
+++ b/api.planx.uk/modules/pay/proxy.ts
@@ -1,5 +1,6 @@
-import { Response, Request } from "express";
-import { fixRequestBody, Options } from "http-proxy-middleware";
+import type { Response, Request } from "express";
+import type { Options } from "http-proxy-middleware";
+import { fixRequestBody } from "http-proxy-middleware";
 import { useProxy } from "../../shared/middleware/proxy.js";
 
 export const usePayProxy = (

--- a/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.test.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.test.ts
@@ -3,7 +3,7 @@ import app from "../../../../server.js";
 import { createScheduledEvent } from "../../../../lib/hasura/metadata/index.js";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
 import { flowWithInviteToPay } from "../../../../tests/mocks/inviteToPayData.js";
-import { MockedFunction } from "vitest";
+import type { MockedFunction } from "vitest";
 
 vi.mock("../../../../lib/hasura/metadata");
 const mockedCreateScheduledEvent = createScheduledEvent as MockedFunction<

--- a/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/createPaymentSendEvents.ts
@@ -1,13 +1,12 @@
-import { ComponentType, Team } from "@opensystemslab/planx-core/types";
-import { NextFunction, Request, Response } from "express";
+import type { Team } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
+import type { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
-import {
-  CombinedResponse,
-  createScheduledEvent,
-} from "../../../../lib/hasura/metadata/index.js";
+import type { CombinedResponse } from "../../../../lib/hasura/metadata/index.js";
+import { createScheduledEvent } from "../../../../lib/hasura/metadata/index.js";
 import { $api, $public } from "../../../../client/index.js";
 import { getMostRecentPublishedFlow } from "../../../../helpers.js";
-import { Flow, Node } from "../../../../types.js";
+import type { Flow, Node } from "../../../../types.js";
 
 enum Destination {
   BOPS = "bops",

--- a/api.planx.uk/modules/pay/service/inviteToPay/paymentRequest.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/paymentRequest.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-request";
-import { Request } from "express";
+import type { Request } from "express";
 import { fetchPaymentViaProxyWithCallback } from "../../controller.js";
-import { GovUKPayment } from "@opensystemslab/planx-core/types";
+import type { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { $api } from "../../../../client/index.js";
 import { postPaymentNotificationToSlack } from "../utils.js";
 

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -1,12 +1,12 @@
 import { formatRawProjectTypes } from "@opensystemslab/planx-core";
 import type { PaymentRequest, Team } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
+import type { Template } from "../../../../lib/notify/index.js";
 import {
-  Template,
   getClientForTemplate,
   sendEmail,
 } from "../../../../lib/notify/index.js";
-import { InviteToPayNotifyConfig } from "../../../../types.js";
+import type { InviteToPayNotifyConfig } from "../../../../types.js";
 import {
   calculateExpiryDate,
   getServiceLink,

--- a/api.planx.uk/modules/pay/service/utils.test.ts
+++ b/api.planx.uk/modules/pay/service/utils.test.ts
@@ -1,4 +1,4 @@
-import { GovUKPayment } from "@opensystemslab/planx-core/types";
+import type { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { isTestPayment } from "./utils.js";
 
 describe("isTestPayment() helper function", () => {

--- a/api.planx.uk/modules/pay/service/utils.ts
+++ b/api.planx.uk/modules/pay/service/utils.ts
@@ -1,9 +1,9 @@
-import { GovUKPayment } from "@opensystemslab/planx-core/types";
+import type { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { $api } from "../../../client/index.js";
 import { gql } from "graphql-request";
 
 import SlackNotify from "slack-notify";
-import { Request } from "express";
+import type { Request } from "express";
 
 export const addGovPayPaymentIdToPaymentRequest = async (
   paymentRequestId: string,

--- a/api.planx.uk/modules/pay/types.ts
+++ b/api.planx.uk/modules/pay/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
-import { PaymentRequest } from "@opensystemslab/planx-core/types";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { PaymentRequest } from "@opensystemslab/planx-core/types";
 
 export const paymentProxySchema = z.object({
   query: z.object({

--- a/api.planx.uk/modules/saveAndReturn/controller.ts
+++ b/api.planx.uk/modules/saveAndReturn/controller.ts
@@ -1,6 +1,6 @@
 import { resumeApplication } from "./service/resumeApplication.js";
 import { findSession, validateSession } from "./service/validateSession.js";
-import { ResumeApplication, ValidateSessionController } from "./types.js";
+import type { ResumeApplication, ValidateSessionController } from "./types.js";
 
 export const validateSessionController: ValidateSessionController = async (
   _req,

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
@@ -1,4 +1,4 @@
-import { LowCalSession } from "../../../types.js";
+import type { LowCalSession } from "../../../types.js";
 import supertest from "supertest";
 import app from "../../../server.js";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
@@ -7,8 +7,8 @@ import {
   mockTeam,
 } from "../../../tests/mocks/saveAndReturnMocks.js";
 import { buildContentFromSessions } from "./resumeApplication.js";
-import { PartialDeep } from "type-fest";
-import { Team } from "@opensystemslab/planx-core/types";
+import type { PartialDeep } from "type-fest";
+import type { Team } from "@opensystemslab/planx-core/types";
 
 const ENDPOINT = "/resume-application";
 const TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk";

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
@@ -5,7 +5,7 @@ import { gql } from "graphql-request";
 
 import { $api } from "../../../client/index.js";
 import { sendEmail } from "../../../lib/notify/index.js";
-import { LowCalSession } from "../../../types.js";
+import type { LowCalSession } from "../../../types.js";
 import {
   DAYS_UNTIL_EXPIRY,
   calculateExpiryDate,

--- a/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
@@ -1,6 +1,6 @@
-import { Team } from "@opensystemslab/planx-core/types";
+import type { Team } from "@opensystemslab/planx-core/types";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
-import { LowCalSession, LowCalSessionData } from "../../../types.js";
+import type { LowCalSession, LowCalSessionData } from "../../../types.js";
 import {
   getResumeLink,
   getSessionDetails,

--- a/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -1,15 +1,12 @@
 import { formatRawProjectTypes } from "@opensystemslab/planx-core";
-import { SiteAddress, Team } from "@opensystemslab/planx-core/types";
+import type { SiteAddress, Team } from "@opensystemslab/planx-core/types";
 import { addDays, format } from "date-fns";
 import { gql } from "graphql-request";
 
 import { $api } from "../../../client/index.js";
-import {
-  Template,
-  getClientForTemplate,
-  sendEmail,
-} from "../../../lib/notify/index.js";
-import { LowCalSession } from "../../../types.js";
+import type { Template } from "../../../lib/notify/index.js";
+import { getClientForTemplate, sendEmail } from "../../../lib/notify/index.js";
+import type { LowCalSession } from "../../../types.js";
 
 const DAYS_UNTIL_EXPIRY = 28;
 const REMINDER_DAYS_FROM_EXPIRY = [7, 1];

--- a/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
@@ -15,7 +15,7 @@ import type {
   Node,
 } from "../../../types.js";
 import { $api } from "../../../client/index.js";
-import { ValidationResponse } from "../types.js";
+import type { ValidationResponse } from "../types.js";
 
 export type ReconciledSession = {
   alteredSectionIds: Array<string>;

--- a/api.planx.uk/modules/saveAndReturn/types.ts
+++ b/api.planx.uk/modules/saveAndReturn/types.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
-import { LowCalSessionData } from "../../types.js";
-import { PaymentRequest } from "@opensystemslab/planx-core/types";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { LowCalSessionData } from "../../types.js";
+import type { PaymentRequest } from "@opensystemslab/planx-core/types";
 
 interface ResumeApplicationResponse {
   message: string;

--- a/api.planx.uk/modules/send/bops/bops.test.ts
+++ b/api.planx.uk/modules/send/bops/bops.test.ts
@@ -1,5 +1,6 @@
 import nock from "nock";
 import supertest from "supertest";
+import type planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import app from "../../../server.js";
 import { expectedPlanningPermissionPayload } from "../../../tests/mocks/digitalPlanningDataMocks.js";
@@ -9,8 +10,7 @@ vi.mock("../../saveAndReturn/service/utils", () => ({
 }));
 
 vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const actualCore =
-    await importOriginal<typeof import("@opensystemslab/planx-core")>();
+  const actualCore = await importOriginal<typeof planxCore>();
   const actualCoreDomainClient = actualCore.CoreDomainClient;
 
   return {

--- a/api.planx.uk/modules/send/bops/bops.ts
+++ b/api.planx.uk/modules/send/bops/bops.ts
@@ -1,6 +1,7 @@
-import axios, { AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
+import axios from "axios";
 import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils.js";
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 import { $api } from "../../../client/index.js";
 import { ServerError } from "../../../errors/index.js";

--- a/api.planx.uk/modules/send/createSendEvents/controller.ts
+++ b/api.planx.uk/modules/send/createSendEvents/controller.ts
@@ -1,8 +1,6 @@
-import {
-  CombinedResponse,
-  createScheduledEvent,
-} from "../../../lib/hasura/metadata/index.js";
-import { CreateSendEventsController } from "./types.js";
+import type { CombinedResponse } from "../../../lib/hasura/metadata/index.js";
+import { createScheduledEvent } from "../../../lib/hasura/metadata/index.js";
+import type { CreateSendEventsController } from "./types.js";
 
 // Create "One-off Scheduled Events" in Hasura from Send component for selected destinations
 const createSendEvents: CreateSendEventsController = async (

--- a/api.planx.uk/modules/send/createSendEvents/types.ts
+++ b/api.planx.uk/modules/send/createSendEvents/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { CombinedResponse } from "../../../lib/hasura/metadata/index.js";
-import { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import type { CombinedResponse } from "../../../lib/hasura/metadata/index.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 
 const eventSchema = z.object({
   localAuthority: z.string(),

--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -1,4 +1,5 @@
 import supertest from "supertest";
+import type planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import app from "../../../server.js";
 
@@ -11,8 +12,7 @@ const mockGenerateCSVData = vi.fn().mockResolvedValue([
 ]);
 
 vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const actualCore =
-    await importOriginal<typeof import("@opensystemslab/planx-core")>();
+  const actualCore = await importOriginal<typeof planxCore>();
   const actualCoreDomainClient = actualCore.CoreDomainClient;
 
   return {

--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { sendEmail } from "../../../lib/notify/index.js";
-import { EmailSubmissionNotifyConfig } from "../../../types.js";
+import type { EmailSubmissionNotifyConfig } from "../../../types.js";
 import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils.js";
 import {
   getSessionEmailDetailsById,

--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -1,7 +1,10 @@
 import { gql } from "graphql-request";
 import { $api } from "../../../client/index.js";
-import { Session, TeamContactSettings } from "@opensystemslab/planx-core/types";
-import { EmailSubmissionNotifyConfig } from "../../../types.js";
+import type {
+  Session,
+  TeamContactSettings,
+} from "@opensystemslab/planx-core/types";
+import type { EmailSubmissionNotifyConfig } from "../../../types.js";
 
 interface GetTeamEmailSettings {
   teams: {

--- a/api.planx.uk/modules/send/idox/nexus.ts
+++ b/api.planx.uk/modules/send/idox/nexus.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosRequestConfig, isAxiosError } from "axios";
-import { NextFunction, Request, Response } from "express";
+import type { AxiosRequestConfig } from "axios";
+import axios, { isAxiosError } from "axios";
+import type { NextFunction, Request, Response } from "express";
 import FormData from "form-data";
 import fs from "fs";
 import { gql } from "graphql-request";

--- a/api.planx.uk/modules/send/s3/index.test.ts
+++ b/api.planx.uk/modules/send/s3/index.test.ts
@@ -1,4 +1,5 @@
 import supertest from "supertest";
+import type planxCore from "@opensystemslab/planx-core";
 import app from "../../../server.js";
 import { expectedPlanningPermissionPayload } from "../../../tests/mocks/digitalPlanningDataMocks.js";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
@@ -8,8 +9,7 @@ vi.mock("../../saveAndReturn/service/utils", () => ({
 }));
 
 vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const actualCore =
-    await importOriginal<typeof import("@opensystemslab/planx-core")>();
+  const actualCore = await importOriginal<typeof planxCore>();
   const actualCoreDomainClient = actualCore.CoreDomainClient;
 
   return {

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -1,9 +1,10 @@
-import axios, { AxiosRequestConfig } from "axios";
+import type { AxiosRequestConfig } from "axios";
+import axios from "axios";
 import type { NextFunction, Request, Response } from "express";
 import { gql } from "graphql-request";
 
 import { $api } from "../../../client/index.js";
-import { Passport } from "../../../types.js";
+import type { Passport } from "../../../types.js";
 import { uploadPrivateFile } from "../../file/service/uploadFile.js";
 import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils.js";
 import { isApplicationTypeSupported } from "../utils/helpers.js";

--- a/api.planx.uk/modules/send/uniform/uniform.ts
+++ b/api.planx.uk/modules/send/uniform/uniform.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosRequestConfig, isAxiosError } from "axios";
-import { NextFunction, Request, Response } from "express";
+import type { AxiosRequestConfig } from "axios";
+import axios, { isAxiosError } from "axios";
+import type { NextFunction, Request, Response } from "express";
 import FormData from "form-data";
 import fs from "fs";
 import { gql } from "graphql-request";

--- a/api.planx.uk/modules/send/utils/helpers.ts
+++ b/api.planx.uk/modules/send/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Passport } from "../../../types.js";
+import type { Passport } from "../../../types.js";
 
 /**
  * Checks whether a session's passport data includes an application type supported by the ODP Schema

--- a/api.planx.uk/modules/sendEmail/controller.ts
+++ b/api.planx.uk/modules/sendEmail/controller.ts
@@ -4,8 +4,8 @@ import {
 } from "../pay/service/inviteToPay/index.js";
 import { sendSingleApplicationEmail } from "../saveAndReturn/service/utils.js";
 import { ServerError } from "../../errors/index.js";
-import { NextFunction } from "express";
-import {
+import type { NextFunction } from "express";
+import type {
   ConfirmationEmail,
   PaymentEmail,
   SingleApplicationEmail,

--- a/api.planx.uk/modules/sendEmail/types.ts
+++ b/api.planx.uk/modules/sendEmail/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 
 interface SendEmailResponse {
   message: string;

--- a/api.planx.uk/modules/slack/controller.ts
+++ b/api.planx.uk/modules/slack/controller.ts
@@ -1,7 +1,7 @@
 import SlackNotify from "slack-notify";
 import { z } from "zod";
 import { ServerError } from "../../errors/index.js";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 
 interface SendSlackNotificationResponse {
   message: string;

--- a/api.planx.uk/modules/team/controller.ts
+++ b/api.planx.uk/modules/team/controller.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 import { ServerError } from "../../errors/index.js";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 import * as Service from "./service.js";
 
 interface TeamMemberResponse {

--- a/api.planx.uk/modules/team/service.ts
+++ b/api.planx.uk/modules/team/service.ts
@@ -1,5 +1,5 @@
 import { getClient } from "../../client/index.js";
-import { TeamRole } from "@opensystemslab/planx-core/types";
+import type { TeamRole } from "@opensystemslab/planx-core/types";
 
 interface UpsertMember {
   userEmail: string;

--- a/api.planx.uk/modules/test/controller.ts
+++ b/api.planx.uk/modules/test/controller.ts
@@ -1,4 +1,4 @@
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 export const testSessionMethods: RequestHandler = (req, res) => {
   const hasRegenerate = typeof req.session?.regenerate === "function";

--- a/api.planx.uk/modules/user/controller.ts
+++ b/api.planx.uk/modules/user/controller.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 import { getClient } from "../../client/index.js";
 import { ServerError } from "../../errors/index.js";
-import { RequestHandler } from "express";
-import { User } from "@opensystemslab/planx-core/types";
+import type { RequestHandler } from "express";
+import type { User } from "@opensystemslab/planx-core/types";
 import { userContext } from "../auth/middleware.js";
 
 interface UserResponse {

--- a/api.planx.uk/modules/webhooks/controller.ts
+++ b/api.planx.uk/modules/webhooks/controller.ts
@@ -1,20 +1,20 @@
 import { ServerError } from ".././../errors/index.js";
-import { CreateSessionEventController } from "./service/lowcalSessionEvents/schema.js";
+import type { CreateSessionEventController } from "./service/lowcalSessionEvents/schema.js";
 import {
   createSessionExpiryEvent,
   createSessionReminderEvent,
 } from "./service/lowcalSessionEvents/index.js";
-import { SendSlackNotification } from "./service/sendNotification/types.js";
+import type { SendSlackNotification } from "./service/sendNotification/types.js";
 import { sendSlackNotification } from "./service/sendNotification/index.js";
-import { CreatePaymentEventController } from "./service/paymentRequestEvents/schema.js";
+import type { CreatePaymentEventController } from "./service/paymentRequestEvents/schema.js";
 import {
   createPaymentExpiryEvents,
   createPaymentInvitationEvents,
   createPaymentReminderEvents,
 } from "./service/paymentRequestEvents/index.js";
-import { SanitiseApplicationData } from "./service/sanitiseApplicationData/types.js";
+import type { SanitiseApplicationData } from "./service/sanitiseApplicationData/types.js";
 import { sanitiseApplicationData } from "./service/sanitiseApplicationData/index.js";
-import { IsCleanJSONBController } from "./service/validateInput/schema.js";
+import type { IsCleanJSONBController } from "./service/validateInput/schema.js";
 import { analyzeSessions } from "./service/analyzeSessions/index.js";
 
 export const sendSlackNotificationController: SendSlackNotification = async (

--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/index.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/index.ts
@@ -1,6 +1,6 @@
 import { postToSlack } from "../sanitiseApplicationData/index.js";
 import { operationHandler } from "../sanitiseApplicationData/operations.js";
-import { OperationResult } from "../sanitiseApplicationData/types.js";
+import type { OperationResult } from "../sanitiseApplicationData/types.js";
 import { getAnalyzeSessionOperations } from "./operations.js";
 
 /**

--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.test.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.test.ts
@@ -1,5 +1,5 @@
+import type planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
-
 import {
   getSubmittedUnAnalyzedSessionIds,
   updateLowcalSessionAllowListAnswers,
@@ -9,8 +9,7 @@ vi.mock("../../../../lib/hasura/schema");
 const mockFindSession = vi.fn();
 
 vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const actualCore =
-    await importOriginal<typeof import("@opensystemslab/planx-core")>();
+  const actualCore = await importOriginal<typeof planxCore>();
   const actualCoreDomainClient = actualCore.CoreDomainClient;
   const actualPassport = actualCore.Passport;
 

--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
@@ -2,7 +2,7 @@ import { gql } from "graphql-request";
 
 import { Passport } from "@opensystemslab/planx-core";
 import { $api } from "../../../../client/index.js";
-import { Operation } from "../sanitiseApplicationData/types.js";
+import type { Operation } from "../sanitiseApplicationData/types.js";
 
 /**
  * ALLOW_LIST should stay in sync with

--- a/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/index.test.ts
+++ b/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/index.test.ts
@@ -1,7 +1,7 @@
 import supertest from "supertest";
 import app from "../../../../server.js";
 import { createScheduledEvent } from "../../../../lib/hasura/metadata/index.js";
-import { MockedFunction } from "vitest";
+import type { MockedFunction } from "vitest";
 
 const { post } = supertest(app);
 

--- a/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/index.ts
+++ b/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/index.ts
@@ -5,7 +5,7 @@ import {
   DAYS_UNTIL_EXPIRY,
   REMINDER_DAYS_FROM_EXPIRY,
 } from "../../../saveAndReturn/service/utils.js";
-import { CreateSessionEvent } from "./schema.js";
+import type { CreateSessionEvent } from "./schema.js";
 
 /**
  * Create "reminder" events for a lowcal_session record

--- a/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/lowcalSessionEvents/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
-import { ScheduledEventResponse } from "../../../../lib/hasura/metadata/index.js";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import type { ScheduledEventResponse } from "../../../../lib/hasura/metadata/index.js";
 
 export const createSessionEventSchema = z.object({
   body: z.object({

--- a/api.planx.uk/modules/webhooks/service/paymentRequestEvents/index.test.ts
+++ b/api.planx.uk/modules/webhooks/service/paymentRequestEvents/index.test.ts
@@ -1,8 +1,8 @@
 import supertest from "supertest";
 import app from "../../../../server.js";
 import { createScheduledEvent } from "../../../../lib/hasura/metadata/index.js";
-import { CreatePaymentEvent } from "./schema.js";
-import { MockedFunction } from "vitest";
+import type { CreatePaymentEvent } from "./schema.js";
+import type { MockedFunction } from "vitest";
 
 const { post } = supertest(app);
 

--- a/api.planx.uk/modules/webhooks/service/paymentRequestEvents/index.ts
+++ b/api.planx.uk/modules/webhooks/service/paymentRequestEvents/index.ts
@@ -5,7 +5,7 @@ import {
   DAYS_UNTIL_EXPIRY,
   REMINDER_DAYS_FROM_EXPIRY,
 } from "../../../saveAndReturn/service/utils.js";
-import { CreatePaymentEvent } from "./schema.js";
+import type { CreatePaymentEvent } from "./schema.js";
 
 /**
  * Create two "invitation" events for a payments_request record: one for the nominee and one for the agent

--- a/api.planx.uk/modules/webhooks/service/paymentRequestEvents/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/paymentRequestEvents/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
-import { ScheduledEventResponse } from "../../../../lib/hasura/metadata/index.js";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import type { ScheduledEventResponse } from "../../../../lib/hasura/metadata/index.js";
 
 export const createPaymentEventSchema = z.object({
   body: z.object({

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
@@ -1,7 +1,7 @@
 import SlackNotify from "slack-notify";
 
 import { getOperations, operationHandler } from "./operations.js";
-import { OperationResult } from "./types.js";
+import type { OperationResult } from "./types.js";
 import { getFormattedEnvironment } from "../../../../helpers.js";
 
 /**

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
@@ -1,3 +1,4 @@
+import type planxCore from "@opensystemslab/planx-core";
 import { runSQL } from "../../../../lib/hasura/schema/index.js";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
 import {
@@ -26,7 +27,7 @@ import {
   deleteHasuraScheduledEventsForSubmittedSessions,
   deleteFeedback,
 } from "./operations.js";
-import { MockedFunction } from "vitest";
+import type { MockedFunction } from "vitest";
 
 vi.mock("../../../../lib/hasura/schema");
 const mockRunSQL = runSQL as MockedFunction<typeof runSQL>;
@@ -34,8 +35,7 @@ const mockRunSQL = runSQL as MockedFunction<typeof runSQL>;
 const mockFindSession = vi.fn();
 
 vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const actualCore =
-    await importOriginal<typeof import("@opensystemslab/planx-core")>();
+  const actualCore = await importOriginal<typeof planxCore>();
   const actualCoreDomainClient = actualCore.CoreDomainClient;
   const actualPassport = actualCore.Passport;
 

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-request";
 import { subMonths } from "date-fns";
 
-import { Operation, OperationResult, QueryResult } from "./types.js";
+import type { Operation, OperationResult, QueryResult } from "./types.js";
 import { runSQL } from "../../../../lib/hasura/schema/index.js";
 import { deleteFilesByURL } from "../../../file/service/deleteFile.js";
 import { $api } from "../../../../client/index.js";

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/types.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/types.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import type { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
 
 export interface OperationResult {
   operationName: string;

--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
@@ -1,7 +1,7 @@
 import supertest from "supertest";
 import app from "../../../../server.js";
 import SlackNotify from "slack-notify";
-import { BOPSBody, EmailBody, S3Body, UniformBody } from "./types.js";
+import type { BOPSBody, EmailBody, S3Body, UniformBody } from "./types.js";
 import { $api } from "../../../../client/index.js";
 
 const mockSessionWithFee = {

--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -1,6 +1,6 @@
 import { Passport } from "@opensystemslab/planx-core";
 import SlackNotify from "slack-notify";
-import {
+import type {
   BOPSEventData,
   EmailEventData,
   EventData,

--- a/api.planx.uk/modules/webhooks/service/sendNotification/types.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/types.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
-import {
+import type { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import type {
   bopsSubmissionSchema,
   emailSubmissionSchema,
   s3SubmissionSchema,

--- a/api.planx.uk/modules/webhooks/service/validateInput/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/validateInput/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
 import { isCleanHTML, isObjectValid } from "./utils.js";
 
 // Definition: https://hasura.io/docs/latest/schema/postgres/input-validations/#response

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -53,7 +53,6 @@
     "string-to-stream": "^3.0.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",
-    "ts-node": "^10.9.2",
     "type-fest": "^4.18.1",
     "zod": "^3.23.5"
   },

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -139,9 +139,6 @@ dependencies:
   swagger-ui-express:
     specifier: ^5.0.0
     version: 5.0.0(express@4.21.0)
-  ts-node:
-    specifier: ^10.9.2
-    version: 10.9.2(@types/node@18.19.13)(typescript@5.5.2)
   type-fest:
     specifier: ^4.18.1
     version: 4.18.1
@@ -667,13 +664,6 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@cspotcode/source-map-support@0.8.1:
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
-    dev: false
-
   /@emotion/babel-plugin@11.12.0:
     resolution: {integrity: sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==}
     dependencies:
@@ -1163,13 +1153,6 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  /@jridgewell/trace-mapping@0.3.9:
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
-    dev: false
-
   /@jsdevtools/ono@7.1.3:
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
     dev: false
@@ -1505,22 +1488,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@tsconfig/node10@1.0.11:
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
-    dev: false
-
-  /@tsconfig/node12@1.0.11:
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-    dev: false
-
-  /@tsconfig/node14@1.0.3:
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-    dev: false
-
-  /@tsconfig/node16@1.0.4:
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-    dev: false
 
   /@types/adm-zip@0.5.0:
     resolution: {integrity: sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==}
@@ -2075,13 +2042,6 @@ packages:
     dependencies:
       acorn: 8.12.1
 
-  /acorn-walk@8.3.3:
-    resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
-    engines: {node: '>=0.4.0'}
-    dependencies:
-      acorn: 8.12.1
-    dev: false
-
   /acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
@@ -2166,10 +2126,6 @@ packages:
 
   /append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
-    dev: false
-
-  /arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: false
 
   /argparse@2.0.1:
@@ -2634,10 +2590,6 @@ packages:
       yaml: 1.10.2
     dev: false
 
-  /create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-    dev: false
-
   /cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
     dependencies:
@@ -2812,11 +2764,6 @@ packages:
     resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
     engines: {node: '>=0.3.1'}
     dev: true
-
-  /diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -4326,10 +4273,6 @@ packages:
       semver: 7.6.3
     dev: true
 
-  /make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-    dev: false
-
   /marked@14.1.2:
     resolution: {integrity: sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==}
     engines: {node: '>= 18'}
@@ -5695,37 +5638,6 @@ packages:
     dependencies:
       punycode: 2.3.1
 
-  /ts-node@10.9.2(@types/node@18.19.13)(typescript@5.5.2):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.13
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.5.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: false
-
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
@@ -5801,6 +5713,7 @@ packages:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /uid2@0.0.4:
     resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
@@ -5883,10 +5796,6 @@ packages:
   /uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
     hasBin: true
-    dev: false
-
-  /v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: false
 
   /validator@13.12.0:
@@ -6202,11 +6111,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-    dev: false
-
-  /yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
     dev: false
 
   /yocto-queue@0.1.0:

--- a/api.planx.uk/rateLimit.ts
+++ b/api.planx.uk/rateLimit.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 
 // Broad limiter to prevent egregious abuse

--- a/api.planx.uk/server.ts
+++ b/api.planx.uk/server.ts
@@ -1,12 +1,12 @@
-import { Role } from "@opensystemslab/planx-core/types";
+import type { Role } from "@opensystemslab/planx-core/types";
 import assert from "assert";
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
 import cookieSession from "cookie-session";
-import cors, { CorsOptions } from "cors";
-import express from "express";
+import type { CorsOptions } from "cors";
+import cors from "cors";
 import type { ErrorRequestHandler, Request } from "express";
-import "express-async-errors";
+import express from "express";
 import pinoLogger from "express-pino-logger";
 import helmet from "helmet";
 import { Server, type IncomingMessage } from "http";

--- a/api.planx.uk/session.ts
+++ b/api.planx.uk/session.ts
@@ -1,4 +1,4 @@
-import { RequestHandler } from "http-proxy-middleware";
+import type { RequestHandler } from "http-proxy-middleware";
 
 // this middleware registers dummy methods on req.session to resolve passport/cookie-session incompatibility
 export const registerSessionStubs: RequestHandler = (req, _res, next): void => {

--- a/api.planx.uk/shared/middleware/proxy.ts
+++ b/api.planx.uk/shared/middleware/proxy.ts
@@ -1,4 +1,5 @@
-import { createProxyMiddleware, Options } from "http-proxy-middleware";
+import type { Options } from "http-proxy-middleware";
+import { createProxyMiddleware } from "http-proxy-middleware";
 
 // debug, info, warn, error, silent
 const LOG_LEVEL = process.env.NODE_ENV === "test" ? "silent" : "debug";

--- a/api.planx.uk/shared/middleware/validate.ts
+++ b/api.planx.uk/shared/middleware/validate.ts
@@ -1,5 +1,5 @@
-import { Request, RequestHandler, Response, NextFunction } from "express";
-import { z } from "zod";
+import type { Request, RequestHandler, Response, NextFunction } from "express";
+import type { z } from "zod";
 
 /**
  * Middleware to validate incoming requests to the API

--- a/api.planx.uk/tests/mockJWT.ts
+++ b/api.planx.uk/tests/mockJWT.ts
@@ -1,4 +1,4 @@
-import { Role } from "@opensystemslab/planx-core/types";
+import type { Role } from "@opensystemslab/planx-core/types";
 import { sign } from "jsonwebtoken";
 
 function getJWT({ role }: { role: Role }) {

--- a/api.planx.uk/tests/mocks/flattenPortals.ts
+++ b/api.planx.uk/tests/mocks/flattenPortals.ts
@@ -1,4 +1,4 @@
-import { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 
 export const mockDraftParent: FlowGraph = {
   _root: {

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -3,7 +3,7 @@ import type {
   PaymentRequest,
   FlowGraph,
 } from "@opensystemslab/planx-core/types";
-import { Flow } from "../../types.js";
+import type { Flow } from "../../types.js";
 
 export const validEmail = "the-payee@opensystemslab.io";
 

--- a/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidV4 } from "uuid";
 import type { LowCalSession, Flow } from "../../types.js";
-import { Team } from "@opensystemslab/planx-core/types";
+import type { Team } from "@opensystemslab/planx-core/types";
 
 export const mockTeam = {
   id: 1,

--- a/api.planx.uk/tests/mocks/validateAndPublishMocks.ts
+++ b/api.planx.uk/tests/mocks/validateAndPublishMocks.ts
@@ -1,4 +1,4 @@
-import { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 
 export const mockFlowData: FlowGraph = {
   _root: {

--- a/api.planx.uk/tsconfig.json
+++ b/api.planx.uk/tsconfig.json
@@ -16,8 +16,7 @@
     "target": "esnext",
     "types": ["vitest/globals"],
     // ensure the code is ready for per-file transpilation by tsx (used in dev mode)
-    "isolatedModules": true,
-    // TODO: implement "verbatimModuleSyntax" option (laborious)
+    "verbatimModuleSyntax": true,
   },
   "exclude": ["node_modules", "dist"],
 }

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   GovUKPayment,
   Team,
   PaymentRequest,


### PR DESCRIPTION
This PR ~is currently~ was serving a purpose (as a rebase platform) in troubleshooting errors with Jest in #3453 (I explain my findings below), but it may also be worth merging at some point on its own merit.

The majority of the actual `import ...` fixes were done automatically using the [`consistent-type-imports` eslint rule](https://typescript-eslint.io/rules/consistent-type-imports/). I note that the typescript-eslint folks [don't recommend](https://typescript-eslint.io/rules/consistent-type-imports/#comparison-with-importsnotusedasvalues--verbatimmodulesyntax) using `verbatimModuleSyntax` and this rule together, but I'm not sure I'm convinced. I think any conflict here is outweighed by the value of being able to autofix lints? But open to being wrong!

If we'd rather bin the new eslint rule, it has largely served its purpose in automating the initial round of fixes, and TypeScript should flag any new failure to adhere to `verbatimModuleSyntax` in-IDE anyway, so it's not a significant loss.

## Exploration

See the _No transformations between module systems_ section [here](https://github.com/microsoft/TypeScript/issues/51479) for an important corollary of imposing [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) (which was introduced in TS v5 and implies `isolatedModules`, `importsNotUsedAsValues` and `preserveValueImports`, the latter two of which are thereafter deprecated):

> ESM syntax cannot be used in files that will emit CommonJS syntax.

More than any other switch I can throw, this change seems to cause TypeScript to aggressively enforce that *every module* is ESM-compliant, or else it will throw an error.

This is exactly why I have to add the `ts-node` options to `tsconfig.json`, and adapt the `tsconfig.test.json` which the `jest.config.ts` reads. As per [this comment](https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1503684089), both tools will error out if they abide by the `"verbatimModuleSyntax": true` option in the root tsconfig.

That is, if we comment out `"verbatimModuleSyntax": false` in the `ts-node` specific compiler options in `tsconfig.json`, we get the following instead:

```
Error: Jest: Failed to parse the TypeScript config file /home/dan/code/planx-new/api.planx.uk/jest.config.ts
  TSError: ⨯ Unable to compile TypeScript:
jest.config.ts:49:1 - error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.

49 export default config;
```

The thing to understand here is that Jest uses `ts-node` to transpile the `jest.config.ts` file into JS in order to parse it, and it [instructs ts-node to consider all files as commonJS](https://github.com/jestjs/jest/blob/0d96de975783ee78192c1037862ea3089f52dc25/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L146), in a way which is difficult to overwrite from tsconfig.

This is not too much of a problem - `ts-node` is only used for this specific purpose, and we can probably stand one file being interpreted as cjs for the sole purpose of initiating tests. After the config is read in, Jest takes over, and the first thing is does it try to transform all files into JS using `ts-jest` as the transpiler.

If however, we comment out `tsconfig: ...` in `jest.config.ts`, we get something like the following:

```
 FAIL  ./server.test.js
  ● Test suite failed to run

    server.ts:3:8 - error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
```

Now _this_ is a helpful error, and illustrates the real problem at hand. It tells us that `ts-jest` is genuinely not interpreting `server.ts` as an ESM module, despite the `"type": "module"` in `package.json`, the `useEsm` and `extensionsToTreatAsEsm` options in the jest config, etc!

### Conclusion

This demonstrates that perhaps the [Jest errors](https://github.com/theopensystemslab/planx-new/actions/runs/10409160785/job/28828151209?pr=3453) are more genuine/instructive than I imagined. Despite all the config in the world, jest/ts-jest refuse to recognise our `api.planx.uk` codebase as being composed of ESM modules. Perhaps the solution is simply to not enforce ESM for tests? 🤔 