### PR TITLE
Revert "chore: Add "no-nested-ternary" ESLint rule to projects"

### DIFF
--- a/api.planx.uk/.eslintrc
+++ b/api.planx.uk/.eslintrc
@@ -29,8 +29,7 @@
           "supertest.**.expect"
         ]
       }
-    ],
-    "no-nested-ternary": "error"
+    ]
   },
   "globals": {
     "require": "readonly",

--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -15,8 +15,7 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "no-nested-ternary": "error"
+    "@typescript-eslint/no-non-null-assertion": "off"
   },
   "ignorePatterns": [ "dist/**", "pnpm-lock.yaml" ]
 }

--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -73,8 +73,7 @@
     "@typescript-eslint/no-var-requires": "warn",
     "@typescript-eslint/no-empty-function": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/ban-ts-comment": "off",
-    "no-nested-ternary": "error"
+    "@typescript-eslint/ban-ts-comment": "off"
   },
   "settings": {
     "jest": {

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -316,21 +316,24 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
                   }),
             },
           },
-          ...[options && options
-            .filter((o) => o.data.text)
-            .map((o) => ({
-              ...o,
-              id: o.id || undefined,
-              type: TYPES.Answer,
-            }))],
-          ...[groupedOptions && groupedOptions
-            .flatMap((gr) => gr.children)
-            .filter((o) => o.data.text)
-            .map((o) => ({
-              ...o,
-              id: o.id || undefined,
-              type: TYPES.Answer,
-            }))]
+          options
+            ? options
+                .filter((o) => o.data.text)
+                .map((o) => ({
+                  ...o,
+                  id: o.id || undefined,
+                  type: TYPES.Answer,
+                }))
+            : groupedOptions
+            ? groupedOptions
+                .flatMap((gr) => gr.children)
+                .filter((o) => o.data.text)
+                .map((o) => ({
+                  ...o,
+                  id: o.id || undefined,
+                  type: TYPES.Answer,
+                }))
+            : [],
         );
       } else {
         alert(JSON.stringify({ type, ...values, options }, null, 2));

--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -5,7 +5,6 @@ import {
   type Checklist,
   checklistValidationSchema,
   getFlatOptions,
-  getLayout,
   type Group,
 } from "@planx/components/Checklist/model";
 import ImageButton from "@planx/components/shared/Buttons/ImageButton";
@@ -72,7 +71,14 @@ const ChecklistComponent: React.FC<Props> = (props) => {
     initialExpandedGroups,
   );
 
-  const layout = getLayout({ options, groupedOptions});
+  const layout = options
+    ? options.find((o) => o.data.img)
+      ? ChecklistLayout.Images
+      : ChecklistLayout.Basic
+    : groupedOptions
+    ? ChecklistLayout.Grouped
+    : ChecklistLayout.Basic;
+
   const flatOptions = getFlatOptions({ options, groupedOptions });
 
   const changeCheckbox = (id: string) => (_checked: any) => {
@@ -111,7 +117,7 @@ const ChecklistComponent: React.FC<Props> = (props) => {
             component="fieldset"
           >
             <legend style={visuallyHidden}>{text}</legend>
-            {options && (
+            {options ? (
               options.map((option) =>
                 layout === ChecklistLayout.Basic ? (
                   <FormWrapper key={option.id}>
@@ -143,9 +149,7 @@ const ChecklistComponent: React.FC<Props> = (props) => {
                   </Grid>
                 ),
               )
-            )}
-
-            {groupedOptions && (
+            ) : groupedOptions ? (
               <FormWrapper>
                 <Grid item xs={12}>
                   <ExpandableList>
@@ -191,7 +195,7 @@ const ChecklistComponent: React.FC<Props> = (props) => {
                   </ExpandableList>
                 </Grid>
               </FormWrapper>
-            )}
+            ) : null}
           </Grid>
         </ErrorWrapper>
       </FullWidthWrapper>

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -1,7 +1,6 @@
 import { array } from "yup";
 
 import { MoreInformation, Option } from "../shared";
-import { ChecklistLayout } from "./Public";
 
 export interface Group<T> {
   title: string;
@@ -24,7 +23,7 @@ interface ChecklistExpandableProps {
 }
 
 export const toggleExpandableChecklist = (
-  checklist: ChecklistExpandableProps
+  checklist: ChecklistExpandableProps,
 ): ChecklistExpandableProps => {
   if (checklist.options !== undefined && checklist.options.length > 0) {
     return {
@@ -74,21 +73,6 @@ export const getFlatOptions = ({
     return groupedOptions.flatMap((group) => group.children);
   }
   return [];
-};
-
-export const getLayout = ({
-  options,
-  groupedOptions,
-}: {
-  options: Checklist["options"];
-  groupedOptions: Checklist["groupedOptions"];
-}): ChecklistLayout => {
-  const hasImages = options?.some((o) => o.data.img);
-  if (hasImages) return ChecklistLayout.Images;
-  
-  if (groupedOptions) return ChecklistLayout.Grouped;
-
-  return ChecklistLayout.Basic;
 };
 
 export const checklistValidationSchema = ({

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
@@ -8,13 +8,13 @@ import digitalLandResponseMock from "./mocks/digitalLandResponseMock";
 import PlanningConstraints from "./Public";
 
 jest.spyOn(SWR, "default").mockImplementation((url: any) => {
-  const isGISRequest = url()?.startsWith(`${process.env.REACT_APP_API_URL}/gis/`);
-  const isRoadsRequest = url()?.startsWith(`${process.env.REACT_APP_API_URL}/roads/`);
-
-  if (isGISRequest) return { data: digitalLandResponseMock } as any;
-  if (isRoadsRequest) return { data: classifiedRoadsResponseMock } as any;
-
-  return { data: null };
+  return {
+    data: url()?.startsWith(`${process.env.REACT_APP_API_URL}/gis/`)
+      ? digitalLandResponseMock
+      : url()?.startsWith(`${process.env.REACT_APP_API_URL}/roads/`)
+      ? classifiedRoadsResponseMock
+      : null,
+  } as any;
 });
 
 it("renders correctly", async () => {

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -60,25 +60,16 @@ const Responses = ({
   flagColor?: string;
 }) => {
   const breadcrumbs = useStore((state) => state.breadcrumbs);
-
-  const hasAffectedResult = (response: Response): boolean => {
-    // Remove invalid breadcrumbs
-    const breadcrumb = breadcrumbs[response.question.id];
-    if (!breadcrumb) return false;
-
-    // Retain all user answered questions
-    const isAnsweredByUser = breadcrumbs[response.question.id].auto !== true;
-    if (isAnsweredByUser) return true;
-
-    // Retain responses with flags which are auto answered
-    const hasFlag = response.selections.some((s) => s.data?.flag);
-    return hasFlag;
-  }
-
   return (
     <>
       {responses
-        .filter(hasAffectedResult)
+        .filter((response) =>
+          breadcrumbs[response.question.id]
+            ? breadcrumbs[response.question.id].auto
+              ? response.selections.some((s) => s.data?.flag)
+              : true
+            : false,
+        )
         .map(({ question, selections }: Response) => (
           <ResultReason
             key={question.id}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackPage.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackPage.tsx
@@ -225,17 +225,11 @@ const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
     }
   };
 
-  const generateCommentSummary = (userComment: string | null) => {
-    if (!userComment) return "No comment";
-
-    const COMMENT_LENGTH = 50;
-    const shouldBeSummarised = userComment.length > COMMENT_LENGTH;
-    if (shouldBeSummarised) return `${userComment.slice(0, COMMENT_LENGTH)}...`
-
-    return userComment;
-  }
-
-  const commentSummary = generateCommentSummary(item.userComment);
+  const commentSummary = item.userComment
+    ? item.userComment.length > 50
+      ? `${item.userComment.slice(0, 50)}...`
+      : item.userComment
+    : "No comment";
 
   const filteredFeedbackItems = (() => {
     switch (item.type) {

--- a/editor.planx.uk/src/ui/editor/RichTextInput.test.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.test.tsx
@@ -12,13 +12,8 @@ test("modifyDeep helper", () => {
    * the value unchanged at that level but keep traversing downwards to see if there is something to change.
    */
   expect(
-    modifyDeep((val) =>{
-      if (typeof val !== "number") return null;
-      const isEven = val % 2 === 0;
-      return isEven
-        ? val + 1 
-        : val;
-    }
+    modifyDeep((val) =>
+      typeof val === "number" ? (val % 2 === 0 ? val + 1 : val) : null,
     )({
       a: { c: { val: 2 } },
       b: { val: 3 },


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#3514

Also running regression tests against this branch here: https://github.com/theopensystemslab/planx-new/actions/runs/10470664105

We've had issues with SWR requests validating correctly since this change merged, reverting this to see if it's connected (seems doubtful, but we're really scratching our heads with this bug!) - full context in this thread: https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1724054282014549