### PR TITLE
fix: when proposing a new address, map should display at full width and lower zoom

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -13,6 +13,7 @@ import {
 } from "@planx/components/shared/Preview/MapContainer";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
+import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input";
@@ -125,65 +126,72 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
 
   return (
     <>
-      <ErrorWrapper error={props.mapValidationError} id="plot-new-address-map">
-        <MapContainer environment={environment} size="large">
-          <p style={visuallyHidden}>
-            An interactive map centred on the local authority district, showing
-            the Ordnance Survey basemap. Click to place a point representing
-            your proposed site location.
-          </p>
-          {/* @ts-ignore */}
-          <my-map
-            id="plot-new-address-map"
-            ariaLabelOlFixedOverlay="An interactive map for providing your site location"
-            data-testid="map-web-component"
-            zoom={14}
-            drawMode
-            drawType="Point"
-            drawGeojsonData={
-              coordinates &&
-              JSON.stringify({
-                type: "Feature",
-                geometry: {
-                  type: "Point",
-                  coordinates: [coordinates?.longitude, coordinates?.latitude],
-                },
-                properties: {},
-              })
-            }
-            drawGeojsonDataBuffer={20}
-            resetControlImage="trash"
-            showScale
-            showNorthArrow
-            osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
-            clipGeojsonData={JSON.stringify(boundaryBBox)}
-            collapseAttributions={window.innerWidth < 500 ? true : undefined}
-          />
-        </MapContainer>
-      </ErrorWrapper>
-      <MapFooter>
-        <Typography variant="body2">
-          The coordinate location of your address point is:{" "}
-          <strong>
-            {`${
-              (coordinates?.x && Math.round(coordinates.x)) || 0
-            } Easting (X), ${
-              (coordinates?.y && Math.round(coordinates.y)) || 0
-            } Northing (Y)`}
-          </strong>
-        </Typography>
-        <Link
-          component="button"
-          onClick={() => {
-            props.setPage("os-address");
-            props.setAddress(undefined);
-          }}
+      <FullWidthWrapper>
+        <ErrorWrapper
+          error={props.mapValidationError}
+          id="plot-new-address-map"
         >
+          <MapContainer environment={environment} size="large">
+            <p style={visuallyHidden}>
+              An interactive map centred on the local authority district,
+              showing the Ordnance Survey basemap. Click to place a point
+              representing your proposed site location.
+            </p>
+            {/* @ts-ignore */}
+            <my-map
+              id="plot-new-address-map"
+              ariaLabelOlFixedOverlay="An interactive map for providing your site location"
+              data-testid="map-web-component"
+              zoom={10}
+              drawMode
+              drawType="Point"
+              drawGeojsonData={
+                coordinates &&
+                JSON.stringify({
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [
+                      coordinates?.longitude,
+                      coordinates?.latitude,
+                    ],
+                  },
+                  properties: {},
+                })
+              }
+              resetControlImage="trash"
+              showScale
+              showNorthArrow
+              osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
+              clipGeojsonData={JSON.stringify(boundaryBBox)}
+              collapseAttributions={window.innerWidth < 500 ? true : undefined}
+            />
+          </MapContainer>
+        </ErrorWrapper>
+        <MapFooter>
           <Typography variant="body2">
-            I want to select an existing address
+            The coordinate location of your address point is:{" "}
+            <strong>
+              {`${
+                (coordinates?.x && Math.round(coordinates.x)) || 0
+              } Easting (X), ${
+                (coordinates?.y && Math.round(coordinates.y)) || 0
+              } Northing (Y)`}
+            </strong>
           </Typography>
-        </Link>
-      </MapFooter>
+          <Link
+            component="button"
+            onClick={() => {
+              props.setPage("os-address");
+              props.setAddress(undefined);
+            }}
+          >
+            <Typography variant="body2">
+              I want to select an existing address
+            </Typography>
+          </Link>
+        </MapFooter>
+      </FullWidthWrapper>
       <DescriptionInput data-testid="new-address-input" mt={2}>
         <InputLabel
           label={props.descriptionLabel || DEFAULT_NEW_ADDRESS_LABEL}


### PR DESCRIPTION
Fixes issues raised by Tewkesbury & West Berks linked here: https://trello.com/c/TAY09Mpw/2980-diagnose-and-fix-map-center-zoom-issue-when-displaying-team-boundaries

**Quick but key changes here:**
- FindProperty map gets a `FullWidthWrapper` similar to our other interactive maps (eg DrawBoundary) for more real-estate
- Lowered `zoom` from `14` to `10` which seems to better accomodate more spacious rural councils while still working for London boroughs like Lambeth too
- Removed `drawGeojsonDataBuffer` prop - we don't need this for initial render, and when coming "back" after having plotted a new address, the map defaults will still be smartly zoomed into & centered on your existing point

No changes necessary to how we store boundaries or calculate bounding-boxes - that's all correct, was purely a viewport / display issue here I believe! 

The viewport is still "clipped" to the council boundary, and now that we're starting at a lower zoom, don't expect to be able to zoom out much from the starting location, but it should feel more "centered" on the full council now (rather than the center of the boundary like before).

**Before & afters:** 
- Tewkesbury
![Screenshot from 2024-08-20 15-22-02](https://github.com/user-attachments/assets/f3a1a41a-af6e-4743-89f7-3da4bb03cfdf)
![Screenshot from 2024-08-20 15-21-28](https://github.com/user-attachments/assets/61e87043-500e-4585-8d40-84b5927c16de)

- West Berks
![Screenshot from 2024-08-20 15-24-30](https://github.com/user-attachments/assets/309cf107-70fa-4199-adeb-aac49f985067)
![Screenshot from 2024-08-20 15-26-20](https://github.com/user-attachments/assets/aa95e5c1-f842-4f31-884f-41c48702cae9)

- Lambeth (did not report issue, but is quite a different scope boundary than above examples, so want to confirm it still displays reasonably too!)
![Screenshot from 2024-08-20 15-40-09](https://github.com/user-attachments/assets/3949cb87-d94d-4482-9c80-d44999be017c)
![Screenshot from 2024-08-20 15-27-21](https://github.com/user-attachments/assets/268ed36c-d9cb-40d2-967d-ad99a1d2298b)
