### PR TITLE
fix: hard-code Idox Nexus organisation names

### DIFF
--- a/api.planx.uk/modules/send/idox/nexus.ts
+++ b/api.planx.uk/modules/send/idox/nexus.ts
@@ -90,7 +90,14 @@ export async function sendToIdoxNexus(
     //   Switch to `team_integrations`-based approach later
     const orgIds = Object.keys(organisations);
     const randomOrgId = orgIds[Math.floor(Math.random() * orgIds.length)];
-    const randomOrg = organisations[randomOrgId];
+    // Dev auth endpoint returns "Multi-organisation" as every org name, but Idox expects these
+    const orgNamesMap: Record<string, string> = {
+      "210051": "Open System Labs 001",
+      "210052": "Open System Labs 002",
+      "210053": "Open System Labs 003",
+      "210054": "Open System Labs 004",
+    };
+    const randomOrg = orgNamesMap[randomOrgId];
 
     // Create a zip containing only the ODP Schema JSON
     //   Do this BEFORE creating a submission in order to throw any validation errors early

--- a/api.planx.uk/modules/send/idox/nexus.ts
+++ b/api.planx.uk/modules/send/idox/nexus.ts
@@ -20,7 +20,7 @@ interface RawIdoxNexusAuthResponse {
 
 interface IdoxNexusAuthResponse {
   token: string;
-  organisations: Record<string, string>;
+  organisations: Record<number, string>;
   authorities: string[];
 }
 
@@ -90,7 +90,7 @@ export async function sendToIdoxNexus(
     //   Switch to `team_integrations`-based approach later
     const orgIds = Object.keys(organisations);
     const randomOrgId = orgIds[Math.floor(Math.random() * orgIds.length)];
-    // Dev auth endpoint returns "Multi-organisation" as every org name, but Idox expects these
+    // Dev auth endpoint returns "Multi-organisation" as every org name, but Idox expects these (OSL typo is "correct")
     const orgNamesMap: Record<string, string> = {
       "210051": "Open System Labs 001",
       "210052": "Open System Labs 002",


### PR DESCRIPTION
Per latest email from Iain - our auth endpoint returns the correct organisation ID, but a generic organisation name "Multi-organisation", yet Idox is expecting one of these organisation names - so we're hard-coding for now :shrug: 