### PR TITLE
chore: update Confirmation banner description to use rich text & reword details

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -20,18 +20,6 @@ export const Basic = {
     description: `A payment receipt has been emailed to you. You will also 
     receive an email to confirm when your application has been received.`,
     color: { background: "rgba(1, 99, 96, 0.1)", text: "#000" },
-    details: {
-      "Planning Application Reference": "LBL–LDCP-2138261",
-      "Property Address": "45, Greenfield Road, London SE22 7FF",
-      "Application type":
-        "Application for a Certificate of Lawfulness – Proposed",
-      Submitted: new Date().toLocaleDateString("en-gb", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      }),
-      "GOV.UK Payment reference": "qe817o3kds9474rfkfldfHSK874JB",
-    },
     nextSteps: [
       { title: "Validation", description: "Something will be validated" },
       { title: "Site visit", description: "Someone will visit" },

--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -3,12 +3,12 @@ import React from "react";
 
 import Wrapper from "../fixtures/Wrapper";
 import Editor from "./Editor";
-import Confirmation from "./Public";
+import Confirmation, { Presentational } from "./Public";
 
 const meta = {
   title: "PlanX Components/Confirmation",
-  component: Confirmation,
-} satisfies Meta<typeof Confirmation>;
+  component: Presentational,
+} satisfies Meta<typeof Presentational>;
 
 export default meta;
 
@@ -20,6 +20,19 @@ export const Basic = {
     description: `A payment receipt has been emailed to you. You will also 
     receive an email to confirm when your application has been received.`,
     color: { background: "rgba(1, 99, 96, 0.1)", text: "#000" },
+    sessionId: "123-t3st-456",
+    applicableDetails: {
+      "Planning Application Reference": "LBL–LDCP-2138261",
+      "Property Address": "45, Greenfield Road, London SE22 7FF",
+      "Application type":
+        "Application for a Certificate of Lawfulness – Proposed",
+      Submitted: new Date().toLocaleDateString("en-gb", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      }),
+      "GOV.UK Payment reference": "qe817o3kds9474rfkfldfHSK874JB",
+    },
     nextSteps: [
       { title: "Validation", description: "Something will be validated" },
       { title: "Site visit", description: "Someone will visit" },
@@ -36,6 +49,7 @@ export const Basic = {
       <br/><br/>
       What did you think of this service? Please give us your feedback using the link in the footer below.
     `,
+    data: [],
   },
 } satisfies Story;
 

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -16,7 +16,7 @@ import { Confirmation, parseNextSteps, Step } from "./model";
 
 export type Props = EditorProps<TYPES.Confirmation, Confirmation>;
 
-function StepEditor(props: ListManagerEditorProps<Step>) {
+function NextStepEditor(props: ListManagerEditorProps<Step>) {
   return (
     <Box width="100%">
       <InputRow>
@@ -55,10 +55,14 @@ export default function ConfirmationEditor(props: Props) {
   const type = TYPES.Confirmation;
   const formik = useFormik({
     initialValues: {
+      color: props.node?.color || {
+        text: "#000",
+        background: "rgba(1, 99, 96, 0.1)",
+      },
       heading: props.node?.data?.heading || "Application sent",
       description:
         props.node?.data?.description ||
-        `A payment receipt has been emailed to you. You will also receive an email to confirm when your application has been received.`,
+        `<p>A payment receipt has been emailed to you. You will also receive an email to confirm when your application has been received.</p>`,
       moreInfo:
         props.node?.data?.moreInfo ||
         `<h2>You will be contacted</h2>
@@ -95,7 +99,7 @@ export default function ConfirmationEditor(props: Props) {
             />
           </InputRow>
           <InputRow>
-            <Input
+            <RichTextInput
               placeholder="Description"
               name="description"
               value={formik.values.description}
@@ -112,7 +116,7 @@ export default function ConfirmationEditor(props: Props) {
             onChange={(steps: Step[]) => {
               formik.setFieldValue("nextSteps", steps);
             }}
-            Editor={StepEditor}
+            Editor={NextStepEditor}
             newValue={() => ({ title: "", description: "" })}
           />
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -16,9 +16,9 @@ jest.mock("@opensystemslab/planx-core", () => {
 it("should not have any accessibility violations", async () => {
   const { container } = setup(
     <ConfirmationComponent
+      color={{ text: "#000", background: "rgba(1, 99, 96, 0.1)" }}
       heading="heading"
       description="description"
-      details={{ key1: "something", key2: "something else" }}
       nextSteps={[
         { title: "title1", description: "description1" },
         { title: "title2", description: "description2" },

--- a/editor.planx.uk/src/@planx/components/Confirmation/model.ts
+++ b/editor.planx.uk/src/@planx/components/Confirmation/model.ts
@@ -7,7 +7,6 @@ export interface Confirmation {
   heading?: string;
   description?: string;
   color?: { text: string; background: string };
-  details?: { [key: string]: string };
   nextSteps?: Step[];
   moreInfo?: string;
   contactInfo?: string;

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -1,9 +1,7 @@
 import {
+  ComponentType as TYPES,
   DEFAULT_FLAG_CATEGORY,
-  GOV_PAY_PASSPORT_KEY,
-  GovUKPayment,
 } from "@opensystemslab/planx-core/types";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import AddressInput from "@planx/components/AddressInput/Public";
 import Calculate from "@planx/components/Calculate/Public";
 import Checklist from "@planx/components/Checklist/Public";
@@ -31,7 +29,6 @@ import Send from "@planx/components/Send/Public";
 import SetValue from "@planx/components/SetValue/Public";
 import TaskList from "@planx/components/TaskList/Public";
 import TextInput from "@planx/components/TextInput/Public";
-import { objectWithoutNullishValues } from "lib/objectHelpers";
 import mapAccum from "ramda/src/mapAccum";
 import React from "react";
 
@@ -87,6 +84,7 @@ const Node: React.FC<any> = (props: Props) => {
   switch (props.node.type) {
     case TYPES.Calculate:
       return <Calculate {...allProps} />;
+
     case TYPES.Checklist: {
       const childNodes = childNodesOf(props.node.id);
       return (
@@ -114,43 +112,10 @@ const Node: React.FC<any> = (props: Props) => {
         />
       );
     }
-    case TYPES.Confirmation: {
-      const payment: GovUKPayment | undefined =
-        passport.data?.[GOV_PAY_PASSPORT_KEY];
 
-      const details = {
-        "Planning application reference": payment?.reference ?? sessionId,
+    case TYPES.Confirmation:
+      return <Confirmation {...allProps} />;
 
-        "Property address": passport.data?._address?.title,
-
-        "Application type": [
-          flowName.replace("Apply", "Application"),
-          getWorkStatus(passport),
-        ]
-          .filter(Boolean)
-          .join(" - "),
-
-        // XXX: If there is no payment we can't alternatively show Date.now() because it
-        //      will change after page refresh. BOPS submission time needs to be queryable.
-        Submitted: payment?.created_date
-          ? new Date(payment.created_date).toLocaleDateString("en-gb", {
-              day: "numeric",
-              month: "long",
-              year: "numeric",
-            })
-          : undefined,
-
-        "GOV.UK Payment reference": payment?.payment_id,
-      };
-
-      return (
-        <Confirmation
-          {...allProps}
-          details={objectWithoutNullishValues(details)}
-          color={{ text: "#000", background: "rgba(1, 99, 96, 0.1)" }}
-        />
-      );
-    }
     case TYPES.Content:
       return <Content {...allProps} />;
 
@@ -209,6 +174,7 @@ const Node: React.FC<any> = (props: Props) => {
         />
       );
     }
+
     case TYPES.Review:
       return <Review {...allProps} />;
 
@@ -267,6 +233,7 @@ const Node: React.FC<any> = (props: Props) => {
     case TYPES.Answer:
     case undefined:
       return null;
+
     default:
       console.error({ nodeNotFound: props });
       return exhaustiveCheck(props.node.type);
@@ -275,15 +242,6 @@ const Node: React.FC<any> = (props: Props) => {
 
 function exhaustiveCheck(type: never): never {
   throw new Error(`Missing type ${type}`);
-}
-
-function getWorkStatus(passport: Store.passport): string | undefined {
-  switch (passport?.data?.["application.type"]?.toString()) {
-    case "ldc.existing":
-      return "existing";
-    case "ldc.proposed":
-      return "proposed";
-  }
 }
 
 export default Node;


### PR DESCRIPTION
**Changes:**
- Updates banner `description` to be a rich text input instead of plain text
- Refactors `details` to be handled directly in the `Confirmation` component rather than at the `Node` level
  - There was an original request to make the "details" property names customisable while keeping the existing values, but after chatting with August we decided against this approach
  - We don't let editors change the text of other static pages (eg Application Saved) or Gov Notify email templates, and we ultimately want to ensure all these fields have consistent naming between these various places - so customisation in this one place doesn't feel like the right solution and would likely lead to Confirmation page language that is out of sync/disjointed from other parts of the service
  - We did however update the existing language to be slightly more generic and accurate - eg `Planning application reference` &rarr; `Application reference` (now matches emails), `Submitted` &rarr; `Paid at` (matches actual data :see_no_evil:)
  
![Screenshot from 2024-08-21 19-56-09](https://github.com/user-attachments/assets/5ae68df8-2a90-40b3-b7b8-db58971e578e)

**Follow-ups:**
- I'll create a _new_ Trello ticket to pick back up the larger discussion of if we want to drop "application" language throughout, everything we need to touch to do that fully, and how we might achieve it (eg do we just agree on another word or read dynamically from schema application types where possible etc) - see thread here: https://opensystemslab.slack.com/archives/C07F7215W7P/p1724253793464279