### PR TITLE
fix: Correct logic for `slotsSchema` validation

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.test.ts
@@ -185,6 +185,19 @@ describe("slotSchema", () => {
     expect(result).toBe(false);
   });
 
+  it("rejects slots which failed to upload", async () => {
+    const mockSlots = [
+      { status: "error" },
+      { status: "success" },
+    ] as FileUploadSlot[];
+
+    const result = await slotsSchema.isValid(mockSlots, {
+      context: { fileList: mockFileList },
+    });
+
+    expect(result).toBe(false);
+  });
+
   it("allows slots with all files uploaded", async () => {
     const mockSlots = [
       { status: "success" },
@@ -193,6 +206,40 @@ describe("slotSchema", () => {
 
     const result = await slotsSchema.isValid(mockSlots, {
       context: { fileList: mockFileList },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("allows users to proceed if there are no required files", async () => {
+    const mockSlots: FileUploadSlot[] = [];
+
+    const result = await slotsSchema.isValid(mockSlots, {
+      context: {
+        fileList: {
+          required: [],
+          recommended: [
+            { ...mockFileTypes.AlwaysRecommended, slots: [{ id: "123" }] },
+          ],
+          optional: [{ ...mockFileTypes.NotRequired, slots: [{ id: "456" }] }],
+        },
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("allows users to proceed if there are no required files, and they have not uploaded any optional or recommended files", async () => {
+    const mockSlots: FileUploadSlot[] = [];
+
+    const result = await slotsSchema.isValid(mockSlots, {
+      context: {
+        fileList: {
+          required: [],
+          recommended: [{ ...mockFileTypes.AlwaysRecommended }],
+          optional: [{ ...mockFileTypes.NotRequired }],
+        },
+      },
     });
 
     expect(result).toBe(true);

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -79,12 +79,11 @@ export const slotsSchema = array()
       if (!slots) throw new Error("Missing slots for slotsSchema");
 
       const { fileList } = context as SlotsSchemaTestContext;
-      const allFilesOptional =
-        !fileList.recommended.length && !fileList.required.length;
-      const isMinFileUploadCountSatisfied =
-        allFilesOptional || slots.length > 0;
+      const noFilesAreRequired = Boolean(!fileList.required.length);
+      if (noFilesAreRequired) return true;
 
-      return isMinFileUploadCountSatisfied;
+      const isAtLeastOneFileUploaded = slots.length > 0;
+      return isAtLeastOneFileUploaded;
     },
   })
   .test({
@@ -101,11 +100,8 @@ export const slotsSchema = array()
     name: "errorStatus",
     message: "Remove files which failed to upload",
     test: (slots?: Array<FileUploadSlot>) => {
-      return Boolean(
-        slots &&
-          slots.length > 0 &&
-          !slots.some((slot) => slot.status === "error"),
-      );
+      const didAnyUploadFail = slots?.some((slot) => slot.status === "error");
+      return !didAnyUploadFail;
     },
   });
 


### PR DESCRIPTION
## What does this PR do?
Addresses issues outlined in this ticket - https://trello.com/c/zYOIK4d1/2996-allow-users-to-bypass-upload-and-label-exemptions-not-working-correctly

> Component requires either all files to be optional or files uploaded to be > 0. Recommended files are however not treated as optional, effectively being treated as if required. The allFilesOptional exemption should really be a noFilesRequired exemption, as the only time a users should be blocked from proceeding without uploading anything is when one or more files are required. Related issue: Even when all files are set to optional, with no uploaded files the component still always triggers the “Remove files which failed to upload” error.

This is now fixed (with added tests). The "Remove files which failed to upload” error was over-eager and giving false positives, the allFilesOptional test has been updated to make the syntax a little clearer, but it's still logically the same.