### PR TITLE
fix: Update store on flow status change

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -47,6 +47,7 @@ export const settingsStore: StateCreator<
       flow: { id },
       status: newStatus,
     });
+    set({ flowStatus: newStatus });
     return Boolean(result?.id);
   },
 


### PR DESCRIPTION
Small UX improvement I noticed when turning a flow online/offline for testing.

By directly updating the store, Zustand will reactively update our UI so we don't have to reload the component (e.g. via navigation) to see the update.

https://github.com/user-attachments/assets/bf976ac5-50ae-4995-ad24-9f02c0eabba9

