### PR TITLE
refactor: Move `submission_email` from `teams` to `team_settings`

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1768,25 +1768,24 @@
       permission:
         check: {}
         columns:
-          - id
+          - boundary_bbox
+          - boundary_url
+          - email_reply_to_id
           - external_planning_site_name
           - external_planning_site_url
-          - homepage
           - help_email
           - help_opening_hours
           - help_phone
-          - email_reply_to_id
-          - team_id
-          - boundary_bbox
+          - homepage
+          - id
           - reference_code
-          - boundary_url
+          - submission_email
+          - team_id
       comment: ""
   select_permissions:
     - role: api
       permission:
         columns:
-          - id
-          - team_id
           - boundary_bbox
           - boundary_url
           - email_reply_to_id
@@ -1796,14 +1795,15 @@
           - help_opening_hours
           - help_phone
           - homepage
+          - id
           - reference_code
+          - submission_email
+          - team_id
         filter: {}
       comment: ""
     - role: platformAdmin
       permission:
         columns:
-          - id
-          - team_id
           - boundary_bbox
           - boundary_url
           - email_reply_to_id
@@ -1813,7 +1813,10 @@
           - help_opening_hours
           - help_phone
           - homepage
+          - id
           - reference_code
+          - submission_email
+          - team_id
         filter: {}
       comment: ""
     - role: public
@@ -1830,14 +1833,13 @@
           - homepage
           - id
           - reference_code
+          - submission_email
           - team_id
         filter: {}
       comment: ""
     - role: teamEditor
       permission:
         columns:
-          - id
-          - team_id
           - boundary_bbox
           - boundary_url
           - email_reply_to_id
@@ -1847,7 +1849,10 @@
           - help_opening_hours
           - help_phone
           - homepage
+          - id
           - reference_code
+          - submission_email
+          - team_id
         filter: {}
       comment: ""
   update_permissions:
@@ -1864,6 +1869,7 @@
           - help_phone
           - homepage
           - reference_code
+          - submission_email
         filter: {}
         check: null
       comment: ""
@@ -1880,6 +1886,7 @@
           - help_phone
           - homepage
           - reference_code
+          - submission_email
         filter:
           team:
             members:

--- a/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/down.sql
+++ b/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/down.sql
@@ -1,4 +1,2 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."team_settings" add column "submission_email" text
---  null;
+ALTER TABLE team_settings
+DROP COLUMN submission_email;

--- a/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/down.sql
+++ b/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."team_settings" add column "submission_email" text
+--  null;

--- a/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/up.sql
+++ b/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."team_settings" add column "submission_email" text
+ null;

--- a/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/up.sql
+++ b/hasura.planx.uk/migrations/1724407660297_alter_table_public_team_settings_add_column_submission_email/up.sql
@@ -1,2 +1,3 @@
 alter table "public"."team_settings" add column "submission_email" text
  null;
+comment on column "public"."team_settings"."submission_email" is E'Referenced by Send component when configured to email planning office';

--- a/hasura.planx.uk/migrations/1724408755595_populate_team_settings_submissions_email/down.sql
+++ b/hasura.planx.uk/migrations/1724408755595_populate_team_settings_submissions_email/down.sql
@@ -1,0 +1,6 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- UPDATE team_settings
+-- SET submission_email = teams.submission_email
+-- FROM teams
+-- WHERE team_settings.team_id = teams.id;

--- a/hasura.planx.uk/migrations/1724408755595_populate_team_settings_submissions_email/up.sql
+++ b/hasura.planx.uk/migrations/1724408755595_populate_team_settings_submissions_email/up.sql
@@ -1,0 +1,4 @@
+UPDATE team_settings
+SET submission_email = teams.submission_email
+FROM teams
+WHERE team_settings.team_id = teams.id;


### PR DESCRIPTION
## What does this PR do?

This PR sets up work contained in this Trello Ticket: https://trello.com/c/dVsTQpZZ/2984-allow-editors-to-see-update-their-teams-submission-email-in-team-settings-form

With `submission_email` moving to the **General Settings** tab of a Team's settings, it makes sense to move `submission_email` to the `team_settings` table for future reference and consistency. 

For this to happen, I had to add a new column to `team_settings` + update permissions to include the new column + add a script to move values from `teams` table to `team_settings` using `teams.id = team_settings.team_id` as the WHERE clause.

