### PR TITLE
chore: Updating remaining `REACT_APP_*` envs to `VITE_APP_*`

### DIFF
--- a/e2e/tests/ui-driven/install-dependencies.sh
+++ b/e2e/tests/ui-driven/install-dependencies.sh
@@ -5,7 +5,7 @@ cd $(dirname "$0")
 
 source ../../../.env
 
-(cd ../../../editor.planx.uk && pnpm install --frozen-lockfile && REACT_APP_ENV=test pnpm build)
+(cd ../../../editor.planx.uk && pnpm install --frozen-lockfile && VITE_APP_ENV=test pnpm build)
 
 if [ -z "${CI}" ]; then
   echo "Please make sure you have Chrome installed on this machine."

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public.tsx
@@ -79,7 +79,9 @@ function MapAndLabelComponent(props: Props) {
               teamSettings?.boundaryBBox &&
               JSON.stringify(teamSettings?.boundaryBBox)
             }
-            osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
+            osProxyEndpoint={`${
+              import.meta.env.VITE_APP_API_URL
+            }/proxy/ordnance-survey`}
             osCopyright={`© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
             collapseAttributions={window.innerWidth < 500 ? true : undefined}
           />

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -61,7 +61,9 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
             maxZoom={23}
             latitude={Number(passport?.data?._address?.latitude)}
             longitude={Number(passport?.data?._address?.longitude)}
-            osProxyEndpoint={`${process.env.REACT_APP_API_URL}/proxy/ordnance-survey`}
+            osProxyEndpoint={`${
+              import.meta.env.VITE_APP_API_URL
+            }/proxy/ordnance-survey`}
             osCopyright={`Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
             clipGeojsonData={
               teamSettings?.boundaryBBox &&

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings.tsx
@@ -260,7 +260,7 @@ const ServiceSettings: React.FC = () => {
     const message = `${emoji[status]} *${teamSlug}/${flowSlug}* is now ${status} (@Silvia)`;
 
     return axios.post(
-      `${process.env.REACT_APP_API_URL}/send-slack-notification`,
+      `${import.meta.env.VITE_APP_API_URL}/send-slack-notification`,
       {
         message: message,
       },


### PR DESCRIPTION
A few env vars introduced via a rebase which were then missed!