### PR TITLE
test: Setup axios mocks in outstanding frontend tests

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -16,7 +16,9 @@ import {
 } from "../model";
 import DrawBoundary from "./";
 
+vi.mock("axios");
 const mockedAxios = vi.mocked(axios, true);
+
 global.URL.createObjectURL = vi.fn();
 
 const { getState, setState } = useStore;
@@ -176,7 +178,7 @@ test("hides the upload option and allows user to continue without drawing if edi
   expect(handleSubmit).toHaveBeenCalledTimes(1);
 });
 
-test.skip("captures output data in the correct format when uploading a file", async () => {
+test("captures output data in the correct format when uploading a file", async () => {
   // Setup file mock
   const mockFileName = "test.png";
   const mockFileURL =
@@ -238,7 +240,7 @@ test.skip("captures output data in the correct format when uploading a file", as
   );
 });
 
-test.skip("appends to existing '_requestedFiles' value", async () => {
+test("appends to existing '_requestedFiles' value", async () => {
   // Setup file mock
   const mockFileName = "test.png";
   const mockFileURL =
@@ -383,7 +385,7 @@ test.skip("appends to existing '_requestedFiles' value", async () => {
   expect(optional).toHaveLength(0);
 });
 
-test.skip("submits data based on the page you continue onwards from", async () => {
+test("submits data based on the page you continue onwards from", async () => {
   // Context - Planning Officers don't want to receive both geojson and an uploaded locationPlan, only one or the other
   //   But accessibility auditing says a user should always be able to toggle between draw & upload pages with their previous inputs retained
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.test.tsx
@@ -16,6 +16,7 @@ import FileUploadAndLabelComponent from "./Public";
 const { getState, setState } = useStore;
 let initialState: FullStore;
 
+vi.mock("axios");
 const mockedAxios = vi.mocked(axios, true);
 
 window.URL.createObjectURL = vi.fn();
@@ -193,7 +194,7 @@ describe("Modal trigger", () => {
     expect(fileTaggingModal).not.toBeInTheDocument();
   });
 
-  test.skip("Modal opens when a single file is uploaded", async () => {
+  test("Modal opens when a single file is uploaded", async () => {
     const { getByTestId, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
@@ -224,7 +225,7 @@ describe("Modal trigger", () => {
     expect(await within(fileTaggingModal).findByText("test.png")).toBeVisible();
   });
 
-  test.skip("Modal opens when multiple files are uploaded", async () => {
+  test("Modal opens when multiple files are uploaded", async () => {
     const { getByTestId, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
@@ -269,7 +270,7 @@ describe("Modal trigger", () => {
     ).toBeVisible();
   });
 
-  test.skip("Modal does not open when a file is deleted", async () => {
+  test("Modal does not open when a file is deleted", async () => {
     const { getByTestId, getByLabelText, queryByText, getByText, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
@@ -329,7 +330,7 @@ describe("Modal trigger", () => {
 });
 
 describe("Adding tags and syncing state", () => {
-  test.skip("Can continue when all required file types are uploaded and tagged", async () => {
+  test("Can continue when all required file types are uploaded and tagged", async () => {
     const handleSubmit = vi.fn();
     const {
       getAllByRole,
@@ -411,7 +412,7 @@ describe("Adding tags and syncing state", () => {
     expect(handleSubmit).toHaveBeenCalledTimes(1);
   });
 
-  test.skip("Cannot continue when only an optional file type is uploaded and tagged", async () => {
+  test("Cannot continue when only an optional file type is uploaded and tagged", async () => {
     const handleSubmit = vi.fn();
     const {
       getAllByRole,
@@ -494,7 +495,7 @@ describe("Adding tags and syncing state", () => {
 });
 
 describe("Error handling", () => {
-  test.skip("An error is thrown if a user does not upload any files", async () => {
+  test("An error is thrown if a user does not upload any files", async () => {
     const handleSubmit = vi.fn();
 
     const { getByTestId, getByRole, findByText, user } = setup(
@@ -549,7 +550,7 @@ describe("Error handling", () => {
     expect(dropzoneError).toBeVisible();
   });
 
-  test.skip("An error is thrown in the modal if a user does not tag all files", async () => {
+  test("An error is thrown in the modal if a user does not tag all files", async () => {
     const { getByTestId, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
@@ -587,7 +588,7 @@ describe("Error handling", () => {
     expect(modalError).toBeVisible();
   });
 
-  test.skip("An error is thrown in the main component if a user does not tag all files", async () => {
+  test("An error is thrown in the main component if a user does not tag all files", async () => {
     const handleSubmit = vi.fn();
 
     const { getAllByRole, getByTestId, getByRole, findByText, user } = setup(
@@ -647,7 +648,7 @@ describe("Submitting data", () => {
 
   afterEach(() => waitFor(() => setState(initialState)));
 
-  it.skip("records the user uploaded files", async () => {
+  it("records the user uploaded files", async () => {
     const handleSubmit = vi.fn();
     const { getByText, user } = setup(
       <FileUploadAndLabelComponent
@@ -675,7 +676,7 @@ describe("Submitting data", () => {
     );
   });
 
-  it.skip("records the full file type list presented to the user", async () => {
+  it("records the full file type list presented to the user", async () => {
     const handleSubmit = vi.fn();
     const { getByText, user } = setup(
       <FileUploadAndLabelComponent
@@ -697,7 +698,7 @@ describe("Submitting data", () => {
     expect(requestedFiles.optional).toContain("utilityBill");
   });
 
-  it.skip("appends to the list of existing requested files", async () => {
+  it("appends to the list of existing requested files", async () => {
     // Mimic having passed file upload / file upload and label component
     const breadcrumbs: Breadcrumbs = {
       previousFileUploadComponent: {

--- a/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
@@ -8,17 +8,18 @@ import hasuraEventsResponseMock from "./mocks/hasuraEventsResponseMock";
 import { Destination } from "./model";
 import SendComponent from "./Public";
 
-// const mockAxios = vi.mocked(axios, true);
+vi.mock("axios");
+const mockAxios = vi.mocked(axios, true);
 
-// mockAxios.post.mockImplementation((url: any) => {
-//   return {
-//     value: url()?.startsWith(
-//       `${import.meta.env.VITE_APP_API_URL}/create-send-events/`,
-//     )
-//       ? hasuraEventsResponseMock
-//       : null,
-//   } as any;
-// });
+mockAxios.post.mockResolvedValue(async (url: string) => {
+  return {
+    value: url.startsWith(
+      `${import.meta.env.VITE_APP_API_URL}/create-send-events/`,
+    )
+      ? hasuraEventsResponseMock
+      : null,
+  };
+});
 
 it.todo("renders correctly");
 


### PR DESCRIPTION
## What does this PR do?
- Context - outstanding task from https://github.com/theopensystemslab/planx-new/pull/3549
- Uncomments tests which were skipped in order to migrate to vitest
- Sets up axios mocks for these tests
- All remaining `.skip()` tests left in Editor are intentional