### PR TITLE
feat: display static map for inactive List "map" fields

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -105,7 +105,9 @@ const InactiveListCard: React.FC<{
         <TableBody>
           {schema.fields.map((field, j) => (
             <TableRow key={`tableRow-${j}`}>
-              <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+              <TableCell
+                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, maxWidth: "100px" }}
+              >
                 {field.data.title}
               </TableCell>
               <TableCell>

--- a/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -43,6 +43,60 @@ export function formatSchemaDisplayValue(
       );
       return matchingOption?.data.text;
     }
+    case "map": {
+      const feature = value[0] as string as any; // won't be necessary to cast once we're only setting "geojsonData" prop in future
+      const drawType = field.data.mapOptions?.drawType;
+
+      switch (drawType) {
+        case "Point":
+          // Our "geojsonData" layer doesn't have a "point" style yet, so make due with center marker for now!
+          //   Once style layers are more comprehensive, share same map as "Polygon" style here
+          return (
+            <>
+              {/* @ts-ignore */}
+              <my-map
+                id="inactive-list-map"
+                latitude={feature.geometry.coordinates[1]}
+                longitude={feature.geometry.coordinates[0]}
+                zoom={19}
+                showCentreMarker
+                markerLatitude={feature.geometry.coordinates[1]}
+                markerLongitude={feature.geometry.coordinates[0]}
+                markerColor={field.data.mapOptions?.drawColor}
+                osProxyEndpoint={`${
+                  import.meta.env.VITE_APP_API_URL
+                }/proxy/ordnance-survey`}
+                hideResetControl
+                staticMode
+                style={{ width: "100%", height: "30vh" }}
+                osCopyright={`© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
+                collapseAttributions
+              />
+            </>
+          );
+        case "Polygon":
+          return (
+            <>
+              {/* @ts-ignore */}
+              <my-map
+                id="inactive-list-map"
+                geojsonData={JSON.stringify(feature)}
+                geojsonColor={field.data.mapOptions?.drawColor}
+                geojsonFill
+                geojsonBuffer={20}
+                osProxyEndpoint={`${
+                  import.meta.env.VITE_APP_API_URL
+                }/proxy/ordnance-survey`}
+                hideResetControl
+                staticMode
+                style={{ width: "100%", height: "30vh" }}
+                osCopyright={`© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
+                collapseAttributions
+              />
+            </>
+          );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Last piece in order to have an end-to-end List option demo ready for tmrw morning - shows a static map when the List item is inactive for any "map" field types. 

Hit a funny quirk here testing with "points" where I realised a limitation in the map repository - our `geojsonData` layer has only ever accounted for polygons before and doesn't currently have a "point" style associated with it ! So will make that update in `@opensytemslab/map` for a future release, and in the meantime we just slightly adjust our rendering rules based on `drawType` here :+1: 

![Screenshot from 2024-08-27 12-24-09](https://github.com/user-attachments/assets/1ce36afe-561a-439e-b729-691c25593219)

(Also sorry Rory @RODO94 I know we bookmarked this task to your name last week, but trying to keep momentum ahead of demos & UR deadline! will be plenty more followup tasks when you're ready to come back into works to trees !)