### PR TITLE
fix: submission_email being populated from PROD

### DIFF
--- a/scripts/seed-database/write/team_settings.sql
+++ b/scripts/seed-database/write/team_settings.sql
@@ -30,8 +30,7 @@ INSERT INTO
     external_planning_site_url,
     external_planning_site_name,
     boundary_url,
-    boundary_bbox,
-    submission_email
+    boundary_bbox
   )
 SELECT
     id,
@@ -45,8 +44,7 @@ SELECT
     external_planning_site_url,
     external_planning_site_name,
     boundary_url,
-    boundary_bbox,
-    submission_email
+    boundary_bbox
 FROM
   sync_team_settings ON CONFLICT (id) DO
 UPDATE
@@ -61,8 +59,7 @@ SET
     external_planning_site_url = EXCLUDED.external_planning_site_url,
     external_planning_site_name = EXCLUDED.external_planning_site_name,
     boundary_url = EXCLUDED.boundary_url,
-    boundary_bbox = EXCLUDED.boundary_bbox,
-    submission_email = EXCLUDED.submission_email;
+    boundary_bbox = EXCLUDED.boundary_bbox;
 SELECT
   setval('team_settings_id_seq', max(id))
 FROM


### PR DESCRIPTION
Seen from my previous fix: https://github.com/theopensystemslab/planx-new/pull/3571, that my database was being populated with Production data, which is not aligned with how it is scripted for the `teams` table.

I have altered that now so we don't send anything to council submission emails by accident when working on our local branches