### PR TITLE
refactor: Move editor console to tab

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
@@ -25,7 +25,7 @@ const StyledTab = styled(({ tabTheme, ...props }: StyledTabProps) => (
   [`&.${tabClasses.selected}`]: {
     background:
       tabTheme === "dark"
-        ? theme.palette.text.primary
+        ? theme.palette.background.dark
         : theme.palette.background.default,
     borderColor: theme.palette.border.main,
     borderBottomColor: theme.palette.common.white,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
@@ -1,0 +1,39 @@
+import { styled } from "@mui/material/styles";
+import Tab, { tabClasses, TabProps } from "@mui/material/Tab";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+interface StyledTabProps extends TabProps {
+  tabTheme?: "light" | "dark";
+}
+
+const StyledTab = styled(({ tabTheme, ...props }: StyledTabProps) => (
+  <Tab {...props} disableFocusRipple disableTouchRipple disableRipple />
+))<StyledTabProps>(({ theme, tabTheme }) => ({
+  position: "relative",
+  zIndex: 1,
+  textTransform: "none",
+  background: "transparent",
+  border: `1px solid transparent`,
+  borderBottomColor: theme.palette.border.main,
+  color: theme.palette.primary.main,
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  minHeight: "36px",
+  margin: theme.spacing(0, 0.5),
+  marginBottom: "-1px",
+  padding: "0.5em",
+  [`&.${tabClasses.selected}`]: {
+    background:
+      tabTheme === "dark"
+        ? theme.palette.text.primary
+        : theme.palette.background.default,
+    borderColor: theme.palette.border.main,
+    borderBottomColor: theme.palette.common.white,
+    color:
+      tabTheme === "dark"
+        ? theme.palette.common.white
+        : theme.palette.text.primary,
+  },
+}));
+
+export default StyledTab;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -11,7 +11,6 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
-import Tab, { tabClasses } from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -34,6 +33,7 @@ import {
   ValidationChecks,
 } from "./PublishDialog";
 import Search from "./Search";
+import StyledTab from "./StyledTab";
 
 type SidebarTabs = "PreviewBrowser" | "History" | "Search" | "Console";
 
@@ -114,27 +114,6 @@ const TabList = styled(Box)(({ theme }) => ({
     display: "none",
   },
 }));
-
-const StyledTab = styled(Tab)(({ theme }) => ({
-  position: "relative",
-  zIndex: 1,
-  textTransform: "none",
-  background: "transparent",
-  border: `1px solid transparent`,
-  borderBottomColor: theme.palette.border.main,
-  color: theme.palette.primary.main,
-  fontWeight: "600",
-  minHeight: "36px",
-  margin: theme.spacing(0, 0.5),
-  marginBottom: "-1px",
-  padding: "0.5em",
-  [`&.${tabClasses.selected}`]: {
-    background: theme.palette.background.default,
-    borderColor: theme.palette.border.main,
-    borderBottomColor: theme.palette.common.white,
-    color: theme.palette.text.primary,
-  },
-})) as typeof Tab;
 
 const SidebarTab = (props: any) => (
   <StyledTab disableFocusRipple disableTouchRipple disableRipple {...props} />
@@ -415,12 +394,12 @@ const Sidebar: React.FC<{
       </Header>
       <TabList>
         <Tabs centered onChange={handleChange} value={activeTab} aria-label="">
-          <SidebarTab value="PreviewBrowser" label="Preview" />
-          <SidebarTab value="History" label="History" />
+          <StyledTab value="PreviewBrowser" label="Preview" tabTheme="light" />
+          <StyledTab value="History" label="History" tabTheme="light" />
           {hasFeatureFlag("SEARCH") && (
-            <SidebarTab value="Search" label="Search" />
+            <StyledTab value="Search" label="Search" tabTheme="light" />
           )}
-          <SidebarTab value="Console" label="Console" />
+          <StyledTab value="Console" label="Console" tabTheme="dark" />
         </Tabs>
       </TabList>
       {activeTab === "PreviewBrowser" && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,5 +1,4 @@
 import LanguageIcon from "@mui/icons-material/Language";
-import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
 import Badge from "@mui/material/Badge";
@@ -36,12 +35,14 @@ import {
 } from "./PublishDialog";
 import Search from "./Search";
 
-type SidebarTabs = "PreviewBrowser" | "History" | "Search";
+type SidebarTabs = "PreviewBrowser" | "History" | "Search" | "Console";
 
-const Console = styled(Box)(() => ({
+const Console = styled(Box)(({ theme }) => ({
   overflow: "auto",
-  padding: 20,
-  maxHeight: "50%",
+  padding: theme.spacing(2),
+  height: "100%",
+  backgroundColor: theme.palette.text.primary,
+  color: theme.palette.common.white,
 }));
 
 const Root = styled(Box)(({ theme }) => ({
@@ -135,6 +136,10 @@ const StyledTab = styled(Tab)(({ theme }) => ({
   },
 })) as typeof Tab;
 
+const SidebarTab = (props: any) => (
+  <StyledTab disableFocusRipple disableTouchRipple disableRipple {...props} />
+);
+
 const DebugConsole = () => {
   const [passport, breadcrumbs, flowId, cachedBreadcrumbs] = useStore(
     (state) => [
@@ -145,7 +150,7 @@ const DebugConsole = () => {
     ],
   );
   return (
-    <Console borderTop={2} borderColor="border.main" bgcolor="background.paper">
+    <Console>
       <Typography variant="body2">
         <a
           href={`${
@@ -153,11 +158,12 @@ const DebugConsole = () => {
           }/flows/${flowId}/download-schema`}
           target="_blank"
           rel="noopener noreferrer"
+          style={{ color: "inherit" }}
         >
           Download the flow schema
         </a>
       </Typography>
-      <pre>
+      <pre style={{ whiteSpace: "pre-wrap", fontSize: "medium" }}>
         {JSON.stringify({ passport, breadcrumbs, cachedBreadcrumbs }, null, 2)}
       </pre>
     </Console>
@@ -269,12 +275,6 @@ const Sidebar: React.FC<{
             disabled
             value={props.url.replace("/published", "/preview")}
           />
-
-          <Tooltip arrow title="Toggle debug console">
-            <MenuOpenIcon
-              onClick={() => setDebugConsoleVisibility(!showDebugConsole)}
-            />
-          </Tooltip>
 
           <Permission.IsPlatformAdmin>
             <Tooltip arrow title="Open draft service">
@@ -415,29 +415,12 @@ const Sidebar: React.FC<{
       </Header>
       <TabList>
         <Tabs centered onChange={handleChange} value={activeTab} aria-label="">
-          <StyledTab
-            disableFocusRipple
-            disableTouchRipple
-            disableRipple
-            value="PreviewBrowser"
-            label="Preview"
-          />
-          <StyledTab
-            disableFocusRipple
-            disableTouchRipple
-            disableRipple
-            value="History"
-            label="History"
-          />
+          <SidebarTab value="PreviewBrowser" label="Preview" />
+          <SidebarTab value="History" label="History" />
           {hasFeatureFlag("SEARCH") && (
-            <StyledTab
-              disableFocusRipple
-              disableTouchRipple
-              disableRipple
-              value="Search"
-              label="Search"
-            />
+            <SidebarTab value="Search" label="Search" />
           )}
+          <SidebarTab value="Console" label="Console" />
         </Tabs>
       </TabList>
       {activeTab === "PreviewBrowser" && (
@@ -466,7 +449,11 @@ const Sidebar: React.FC<{
           <Search />
         </SidebarContainer>
       )}
-      {showDebugConsole && <DebugConsole />}
+      {activeTab === "Console" && (
+        <SidebarContainer>
+          <DebugConsole />
+        </SidebarContainer>
+      )}
     </Root>
   );
 });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -115,10 +115,6 @@ const TabList = styled(Box)(({ theme }) => ({
   },
 }));
 
-const SidebarTab = (props: any) => (
-  <StyledTab disableFocusRipple disableTouchRipple disableRipple {...props} />
-);
-
 const DebugConsole = () => {
   const [passport, breadcrumbs, flowId, cachedBreadcrumbs] = useStore(
     (state) => [

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -41,7 +41,7 @@ const Console = styled(Box)(({ theme }) => ({
   overflow: "auto",
   padding: theme.spacing(2),
   height: "100%",
-  backgroundColor: theme.palette.text.primary,
+  backgroundColor: theme.palette.background.dark,
   color: theme.palette.common.white,
 }));
 


### PR DESCRIPTION
## What does this PR do?

🚧 **Edit sidebar icon replacement pt2** 🚧

Replaces console icon with a dedicated tab for the console. This is given a 'dark' theme with corresponding prop for dark tabs.

I've also moved `StyledTab` to its own file, I was unsure whether this should remain in the current folder, or be moved to the wider UI components folders, as it is only used in this place. Open to suggestions on this one.

Example:
https://3578.planx.pizza/lambeth/apply-for-planning-permission