### PR TITLE
chore: update Metabase to v0.50.22

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   metabase:
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.47.8
+    image: metabase/metabase:v0.50.22
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -184,7 +184,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.47.8",
+        image: "metabase/metabase:v0.50.22",
         portMappings: [metabaseListenerHttp],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
Updates Metabase to [v0.50.22](https://github.com/metabase/metabase/releases/tag/v0.50.22), doing exactly as PR #2451 did. 

By the looks of it, no [big Metabase backup](https://www.metabase.com/docs/v0.50/installation-and-operation/backing-up-metabase-application-data) was done last time and data was just checked in staging--so no backup done here either. 

Let me know if anything further is needed! 