### PR TITLE
feat: Setup Storybook for `MapAndLabel`

### DIFF
--- a/editor.planx.uk/.storybook/preview.tsx
+++ b/editor.planx.uk/.storybook/preview.tsx
@@ -4,8 +4,13 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { defaultTheme } from "../src/theme";
 import React from "react";
+import { MyMap } from "@opensystemslab/map";
 
 import { reactNaviDecorator } from "./__mocks__/react-navi";
+
+if (!window.customElements.get("my-map")) {
+  window.customElements.define("my-map", MyMap);
+}
 
 export const decorators = [
   (Story) => (

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -8,7 +8,6 @@ import {
   getPreviouslySubmittedData,
   makeData,
 } from "@planx/components/shared/utils";
-import { PublicProps } from "@planx/components/ui";
 import { FormikProps, useFormik } from "formik";
 import React, {
   createContext,
@@ -17,7 +16,7 @@ import React, {
   useState,
 } from "react";
 
-import { MapAndLabel } from "../model";
+import { PresentationalProps } from ".";
 
 interface MapAndLabelContextValue {
   schema: Schema;
@@ -27,7 +26,7 @@ interface MapAndLabelContextValue {
   cancelEditItem: () => void;
   formik: FormikProps<SchemaUserData>;
   validateAndSubmitForm: () => void;
-  mapAndLabelProps: PublicProps<MapAndLabel>;
+  mapAndLabelProps: PresentationalProps;
   errors: {
     unsavedItem: boolean;
     min: boolean;
@@ -35,7 +34,7 @@ interface MapAndLabelContextValue {
   };
 }
 
-type MapAndLabelProviderProps = PropsWithChildren<PublicProps<MapAndLabel>>;
+type MapAndLabelProviderProps = PropsWithChildren<PresentationalProps>;
 
 const MapAndLabelContext = createContext<MapAndLabelContextValue | undefined>(
   undefined,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/MapAndLabel.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/MapAndLabel.stories.tsx
@@ -1,0 +1,37 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import Wrapper from "../../fixtures/Wrapper";
+import Editor from "../Editor";
+import { Trees } from "../schemas/Trees";
+import { Presentational as Public, PresentationalProps } from ".";
+
+const meta = {
+  title: "PlanX Components/MapAndLabel",
+  component: Public,
+} satisfies Meta<typeof Public>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const props: PresentationalProps = {
+  title: "Map and label the works to trees for this property",
+  description: "Add one or many trees below",
+  schemaName: "Trees",
+  fn: "MockFn",
+  schema: Trees,
+  basemap: "OSM",
+  drawColor: "#00FF00",
+  drawType: "Point",
+  longitude: -0.1629784,
+  latitude: 51.5230919,
+};
+
+export const Basic: Story = {
+  args: props,
+};
+
+export const WithEditor = () => {
+  return <Wrapper Editor={Editor} Public={() => <Public {...props} />} />;
+};


### PR DESCRIPTION
## What does this PR do?
 - Sets up `MapAndLabel.stories.tsx`
 - Splits up store logic from the rest of the component for simpler testing - the same pattern used in multiple other components for import to Storybook

## Motivation
I started looking at [the next item here to pick up](https://trello.com/c/JafdzU94/2855-epic-allow-applicants-to-work-to-trees-to-see-and-add-more-information-about-protected-trees-on-a-map) and was hitting a few issues setting up state before implementing tests. It seemed worthwhile to handle this once now before we start writing tests and then having to refactor them.

Also, having Storybook should prove helpful to avoid the `FindProperty` step beforehand when working on this and testing!