### PR TITLE
test(api): Add autoUpdate flag to API Vitest config

### DIFF
--- a/api.planx.uk/vitest.config.ts
+++ b/api.planx.uk/vitest.config.ts
@@ -13,8 +13,11 @@ export default defineConfig({
       // html reporter required to inspect coverage in Vitest UI dashboard
       reporter: ["lcov", "html", "text-summary"],
       thresholds: {
-        functions: 55,
-        // TODO: could add autoUpdate flag here so that function coverage is only allowed to increase
+        statements: 72.03,
+        branches: 54.92,
+        functions: 67.62,
+        lines: 71.84,
+        autoUpdate: true,
       },
     },
   },


### PR DESCRIPTION
## What does this PR do?
 - Adds `autoUpdate` flag to Vitest config in API
 - This will automatically update thresholds as they increase ([docs](https://vitest.dev/config/#coverage-thresholds-autoupdate))
 - Please see https://github.com/theopensystemslab/planx-new/pull/3555 and https://github.com/theopensystemslab/planx-new/pull/3555#discussion_r1730900264 for context
