### PR TITLE
test(api): Setup eslint-plugin-vite

### DIFF
--- a/api.planx.uk/.eslintrc
+++ b/api.planx.uk/.eslintrc
@@ -5,7 +5,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier"
+    "prettier",
+    "plugin:@vitest/legacy-recommended"
   ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "warn",
@@ -17,7 +18,19 @@
       }
     ],
     "@typescript-eslint/no-non-null-assertion": "off",
-    "no-nested-ternary": "error"
+    "no-nested-ternary": "error",
+    "@vitest/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": [
+          "expect",
+          // Allow Supertest expect() calls
+          "get.expect",
+          "post.expect",
+          "supertest.**.expect"
+        ]
+      }
+    ]
   },
   "globals": {
     "require": "readonly",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -101,6 +101,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@vitest/coverage-istanbul": "^2.0.5",
+    "@vitest/eslint-plugin": "^1.1.0",
     "@vitest/ui": "^2.0.5",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -222,6 +222,9 @@ devDependencies:
   '@vitest/coverage-istanbul':
     specifier: ^2.0.5
     version: 2.0.5(vitest@2.0.5)
+  '@vitest/eslint-plugin':
+    specifier: ^1.1.0
+    version: 1.1.0(eslint@8.57.0)(typescript@5.5.2)(vitest@2.0.5)
   '@vitest/ui':
     specifier: ^2.0.5
     version: 2.0.5(vitest@2.0.5)
@@ -1960,6 +1963,26 @@ packages:
       vitest: 2.0.5(@types/node@18.19.13)(@vitest/ui@2.0.5)(jsdom@24.1.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@vitest/eslint-plugin@1.1.0(eslint@8.57.0)(typescript@5.5.2)(vitest@2.0.5):
+    resolution: {integrity: sha512-Ur80Y27Wbw8gFHJ3cv6vypcjXmrx6QHfw+q435h6Q2L+tf+h4Xf5pJTCL4YU/Jps9EVeggQxS85OcUZU7sdXRw==}
+    peerDependencies:
+      '@typescript-eslint/utils': '>= 8.0'
+      eslint: '>= 8.57.0'
+      typescript: '>= 5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      typescript:
+        optional: true
+      vitest:
+        optional: true
+    dependencies:
+      eslint: 8.57.0
+      typescript: 5.5.2
+      vitest: 2.0.5(@types/node@18.19.13)(@vitest/ui@2.0.5)(jsdom@24.1.0)
     dev: true
 
   /@vitest/expect@2.0.5:


### PR DESCRIPTION
## What does this PR do?
 - Sets up [eslint-plugin-vite](https://github.com/vitest-dev/eslint-plugin-vitest), which replaces eslint-plugin-jest
 - Adds rule to allow supertest assertions to be allowed by linting
 - Please see #3555 and https://github.com/theopensystemslab/planx-new/pull/3555#discussion_r1730883773 for context
