### PR TITLE
feat: add Lost/Gained list schema to GLA residential units

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -27,6 +27,8 @@ import { ResidentialUnitsGLANew } from "./schemas/ResidentialUnits/GLA/New";
 import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebuilt";
 import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Removed";
 import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
+import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
+import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
 import { Trees } from "./schemas/Trees";
 
@@ -50,6 +52,14 @@ export const SCHEMAS = [
   {
     name: "Residential units (GLA) - Retained",
     schema: ResidentialUnitsGLARetained,
+  },
+  {
+    name: "Residential units (GLA) - Lost",
+    schema: ResidentialUnitsGLALost,
+  },
+  {
+    name: "Residential units (GLA) - Gained",
+    schema: ResidentialUnitsGLAGained,
   },
   { name: "Non-residential floorspace", schema: NonResidentialFloorspace },
   {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Existing.ts
@@ -6,6 +6,27 @@ export const ResidentialUnitsExisting: Schema = {
     {
       type: "question",
       data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "house", data: { text: "House", val: "house" } },
+          {
+            id: "flat",
+            data: { text: "Flat, apartment or maisonette", val: "flat" },
+          },
+          {
+            id: "sheltered",
+            data: { text: "Sheltered housing", val: "sheltered" },
+          },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
         title: "What best describes the tenure of this unit?",
         fn: "tenure",
         options: [
@@ -31,27 +52,6 @@ export const ResidentialUnitsExisting: Schema = {
       },
     },
     {
-      type: "question",
-      data: {
-        title: "What best describes the type of this unit?",
-        fn: "type",
-        options: [
-          { id: "house", data: { text: "House", val: "house" } },
-          {
-            id: "flat",
-            data: { text: "Flat, apartment or maisonette", val: "flat" },
-          },
-          {
-            id: "sheltered",
-            data: { text: "Sheltered housing", val: "sheltered" },
-          },
-          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
-          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
-          { id: "other", data: { text: "Other", val: "other" } },
-        ],
-      },
-    },
-    {
       type: "number",
       data: {
         title: "How many bedrooms does this unit have?",
@@ -62,7 +62,7 @@ export const ResidentialUnitsExisting: Schema = {
     {
       type: "number",
       data: {
-        title: "How many existing units fit the descriptions above?",
+        title: "How many units of the type described above exist on the site?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
@@ -4,6 +4,45 @@ export const ResidentialUnitsGLAGained: Schema = {
   type: "Gained residential unit type",
   fields: [
     {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home", val: "terraced" } },
+          {
+            id: "semiDetached",
+            data: { text: "Semi detached home", val: "semiDetached" },
+          },
+          { id: "detached", data: { text: "Detached home", val: "detached" } },
+          {
+            id: "flat",
+            data: { text: "Flat/apartment or maisonette", val: "flat" },
+          },
+          { id: "LW", data: { text: "Live/work unit", val: "LW" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "coLiving", data: { text: "Co living unit", val: "coLiving" } },
+          { id: "hostel", data: { text: "Hostel room", val: "hostel" } },
+          { id: "HMO", data: { text: "HMO", val: "HMO" } },
+          {
+            id: "student",
+            data: { text: "Student accommodation", val: "student" },
+          },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What will be the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
       type: "number",
       data: {
         title: "How many habitable rooms will this unit have?",
@@ -64,36 +103,6 @@ export const ResidentialUnitsGLAGained: Schema = {
           {
             id: "marketForSale",
             data: { text: "Market for sale", val: "marketForSale" },
-          },
-          { id: "other", data: { text: "Other", val: "other" } },
-        ],
-      },
-    },
-    {
-      type: "question",
-      data: {
-        title: "What best describes the type of this unit?",
-        fn: "type",
-        options: [
-          { id: "terraced", data: { text: "Terraced home", val: "terraced" } },
-          {
-            id: "semiDetached",
-            data: { text: "Semi detached home", val: "semiDetached" },
-          },
-          { id: "detached", data: { text: "Detached home", val: "detached" } },
-          {
-            id: "flat",
-            data: { text: "Flat/apartment or maisonette", val: "flat" },
-          },
-          { id: "LW", data: { text: "Live/work unit", val: "LW" } },
-          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
-          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
-          { id: "coLiving", data: { text: "Co living unit", val: "coLiving" } },
-          { id: "hostel", data: { text: "Hostel room", val: "hostel" } },
-          { id: "HMO", data: { text: "HMO", val: "HMO" } },
-          {
-            id: "student",
-            data: { text: "Student accommodation", val: "student" },
           },
           { id: "other", data: { text: "Other", val: "other" } },
         ],
@@ -163,21 +172,12 @@ export const ResidentialUnitsGLAGained: Schema = {
     {
       type: "question",
       data: {
-        title: "Is this unit built on garden land?",
+        title: "Will this unit be built on garden land?",
         fn: "garden",
         options: [
           { id: "true", data: { text: "Yes", val: "true" } },
           { id: "false", data: { text: "No", val: "false" } },
         ],
-      },
-    },
-    {
-      type: "number",
-      data: {
-        title: "What will be the Gross Internal Floor Area (GIA) of this unit?",
-        units: "m²",
-        fn: "area",
-        allowNegatives: false,
       },
     },
     {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
@@ -205,7 +205,7 @@ export const ResidentialUnitsGLAGained: Schema = {
     {
       type: "number",
       data: {
-        title: "How many units that fit the descriptions above are gained?",
+        title: "How many units of the type described above are gained?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Gained.ts
@@ -1,0 +1,215 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+
+export const ResidentialUnitsGLAGained: Schema = {
+  type: "Gained residential unit type",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title: "How many habitable rooms will this unit have?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many bedrooms will this unit have?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent", val: "LAR" } },
+          {
+            id: "AR",
+            data: {
+              text: "Affordable rent (not at LAR benchmark rents)",
+              val: "AR",
+            },
+          },
+          { id: "SR", data: { text: "Social rent", val: "SR" } },
+          { id: "LRR", data: { text: "London Living Rent", val: "LRR" } },
+          {
+            id: "sharedEquity",
+            data: { text: "Shared equity", val: "sharedEquity" },
+          },
+          { id: "LSO", data: { text: "London Shared Ownership", val: "LSO" } },
+          { id: "DMS", data: { text: "Discount market sale", val: "DMS" } },
+          { id: "DMR", data: { text: "Discount market rent", val: "DMR" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+              val: "DMRLLR",
+            },
+          },
+          {
+            id: "marketForRent",
+            data: { text: "Market for rent", val: "marketForRent" },
+          },
+          { id: "SH", data: { text: "Starter homes", val: "SH" } },
+          {
+            id: "selfCustomBuild",
+            data: {
+              text: "Self-build and custom build",
+              val: "selfCustomBuild",
+            },
+          },
+          {
+            id: "marketForSale",
+            data: { text: "Market for sale", val: "marketForSale" },
+          },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home", val: "terraced" } },
+          {
+            id: "semiDetached",
+            data: { text: "Semi detached home", val: "semiDetached" },
+          },
+          { id: "detached", data: { text: "Detached home", val: "detached" } },
+          {
+            id: "flat",
+            data: { text: "Flat/apartment or maisonette", val: "flat" },
+          },
+          { id: "LW", data: { text: "Live/work unit", val: "LW" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "coLiving", data: { text: "Co living unit", val: "coLiving" } },
+          { id: "hostel", data: { text: "Hostel room", val: "hostel" } },
+          { id: "HMO", data: { text: "HMO", val: "HMO" } },
+          {
+            id: "student",
+            data: { text: "Student accommodation", val: "student" },
+          },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private", val: "private" } },
+          {
+            id: "privateRented",
+            data: { text: "Private rented sector", val: "privateRented" },
+          },
+          { id: "HA", data: { text: "Housing association", val: "HA" } },
+          { id: "LA", data: { text: "Local authority", val: "LA" } },
+          {
+            id: "publicAuthority",
+            data: { text: "Other public authority", val: "publicAuthority" },
+          },
+          {
+            id: "councilDelivery",
+            data: { text: "Council delivery company", val: "councilDelivery" },
+          },
+          {
+            id: "councilBuildToRent",
+            data: {
+              text: "Council delivered build to rent",
+              val: "councilBuildToRent",
+            },
+          },
+          {
+            id: "affordableHousing",
+            data: {
+              text: "Other affordable housing provider",
+              val: "affordableHousing",
+            },
+          },
+          { id: "selfBuild", data: { text: "Self-build", val: "selfBuild" } },
+        ],
+      },
+    },
+    {
+      type: "checklist",
+      data: {
+        title: "Will this unit be compliant with any of the following?",
+        fn: "compliance",
+        options: [
+          {
+            id: "m42",
+            data: { text: "Part M4(2) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432a",
+            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432b",
+            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+          },
+          { id: "none", data: { text: "None of these" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit built on garden land?",
+        fn: "garden",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What will be the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Will this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many units that fit the descriptions above are gained?",
+        fn: "identicalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
@@ -4,6 +4,45 @@ export const ResidentialUnitsGLALost: Schema = {
   type: "Lost residential unit type",
   fields: [
     {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home", val: "terraced" } },
+          {
+            id: "semiDetached",
+            data: { text: "Semi detached home", val: "semiDetached" },
+          },
+          { id: "detached", data: { text: "Detached home", val: "detached" } },
+          {
+            id: "flat",
+            data: { text: "Flat/apartment or maisonette", val: "flat" },
+          },
+          { id: "LW", data: { text: "Live/work unit", val: "LW" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "coLiving", data: { text: "Co living unit", val: "coLiving" } },
+          { id: "hostel", data: { text: "Hostel room", val: "hostel" } },
+          { id: "HMO", data: { text: "HMO", val: "HMO" } },
+          {
+            id: "student",
+            data: { text: "Student accommodation", val: "student" },
+          },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
       type: "number",
       data: {
         title: "How many habitable rooms does this unit have?",
@@ -64,36 +103,6 @@ export const ResidentialUnitsGLALost: Schema = {
           {
             id: "marketForSale",
             data: { text: "Market for sale", val: "marketForSale" },
-          },
-          { id: "other", data: { text: "Other", val: "other" } },
-        ],
-      },
-    },
-    {
-      type: "question",
-      data: {
-        title: "What best describes the type of this unit?",
-        fn: "type",
-        options: [
-          { id: "terraced", data: { text: "Terraced home", val: "terraced" } },
-          {
-            id: "semiDetached",
-            data: { text: "Semi detached home", val: "semiDetached" },
-          },
-          { id: "detached", data: { text: "Detached home", val: "detached" } },
-          {
-            id: "flat",
-            data: { text: "Flat/apartment or maisonette", val: "flat" },
-          },
-          { id: "LW", data: { text: "Live/work unit", val: "LW" } },
-          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
-          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
-          { id: "coLiving", data: { text: "Co living unit", val: "coLiving" } },
-          { id: "hostel", data: { text: "Hostel room", val: "hostel" } },
-          { id: "HMO", data: { text: "HMO", val: "HMO" } },
-          {
-            id: "student",
-            data: { text: "Student accommodation", val: "student" },
           },
           { id: "other", data: { text: "Other", val: "other" } },
         ],
@@ -169,15 +178,6 @@ export const ResidentialUnitsGLALost: Schema = {
           { id: "true", data: { text: "Yes", val: "true" } },
           { id: "false", data: { text: "No", val: "false" } },
         ],
-      },
-    },
-    {
-      type: "number",
-      data: {
-        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
-        units: "m²",
-        fn: "area",
-        allowNegatives: false,
       },
     },
     {

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
@@ -1,0 +1,215 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+
+export const ResidentialUnitsGLALost: Schema = {
+  type: "Lost residential unit type",
+  fields: [
+    {
+      type: "number",
+      data: {
+        title: "How many habitable rooms does this unit have?",
+        fn: "habitable",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many bedrooms does this unit have?",
+        fn: "bedrooms",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Which best describes the tenure of this unit?",
+        fn: "tenure",
+        options: [
+          { id: "LAR", data: { text: "London Affordable Rent", val: "LAR" } },
+          {
+            id: "AR",
+            data: {
+              text: "Affordable rent (not at LAR benchmark rents)",
+              val: "AR",
+            },
+          },
+          { id: "SR", data: { text: "Social rent", val: "SR" } },
+          { id: "LRR", data: { text: "London Living Rent", val: "LRR" } },
+          {
+            id: "sharedEquity",
+            data: { text: "Shared equity", val: "sharedEquity" },
+          },
+          { id: "LSO", data: { text: "London Shared Ownership", val: "LSO" } },
+          { id: "DMS", data: { text: "Discount market sale", val: "DMS" } },
+          { id: "DMR", data: { text: "Discount market rent", val: "DMR" } },
+          {
+            id: "DMRLLR",
+            data: {
+              text: "Discount market rent (charged at London Living Rents)",
+              val: "DMRLLR",
+            },
+          },
+          {
+            id: "marketForRent",
+            data: { text: "Market for rent", val: "marketForRent" },
+          },
+          { id: "SH", data: { text: "Starter homes", val: "SH" } },
+          {
+            id: "selfCustomBuild",
+            data: {
+              text: "Self-build and custom build",
+              val: "selfCustomBuild",
+            },
+          },
+          {
+            id: "marketForSale",
+            data: { text: "Market for sale", val: "marketForSale" },
+          },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "terraced", data: { text: "Terraced home", val: "terraced" } },
+          {
+            id: "semiDetached",
+            data: { text: "Semi detached home", val: "semiDetached" },
+          },
+          { id: "detached", data: { text: "Detached home", val: "detached" } },
+          {
+            id: "flat",
+            data: { text: "Flat/apartment or maisonette", val: "flat" },
+          },
+          { id: "LW", data: { text: "Live/work unit", val: "LW" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "coLiving", data: { text: "Co living unit", val: "coLiving" } },
+          { id: "hostel", data: { text: "Hostel room", val: "hostel" } },
+          { id: "HMO", data: { text: "HMO", val: "HMO" } },
+          {
+            id: "student",
+            data: { text: "Student accommodation", val: "student" },
+          },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "What best describes the provider of this unit?",
+        fn: "provider",
+        options: [
+          { id: "private", data: { text: "Private", val: "private" } },
+          {
+            id: "privateRented",
+            data: { text: "Private rented sector", val: "privateRented" },
+          },
+          { id: "HA", data: { text: "Housing association", val: "HA" } },
+          { id: "LA", data: { text: "Local authority", val: "LA" } },
+          {
+            id: "publicAuthority",
+            data: { text: "Other public authority", val: "publicAuthority" },
+          },
+          {
+            id: "councilDelivery",
+            data: { text: "Council delivery company", val: "councilDelivery" },
+          },
+          {
+            id: "councilBuildToRent",
+            data: {
+              text: "Council delivered build to rent",
+              val: "councilBuildToRent",
+            },
+          },
+          {
+            id: "affordableHousing",
+            data: {
+              text: "Other affordable housing provider",
+              val: "affordableHousing",
+            },
+          },
+          { id: "selfBuild", data: { text: "Self-build", val: "selfBuild" } },
+        ],
+      },
+    },
+    {
+      type: "checklist",
+      data: {
+        title: "Is this unit compliant with any of the following?",
+        fn: "compliance",
+        options: [
+          {
+            id: "m42",
+            data: { text: "Part M4(2) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432a",
+            data: { text: "Part M4(3)(2a) of the Building Regulations 2010" },
+          },
+          {
+            id: "m432b",
+            data: { text: "Part M4(3)(2b) of the Building Regulations 2010" },
+          },
+          { id: "none", data: { text: "None of these" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit built on garden land?",
+        fn: "garden",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "What is the Gross Internal Floor Area (GIA) of this unit?",
+        units: "m²",
+        fn: "area",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Does this unit provide sheltered accommodation?",
+        fn: "sheltered",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is this unit specifically designed for older people?",
+        fn: "olderPersons",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many units that fit the descriptions above are lost?",
+        fn: "identicalUnits",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/GLA/Lost.ts
@@ -205,7 +205,7 @@ export const ResidentialUnitsGLALost: Schema = {
     {
       type: "number",
       data: {
-        title: "How many units that fit the descriptions above are lost?",
+        title: "How many units of the type described above are lost?",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
@@ -6,6 +6,27 @@ export const ResidentialUnitsProposed: Schema = {
     {
       type: "question",
       data: {
+        title: "What best describes the type of this unit?",
+        fn: "type",
+        options: [
+          { id: "house", data: { text: "House", val: "house" } },
+          {
+            id: "flat",
+            data: { text: "Flat, apartment or maisonette", val: "flat" },
+          },
+          {
+            id: "sheltered",
+            data: { text: "Sheltered housing", val: "sheltered" },
+          },
+          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
+          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
+          { id: "other", data: { text: "Other", val: "other" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
         title: "What best describes the tenure of this unit?",
         fn: "tenure",
         options: [
@@ -31,27 +52,6 @@ export const ResidentialUnitsProposed: Schema = {
       },
     },
     {
-      type: "question",
-      data: {
-        title: "What best describes the type of this unit?",
-        fn: "type",
-        options: [
-          { id: "house", data: { text: "House", val: "house" } },
-          {
-            id: "flat",
-            data: { text: "Flat, apartment or maisonette", val: "flat" },
-          },
-          {
-            id: "sheltered",
-            data: { text: "Sheltered housing", val: "sheltered" },
-          },
-          { id: "studio", data: { text: "Studio or bedsit", val: "studio" } },
-          { id: "cluster", data: { text: "Cluster flat", val: "cluster" } },
-          { id: "other", data: { text: "Other", val: "other" } },
-        ],
-      },
-    },
-    {
       type: "number",
       data: {
         title: "How many bedrooms will this unit have?",
@@ -62,7 +62,9 @@ export const ResidentialUnitsProposed: Schema = {
     {
       type: "number",
       data: {
-        title: "How many proposed units fit the descriptions above?",
+        title: "How many units of the type described above are proposed?",
+        description:
+          "This is the number of units of the type described above that will be on the site after completion of the project.",
         fn: "identicalUnits",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/ResidentialUnits/Proposed.ts
@@ -62,9 +62,9 @@ export const ResidentialUnitsProposed: Schema = {
     {
       type: "number",
       data: {
-        title: "How many units of the type described above are proposed?",
+        title: "How many units of the type described above are you proposing?",
         description:
-          "This is the number of units of the type described above that will be on the site after completion of the project.",
+          "This is the total number of units of this type that will be on the site after completion of the project.",
         fn: "identicalUnits",
         allowNegatives: false,
       },


### PR DESCRIPTION
Add Lost/Gained list schema to GLA residential units in addition to current New/Retained/Rebuilt/Removed distinction. The current structure attempts to capture both national and GLA requirements in one structure. GLA councils do however not capture the nationally required information in their current form submissions. This is an alternative and simplified mode of capturing the GLA information.