### PR TITLE
feat: Basic validation for `MapAndLabel`

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -552,7 +552,7 @@ describe("Form validation and error handling", () => {
 
   test(
     "an error displays if the maximum number of items is exceeded",
-    { timeout: 20000 },
+    { timeout: 25000 },
     async () => {
       const { user, getAllByTestId, getByTestId, getByText } = setup(
         <ListComponent {...mockZooProps} />,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -118,7 +118,6 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
   };
 
   const editItem = (index: number) => {
-    setActiveItemInitialState(formik.values.schemaData[index]);
     setActiveIndex(index);
   };
 
@@ -128,6 +127,8 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     formik.setFieldValue(`schemaData[${activeIndex}]`, activeItemInitialState);
 
   const addFeature = () => {
+    resetErrors();
+
     const currentFeatures = formik.values.schemaData;
     const updatedFeatures = [...currentFeatures, initialValues];
     formik.setFieldValue("schemaData", updatedFeatures);

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -9,6 +9,7 @@ import {
   makeData,
 } from "@planx/components/shared/utils";
 import { FormikProps, useFormik } from "formik";
+import { get } from "lodash";
 import React, {
   createContext,
   PropsWithChildren,
@@ -26,6 +27,7 @@ interface MapAndLabelContextValue {
   cancelEditItem: () => void;
   formik: FormikProps<SchemaUserData>;
   validateAndSubmitForm: () => void;
+  isTabInvalid: (index: number) => boolean;
   addFeature: () => void;
   mapAndLabelProps: PresentationalProps;
   errors: {
@@ -103,9 +105,6 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
       return setMinError(true);
     }
 
-    // const errors = await formik.validateForm();
-    // console.log({errors})
-
     formik.handleSubmit();
   };
 
@@ -120,6 +119,9 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
   const editItem = (index: number) => {
     setActiveIndex(index);
   };
+
+  const isTabInvalid = (index: number) =>
+    Boolean(get(formik.errors, ["schemaData", index]));
 
   const exitEditMode = () => setActiveIndex(-1);
 
@@ -151,6 +153,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
         formik,
         validateAndSubmitForm,
         addFeature,
+        isTabInvalid,
         errors: {
           unsavedItem: unsavedItemError,
           min: minError,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -92,12 +92,15 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
 
   const validateAndSubmitForm = () => {
     // Do not allow submissions with an unsaved item
-    if (activeIndex !== -1) return setUnsavedItemError(true);
+    // if (activeIndex !== -1) return setUnsavedItemError(true);
 
     // Manually validate minimum number of items
-    if (formik.values.schemaData.length < schema.min) {
-      return setMinError(true);
-    }
+    // if (formik.values.schemaData.length < schema.min) {
+    //   return setMinError(true);
+    // }
+
+    // const errors = await formik.validateForm();
+    // console.log({errors})
 
     formik.handleSubmit();
   };

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -26,6 +26,7 @@ interface MapAndLabelContextValue {
   cancelEditItem: () => void;
   formik: FormikProps<SchemaUserData>;
   validateAndSubmitForm: () => void;
+  addFeature: () => void;
   mapAndLabelProps: PresentationalProps;
   errors: {
     unsavedItem: boolean;
@@ -44,13 +45,15 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
   props,
 ) => {
   const { schema, children, handleSubmit } = props;
-  const { formikConfig, initialValues: _initialValues } = useSchema({
+  const { formikConfig, initialValues } = useSchema({
     schema,
     previousValues: getPreviouslySubmittedData(props),
   });
 
   const formik = useFormik<SchemaUserData>({
     ...formikConfig,
+    // The user interactions are map driven - start with no values added
+    initialValues: { schemaData: [] },
     onSubmit: (values) => {
       const defaultPassportData = makeData(props, values.schemaData)?.["data"];
 
@@ -80,6 +83,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     setUnsavedItemError(false);
   };
 
+  // TODO: Not required?
   const saveItem = async () => {
     resetErrors();
 
@@ -95,9 +99,9 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     // if (activeIndex !== -1) return setUnsavedItemError(true);
 
     // Manually validate minimum number of items
-    // if (formik.values.schemaData.length < schema.min) {
-    //   return setMinError(true);
-    // }
+    if (formik.values.schemaData.length < schema.min) {
+      return setMinError(true);
+    }
 
     // const errors = await formik.validateForm();
     // console.log({errors})
@@ -123,6 +127,12 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
   const resetItemToPreviousState = () =>
     formik.setFieldValue(`schemaData[${activeIndex}]`, activeItemInitialState);
 
+  const addFeature = () => {
+    const currentFeatures = formik.values.schemaData;
+    const updatedFeatures = [...currentFeatures, initialValues];
+    formik.setFieldValue("schemaData", updatedFeatures);
+  };
+
   return (
     <MapAndLabelContext.Provider
       value={{
@@ -134,6 +144,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
         cancelEditItem,
         formik,
         validateAndSubmitForm,
+        addFeature,
         errors: {
           unsavedItem: unsavedItemError,
           min: minError,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -1,9 +1,5 @@
 import { useSchema } from "@planx/components/shared/Schema/hook";
-import {
-  Schema,
-  SchemaUserData,
-  SchemaUserResponse,
-} from "@planx/components/shared/Schema/model";
+import { Schema, SchemaUserData } from "@planx/components/shared/Schema/model";
 import {
   getPreviouslySubmittedData,
   makeData,
@@ -22,16 +18,13 @@ import { PresentationalProps } from ".";
 interface MapAndLabelContextValue {
   schema: Schema;
   activeIndex: number;
-  saveItem: () => Promise<void>;
-  editItem: (index: number) => void;
-  cancelEditItem: () => void;
+  editFeature: (index: number) => void;
   formik: FormikProps<SchemaUserData>;
   validateAndSubmitForm: () => void;
-  isTabInvalid: (index: number) => boolean;
+  isFeatureInvalid: (index: number) => boolean;
   addFeature: () => void;
   mapAndLabelProps: PresentationalProps;
   errors: {
-    unsavedItem: boolean;
     min: boolean;
     max: boolean;
   };
@@ -71,36 +64,16 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     props.previouslySubmittedData ? -1 : 0,
   );
 
-  const [activeItemInitialState, setActiveItemInitialState] = useState<
-    SchemaUserResponse | undefined
-  >(undefined);
-
-  const [unsavedItemError, setUnsavedItemError] = useState<boolean>(false);
   const [minError, setMinError] = useState<boolean>(false);
   const [maxError, setMaxError] = useState<boolean>(false);
 
   const resetErrors = () => {
     setMinError(false);
     setMaxError(false);
-    setUnsavedItemError(false);
-  };
-
-  // TODO: Not required?
-  const saveItem = async () => {
-    resetErrors();
-
-    const errors = await formik.validateForm();
-    const isValid = !errors.schemaData?.length;
-    if (isValid) {
-      exitEditMode();
-    }
   };
 
   const validateAndSubmitForm = () => {
-    // Do not allow submissions with an unsaved item
-    // if (activeIndex !== -1) return setUnsavedItemError(true);
-
-    // Manually validate minimum number of items
+    // Manually validate minimum number of features
     if (formik.values.schemaData.length < schema.min) {
       return setMinError(true);
     }
@@ -108,25 +81,12 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     formik.handleSubmit();
   };
 
-  const cancelEditItem = () => {
-    if (activeItemInitialState) resetItemToPreviousState();
-
-    setActiveItemInitialState(undefined);
-
-    exitEditMode();
-  };
-
-  const editItem = (index: number) => {
+  const editFeature = (index: number) => {
     setActiveIndex(index);
   };
 
-  const isTabInvalid = (index: number) =>
+  const isFeatureInvalid = (index: number) =>
     Boolean(get(formik.errors, ["schemaData", index]));
-
-  const exitEditMode = () => setActiveIndex(-1);
-
-  const resetItemToPreviousState = () =>
-    formik.setFieldValue(`schemaData[${activeIndex}]`, activeItemInitialState);
 
   const addFeature = () => {
     resetErrors();
@@ -145,17 +105,14 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     <MapAndLabelContext.Provider
       value={{
         activeIndex,
-        saveItem,
         schema,
         mapAndLabelProps: props,
-        editItem,
-        cancelEditItem,
+        editFeature,
         formik,
         validateAndSubmitForm,
         addFeature,
-        isTabInvalid,
+        isFeatureInvalid,
         errors: {
-          unsavedItem: unsavedItemError,
           min: minError,
           max: maxError,
         },

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -132,6 +132,11 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     const currentFeatures = formik.values.schemaData;
     const updatedFeatures = [...currentFeatures, initialValues];
     formik.setFieldValue("schemaData", updatedFeatures);
+
+    // TODO: Handle more gracefully - stop user from adding new feature to map?
+    if (schema.max && updatedFeatures.length > schema.max) {
+      setMaxError(true);
+    }
   };
 
   return (

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -44,7 +44,7 @@ function a11yProps(index: number) {
 const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
   features,
 }) => {
-  const { schema, activeIndex, formik, editItem, isTabInvalid } =
+  const { schema, activeIndex, formik, editFeature, isFeatureInvalid } =
     useMapAndLabelContext();
 
   return (
@@ -62,7 +62,7 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
           variant="scrollable"
           value={activeIndex.toString()}
           onChange={(_e, newValue) => {
-            editItem(parseInt(newValue, 10));
+            editFeature(parseInt(newValue, 10));
           }}
           // TODO!
           aria-label="Vertical tabs example"
@@ -74,7 +74,7 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
               value={i.toString()}
               label={`${schema.type} ${feature.properties?.label}`}
               {...a11yProps(i)}
-              {...(isTabInvalid(i) && {
+              {...(isFeatureInvalid(i) && {
                 sx: (theme) => ({
                   backgroundColor: theme.palette.action.focus,
                 }),

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -44,7 +44,8 @@ function a11yProps(index: number) {
 const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
   features,
 }) => {
-  const { schema, activeIndex, formik, editItem } = useMapAndLabelContext();
+  const { schema, activeIndex, formik, editItem, isTabInvalid } =
+    useMapAndLabelContext();
 
   return (
     <Box
@@ -73,6 +74,11 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
               value={i.toString()}
               label={`${schema.type} ${feature.properties?.label}`}
               {...a11yProps(i)}
+              {...(isTabInvalid(i) && {
+                sx: (theme) => ({
+                  backgroundColor: theme.palette.action.focus,
+                }),
+              })}
             />
           ))}
         </Tabs>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -17,6 +17,7 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import SelectInput from "ui/editor/SelectInput";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import InputLabel from "ui/public/InputLabel";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import Card from "../../shared/Preview/Card";
 import CardHeader from "../../shared/Preview/CardHeader";
@@ -171,7 +172,8 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
 };
 
 const Root = () => {
-  const { validateAndSubmitForm, mapAndLabelProps } = useMapAndLabelContext();
+  const { validateAndSubmitForm, mapAndLabelProps, errors } =
+    useMapAndLabelContext();
   const {
     title,
     description,
@@ -218,34 +220,41 @@ const Root = () => {
         howMeasured={howMeasured}
       />
       <FullWidthWrapper>
-        <MapContainer environment="standalone">
-          {/* @ts-ignore */}
-          <my-map
-            id="map-and-label-map"
-            basemap={basemap}
-            ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
-            drawMode
-            drawMany
-            drawColor={drawColor}
-            drawType={drawType}
-            drawPointer="crosshair"
-            zoom={20}
-            maxZoom={23}
-            latitude={latitude}
-            longitude={longitude}
-            osProxyEndpoint={`${
-              import.meta.env.VITE_APP_API_URL
-            }/proxy/ordnance-survey`}
-            osCopyright={
-              basemap === "OSVectorTile"
-                ? `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`
-                : ``
-            }
-            clipGeojsonData={boundaryBBox && JSON.stringify(boundaryBBox)}
-            mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
-            collapseAttributions
-          />
-        </MapContainer>
+        <ErrorWrapper
+          error={
+            errors.min
+              ? "Please add at least one feature to the map"
+              : undefined
+          }
+        >
+          <MapContainer environment="standalone">
+            {/* @ts-ignore */}
+            <my-map
+              id="map-and-label-map"
+              basemap={basemap}
+              ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
+              drawMode
+              drawMany
+              drawColor={drawColor}
+              drawType={drawType}
+              drawPointer="crosshair"
+              zoom={20}
+              maxZoom={23}
+              latitude={latitude}
+              longitude={longitude}
+              osProxyEndpoint={`${import.meta.env.VITE_APP_API_URL
+                }/proxy/ordnance-survey`}
+              osCopyright={
+                basemap === "OSVectorTile"
+                  ? `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`
+                  : ``
+              }
+              clipGeojsonData={boundaryBBox && JSON.stringify(boundaryBBox)}
+              mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
+              collapseAttributions
+            />
+          </MapContainer>
+        </ErrorWrapper>
         {features && features?.length > 0 ? (
           <VerticalFeatureTabs features={features} />
         ) : (

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -190,11 +190,13 @@ const Root = () => {
   } = mapAndLabelProps;
 
   const [features, setFeatures] = useState<Feature[] | undefined>(undefined);
+  const { addFeature } = useMapAndLabelContext();
 
   useEffect(() => {
     const geojsonChangeHandler = ({ detail: geojson }: any) => {
       if (geojson["EPSG:3857"]?.features) {
         setFeatures(geojson["EPSG:3857"].features);
+        addFeature();
       } else {
         // if the user clicks 'reset' on the map, geojson will be empty object, so set features to undefined
         setFeatures(undefined);
@@ -208,7 +210,7 @@ const Root = () => {
     return function cleanup() {
       map?.removeEventListener("geojsonChange", geojsonChangeHandler);
     };
-  }, [setFeatures]);
+  }, [setFeatures, addFeature]);
 
   return (
     <Card handleSubmit={validateAndSubmitForm} isValid>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -186,7 +186,7 @@ const Root = () => {
   } = mapAndLabelProps;
 
   const [features, setFeatures] = useState<Feature[] | undefined>(undefined);
-  const { addFeature } = useMapAndLabelContext();
+  const { addFeature, schema } = useMapAndLabelContext();
 
   useEffect(() => {
     const geojsonChangeHandler = ({ detail: geojson }: any) => {
@@ -208,6 +208,11 @@ const Root = () => {
     };
   }, [setFeatures, addFeature]);
 
+  const rootError: string =
+    (errors.min && `You must provide at least ${schema.min} response(s)`) ||
+    (errors.max && `You can provide at most ${schema.max} response(s)`) ||
+    "";
+
   return (
     <Card handleSubmit={validateAndSubmitForm} isValid>
       <CardHeader
@@ -218,13 +223,7 @@ const Root = () => {
         howMeasured={howMeasured}
       />
       <FullWidthWrapper>
-        <ErrorWrapper
-          error={
-            errors.min
-              ? "Please add at least one feature to the map"
-              : undefined
-          }
-        >
+        <ErrorWrapper error={rootError}>
           <MapContainer environment="standalone">
             {/* @ts-ignore */}
             <my-map

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -44,14 +44,7 @@ function a11yProps(index: number) {
 const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
   features,
 }) => {
-  const { schema, activeIndex, formik } = useMapAndLabelContext();
-  const [activeTab, setActiveTab] = useState<string>(
-    features[features.length - 1].properties?.label || "",
-  );
-
-  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
-    setActiveTab(newValue);
-  };
+  const { schema, activeIndex, formik, editItem } = useMapAndLabelContext();
 
   return (
     <Box
@@ -62,19 +55,22 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
         maxHeight: "fit-content",
       }}
     >
-      <TabContext value={activeTab}>
+      <TabContext value={activeIndex.toString()}>
         <Tabs
           orientation="vertical"
           variant="scrollable"
-          value={activeTab}
-          onChange={handleChange}
+          value={activeIndex.toString()}
+          onChange={(_e, newValue) => {
+            editItem(parseInt(newValue, 10));
+          }}
+          // TODO!
           aria-label="Vertical tabs example"
           sx={{ borderRight: 1, borderColor: "divider" }}
         >
           {features.map((feature, i) => (
             <Tab
               key={`tab-${i}`}
-              value={feature.properties?.label}
+              value={i.toString()}
               label={`${schema.type} ${feature.properties?.label}`}
               {...a11yProps(i)}
             />
@@ -83,7 +79,7 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
         {features.map((feature, i) => (
           <TabPanel
             key={`tabpanel-${i}`}
-            value={feature.properties?.label}
+            value={i.toString()}
             sx={{ width: "100%" }}
           >
             <Box

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -111,35 +111,36 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
                       } m²)`}
                 </Typography>
               </Box>
-              <Box>
-                <InputLabel label="Copy from" id={`select-${i}`}>
-                  <SelectInput
-                    bordered
-                    required
-                    title={"Copy from"}
-                    labelId={`select-label-${i}`}
-                    value={""}
-                    onChange={() =>
-                      console.log(`TODO - Copy data from another tab`)
-                    }
-                    name={""}
-                    style={{ width: "200px" }}
-                  >
-                    {features
-                      .filter(
-                        (feature) => feature.properties?.label !== activeTab,
-                      )
-                      .map((option) => (
-                        <MenuItem
-                          key={option.properties?.label}
-                          value={option.properties?.label}
-                        >
-                          {`${schema.type} ${option.properties?.label}`}
-                        </MenuItem>
-                      ))}
-                  </SelectInput>
-                </InputLabel>
-              </Box>
+              {features.length > 1 && (
+                <Box>
+                  <InputLabel label="Copy from" id={`select-${i}`}>
+                    <SelectInput
+                      bordered
+                      required
+                      title={"Copy from"}
+                      labelId={`select-label-${i}`}
+                      value={""}
+                      onChange={() =>
+                        console.log(`TODO - Copy data from another tab`)
+                      }
+                      name={""}
+                      style={{ width: "200px" }}
+                    >
+                      {/* Iterate over all other features */}
+                      {features
+                        .filter((_, j) => j !== i)
+                        .map((option) => (
+                          <MenuItem
+                            key={option.properties?.label}
+                            value={option.properties?.label}
+                          >
+                            {`${schema.type} ${option.properties?.label}`}
+                          </MenuItem>
+                        ))}
+                    </SelectInput>
+                  </InputLabel>
+                </Box>
+              )}
             </Box>
             <SchemaFields
               sx={(theme) => ({
@@ -245,8 +246,9 @@ const Root = () => {
               maxZoom={23}
               latitude={latitude}
               longitude={longitude}
-              osProxyEndpoint={`${import.meta.env.VITE_APP_API_URL
-                }/proxy/ordnance-survey`}
+              osProxyEndpoint={`${
+                import.meta.env.VITE_APP_API_URL
+              }/proxy/ordnance-survey`}
               osCopyright={
                 basemap === "OSVectorTile"
                   ? `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`


### PR DESCRIPTION
## What does this PR do?
- Wires up Formik validation on the `MapAndLabel` component
  - Validation is triggered when hitting continue
  - The minimum number of items is checked
  - The maximum number of items is checked
  - Errors in tabs are highlighted - certainly not advocating for this to be the final style but I just wanted to get the data flow set up here. 
 - Removes some List specific functionality from `MapAndLabelContext`
 - Starts using the language of "features" instead of "items" - feels a little clearer and less generic, but super open to feedback here.
 - No tests! Interaction with the Map webcomponent is proving tricky - I'll have a PR later today with my various attempts documented, and I'll work on mocking the GeoJSON change event as an alternative.

## Demo

https://github.com/user-attachments/assets/035be7c6-50d7-4a78-abb1-79501b7078fe

