### PR TITLE
style: Simplify editor sidebar tabs

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
@@ -19,7 +19,7 @@ const StyledTab = styled((props: TabProps) => (
   [`&.${tabClasses.selected}`]: {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
     color: theme.palette.text.primary,
-    boxShadow: `inset 0 -3px 0 ${theme.palette.warning.main}`,
+    boxShadow: `inset 0 -3px 0 ${theme.palette.info.main}`,
   },
 }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
@@ -3,36 +3,23 @@ import Tab, { tabClasses, TabProps } from "@mui/material/Tab";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-interface StyledTabProps extends TabProps {
-  tabTheme?: "light" | "dark";
-}
-
-const StyledTab = styled(({ tabTheme, ...props }: StyledTabProps) => (
+const StyledTab = styled((props: TabProps) => (
   <Tab {...props} disableFocusRipple disableTouchRipple disableRipple />
-))<StyledTabProps>(({ theme, tabTheme }) => ({
+))<TabProps>(({ theme }) => ({
   position: "relative",
   zIndex: 1,
   textTransform: "none",
   background: "transparent",
-  border: `1px solid transparent`,
   borderBottomColor: theme.palette.border.main,
-  color: theme.palette.primary.main,
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  color: theme.palette.text.primary,
+  minWidth: "75px",
   minHeight: "36px",
   margin: theme.spacing(0, 0.5),
-  marginBottom: "-1px",
-  padding: "0.5em",
+  padding: "0.75em 0.25em",
   [`&.${tabClasses.selected}`]: {
-    background:
-      tabTheme === "dark"
-        ? theme.palette.background.dark
-        : theme.palette.background.default,
-    borderColor: theme.palette.border.main,
-    borderBottomColor: theme.palette.common.white,
-    color:
-      tabTheme === "dark"
-        ? theme.palette.common.white
-        : theme.palette.text.primary,
+    fontWeight: FONT_WEIGHT_SEMI_BOLD,
+    color: theme.palette.text.primary,
+    boxShadow: `inset 0 -3px 0 ${theme.palette.background.dark}`,
   },
 }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/StyledTab.tsx
@@ -19,7 +19,7 @@ const StyledTab = styled((props: TabProps) => (
   [`&.${tabClasses.selected}`]: {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
     color: theme.palette.text.primary,
-    boxShadow: `inset 0 -3px 0 ${theme.palette.background.dark}`,
+    boxShadow: `inset 0 -3px 0 ${theme.palette.warning.main}`,
   },
 }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -69,7 +69,7 @@ const SidebarContainer = styled(Box)(() => ({
 }));
 
 const Header = styled("header")(({ theme }) => ({
-  padding: theme.spacing(1),
+  padding: theme.spacing(1, 1.5),
   "& input": {
     flex: "1",
     padding: "5px",
@@ -108,6 +108,7 @@ const TabList = styled(Box)(({ theme }) => ({
   },
   "& .MuiTabs-root": {
     minHeight: "0",
+    padding: theme.spacing(0, 1.5),
   },
   // Hide default MUI indicator as we're using custom styling
   "& .MuiTabs-indicator": {
@@ -389,13 +390,13 @@ const Sidebar: React.FC<{
         </Box>
       </Header>
       <TabList>
-        <Tabs centered onChange={handleChange} value={activeTab} aria-label="">
-          <StyledTab value="PreviewBrowser" label="Preview" tabTheme="light" />
-          <StyledTab value="History" label="History" tabTheme="light" />
+        <Tabs onChange={handleChange} value={activeTab} aria-label="">
+          <StyledTab value="PreviewBrowser" label="Preview" />
+          <StyledTab value="History" label="History" />
           {hasFeatureFlag("SEARCH") && (
-            <StyledTab value="Search" label="Search" tabTheme="light" />
+            <StyledTab value="Search" label="Search" />
           )}
-          <StyledTab value="Console" label="Console" tabTheme="dark" />
+          <StyledTab value="Console" label="Console" />
         </Tabs>
       </TabList>
       {activeTab === "PreviewBrowser" && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -298,12 +298,7 @@ const Sidebar: React.FC<{
           )}
         </Box>
         <Box width="100%" mt={2}>
-          <Box
-            display="flex"
-            flexDirection="column"
-            alignItems="flex-end"
-            marginRight={1}
-          >
+          <Box display="flex" flexDirection="column" alignItems="flex-end">
             <Badge
               sx={{ width: "100%" }}
               badgeContent={alteredNodes && alteredNodes.length}


### PR DESCRIPTION
## What does this PR do?

Simplify the sidebar tabs so that they don't require a colour theme prop, and also take up less visual space.

Before:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/b30f3a99-34ad-412e-8f55-9268cdf2a635">

After:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/6a1c811f-d379-47db-9b3c-61172c57c493">

Preview:
https://3591.planx.pizza/lambeth/apply-for-planning-permission