### PR TITLE
feat(map-and-label): Copy feature

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -101,12 +101,6 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     }
   };
 
-  const addFeature = () => {
-    const currentFeatures = formik.values.schemaData;
-    const updatedFeatures = [...currentFeatures, initialValues];
-    formik.setFieldValue("schemaData", updatedFeatures);
-  };
-
   return (
     <MapAndLabelContext.Provider
       value={{

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -23,6 +23,7 @@ interface MapAndLabelContextValue {
   validateAndSubmitForm: () => void;
   isFeatureInvalid: (index: number) => boolean;
   addFeature: () => void;
+  copyFeature: (sourceIndex: number, destinationIndex: number) => void;
   mapAndLabelProps: PresentationalProps;
   errors: {
     min: boolean;
@@ -101,6 +102,11 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     }
   };
 
+  const copyFeature = (sourceIndex: number, destinationIndex: number) => {
+    const sourceFeature = formik.values.schemaData[sourceIndex];
+    formik.setFieldValue(`schemaData[${destinationIndex}]`, sourceFeature);
+  };
+
   return (
     <MapAndLabelContext.Provider
       value={{
@@ -111,6 +117,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
         formik,
         validateAndSubmitForm,
         addFeature,
+        copyFeature,
         isFeatureInvalid,
         errors: {
           min: minError,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -101,6 +101,12 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     }
   };
 
+  const addFeature = () => {
+    const currentFeatures = formik.values.schemaData;
+    const updatedFeatures = [...currentFeatures, initialValues];
+    formik.setFieldValue("schemaData", updatedFeatures);
+  };
+
   return (
     <MapAndLabelContext.Provider
       value={{

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -8,29 +8,39 @@ import InputLabel from "ui/public/InputLabel";
 import { useMapAndLabelContext } from "./Context";
 
 interface Props {
-  index: number;
+  destinationIndex: number;
   features: Feature[];
 }
 
-export const CopyFeature: React.FC<Props> = ({ index: i, features }) => {
-  const { schema } = useMapAndLabelContext();
+export const CopyFeature: React.FC<Props> = ({
+  destinationIndex,
+  features,
+}) => {
+  const { schema, copyFeature } = useMapAndLabelContext();
 
   // Only show component if there are multiple features
   if (features.length < 2) return null;
 
   // We can only copy from other features
-  const sourceFeatures = features.filter((_, j) => j !== i);
+  const sourceFeatures = features.filter(
+    (_, sourceIndex) => sourceIndex !== destinationIndex,
+  );
 
   return (
     <Box>
-      <InputLabel label="Copy from" id={`select-${i}`}>
+      <InputLabel label="Copy from" id={`select-${destinationIndex}`}>
         <SelectInput
           bordered
           required
           title={"Copy from"}
-          labelId={`select-label-${i}`}
+          labelId={`select-label-${destinationIndex}`}
           value={""}
-          onChange={() => console.log(`TODO - Copy data from another tab`)}
+          onChange={(e) => {
+            const label = e.target.value as string;
+            // Convert text label to zero-indexed integer
+            const sourceIndex = parseInt(label, 10) - 1;
+            copyFeature(sourceIndex, destinationIndex);
+          }}
           name={""}
           style={{ width: "200px" }}
         >

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -1,0 +1,49 @@
+import Box from "@mui/material/Box";
+import MenuItem from "@mui/material/MenuItem";
+import { Feature } from "geojson";
+import React from "react";
+import SelectInput from "ui/editor/SelectInput";
+import InputLabel from "ui/public/InputLabel";
+
+import { useMapAndLabelContext } from "./Context";
+
+interface Props {
+  index: number;
+  features: Feature[];
+}
+
+export const CopyFeature: React.FC<Props> = ({ index: i, features }) => {
+  const { schema } = useMapAndLabelContext();
+
+  // Only show component if there are multiple features
+  if (features.length < 2) return null;
+
+  // We can only copy from other features
+  const sourceFeatures = features.filter((_, j) => j !== i);
+
+  return (
+    <Box>
+      <InputLabel label="Copy from" id={`select-${i}`}>
+        <SelectInput
+          bordered
+          required
+          title={"Copy from"}
+          labelId={`select-label-${i}`}
+          value={""}
+          onChange={() => console.log(`TODO - Copy data from another tab`)}
+          name={""}
+          style={{ width: "200px" }}
+        >
+          {sourceFeatures.map((option) => (
+            <MenuItem
+              key={option.properties?.label}
+              value={option.properties?.label}
+            >
+              {`${schema.type} ${option.properties?.label}`}
+            </MenuItem>
+          ))}
+        </SelectInput>
+      </InputLabel>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import MenuItem from "@mui/material/MenuItem";
+import { visuallyHidden } from "@mui/utils";
 import { Feature } from "geojson";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput";
@@ -18,8 +19,8 @@ export const CopyFeature: React.FC<Props> = ({
 }) => {
   const { schema, copyFeature } = useMapAndLabelContext();
 
-  // Only show component if there are multiple features
-  if (features.length < 2) return null;
+  // Only enable component if there are multiple features
+  const isDisabled = features.length < 2;
 
   // We can only copy from other features
   const sourceFeatures = features.filter(
@@ -30,6 +31,8 @@ export const CopyFeature: React.FC<Props> = ({
     <Box>
       <InputLabel label="Copy from" id={`select-${destinationIndex}`}>
         <SelectInput
+          disabled={isDisabled}
+          aria-describedby="copy-feature-description"
           bordered
           required
           title={"Copy from"}
@@ -41,9 +44,13 @@ export const CopyFeature: React.FC<Props> = ({
             const sourceIndex = parseInt(label, 10) - 1;
             copyFeature(sourceIndex, destinationIndex);
           }}
-          name={""}
+          name={"copyFeature"}
           style={{ width: "200px" }}
         >
+          <span id="copy-feature-description" style={visuallyHidden}>
+            Please add at least two features to the map in order to enable this
+            feature
+          </span>
           {sourceFeatures.map((option) => (
             <MenuItem
               key={option.properties?.label}

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -109,7 +109,7 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
                       } m²)`}
                 </Typography>
               </Box>
-              <CopyFeature features={features} index={i} />
+              <CopyFeature features={features} destinationIndex={i} />
             </Box>
             <SchemaFields
               sx={(theme) => ({

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -3,7 +3,6 @@ import TabContext from "@mui/lab/TabContext";
 import TabPanel from "@mui/lab/TabPanel";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import MenuItem from "@mui/material/MenuItem";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
@@ -14,9 +13,7 @@ import { Feature, GeoJsonObject } from "geojson";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import SelectInput from "ui/editor/SelectInput";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
-import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import Card from "../../shared/Preview/Card";
@@ -25,6 +22,7 @@ import { MapContainer } from "../../shared/Preview/MapContainer";
 import { PublicProps } from "../../ui";
 import type { MapAndLabel } from "./../model";
 import { MapAndLabelProvider, useMapAndLabelContext } from "./Context";
+import { CopyFeature } from "./CopyFeature";
 
 type Props = PublicProps<MapAndLabel>;
 
@@ -111,36 +109,7 @@ const VerticalFeatureTabs: React.FC<{ features: Feature[] }> = ({
                       } m²)`}
                 </Typography>
               </Box>
-              {features.length > 1 && (
-                <Box>
-                  <InputLabel label="Copy from" id={`select-${i}`}>
-                    <SelectInput
-                      bordered
-                      required
-                      title={"Copy from"}
-                      labelId={`select-label-${i}`}
-                      value={""}
-                      onChange={() =>
-                        console.log(`TODO - Copy data from another tab`)
-                      }
-                      name={""}
-                      style={{ width: "200px" }}
-                    >
-                      {/* Iterate over all other features */}
-                      {features
-                        .filter((_, j) => j !== i)
-                        .map((option) => (
-                          <MenuItem
-                            key={option.properties?.label}
-                            value={option.properties?.label}
-                          >
-                            {`${schema.type} ${option.properties?.label}`}
-                          </MenuItem>
-                        ))}
-                    </SelectInput>
-                  </InputLabel>
-                </Box>
-              )}
+              <CopyFeature features={features} index={i} />
             </Box>
             <SchemaFields
               sx={(theme) => ({

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -470,6 +470,29 @@ const getThemeOptions = ({
           },
         ],
       },
+      MuiInputBase: {
+        styleOverrides: {
+          root: {
+            "&.Mui-disabled": {
+              backgroundColor: palette.grey[200],
+            },
+          },
+        },
+      },
+      MuiSelect: {
+        styleOverrides: {
+          root: {
+            "&.Mui-disabled": {
+              backgroundColor: palette.grey[200],
+            },
+          },
+          icon: {
+            "&.Mui-disabled": {
+              color: palette.grey[400],
+            },
+          },
+        },
+      },
       MuiSwitch: {
         styleOverrides: {
           root: {


### PR DESCRIPTION
## What does this PR do?
 - Moves the `CopyFeature` select to its own component
 - Wires up this behaviour via a method in the provider

## To Do
- [x] Populate value & name props on the `SelectInput`
- [x] A11y: Don't add/remove, just disable / apply visually hidden modifier

## Demo
https://github.com/user-attachments/assets/1ff9a34b-b369-4d64-b8a0-634724cd14fb

