### PR TITLE
chore: Add `--open` flag to vite in dev mode

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -170,7 +170,7 @@
   },
   "packageManager": "pnpm@8.6.6",
   "scripts": {
-    "start": "vite",
+    "start": "vite --open",
     "build": "tsc && vite build",
     "serve": "vite preview",
     "test": "vitest",


### PR DESCRIPTION
Matches previous craco behaviour (clicking an extra link is hard! 😅)
