### PR TITLE
fix(e2e): Update types for `submissionEmail`

### DIFF
--- a/e2e/tests/api-driven/src/globalHelpers.ts
+++ b/e2e/tests/api-driven/src/globalHelpers.ts
@@ -8,10 +8,9 @@ export function createTeam(
     $admin.team.create({
       name: "E2E Test Team",
       slug: "E2E",
-
+      submissionEmail: TEST_EMAIL,
       settings: {
         homepage: "http://www.planx.uk",
-        submissionEmail: TEST_EMAIL,
       },
       ...args,
     }),

--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -39,9 +39,9 @@ export const contextDefaults: Context = {
       logo: "https://raw.githubusercontent.com/theopensystemslab/planx-team-logos/main/planx-testing.svg",
       primaryColour: "#444444",
     },
+    submissionEmail: "simulate-delivered@notifications.service.gov.uk",
     settings: {
       homepage: "planx.uk",
-      submissionEmail: "simulate-delivered@notifications.service.gov.uk",
     },
   },
 };
@@ -58,9 +58,9 @@ export async function setUpTestContext(
     context.team.id = await $admin.team.create({
       slug: context.team.slug,
       name: context.team.name,
+      submissionEmail: context.team.submissionEmail,
       settings: {
         homepage: context.team.settings?.homepage,
-        submissionEmail: context.team.submissionEmail,
       },
     });
   }


### PR DESCRIPTION
Just a type issue falling out from https://github.com/theopensystemslab/planx-new/pull/3582 and https://github.com/theopensystemslab/planx-core/pull/489

<img width="801" alt="image" src="https://github.com/user-attachments/assets/85b2d96c-2cd8-40c8-abb3-e034eee3ecd9">

As seen in the screenshot above, linting does catch this - I guess this means this wasn't run correctly when updating the `package.json` in `/e2e`? Again, could be Husky + subdirectories, or maybe an indication we should run a global lint check on CI?

🚀 Regression tests running here - https://github.com/theopensystemslab/planx-new/actions/runs/10643909814