### PR TITLE
Revert "feat: API changes for handling new `submission_email` location"

### DIFF
--- a/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
+++ b/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
@@ -17,10 +17,10 @@ export async function downloadApplicationFiles(
 
   try {
     // Confirm that the provided email matches the stored team settings for the provided localAuthority
-    const { notifyPersonalisation } = await getTeamEmailSettings(
+    const { sendToEmail } = await getTeamEmailSettings(
       req.query.localAuthority as string,
     );
-    if (notifyPersonalisation.sendToEmail !== req.query.email) {
+    if (sendToEmail !== req.query.email) {
       return next({
         status: 403,
         message:

--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -49,10 +49,8 @@ describe(`sending an application by email to a planning office`, () => {
       data: {
         teams: [
           {
-            notifyPersonalisation: {
-              emailReplyToId: "abc123",
-              sendToEmail: "planning.office.example@council.gov.uk",
-            },
+            sendToEmail: "planning.office.example@council.gov.uk",
+            settings: { emailReplyToId: "abc123" },
           },
         ],
       },
@@ -147,17 +145,15 @@ describe(`sending an application by email to a planning office`, () => {
       });
   });
 
-  it("errors if this team does not have a 'submission_email' configured in team settings", async () => {
+  it("errors if this team does not have a 'submission_email' configured in teams", async () => {
     queryMock.mockQuery({
       name: "GetTeamEmailSettings",
       matchOnVariables: false,
       data: {
         teams: [
           {
-            notifyPersonalisation: {
-              emailReplyToId: "abc123",
-              sendToEmail: null,
-            },
+            sendToEmail: null,
+            settings: { emailReplyToId: "abc123" },
           },
         ],
       },
@@ -204,13 +200,7 @@ describe(`downloading application data received by email`, () => {
       name: "GetTeamEmailSettings",
       matchOnVariables: false,
       data: {
-        teams: [
-          {
-            notifyPersonalisation: {
-              sendToEmail: "planning.office.example@council.gov.uk",
-            },
-          },
-        ],
+        teams: [{ sendToEmail: "planning.office.example@council.gov.uk" }],
       },
       variables: { slug: "southwark" },
     });

--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -8,7 +8,8 @@ import { EmailSubmissionNotifyConfig } from "../../../types.js";
 
 interface GetTeamEmailSettings {
   teams: {
-    notifyPersonalisation: NotifyPersonalisation & { sendToEmail: string };
+    sendToEmail: string;
+    notifyPersonalisation: NotifyPersonalisation;
   }[];
 }
 
@@ -17,12 +18,12 @@ export async function getTeamEmailSettings(localAuthority: string) {
     gql`
       query GetTeamEmailSettings($slug: String) {
         teams(where: { slug: { _eq: $slug } }) {
+          sendToEmail: submission_email
           notifyPersonalisation: team_settings {
             helpEmail: help_email
             helpPhone: help_phone
             emailReplyToId: email_reply_to_id
             helpOpeningHours: help_opening_hours
-            sendToEmail: submission_email
           }
         }
       }
@@ -31,6 +32,7 @@ export async function getTeamEmailSettings(localAuthority: string) {
       slug: localAuthority,
     },
   );
+
   return response?.teams[0];
 }
 

--- a/e2e/tests/api-driven/src/globalHelpers.ts
+++ b/e2e/tests/api-driven/src/globalHelpers.ts
@@ -8,10 +8,9 @@ export function createTeam(
     $admin.team.create({
       name: "E2E Test Team",
       slug: "E2E",
-
+      submissionEmail: TEST_EMAIL,
       settings: {
         homepage: "http://www.planx.uk",
-        submissionEmail: TEST_EMAIL,
       },
       ...args,
     }),

--- a/e2e/tests/ui-driven/src/context.ts
+++ b/e2e/tests/ui-driven/src/context.ts
@@ -41,8 +41,8 @@ export const contextDefaults: Context = {
     },
     settings: {
       homepage: "planx.uk",
-      submissionEmail: "simulate-delivered@notifications.service.gov.uk",
     },
+    submissionEmail: "simulate-delivered@notifications.service.gov.uk",
   },
 };
 
@@ -58,9 +58,9 @@ export async function setUpTestContext(
     context.team.id = await $admin.team.create({
       slug: context.team.slug,
       name: context.team.name,
+      submissionEmail: context.team.submissionEmail,
       settings: {
         homepage: context.team.settings?.homepage,
-        submissionEmail: context.team.submissionEmail,
       },
     });
   }


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#3582 due to failing regression tests

✅ Regression test passing on this branch here - https://github.com/theopensystemslab/planx-new/actions/runs/10643974774

I suspect that this is due to the field `TeamSettings.submissionEmail` still being valid [here](https://github.com/theopensystemslab/planx-core/blob/main/src/types/team.ts#L32) - as it's not removed, there may be a reference to it somewhere that wasn't caught in theopensystemslab/planx-new#3582?