### PR TITLE
fix: handle no existing team members case when adding a new editor

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -56,15 +56,64 @@ export const MembersTable = ({
 
   if (members.length === 0) {
     return (
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>
-              <strong>No members found</strong>
-            </TableCell>
-          </TableRow>
-        </TableHead>
-      </Table>
+      <>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                <strong>No members found</strong>
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          {showAddMemberButton && (
+            <TableRow>
+              <TableCell colSpan={3}>
+                <AddButton onClick={() => setShowModal(true)}>
+                  Add a new editor
+                </AddButton>
+              </TableCell>
+            </TableRow>
+          )}
+        </Table>
+        {showAddMemberButton && (
+          <Snackbar
+            open={showSuccessToast}
+            autoHideDuration={6000}
+            onClose={handleCloseSuccessToast}
+          >
+            <Alert
+              onClose={handleCloseSuccessToast}
+              severity="success"
+              sx={{ width: "100%" }}
+            >
+              Successfully added a user
+            </Alert>
+          </Snackbar>
+        )}
+        {showAddMemberButton && (
+          <Snackbar
+            open={showErrorToast}
+            autoHideDuration={6000}
+            onClose={handleCloseErrorToast}
+          >
+            <Alert
+              onClose={handleCloseErrorToast}
+              severity="error"
+              sx={{ width: "100%" }}
+            >
+              Failed to add new user, please try again
+            </Alert>
+          </Snackbar>
+        )}
+        {showModal && (
+          <AddNewEditorModal
+            setShowSuccessToast={setShowSuccessToast}
+            setShowErrorToast={setShowErrorToast}
+            showModal={showModal}
+            setShowModal={setShowModal}
+          />
+        )}
+      </>
     );
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.noExistingMembers.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.noExistingMembers.test.tsx
@@ -1,0 +1,30 @@
+import { screen, within } from "@testing-library/react";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+import { TeamMember } from "../types";
+import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
+
+const mockTeamMembersDataWithNoTeamEditors: TeamMember[] = [
+  {
+    firstName: "Donella",
+    lastName: "Meadows",
+    email: "donella@example.com",
+    id: 1,
+    role: "platformAdmin",
+  },
+];
+
+describe("when a user views the 'Team members' screen but there are no existing team editors listed", () => {
+  beforeEach(async () => {
+    useStore.setState({ teamMembers: mockTeamMembersDataWithNoTeamEditors });
+    const { getByText } = await setupTeamMembersScreen();
+    getByText("No members found");
+  });
+
+  it("shows the 'add a new editor' button", async () => {
+    const teamEditorsTable = screen.getByTestId("team-editors");
+    expect(
+      await within(teamEditorsTable).findByText("Add a new editor"),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Fixes case where the 'add' button wasn't visible for teams where there were no team editors already.


| Before                      | After                  |
| ------------------------ | ------------------------ |
| <img src="https://github.com/user-attachments/assets/229e5a9d-005e-4000-b4e5-024836f3301b" width="300"> | <img src="https://github.com/user-attachments/assets/7422e0bb-6629-4104-8be2-08ee9ced4a16" width="300"> |


Trello ticket: https://trello.com/c/piMcGsJa/2973-add-user-in-editor

Fix for comment raised in Slack: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1724945320946359?thread_ts=1724942587.700829&cid=C5Q59R3HB

