### PR TITLE
WIP: remove react toastify

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -79,7 +79,6 @@
     "react-markdown": "^8.0.7",
     "react-navi": "^0.15.0",
     "react-navi-helmet-async": "^0.15.0",
-    "react-toastify": "^9.1.3",
     "react-use": "^17.5.0",
     "reconnecting-websocket": "^4.4.0",
     "rxjs": "^7.8.1",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -238,9 +238,6 @@ dependencies:
   react-navi-helmet-async:
     specifier: ^0.15.0
     version: 0.15.0(navi@0.15.0)(react-dom@18.2.0)(react-navi@0.15.0)(react@18.2.0)
-  react-toastify:
-    specifier: ^9.1.3
-    version: 9.1.3(react-dom@18.2.0)(react@18.2.0)
   react-use:
     specifier: ^17.5.0
     version: 17.5.0(react-dom@18.2.0)(react@18.2.0)
@@ -9260,7 +9257,7 @@ packages:
     dev: true
 
   /batch@0.6.1:
-    resolution: {integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=}
+    resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: true
 
   /bfj@7.1.0:
@@ -9400,7 +9397,7 @@ packages:
     dev: true
 
   /bytes@3.0.0:
-    resolution: {integrity: sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=}
+    resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
     dev: true
 
@@ -9738,6 +9735,7 @@ packages:
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
+    dev: true
 
   /clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -17834,17 +17832,6 @@ packages:
       use-latest: 1.2.1(@types/react@18.2.45)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
-
-  /react-toastify@9.1.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==}
-    peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
-    dependencies:
-      clsx: 1.2.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -5,7 +5,7 @@ import {
   DESCRIPTION_TEXT,
   ERROR_MESSAGE,
 } from "@planx/components/shared/constants";
-import { publicClient } from "lib/graphql";
+import useApolloClientSetup from "hooks/useApolloClientSetup";
 import find from "lodash/find";
 import { parse, toNormalised } from "postcode";
 import React, { useEffect, useState } from "react";
@@ -45,6 +45,8 @@ const AutocompleteWrapper = styled(Box)(({ theme }) => ({
 }));
 
 export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
+  const { publicClient } = useApolloClientSetup();
+
   const [postcode, setPostcode] = useState<string | null>(
     props.initialPostcode ?? null,
   );

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -8,7 +8,7 @@ import CardHeader from "@planx/components/shared/Preview/CardHeader";
 import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
 import type { PublicProps } from "@planx/components/ui";
 import { Feature } from "geojson";
-import { publicClient } from "lib/graphql";
+import useApolloClientSetup from "hooks/useApolloClientSetup";
 import find from "lodash/find";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -24,6 +24,7 @@ import type { PropertyInformation } from "./model";
 export default Component;
 
 function Component(props: PublicProps<PropertyInformation>) {
+  const { publicClient } = useApolloClientSetup();
   const [passport, overrideAnswer] = useStore((state) => [
     state.computePassport(),
     state.overrideAnswer,

--- a/editor.planx.uk/src/App.tsx
+++ b/editor.planx.uk/src/App.tsx
@@ -1,5 +1,4 @@
 import "core-js/actual/string/replace-all"; // replace-all polyfill
-import "react-toastify/dist/ReactToastify.css";
 import "./app.css";
 
 import { ApolloProvider } from "@apollo/client";
@@ -13,7 +12,6 @@ import { AnalyticsProvider } from "pages/FlowEditor/lib/analytics/provider";
 import React, { Suspense } from "react";
 import { Router, View } from "react-navi";
 import HelmetProvider from "react-navi-helmet-async";
-import { ToastContainer } from "react-toastify";
 
 // import { client } from "./lib/graphql";
 import navigation from "./lib/navigation";
@@ -58,7 +56,6 @@ const App = () => {
           </Router>
         </AnalyticsProvider>
       </ApolloProvider>
-      <ToastContainer icon={false} theme="colored" />
     </ToastContextProvider>
   );
 };

--- a/editor.planx.uk/src/App.tsx
+++ b/editor.planx.uk/src/App.tsx
@@ -1,0 +1,66 @@
+import "core-js/actual/string/replace-all"; // replace-all polyfill
+import "react-toastify/dist/ReactToastify.css";
+import "./app.css";
+
+import { ApolloProvider } from "@apollo/client";
+import CssBaseline from "@mui/material/CssBaseline";
+import { MyMap } from "@opensystemslab/map";
+import { Layout } from "components/Layout";
+import { ToastContextProvider } from "contexts/ToastContext";
+import useApolloClientSetup from "hooks/useApolloClientSetup";
+import { getCookie, setCookie } from "lib/cookie";
+import { AnalyticsProvider } from "pages/FlowEditor/lib/analytics/provider";
+import React, { Suspense } from "react";
+import { Router, View } from "react-navi";
+import HelmetProvider from "react-navi-helmet-async";
+import { ToastContainer } from "react-toastify";
+
+// import { client } from "./lib/graphql";
+import navigation from "./lib/navigation";
+
+const App = () => {
+  if (!window.customElements.get("my-map")) {
+    window.customElements.define("my-map", MyMap);
+  }
+
+  const hasJWT = (): boolean | void => {
+    // This cookie indicates the presence of the secure httpOnly "jwt" cookie
+    const authCookie = getCookie("auth");
+    if (authCookie) return true;
+
+    // If JWT not set via cookie, check search params
+    const jwtSearchParams = new URLSearchParams(window.location.search).get(
+      "jwt",
+    );
+    if (!jwtSearchParams) return false;
+
+    // Remove JWT from URL, and re-run this function
+    setCookie("jwt", jwtSearchParams);
+    setCookie("auth", { loggedIn: true });
+    // TODO: observe any redirect in secure fashion
+    window.location.href = "/";
+  };
+  const { client } = useApolloClientSetup();
+
+  return (
+    <ToastContextProvider>
+      <ApolloProvider client={client}>
+        <AnalyticsProvider>
+          <Router context={{ currentUser: hasJWT() }} navigation={navigation}>
+            <HelmetProvider>
+              <Layout>
+                <CssBaseline />
+                <Suspense fallback={null}>
+                  <View />
+                </Suspense>
+              </Layout>
+            </HelmetProvider>
+          </Router>
+        </AnalyticsProvider>
+      </ApolloProvider>
+      <ToastContainer icon={false} theme="colored" />
+    </ToastContextProvider>
+  );
+};
+
+export default App;

--- a/editor.planx.uk/src/components/Layout.tsx
+++ b/editor.planx.uk/src/components/Layout.tsx
@@ -1,0 +1,48 @@
+import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
+import ErrorPage from "pages/ErrorPage";
+import React, { useEffect } from "react";
+import { NotFoundBoundary, useLoadingRoute } from "react-navi";
+
+import { defaultTheme } from "../theme";
+import DelayedLoadingIndicator from "./DelayedLoadingIndicator";
+
+export const Layout: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const isLoading = useLoadingRoute();
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      // set the page title based on whatever heading is currently shown
+      // on screen. If there's no heading then the title will be "PlanX"
+      document.title = [
+        document.querySelector("[role=heading],h1,h2,h3")?.textContent,
+        "PlanX",
+      ]
+        .filter(Boolean)
+        .join(" - ");
+    });
+
+    observer.observe(document.getElementById("root")!, {
+      attributes: false,
+      childList: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={defaultTheme}>
+        <NotFoundBoundary render={() => <ErrorPage title="Not found" />}>
+          {isLoading ? (
+            <DelayedLoadingIndicator msDelayBeforeVisible={500} />
+          ) : (
+            children
+          )}
+        </NotFoundBoundary>
+      </ThemeProvider>
+    </StyledEngineProvider>
+  );
+};

--- a/editor.planx.uk/src/components/Toast/types.ts
+++ b/editor.planx.uk/src/components/Toast/types.ts
@@ -1,7 +1,7 @@
 export interface Toast {
   message: string;
   type: ToastType;
-  id: number;
+  id: string;
 }
 export type ToastType = "success" | "warning" | "info" | "error";
 
@@ -9,21 +9,21 @@ export type ToastState = {
   toasts: Toast[];
 };
 
-export type ToastAction = AddToast | DeleteToast;
+export type ToastAction = AddToast | RemoveToast;
 
 type AddToast = {
   type: "ADD_TOAST";
   payload: Toast;
 };
 
-type DeleteToast = {
-  type: "DELETE_TOAST";
-  payload: { id: number };
+type RemoveToast = {
+  type: "REMOVE_TOAST";
+  payload: { id: string };
 };
 
 export type ToastContextType = {
   addToast: (type: ToastType, message: string) => void;
-  remove: (id: number) => void;
+  remove: (id: string) => void;
   success: (message: string) => void;
   warning: (message: string) => void;
   info: (message: string) => void;

--- a/editor.planx.uk/src/contexts/ToastContext.tsx
+++ b/editor.planx.uk/src/contexts/ToastContext.tsx
@@ -7,9 +7,10 @@ import {
 } from "components/Toast/types";
 import React, { createContext, ReactNode, useReducer } from "react";
 import { toastReducer } from "reducers/toastReducer";
+import { v4 as uuidv4 } from "uuid";
 
 const defaultCreateContextValue = {
-  remove: (_id: number) => {},
+  remove: (_id: string) => {},
   addToast: (_type: ToastType, _message: string) => {},
   success: (_message: string) => {},
   warning: (_message: string) => {},
@@ -30,11 +31,11 @@ export const ToastContextProvider = ({
 }: Readonly<{ children: ReactNode }>) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
   const addToast = (type: ToastType, message: string) => {
-    const id = Math.floor(Math.random() * 10_000_000);
+    const id = uuidv4();
     dispatch({ type: "ADD_TOAST", payload: { id, message, type } });
   };
-  const remove = (id: number) => {
-    dispatch({ type: "DELETE_TOAST", payload: { id } });
+  const remove = (id: string) => {
+    dispatch({ type: "REMOVE_TOAST", payload: { id } });
   };
   const success = (message: string) => {
     addToast("success", message);

--- a/editor.planx.uk/src/hooks/useApolloClientSetup.ts
+++ b/editor.planx.uk/src/hooks/useApolloClientSetup.ts
@@ -1,0 +1,191 @@
+import {
+  ApolloClient,
+  createHttpLink,
+  from,
+  InMemoryCache,
+  Operation,
+  split,
+} from "@apollo/client";
+import { GraphQLErrors } from "@apollo/client/errors";
+import { onError } from "@apollo/client/link/error";
+import { RetryLink } from "@apollo/client/link/retry";
+import { WebSocketLink } from "@apollo/client/link/ws";
+import { getMainDefinition } from "@apollo/client/utilities";
+import { logger } from "airbrake";
+import { authMiddleware, getJWT } from "lib/graphql";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { useMemo } from "react";
+
+import { useToast } from "./useToast";
+
+const useApolloClientSetup = () => {
+  const toast = useToast();
+
+  // function used to verify response status
+  const customFetch = async (
+    input: RequestInfo,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const fetchResult = await fetch(input, init);
+    // eslint-disable-next-line no-prototype-builtins
+    const isGraphQLError = fetchResult.body?.hasOwnProperty("errors");
+    const isSuccess =
+      isGraphQLError ||
+      (fetchResult.status >= 200 && fetchResult.status <= 299);
+    if (isSuccess) {
+      // NB: it's okay if toast.dismiss() gets called more than once
+      //   toast.dismiss(toastId);
+    }
+
+    return fetchResult;
+  };
+
+  const errorLink = onError(({ graphQLErrors, operation }) => {
+    if (graphQLErrors) {
+      handleHasuraGraphQLErrors(graphQLErrors, operation);
+    } else {
+      console.error(
+        `[Error]: Operation name: ${
+          operation.operationName
+        }. Details: ${JSON.stringify(operation)}`,
+      );
+      toast.error("Network error, attempting to reconnect…");
+    }
+  });
+
+  const handleHasuraGraphQLErrors = (
+    errors: GraphQLErrors,
+    operation: Operation,
+  ) => {
+    errors.forEach(({ message, locations, path }) => {
+      console.error(
+        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+      );
+
+      const errors = parseErrorTypeFromHasuraResponse(message);
+
+      if (errors.validation) handleValidationErrors(operation);
+      if (errors.permission) handlePermissionErrors(operation);
+    });
+  };
+
+  const parseErrorTypeFromHasuraResponse = (message: string) => {
+    const permissionErrors = [
+      // Constraints error - user does not have access to this resource
+      /permission has failed/gi,
+      // Query or mutation error - user does not have access to this query
+      /not found in type/gi,
+    ];
+
+    const validationErrors = [/Invalid HTML content/gi];
+
+    return {
+      permission: permissionErrors.some((re) => re.test(message)),
+      validation: validationErrors.some((re) => re.test(message)),
+    };
+  };
+
+  const handleValidationErrors = (operation: Operation) => {
+    const user = useStore.getState().getUser();
+    logger.notify(
+      `[Validation error]: User ${user?.id} cannot submit invalid HTML via ${operation.operationName} mutation`,
+    );
+
+    toast.error("Validation error - data not saved");
+  };
+
+  const handlePermissionErrors = (operation: Operation) => {
+    const user = useStore.getState().getUser();
+    const team = useStore.getState().teamName;
+    logger.notify(
+      `[Permission error]: User ${user?.id} cannot execute ${operation.operationName} for ${team}`,
+    );
+
+    toast.error("Permission error");
+  };
+
+  const retryLink = useMemo(() => {
+    return new RetryLink({
+      delay: {
+        initial: 500,
+        max: Infinity,
+      },
+      attempts: {
+        max: Infinity,
+      },
+    });
+  }, []);
+
+  const publicHttpLink = createHttpLink({
+    uri: import.meta.env.VITE_APP_HASURA_URL,
+    fetch: customFetch,
+    headers: { "x-hasura-role": "public" },
+  });
+
+  /**
+   * Authenticated web socket connection - used for GraphQL subscriptions
+   */
+  const authWsLink = new WebSocketLink({
+    uri: import.meta.env.VITE_APP_HASURA_WEBSOCKET!,
+    options: {
+      reconnect: true,
+      connectionParams: async () => {
+        const jwt = await getJWT();
+        return {
+          headers: {
+            authorization: jwt ? `Bearer ${jwt}` : undefined,
+          },
+        };
+      },
+    },
+  });
+
+  const httpLink = createHttpLink({
+    uri: import.meta.env.VITE_APP_HASURA_URL,
+    fetch: customFetch,
+  });
+
+  const authHttpLink = authMiddleware.concat(httpLink);
+
+  /**
+   * Split requests between HTTPS and WS, based on operation types
+   *  - Queries and mutations -> HTTPS
+   *  - Subscriptions -> WS
+   */
+  const splitLink = split(
+    ({ query }) => {
+      const definition = getMainDefinition(query);
+      return (
+        definition.kind === "OperationDefinition" &&
+        definition.operation === "subscription"
+      );
+    },
+    authWsLink,
+    authHttpLink,
+  );
+
+  /**
+   * Client used to make all requests by authorised users
+   */
+  const client = useMemo(() => {
+    return new ApolloClient({
+      link: from([retryLink, errorLink, splitLink]),
+      cache: new InMemoryCache(),
+    });
+  }, [errorLink, retryLink, splitLink]);
+
+  /**
+   * Client used to make requests in all public interface
+   * e.g. /published, /preview, /draft, /pay
+   */
+  const publicClient = useMemo(() => {
+    return new ApolloClient({
+      link: from([retryLink, errorLink, publicHttpLink]),
+      cache: new InMemoryCache(),
+    });
+  }, [errorLink, publicHttpLink, retryLink]);
+
+  return { client, publicClient };
+};
+
+export default useApolloClientSetup;

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -1,5 +1,4 @@
 import "core-js/actual/string/replace-all"; // replace-all polyfill
-import "react-toastify/dist/ReactToastify.css";
 import "./app.css";
 
 import App from "App";

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -2,26 +2,12 @@ import "core-js/actual/string/replace-all"; // replace-all polyfill
 import "react-toastify/dist/ReactToastify.css";
 import "./app.css";
 
-import { ApolloProvider } from "@apollo/client";
-import CssBaseline from "@mui/material/CssBaseline";
-import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
-import { MyMap } from "@opensystemslab/map";
-import { ToastContextProvider } from "contexts/ToastContext";
-import { getCookie, setCookie } from "lib/cookie";
-import ErrorPage from "pages/ErrorPage";
-import { AnalyticsProvider } from "pages/FlowEditor/lib/analytics/provider";
-import React, { Suspense, useEffect } from "react";
+import App from "App";
+import React from "react";
 import { createRoot } from "react-dom/client";
-import { NotFoundBoundary, Router, useLoadingRoute, View } from "react-navi";
-import HelmetProvider from "react-navi-helmet-async";
-import { ToastContainer } from "react-toastify";
 
-// init airbrake before everything else
 import * as airbrake from "./airbrake";
-import DelayedLoadingIndicator from "./components/DelayedLoadingIndicator";
-import { client } from "./lib/graphql";
-import navigation from "./lib/navigation";
-import { defaultTheme } from "./theme";
+// init airbrake before everything else
 
 if (import.meta.env.VITE_APP_ENV !== "production") {
   console.log(`ENV: ${import.meta.env.VITE_APP_ENV}`);
@@ -30,85 +16,4 @@ if (import.meta.env.VITE_APP_ENV !== "production") {
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);
 
-if (!window.customElements.get("my-map")) {
-  window.customElements.define("my-map", MyMap);
-}
-
-const hasJWT = (): boolean | void => {
-  // This cookie indicates the presence of the secure httpOnly "jwt" cookie
-  const authCookie = getCookie("auth");
-  if (authCookie) return true;
-
-  // If JWT not set via cookie, check search params
-  const jwtSearchParams = new URLSearchParams(window.location.search).get(
-    "jwt",
-  );
-  if (!jwtSearchParams) return false;
-
-  // Remove JWT from URL, and re-run this function
-  setCookie("jwt", jwtSearchParams);
-  setCookie("auth", { loggedIn: true });
-  // TODO: observe any redirect in secure fashion
-  window.location.href = "/";
-};
-
-const Layout: React.FC<{
-  children: React.ReactNode;
-}> = ({ children }) => {
-  const isLoading = useLoadingRoute();
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      // set the page title based on whatever heading is currently shown
-      // on screen. If there's no heading then the title will be "PlanX"
-      document.title = [
-        document.querySelector("[role=heading],h1,h2,h3")?.textContent,
-        "PlanX",
-      ]
-        .filter(Boolean)
-        .join(" - ");
-    });
-
-    observer.observe(document.getElementById("root")!, {
-      attributes: false,
-      childList: true,
-      subtree: true,
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={defaultTheme}>
-        <NotFoundBoundary render={() => <ErrorPage title="Not found" />}>
-          {isLoading ? (
-            <DelayedLoadingIndicator msDelayBeforeVisible={500} />
-          ) : (
-            children
-          )}
-        </NotFoundBoundary>
-      </ThemeProvider>
-    </StyledEngineProvider>
-  );
-};
-
-root.render(
-  <ToastContextProvider>
-    <ApolloProvider client={client}>
-      <AnalyticsProvider>
-        <Router context={{ currentUser: hasJWT() }} navigation={navigation}>
-          <HelmetProvider>
-            <Layout>
-              <CssBaseline />
-              <Suspense fallback={null}>
-                <View />
-              </Suspense>
-            </Layout>
-          </HelmetProvider>
-        </Router>
-      </AnalyticsProvider>
-    </ApolloProvider>
-    <ToastContainer icon={false} theme="colored" />
-  </ToastContextProvider>,
-);
+root.render(<App />);

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -1,46 +1,7 @@
-import {
-  ApolloClient,
-  createHttpLink,
-  DefaultContext,
-  from,
-  InMemoryCache,
-  Operation,
-  split,
-} from "@apollo/client";
-import { GraphQLErrors } from "@apollo/client/errors";
+import { DefaultContext } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
-import { onError } from "@apollo/client/link/error";
 import { RetryLink } from "@apollo/client/link/retry";
-import { WebSocketLink } from "@apollo/client/link/ws";
-import { getMainDefinition } from "@apollo/client/utilities";
-import { logger } from "airbrake";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { toast } from "react-toastify";
-
-const toastId = "error_toast";
-
-// function used to verify response status
-const customFetch = async (
-  input: RequestInfo,
-  init?: RequestInit,
-): Promise<Response> => {
-  const fetchResult = await fetch(input, init);
-  // eslint-disable-next-line no-prototype-builtins
-  const isGraphQLError = fetchResult.body?.hasOwnProperty("errors");
-  const isSuccess =
-    isGraphQLError || (fetchResult.status >= 200 && fetchResult.status <= 299);
-  if (isSuccess) {
-    // NB: it's okay if toast.dismiss() gets called more than once
-    toast.dismiss(toastId);
-  }
-
-  return fetchResult;
-};
-
-const httpLink = createHttpLink({
-  uri: import.meta.env.VITE_APP_HASURA_URL,
-  fetch: customFetch,
-});
 
 /**
  * Set auth header in Apollo client
@@ -56,127 +17,7 @@ export const authMiddleware = setContext(async () => {
   };
 });
 
-const authHttpLink = authMiddleware.concat(httpLink);
-
-/**
- * Authenticated web socket connection - used for GraphQL subscriptions
- */
-const authWsLink = new WebSocketLink({
-  uri: import.meta.env.VITE_APP_HASURA_WEBSOCKET!,
-  options: {
-    reconnect: true,
-    connectionParams: async () => {
-      const jwt = await getJWT();
-      return {
-        headers: {
-          authorization: jwt ? `Bearer ${jwt}` : undefined,
-        },
-      };
-    },
-  },
-});
-
-/**
- * Split requests between HTTPS and WS, based on operation types
- *  - Queries and mutations -> HTTPS
- *  - Subscriptions -> WS
- */
-const splitLink = split(
-  ({ query }) => {
-    const definition = getMainDefinition(query);
-    return (
-      definition.kind === "OperationDefinition" &&
-      definition.operation === "subscription"
-    );
-  },
-  authWsLink,
-  authHttpLink,
-);
-
-const publicHttpLink = createHttpLink({
-  uri: import.meta.env.VITE_APP_HASURA_URL,
-  fetch: customFetch,
-  headers: { "x-hasura-role": "public" },
-});
-
-const errorLink = onError(({ graphQLErrors, operation }) => {
-  if (graphQLErrors) {
-    handleHasuraGraphQLErrors(graphQLErrors, operation);
-  } else {
-    console.error(
-      `[Error]: Operation name: ${
-        operation.operationName
-      }. Details: ${JSON.stringify(operation)}`,
-    );
-    toast.error("Network error, attempting to reconnect…", {
-      toastId,
-      autoClose: false,
-      hideProgressBar: true,
-      progress: undefined,
-    });
-  }
-});
-
-const handleHasuraGraphQLErrors = (
-  errors: GraphQLErrors,
-  operation: Operation,
-) => {
-  errors.forEach(({ message, locations, path }) => {
-    console.error(
-      `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-    );
-
-    const errors = parseErrorTypeFromHasuraResponse(message);
-
-    if (errors.validation) handleValidationErrors(operation);
-    if (errors.permission) handlePermissionErrors(operation);
-  });
-};
-
-const parseErrorTypeFromHasuraResponse = (message: string) => {
-  const permissionErrors = [
-    // Constraints error - user does not have access to this resource
-    /permission has failed/gi,
-    // Query or mutation error - user does not have access to this query
-    /not found in type/gi,
-  ];
-
-  const validationErrors = [/Invalid HTML content/gi];
-
-  return {
-    permission: permissionErrors.some((re) => re.test(message)),
-    validation: validationErrors.some((re) => re.test(message)),
-  };
-};
-
-const handleValidationErrors = (operation: Operation) => {
-  const user = useStore.getState().getUser();
-  logger.notify(
-    `[Validation error]: User ${user?.id} cannot submit invalid HTML via ${operation.operationName} mutation`,
-  );
-
-  toast.error("Validation error - data not saved", {
-    toastId: "validation_error",
-    hideProgressBar: true,
-    progress: undefined,
-  });
-};
-
-const handlePermissionErrors = (operation: Operation) => {
-  const user = useStore.getState().getUser();
-  const team = useStore.getState().teamName;
-  logger.notify(
-    `[Permission error]: User ${user?.id} cannot execute ${operation.operationName} for ${team}`,
-  );
-
-  toast.error("Permission error", {
-    toastId: "permission_error",
-    hideProgressBar: true,
-    progress: undefined,
-  });
-};
-
-const retryLink = new RetryLink({
+export const retryLink = new RetryLink({
   delay: {
     initial: 500,
     max: Infinity,
@@ -189,7 +30,7 @@ const retryLink = new RetryLink({
 /**
  * Get the JWT from the store, and wait if not available
  */
-const getJWT = async () => {
+export const getJWT = async () => {
   const jwt = useStore.getState().jwt;
   if (jwt) return jwt;
 
@@ -208,23 +49,6 @@ const waitForAuthentication = async () =>
       }
     });
   });
-
-/**
- * Client used to make all requests by authorised users
- */
-export const client = new ApolloClient({
-  link: from([retryLink, errorLink, splitLink]),
-  cache: new InMemoryCache(),
-});
-
-/**
- * Client used to make requests in all public interface
- * e.g. /published, /preview, /draft, /pay
- */
-export const publicClient = new ApolloClient({
-  link: from([retryLink, errorLink, publicHttpLink]),
-  cache: new InMemoryCache(),
-});
 
 /**
  * Explicitly connect to Hasura using the "public" role

--- a/editor.planx.uk/src/reducers/toastReducer.ts
+++ b/editor.planx.uk/src/reducers/toastReducer.ts
@@ -7,7 +7,7 @@ export const toastReducer = (state: ToastState, action: ToastAction) => {
         ...state,
         toasts: [...state.toasts, action.payload],
       };
-    case "DELETE_TOAST": {
+    case "REMOVE_TOAST": {
       const updatedToasts = state.toasts.filter(
         (toast) => toast.id !== action.payload.id,
       );


### PR DESCRIPTION
This is more convoluted than I thought. 

To use `useToast`, the function it is called in has to be a hook or component itself. It was used in `src/lib/graphql` so I tried to make that into a hook. But then to comply with React's [Rule of Hooks](https://react.dev/reference/rules/rules-of-hooks), all the non-component files that use `client` or `publicClient` would need to become hooks or components themselves too! And there is a lot of them! E.g. every file in `/routes`. 

Maybe we could discuss this more, but I feel like my current ideas involve rewriting and refactoring a lot of stuff which probably isn't worth it just to get rid of a toast library 😅 

