### PR TITLE
feat: enable "back" & "edit" navigation for List map fields and MapAndLabel using `@opensystemslab/map` v1.0.0-alpha.2

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -14,7 +14,7 @@
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
-    "@opensystemslab/map": "1.0.0-alpha.1",
+    "@opensystemslab/map": "1.0.0-alpha.2",
     "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d46df8d",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -44,8 +44,8 @@ dependencies:
     specifier: ^5.15.11
     version: 5.15.11(@types/react@18.2.45)(react@18.2.0)
   '@opensystemslab/map':
-    specifier: 1.0.0-alpha.1
-    version: 1.0.0-alpha.1
+    specifier: 1.0.0-alpha.2
+    version: 1.0.0-alpha.2
   '@opensystemslab/planx-core':
     specifier: git+https://github.com/theopensystemslab/planx-core#d46df8d
     version: github.com/theopensystemslab/planx-core/d46df8d(@types/react@18.2.45)
@@ -5610,13 +5610,13 @@ packages:
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
     dev: true
 
-  /@opensystemslab/map@1.0.0-alpha.1:
-    resolution: {integrity: sha512-T8foDyKS18algLun1uV4o4j0VL+TfsvNL0YnqKj26E8m6x6RMx6gbo5njjRH0bRnj14E8IsLaRN546fGoZhrWw==}
+  /@opensystemslab/map@1.0.0-alpha.2:
+    resolution: {integrity: sha512-S7amFaUpI3C+/8UKc/EO2JTysV2S300ANFDVUzSb2KWyZSPyQUBOgiy+RWJhrOQmjTozbopLwCbaZY+sAURXLQ==}
     dependencies:
       '@turf/union': 7.0.0
       accessible-autocomplete: 2.0.4
       file-saver: 2.0.5
-      govuk-frontend: 5.4.1
+      govuk-frontend: 5.6.0
       jspdf: 2.5.1
       lit: 3.1.4
       ol: 9.2.4
@@ -12505,8 +12505,8 @@ packages:
     dependencies:
       get-intrinsic: 1.2.4
 
-  /govuk-frontend@5.4.1:
-    resolution: {integrity: sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==}
+  /govuk-frontend@5.6.0:
+    resolution: {integrity: sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==}
     engines: {node: '>= 4.2.0'}
     dev: false
 

--- a/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
@@ -63,12 +63,13 @@ export const Trees: Schema = {
     {
       type: "map",
       data: {
-        title: "Where is it?",
+        title: "Where is it? Plot as many as apply",
         fn: "features",
         mapOptions: {
           basemap: "OSVectorTile",
           drawType: "Point",
           drawColor: "#66ff00",
+          drawMany: true,
         },
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
@@ -66,7 +66,7 @@ export const Trees: Schema = {
         title: "Where is it? Plot as many as apply",
         fn: "features",
         mapOptions: {
-          basemap: "OSVectorTile",
+          basemap: "MapboxSatellite",
           drawType: "Point",
           drawColor: "#66ff00",
           drawMany: true,

--- a/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -44,19 +44,22 @@ export function formatSchemaDisplayValue(
       return matchingOption?.data.text;
     }
     case "map": {
-      const feature = value[0];
       return (
         <>
           {/* @ts-ignore */}
           <my-map
             id="inactive-list-map"
             basemap={field.data.mapOptions?.basemap}
-            geojsonData={JSON.stringify(feature)}
+            geojsonData={JSON.stringify({
+              type: "FeatureCollection",
+              features: value,
+            })}
             geojsonColor={field.data.mapOptions?.drawColor}
             geojsonFill
             geojsonBuffer={20}
-            osProxyEndpoint={`${import.meta.env.VITE_APP_API_URL
-              }/proxy/ordnance-survey`}
+            osProxyEndpoint={`${
+              import.meta.env.VITE_APP_API_URL
+            }/proxy/ordnance-survey`}
             hideResetControl
             staticMode
             style={{ width: "100%", height: "30vh" }}
@@ -165,9 +168,9 @@ export function flatten<T extends Record<string, any>>(
 
     return isObject && depth > 0
       ? {
-        ...acc,
-        ...flatten(value, { depth: depth - 1, path: newPath, separator }),
-      }
+          ...acc,
+          ...flatten(value, { depth: depth - 1, path: newPath, separator }),
+        }
       : { ...acc, [newPath]: value };
   }, {} as T);
 }

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -93,9 +93,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     },
   });
 
-  const [activeIndex, setActiveIndex] = useState<number>(
-    props.previouslySubmittedData ? -1 : 0,
-  );
+  const [activeIndex, setActiveIndex] = useState<number>(0);
 
   const [minError, setMinError] = useState<boolean>(false);
   const [maxError, setMaxError] = useState<boolean>(false);

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -322,7 +322,7 @@ function MapAndLabelComponent(props: Props) {
       {...props}
       latitude={latitude}
       longitude={longitude}
-      boundaryBBox={teamSettings.boundaryBBox}
+      boundaryBBox={teamSettings?.boundaryBBox}
     />
   );
 }

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -9,7 +9,7 @@ import Typography from "@mui/material/Typography";
 import { SiteAddress } from "@planx/components/FindProperty/model";
 import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
 import { SchemaFields } from "@planx/components/shared/Schema/SchemaFields";
-import { Feature, GeoJsonObject } from "geojson";
+import { Feature, FeatureCollection, GeoJsonObject } from "geojson";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -163,11 +163,18 @@ const PlotFeatureToBegin = () => (
 );
 
 const Root = () => {
-  const { validateAndSubmitForm, mapAndLabelProps, errors } =
-    useMapAndLabelContext();
+  const {
+    validateAndSubmitForm,
+    mapAndLabelProps,
+    errors,
+    addFeature,
+    schema,
+    formik,
+  } = useMapAndLabelContext();
   const {
     title,
     description,
+    fn,
     info,
     policyRef,
     howMeasured,
@@ -178,19 +185,28 @@ const Root = () => {
     latitude,
     longitude,
     boundaryBBox,
+    previouslySubmittedData,
   } = mapAndLabelProps;
 
-  const [features, setFeatures] = useState<Feature[] | undefined>(undefined);
-  const { addFeature, schema } = useMapAndLabelContext();
+  const previousFeatures = previouslySubmittedData?.data?.[
+    fn
+  ] as FeatureCollection;
+  const [features, setFeatures] = useState<Feature[] | undefined>(
+    previousFeatures?.features?.length > 0
+      ? previousFeatures.features
+      : undefined,
+  );
 
   useEffect(() => {
     const geojsonChangeHandler = ({ detail: geojson }: any) => {
       if (geojson["EPSG:3857"]?.features) {
         setFeatures(geojson["EPSG:3857"].features);
+        formik.setFieldValue("geoData", geojson["EPSG:3857"].features);
         addFeature();
       } else {
         // if the user clicks 'reset' on the map, geojson will be empty object, so set features to undefined
         setFeatures(undefined);
+        formik.setFieldValue("geoData", undefined);
       }
     };
 
@@ -228,6 +244,13 @@ const Root = () => {
               basemap={basemap}
               ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
               drawMode
+              drawGeojsonData={
+                features &&
+                JSON.stringify({
+                  type: "FeatureCollection",
+                  features: features,
+                })
+              }
               drawMany
               drawColor={drawColor}
               drawType={drawType}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -101,7 +101,7 @@ const presentationalComponents: {
   [TYPES.InternalPortal]: undefined,
   [TYPES.FileUploadAndLabel]: FileUploadAndLabel,
   [TYPES.List]: List,
-  [TYPES.MapAndLabel]: undefined,
+  [TYPES.MapAndLabel]: MapAndLabel,
   [TYPES.Notice]: undefined,
   [TYPES.NextSteps]: undefined,
   [TYPES.NumberInput]: NumberInput,
@@ -353,6 +353,16 @@ function List(props: ComponentProps) {
     <>
       <Box component="dt">{props.node.data.title}</Box>
       <Box component="dd">{summary}</Box>
+    </>
+  );
+}
+
+function MapAndLabel(props: ComponentProps) {
+  const geojson = props.passport.data?.[props.node.data.fn];
+  return (
+    <>
+      <Box component="dt">{props.node.data.title}</Box>
+      <Box component="dd">{`${geojson?.features?.length || 0} features`}</Box>
     </>
   );
 }

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -21,7 +21,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   const editableFeatures = props.formik.values.schemaData?.[props.activeIndex]
     ?.features as Feature[];
   const [features, setFeatures] = useState<Feature[] | undefined>(
-    editableFeatures.length > 0 ? editableFeatures : undefined,
+    editableFeatures?.length > 0 ? editableFeatures : undefined,
   );
 
   useEffect(() => {

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -18,7 +18,11 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   const teamSettings = useStore.getState().teamSettings;
   const passport = useStore((state) => state.computePassport());
 
-  const [_features, setFeatures] = useState<Feature[] | undefined>(undefined);
+  const editableFeatures = props.formik.values.schemaData?.[props.activeIndex]
+    ?.features as Feature[];
+  const [features, setFeatures] = useState<Feature[] | undefined>(
+    editableFeatures.length > 0 ? editableFeatures : undefined,
+  );
 
   useEffect(() => {
     const geojsonChangeHandler = async ({ detail: geojson }: any) => {
@@ -53,6 +57,10 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
             height={400}
             basemap={mapOptions?.basemap}
             drawMode
+            drawGeojsonData={
+              features &&
+              JSON.stringify({ type: "FeatureCollection", features: features })
+            }
             drawMany={mapOptions?.drawMany}
             drawColor={mapOptions?.drawColor}
             drawType={mapOptions?.drawType}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -125,7 +125,10 @@ export type SchemaUserResponse = Record<
 /**
  * Output data from a form using the useSchema hook
  */
-export type SchemaUserData = { schemaData: SchemaUserResponse[] };
+export type SchemaUserData = {
+  schemaData: SchemaUserResponse[];
+  geoData?: Feature[];
+};
 
 /**
  * For each field in schema, return a map of Yup validation schema


### PR DESCRIPTION
**A few key changes in here!** 
- Bumps `@opensystemslab/map` to v1.0.0-alpha.2
  - Fixes shifty labels when modifying features; now when you modify it should keep the same label
  - Enables processing a GeoJSON "FeatureCollection" passed into `drawGeojsonData` prop which is required for "back" navigation when `drawMany` is enabled (previously supported single "Feature")
- **[List]** Pre-populates drawing layer on the map when you click "Edit" for an existing item 
  - Replaces #3601
- **[List]** Fix bug preventing existing/pre-populated features from being successfully "cleared"
- **[MapAndLabel]** Updates `handleSubmit` to produce GeoJSON data
- **[MapAndLabel]** Pre-populates map drawing layer and tab fields when you come "back" or "change" from the Review page
- **[MapAndLabel]** Adds a very basic Review page summary
- **[MapAndLabel]** Fixes bug where no tabs were active when coming "back"/"changing" - always default to tab 0 as active

**Testing:** 
- https://3612.planx.pizza/testing/works-to-trees-prototype (toggle on `"TREES"` feature flag first!) 

**Known bugs:**
- **[MapAndLabel]** "Remove" button is still not hooked up, but introduction of `drawGeojsonData` here is precursor to being able to complete https://github.com/theopensystemslab/planx-new/pull/3595