### PR TITLE
fix: List component input spacing

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -70,6 +70,11 @@ const ActiveListCard: React.FC<{
           {!isPageComponent && ` ${i + 1}`}
         </Typography>
         <SchemaFields
+          sx={(theme) => ({
+            display: "flex",
+            flexDirection: "column",
+            gap: theme.spacing(2),
+          })}
           schema={schema}
           activeIndex={activeIndex}
           formik={formik}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/SchemaFields.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/SchemaFields.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import { SxProps, Theme } from "@mui/material/styles";
+import { styled } from "@mui/material/styles";
 import { FormikProps } from "formik";
 import React from "react";
 import InputRow from "ui/shared/InputRow";
@@ -20,6 +21,13 @@ interface SchemaFieldsProps {
   sx?: SxProps<Theme>;
 }
 
+const ListRows = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(1, 0),
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing(1.5),
+}));
+
 /**
  * Display a set of fields for the provided schema
  */
@@ -29,11 +37,11 @@ export const SchemaFields: React.FC<SchemaFieldsProps> = ({
   sx,
   activeIndex = 0,
 }) => (
-  <Box sx={sx}>
+  <ListRows sx={sx}>
     {schema.fields.map((field, i) => (
       <InputRow key={i}>
         <InputFields {...field} activeIndex={activeIndex} formik={formik} />
       </InputRow>
     ))}
-  </Box>
+  </ListRows>
 );

--- a/editor.planx.uk/src/@planx/components/shared/Schema/SchemaFields.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/SchemaFields.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box";
 import { SxProps, Theme } from "@mui/material/styles";
-import { styled } from "@mui/material/styles";
 import { FormikProps } from "formik";
 import React from "react";
 import InputRow from "ui/shared/InputRow";
@@ -21,13 +20,6 @@ interface SchemaFieldsProps {
   sx?: SxProps<Theme>;
 }
 
-const ListRows = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(1, 0),
-  display: "flex",
-  flexDirection: "column",
-  gap: theme.spacing(1.5),
-}));
-
 /**
  * Display a set of fields for the provided schema
  */
@@ -37,11 +29,11 @@ export const SchemaFields: React.FC<SchemaFieldsProps> = ({
   sx,
   activeIndex = 0,
 }) => (
-  <ListRows sx={sx}>
+  <Box sx={sx}>
     {schema.fields.map((field, i) => (
       <InputRow key={i}>
         <InputFields {...field} activeIndex={activeIndex} formik={formik} />
       </InputRow>
     ))}
-  </ListRows>
+  </Box>
 );


### PR DESCRIPTION
## What does this PR do?

Adds padding to list component inputs so that labels are correctly visually associated with corresponding inputs.

**Before:**
<img width="714" alt="image" src="https://github.com/user-attachments/assets/5500acb1-6cca-4b04-985c-15d775ec672f">

**After:**
<img width="714" alt="image" src="https://github.com/user-attachments/assets/2b1cbe16-60ee-45a2-880b-27b7124dd0b7">