### PR TITLE
fix: initial works to trees feedback

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -29,6 +29,7 @@ import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Remov
 import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
 import { Trees } from "./schemas/Trees";
+import { TreesMapFirst } from "./schemas/TreesMapFirst";
 
 type Props = EditorProps<TYPES.List, List>;
 
@@ -62,7 +63,12 @@ export const SCHEMAS = [
   { name: "Protected spaces (GLA)", schema: ProtectedSpaceGLA },
   { name: "Open spaces (GLA)", schema: OpenSpaceGLA },
   { name: "Proposed advertisements", schema: ProposedAdvertisements },
-  ...(hasFeatureFlag("TREES") ? [{ name: "Trees", schema: Trees }] : []),
+  ...(hasFeatureFlag("TREES")
+    ? [
+        { name: "Trees", schema: Trees },
+        { name: "Trees (Map first)", schema: TreesMapFirst },
+      ]
+    : []),
 ];
 
 function ListComponent(props: Props) {

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -396,6 +396,7 @@ describe("Building a list", () => {
     async () => {
       const {
         getByLabelText,
+        getByText,
         user,
         queryByText,
         getByTestId,
@@ -433,7 +434,7 @@ describe("Building a list", () => {
       await user.click(secondCancelButton);
 
       expect(queryByText("my.new.email@test.com")).not.toBeInTheDocument();
-      expect(secondEmail).toBeInTheDocument();
+      expect(getByText("richard.parker@pi.com")).toBeInTheDocument();
     },
   );
 });

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -25,8 +25,14 @@ describe("Basic UI", () => {
   });
 
   it("parses provided schema to render expected form", async () => {
-    const { getByLabelText, getByText, user, getByRole, queryAllByRole } =
-      setup(<ListComponent {...mockZooProps} />);
+    const {
+      getByLabelText,
+      getByText,
+      user,
+      getByRole,
+      queryAllByRole,
+      queryByTestId,
+    } = setup(<ListComponent {...mockZooProps} />);
 
     // Text inputs are generated from schema...
     const textInput = getByLabelText(/What's their name?/) as HTMLInputElement;
@@ -87,8 +93,12 @@ describe("Basic UI", () => {
     expect(radioButton1).not.toBeChecked();
     expect(radioButton2).not.toBeChecked();
 
-    expect(getByText(/Save/, { selector: "button" })).toBeInTheDocument();
-    expect(getByText(/Cancel/, { selector: "button" })).toBeInTheDocument();
+    const saveButton = queryByTestId("save-item-button");
+    expect(saveButton).toBeInTheDocument();
+
+    // Hidden on initial item
+    const cancelButton = queryByTestId("cancel-edit-item-button");
+    expect(cancelButton).not.toBeInTheDocument();
   });
 
   it("should not have any accessibility violations", async () => {
@@ -349,44 +359,81 @@ describe("Building a list", () => {
     },
   );
 
-  test("Cancelling an invalid (new) item removes it", async () => {
-    const { getAllByTestId, getByText, user, queryAllByTestId } = setup(
-      <ListComponent {...mockZooProps} />,
-    );
+  test(
+    "Cancelling an invalid (new) item removes it",
+    { timeout: 20000 },
+    async () => {
+      const { getAllByTestId, getByText, user, queryAllByTestId, getByTestId } =
+        setup(<ListComponent {...mockZooProps} />);
 
-    let cards = getAllByTestId(/list-card/);
-    expect(cards).toHaveLength(1);
+      let cards = getAllByTestId(/list-card/);
+      expect(cards).toHaveLength(1);
 
-    const cancelButton = getByText(/Cancel/, { selector: "button" });
-    await user.click(cancelButton);
+      // "Cancel" is hidden from initial item, so fill out an item first
+      await fillInResponse(user);
 
-    cards = queryAllByTestId(/list-card/);
-    expect(cards).toHaveLength(0);
-  });
+      const addItemButton = getByTestId("list-add-button");
+      await user.click(addItemButton);
+
+      const [_firstCard, secondCard] = getAllByTestId(/list-card/);
+
+      // Second card is active
+      expect(
+        within(secondCard!).getByLabelText(/What's their name?/),
+      ).toBeInTheDocument();
+
+      const cancelButton = getByText(/Cancel/, { selector: "button" });
+      await user.click(cancelButton);
+
+      cards = queryAllByTestId(/list-card/);
+      expect(cards).toHaveLength(1);
+    },
+  );
 
   test(
     "Cancelling a valid (existing) item resets previous state",
     { timeout: 20000 },
     async () => {
-      const { getByLabelText, getByText, user, queryByText } = setup(
-        <ListComponent {...mockZooProps} />,
-      );
+      const {
+        getByLabelText,
+        user,
+        queryByText,
+        getByTestId,
+        getAllByTestId,
+        getAllByText,
+      } = setup(<ListComponent {...mockZooProps} />);
 
       await fillInResponse(user);
 
-      expect(getByText("richard.parker@pi.com")).toBeInTheDocument();
+      const addItemButton = getByTestId("list-add-button");
+      await user.click(addItemButton);
 
-      const editButton = getByText(/Edit/, { selector: "button" });
-      await user.click(editButton);
+      const [_firstCard, secondCard] = getAllByTestId(/list-card/);
+
+      // Second card is active
+      expect(
+        within(secondCard!).getByLabelText(/What's their name?/),
+      ).toBeInTheDocument();
+
+      // "Cancel" button was hidden on first item, so fill in second item
+      await fillInResponse(user);
+
+      const secondEmail = getAllByText("richard.parker@pi.com")[1];
+      expect(secondEmail).toBeInTheDocument();
+
+      const secondEditButton = getAllByText(/Edit/, { selector: "button" })[1];
+      await user.click(secondEditButton);
 
       const emailInput = getByLabelText(/email/);
       await user.type(emailInput, "my.new.email@test.com");
 
-      const cancelButton = getByText(/Cancel/, { selector: "button" });
-      await user.click(cancelButton);
+      const secondCancelButton = getAllByText(/Cancel/, {
+        selector: "button",
+      })[1];
+      await user.click(secondCancelButton);
 
       expect(queryByText("my.new.email@test.com")).not.toBeInTheDocument();
-      expect(getByText("richard.parker@pi.com")).toBeInTheDocument();
+      expect(secondEmail).toBeInTheDocument();
     },
   );
 });
@@ -533,22 +580,31 @@ describe("Form validation and error handling", () => {
     });
   });
 
-  test("an error displays if the minimum number of items is not met", async () => {
-    const { user, getByRole, getByTestId, getByText } = setup(
-      <ListComponent {...mockZooProps} />,
-    );
+  test(
+    "an error displays if the minimum number of items is not met",
+    { timeout: 10000 },
+    async () => {
+      const mockWithMinTwo = merge(cloneDeep(mockZooProps), {
+        schema: { min: 2 },
+      });
+      const { user, getByTestId, getByText } = setup(
+        <ListComponent {...mockWithMinTwo} />,
+      );
 
-    const minNumberOfItems = mockZooProps.schema.min;
-    expect(minNumberOfItems).toEqual(1);
+      const minNumberOfItems = mockWithMinTwo.schema.min;
+      expect(minNumberOfItems).toEqual(2);
 
-    await user.click(getByRole("button", { name: /Cancel/ }));
-    await user.click(getByTestId("continue-button"));
+      // Fill in one response only
+      await fillInResponse(user);
 
-    const minItemsErrorMessage = getByText(
-      `You must provide at least ${minNumberOfItems} response(s)`,
-    );
-    expect(minItemsErrorMessage).toBeVisible();
-  });
+      await user.click(getByTestId("continue-button"));
+
+      const minItemsErrorMessage = getByText(
+        `You must provide at least ${minNumberOfItems} response(s)`,
+      );
+      expect(minItemsErrorMessage).toBeVisible();
+    },
+  );
 
   test(
     "an error displays if the maximum number of items is exceeded",

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -60,6 +60,10 @@ const ActiveListCard: React.FC<{
     }
   }, []);
 
+  // TODO - hide "Cancel" button on initial card
+  const _isInitialCard =
+    activeIndex === 0 && formik.values?.schemaData?.length === 1;
+
   return (
     <ErrorWrapper
       error={errors.unsavedItem ? "Please save in order to continue" : ""}

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -60,8 +60,7 @@ const ActiveListCard: React.FC<{
     }
   }, []);
 
-  // TODO - hide "Cancel" button on initial card
-  const _isInitialCard =
+  const isInitialCard =
     activeIndex === 0 && formik.values?.schemaData?.length === 1;
 
   return (
@@ -87,11 +86,19 @@ const ActiveListCard: React.FC<{
           <Button
             variant="contained"
             color="primary"
+            data-testid="save-item-button"
             onClick={async () => await saveItem()}
           >
             Save
           </Button>
-          {!isPageComponent && <Button onClick={cancelEditItem}>Cancel</Button>}
+          {!isPageComponent && !isInitialCard && (
+            <Button
+              data-testid="cancel-edit-item-button"
+              onClick={cancelEditItem}
+            >
+              Cancel
+            </Button>
+          )}
         </Box>
       </ListCard>
     </ErrorWrapper>

--- a/editor.planx.uk/src/@planx/components/List/schemas/TreesMapFirst.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/TreesMapFirst.ts
@@ -1,0 +1,78 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const TreesMapFirst: Schema = {
+  type: "Tree",
+  fields: [
+    {
+      type: "map",
+      data: {
+        title: "Where is it? Plot as many as apply",
+        fn: "features",
+        mapOptions: {
+          basemap: "MapboxSatellite",
+          drawType: "Point",
+          drawColor: "#66ff00",
+          drawMany: true,
+        },
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Species",
+        fn: "species",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Proposed work",
+        fn: "work",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Justification",
+        fn: "justification",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Urgency",
+        fn: "urgency",
+        options: [
+          {
+            id: "low",
+            data: { text: "Low", val: "low" },
+          },
+          {
+            id: "moderate",
+            data: { text: "Moderate", val: "moderate" },
+          },
+          {
+            id: "high",
+            data: { text: "High", val: "high" },
+          },
+          {
+            id: "urgent",
+            data: { text: "Urgent", val: "urgent" },
+          },
+        ],
+      },
+    },
+    {
+      type: "date",
+      data: {
+        title: "Expected completion date",
+        fn: "completionDate",
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
@@ -11,14 +11,11 @@ export const DateFieldInput: React.FC<Props<DateField>> = (props) => {
   const { data, formik } = props;
   const { id, errorMessage, name, value } = getFieldProps(props);
 
-  if (typeof value !== "string")
-    throw Error("'value' prop for DateFieldInput must be of type string");
-
   return (
     <InputLabel label={data.title} htmlFor={id}>
       <Box sx={{ display: "flex", alignItems: "baseline" }}>
         <DateInput
-          value={value}
+          value={value?.toString()}
           bordered
           onChange={(newDate: string, eventType: string) => {
             formik.setFieldValue(name, paddedDate(newDate, eventType));


### PR DESCRIPTION
Working through feedback here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1725376092471139

- [x] List option schema should order the "map" field first, rather than last (not removing original schema yet)
- [x] "DateInput" field no longer throws a type error when tabbing through
- [x] "Cancel" button should be hidden on initial List item