### PR TITLE
style: List component summary vertical alignment

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -120,10 +120,7 @@ const InactiveListCard: React.FC<{
       <Table>
         <TableBody>
           {schema.fields.map((field, j) => (
-            <TableRow
-              key={`tableRow-${j}`}
-              sx={{ "& > *": { verticalAlign: "top" } }}
-            >
+            <TableRow key={`tableRow-${j}`} sx={{ verticalAlign: "top" }}>
               <TableCell
                 sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, maxWidth: "100px" }}
               >

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -120,7 +120,10 @@ const InactiveListCard: React.FC<{
       <Table>
         <TableBody>
           {schema.fields.map((field, j) => (
-            <TableRow key={`tableRow-${j}`}>
+            <TableRow
+              key={`tableRow-${j}`}
+              sx={{ "& > *": { verticalAlign: "top" } }}
+            >
               <TableCell
                 sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, maxWidth: "100px" }}
               >


### PR DESCRIPTION
## What does this PR do?

Quick one: updates vertical alignment of list component summary table to top, to be consistent with our other use of summary tables (Review page for example).

**Before:**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/15562ab8-8eb6-4b76-a046-284ead0f6b67">

**After:**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/69655a21-d1fd-4a59-b500-00cf6a23a5db">

