### PR TITLE
fix: display schema field descriptions if set

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -39,6 +39,12 @@ describe("Basic UI", () => {
     expect(textInput).toBeInTheDocument();
     expect(textInput.type).toBe("text");
 
+    // Input field descriptions are generated from schema if they exist...
+    const textInputDescription = getByText(
+      /Please make it cute/,
+    ) as HTMLElement;
+    expect(textInputDescription).toBeInTheDocument();
+
     // Props are correctly read
     const emailInput = getByLabelText(
       /What's their email address?/,

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
@@ -1,5 +1,4 @@
 import Grid from "@mui/material/Grid";
-import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import type { ChecklistField } from "@planx/components/shared/Schema/model";
 import React from "react";
@@ -8,6 +7,7 @@ import ChecklistItem from "ui/shared/ChecklistItem";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
   const {
@@ -39,11 +39,7 @@ export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
 
   return (
     <InputLabel label={title} id={`checklist-label-${id}`}>
-      {description && (
-        <Typography variant="body2" mb={1.5}>
-          {description}
-        </Typography>
-      )}
+      {description && <FieldInputDescription description={description} />}
       <ErrorWrapper error={errorMessage} id={id}>
         <Grid container component="fieldset">
           <legend style={visuallyHidden}>{title}</legend>

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
@@ -1,4 +1,5 @@
 import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import type { ChecklistField } from "@planx/components/shared/Schema/model";
 import React from "react";
@@ -10,7 +11,7 @@ import { getFieldProps, Props } from ".";
 
 export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
   const {
-    data: { title, options },
+    data: { title, description, options },
     formik,
   } = props;
   const { id, errorMessage, name, value } = getFieldProps(props);
@@ -38,6 +39,11 @@ export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
 
   return (
     <InputLabel label={title} id={`checklist-label-${id}`}>
+      {description && (
+        <Typography variant="body2" mb={1.5}>
+          {description}
+        </Typography>
+      )}
       <ErrorWrapper error={errorMessage} id={id}>
         <Grid container component="fieldset">
           <legend style={visuallyHidden}>{title}</legend>

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import { paddedDate } from "@planx/components/DateInput/model";
 import type { DateField } from "@planx/components/shared/Schema/model";
 import React from "react";
@@ -7,6 +6,7 @@ import InputLabel from "ui/public/InputLabel";
 import DateInput from "ui/shared/DateInput";
 
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const DateFieldInput: React.FC<Props<DateField>> = (props) => {
   const { data, formik } = props;
@@ -15,9 +15,7 @@ export const DateFieldInput: React.FC<Props<DateField>> = (props) => {
   return (
     <InputLabel label={data.title} htmlFor={id}>
       {data.description && (
-        <Typography variant="body2" mb={1.5}>
-          {data.description}
-        </Typography>
+        <FieldInputDescription description={data.description} />
       )}
       <Box sx={{ display: "flex", alignItems: "baseline" }}>
         <DateInput

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { paddedDate } from "@planx/components/DateInput/model";
 import type { DateField } from "@planx/components/shared/Schema/model";
 import React from "react";
@@ -13,6 +14,11 @@ export const DateFieldInput: React.FC<Props<DateField>> = (props) => {
 
   return (
     <InputLabel label={data.title} htmlFor={id}>
+      {data.description && (
+        <Typography variant="body2" mb={1.5}>
+          {data.description}
+        </Typography>
+      )}
       <Box sx={{ display: "flex", alignItems: "baseline" }}>
         <DateInput
           value={value?.toString()}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -1,3 +1,4 @@
+import Typography from "@mui/material/Typography";
 import { MapContainer } from "@planx/components/shared/Preview/MapContainer";
 import type { MapField } from "@planx/components/shared/Schema/model";
 import { Feature } from "geojson";
@@ -11,7 +12,7 @@ import { getFieldProps, Props } from ".";
 export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   const {
     formik,
-    data: { title, mapOptions },
+    data: { title, description, mapOptions },
   } = props;
   const { id, errorMessage, name } = getFieldProps(props);
 
@@ -47,6 +48,11 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
 
   return (
     <InputLabel label={title} id={`map-label-${id}`} htmlFor={id}>
+      {description && (
+        <Typography variant="body2" mb={1.5}>
+          {description}
+        </Typography>
+      )}
       <ErrorWrapper error={errorMessage} id={id}>
         <MapContainer environment="standalone">
           {/* @ts-ignore */}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -1,4 +1,3 @@
-import Typography from "@mui/material/Typography";
 import { MapContainer } from "@planx/components/shared/Preview/MapContainer";
 import type { MapField } from "@planx/components/shared/Schema/model";
 import { Feature } from "geojson";
@@ -8,6 +7,7 @@ import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   const {
@@ -48,11 +48,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
 
   return (
     <InputLabel label={title} id={`map-label-${id}`} htmlFor={id}>
-      {description && (
-        <Typography variant="body2" mb={1.5}>
-          {description}
-        </Typography>
-      )}
+      {description && <FieldInputDescription description={description} />}
       <ErrorWrapper error={errorMessage} id={id}>
         <MapContainer environment="standalone">
           {/* @ts-ignore */}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import type { NumberField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
@@ -15,6 +16,11 @@ export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
 
   return (
     <InputLabel label={data.title} htmlFor={id}>
+      {data.description && (
+        <Typography variant="body2" mb={1.5}>
+          {data.description}
+        </Typography>
+      )}
       <Box sx={{ display: "flex", alignItems: "baseline" }}>
         <Input
           {...fieldProps}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import type { NumberField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
@@ -8,6 +7,7 @@ import InputRowLabel from "ui/shared/InputRowLabel";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../constants";
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
   const fieldProps = getFieldProps(props);
@@ -17,9 +17,7 @@ export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
   return (
     <InputLabel label={data.title} htmlFor={id}>
       {data.description && (
-        <Typography variant="body2" mb={1.5}>
-          {data.description}
-        </Typography>
+        <FieldInputDescription description={data.description} />
       )}
       <Box sx={{ display: "flex", alignItems: "baseline" }}>
         <Input

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/RadioFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/RadioFieldInput.tsx
@@ -1,13 +1,13 @@
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import RadioGroup from "@mui/material/RadioGroup";
-import Typography from "@mui/material/Typography";
 import type { QuestionField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import BasicRadio from "../../Radio/BasicRadio";
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const RadioFieldInput: React.FC<Props<QuestionField>> = (props) => {
   const { data, formik } = props;
@@ -28,9 +28,7 @@ export const RadioFieldInput: React.FC<Props<QuestionField>> = (props) => {
         {data.title}
       </FormLabel>
       {data.description && (
-        <Typography variant="body2" mb={1.5}>
-          {data.description}
-        </Typography>
+        <FieldInputDescription description={data.description} />
       )}
       <ErrorWrapper id={`${id}-error`} error={errorMessage}>
         <RadioGroup

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/RadioFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/RadioFieldInput.tsx
@@ -1,6 +1,7 @@
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import RadioGroup from "@mui/material/RadioGroup";
+import Typography from "@mui/material/Typography";
 import type { QuestionField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -26,6 +27,11 @@ export const RadioFieldInput: React.FC<Props<QuestionField>> = (props) => {
       >
         {data.title}
       </FormLabel>
+      {data.description && (
+        <Typography variant="body2" mb={1.5}>
+          {data.description}
+        </Typography>
+      )}
       <ErrorWrapper id={`${id}-error`} error={errorMessage}>
         <RadioGroup
           aria-labelledby={`radio-buttons-group-label-${id}`}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
@@ -1,5 +1,4 @@
 import MenuItem from "@mui/material/MenuItem";
-import Typography from "@mui/material/Typography";
 import type { QuestionField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput";
@@ -7,6 +6,7 @@ import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
   const { data, formik } = props;
@@ -15,9 +15,7 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
   return (
     <InputLabel label={data.title} id={`select-label-${id}`}>
       {data.description && (
-        <Typography variant="body2" mb={1.5}>
-          {data.description}
-        </Typography>
+        <FieldInputDescription description={data.description} />
       )}
       <ErrorWrapper id={`${id}-error`} error={errorMessage}>
         <SelectInput

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
@@ -1,4 +1,5 @@
 import MenuItem from "@mui/material/MenuItem";
+import Typography from "@mui/material/Typography";
 import type { QuestionField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput";
@@ -13,6 +14,11 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
 
   return (
     <InputLabel label={data.title} id={`select-label-${id}`}>
+      {data.description && (
+        <Typography variant="body2" mb={1.5}>
+          {data.description}
+        </Typography>
+      )}
       <ErrorWrapper id={`${id}-error`} error={errorMessage}>
         <SelectInput
           bordered

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
@@ -1,4 +1,3 @@
-import Typography from "@mui/material/Typography";
 import type { TextField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
@@ -6,6 +5,7 @@ import Input from "ui/shared/Input";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../constants";
 import { getFieldProps, Props } from ".";
+import { FieldInputDescription } from "./shared";
 
 export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
   const fieldProps = getFieldProps(props);
@@ -15,9 +15,7 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
   return (
     <InputLabel label={data.title} htmlFor={id}>
       {data.description && (
-        <Typography variant="body2" mb={1.5}>
-          {data.description}
-        </Typography>
+        <FieldInputDescription description={data.description} />
       )}
       <Input
         {...fieldProps}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
@@ -1,3 +1,4 @@
+import Typography from "@mui/material/Typography";
 import type { TextField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
@@ -13,6 +14,11 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
 
   return (
     <InputLabel label={data.title} htmlFor={id}>
+      {data.description && (
+        <Typography variant="body2" mb={1.5}>
+          {data.description}
+        </Typography>
+      )}
       <Input
         {...fieldProps}
         onChange={formik.handleChange}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/shared.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/shared.tsx
@@ -1,0 +1,19 @@
+import Typography from "@mui/material/Typography";
+import React from "react";
+import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
+
+interface FieldInputDescriptionProps {
+  description: string;
+}
+
+export const FieldInputDescription: React.FC<FieldInputDescriptionProps> = ({
+  description,
+}) => (
+  <Typography variant="body2" mb={1.5}>
+    <ReactMarkdownOrHtml
+      source={description}
+      openLinksOnNewTab
+      // TODO a11y props? eg `id={DESCRIPTION_TEXT}` but unique ??
+    />
+  </Typography>
+);

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/shared.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/shared.tsx
@@ -1,6 +1,5 @@
 import Typography from "@mui/material/Typography";
 import React from "react";
-import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
 interface FieldInputDescriptionProps {
   description: string;
@@ -10,10 +9,6 @@ export const FieldInputDescription: React.FC<FieldInputDescriptionProps> = ({
   description,
 }) => (
   <Typography variant="body2" mb={1.5}>
-    <ReactMarkdownOrHtml
-      source={description}
-      openLinksOnNewTab
-      // TODO a11y props? eg `id={DESCRIPTION_TEXT}` but unique ??
-    />
+    {description}
   </Typography>
 );

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -85,6 +85,7 @@ export type MapField = {
   type: "map";
   data: {
     title: string;
+    description?: string;
     fn: string;
     mapOptions?: {
       basemap?: "OSVectorTile" | "OSRaster" | "MapboxSatellite" | "OSM";


### PR DESCRIPTION
Fixes a regression flagged here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1725446829984269

**Locally edited schema to include descriptions:** 
![Screenshot from 2024-09-04 13-10-43](https://github.com/user-attachments/assets/c6a250e4-cc2c-4d1e-a34c-8dcdf296aee8)

**And how descriptions display with validation errors:**
![Screenshot from 2024-09-04 13-11-14](https://github.com/user-attachments/assets/8e9635ad-c673-4ea9-bdcd-f40033331cd3)