### PR TITLE
feat: add parking schemas to list component

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -20,8 +20,10 @@ import { BuildingDetailsGLA } from "./schemas/GLA/BuildingDetails";
 import { CommunalSpaceGLA } from "./schemas/GLA/CommunalSpace";
 import { ExistingAndProposedUsesGLA } from "./schemas/GLA/ExistingAndProposedUses";
 import { OpenSpaceGLA } from "./schemas/GLA/OpenSpace";
+import { ParkingGLA } from "./schemas/GLA/ParkingGLA";
 import { ProtectedSpaceGLA } from "./schemas/GLA/ProtectedSpace";
 import { MaterialDetails } from "./schemas/Materials";
+import { Parking } from "./schemas/Parking";
 import { ResidentialUnitsExisting } from "./schemas/ResidentialUnits/Existing";
 import { ResidentialUnitsGLANew } from "./schemas/ResidentialUnits/GLA/New";
 import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebuilt";
@@ -63,6 +65,8 @@ export const SCHEMAS = [
   { name: "Protected spaces (GLA)", schema: ProtectedSpaceGLA },
   { name: "Open spaces (GLA)", schema: OpenSpaceGLA },
   { name: "Proposed advertisements", schema: ProposedAdvertisements },
+  { name: "Parking details", schema: Parking },
+  { name: "Parking details (GLA)", schema: ParkingGLA },
   ...(hasFeatureFlag("TREES")
     ? [
         { name: "Trees", schema: Trees },

--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/ParkingGLA.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/ParkingGLA.ts
@@ -1,0 +1,83 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+
+export const ParkingGLA: Schema = {
+  type: "Parking space type",
+  fields: [
+    {
+      type: "question",
+      data: {
+        title: "Type",
+        fn: "type",
+        options: [
+          { id: "cars", data: { text: "Cars", val: "cars" } },
+          {
+            id: "vans",
+            data: { text: "Vans or minibuses", val: "vans" },
+          },
+          {
+            id: "motorcycles",
+            data: { text: "Motorcycles", val: "motorcycles" },
+          },
+          {
+            id: "cycles",
+            data: {
+              text: "Bicycles",
+              val: "cycles",
+            },
+          },
+          {
+            id: "bus",
+            data: {
+              text: "Buses",
+              val: "bus",
+            },
+          },
+          {
+            id: "disabled",
+            data: { text: "Disabled person parking", val: "disabled" },
+          },
+          {
+            id: "carClub",
+            data: {
+              text: "Car club",
+              val: "carClub",
+            },
+          },
+          {
+            id: "offStreet.residential",
+            data: {
+              text: "Residential off-street parking",
+              val: "offStreet.residential",
+            },
+          },
+          {
+            id: "other",
+            data: {
+              text: "Other",
+              val: "other",
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many existing spaces of this type are there on the site?",
+        fn: "existing",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many spaces of this type are you proposing?",
+        description:
+          "This is the total number of parking spaces of this type after the works, including any retained spaces.",
+        fn: "proposed",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/Parking.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/Parking.ts
@@ -1,0 +1,62 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+
+export const Parking: Schema = {
+  type: "Parking space type",
+  fields: [
+    {
+      type: "question",
+      data: {
+        title: "Type",
+        fn: "type",
+        options: [
+          { id: "cars", data: { text: "Cars", val: "cars" } },
+          {
+            id: "vans",
+            data: { text: "Vans or minibuses", val: "vans" },
+          },
+          {
+            id: "motorcycles",
+            data: { text: "Motorcycles", val: "motorcycles" },
+          },
+          {
+            id: "disabled",
+            data: { text: "Disabled person parking", val: "disabled" },
+          },
+          {
+            id: "cycles",
+            data: {
+              text: "Bicycles",
+              val: "cycles",
+            },
+          },
+          {
+            id: "other",
+            data: {
+              text: "Other (e.g. bus)",
+              val: "other",
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many existing spaces of this type are there on the site?",
+        fn: "existing",
+        allowNegatives: false,
+      },
+    },
+    {
+      type: "number",
+      data: {
+        title: "How many spaces of this type are you proposing?",
+        description:
+          "This is the total number of parking spaces of this type after the works, including any retained spaces.",
+        fn: "proposed",
+        allowNegatives: false,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
Add parking space list component schemas for both GLA and non-GLA councils.