### PR TITLE
feat: Full width map for list component

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -205,6 +205,40 @@ const Root = () => {
     );
   }
 
+  const listContent = (
+    <ErrorWrapper error={rootError}>
+      <>
+        {formik.values.schemaData.map((_, i) =>
+          i === activeIndex ? (
+            <ActiveListCard key={`card-${i}`} index={i} />
+          ) : (
+            <InactiveListCard key={`card-${i}`} index={i} />
+          ),
+        )}
+        {shouldShowAddAnotherButton && (
+          <ErrorWrapper
+            error={
+              errors.addItem
+                ? `Please save all responses before adding another ${schema.type.toLowerCase()}`
+                : ""
+            }
+          >
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={addNewItem}
+              sx={{ "@media (min-width: 768px)": { width: "100%" } }}
+              size="large"
+              data-testid="list-add-button"
+            >
+              + Add another {schema.type.toLowerCase()}
+            </Button>
+          </ErrorWrapper>
+        )}
+      </>
+    </ErrorWrapper>
+  );
+
   return (
     <Card handleSubmit={validateAndSubmitForm} isValid>
       <CardHeader
@@ -214,38 +248,11 @@ const Root = () => {
         policyRef={policyRef}
         howMeasured={howMeasured}
       />
-      <FullWidthWrapper>
-        <ErrorWrapper error={rootError}>
-          <>
-            {formik.values.schemaData.map((_, i) =>
-              i === activeIndex ? (
-                <ActiveListCard key={`card-${i}`} index={i} />
-              ) : (
-                <InactiveListCard key={`card-${i}`} index={i} />
-              ),
-            )}
-            {shouldShowAddAnotherButton && (
-              <ErrorWrapper
-                error={
-                  errors.addItem
-                    ? `Please save all responses before adding another ${schema.type.toLowerCase()}`
-                    : ""
-                }
-              >
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  onClick={addNewItem}
-                  sx={{ width: "100%" }}
-                  data-testid="list-add-button"
-                >
-                  + Add another {schema.type.toLowerCase()}
-                </Button>
-              </ErrorWrapper>
-            )}
-          </>
-        </ErrorWrapper>
-      </FullWidthWrapper>
+      {hasMapField ? (
+        <FullWidthWrapper>{listContent}</FullWidthWrapper>
+      ) : (
+        listContent
+      )}
     </Card>
   );
 };

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -15,6 +15,7 @@ import { PublicProps } from "@planx/components/ui";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import Card from "../../shared/Preview/Card";
@@ -33,6 +34,9 @@ const ListCard = styled(Box)(({ theme }) => ({
   flexDirection: "column",
   gap: theme.spacing(2),
   marginBottom: theme.spacing(2),
+  "& label, & table": {
+    maxWidth: theme.breakpoints.values.formWrap,
+  },
 }));
 
 const CardButton = styled(Button)(({ theme }) => ({
@@ -210,36 +214,38 @@ const Root = () => {
         policyRef={policyRef}
         howMeasured={howMeasured}
       />
-      <ErrorWrapper error={rootError}>
-        <>
-          {formik.values.schemaData.map((_, i) =>
-            i === activeIndex ? (
-              <ActiveListCard key={`card-${i}`} index={i} />
-            ) : (
-              <InactiveListCard key={`card-${i}`} index={i} />
-            ),
-          )}
-          {shouldShowAddAnotherButton && (
-            <ErrorWrapper
-              error={
-                errors.addItem
-                  ? `Please save all responses before adding another ${schema.type.toLowerCase()}`
-                  : ""
-              }
-            >
-              <Button
-                variant="contained"
-                color="secondary"
-                onClick={addNewItem}
-                sx={{ width: "100%" }}
-                data-testid="list-add-button"
+      <FullWidthWrapper>
+        <ErrorWrapper error={rootError}>
+          <>
+            {formik.values.schemaData.map((_, i) =>
+              i === activeIndex ? (
+                <ActiveListCard key={`card-${i}`} index={i} />
+              ) : (
+                <InactiveListCard key={`card-${i}`} index={i} />
+              ),
+            )}
+            {shouldShowAddAnotherButton && (
+              <ErrorWrapper
+                error={
+                  errors.addItem
+                    ? `Please save all responses before adding another ${schema.type.toLowerCase()}`
+                    : ""
+                }
               >
-                + Add another {schema.type.toLowerCase()}
-              </Button>
-            </ErrorWrapper>
-          )}
-        </>
-      </ErrorWrapper>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  onClick={addNewItem}
+                  sx={{ width: "100%" }}
+                  data-testid="list-add-button"
+                >
+                  + Add another {schema.type.toLowerCase()}
+                </Button>
+              </ErrorWrapper>
+            )}
+          </>
+        </ErrorWrapper>
+      </FullWidthWrapper>
     </Card>
   );
 };

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import { MapContainer } from "@planx/components/shared/Preview/MapContainer";
 import type { MapField } from "@planx/components/shared/Schema/model";
 import { Feature } from "geojson";
@@ -47,47 +48,52 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   }, [setFeatures]);
 
   return (
-    <InputLabel label={title} id={`map-label-${id}`} htmlFor={id}>
-      {description && <FieldInputDescription description={description} />}
-      <ErrorWrapper error={errorMessage} id={id}>
-        <MapContainer environment="standalone">
-          {/* @ts-ignore */}
-          <my-map
-            id={id}
-            // TODO
-            // ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
-            height={400}
-            basemap={mapOptions?.basemap}
-            drawMode
-            drawGeojsonData={
-              features &&
-              JSON.stringify({ type: "FeatureCollection", features: features })
-            }
-            drawMany={mapOptions?.drawMany}
-            drawColor={mapOptions?.drawColor}
-            drawType={mapOptions?.drawType}
-            drawPointer="crosshair"
-            zoom={20}
-            maxZoom={23}
-            latitude={Number(passport?.data?._address?.latitude)}
-            longitude={Number(passport?.data?._address?.longitude)}
-            osProxyEndpoint={`${
-              import.meta.env.VITE_APP_API_URL
-            }/proxy/ordnance-survey`}
-            osCopyright={
-              mapOptions?.basemap === "OSVectorTile"
-                ? `Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`
-                : ``
-            }
-            clipGeojsonData={
-              teamSettings?.boundaryBBox &&
-              JSON.stringify(teamSettings?.boundaryBBox)
-            }
-            mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
-            collapseAttributions
-          />
-        </MapContainer>
-      </ErrorWrapper>
-    </InputLabel>
+    <Box sx={{ "& > label": { maxWidth: "100% !important" } }}>
+      <InputLabel label={title} id={`map-label-${id}`} htmlFor={id}>
+        {description && <FieldInputDescription description={description} />}
+        <ErrorWrapper error={errorMessage} id={id}>
+          <MapContainer environment="standalone">
+            {/* @ts-ignore */}
+            <my-map
+              id={id}
+              // TODO
+              // ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
+              height={400}
+              basemap={mapOptions?.basemap}
+              drawMode
+              drawGeojsonData={
+                features &&
+                JSON.stringify({
+                  type: "FeatureCollection",
+                  features: features,
+                })
+              }
+              drawMany={mapOptions?.drawMany}
+              drawColor={mapOptions?.drawColor}
+              drawType={mapOptions?.drawType}
+              drawPointer="crosshair"
+              zoom={20}
+              maxZoom={23}
+              latitude={Number(passport?.data?._address?.latitude)}
+              longitude={Number(passport?.data?._address?.longitude)}
+              osProxyEndpoint={`${
+                import.meta.env.VITE_APP_API_URL
+              }/proxy/ordnance-survey`}
+              osCopyright={
+                mapOptions?.basemap === "OSVectorTile"
+                  ? `Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`
+                  : ``
+              }
+              clipGeojsonData={
+                teamSettings?.boundaryBBox &&
+                JSON.stringify(teamSettings?.boundaryBBox)
+              }
+              mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
+              collapseAttributions
+            />
+          </MapContainer>
+        </ErrorWrapper>
+      </InputLabel>
+    </Box>
   );
 };


### PR DESCRIPTION
## What does this PR do?

Ensures maps in the List component span the full width of `contentWrap` (in line with Map + Label).

Not the most elegant solution, but enough to be functional in the testing prototype.

Feature flag:
`window.featureFlags.toggle("TREES")`

Demo:
https://3632.planx.pizza/testing/full-width-map-testing/preview

Preview:
<img width="749" alt="image" src="https://github.com/user-attachments/assets/6b3cb0d5-3d42-4959-ab3c-d2347a64a588">