### PR TITLE
tidy: drop `submission_email` column from `teams` table and adjust seed-database/write script

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2055,7 +2055,6 @@
           - notify_personalisation
           - settings
           - slug
-          - submission_email
           - updated_at
   select_permissions:
     - role: api
@@ -2070,7 +2069,6 @@
           - reference_code
           - settings
           - slug
-          - submission_email
           - updated_at
         computed_fields:
           - boundary_bbox
@@ -2130,35 +2128,8 @@
           - notify_personalisation
           - settings
           - slug
-          - submission_email
         filter: {}
         check: null
-- table:
-    name: teams_summary
-    schema: public
-  select_permissions:
-    - role: platformAdmin
-      permission:
-        columns:
-          - govpay_enabled
-          - planning_data_enabled
-          - id
-          - govnotify_personalisation
-          - action_colour
-          - article_4s_enabled
-          - bops_submission_url
-          - favicon
-          - homepage
-          - link_colour
-          - logo
-          - name
-          - primary_colour
-          - reference_code
-          - send_to_email_address
-          - slug
-          - subdomain
-        filter: {}
-      comment: ""
 - table:
     name: uniform_applications
     schema: public

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2157,6 +2157,110 @@
         filter: {}
       comment: ""
 - table:
+    name: teams_summary
+    schema: public
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
+- table:
+    name: teams_summary
+    schema: public
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
+- table:
+    name: teams_summary
+    schema: public
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+          columns: "*"
+- table:
+    name: teams_summary
+    schema: public
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
+- table:
     name: uniform_applications
     schema: public
   insert_permissions:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -157,7 +157,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -171,7 +171,7 @@
         query_params:
           type: bops-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: document_template
@@ -225,7 +225,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -239,7 +239,7 @@
         query_params:
           type: email-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: feedback
@@ -451,9 +451,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: platformAdmin
       permission:
@@ -475,9 +475,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: teamEditor
       permission:
@@ -506,9 +506,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   select_permissions:
     - role: api
@@ -609,9 +609,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: platformAdmin
       permission:
@@ -629,9 +629,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: teamEditor
       permission:
@@ -656,9 +656,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   delete_permissions:
     - role: platformAdmin
@@ -689,9 +689,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   select_permissions:
     - role: platformAdmin
@@ -724,9 +724,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
 - table:
     name: lowcal_sessions
@@ -873,7 +873,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/send-email/confirmation'
+        url: "{{$base_url}}/send-email/confirmation"
         version: 2
     - name: setup_lowcal_expiry_events
       definition:
@@ -903,7 +903,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
+        url: "{{$base_url}}/webhooks/hasura/create-expiry-event"
         version: 2
     - name: setup_lowcal_reminder_events
       definition:
@@ -933,7 +933,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
+        url: "{{$base_url}}/webhooks/hasura/create-reminder-event"
         version: 2
 - table:
     name: operations
@@ -1110,7 +1110,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1132,13 +1132,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-expiry-events"
         version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1160,13 +1160,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-invitation-events"
         version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1188,7 +1188,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-reminder-events"
         version: 2
     - name: setup_payment_send_events
       definition:
@@ -1217,7 +1217,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-send-events"
         version: 2
 - table:
     name: payment_status
@@ -1449,12 +1449,12 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
         timeout_sec: 60
-      webhook: '{{HASURA_PLANX_API_URL}}'
+      webhook: "{{HASURA_PLANX_API_URL}}"
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
@@ -1463,7 +1463,7 @@
         query_params:
           type: s3-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: sessions
@@ -2131,6 +2131,32 @@
         filter: {}
         check: null
 - table:
+    name: teams_summary
+    schema: public
+  select_permissions:
+    - role: platformAdmin
+      permission:
+        columns:
+          - govpay_enabled
+          - planning_data_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - article_4s_enabled
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
+- table:
     name: uniform_applications
     schema: public
   insert_permissions:
@@ -2181,7 +2207,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -2195,7 +2221,7 @@
         query_params:
           type: uniform-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: user_roles

--- a/hasura.planx.uk/migrations/1725611185485_alter_table_public_teams_drop_column_submission_email/down.sql
+++ b/hasura.planx.uk/migrations/1725611185485_alter_table_public_teams_drop_column_submission_email/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."teams"."submission_email" is E'Teams are core way we organise `flows` and configure settings like theme colour, logo, and contact info; name usually reflects a council but not exclusively';
+alter table "public"."teams" alter column "submission_email" drop not null;
+alter table "public"."teams" add column "submission_email" text;

--- a/hasura.planx.uk/migrations/1725611185485_alter_table_public_teams_drop_column_submission_email/up.sql
+++ b/hasura.planx.uk/migrations/1725611185485_alter_table_public_teams_drop_column_submission_email/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."teams" drop column "submission_email" cascade;

--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -8,7 +8,6 @@ CREATE TEMPORARY TABLE sync_teams (
   settings jsonb,
   notify_personalisation jsonb,
   domain text,
-  submission_email text,
   boundary jsonb,
   reference_code text
 );


### PR DESCRIPTION
# What does this PR do?

To finish the work on https://trello.com/c/dVsTQpZZ/2984-allow-editors-to-see-update-their-teams-submission-email-in-team-settings-form

I have dropped the redundant column and adjusted the scripts which create the local DBs.

Ran regression testing and all passed