### PR TITLE
style: Layout for inactive list card with map

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -124,9 +124,7 @@ const InactiveListCard: React.FC<{
   const { schema, formik, removeItem, editItem, isPageComponent } =
     useListContext();
 
-  const mapPreview = schema.fields.find(
-    (field) => field.data.fn === "features",
-  );
+  const mapPreview = schema.fields.find((field) => field.type === "map");
 
   return (
     <ListCard data-testid={`list-card-${i}`}>
@@ -147,7 +145,7 @@ const InactiveListCard: React.FC<{
           <TableBody>
             {schema.fields.map(
               (field, j) =>
-                field.data.fn !== "features" && (
+                field.type !== "map" && (
                   <TableRow key={`tableRow-${j}`} sx={{ verticalAlign: "top" }}>
                     <TableCell
                       sx={{

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -27,12 +27,12 @@ import { ListProvider, useListContext } from "./Context";
 export type Props = PublicProps<List>;
 
 const ListCard = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(2),
+  padding: theme.spacing(2.5),
   backgroundColor: theme.palette.background.paper,
-  border: "1px solid darkgray",
+  border: `1px solid ${theme.palette.border.main}`,
   display: "flex",
   flexDirection: "column",
-  gap: theme.spacing(2),
+  gap: theme.spacing(3),
   marginBottom: theme.spacing(2),
   "& label, & table": {
     maxWidth: theme.breakpoints.values.formWrap,
@@ -40,8 +40,17 @@ const ListCard = styled(Box)(({ theme }) => ({
 }));
 
 const CardButton = styled(Button)(({ theme }) => ({
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  gap: theme.spacing(1),
+  background: theme.palette.common.white,
+}));
+
+const InactiveListCardLayout = styled(Box)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
   gap: theme.spacing(2),
+  [theme.breakpoints.up("md")]: {
+    flexDirection: "row",
+  },
 }));
 
 const ActiveListCard: React.FC<{
@@ -96,12 +105,12 @@ const ActiveListCard: React.FC<{
             Save
           </Button>
           {!isPageComponent && !isInitialCard && (
-            <Button
+            <CardButton
               data-testid="cancel-edit-item-button"
               onClick={cancelEditItem}
             >
               Cancel
-            </Button>
+            </CardButton>
           )}
         </Box>
       </ListCard>
@@ -115,39 +124,58 @@ const InactiveListCard: React.FC<{
   const { schema, formik, removeItem, editItem, isPageComponent } =
     useListContext();
 
+  const mapPreview = schema.fields.find(
+    (field) => field.data.fn === "features",
+  );
+
   return (
     <ListCard data-testid={`list-card-${i}`}>
       <Typography component="h2" variant="h3">
         {schema.type}
         {!isPageComponent && ` ${i + 1}`}
       </Typography>
-      <Table>
-        <TableBody>
-          {schema.fields.map((field, j) => (
-            <TableRow key={`tableRow-${j}`} sx={{ verticalAlign: "top" }}>
-              <TableCell
-                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, maxWidth: "100px" }}
-              >
-                {field.data.title}
-              </TableCell>
-              <TableCell>
-                {formatSchemaDisplayValue(
-                  formik.values.schemaData[i][field.data.fn],
-                  schema.fields[j],
-                )}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <InactiveListCardLayout>
+        {mapPreview && (
+          <Box sx={{ flexBasis: "50%" }}>
+            {formatSchemaDisplayValue(
+              formik.values.schemaData[i][mapPreview.data.fn],
+              mapPreview,
+            )}
+          </Box>
+        )}
+        <Table>
+          <TableBody>
+            {schema.fields.map(
+              (field, j) =>
+                field.data.fn !== "features" && (
+                  <TableRow key={`tableRow-${j}`} sx={{ verticalAlign: "top" }}>
+                    <TableCell
+                      sx={{
+                        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+                        maxWidth: "160px",
+                      }}
+                    >
+                      {field.data.title}
+                    </TableCell>
+                    <TableCell>
+                      {formatSchemaDisplayValue(
+                        formik.values.schemaData[i][field.data.fn],
+                        schema.fields[j],
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ),
+            )}
+          </TableBody>
+        </Table>
+      </InactiveListCardLayout>
       <Box display="flex" gap={2}>
         <CardButton onClick={() => removeItem(i)}>
           <DeleteIcon color="warning" fontSize="medium" />
           Remove
         </CardButton>
         <CardButton onClick={() => editItem(i)}>
-          {/* TODO: Is primary colour really right here? */}
-          <EditIcon color="primary" fontSize="medium" />
+          <EditIcon fontSize="medium" />
           Edit
         </CardButton>
       </Box>


### PR DESCRIPTION
## What does this PR do?

Updates layout of the inactive list card so that cards with maps are arranged in a horizontal layout on desktop.

Also general style improvements to the list component as a whole (button contrast, table column widths).

**Preview:**
<img width="1015" alt="image" src="https://github.com/user-attachments/assets/fcb37eae-7d72-493c-8e52-80a990f5b84a">
