### PR TITLE
chore: remove `TREES` feature flag

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -25,12 +25,12 @@ import { ProtectedSpaceGLA } from "./schemas/GLA/ProtectedSpace";
 import { MaterialDetails } from "./schemas/Materials";
 import { Parking } from "./schemas/Parking";
 import { ResidentialUnitsExisting } from "./schemas/ResidentialUnits/Existing";
+import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained";
+import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
 import { ResidentialUnitsGLANew } from "./schemas/ResidentialUnits/GLA/New";
 import { ResidentialUnitsGLARebuilt } from "./schemas/ResidentialUnits/GLA/Rebuilt";
 import { ResidentialUnitsGLARemoved } from "./schemas/ResidentialUnits/GLA/Removed";
 import { ResidentialUnitsGLARetained } from "./schemas/ResidentialUnits/GLA/Retained";
-import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
-import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
 import { Trees } from "./schemas/Trees";
 import { TreesMapFirst } from "./schemas/TreesMapFirst";
@@ -77,12 +77,8 @@ export const SCHEMAS = [
   { name: "Proposed advertisements", schema: ProposedAdvertisements },
   { name: "Parking details", schema: Parking },
   { name: "Parking details (GLA)", schema: ParkingGLA },
-  ...(hasFeatureFlag("TREES")
-    ? [
-        { name: "Trees", schema: Trees },
-        { name: "Trees (Map first)", schema: TreesMapFirst },
-      ]
-    : []),
+  { name: "Trees", schema: Trees },
+  { name: "Trees (Map first)", schema: TreesMapFirst },
 ];
 
 function ListComponent(props: Props) {

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["SEARCH", "TREES", "ADD_NEW_EDITOR"] as const;
+const AVAILABLE_FEATURE_FLAGS = ["SEARCH", "ADD_NEW_EDITOR"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -62,9 +62,7 @@ const NodeTypeSelect: React.FC<{
         <option value={TYPES.AddressInput}>Address Input</option>
         <option value={TYPES.ContactInput}>Contact Input</option>
         <option value={TYPES.List}>List</option>
-        {hasFeatureFlag("TREES") && (
-          <option value={TYPES.MapAndLabel}>Map and Label</option>
-        )}
+        <option value={TYPES.MapAndLabel}>Map and Label (Testing only)</option>
       </optgroup>
       <optgroup label="Information">
         <option value={TYPES.TaskList}>Task List</option>


### PR DESCRIPTION
This will make it easier for Nomensa to test on staging next week!

Map & Label still appears with a "(Testing only)" caveat when selecting from components list