### PR TITLE
refactor: remove `submission_email` column from `teams` table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2055,7 +2055,6 @@
           - notify_personalisation
           - settings
           - slug
-          - submission_email
           - updated_at
   select_permissions:
     - role: api
@@ -2070,7 +2069,6 @@
           - reference_code
           - settings
           - slug
-          - submission_email
           - updated_at
         computed_fields:
           - boundary_bbox
@@ -2130,7 +2128,6 @@
           - notify_personalisation
           - settings
           - slug
-          - submission_email
         filter: {}
         check: null
 - table:

--- a/hasura.planx.uk/migrations/1725873202035_alter_table_public_teams_drop_column_submission_email/down.sql
+++ b/hasura.planx.uk/migrations/1725873202035_alter_table_public_teams_drop_column_submission_email/down.sql
@@ -1,0 +1,31 @@
+alter table "public"."teams" add column "submission_email" text;
+alter table "public"."teams" alter column "submission_email" drop not null;
+comment on column "public"."teams"."submission_email" is E'Teams are core way we organise `flows` and configure settings like theme colour, logo, and contact info; name usually reflects a council but not exclusively';
+
+
+ CREATE OR REPLACE VIEW "public"."teams_summary" AS
+  SELECT t.id,
+     t.name,
+     t.slug,
+     t.reference_code,
+     (t.settings ->> 'homepage'::text) AS homepage,
+     t.domain AS subdomain,
+     ti.has_planning_data AS planning_data_enabled,
+     '@todo'::text AS article_4s_enabled,
+     jsonb_build_object('helpEmail', ts.help_email, 'helpPhone', ts.help_phone, 'emailReplyToId', ts.email_reply_to_id, 'helpOpeningHours', ts.help_opening_hours) AS govnotify_personalisation,
+         CASE
+             WHEN (COALESCE(ti.production_govpay_secret, ti.staging_govpay_secret) IS NOT NULL) THEN true
+             ELSE false
+         END AS govpay_enabled,
+     t.submission_email AS send_to_email_address,
+     COALESCE(ti.production_bops_submission_url, ti.staging_bops_submission_url) AS bops_submission_url,
+     tt.logo,
+     tt.favicon,
+     tt.primary_colour,
+     tt.link_colour,
+     tt.action_colour
+    FROM (((teams t
+      JOIN team_integrations ti ON ((ti.team_id = t.id)))
+      JOIN team_themes tt ON ((tt.team_id = t.id)))
+      JOIN team_settings ts ON ((ts.team_id = t.id)))
+   ORDER BY t.name;

--- a/hasura.planx.uk/migrations/1725873202035_alter_table_public_teams_drop_column_submission_email/down.sql
+++ b/hasura.planx.uk/migrations/1725873202035_alter_table_public_teams_drop_column_submission_email/down.sql
@@ -1,6 +1,5 @@
 alter table "public"."teams" add column "submission_email" text;
-alter table "public"."teams" alter column "submission_email" drop not null;
-comment on column "public"."teams"."submission_email" is E'Teams are core way we organise `flows` and configure settings like theme colour, logo, and contact info; name usually reflects a council but not exclusively';
+comment on column "public"."teams"."submission_email" is E'Referenced by Send component when configured to email planning office';
 
 
  CREATE OR REPLACE VIEW "public"."teams_summary" AS

--- a/hasura.planx.uk/migrations/1725873202035_alter_table_public_teams_drop_column_submission_email/up.sql
+++ b/hasura.planx.uk/migrations/1725873202035_alter_table_public_teams_drop_column_submission_email/up.sql
@@ -1,0 +1,30 @@
+
+CREATE OR REPLACE VIEW "public"."teams_summary" AS 
+ SELECT t.id,
+    t.name,
+    t.slug,
+    t.reference_code,
+    ts.homepage AS homepage,
+    t.domain AS subdomain,
+    ti.has_planning_data AS planning_data_enabled,
+    '@todo'::text AS article_4s_enabled,
+    jsonb_build_object('helpEmail', ts.help_email, 'helpPhone', ts.help_phone, 'emailReplyToId', ts.email_reply_to_id, 'helpOpeningHours', ts.help_opening_hours) AS govnotify_personalisation,
+        CASE
+            WHEN (COALESCE(ti.production_govpay_secret, ti.staging_govpay_secret) IS NOT NULL) THEN true
+            ELSE false
+        END AS govpay_enabled,
+    ts.submission_email AS send_to_email_address,
+    COALESCE(ti.production_bops_submission_url, ti.staging_bops_submission_url) AS bops_submission_url,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour
+   FROM (((teams t
+     JOIN team_integrations ti ON ((ti.team_id = t.id)))
+     JOIN team_themes tt ON ((tt.team_id = t.id)))
+     JOIN team_settings ts ON ((ts.team_id = t.id)))
+  ORDER BY t.name;
+
+
+alter table "public"."teams" drop column "submission_email" cascade;

--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -8,7 +8,6 @@ CREATE TEMPORARY TABLE sync_teams (
   settings jsonb,
   notify_personalisation jsonb,
   domain text,
-  submission_email text,
   boundary jsonb,
   reference_code text
 );


### PR DESCRIPTION
# What does this PR do?

To finish the work on https://trello.com/c/dVsTQpZZ/2984-allow-editors-to-see-update-their-teams-submission-email-in-team-settings-form

I have dropped the redundant column and adjusted the scripts which create the local DBs.

In order to keep the `team_summary` table, I had to adjust the sql code which creates it. From here I also repointed the `homepage` column of this table from `teams` table to `team_settings` table.

`Up` script running order: 

1. Change `team_summary` view using `team_settings.submission_email` column
2. Remove `teams.submission_email` column

`Down` script:

1. Add `teams.submission_email` column
2. Replace `team_summary` view using new column

Regression tests passing