### PR TITLE
chore: `MapAndLabel` tidy ups

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -70,8 +70,12 @@ const VerticalFeatureTabs: React.FC = () => {
     throw new Error("Cannot render MapAndLabel tabs without features");
   }
 
-  // Features is inherently sorted by recently added/modified, order tabs by stable labels
-  const sortedFeatures = sortBy(features, ["properties.label"]);
+  // Features is inherently sorted by recently added/modified, order tabs by stable labels (labels are integers stored as strings)
+  const sortedFeatures = sortBy(features, [
+    function (f) {
+      return Number(f.properties?.label);
+    },
+  ]);
 
   return (
     <Box


### PR DESCRIPTION
A few tidy ups & fixes now that all major functionality is merged & open for testing ! Follows on from #3625 

- [x] Tabs correctly sorted - previous bug where 10 was getting sorted before 2 because geojson `properties` require labels to be stored as strings, but we want to sort them as numbers 
- [ ] `activeTabIndex` more consistently managed based on length of `features` when adding & removing features
- [ ] When editing a feature, correctly set the right tab index
- [ ] After removing a feature, make zoom / map viewport repositioning less jumpy
- [ ] When coming "back"/"changing", ensure latest tab is set as active one by default