### PR TITLE
feat: Navigate to node from search results

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e3c9e7e",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#94b20aa",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ec52620",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e3c9e7e",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.3
     version: 1.0.0-alpha.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#e3c9e7e
-    version: github.com/theopensystemslab/planx-core/e3c9e7e(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#94b20aa
+    version: github.com/theopensystemslab/planx-core/94b20aa(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -7744,7 +7744,6 @@ packages:
 
   /@types/lodash@4.17.7:
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
-    dev: true
 
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -11907,8 +11906,8 @@ packages:
   /fast-uri@3.0.1:
     resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
 
-  /fast-xml-parser@4.4.1:
-    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+  /fast-xml-parser@4.5.0:
+    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -14373,13 +14372,14 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  /json-schema-to-typescript@15.0.1:
-    resolution: {integrity: sha512-gSSg20skxv+ZQqR8Y8itZt+2iYFGNgneuTgf/Va0TBw+zo6JsykDG1bqhkhMs5g/vIdqmZx55oQJLbgOEuxPJw==}
+  /json-schema-to-typescript@15.0.2:
+    resolution: {integrity: sha512-+cRBw+bBJ3k783mZroDIgz1pLNPB4hvj6nnbHTWwEVl0dkW8qdZ+M9jWhBb+Y0FAdHvNsXACga3lewGO8lktrw==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
       '@apidevtools/json-schema-ref-parser': 11.6.4
       '@types/json-schema': 7.0.15
+      '@types/lodash': 4.17.7
       glob: 10.4.5
       is-glob: 4.0.3
       js-yaml: 4.1.0
@@ -14929,8 +14929,8 @@ packages:
       react: 18.3.1
     dev: true
 
-  /marked@14.1.0:
-    resolution: {integrity: sha512-P93GikH/Pde0hM5TAXEd8I4JAYi8IB03n8qzW8Bh1BIEFpEyBoYxi/XWZA53LSpTeLBiMQOoSMj0u5E/tiVYTA==}
+  /marked@14.1.2:
+    resolution: {integrity: sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -19994,8 +19994,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /type-fest@4.26.0:
-    resolution: {integrity: sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==}
+  /type-fest@4.26.1:
+    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
     engines: {node: '>=16'}
     dev: false
 
@@ -21378,9 +21378,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/e3c9e7e(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e3c9e7e}
-    id: github.com/theopensystemslab/planx-core/e3c9e7e
+  github.com/theopensystemslab/planx-core/94b20aa(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/94b20aa}
+    id: github.com/theopensystemslab/planx-core/94b20aa
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -21397,16 +21397,16 @@ packages:
       copyfiles: 2.4.1
       docx: 8.5.0
       eslint: 8.57.0
-      fast-xml-parser: 4.4.1
+      fast-xml-parser: 4.5.0
       graphql: 16.9.0
       graphql-request: 6.1.0(graphql@16.9.0)
-      json-schema-to-typescript: 15.0.1
+      json-schema-to-typescript: 15.0.2
       lodash: 4.17.21
-      marked: 14.1.0
+      marked: 14.1.2
       prettier: 3.3.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.26.0
+      type-fest: 4.26.1
       uuid: 10.0.0
       zod: 3.23.8
     transitivePeerDependencies:

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.3
     version: 1.0.0-alpha.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ec52620
-    version: github.com/theopensystemslab/planx-core/ec52620(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#e3c9e7e
+    version: github.com/theopensystemslab/planx-core/e3c9e7e(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -21378,9 +21378,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/ec52620(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ec52620}
-    id: github.com/theopensystemslab/planx-core/ec52620
+  github.com/theopensystemslab/planx-core/e3c9e7e(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e3c9e7e}
+    id: github.com/theopensystemslab/planx-core/e3c9e7e
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/NodeSearchResults.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/NodeSearchResults.test.tsx
@@ -1,10 +1,17 @@
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { setup } from "testUtils";
+import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
 import { flow, results } from "./mocks/simple";
 import { NodeSearchResults } from "./NodeSearchResults";
+
+vi.mock("react-navi", () => ({
+  useNavigation: () => ({
+    navigate: vi.fn(),
+  }),
+}));
 
 beforeAll(() => useStore.setState({ flow }));
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
@@ -5,7 +5,9 @@ import Typography from "@mui/material/Typography";
 import { IndexedNode } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/ui";
 import type { SearchResult } from "hooks/useSearch";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import { useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { Headline } from "../Headline";
@@ -25,11 +27,12 @@ export const SearchResultCard: React.FC<{
     getDisplayDetailsForResult(result);
   const Icon = ICONS[iconKey];
 
+  const getURLForNode = useStore((state) => state.getURLForNode);
+  const { navigate } = useNavigation();
+
   const handleClick = () => {
-    console.log({ result });
-    // get path for node
-    // generate url from path
-    // navigate to url
+    const url = getURLForNode(result.item.id);
+    navigate(url);
   };
 
   return (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
@@ -7,6 +7,12 @@ import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
+vi.mock("react-navi", () => ({
+  useNavigation: () => ({
+    navigate: vi.fn(),
+  }),
+}));
+
 import Search from ".";
 import { flow } from "./mocks/simple";
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getURLForNode.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getURLForNode.test.ts
@@ -1,11 +1,74 @@
+import { useStore } from "../store";
+import { orderedFlow } from "./mocks/getURLForNode/orderedFlow";
+
+const { getState, setState } = useStore;
+const { getURLForNode } = getState();
+
+beforeAll(() =>
+  setState({ orderedFlow, teamSlug: "testTeam", flowSlug: "testFlow" }),
+);
+
 describe("constructing URLs for nodes", () => {
-  test.todo("a question node on the root");
-  test.todo("an answer node, of a question on the root");
-  test.todo("a question node, deeply branched");
-  test.todo("an answer node, of a deeply branched question");
-  test.todo("a question node, within an internal portal");
-  test.todo("an answer node, within an internal portal");
-  test.todo("a question node, deeply within internal portals");
-  test.todo("an answer node, deeply within internal portals");
-  test.todo("a cloned node");
+  test("a question node on the root", () => {
+    const url = getURLForNode("bandQuestion");
+    expect(url).toEqual(
+      "/testTeam/testFlow/nodes/_root/nodes/bandQuestion/edit",
+    );
+  });
+
+  test("an answer node, of a question on the root", () => {
+    const url = getURLForNode("beatlesAnswer");
+    expect(url).toEqual(
+      "/testTeam/testFlow/nodes/_root/nodes/bandQuestion/edit",
+    );
+  });
+
+  test("a question node, deeply branched", () => {
+    const url = getURLForNode("bestSongQuestion");
+    expect(url).toEqual(
+      "/testTeam/testFlow/nodes/whiteAlbumAnswer/nodes/bestSongQuestion/edit",
+    );
+  });
+
+  test("an answer node, of a deeply branched question", () => {
+    const url = getURLForNode("helterSkelterAnswer");
+    expect(url).toEqual(
+      "/testTeam/testFlow/nodes/whiteAlbumAnswer/nodes/bestSongQuestion/edit",
+    );
+  });
+
+  test("a question node, within an internal portal", () => {
+    const url = getURLForNode("bestDirectorQuestion");
+    expect(url).toEqual(
+      "/testTeam/testFlow,moviesPortal/nodes/moviesPortal/nodes/bestDirectorQuestion/edit",
+    );
+  });
+
+  test("an answer node, within an internal portal", () => {
+    const url = getURLForNode("tarantinoAnswer");
+    expect(url).toEqual(
+      "/testTeam/testFlow,moviesPortal/nodes/moviesPortal/nodes/bestDirectorQuestion/edit",
+    );
+  });
+
+  test("a question node, deeply within internal portals", () => {
+    const url = getURLForNode("tarantinoMovieQuestion");
+    expect(url).toEqual(
+      "/testTeam/testFlow,tarantinoPortal,moviesPortal/nodes/tarantinoPortal/nodes/tarantinoMovieQuestion/edit",
+    );
+  });
+
+  test("an answer node, deeply within internal portals", () => {
+    const url = getURLForNode("reservoirDogsAnswer");
+    expect(url).toEqual(
+      "/testTeam/testFlow,tarantinoPortal,moviesPortal/nodes/tarantinoPortal/nodes/tarantinoMovieQuestion/edit",
+    );
+  });
+
+  test("a cloned node", () => {
+    const url = getURLForNode("tellMyWhyTextInput");
+    expect(url).toEqual(
+      "/testTeam/testFlow/nodes/gentlyWeepsAnswer/nodes/tellMyWhyTextInput/edit",
+    );
+  });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getURLForNode.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getURLForNode.test.ts
@@ -1,0 +1,11 @@
+describe("constructing URLs for nodes", () => {
+  test.todo("a question node on the root");
+  test.todo("an answer node, of a question on the root");
+  test.todo("a question node, deeply branched");
+  test.todo("an answer node, of a deeply branched question");
+  test.todo("a question node, within an internal portal");
+  test.todo("an answer node, within an internal portal");
+  test.todo("a question node, deeply within internal portals");
+  test.todo("an answer node, deeply within internal portals");
+  test.todo("a cloned node");
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/getURLForNode/orderedFlow.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/getURLForNode/orderedFlow.ts
@@ -1,0 +1,176 @@
+import { OrderedFlow } from "@opensystemslab/planx-core/types";
+
+export const orderedFlow: OrderedFlow = [
+  {
+    id: "bandQuestion",
+    parentId: "_root",
+    type: 100,
+    edges: ["beatlesAnswer", "rollingStonesAnswer"],
+    data: {
+      fn: "band",
+      text: "Best band?",
+    },
+  },
+  {
+    id: "beatlesAnswer",
+    parentId: "bandQuestion",
+    type: 200,
+    edges: ["bestAlbumQuestion"],
+    data: {
+      val: "beatles",
+      text: "Beatles",
+    },
+  },
+  {
+    id: "bestAlbumQuestion",
+    parentId: "beatlesAnswer",
+    type: 100,
+    edges: ["sgtPepperAnswer", "whiteAlbumAnswer"],
+    data: {
+      fn: "beatles.album",
+      text: "Best album?",
+    },
+  },
+  {
+    id: "sgtPepperAnswer",
+    parentId: "bestAlbumQuestion",
+    type: 200,
+    data: {
+      val: "sgtPepper",
+      text: "Sgt Pepper",
+    },
+  },
+  {
+    id: "whiteAlbumAnswer",
+    parentId: "bestAlbumQuestion",
+    type: 200,
+    edges: ["bestSongQuestion"],
+    data: {
+      val: "whiteAlbum",
+      text: "The White Album",
+    },
+  },
+  {
+    id: "bestSongQuestion",
+    parentId: "whiteAlbumAnswer",
+    type: 100,
+    edges: ["gentlyWeepsAnswer", "helterSkelterAnswer"],
+    data: {
+      fn: "band.album.whiteAlbum",
+      text: "Best song?",
+    },
+  },
+  {
+    id: "gentlyWeepsAnswer",
+    parentId: "bestSongQuestion",
+    type: 200,
+    edges: ["tellMyWhyTextInput"],
+    data: {
+      val: "gentlyWeeps",
+      text: "While my guitar gently weeps",
+    },
+  },
+  {
+    id: "tellMyWhyTextInput",
+    parentId: "gentlyWeepsAnswer",
+    type: 110,
+    data: {
+      fn: "best.song.reason",
+      title: "Tell me why!",
+    },
+  },
+  {
+    id: "helterSkelterAnswer",
+    parentId: "bestSongQuestion",
+    type: 200,
+    edges: ["tellMyWhyTextInput"],
+    data: {
+      val: "helterSkelter",
+      text: "Helter Skelter",
+    },
+  },
+  {
+    id: "rollingStonesAnswer",
+    parentId: "bandQuestion",
+    type: 200,
+    data: {
+      val: "rollingStones",
+      text: "Rolling Stones",
+    },
+  },
+  {
+    id: "moviesPortal",
+    parentId: "_root",
+    type: 300,
+    edges: ["bestDirectorQuestion"],
+    data: {
+      text: "Movies",
+    },
+  },
+  {
+    id: "bestDirectorQuestion",
+    parentId: "moviesPortal",
+    type: 100,
+    edges: ["kubrickAnswer", "tarantinoAnswer"],
+    data: {
+      fn: "director",
+      text: "Best director?",
+    },
+  },
+  {
+    id: "kubrickAnswer",
+    parentId: "bestDirectorQuestion",
+    type: 200,
+    data: {
+      val: "kubrick",
+      text: "Stanley Kubrick",
+    },
+  },
+  {
+    id: "tarantinoAnswer",
+    parentId: "bestDirectorQuestion",
+    type: 200,
+    edges: ["tarantinoPortal"],
+    data: {
+      val: "tarantino",
+      text: "Quentin Tarantino",
+    },
+  },
+  {
+    id: "tarantinoPortal",
+    parentId: "tarantinoAnswer",
+    type: 300,
+    edges: ["tarantinoMovieQuestion"],
+    data: {
+      text: "Tarantino Movies",
+    },
+  },
+  {
+    id: "tarantinoMovieQuestion",
+    parentId: "tarantinoPortal",
+    type: 100,
+    edges: ["jackieBrownAnswer", "reservoirDogsAnswer"],
+    data: {
+      fn: "movie.tarantino",
+      text: "Best Tarantino movie?",
+    },
+  },
+  {
+    id: "jackieBrownAnswer",
+    parentId: "tarantinoMovieQuestion",
+    type: 200,
+    data: {
+      val: "jackieBrown",
+      text: "Jackie Brown",
+    },
+  },
+  {
+    id: "reservoirDogsAnswer",
+    parentId: "tarantinoMovieQuestion",
+    type: 200,
+    data: {
+      val: "reservoirDogs",
+      text: "Reservoir Dogs",
+    },
+  },
+];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -497,31 +497,24 @@ export const editorStore: StateCreator<
     const { orderedFlow: flow, flowSlug, teamSlug } = get();
     if (!flow) throw Error("Missing ordered flow!");
 
-    const [node, parent, grandparent, ...rest] = getPathForNode({
-      nodeId,
-      flow,
-    });
-    console.log({ node, parent, grandparent, rest });
-    const internalPortals = rest.filter(
+    const path = getPathForNode({ nodeId, flow });
+    const internalPortals = path.filter(
       ({ type }) => type === ComponentType.InternalPortal,
     );
-    console.log({ internalPortals });
+    const [node, parent, grandparent] = path;
 
-    // based on node type, construct URL
-    // Answer nodes use parent and grandparent
-    let urlPath = `/${teamSlug}/${flowSlug}`;
-    if (internalPortals.length) {
-      const portalPath = internalPortals.map(({ id }) => id).join(",");
-      urlPath += `/${portalPath}`;
-    }
+    // Construct the internal portal path if applicable
+    const portalPath = internalPortals.length
+      ? "," + internalPortals.map(({ id }) => id).join(",")
+      : "";
 
-    if (node.type === ComponentType.Answer) {
-      urlPath += `/nodes/${grandparent.id}/nodes/${parent.id}/edit`;
-    } else {
-      urlPath += `/nodes/${parent.id}/nodes/${node.id}/edit`;
-    }
+    // Determine node path based on the node type
+    const nodePath =
+      node.type === ComponentType.Answer
+        ? `nodes/${grandparent.id}/nodes/${parent.id}/edit`
+        : `nodes/${parent.id}/nodes/${node.id}/edit`;
 
-    console.log(urlPath);
+    const urlPath = `/${teamSlug}/${flowSlug}${portalPath}/${nodePath}`;
     return urlPath;
   },
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -1,6 +1,10 @@
 import { gql } from "@apollo/client";
-import { sortFlow } from "@opensystemslab/planx-core";
-import { FlowGraph, OrderedFlow } from "@opensystemslab/planx-core/types";
+import { getPathForNode, sortFlow } from "@opensystemslab/planx-core";
+import {
+  ComponentType,
+  FlowGraph,
+  OrderedFlow,
+} from "@opensystemslab/planx-core/types";
 import {
   add,
   clone,
@@ -107,6 +111,7 @@ export interface EditorStore extends Store.Store {
     name: string;
     href: string;
   }) => void;
+  getURLForNode: (nodeId: string) => string;
 }
 
 export const editorStore: StateCreator<
@@ -486,5 +491,37 @@ export const editorStore: StateCreator<
     const externalPortals = get().externalPortals;
     externalPortals[id] = { name, href };
     set({ externalPortals });
+  },
+
+  getURLForNode: (nodeId) => {
+    const { orderedFlow: flow, flowSlug, teamSlug } = get();
+    if (!flow) throw Error("Missing ordered flow!");
+
+    const [node, parent, grandparent, ...rest] = getPathForNode({
+      nodeId,
+      flow,
+    });
+    console.log({ node, parent, grandparent, rest });
+    const internalPortals = rest.filter(
+      ({ type }) => type === ComponentType.InternalPortal,
+    );
+    console.log({ internalPortals });
+
+    // based on node type, construct URL
+    // Answer nodes use parent and grandparent
+    let urlPath = `/${teamSlug}/${flowSlug}`;
+    if (internalPortals.length) {
+      const portalPath = internalPortals.map(({ id }) => id).join(",");
+      urlPath += `/${portalPath}`;
+    }
+
+    if (node.type === ComponentType.Answer) {
+      urlPath += `/nodes/${grandparent.id}/nodes/${parent.id}/edit`;
+    } else {
+      urlPath += `/nodes/${parent.id}/nodes/${node.id}/edit`;
+    }
+
+    console.log(urlPath);
+    return urlPath;
   },
 });


### PR DESCRIPTION
## What does this PR do?
 - Uses [the planx-core function `getPathForNode()`](https://github.com/theopensystemslab/planx-core/pull/506/) to construct a PlanX relative URL
 - Wires this up to search result cards

Test flow on Pizza - https://3650.planx.pizza/testing/flow-navigation-search

Prior art - https://github.com/theopensystemslab/planx-new/pull/3460

https://github.com/user-attachments/assets/e10a21c5-1614-4358-a57c-1e4d42786019

## To Do (this PR)
- Bump planx-core across all projects once https://github.com/theopensystemslab/planx-core/pull/506/ approved and merged

## Next step...
- Portal "wrapper" UI for cards

