### PR TITLE
feat: Add compact checkbox option

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -43,11 +43,12 @@ const Search: React.FC = () => {
   });
 
   const debouncedSearch = useMemo(
-    () => debounce((pattern: string) => {
-      console.debug("Search term: ", pattern)
-      return search(pattern);
-    }, DEBOUNCE_MS),
-    [search]
+    () =>
+      debounce((pattern: string) => {
+        console.debug("Search term: ", pattern);
+        return search(pattern);
+      }, DEBOUNCE_MS),
+    [search],
   );
 
   return (
@@ -77,7 +78,8 @@ const Search: React.FC = () => {
           id={"search-data-field-facet"}
           checked
           inputProps={{ disabled: true }}
-          onChange={() => { }}
+          onChange={() => {}}
+          variant="compact"
         />
         <Box pt={3}>
           {formik.values.pattern && (

--- a/editor.planx.uk/src/ui/shared/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox.tsx
@@ -11,8 +11,8 @@ const Root = styled(Box, {
     display: "inline-flex",
     flexShrink: 0,
     position: "relative",
-    width: variant === "compact" ? 24 : 40,
-    height: variant === "compact" ? 24 : 40,
+    width: 40,
+    height: 40,
     borderColor: theme.palette.text.primary,
     border: "2px solid",
     backgroundColor: theme.palette.common.white,
@@ -21,15 +21,23 @@ const Root = styled(Box, {
       border: `2px solid ${theme.palette.grey[400]}`,
       backgroundColor: theme.palette.grey[400],
     }),
+    ...(variant === "compact" && {
+      width: 24,
+      height: 24,
+    }),
   }),
 );
 
 const Input = styled("input")<{ variant?: "default" | "compact" }>(
   ({ variant }) => ({
     opacity: 0,
-    width: variant === "compact" ? 16 : 24,
-    height: variant === "compact" ? 16 : 24,
+    width: 24,
+    height: 24,
     cursor: "pointer",
+    ...(variant === "compact" && {
+      width: 16,
+      height: 16,
+    }),
   }),
 );
 
@@ -46,18 +54,29 @@ const Icon = styled("span", {
   display: checked ? "block" : "none",
   content: "''",
   position: "absolute",
-  height: variant === "compact" ? 12 : 24,
-  width: variant === "compact" ? 7 : 12,
-  borderBottom: variant === "compact" ? "3px solid" : "5px solid",
-  borderRight: variant === "compact" ? "3px solid" : "5px solid",
+  height: 24,
+  width: 12,
+  borderBottom: "5px solid",
+  borderRight: "5px solid",
   left: "50%",
-  top: variant === "compact" ? "44%" : "42%",
+  top: "42%",
   transform: "translate(-50%, -50%) rotate(45deg)",
   cursor: "pointer",
+  ...(variant === "compact" && {
+    height: 12,
+    width: 7,
+    borderBottom: "3px solid",
+    borderRight: "3px solid",
+    top: "44%",
+  }),
   ...(disabled && {
-    borderBottom: variant === "compact" ? "3px solid" : "5px solid",
-    borderRight: variant === "compact" ? "3px solid" : "5px solid",
+    borderBottom: "5px solid",
+    borderRight: "5px solid",
     borderColor: theme.palette.common.white,
+    ...(variant === "compact" && {
+      borderBottom: "3px solid",
+      borderRight: "3px solid",
+    }),
   }),
 }));
 

--- a/editor.planx.uk/src/ui/shared/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox.tsx
@@ -4,54 +4,58 @@ import React from "react";
 import { borderedFocusStyle } from "theme";
 
 const Root = styled(Box, {
-  shouldForwardProp: (prop) => !["disabled"].includes(prop.toString()),
-})<BoxProps & { disabled?: boolean }>(({ theme, disabled }) => ({
-  display: "inline-flex",
-  flexShrink: 0,
-  position: "relative",
-  width: 40,
-  height: 40,
-  borderColor: theme.palette.text.primary,
-  border: "2px solid",
-  backgroundColor: theme.palette.common.white,
-  "&:focus-within": borderedFocusStyle,
-  ...(disabled && {
-    border: `2px solid ${theme.palette.grey[400]}`,
-    backgroundColor: theme.palette.grey[400],
+  shouldForwardProp: (prop) =>
+    !["disabled", "compact"].includes(prop.toString()),
+})<BoxProps & { disabled?: boolean; compact?: boolean }>(
+  ({ theme, disabled, compact }) => ({
+    display: "inline-flex",
+    flexShrink: 0,
+    position: "relative",
+    width: compact ? 24 : 40,
+    height: compact ? 24 : 40,
+    borderColor: theme.palette.text.primary,
+    border: "2px solid",
+    backgroundColor: theme.palette.common.white,
+    "&:focus-within": borderedFocusStyle,
+    ...(disabled && {
+      border: `2px solid ${theme.palette.grey[400]}`,
+      backgroundColor: theme.palette.grey[400],
+    }),
   }),
-}));
+);
 
-const Input = styled("input")(() => ({
+const Input = styled("input")<{ compact?: boolean }>(({ compact }) => ({
   opacity: 0,
-  width: 24,
-  height: 24,
+  width: compact ? 16 : 24,
+  height: compact ? 16 : 24,
   cursor: "pointer",
 }));
 
 interface IconProps extends React.HTMLAttributes<HTMLSpanElement> {
   checked: boolean;
   disabled?: boolean;
+  compact?: boolean;
 }
 
 const Icon = styled("span", {
   shouldForwardProp: (prop) =>
-    !["checked", "disabled"].includes(prop.toString()),
-})<IconProps>(({ theme, checked, disabled }) => ({
+    !["checked", "disabled", "compact"].includes(prop.toString()),
+})<IconProps>(({ theme, checked, disabled, compact }) => ({
   display: checked ? "block" : "none",
   content: "''",
   position: "absolute",
-  height: 24,
-  width: 12,
-  borderColor: theme.palette.text.primary,
-  borderBottom: "5px solid",
-  borderRight: "5px solid",
+  height: compact ? 12 : 24,
+  width: compact ? 7 : 12,
+  borderBottom: compact ? "3px solid" : "5px solid",
+  borderRight: compact ? "3px solid" : "5px solid",
   left: "50%",
   top: "42%",
   transform: "translate(-50%, -50%) rotate(45deg)",
   cursor: "pointer",
   ...(disabled && {
-    borderBottom: `5px solid white`,
-    borderRight: `5px solid white`,
+    borderBottom: compact ? "3px solid" : "5px solid",
+    borderRight: compact ? "3px solid" : "5px solid",
+    borderColor: theme.palette.common.white,
   }),
 }));
 
@@ -60,6 +64,7 @@ export interface Props {
   checked: boolean;
   onChange?: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  compact?: boolean;
 }
 
 export default function Checkbox({
@@ -67,6 +72,7 @@ export default function Checkbox({
   checked,
   onChange,
   inputProps,
+  compact,
 }: Props): FCReturn {
   const handleChange = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     e.preventDefault();
@@ -74,15 +80,24 @@ export default function Checkbox({
   };
 
   return (
-    <Root onClick={handleChange} disabled={inputProps?.disabled}>
+    <Root
+      onClick={handleChange}
+      disabled={inputProps?.disabled}
+      compact={compact}
+    >
       <Input
         defaultChecked={checked}
         type="checkbox"
         id={id}
         data-testid={id}
         {...inputProps}
+        compact={compact}
       />
-      <Icon checked={checked} disabled={inputProps?.disabled} />
+      <Icon
+        checked={checked}
+        disabled={inputProps?.disabled}
+        compact={compact}
+      />
     </Root>
   );
 }

--- a/editor.planx.uk/src/ui/shared/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox.tsx
@@ -5,14 +5,14 @@ import { borderedFocusStyle } from "theme";
 
 const Root = styled(Box, {
   shouldForwardProp: (prop) =>
-    !["disabled", "compact"].includes(prop.toString()),
-})<BoxProps & { disabled?: boolean; compact?: boolean }>(
-  ({ theme, disabled, compact }) => ({
+    !["disabled", "variant"].includes(prop.toString()),
+})<BoxProps & { disabled?: boolean; variant?: "default" | "compact" }>(
+  ({ theme, disabled, variant }) => ({
     display: "inline-flex",
     flexShrink: 0,
     position: "relative",
-    width: compact ? 24 : 40,
-    height: compact ? 24 : 40,
+    width: variant === "compact" ? 24 : 40,
+    height: variant === "compact" ? 24 : 40,
     borderColor: theme.palette.text.primary,
     border: "2px solid",
     backgroundColor: theme.palette.common.white,
@@ -24,37 +24,39 @@ const Root = styled(Box, {
   }),
 );
 
-const Input = styled("input")<{ compact?: boolean }>(({ compact }) => ({
-  opacity: 0,
-  width: compact ? 16 : 24,
-  height: compact ? 16 : 24,
-  cursor: "pointer",
-}));
+const Input = styled("input")<{ variant?: "default" | "compact" }>(
+  ({ variant }) => ({
+    opacity: 0,
+    width: variant === "compact" ? 16 : 24,
+    height: variant === "compact" ? 16 : 24,
+    cursor: "pointer",
+  }),
+);
 
 interface IconProps extends React.HTMLAttributes<HTMLSpanElement> {
   checked: boolean;
   disabled?: boolean;
-  compact?: boolean;
+  variant?: "default" | "compact";
 }
 
 const Icon = styled("span", {
   shouldForwardProp: (prop) =>
-    !["checked", "disabled", "compact"].includes(prop.toString()),
-})<IconProps>(({ theme, checked, disabled, compact }) => ({
+    !["checked", "disabled", "variant"].includes(prop.toString()),
+})<IconProps>(({ theme, checked, disabled, variant }) => ({
   display: checked ? "block" : "none",
   content: "''",
   position: "absolute",
-  height: compact ? 12 : 24,
-  width: compact ? 7 : 12,
-  borderBottom: compact ? "3px solid" : "5px solid",
-  borderRight: compact ? "3px solid" : "5px solid",
+  height: variant === "compact" ? 12 : 24,
+  width: variant === "compact" ? 7 : 12,
+  borderBottom: variant === "compact" ? "3px solid" : "5px solid",
+  borderRight: variant === "compact" ? "3px solid" : "5px solid",
   left: "50%",
-  top: "42%",
+  top: variant === "compact" ? "44%" : "42%",
   transform: "translate(-50%, -50%) rotate(45deg)",
   cursor: "pointer",
   ...(disabled && {
-    borderBottom: compact ? "3px solid" : "5px solid",
-    borderRight: compact ? "3px solid" : "5px solid",
+    borderBottom: variant === "compact" ? "3px solid" : "5px solid",
+    borderRight: variant === "compact" ? "3px solid" : "5px solid",
     borderColor: theme.palette.common.white,
   }),
 }));
@@ -64,7 +66,7 @@ export interface Props {
   checked: boolean;
   onChange?: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-  compact?: boolean;
+  variant?: "default" | "compact";
 }
 
 export default function Checkbox({
@@ -72,7 +74,7 @@ export default function Checkbox({
   checked,
   onChange,
   inputProps,
-  compact,
+  variant = "default",
 }: Props): FCReturn {
   const handleChange = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     e.preventDefault();
@@ -83,7 +85,7 @@ export default function Checkbox({
     <Root
       onClick={handleChange}
       disabled={inputProps?.disabled}
-      compact={compact}
+      variant={variant}
     >
       <Input
         defaultChecked={checked}
@@ -91,12 +93,12 @@ export default function Checkbox({
         id={id}
         data-testid={id}
         {...inputProps}
-        compact={compact}
+        variant={variant}
       />
       <Icon
         checked={checked}
         disabled={inputProps?.disabled}
-        compact={compact}
+        variant={variant}
       />
     </Root>
   );

--- a/editor.planx.uk/src/ui/shared/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem.tsx
@@ -27,6 +27,7 @@ interface Props {
   checked: boolean;
   onChange: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  compact?: boolean;
 }
 
 export default function ChecklistItem({
@@ -35,6 +36,7 @@ export default function ChecklistItem({
   checked,
   id,
   inputProps,
+  compact,
 }: Props): FCReturn {
   return (
     <Root>
@@ -43,6 +45,7 @@ export default function ChecklistItem({
         id={id}
         onChange={onChange}
         inputProps={inputProps}
+        compact={compact}
       />
       <Label variant="body1" className="label" component={"label"} htmlFor={id}>
         {label}

--- a/editor.planx.uk/src/ui/shared/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem.tsx
@@ -27,7 +27,7 @@ interface Props {
   checked: boolean;
   onChange: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-  compact?: boolean;
+  variant: "default" | "compact";
 }
 
 export default function ChecklistItem({
@@ -36,7 +36,7 @@ export default function ChecklistItem({
   checked,
   id,
   inputProps,
-  compact,
+  variant,
 }: Props): FCReturn {
   return (
     <Root>
@@ -45,7 +45,7 @@ export default function ChecklistItem({
         id={id}
         onChange={onChange}
         inputProps={inputProps}
-        compact={compact}
+        variant={variant}
       />
       <Label variant="body1" className="label" component={"label"} htmlFor={id}>
         {label}

--- a/editor.planx.uk/src/ui/shared/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem.tsx
@@ -27,7 +27,7 @@ interface Props {
   checked: boolean;
   onChange: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-  variant: "default" | "compact";
+  variant?: "default" | "compact";
 }
 
 export default function ChecklistItem({


### PR DESCRIPTION
## What does this PR do?

Adds a "compact" option to checkboxes, in line with the GOV.UK style smaller checkboxes:
https://design-system.service.gov.uk/components/checkboxes/#smaller-checkboxes

This will initially be used for toggling data (and other options) in the search function, but will useful throughout other search / filtering options within the PlanX editor.

**Before:**
<img width="502" alt="image" src="https://github.com/user-attachments/assets/0272b893-a6cf-4854-950c-b65321cae6b7">

**After:**
<img width="502" alt="image" src="https://github.com/user-attachments/assets/51b55e96-e879-40a9-aa69-afcfe94079d7">