### PR TITLE
feat: Better handling of GovPay errors

### DIFF
--- a/api.planx.uk/modules/pay/helpers.ts
+++ b/api.planx.uk/modules/pay/helpers.ts
@@ -2,6 +2,17 @@ import { gql } from "graphql-request";
 import airbrake from "../../airbrake.js";
 import { $api } from "../../client/index.js";
 
+/**
+ * Gracefully handle GovPay errors
+ * Docs: https://docs.payments.service.gov.uk/api_reference/#responses
+ */
+export const handleGovPayErrors = (res: unknown) =>
+  JSON.stringify({
+    message:
+      "GovPay responded with an error when attempting to proxy to their API",
+    govPayResponse: res,
+  });
+
 export async function logPaymentStatus({
   sessionId,
   flowId,


### PR DESCRIPTION
## What's the problem?
 - The GovPay API is being interacted with whilst the account in question (Barnet) is not yet configured - I've reached out to explain this to Barnet
 - GovPay is returning the following message - `Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/`
 - We're not accounting for GovPay errors of this type (no paymentId created), which causes are logging to fail
 - Caught in Airbrake x2 - https://planx.airbrake.io/projects/329753/groups/3888910995787193650/notices/3888910993592626836?tab=overview

## What's the solution?
- Add a handler for these errors which returns early if there's an issue
- The frontend already handles these errors

## Also...
The pattern of proxies and nested callbacks within the Pay module is a little tricky to get around at times. I think a wider refactor here to follow a more linear middleware pattern here would make this code easier to understand and work with. It would also mean that we could ensure that logging and error handling were carried out as standard on pay endpoints. This work is outside the scope of this bug fix, but wanted to flag it!
