### PR TITLE
 refactor: Import `Node` type from `planx-core`

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -42,16 +42,22 @@
           },
           {
             "name": "@testing-library/react",
-            "importNames": ["render"],
+            "importNames": [
+              "render"
+            ],
             "message": "Please import setup() from testUtils to render test component"
           },
           {
             "name": "@mui/styles",
-            "importNames": ["styled"],
+            "importNames": [
+              "styled"
+            ],
             "message": "Please import styled from '@mui/material/styles'. Reason: https://mui.com/system/styled/#what-problems-does-it-solve"
           }
         ],
-        "patterns": ["@mui/*/*/*"]
+        "patterns": [
+          "@mui/*/*/*"
+        ]
       }
     ],
     "@typescript-eslint/no-unused-vars": [
@@ -68,6 +74,19 @@
     "@typescript-eslint/no-empty-function": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "typeLike",
+        "format": [
+          "PascalCase"
+        ],
+        "custom": {
+          "regex": "^[A-Z]",
+          "match": true
+        }
+      }
+    ],
     "no-nested-ternary": "error"
   },
   "settings": {
@@ -80,7 +99,9 @@
       "files": [
         "**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)"
       ],
-      "extends": ["plugin:testing-library/react"]
+      "extends": [
+        "plugin:testing-library/react"
+      ]
     }
   ]
 }

--- a/editor.planx.uk/src/@planx/components/Calculate/logic.test.ts
+++ b/editor.planx.uk/src/@planx/components/Calculate/logic.test.ts
@@ -41,7 +41,7 @@ test("When formatOutputForAutomations is false, Calculate writes a number and fu
   expect(upcomingCardIds()).toEqual(["Question"]);
 });
 
-const flowWithAutomation: Store.flow = {
+const flowWithAutomation: Store.Flow = {
   _root: {
     edges: ["Calculate", "Question"],
   },
@@ -95,7 +95,7 @@ const flowWithAutomation: Store.flow = {
   },
 };
 
-const flowWithoutAutomation: Store.flow = {
+const flowWithoutAutomation: Store.Flow = {
   _root: {
     edges: ["Calculate", "Question"],
   },

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -142,7 +142,7 @@ export function Presentational(props: PresentationalProps) {
 }
 
 // TODO - Retire in favor of ODP Schema application type descriptions or fallback to flowName
-function getWorkStatus(passport: Store.passport): string | undefined {
+function getWorkStatus(passport: Store.Passport): string | undefined {
   switch (passport?.data?.["application.type"]?.toString()) {
     case "ldc.existing":
       return "existing";

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -138,7 +138,7 @@ export default function Component(props: Props) {
   }, [boundary]);
 
   const validateAndSubmit = () => {
-    const newPassportData: Store.userData["data"] = {};
+    const newPassportData: Store.UserData["data"] = {};
 
     // Used the map
     if (page === "draw") {

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -18,7 +18,7 @@ interface Props extends MoreInformation {
   fn: string;
   description?: string;
   handleSubmit: handleSubmit;
-  previouslySubmittedData?: Store.userData;
+  previouslySubmittedData?: Store.UserData;
 }
 
 export interface FileUploadSlot {

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -2,7 +2,7 @@ import { MoreInformation } from "@planx/components/shared";
 import Card from "@planx/components/shared/Preview/Card";
 import CardHeader from "@planx/components/shared/Preview/CardHeader";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
-import type { handleSubmit } from "pages/Preview/Node";
+import type { HandleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useRef, useState } from "react";
 import { FileWithPath } from "react-dropzone";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -17,7 +17,7 @@ interface Props extends MoreInformation {
   title?: string;
   fn: string;
   description?: string;
-  handleSubmit: handleSubmit;
+  handleSubmit: HandleSubmit;
   previouslySubmittedData?: Store.UserData;
 }
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.test.ts
@@ -433,7 +433,7 @@ describe("getRecoveredData function", () => {
     };
 
     // Mock breadcrumb data with FileType.fn -> UserFile mapped
-    const previouslySubmittedData: Store.userData = {
+    const previouslySubmittedData: Store.UserData = {
       data: {
         requiredFileFn: [
           {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.test.ts
@@ -30,7 +30,7 @@ import {
 describe("createFileList function", () => {
   it("adds 'AlwaysRequired' FileTypes to the 'required' array", () => {
     const fileTypes = [mockFileTypes[Condition.AlwaysRequired]];
-    const passport: Store.passport = { data: {} };
+    const passport: Store.Passport = { data: {} };
 
     const expected: FileList = {
       required: [mockFileTypes[Condition.AlwaysRequired]],
@@ -44,7 +44,7 @@ describe("createFileList function", () => {
 
   it("adds 'AlwaysRecommended' FileTypes to the 'recommended' array", () => {
     const fileTypes = [mockFileTypes[Condition.AlwaysRecommended]];
-    const passport: Store.passport = { data: {} };
+    const passport: Store.Passport = { data: {} };
 
     const expected: FileList = {
       required: [],
@@ -58,7 +58,7 @@ describe("createFileList function", () => {
 
   it("adds 'RequiredIf' FileTypes to the 'required' array if the rule is met", () => {
     const fileTypes = [mockFileTypes[Condition.RequiredIf]];
-    const passport: Store.passport = { data: { testFn: "testVal" } };
+    const passport: Store.Passport = { data: { testFn: "testVal" } };
 
     const expected: FileList = {
       required: [mockFileTypes[Condition.RequiredIf]],
@@ -72,7 +72,7 @@ describe("createFileList function", () => {
 
   it("does not add 'RequiredIf' FileTypes to the 'required' array if the rule is not met", () => {
     const fileTypes = [mockFileTypes[Condition.RequiredIf]];
-    const passport: Store.passport = { data: {} };
+    const passport: Store.Passport = { data: {} };
 
     const expected: FileList = {
       required: [],
@@ -86,7 +86,7 @@ describe("createFileList function", () => {
 
   it("adds 'RecommendedIf' FileTypes to the 'recommended' array if the rule is met", () => {
     const fileTypes = [mockFileTypes[Condition.RecommendedIf]];
-    const passport: Store.passport = { data: { testFn: "testVal" } };
+    const passport: Store.Passport = { data: { testFn: "testVal" } };
 
     const expected: FileList = {
       required: [],
@@ -100,7 +100,7 @@ describe("createFileList function", () => {
 
   it("does not add 'RecommendedIf' FileTypes to the 'recommended' array if the rule is not met", () => {
     const fileTypes = [mockFileTypes[Condition.RecommendedIf]];
-    const passport: Store.passport = { data: {} };
+    const passport: Store.Passport = { data: {} };
 
     const expected: FileList = {
       required: [],
@@ -114,7 +114,7 @@ describe("createFileList function", () => {
 
   it("adds 'NotRequired' FileTypes to the 'optional' array", () => {
     const fileTypes = [mockFileTypes[Condition.NotRequired]];
-    const passport: Store.passport = { data: {} };
+    const passport: Store.Passport = { data: {} };
 
     const expected: FileList = {
       required: [],
@@ -132,7 +132,7 @@ describe("createFileList function", () => {
       mockFileTypes[Condition.AlwaysRequired],
       mockFileTypes[Condition.AlwaysRequired],
     ];
-    const passport: Store.passport = { data: {} };
+    const passport: Store.Passport = { data: {} };
 
     const expected: FileList = {
       required: [mockFileTypes[Condition.AlwaysRequired]],
@@ -152,7 +152,7 @@ describe("createFileList function", () => {
       mockFileTypes[Condition.RecommendedIf],
       mockFileTypes[Condition.NotRequired],
     ];
-    const passport: Store.passport = { data: { testFn: "testVal" } };
+    const passport: Store.Passport = { data: { testFn: "testVal" } };
 
     const expected: FileList = {
       required: [mockFileTypes[Condition.AlwaysRequired]],
@@ -197,7 +197,7 @@ describe("createFileList function", () => {
         },
       },
     ];
-    const passport: Store.passport = {
+    const passport: Store.Passport = {
       data: {
         "documentA.required": ["true"],
         "documentB.recommended": ["true"],
@@ -280,7 +280,7 @@ describe("createFileList function", () => {
         },
       },
     ];
-    const passport: Store.passport = {
+    const passport: Store.Passport = {
       data: { "required.file": "true", "recommended.file": ["true"] },
     };
 
@@ -355,7 +355,7 @@ describe("createFileList function", () => {
         },
       },
     ];
-    const passport: Store.passport = {
+    const passport: Store.Passport = {
       data: { "required.file": "true", "recommended.file": ["true"] },
     };
 
@@ -592,21 +592,21 @@ describe("isRuleMet function", () => {
   };
 
   it("matches on an exact value", () => {
-    const mockPassport: Store.passport = { data: { testFn: "testValue" } };
+    const mockPassport: Store.Passport = { data: { testFn: "testValue" } };
     const result = isRuleMet(mockPassport, mockRule);
 
     expect(result).toBe(true);
   });
 
   it("does not match if an exact value is not present", () => {
-    const mockPassport: Store.passport = { data: { testFn: "missingValue" } };
+    const mockPassport: Store.Passport = { data: { testFn: "missingValue" } };
     const result = isRuleMet(mockPassport, mockRule);
 
     expect(result).toBe(false);
   });
 
   it("does not match if the passport key is not present", () => {
-    const mockPassport: Store.passport = {
+    const mockPassport: Store.Passport = {
       data: { missingKey: "missingValue" },
     };
     const result = isRuleMet(mockPassport, mockRule);
@@ -615,7 +615,7 @@ describe("isRuleMet function", () => {
   });
 
   it("matches on an exact value in an array", () => {
-    const mockPassport: Store.passport = {
+    const mockPassport: Store.Passport = {
       data: { testFn: ["value1", "value2", "testValue"] },
     };
     const result = isRuleMet(mockPassport, mockRule);
@@ -624,7 +624,7 @@ describe("isRuleMet function", () => {
   });
 
   it("matches on an granular value", () => {
-    const mockPassport: Store.passport = {
+    const mockPassport: Store.Passport = {
       data: {
         testFn: ["value1.more.value", "value2", "testValue.more.detail"],
       },
@@ -635,7 +635,7 @@ describe("isRuleMet function", () => {
   });
 
   it("does not match on a partial granular value (prefix)", () => {
-    const mockPassport: Store.passport = {
+    const mockPassport: Store.Passport = {
       data: { testFn: ["somethingtestValue.more.detail"] },
     };
     const result = isRuleMet(mockPassport, mockRule);
@@ -644,7 +644,7 @@ describe("isRuleMet function", () => {
   });
 
   it("does not match on a partial granular value (suffix)", () => {
-    const mockPassport: Store.passport = {
+    const mockPassport: Store.Passport = {
       data: { testFn: ["testValueSomething.more.detail"] },
     };
     const result = isRuleMet(mockPassport, mockRule);
@@ -653,7 +653,7 @@ describe("isRuleMet function", () => {
   });
 
   it("does not match on a granular which is not a 'parent'", () => {
-    const mockPassport: Store.passport = {
+    const mockPassport: Store.Passport = {
       data: { testFn: ["parent.child.testValue"] },
     };
     const result = isRuleMet(mockPassport, mockRule);

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -122,7 +122,7 @@ export const createFileList = ({
   passport,
   fileTypes,
 }: {
-  passport: Readonly<Store.passport>;
+  passport: Readonly<Store.Passport>;
   fileTypes: FileType[];
 }): FileList => {
   const fileList: FileList = { required: [], recommended: [], optional: [] };
@@ -160,7 +160,7 @@ const populateFileList = ({
 }: {
   fileList: FileList;
   fileType: FileType;
-  passport: Store.passport;
+  passport: Store.Passport;
 }): boolean => {
   switch (fileType.rule.condition) {
     case Condition.AlwaysRequired:
@@ -192,7 +192,7 @@ const populateFileList = ({
 };
 
 export const isRuleMet = (
-  passport: Store.passport,
+  passport: Store.Passport,
   rule: ConditionalRule<Condition.RequiredIf | Condition.RecommendedIf>,
 ): boolean => {
   const passportVal = passport.data?.[rule.fn];

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -254,8 +254,8 @@ const getUpdatedRequestedFiles = (fileList: FileList) => {
  * Generate payload for FileUploadAndLabel breadcrumb
  * Not responsible for validation - this happens at the component level
  */
-export const generatePayload = (fileList: FileList): Store.userData => {
-  const newPassportData: Store.userData["data"] = {};
+export const generatePayload = (fileList: FileList): Store.UserData => {
+  const newPassportData: Store.UserData["data"] = {};
 
   const uploadedFiles = [
     ...fileList.required,
@@ -279,14 +279,14 @@ export const generatePayload = (fileList: FileList): Store.userData => {
 
 const getCachedSlotsFromPreviousData = (
   userFile: UserFile,
-  previouslySubmittedData: Store.userData | undefined,
+  previouslySubmittedData: Store.UserData | undefined,
 ): FileUploadSlot[] =>
   previouslySubmittedData?.data?.[userFile.fn]?.map(
     (file: FormattedUserFile) => file.cachedSlot,
   );
 
 const getRecoveredSlots = (
-  previouslySubmittedData: Store.userData | undefined,
+  previouslySubmittedData: Store.UserData | undefined,
   fileList: FileList,
 ) => {
   const allFiles = [
@@ -307,7 +307,7 @@ const getRecoveredSlots = (
 };
 
 const getRecoveredFileList = (
-  previouslySubmittedData: Store.userData | undefined,
+  previouslySubmittedData: Store.UserData | undefined,
   fileList: FileList,
 ) => {
   const recoveredFileList = cloneDeep(fileList);
@@ -327,7 +327,7 @@ const getRecoveredFileList = (
 };
 
 export const getRecoveredData = (
-  previouslySubmittedData: Store.userData | undefined,
+  previouslySubmittedData: Store.UserData | undefined,
   fileList: FileList,
 ) => {
   const recoveredSlots = getRecoveredSlots(previouslySubmittedData, fileList);

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -140,7 +140,7 @@ function Component(props: Props) {
     }
 
     if (address) {
-      const newPassportData: Store.userData["data"] = {};
+      const newPassportData: Store.UserData["data"] = {};
       newPassportData["_address"] = address;
       if (address?.planx_value) {
         newPassportData["property.type"] = [address.planx_value];

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -24,7 +24,7 @@ vi.spyOn(ReactNavi, "useCurrentRoute").mockImplementation(
 const resumeButtonText = "Resume an application you have already started";
 const saveButtonText = "Save and return to this application later";
 
-const flowWithUndefinedFee: Store.flow = {
+const flowWithUndefinedFee: Store.Flow = {
   _root: {
     edges: ["setValue", "pay"],
   },
@@ -44,7 +44,7 @@ const flowWithUndefinedFee: Store.flow = {
   },
 };
 
-const flowWithZeroFee: Store.flow = {
+const flowWithZeroFee: Store.Flow = {
   _root: {
     edges: ["setValue", "pay"],
   },

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -8,7 +8,7 @@ import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import { setLocalFlow } from "lib/local.new";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { handleSubmit } from "pages/Preview/Node";
+import { HandleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useReducer } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import type { Session } from "types";
@@ -19,7 +19,7 @@ import Confirm from "./Confirm";
 
 export default Component;
 interface Props extends Pay {
-  handleSubmit: handleSubmit;
+  handleSubmit: HandleSubmit;
 }
 
 type ComponentState =

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -11,7 +11,7 @@ import type { PublicProps } from "@planx/components/ui";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import capitalize from "lodash/capitalize";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { handleSubmit } from "pages/Preview/Node";
+import { HandleSubmit } from "pages/Preview/Node";
 import React, { useState } from "react";
 import useSWR, { Fetcher } from "swr";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
@@ -368,7 +368,7 @@ interface ConstraintsFetchErrorProps {
   title: string;
   description: string;
   refreshConstraints: () => void;
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
 }
 
 const ConstraintsFetchError = (props: ConstraintsFetchErrorProps) => (
@@ -400,7 +400,7 @@ const ConstraintsFetchError = (props: ConstraintsFetchErrorProps) => (
 interface ConstraintsGraphErrorProps {
   title: string;
   description: string;
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
 }
 
 const ConstraintsGraphError = (props: ConstraintsGraphErrorProps) => (

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -12,7 +12,7 @@ import { publicClient } from "lib/graphql";
 import find from "lodash/find";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { handleSubmit } from "pages/Preview/Node";
+import { HandleSubmit } from "pages/Preview/Node";
 import React from "react";
 
 import type { SiteAddress } from "../FindProperty/model";
@@ -89,7 +89,7 @@ export interface PresentationalProps {
   titleBoundary?: Feature;
   blpuCodes?: any;
   overrideAnswer: (fn: string) => void;
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
 }
 
 // Export this component for testing visual presentation with mocked props

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -10,7 +10,7 @@ import DescriptionRadio from "@planx/components/shared/Radio/DescriptionRadio";
 import ImageRadio from "@planx/components/shared/Radio/ImageRadio";
 import { useFormik } from "formik";
 import { Store } from "pages/FlowEditor/lib/store";
-import { handleSubmit } from "pages/Preview/Node";
+import { HandleSubmit } from "pages/Preview/Node";
 import React from "react";
 import FormWrapper from "ui/public/FormWrapper";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
@@ -34,7 +34,7 @@ export interface IQuestion {
     img?: string;
   }[];
   previouslySubmittedData?: Store.UserData;
-  handleSubmit: handleSubmit;
+  handleSubmit: HandleSubmit;
 }
 
 export enum QuestionLayout {

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -33,7 +33,7 @@ export interface IQuestion {
     description?: string;
     img?: string;
   }[];
-  previouslySubmittedData?: Store.userData;
+  previouslySubmittedData?: Store.UserData;
   handleSubmit: handleSubmit;
 }
 

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -9,16 +9,14 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import { useStore } from "pages/FlowEditor/lib/store";
+import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import Caret from "ui/icons/Caret";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml";
 
-import type { Node } from "../../../../types";
-
 interface IResultReason {
   id: string;
-  question: Node;
+  question: Store.Node;
   response: string;
   showChangeButton?: boolean;
   flagColor?: string;

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -6,10 +6,11 @@ import Card from "@planx/components/shared/Preview/Card";
 import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
+import { Response } from "pages/FlowEditor/lib/store/preview";
 import type { handleSubmit } from "pages/Preview/Node";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import type { Node, TextContent } from "types";
+import type { TextContent } from "types";
 
 import ResultReason from "./ResultReason";
 import ResultSummary from "./ResultSummary";
@@ -27,12 +28,6 @@ export interface Props {
   responses: Array<Response>;
   disclaimer?: TextContent;
   previouslySubmittedData?: Store.userData;
-}
-
-interface Response {
-  question: Node;
-  selections: Array<Node>;
-  hidden: boolean;
 }
 
 const DisclaimerContent = styled(Typography)(({ theme }) => ({
@@ -85,7 +80,7 @@ const Responses = ({
             id={question.id}
             question={question}
             showChangeButton={allowChanges && !breadcrumbs[question.id].auto}
-            response={selections.map((s) => s.data.text).join(",")}
+            response={selections.map((s) => s.data?.text).join(",")}
             flagColor={flagColor}
           />
         ))}

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -27,7 +27,7 @@ export interface Props {
   reasonsTitle?: string;
   responses: Array<Response>;
   disclaimer?: TextContent;
-  previouslySubmittedData?: Store.userData;
+  previouslySubmittedData?: Store.UserData;
 }
 
 const DisclaimerContent = styled(Typography)(({ theme }) => ({

--- a/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/index.tsx
@@ -7,7 +7,7 @@ import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import { Response } from "pages/FlowEditor/lib/store/preview";
-import type { handleSubmit } from "pages/Preview/Node";
+import type { HandleSubmit } from "pages/Preview/Node";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import type { TextContent } from "types";
@@ -17,7 +17,7 @@ import ResultSummary from "./ResultSummary";
 
 export interface Props {
   allowChanges?: boolean;
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
   headingColor: {
     text: string;
     background: string;

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -4,7 +4,7 @@ import CardHeader from "@planx/components/shared/Preview/CardHeader";
 import SummaryListsBySections from "@planx/components/shared/Preview/SummaryList";
 import { Store } from "pages/FlowEditor/lib/store";
 import { sortBreadcrumbs } from "pages/FlowEditor/lib/store/preview";
-import type { handleSubmit } from "pages/Preview/Node";
+import type { HandleSubmit } from "pages/Preview/Node";
 import React from "react";
 
 export default Component;
@@ -15,7 +15,7 @@ interface Props {
   breadcrumbs: Store.Breadcrumbs;
   flow: Store.Flow;
   passport: Store.Passport;
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
   changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;
 }

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -14,7 +14,7 @@ interface Props {
   description: string;
   breadcrumbs: Store.breadcrumbs;
   flow: Store.flow;
-  passport: Store.passport;
+  passport: Store.Passport;
   handleSubmit?: handleSubmit;
   changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -12,7 +12,7 @@ export default Component;
 interface Props {
   title: string;
   description: string;
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   flow: Store.flow;
   passport: Store.Passport;
   handleSubmit?: handleSubmit;
@@ -22,7 +22,7 @@ interface Props {
 
 function Component(props: Props) {
   // ensure questions & answers display in expected order
-  const sortedBreadcrumbs: Store.breadcrumbs = sortBreadcrumbs(
+  const sortedBreadcrumbs: Store.Breadcrumbs = sortBreadcrumbs(
     props.breadcrumbs,
     props.flow,
   );

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -1,3 +1,4 @@
+import { NodeId } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
 import CardHeader from "@planx/components/shared/Preview/CardHeader";
 import SummaryListsBySections from "@planx/components/shared/Preview/SummaryList";
@@ -15,7 +16,7 @@ interface Props {
   flow: Store.flow;
   passport: Store.passport;
   handleSubmit?: handleSubmit;
-  changeAnswer: (id: Store.nodeId) => void;
+  changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;
 }
 

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -13,7 +13,7 @@ interface Props {
   title: string;
   description: string;
   breadcrumbs: Store.Breadcrumbs;
-  flow: Store.flow;
+  flow: Store.Flow;
   passport: Store.Passport;
   handleSubmit?: handleSubmit;
   changeAnswer: (id: NodeId) => void;

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -102,7 +102,7 @@ export const Root = ({
 );
 
 type SectionsOverviewListProps = {
-  flow: Store.flow;
+  flow: Store.Flow;
   showChange: boolean;
   changeAnswer: (sectionId: string) => void;
   nextQuestion: () => void;

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -63,7 +63,7 @@ interface RootProps
   currentSectionIndex: number;
   flowName: string;
   sectionNodes: Record<string, SectionNode>;
-  currentCard: Store.node | null;
+  currentCard: Store.Node | null;
   sectionCount: number;
 }
 
@@ -107,7 +107,7 @@ type SectionsOverviewListProps = {
   changeAnswer: (sectionId: string) => void;
   nextQuestion: () => void;
   sectionNodes: Record<string, SectionNode>;
-  currentCard: Store.node | null;
+  currentCard: Store.Node | null;
   breadcrumbs: Store.breadcrumbs;
   cachedBreadcrumbs?: Store.cachedBreadcrumbs;
   isReconciliation?: boolean;

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -108,7 +108,7 @@ type SectionsOverviewListProps = {
   nextQuestion: () => void;
   sectionNodes: Record<string, SectionNode>;
   currentCard: Store.Node | null;
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   cachedBreadcrumbs?: Store.cachedBreadcrumbs;
   isReconciliation?: boolean;
   alteredSectionIds?: string[];

--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -109,7 +109,7 @@ type SectionsOverviewListProps = {
   sectionNodes: Record<string, SectionNode>;
   currentCard: Store.Node | null;
   breadcrumbs: Store.Breadcrumbs;
-  cachedBreadcrumbs?: Store.cachedBreadcrumbs;
+  cachedBreadcrumbs?: Store.CachedBreadcrumbs;
   isReconciliation?: boolean;
   alteredSectionIds?: string[];
 };

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -26,7 +26,7 @@ export function computeSectionStatuses({
 }: {
   sectionNodes: Record<string, SectionNode>;
   currentCard: Store.Node | null;
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   cachedBreadcrumbs?: Store.cachedBreadcrumbs;
   isReconciliation?: boolean;
   alteredSectionIds?: string[];

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -27,7 +27,7 @@ export function computeSectionStatuses({
   sectionNodes: Record<string, SectionNode>;
   currentCard: Store.Node | null;
   breadcrumbs: Store.Breadcrumbs;
-  cachedBreadcrumbs?: Store.cachedBreadcrumbs;
+  cachedBreadcrumbs?: Store.CachedBreadcrumbs;
   isReconciliation?: boolean;
   alteredSectionIds?: string[];
 }): Record<string, SectionStatus> {

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -25,7 +25,7 @@ export function computeSectionStatuses({
   alteredSectionIds,
 }: {
   sectionNodes: Record<string, SectionNode>;
-  currentCard: Store.node | null;
+  currentCard: Store.Node | null;
   breadcrumbs: Store.breadcrumbs;
   cachedBreadcrumbs?: Store.cachedBreadcrumbs;
   isReconciliation?: boolean;

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -38,7 +38,7 @@ export function getCombinedEventsPayload({
 }: {
   destinations: Destination[];
   teamSlug: string;
-  passport: Store.passport;
+  passport: Store.Passport;
   sessionId: string;
 }) {
   const combinedEventsPayload: Record<string, EventPayload> = {};

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.test.ts
@@ -21,7 +21,7 @@ describe("calculateNewValues() helper function", () => {
           fn: mockKey,
           val: "lion",
         };
-        const mockPassport: Store.passport = {
+        const mockPassport: Store.Passport = {
           data: { mockNode: mockSetValue, [mockKey]: previous },
         };
 
@@ -57,7 +57,7 @@ describe("calculateNewValues() helper function", () => {
           fn: mockKey,
           val: "lion",
         };
-        const mockPassport: Store.passport = {
+        const mockPassport: Store.Passport = {
           data: { mockNode: mockSetValue, [mockKey]: previous },
         };
 
@@ -93,7 +93,7 @@ describe("calculateNewValues() helper function", () => {
           fn: mockKey,
           val: "lion",
         };
-        const mockPassport: Store.passport = {
+        const mockPassport: Store.Passport = {
           data: { mockNode: mockSetValue, [mockKey]: previous },
         };
 
@@ -129,7 +129,7 @@ describe("calculateNewValues() helper function", () => {
           fn: mockKey,
           val: "lion",
         };
-        const mockPassport: Store.passport = {
+        const mockPassport: Store.Passport = {
           data: { mockNode: mockSetValue, [mockKey]: previous },
         };
 

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.ts
@@ -7,8 +7,8 @@ type PreviousValues = string | string[] | undefined;
 type HandleSetValue = (params: {
   nodeData: SetValue;
   previousValues: PreviousValues;
-  passport: Store.passport;
-}) => Store.passport;
+  passport: Store.Passport;
+}) => Store.Passport;
 
 /**
  * Handle modifying passport values when passing through a SetValue component

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -122,7 +122,7 @@ const presentationalComponents: {
   [TYPES.TextInput]: TextInput,
 } as const;
 
-type BreadcrumbEntry = [NodeId, Store.breadcrumbs];
+type BreadcrumbEntry = [NodeId, Store.Breadcrumbs];
 
 interface SummaryListBaseProps {
   flow: Store.flow;
@@ -132,7 +132,7 @@ interface SummaryListBaseProps {
 }
 
 interface SummaryListsBySectionsProps extends SummaryListBaseProps {
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   sectionComponent: React.ElementType<any> | undefined;
 }
 
@@ -169,7 +169,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
   };
 
   const removeNonPresentationalNodes = (
-    section: Store.breadcrumbs,
+    section: Store.Breadcrumbs,
   ): BreadcrumbEntry[] => {
     // Typecast to preserve Store.userData
     const entries = Object.entries(section) as BreadcrumbEntry[];

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -126,7 +126,7 @@ type BreadcrumbEntry = [NodeId, Store.breadcrumbs];
 
 interface SummaryListBaseProps {
   flow: Store.flow;
-  passport: Store.passport;
+  passport: Store.Passport;
   changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;
 }
@@ -337,7 +337,7 @@ interface ComponentProps {
   node: any;
   userData?: Store.userData;
   flow: Store.flow;
-  passport: Store.passport;
+  passport: Store.Passport;
   nodeId: NodeId;
 }
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -125,7 +125,7 @@ const presentationalComponents: {
 type BreadcrumbEntry = [NodeId, Store.Breadcrumbs];
 
 interface SummaryListBaseProps {
-  flow: Store.flow;
+  flow: Store.Flow;
   passport: Store.Passport;
   changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;
@@ -336,7 +336,7 @@ function SummaryList(props: SummaryListProps) {
 interface ComponentProps {
   node: any;
   userData?: Store.userData;
-  flow: Store.flow;
+  flow: Store.Flow;
   passport: Store.Passport;
   nodeId: NodeId;
 }

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -139,7 +139,7 @@ interface SummaryListsBySectionsProps extends SummaryListBaseProps {
 interface SummaryBreadcrumb {
   component: React.FC<ComponentProps>;
   nodeId: NodeId;
-  userData: Store.userData;
+  userData: Store.UserData;
   node: Store.Node;
 }
 
@@ -335,7 +335,7 @@ function SummaryList(props: SummaryListProps) {
 
 interface ComponentProps {
   node: any;
-  userData?: Store.userData;
+  userData?: Store.UserData;
   flow: Store.Flow;
   passport: Store.Passport;
   nodeId: NodeId;

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -3,7 +3,10 @@ import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  NodeId,
+} from "@opensystemslab/planx-core/types";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
 import { ConfirmationDialog } from "components/ConfirmationDialog";
@@ -119,12 +122,12 @@ const presentationalComponents: {
   [TYPES.TextInput]: TextInput,
 } as const;
 
-type BreadcrumbEntry = [Store.nodeId, Store.breadcrumbs];
+type BreadcrumbEntry = [NodeId, Store.breadcrumbs];
 
 interface SummaryListBaseProps {
   flow: Store.flow;
   passport: Store.passport;
-  changeAnswer: (id: Store.nodeId) => void;
+  changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;
 }
 
@@ -135,7 +138,7 @@ interface SummaryListsBySectionsProps extends SummaryListBaseProps {
 
 interface SummaryBreadcrumb {
   component: React.FC<ComponentProps>;
-  nodeId: Store.nodeId;
+  nodeId: NodeId;
   userData: Store.userData;
   node: Store.node;
 }
@@ -247,7 +250,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
 function SummaryList(props: SummaryListProps) {
   const { trackEvent } = useAnalyticsTracking();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [nodeToChange, setNodeToChange] = useState<Store.nodeId | undefined>(
+  const [nodeToChange, setNodeToChange] = useState<NodeId | undefined>(
     undefined,
   );
 
@@ -264,7 +267,7 @@ function SummaryList(props: SummaryListProps) {
     }
   };
 
-  const handleChange = (nodeId: Store.nodeId) => {
+  const handleChange = (nodeId: NodeId) => {
     setNodeToChange(nodeId);
     setIsDialogOpen(true);
   };
@@ -335,7 +338,7 @@ interface ComponentProps {
   userData?: Store.userData;
   flow: Store.flow;
   passport: Store.passport;
-  nodeId: Store.nodeId;
+  nodeId: NodeId;
 }
 
 function List(props: ComponentProps) {

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -140,7 +140,7 @@ interface SummaryBreadcrumb {
   component: React.FC<ComponentProps>;
   nodeId: NodeId;
   userData: Store.userData;
-  node: Store.node;
+  node: Store.Node;
 }
 
 interface SummaryListProps extends SummaryListBaseProps {

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -51,7 +51,7 @@ export type PublicProps<Data> = Data & {
   resetButton?: boolean;
   resetPreview?: () => void;
   autoFocus?: boolean;
-  previouslySubmittedData?: Store.userData;
+  previouslySubmittedData?: Store.UserData;
 };
 
 // XXX: We define the Icon type in terms of one of the Icons so as not to have to repeat ourselves

--- a/editor.planx.uk/src/@planx/components/ui.tsx
+++ b/editor.planx.uk/src/@planx/components/ui.tsx
@@ -28,7 +28,7 @@ import SquareFoot from "@mui/icons-material/SquareFoot";
 import TextFields from "@mui/icons-material/TextFields";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { Store } from "pages/FlowEditor/lib/store";
-import type { handleSubmit } from "pages/Preview/Node";
+import type { HandleSubmit } from "pages/Preview/Node";
 import React, { ChangeEvent } from "react";
 import ImgInput from "ui/editor/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
@@ -47,7 +47,7 @@ export interface EditorProps<Type, Data> {
 
 export type PublicProps<Data> = Data & {
   id?: string;
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
   resetButton?: boolean;
   resetPreview?: () => void;
   autoFocus?: boolean;

--- a/editor.planx.uk/src/@planx/graph/types.d.ts
+++ b/editor.planx.uk/src/@planx/graph/types.d.ts
@@ -1,15 +1,15 @@
 declare module "nanoid-good";
 
 export namespace OT {
-  export type path = Array<string | number>;
+  export type Path = Array<string | number>;
 
   export namespace Object {
     export interface Add {
-      p: OT.path;
+      p: OT.Path;
       oi: any;
     }
     export interface Remove {
-      p: OT.path;
+      p: OT.Path;
       od: any;
     }
     export type Replace = OT.Object.Remove & OT.Object.Add;
@@ -17,11 +17,11 @@ export namespace OT {
 
   export namespace Array {
     export interface Add {
-      p: OT.path;
+      p: OT.Path;
       li: any;
     }
     export interface Remove {
-      p: OT.path;
+      p: OT.Path;
       ld: any;
     }
     export type Replace = OT.Array.Remove & OT.Array.Add;

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -6,7 +6,7 @@ import { Store, useStore } from "pages/FlowEditor/lib/store";
 import { publicClient } from "./graphql";
 
 type UserData = {
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   passport: Store.Passport;
 };
 

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -17,7 +17,7 @@ export type FeedbackMetadata = {
   nodeType?: string | null;
   device: Bowser.Parser.ParsedResult;
   userData: UserData;
-  nodeData: Store.node["data"];
+  nodeData: Store.Node["data"];
 };
 
 export async function getInternalFeedbackMetadata(): Promise<FeedbackMetadata> {
@@ -56,7 +56,7 @@ export async function insertFeedbackMutation(data: {
   userContext?: string;
   userComment: string;
   feedbackType: string;
-  nodeData?: Store.node["data"];
+  nodeData?: Store.Node["data"];
 }) {
   const result = await publicClient.mutate({
     mutation: gql`

--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -7,7 +7,7 @@ import { publicClient } from "./graphql";
 
 type UserData = {
   breadcrumbs: Store.breadcrumbs;
-  passport: Store.passport;
+  passport: Store.Passport;
 };
 
 export type FeedbackMetadata = {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -147,7 +147,7 @@ const Node: React.FC<any> = (props) => {
   }
 };
 
-const getSetValueText = ({ operation, fn, val }: Store.node["data"]) => {
+const getSetValueText = ({ operation, fn, val }: Store.Node["data"]) => {
   switch (operation) {
     case "append":
       return `Append ${val} to ${fn}`;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/advancedAutomations.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/advancedAutomations.test.ts
@@ -4,7 +4,7 @@ import { Store, useStore } from "../store";
 
 const { getState, setState } = useStore;
 
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: [
       "Imks7j68BD",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/granularity.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/granularity.test.ts
@@ -4,7 +4,7 @@ import { Store, useStore } from "../store";
 
 const { getState, setState } = useStore;
 
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: ["whatisit"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/ordering.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/ordering.test.ts
@@ -4,7 +4,7 @@ import { Store, useStore } from "../store";
 
 const { getState, setState } = useStore;
 
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: ["QuestionTrolley", "ChecklistTrolley"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/canGoBack.test.ts
@@ -7,7 +7,7 @@ const { canGoBack, getCurrentCard, resetPreview, record, changeAnswer } =
   getState();
 
 // https://imgur.com/VFV64ax
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: ["Question", "Pay", "Content", "Confirmation"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
@@ -26,7 +26,7 @@ describe("changeAnswer", () => {
         auto: true,
       },
     } as Store.Breadcrumbs;
-    const cachedBreadcrumbs = {} as Store.cachedBreadcrumbs;
+    const cachedBreadcrumbs = {} as Store.CachedBreadcrumbs;
 
     setState({
       flow,
@@ -62,7 +62,7 @@ describe("changeAnswer", () => {
         answers: ["X9JjnbPpnd"],
         auto: true,
       },
-    } as Store.cachedBreadcrumbs;
+    } as Store.CachedBreadcrumbs;
 
     // Confirm that our original answer is still preserved in cachedBreadcrumbs, but not included in current breadcrumbs
     expect(getState().breadcrumbs).not.toContain(originalAnswer);

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
@@ -25,7 +25,7 @@ describe("changeAnswer", () => {
         answers: ["X9JjnbPpnd"],
         auto: true,
       },
-    } as Store.breadcrumbs;
+    } as Store.Breadcrumbs;
     const cachedBreadcrumbs = {} as Store.cachedBreadcrumbs;
 
     setState({

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.ts
@@ -5,7 +5,7 @@ import flowWithAutoAnswersMock from "../mocks/flowWithAutoAnswers.json";
 
 const { getState, setState } = useStore;
 
-const flowWithAutoAnswers = cloneDeep(flowWithAutoAnswersMock) as Store.flow;
+const flowWithAutoAnswers = cloneDeep(flowWithAutoAnswersMock) as Store.Flow;
 
 const { record, changeAnswer, computePassport } = getState();
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -70,7 +70,7 @@ describe("nodesDependentOnPassport with record", () => {
   test("should remove Draw Boundary and Planning constraints from cachedBreadcrumbs", () => {
     const cachedBreadcrumbs = {
       ...breadcrumbsDependentOnPassport,
-    } as Store.cachedBreadcrumbs;
+    } as Store.CachedBreadcrumbs;
     const userData = {
       data: {
         _address: {
@@ -118,7 +118,7 @@ describe("nodesDependentOnPassport with record", () => {
   test("should remove Planning constraints from cachedBreadcrumbs", () => {
     const cachedBreadcrumbs = {
       ...breadcrumbsDependentOnPassport,
-    } as Store.cachedBreadcrumbs;
+    } as Store.CachedBreadcrumbs;
     const userData = {
       data: {
         "property.boundary.site": {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -13,7 +13,7 @@ let breadcrumbsDependentOnPassport = cloneDeep(
 
 let flowWithPassportComponents = cloneDeep(
   flowWithPassportComponentsMock,
-) as Store.flow;
+) as Store.Flow;
 
 const {
   record,
@@ -31,7 +31,7 @@ beforeEach(() => {
   ) as Store.Breadcrumbs;
   flowWithPassportComponents = cloneDeep(
     flowWithPassportComponentsMock,
-  ) as Store.flow;
+  ) as Store.Flow;
 });
 
 describe("removeNodesDependentOnPassport", () => {
@@ -57,7 +57,7 @@ describe("removeNodesDependentOnPassport", () => {
     const breadcrumbs = { ...mockBreadcrumbs };
 
     const { breadcrumbsWithoutPassportData, removedNodeIds } =
-      removeNodesDependentOnPassport(mockFlowData as Store.flow, breadcrumbs);
+      removeNodesDependentOnPassport(mockFlowData as Store.Flow, breadcrumbs);
 
     const expectedBreadcrumbs = { ...mockBreadcrumbs };
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -9,7 +9,7 @@ const { getState, setState } = useStore;
 
 let breadcrumbsDependentOnPassport = cloneDeep(
   breadcrumbsDependentOnPassportMock,
-) as Store.breadcrumbs;
+) as Store.Breadcrumbs;
 
 let flowWithPassportComponents = cloneDeep(
   flowWithPassportComponentsMock,
@@ -28,7 +28,7 @@ beforeEach(() => {
   resetPreview();
   breadcrumbsDependentOnPassport = cloneDeep(
     breadcrumbsDependentOnPassportMock,
-  ) as Store.breadcrumbs;
+  ) as Store.Breadcrumbs;
   flowWithPassportComponents = cloneDeep(
     flowWithPassportComponentsMock,
   ) as Store.flow;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/upcomingCardIds.test.ts
@@ -5,7 +5,7 @@ import { Store, useStore } from "../../store";
 const { getState, setState } = useStore;
 const { upcomingCardIds, resetPreview, record, getCurrentCard } = getState();
 
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: ["SetValue", "Content", "AutomatedQuestion"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
@@ -6,7 +6,7 @@ import { Store, useStore } from "../store";
 const { getState, setState } = useStore;
 const { resetPreview, record, computePassport, getCurrentCard } = getState();
 
-const baseFlow: Store.flow = {
+const baseFlow: Store.Flow = {
   _root: {
     edges: ["setValue1", "middleOfService", "setValue2", "endOfService"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/unseen.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/unseen.test.ts
@@ -3,7 +3,7 @@ import { Store, useStore } from "../store";
 const { getState, setState } = useStore;
 
 // https://github.com/theopensystemslab/planx-new/pull/430#issue-625111571
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: ["Dq7qLvn9If", "GZAmDGuV3J"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/useNotValues.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/useNotValues.test.ts
@@ -2,7 +2,7 @@ import { Store, useStore } from "../store";
 
 // flow preview: https://i.imgur.com/nCov5CE.png
 
-const flow: Store.flow = {
+const flow: Store.Flow = {
   _root: {
     edges: ["NS7QFc7Cjc", "3cNtq1pLmt", "eTBHJsbJKc"],
   },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -321,7 +321,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   async function updateLastVisibleNodeLogWithAllowListAnswers(
     nodeId: string,
-    breadcrumb: Store.userData,
+    breadcrumb: Store.UserData,
   ) {
     if (shouldSkipTracking()) return;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -13,7 +13,7 @@ import {
 /**
  * Generate meaningful title for content analytic log
  */
-export function getContentTitle(node: Store.node): string {
+export function getContentTitle(node: Store.Node): string {
   const dom = new DOMParser().parseFromString(node.data.content, "text/html");
   const h1 = dom.body.getElementsByTagName("h1")[0]?.textContent;
   const text = h1 || dom.body.textContent;
@@ -25,7 +25,7 @@ export function getContentTitle(node: Store.node): string {
   return title;
 }
 
-export function extractNodeTitle(node: Store.node): string {
+export function extractNodeTitle(node: Store.Node): string {
   const nodeTitle =
     node?.type === TYPES.Content
       ? getContentTitle(node)
@@ -63,7 +63,7 @@ export function generateBackwardsNavigationMetadata(
 }
 
 export function getNodeMetadata(
-  node: Store.node,
+  node: Store.Node,
   resultData: any,
   nodeId: string,
   breadcrumbs: Store.breadcrumbs,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -66,7 +66,7 @@ export function getNodeMetadata(
   node: Store.Node,
   resultData: any,
   nodeId: string,
-  breadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
 ) {
   const isAutoAnswered = breadcrumbs[nodeId]?.auto || false;
   switch (node?.type) {
@@ -103,7 +103,7 @@ export function isAllowListKey(key: any): key is AllowListKey {
 export function getAnswers(
   nodeId: string,
   flow: Store.flow,
-  breadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
 ): Partial<Record<AllowListKey, any>> | undefined {
   const { data } = flow[nodeId];
   const nodeFn: string | undefined = data?.fn || data?.val;
@@ -145,8 +145,8 @@ export function getData(
 }
 
 export function determineLogDirection(
-  breadcrumbs: Store.breadcrumbs,
-  previousBreadcrumbs: Store.breadcrumbs | undefined,
+  breadcrumbs: Store.Breadcrumbs,
+  previousBreadcrumbs: Store.Breadcrumbs | undefined,
 ) {
   if (!previousBreadcrumbs) return;
   const curLength = Object.keys(breadcrumbs).length;
@@ -156,8 +156,8 @@ export function determineLogDirection(
 }
 
 export function findUpdatedBreadcrumbKeys(
-  breadcrumbs: Store.breadcrumbs,
-  previousBreadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
+  previousBreadcrumbs: Store.Breadcrumbs,
 ): string[] | undefined {
   const currentKeys = Object.keys(breadcrumbs);
   const previousKeys = Object.keys(previousBreadcrumbs);
@@ -176,7 +176,7 @@ export function getAllowListAnswers(
   nodeId: string,
   breadcrumb: Store.userData,
   flow: Store.flow,
-  breadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
 ): Partial<Record<AllowListKey, any>> | undefined {
   const answers = getAnswers(nodeId, flow, breadcrumbs);
   const data = getData(breadcrumb);

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -129,7 +129,7 @@ export function getAnswers(
  * e.g. data set automatically by components such as DrawBoundary
  */
 export function getData(
-  breadcrumb: Store.userData,
+  breadcrumb: Store.UserData,
 ): Partial<Record<AllowListKey, any>> | undefined {
   const dataSetByNode = breadcrumb.data;
   if (!dataSetByNode) return;
@@ -174,7 +174,7 @@ export function findUpdatedBreadcrumbKeys(
  */
 export function getAllowListAnswers(
   nodeId: string,
-  breadcrumb: Store.userData,
+  breadcrumb: Store.UserData,
   flow: Store.Flow,
   breadcrumbs: Store.Breadcrumbs,
 ): Partial<Record<AllowListKey, any>> | undefined {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -35,7 +35,7 @@ export function extractNodeTitle(node: Store.Node): string {
 
 export function getTargetNodeDataFromFlow(
   nodeId: string,
-  flow: Store.flow,
+  flow: Store.Flow,
 ): BackwardsTargetMetadata {
   const node = flow[nodeId];
   const nodeType = node?.type ? TYPES[node.type] : null;
@@ -49,7 +49,7 @@ export function getTargetNodeDataFromFlow(
 
 export function generateBackwardsNavigationMetadata(
   initiator: BackwardsNavigationInitiatorType,
-  flow: Store.flow,
+  flow: Store.Flow,
   nodeId?: string,
 ): BackwardsNavigationMetadata {
   const targetNodeMetadata = nodeId
@@ -102,7 +102,7 @@ export function isAllowListKey(key: any): key is AllowListKey {
  */
 export function getAnswers(
   nodeId: string,
-  flow: Store.flow,
+  flow: Store.Flow,
   breadcrumbs: Store.Breadcrumbs,
 ): Partial<Record<AllowListKey, any>> | undefined {
   const { data } = flow[nodeId];
@@ -175,7 +175,7 @@ export function findUpdatedBreadcrumbKeys(
 export function getAllowListAnswers(
   nodeId: string,
   breadcrumb: Store.userData,
-  flow: Store.flow,
+  flow: Store.Flow,
   breadcrumbs: Store.Breadcrumbs,
 ): Partial<Record<AllowListKey, any>> | undefined {
   const answers = getAnswers(nodeId, flow, breadcrumbs);

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -69,7 +69,7 @@ export const editorUIStore: StateCreator<
 });
 
 interface PublishFlowResponse {
-  alteredNodes: Store.node[];
+  alteredNodes: Store.Node[];
   message: string;
 }
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client";
 import { getPathForNode, sortFlow } from "@opensystemslab/planx-core";
 import {
   ComponentType,
+  FlowGraph,
   NodeId,
   OrderedFlow,
 } from "@opensystemslab/planx-core/types";

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { getPathForNode, sortFlow } from "@opensystemslab/planx-core";
 import {
   ComponentType,
-  FlowGraph,
+  NodeId,
   OrderedFlow,
 } from "@opensystemslab/planx-core/types";
 import {
@@ -75,32 +75,32 @@ interface PublishFlowResponse {
 
 export interface EditorStore extends Store.Store {
   addNode: (node: any, relationships?: any) => void;
-  connect: (src: Store.nodeId, tgt: Store.nodeId, object?: any) => void;
-  connectTo: (id: Store.nodeId) => void;
+  connect: (src: NodeId, tgt: NodeId, object?: any) => void;
+  connectTo: (id: NodeId) => void;
   copyFlow: (flowId: string) => Promise<any>;
-  copyNode: (id: Store.nodeId) => void;
+  copyNode: (id: NodeId) => void;
   createFlow: (teamId: any, newSlug: any, newName: string) => Promise<string>;
   deleteFlow: (teamId: number, flowSlug: string) => Promise<object>;
   validateAndDiffFlow: (flowId: string) => Promise<any>;
   getFlows: (teamId: number) => Promise<any>;
-  isClone: (id: Store.nodeId) => boolean;
+  isClone: (id: NodeId) => boolean;
   lastPublished: (flowId: string) => Promise<string>;
   lastPublisher: (flowId: string) => Promise<string>;
   isFlowPublished: boolean;
-  makeUnique: (id: Store.nodeId, parent?: Store.nodeId) => void;
+  makeUnique: (id: NodeId, parent?: NodeId) => void;
   moveFlow: (flowId: string, teamSlug: string) => Promise<any>;
   moveNode: (
-    id: Store.nodeId,
-    parent?: Store.nodeId,
-    toBefore?: Store.nodeId,
-    toParent?: Store.nodeId,
+    id: NodeId,
+    parent?: NodeId,
+    toBefore?: NodeId,
+    toParent?: NodeId,
   ) => void;
-  pasteNode: (toParent: Store.nodeId, toBefore: Store.nodeId) => void;
+  pasteNode: (toParent: NodeId, toBefore: NodeId) => void;
   publishFlow: (
     flowId: string,
     summary?: string,
   ) => Promise<PublishFlowResponse>;
-  removeNode: (id: Store.nodeId, parent: Store.nodeId) => void;
+  removeNode: (id: NodeId, parent: NodeId) => void;
   updateNode: (node: any, relationships?: any) => void;
   undoOperation: (ops: OT.Op[]) => void;
   orderedFlow?: OrderedFlow;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -22,7 +22,7 @@ import { UserStore, userStore } from "./user";
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export declare namespace Store {
   export type Store = Record<string | number | symbol, unknown>;
-  export type flow = Record<NodeId, Node>;
+  export type Flow = Record<NodeId, Node>;
   export type userData = {
     answers?: Array<string>;
     data?: Record<string, any>;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -38,7 +38,7 @@ export declare namespace Store {
   export interface Node extends PlanXCoreNode {
     data?: any;
   }
-  export interface passport {
+  export interface Passport {
     data?: Record<string, any>;
   }
 }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -1,4 +1,7 @@
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  NodeId,
+} from "@opensystemslab/planx-core/types";
 import { isPreviewOnlyDomain } from "routes/utils";
 import { create, StoreApi, UseBoundStore } from "zustand";
 
@@ -19,21 +22,20 @@ import { UserStore, userStore } from "./user";
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export declare namespace Store {
   export type Store = Record<string | number | symbol, unknown>;
-  export type nodeId = string;
-  export type flow = Record<nodeId, node>;
+  export type flow = Record<NodeId, node>;
   export type userData = {
     answers?: Array<string>;
     data?: Record<string, any>;
     auto?: boolean;
     override?: Record<string, any>;
   };
-  export type breadcrumbs = Record<nodeId, userData>;
-  export type cachedBreadcrumbs = Record<nodeId, userData> | undefined;
+  export type breadcrumbs = Record<NodeId, userData>;
+  export type cachedBreadcrumbs = Record<NodeId, userData> | undefined;
   export type node = {
-    id?: nodeId;
+    id?: NodeId;
     type?: TYPES;
     data?: any;
-    edges?: nodeId[];
+    edges?: NodeId[];
   };
   export interface passport {
     data?: Record<string, any>;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -1,5 +1,5 @@
 import {
-  ComponentType as TYPES,
+  Node as PlanXCoreNode,
   NodeId,
 } from "@opensystemslab/planx-core/types";
 import { isPreviewOnlyDomain } from "routes/utils";
@@ -22,7 +22,7 @@ import { UserStore, userStore } from "./user";
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export declare namespace Store {
   export type Store = Record<string | number | symbol, unknown>;
-  export type flow = Record<NodeId, node>;
+  export type flow = Record<NodeId, Node>;
   export type userData = {
     answers?: Array<string>;
     data?: Record<string, any>;
@@ -31,12 +31,13 @@ export declare namespace Store {
   };
   export type breadcrumbs = Record<NodeId, userData>;
   export type cachedBreadcrumbs = Record<NodeId, userData> | undefined;
-  export type node = {
-    id?: NodeId;
-    type?: TYPES;
+  /**
+   * Looser Node type with `any` data
+   * @deprecated Should share type with PlanX core once `Value` is retired and Flow Graph is typed
+   */
+  export interface Node extends PlanXCoreNode {
     data?: any;
-    edges?: NodeId[];
-  };
+  }
   export interface passport {
     data?: Record<string, any>;
   }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -29,7 +29,7 @@ export declare namespace Store {
     auto?: boolean;
     override?: Record<string, any>;
   };
-  export type breadcrumbs = Record<NodeId, userData>;
+  export type Breadcrumbs = Record<NodeId, userData>;
   export type cachedBreadcrumbs = Record<NodeId, userData> | undefined;
   /**
    * Looser Node type with `any` data

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -30,7 +30,7 @@ export declare namespace Store {
     override?: Record<string, any>;
   };
   export type Breadcrumbs = Record<NodeId, userData>;
-  export type cachedBreadcrumbs = Record<NodeId, userData> | undefined;
+  export type CachedBreadcrumbs = Record<NodeId, userData> | undefined;
   /**
    * Looser Node type with `any` data
    * @deprecated Should share type with PlanX core once `Value` is retired and Flow Graph is typed

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -23,14 +23,14 @@ import { UserStore, userStore } from "./user";
 export declare namespace Store {
   export type Store = Record<string | number | symbol, unknown>;
   export type Flow = Record<NodeId, Node>;
-  export type userData = {
+  export type UserData = {
     answers?: Array<string>;
     data?: Record<string, any>;
     auto?: boolean;
     override?: Record<string, any>;
   };
-  export type Breadcrumbs = Record<NodeId, userData>;
-  export type CachedBreadcrumbs = Record<NodeId, userData> | undefined;
+  export type Breadcrumbs = Record<NodeId, UserData>;
+  export type CachedBreadcrumbs = Record<NodeId, UserData> | undefined;
   /**
    * Looser Node type with `any` data
    * @deprecated Should share type with PlanX core once `Value` is retired and Flow Graph is typed

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -6,7 +6,7 @@ import type { StateCreator } from "zustand";
 import { PreviewStore } from "./preview";
 import { SharedStore } from "./shared";
 
-export interface SectionNode extends Store.node {
+export interface SectionNode extends Store.Node {
   data: {
     title: string;
   };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -20,7 +20,7 @@ export interface NavigationStore {
   sectionNodes: Record<string, SectionNode>;
   initNavigationStore: () => void;
   updateSectionData: () => void;
-  filterFlowByType: (type: TYPES) => Store.flow;
+  filterFlowByType: (type: TYPES) => Store.Flow;
   getSortedBreadcrumbsBySection: () => Store.Breadcrumbs[];
   getSectionForNode: (nodeId: string) => SectionNode;
 }
@@ -93,7 +93,7 @@ export const navigationStore: StateCreator<
    * Get a subset of the full flow, by type
    * Returned in correct order, based on _root node's edges
    */
-  filterFlowByType: (type: TYPES): Store.flow => {
+  filterFlowByType: (type: TYPES): Store.Flow => {
     const flow = get().flow;
     const rootEdges = flow._root.edges || [];
     const filteredFlow = Object.fromEntries(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -21,7 +21,7 @@ export interface NavigationStore {
   initNavigationStore: () => void;
   updateSectionData: () => void;
   filterFlowByType: (type: TYPES) => Store.flow;
-  getSortedBreadcrumbsBySection: () => Store.breadcrumbs[];
+  getSortedBreadcrumbsBySection: () => Store.Breadcrumbs[];
   getSectionForNode: (nodeId: string) => SectionNode;
 }
 
@@ -110,7 +110,7 @@ export const navigationStore: StateCreator<
   //    so we can render section node titles as h2s and the following nodes as individual SummaryLists
   getSortedBreadcrumbsBySection: () => {
     const { breadcrumbs, sectionNodes, hasSections } = get();
-    const sortedBreadcrumbsBySection: Store.breadcrumbs[] = [];
+    const sortedBreadcrumbsBySection: Store.Breadcrumbs[] = [];
     if (hasSections) {
       const sortedNodeIdsBySection: string[][] = [];
       Object.keys(sectionNodes).forEach((sectionId, i) => {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -669,7 +669,7 @@ export const previewStore: StateCreator<
 });
 
 const knownNots = (
-  flow: Store.flow,
+  flow: Store.Flow,
   breadcrumbs: Store.Breadcrumbs,
   nots = {},
 ) =>
@@ -700,7 +700,7 @@ const knownNots = (
 
 interface RemoveOrphansFromBreadcrumbsProps {
   id: string;
-  flow: Store.flow;
+  flow: Store.Flow;
   userData: Store.userData;
   breadcrumbs: Store.cachedBreadcrumbs | Store.Breadcrumbs;
 }
@@ -742,7 +742,7 @@ export const removeOrphansFromBreadcrumbs = ({
 
 export const getResultData = (
   breadcrumbs: Store.Breadcrumbs,
-  flow: Store.flow,
+  flow: Store.Flow,
   flagSet: Parameters<PreviewStore["resultData"]>[0] = DEFAULT_FLAG_CATEGORY,
   overrides?: Parameters<PreviewStore["resultData"]>[1],
 ) => {
@@ -829,7 +829,7 @@ export const getResultData = (
 
 export const sortBreadcrumbs = (
   nextBreadcrumbs: Store.Breadcrumbs,
-  flow: Store.flow,
+  flow: Store.Flow,
   editingNodes?: string[],
 ) => {
   return editingNodes?.length
@@ -848,7 +848,7 @@ function handleNodesWithPassport({
   currentNodesPendingEdit,
   breadcrumbs,
 }: {
-  flow: Store.flow;
+  flow: Store.Flow;
   id: string;
   cachedBreadcrumbs: Store.cachedBreadcrumbs;
   userData: Store.userData;
@@ -892,7 +892,7 @@ function handleNodesWithPassport({
 // when changing answers from review component to guarantee that their values are updated.
 // XXX: This logic assumes only one "FindProperty" component per flow.
 export const removeNodesDependentOnPassport = (
-  flow: Store.flow,
+  flow: Store.Flow,
   breadcrumbs: Store.Breadcrumbs,
 ): {
   breadcrumbsWithoutPassportData: Store.Breadcrumbs;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -3,6 +3,7 @@ import type {
   FlagSet,
   GovUKPayment,
   Node,
+  NodeId,
 } from "@opensystemslab/planx-core/types";
 import {
   DEFAULT_FLAG_CATEGORY,
@@ -36,21 +37,21 @@ let memoizedPreviousCardId: string | undefined = undefined;
 let memoizedBreadcrumb: Store.breadcrumbs | undefined = undefined;
 export interface PreviewStore extends Store.Store {
   collectedFlags: (
-    upToNodeId: Store.nodeId,
+    upToNodeId: NodeId,
     visited?: Array<string>,
   ) => Array<string>;
-  currentCard: ({ id: Store.nodeId } & Store.node) | null;
+  currentCard: ({ id: NodeId } & Store.node) | null;
   setCurrentCard: () => void;
-  getCurrentCard: () => ({ id: Store.nodeId } & Store.node) | null;
+  getCurrentCard: () => ({ id: NodeId } & Store.node) | null;
   hasPaid: () => boolean;
   previousCard: (
     node: Store.node | null,
-    upcomingCardIds?: Store.nodeId[],
-  ) => Store.nodeId | undefined;
+    upcomingCardIds?: NodeId[],
+  ) => NodeId | undefined;
   canGoBack: (node: Store.node | null) => boolean;
   getType: (node: Store.node | null) => TYPES | undefined;
   computePassport: () => Readonly<Store.passport>;
-  record: (id: Store.nodeId, userData?: Store.userData) => void;
+  record: (id: NodeId, userData?: Store.userData) => void;
   resultData: (
     flagSet?: string,
     overrides?: {
@@ -65,7 +66,7 @@ export interface PreviewStore extends Store.Store {
   };
   resumeSession: (session: Session) => void;
   sessionId: string;
-  upcomingCardIds: () => Store.nodeId[];
+  upcomingCardIds: () => NodeId[];
   isFinalCard: () => boolean;
   govUkPayment?: GovUKPayment;
   setGovUkPayment: (govUkPayment: GovUKPayment) => void;
@@ -396,10 +397,10 @@ export const previewStore: StateCreator<
       computePassport().data?._nots,
     );
 
-    const ids: Set<Store.nodeId> = new Set();
-    const visited: Set<Store.nodeId> = new Set();
+    const ids: Set<NodeId> = new Set();
+    const visited: Set<NodeId> = new Set();
 
-    const nodeIdsConnectedFrom = (source: Store.nodeId): void => {
+    const nodeIdsConnectedFrom = (source: NodeId): void => {
       return (flow[source]?.edges ?? [])
         .filter((id) => {
           if (visited.has(id)) return false;
@@ -542,8 +543,8 @@ export const previewStore: StateCreator<
                 return acc;
               },
               { edges: [] } as {
-                responseWithNoValueId?: Store.nodeId;
-                edges: Array<Store.nodeId>;
+                responseWithNoValueId?: NodeId;
+                edges: Array<NodeId>;
               },
             );
 
@@ -570,7 +571,7 @@ export const previewStore: StateCreator<
       // of all the answers collected so far
       Object.values(breadcrumbs)
         // in reverse order
-        .flatMap(({ answers }) => answers as Array<Store.nodeId>)
+        .flatMap(({ answers }) => answers as Array<NodeId>)
         // .filter(Boolean)
         .reverse()
         // ending with _root
@@ -671,7 +672,7 @@ const knownNots = (
 
       const _knownNotVals = difference(
         flow[id].edges,
-        answers as Array<Store.nodeId>,
+        answers as Array<NodeId>,
       );
 
       if (flow[id].data?.fn) {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -58,7 +58,7 @@ export interface PreviewStore extends Store.Store {
   canGoBack: (node: Store.Node | null) => boolean;
   getType: (node: Store.Node | null) => TYPES | undefined;
   computePassport: () => Readonly<Store.Passport>;
-  record: (id: NodeId, userData?: Store.userData) => void;
+  record: (id: NodeId, userData?: Store.UserData) => void;
   resultData: (
     flagSet?: string,
     overrides?: {
@@ -303,7 +303,7 @@ export const previewStore: StateCreator<
       // add breadcrumb
       const { answers = [], data = {}, auto = false, override } = userData;
 
-      const breadcrumb: Store.userData = { auto: Boolean(auto) };
+      const breadcrumb: Store.UserData = { auto: Boolean(auto) };
       if (answers?.length > 0) breadcrumb.answers = answers;
 
       const filteredData = objectWithoutNullishValues(data);
@@ -701,7 +701,7 @@ const knownNots = (
 interface RemoveOrphansFromBreadcrumbsProps {
   id: string;
   flow: Store.Flow;
-  userData: Store.userData;
+  userData: Store.UserData;
   breadcrumbs: Store.CachedBreadcrumbs | Store.Breadcrumbs;
 }
 
@@ -851,7 +851,7 @@ function handleNodesWithPassport({
   flow: Store.Flow;
   id: string;
   cachedBreadcrumbs: Store.CachedBreadcrumbs;
-  userData: Store.userData;
+  userData: Store.UserData;
   currentNodesPendingEdit: string[];
   breadcrumbs: Store.Breadcrumbs;
 }) {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -34,7 +34,7 @@ import type { SharedStore } from "./shared";
 
 const SUPPORTED_DECISION_TYPES = [TYPES.Checklist, TYPES.Question];
 let memoizedPreviousCardId: string | undefined = undefined;
-let memoizedBreadcrumb: Store.breadcrumbs | undefined = undefined;
+let memoizedBreadcrumb: Store.Breadcrumbs | undefined = undefined;
 
 export interface Response {
   question: Node & { id: NodeId };
@@ -670,7 +670,7 @@ export const previewStore: StateCreator<
 
 const knownNots = (
   flow: Store.flow,
-  breadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
   nots = {},
 ) =>
   Object.entries(breadcrumbs).reduce(
@@ -702,7 +702,7 @@ interface RemoveOrphansFromBreadcrumbsProps {
   id: string;
   flow: Store.flow;
   userData: Store.userData;
-  breadcrumbs: Store.cachedBreadcrumbs | Store.breadcrumbs;
+  breadcrumbs: Store.cachedBreadcrumbs | Store.Breadcrumbs;
 }
 
 export const removeOrphansFromBreadcrumbs = ({
@@ -712,7 +712,7 @@ export const removeOrphansFromBreadcrumbs = ({
   breadcrumbs,
 }: RemoveOrphansFromBreadcrumbsProps):
   | Store.cachedBreadcrumbs
-  | Store.breadcrumbs => {
+  | Store.Breadcrumbs => {
   // this will prevent a user from "Continuing", therefore log error don't throw it
   if (!flow[id]) {
     logger.notify(
@@ -736,12 +736,12 @@ export const removeOrphansFromBreadcrumbs = ({
         breadcrumbs: acc,
       });
     },
-    { ...breadcrumbs } as Store.cachedBreadcrumbs | Store.breadcrumbs,
+    { ...breadcrumbs } as Store.cachedBreadcrumbs | Store.Breadcrumbs,
   );
 };
 
 export const getResultData = (
-  breadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
   flow: Store.flow,
   flagSet: Parameters<PreviewStore["resultData"]>[0] = DEFAULT_FLAG_CATEGORY,
   overrides?: Parameters<PreviewStore["resultData"]>[1],
@@ -828,7 +828,7 @@ export const getResultData = (
 };
 
 export const sortBreadcrumbs = (
-  nextBreadcrumbs: Store.breadcrumbs,
+  nextBreadcrumbs: Store.Breadcrumbs,
   flow: Store.flow,
   editingNodes?: string[],
 ) => {
@@ -836,7 +836,7 @@ export const sortBreadcrumbs = (
     ? nextBreadcrumbs
     : sortIdsDepthFirst(flow)(new Set(Object.keys(nextBreadcrumbs))).reduce(
         (acc, id) => ({ ...acc, [id]: nextBreadcrumbs[id] }),
-        {} as Store.breadcrumbs,
+        {} as Store.Breadcrumbs,
       );
 };
 
@@ -853,7 +853,7 @@ function handleNodesWithPassport({
   cachedBreadcrumbs: Store.cachedBreadcrumbs;
   userData: Store.userData;
   currentNodesPendingEdit: string[];
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
 }) {
   let nodesPendingEdit = [...currentNodesPendingEdit];
   let newBreadcrumbs: Store.cachedBreadcrumbs = { ...cachedBreadcrumbs };
@@ -893,9 +893,9 @@ function handleNodesWithPassport({
 // XXX: This logic assumes only one "FindProperty" component per flow.
 export const removeNodesDependentOnPassport = (
   flow: Store.flow,
-  breadcrumbs: Store.breadcrumbs,
+  breadcrumbs: Store.Breadcrumbs,
 ): {
-  breadcrumbsWithoutPassportData: Store.breadcrumbs;
+  breadcrumbsWithoutPassportData: Store.Breadcrumbs;
   removedNodeIds: string[];
 } => {
   const DEPENDENT_TYPES = [

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -77,7 +77,7 @@ export interface PreviewStore extends Store.Store {
   isFinalCard: () => boolean;
   govUkPayment?: GovUKPayment;
   setGovUkPayment: (govUkPayment: GovUKPayment) => void;
-  cachedBreadcrumbs?: Store.cachedBreadcrumbs;
+  cachedBreadcrumbs?: Store.CachedBreadcrumbs;
   analyticsId?: number;
   setAnalyticsId: (analyticsId: number) => void;
   restore: boolean;
@@ -702,7 +702,7 @@ interface RemoveOrphansFromBreadcrumbsProps {
   id: string;
   flow: Store.Flow;
   userData: Store.userData;
-  breadcrumbs: Store.cachedBreadcrumbs | Store.Breadcrumbs;
+  breadcrumbs: Store.CachedBreadcrumbs | Store.Breadcrumbs;
 }
 
 export const removeOrphansFromBreadcrumbs = ({
@@ -711,7 +711,7 @@ export const removeOrphansFromBreadcrumbs = ({
   userData,
   breadcrumbs,
 }: RemoveOrphansFromBreadcrumbsProps):
-  | Store.cachedBreadcrumbs
+  | Store.CachedBreadcrumbs
   | Store.Breadcrumbs => {
   // this will prevent a user from "Continuing", therefore log error don't throw it
   if (!flow[id]) {
@@ -736,7 +736,7 @@ export const removeOrphansFromBreadcrumbs = ({
         breadcrumbs: acc,
       });
     },
-    { ...breadcrumbs } as Store.cachedBreadcrumbs | Store.Breadcrumbs,
+    { ...breadcrumbs } as Store.CachedBreadcrumbs | Store.Breadcrumbs,
   );
 };
 
@@ -850,13 +850,13 @@ function handleNodesWithPassport({
 }: {
   flow: Store.Flow;
   id: string;
-  cachedBreadcrumbs: Store.cachedBreadcrumbs;
+  cachedBreadcrumbs: Store.CachedBreadcrumbs;
   userData: Store.userData;
   currentNodesPendingEdit: string[];
   breadcrumbs: Store.Breadcrumbs;
 }) {
   let nodesPendingEdit = [...currentNodesPendingEdit];
-  let newBreadcrumbs: Store.cachedBreadcrumbs = { ...cachedBreadcrumbs };
+  let newBreadcrumbs: Store.CachedBreadcrumbs = { ...cachedBreadcrumbs };
 
   const POPULATE_PASSPORT = [TYPES.FindProperty, TYPES.DrawBoundary];
   const breadcrumbPopulatesPassport =

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -57,7 +57,7 @@ export interface PreviewStore extends Store.Store {
   ) => NodeId | undefined;
   canGoBack: (node: Store.Node | null) => boolean;
   getType: (node: Store.Node | null) => TYPES | undefined;
-  computePassport: () => Readonly<Store.passport>;
+  computePassport: () => Readonly<Store.Passport>;
   record: (id: NodeId, userData?: Store.userData) => void;
   resultData: (
     flagSet?: string,
@@ -218,7 +218,7 @@ export const previewStore: StateCreator<
 
         const key = flow[id].data?.fn;
 
-        const passportData: Store.passport["data"] = {};
+        const passportData: Store.Passport["data"] = {};
 
         if (key) {
           const passportValue = answers
@@ -252,10 +252,10 @@ export const previewStore: StateCreator<
             _acc![id] = value;
             return _acc;
           },
-          {} as Store.passport["data"],
+          {} as Store.Passport["data"],
         );
 
-        let passport: Store.passport = {
+        let passport: Store.Passport = {
           ...acc,
           data: {
             ...acc.data,
@@ -277,7 +277,7 @@ export const previewStore: StateCreator<
       },
       {
         data: {},
-      } as Store.passport,
+      } as Store.Passport,
     );
 
     return passport;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -11,13 +11,13 @@ import { NavigationStore } from "./navigation";
 export type PreviewEnvironment = "editor" | "standalone";
 export interface SharedStore extends Store.Store {
   breadcrumbs: Store.breadcrumbs;
-  childNodesOf: (id?: NodeId) => Store.node[];
+  childNodesOf: (id?: NodeId) => Store.Node[];
   flow: Store.flow;
   flowSlug: string;
   flowName: string;
   flowAnalyticsLink: string | null;
   id: string;
-  getNode: (id: NodeId) => Store.node | undefined;
+  getNode: (id: NodeId) => Store.Node | undefined;
   resetPreview: () => void;
   setFlow: ({
     id,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -10,7 +10,7 @@ import { NavigationStore } from "./navigation";
 
 export type PreviewEnvironment = "editor" | "standalone";
 export interface SharedStore extends Store.Store {
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   childNodesOf: (id?: NodeId) => Store.Node[];
   flow: Store.flow;
   flowSlug: string;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -1,6 +1,6 @@
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { Auth } from "@opensystemslab/planx-core/dist/requests/graphql";
-import { FlowStatus } from "@opensystemslab/planx-core/types";
+import { FlowStatus, NodeId } from "@opensystemslab/planx-core/types";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import { removeSessionIdSearchParam } from "utils";
 import type { StateCreator } from "zustand";
@@ -11,13 +11,13 @@ import { NavigationStore } from "./navigation";
 export type PreviewEnvironment = "editor" | "standalone";
 export interface SharedStore extends Store.Store {
   breadcrumbs: Store.breadcrumbs;
-  childNodesOf: (id?: Store.nodeId) => Store.node[];
+  childNodesOf: (id?: NodeId) => Store.node[];
   flow: Store.flow;
   flowSlug: string;
   flowName: string;
   flowAnalyticsLink: string | null;
   id: string;
-  getNode: (id: Store.nodeId) => Store.node | undefined;
+  getNode: (id: NodeId) => Store.node | undefined;
   resetPreview: () => void;
   setFlow: ({
     id,
@@ -32,7 +32,7 @@ export interface SharedStore extends Store.Store {
     flowName?: string;
     flowStatus?: FlowStatus;
   }) => void;
-  wasVisited: (id: Store.nodeId) => boolean;
+  wasVisited: (id: NodeId) => boolean;
   previewEnvironment: PreviewEnvironment;
   setPreviewEnvironment: (previewEnvironment: PreviewEnvironment) => void;
   setFlowSlug: (flowSlug: string) => void;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -12,7 +12,7 @@ export type PreviewEnvironment = "editor" | "standalone";
 export interface SharedStore extends Store.Store {
   breadcrumbs: Store.Breadcrumbs;
   childNodesOf: (id?: NodeId) => Store.Node[];
-  flow: Store.flow;
+  flow: Store.Flow;
   flowSlug: string;
   flowName: string;
   flowAnalyticsLink: string | null;
@@ -27,7 +27,7 @@ export interface SharedStore extends Store.Store {
     flowStatus,
   }: {
     id?: string;
-    flow?: Store.flow;
+    flow?: Store.Flow;
     flowSlug?: string;
     flowName?: string;
     flowStatus?: FlowStatus;

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -36,10 +36,10 @@ import { exhaustiveCheck } from "utils";
 import type { Store } from "../FlowEditor/lib/store";
 import { useStore } from "../FlowEditor/lib/store";
 
-export type handleSubmit = (userData?: Store.UserData | Event) => void;
+export type HandleSubmit = (userData?: Store.UserData | Event) => void;
 
 interface Props {
-  handleSubmit: handleSubmit;
+  handleSubmit: HandleSubmit;
   node: Store.Node;
   data?: any;
 }

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -36,7 +36,7 @@ import { exhaustiveCheck } from "utils";
 import type { Store } from "../FlowEditor/lib/store";
 import { useStore } from "../FlowEditor/lib/store";
 
-export type handleSubmit = (userData?: Store.userData | Event) => void;
+export type handleSubmit = (userData?: Store.UserData | Event) => void;
 
 interface Props {
   handleSubmit: handleSubmit;

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -40,7 +40,7 @@ export type handleSubmit = (userData?: Store.userData | Event) => void;
 
 interface Props {
   handleSubmit: handleSubmit;
-  node: Store.node;
+  node: Store.Node;
   data?: any;
 }
 

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -14,7 +14,7 @@ import { ApplicationPath, Session } from "types";
 
 import ErrorFallback from "../../components/ErrorFallback";
 import { useStore } from "../FlowEditor/lib/store";
-import Node, { handleSubmit } from "./Node";
+import Node, { HandleSubmit } from "./Node";
 
 const BackBar = styled(Box)(() => ({
   top: 0,
@@ -123,7 +123,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   }, [breadcrumbs]);
 
   const handleSubmit =
-    (id: string): handleSubmit =>
+    (id: string): HandleSubmit =>
     (userData) => {
       const {
         data = undefined,

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -18,10 +18,10 @@ export const rootFlowPath = (includePortals = false) => {
 export const rootTeamPath = () =>
   window.location.pathname.split("/").slice(0, 2).join("/");
 
-export const isSaveReturnFlow = (flowData: Store.flow): boolean =>
+export const isSaveReturnFlow = (flowData: Store.Flow): boolean =>
   Boolean(Object.values(flowData).find((node) => node.type === NodeTypes.Send));
 
-export const setPath = (flowData: Store.flow, req: NaviRequest) => {
+export const setPath = (flowData: Store.Flow, req: NaviRequest) => {
   // XXX: store.path is SingleSession by default
   if (!isSaveReturnFlow(flowData)) return;
 

--- a/editor.planx.uk/src/routes/views/published.tsx
+++ b/editor.planx.uk/src/routes/views/published.tsx
@@ -18,7 +18,7 @@ interface PublishedViewSettings {
 }
 
 interface PublishedFlow extends Flow {
-  publishedFlows: Record<"data", Store.flow>[];
+  publishedFlows: Record<"data", Store.Flow>[];
 }
 
 /**

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -63,7 +63,7 @@ export interface SendEmailPayload {
 }
 export type Session = {
   passport: Store.Passport;
-  breadcrumbs: Store.breadcrumbs;
+  breadcrumbs: Store.Breadcrumbs;
   sessionId: string;
   // TODO: replace `id` with `flow: { id, published_flow_id }`
   id: SharedStore["id"];
@@ -79,7 +79,7 @@ export interface ReconciliationResponse {
 
 // re-export store types
 export type Passport = Store.Passport;
-export type Breadcrumbs = Store.breadcrumbs;
+export type Breadcrumbs = Store.Breadcrumbs;
 
 export enum SectionStatus {
   NeedsUpdated = "NEW INFORMATION NEEDED",

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -41,16 +41,6 @@ export interface TextContent {
   show: boolean;
 }
 
-export interface Node {
-  id: string;
-  data: {
-    text: string;
-    flag?: string;
-    info?: string;
-    policyRef?: string;
-  };
-}
-
 /**
  * Describes the different paths through which a flow can be navigated by a user
  */
@@ -100,7 +90,7 @@ export enum SectionStatus {
   Completed = "COMPLETED",
 }
 
-export interface SectionNode extends Store.node {
+export interface SectionNode extends Store.Node {
   data: {
     title: string;
     description?: string;

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -62,7 +62,7 @@ export interface SendEmailPayload {
   };
 }
 export type Session = {
-  passport: Store.passport;
+  passport: Store.Passport;
   breadcrumbs: Store.breadcrumbs;
   sessionId: string;
   // TODO: replace `id` with `flow: { id, published_flow_id }`
@@ -78,7 +78,7 @@ export interface ReconciliationResponse {
 }
 
 // re-export store types
-export type Passport = Store.passport;
+export type Passport = Store.Passport;
 export type Breadcrumbs = Store.breadcrumbs;
 
 export enum SectionStatus {

--- a/editor.planx.uk/src/ui/public/NextStepsList.tsx
+++ b/editor.planx.uk/src/ui/public/NextStepsList.tsx
@@ -6,16 +6,16 @@ import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { Step as StyledListItem } from "@planx/components/NextSteps/model";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import { handleSubmit } from "pages/Preview/Node";
+import { HandleSubmit } from "pages/Preview/Node";
 import React, { useState } from "react";
 
 interface NextStepsListProps {
   steps: StyledListItem[];
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
 }
 
 interface ListItemProps extends StyledListItem {
-  handleSubmit?: handleSubmit;
+  handleSubmit?: HandleSubmit;
   handleSelectingUrl?: (url: string) => void;
 }
 


### PR DESCRIPTION
## What does this PR do?
 - Shares types for `Node` with `planx-core`
 - Uppercases type which were incorrectly lowercase within the `Store` namespace
   - I also added an ESlint rule for ensuring types and interfaces are always PascalCase, along with a few small fixes