### PR TITLE
chore: extend `SiteAddress` type to account for ranges

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -79,7 +79,19 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
           latitude: selectedAddress.LAT,
           longitude: selectedAddress.LNG,
           organisation: selectedAddress.ORGANISATION || null,
-          sao: selectedAddress.SAO_TEXT,
+          sao: [
+            selectedAddress.SAO_START_NUMBER,
+            selectedAddress.SAO_START_SUFFIX,
+            selectedAddress.SAO_TEXT, // populated in cases of building name only, no street number
+          ]
+            .filter(Boolean)
+            .join(""),
+          saoEnd: [
+            selectedAddress.SAO_END_NUMBER,
+            selectedAddress.SAO_END_SUFFIX,
+          ]
+            .filter(Boolean)
+            .join(""),
           pao: [
             selectedAddress.PAO_START_NUMBER,
             selectedAddress.PAO_START_SUFFIX,
@@ -87,9 +99,17 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
           ]
             .filter(Boolean)
             .join(""),
+          paoEnd: [
+            selectedAddress.PAO_END_NUMBER,
+            selectedAddress.PAO_END_SUFFIX,
+          ]
+            .filter(Boolean)
+            .join(""),
           street: selectedAddress.STREET_DESCRIPTION,
           town: selectedAddress.TOWN_NAME,
           postcode: selectedAddress.POSTCODE_LOCATOR,
+          parish: selectedAddress.PARISH__CODE,
+          ward: selectedAddress.WARD_CODE,
           x: selectedAddress.X_COORDINATE,
           y: selectedAddress.Y_COORDINATE,
           planx_description:

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -30,6 +30,7 @@ const osAddressProps = {
     planx_value: "residential.HMO.parent",
     administrative_area: "SOUTHWARK",
     local_custodian_code: "SOUTHWARK",
+    ward: "E05011109",
     source: "os",
   },
   "property.type": ["residential.HMO.parent"],

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -48,15 +48,19 @@ export interface MinimumSiteAddress {
 
 // Full SiteAddress reflects selecting a record from the OS Places API "LPI" datasource
 export interface SiteAddress extends MinimumSiteAddress {
-  uprn?: string;
-  usrn?: string;
-  blpu_code?: string;
+  uprn: string;
+  usrn: string;
+  blpu_code: string;
   organisation?: string | null;
   sao?: string | null;
+  saoEnd?: string | null;
   pao?: string;
+  paoEnd?: string;
   street?: string;
   town?: string;
   postcode?: string;
+  ward?: string;
+  parish?: string;
   single_line_address?: string;
   planx_description?: string; // joined via table blpu_codes
   planx_value?: string; // joined via table blpu_codes

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -48,9 +48,9 @@ export interface MinimumSiteAddress {
 
 // Full SiteAddress reflects selecting a record from the OS Places API "LPI" datasource
 export interface SiteAddress extends MinimumSiteAddress {
-  uprn: string;
-  usrn: string;
-  blpu_code: string;
+  uprn?: string;
+  usrn?: string;
+  blpu_code?: string;
   organisation?: string | null;
   sao?: string | null;
   saoEnd?: string | null;


### PR DESCRIPTION
It came up in Idox feedback that we aren't currently supporting address ranges in the ODP Schema. I looked through the OneApp JSON example we have and don't see any instances of it handling ranges either, but nonetheless it's low effort for us to start more carefully checking for these. 

So, this PR adds a few extra fields from the OS Places API "LPI" data source to our internal model which we can later decide how to send along in payloads / the ODP Schema (https://github.com/theopensystemslab/digital-planning-data-schemas/pull/236). 

Only additive changes here! 
- `saoEnd`
- `paoEnd`
- `ward`
- `parish`

Links: 
- OS Docs (ctrl + f "LPI Output"): https://osdatahub.os.uk/docs/places/technicalSpecification
- Example response: https://api.editor.planx.dev/proxy/ordnance-survey/search/places/v1/postcode?postcode=SE5+0HU&dataset=LPI&maxResults=100&output_srs=EPSG%3A4326&lr=EN&offset=0