### PR TITLE
feat: display data fields on graph

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -86,8 +86,13 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           onContextMenu={handleContext}
           ref={drag}
         >
-          {Icon && <Icon />}
-          <span>{props.text}</span>
+          <div className="question-icon-wrapper">
+            {Icon && <Icon />}
+            <span className="question-text">{props.text}</span>
+          </div>
+          {props.data?.fn && (
+            <div className="question-schema">{props.data.fn}</div>
+          )}
         </Link>
         {groupedOptions ? (
           <ol className="categories">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -29,6 +29,7 @@ const Option: React.FC<any> = (props) => {
       <Link href={href} prefetch={false} onClick={(e) => e.preventDefault()}>
         <div className="band" style={{ background, color }}></div>
         <div className="text">{props.data.text}</div>
+        {props.data?.val && <div className="schema">{props.data?.val}</div>}
       </Link>
       <ol className="decisions">
         {childNodes.map((child: any) => (

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -250,7 +250,7 @@ $fontMonospace: "Source Code Pro", monospace;
     flex-direction: column;
     padding: 0;
     min-width: 60px;
-    max-width: 200px;
+    max-width: fit-content;
   }
   .band {
     width: 100%;
@@ -261,6 +261,51 @@ $fontMonospace: "Source Code Pro", monospace;
     align-self: center;
     margin: 0;
     padding: 6px 12px;
+    width: 100%;
+    border-bottom: $nodeBorderWidth solid $optionBorder;
+  }
+  .schema {
+    background-color: $hangerBackground;
+    font-family: $fontMonospace;
+    align-self: center;
+    margin: 0;
+    margin-bottom: -$nodeBorderWidth;
+    padding: 6px 12px;
+    width: 100%;
+    border-bottom: $nodeBorderWidth solid $optionBorder;
+  }
+}
+
+.question {
+  > a {
+    border-color: $nodeBorder;
+    flex-direction: column;
+    padding: 0;
+    min-width: 60px;
+    max-width: 300px;
+  }
+  .question-icon-wrapper {
+    display: flex;
+    flex-direction: row;
+    padding: 6px;
+    width: 100%;
+    border-bottom: $nodeBorderWidth solid $nodeBorder;
+  }
+  .question-text {
+    align-self: center;
+    margin: 0;
+    padding: 6px 12px;
+    width: 100%;
+  }
+  .question-schema {
+    background-color: $hangerBackground;
+    font-family: $fontMonospace;
+    align-self: center;
+    margin: 0;
+    margin-bottom: -$nodeBorderWidth;
+    padding: 6px 12px;
+    width: 100%;
+    border-bottom: $nodeBorderWidth solid $nodeBorder;
   }
 }
 


### PR DESCRIPTION
Cherry picked from our prior Biennale experimental / maximalist graph styling #2947 

Wondering if displaying data fields in the graph makes sense alongside preparing to launch search for "data fields only"? Eg, how familiar do we think average editors are with the concept of "data fields" ?

Just an idea, very much think this one is up to Daf, Ian and content team to decide if useful! While I like this style for increased visibility, it definitely stretches out overall size of graphs which may prove harder to navigate?

**Before:**
![Screenshot from 2024-09-15 20-22-02](https://github.com/user-attachments/assets/633e4c45-d790-4615-8d20-d2075935b7da)

**After:**
![Screenshot from 2024-09-15 20-16-58](https://github.com/user-attachments/assets/fb09b9fa-4558-4a97-beb8-03d5050ddc75)

** Does _not_ display data fields (yet?) for any of the "special" component types like DrawBoundary, FileUploadAndLabel etc that search results _are_ handling.