### PR TITLE
fix: Flow URLs should re-compute on re-render of Sidebar

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishFlowButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishFlowButton.tsx
@@ -14,7 +14,6 @@ import React, { useState } from "react";
 import { useAsync } from "react-use";
 import Input from "ui/shared/Input";
 
-import { urls } from "..";
 import {
   AlteredNode,
   AlteredNodesSummaryContent,
@@ -22,7 +21,9 @@ import {
   ValidationChecks,
 } from "./PublishDialog";
 
-export const PublishFlowButton = () => {
+export const PublishFlowButton: React.FC<{ previewURL: string }> = ({
+  previewURL,
+}) => {
   const [
     flowId,
     publishFlow,
@@ -147,7 +148,7 @@ export const PublishFlowButton = () => {
                 <Box pb={2}>
                   <Typography variant="body2">
                     {`Preview these content changes in-service before publishing `}
-                    <Link href={urls.preview} target="_blank">
+                    <Link href={previewURL} target="_blank">
                       {`here (opens in a new tab).`}
                     </Link>
                   </Typography>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -24,14 +24,6 @@ import StyledTab from "./StyledTab";
 
 type SidebarTabs = "PreviewBrowser" | "History" | "Search" | "Console";
 
-const baseUrl = `${window.location.origin}${rootFlowPath(false)}`;
-
-export const urls = {
-  preview: baseUrl + "/preview",
-  draft: baseUrl + "/draft",
-  analytics: baseUrl + "/published" + "?analytics=false",
-};
-
 const Root = styled(Box)(({ theme }) => ({
   position: "relative",
   top: "0",
@@ -111,8 +103,19 @@ const Sidebar: React.FC = React.memo(() => {
 
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
 
-  const handleChange = (event: React.SyntheticEvent, newValue: SidebarTabs) => {
+  const handleChange = (
+    _event: React.SyntheticEvent,
+    newValue: SidebarTabs,
+  ) => {
     setActiveTab(newValue);
+  };
+
+  const baseUrl = `${window.location.origin}${rootFlowPath(false)}`;
+
+  const urls = {
+    preview: baseUrl + "/preview",
+    draft: baseUrl + "/draft",
+    analytics: baseUrl + "/published" + "?analytics=false",
   };
 
   return (
@@ -166,7 +169,7 @@ const Sidebar: React.FC = React.memo(() => {
             </Tooltip>
           )}
         </Box>
-        <PublishFlowButton />
+        <PublishFlowButton previewURL={urls.preview} />
       </Header>
       <TabList>
         <Tabs onChange={handleChange} value={activeTab} aria-label="">


### PR DESCRIPTION
## What's the problem?
 - Bug introduced in https://github.com/theopensystemslab/planx-new/pull/3668
 - URLs are not being re-generated when the route changes
 - This is because by defining `urls` outside of the lifecycle scope of a component, this is never re-generated
 - To recreate - 
   - Navigate to a flow in the Editor, checkout icon hrefs in Sidebar
   - Navigate to another flow
   - Icon hrefs have not updated ❌ 

## What's the solution?
- Calculate within the `Sidebar` component
- Pass URL as prop, instead of importing it