### PR TITLE
feat: Map and Label Remove Tests

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
@@ -364,8 +364,7 @@ describe("remove feature button", () => {
     expect(tabOnePanel).not.toBeInTheDocument();
   });
   it("removes a feature from the form - multiple features", async () => {
-    const { getByTestId, getByRole, user } = setup(<MapAndLabel {...props} />);
-    const map = getByTestId("map-and-label-map");
+    const { getByRole, user } = setup(<MapAndLabel {...props} />);
 
     addMultipleFeatures([point1, point2]);
 

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
@@ -208,7 +208,7 @@ it("does not trigger handleSubmit when errors exist", async () => {
 test.todo("an error displays if the maximum number of items is exceeded");
 
 describe("basic interactions - happy path", () => {
-  it.only("adding an item to the map adds a feature tab", async () => {
+  it("adding an item to the map adds a feature tab", async () => {
     const { getByTestId } = setup(<MapAndLabel {...props} />);
 
     let map = getByTestId("map-and-label-map");

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
@@ -6,7 +6,12 @@ import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
-import { point1, point2, point3 } from "../test/mocks/geojson";
+import {
+  mockFeaturePointObj,
+  point1,
+  point2,
+  point3,
+} from "../test/mocks/geojson";
 import { props } from "../test/mocks/Trees";
 import {
   addFeaturesToMap,
@@ -203,15 +208,18 @@ it("does not trigger handleSubmit when errors exist", async () => {
 test.todo("an error displays if the maximum number of items is exceeded");
 
 describe("basic interactions - happy path", () => {
-  it("adding an item to the map adds a feature tab", async () => {
+  it.only("adding an item to the map adds a feature tab", async () => {
     const { getByTestId } = setup(<MapAndLabel {...props} />);
-    const map = getByTestId("map-and-label-map");
 
+    let map = getByTestId("map-and-label-map");
     addFeaturesToMap(map, [point1]);
 
     const firstTabPanel = getByTestId("vertical-tabpanel-0");
 
     expect(firstTabPanel).toBeVisible();
+
+    map = getByTestId("map-and-label-map");
+    expect(map).toHaveAttribute("drawgeojsondata", mockFeaturePointObj);
   });
 
   it("a user can input details on a single feature and submit", async () => {
@@ -345,7 +353,6 @@ describe("copy feature select", () => {
   it.todo("should not have any accessibility violations");
   // axe checks
 });
-
 describe("remove feature button", () => {
   it("removes a feature from the form - single feature", async () => {
     const { getByTestId, getByRole, user } = setup(<MapAndLabel {...props} />);
@@ -385,10 +392,9 @@ describe("remove feature button", () => {
     expect(tabOne).toBeInTheDocument();
     expect(tabOnePanel).toBeInTheDocument();
   });
-
   it("removes a feature from the map", async () => {
     const { getByTestId, getByRole, user } = setup(<MapAndLabel {...props} />);
-    const map = getByTestId("map-and-label-map");
+    let map = getByTestId("map-and-label-map");
 
     addFeaturesToMap(map, [point1]);
 
@@ -396,9 +402,9 @@ describe("remove feature button", () => {
 
     await user.click(removeButton);
 
-    const mapTwo = getByTestId("map-and-label-map");
+    map = getByTestId("map-and-label-map");
 
-    expect(mapTwo).toHaveAttribute(
+    expect(map).toHaveAttribute(
       "drawgeojsondata",
       `{"type":"FeatureCollection","features":[]}`
     );

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
@@ -347,10 +347,65 @@ describe("copy feature select", () => {
 });
 
 describe("remove feature button", () => {
-  it.todo("removes a feature from the form");
-  // click remove - feature is removed
-  // not tab
-  it.todo("removes a feature from the map");
+  it("removes a feature from the form - single feature", async () => {
+    const { getByTestId, getByRole, user } = setup(<MapAndLabel {...props} />);
+    const map = getByTestId("map-and-label-map");
+
+    addFeaturesToMap(map, [point1]);
+
+    const tabOne = getByRole("tab", { name: /Tree 1/ });
+    const tabOnePanel = getByRole("tabpanel", { name: /Tree 1/ });
+
+    const removeButton = getByRole("button", { name: "Remove" });
+
+    await user.click(removeButton);
+
+    expect(tabOne).not.toBeInTheDocument();
+    expect(tabOnePanel).not.toBeInTheDocument();
+  });
+  it("removes a feature from the form - multiple features", async () => {
+    const { getByTestId, getByRole, user } = setup(<MapAndLabel {...props} />);
+    const map = getByTestId("map-and-label-map");
+
+    addMultipleFeatures([point1, point2]);
+
+    const tabOne = getByRole("tab", { name: /Tree 1/ });
+    const tabTwo = getByRole("tab", { name: /Tree 2/ });
+    const tabTwoPanel = getByRole("tabpanel", { name: /Tree 2/ });
+
+    const removeButton = getByRole("button", { name: "Remove" });
+
+    await user.click(removeButton);
+
+    expect(tabTwo).not.toBeInTheDocument();
+    expect(tabTwoPanel).not.toBeInTheDocument();
+
+    const tabOnePanel = getByRole("tabpanel", { name: /Tree 1/ });
+
+    // Ensure tab one remains
+    expect(tabOne).toBeInTheDocument();
+    expect(tabOnePanel).toBeInTheDocument();
+  });
+
+  it("removes a feature from the map", async () => {
+    const { getByTestId, getByRole, user } = setup(<MapAndLabel {...props} />);
+    const map = getByTestId("map-and-label-map");
+
+    addFeaturesToMap(map, [point1]);
+
+    const removeButton = getByRole("button", { name: "Remove" });
+
+    await user.click(removeButton);
+
+    const mapTwo = getByTestId("map-and-label-map");
+
+    await waitFor(() => {
+      expect(mapTwo).toHaveAttribute(
+        "drawgeojsondata",
+        `{"type":"FeatureCollection","features":[]}`
+      );
+    });
+  });
   // click remove - feature is removed
   // no map icon
 });

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.test.tsx
@@ -399,12 +399,10 @@ describe("remove feature button", () => {
 
     const mapTwo = getByTestId("map-and-label-map");
 
-    await waitFor(() => {
-      expect(mapTwo).toHaveAttribute(
-        "drawgeojsondata",
-        `{"type":"FeatureCollection","features":[]}`
-      );
-    });
+    expect(mapTwo).toHaveAttribute(
+      "drawgeojsondata",
+      `{"type":"FeatureCollection","features":[]}`
+    );
   });
   // click remove - feature is removed
   // no map icon

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/test/mocks/geojson.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/test/mocks/geojson.ts
@@ -32,3 +32,5 @@ export const point3: Feature<Point, { label: string }> = {
     coordinates: [-3.68689607119201, 57.15310833687542],
   },
 };
+
+export const mockFeaturePointObj = `{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"label":"1"},"geometry":{"type":"Point","coordinates":[-3.685929607119201,57.15301433687542]}}]}`;


### PR DESCRIPTION
## What does this PR do?

Following previous work on Map and Label testing, I am continuing through and testing the Remove feature.

To test the feature being deleted the map, I am accessing the `drawgeojson` attribute of `<my-map>` seemed a good way to confirm it has been deleted from the map itself. Open to alternative suggestions though.

```ts
    const mapTwo = getByTestId("map-and-label-map");

    expect(mapTwo).toHaveAttribute(
      "drawgeojsondata",
      `{"type":"FeatureCollection","features":[]}`
    );
```