### PR TITLE
fix: realign members table cell borders

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
@@ -107,16 +108,18 @@ export const MembersTable = ({
               <StyledTableRow key={member.id}>
                 <TableCell
                   sx={{
-                    display: "flex",
+                    display: "table-cell",
                     flexDirection: "row",
                     alignItems: "center",
                   }}
                 >
-                  <StyledAvatar>
-                    {member.firstName[0]}
-                    {member.lastName[0]}
-                  </StyledAvatar>
-                  {member.firstName} {member.lastName}
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <StyledAvatar>
+                      {member.firstName[0]}
+                      {member.lastName[0]}
+                    </StyledAvatar>
+                    {member.firstName} {member.lastName}
+                  </Box>
                 </TableCell>
                 <TableCell>
                   <Chip


### PR DESCRIPTION
| Before                      | After                  |
| ------------------------ | ------------------------ |
| <img src="https://github.com/user-attachments/assets/a81761ff-29f0-46be-9f7b-d1b6353644f5" width="300"> | <img src="https://github.com/user-attachments/assets/f8ca2aae-507e-4ea2-8778-4117302130ec" width="300"> |
