### PR TITLE
test: Basic coverage for `PlanningConstraints` public interface

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -302,6 +302,7 @@ export function PlanningConstraintsContent(
           {negativeConstraints.length > 0 && (
             <SimpleExpand
               id="negative-constraints-list"
+              data-testid="negative-constraints-list"
               buttonText={{
                 open: "Constraints that don't apply to this property",
                 closed: "Hide constraints that don't apply",

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/simpleFlow.ts
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/simpleFlow.ts
@@ -1,3 +1,4 @@
+import { cloneDeep, merge } from "lodash";
 import { Store } from "pages/FlowEditor/lib/store";
 
 export const simpleFlow: Store.Flow = {
@@ -93,3 +94,5 @@ export const simpleBreadcrumbs: Store.Breadcrumbs = {
     },
   },
 };
+
+export const breadcrumbsWithoutUSRN = merge(cloneDeep(simpleBreadcrumbs), { findProperty: { data: { _address: { usrn: null }}}});

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/simpleFlow.ts
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/mocks/simpleFlow.ts
@@ -1,0 +1,95 @@
+import { Store } from "pages/FlowEditor/lib/store";
+
+export const simpleFlow: Store.Flow = {
+  _root: {
+    edges: ["findProperty", "planningConstraints"],
+  },
+  findProperty: {
+    type: 9,
+    data: {
+      title: "Find the property",
+      allowNewAddresses: false,
+      newAddressTitle:
+        "Click or tap at where the property is on the map and name it below",
+      newAddressDescription:
+        "You will need to select a location and provide a name to continue",
+      newAddressDescriptionLabel: "Name the site",
+    },
+  },
+  planningConstraints: {
+    type: 11,
+    data: {
+      title: "Planning constraints",
+      description:
+        "Planning constraints might limit how you can develop or use the property",
+      fn: "property.constraints.planning",
+      disclaimer:
+        "<p><strong>This page does not include information about historic planning conditions that may apply to this property.</strong></p>",
+    },
+  },
+};
+
+export const simpleBreadcrumbs: Store.Breadcrumbs = {
+  findProperty: {
+    auto: false,
+    data: {
+      _address: {
+        uprn: "100071417680",
+        usrn: "2702440",
+        blpu_code: "2",
+        latitude: 52.4804358,
+        longitude: -1.9034539,
+        organisation: null,
+        sao: "",
+        saoEnd: "",
+        pao: "COUNCIL HOUSE",
+        paoEnd: "",
+        street: "VICTORIA SQUARE",
+        town: "BIRMINGHAM",
+        postcode: "B1 1BB",
+        ward: "E05011151",
+        x: 406653.64,
+        y: 286948.41,
+        planx_description: "Local Government Service",
+        planx_value: "commercial.office.workspace.gov.local",
+        single_line_address:
+          "COUNCIL HOUSE, VICTORIA SQUARE, BIRMINGHAM, B1 1BB",
+        title: "COUNCIL HOUSE, VICTORIA SQUARE",
+        source: "os",
+      },
+      "property.type": ["commercial.office.workspace.gov.local"],
+      "property.localAuthorityDistrict": ["Birmingham"],
+      "property.region": ["West Midlands"],
+      "property.boundary.title": {
+        geometry: {
+          type: "MultiPolygon",
+          coordinates: [
+            [
+              [
+                [-1.903955, 52.480237],
+                [-1.903881, 52.480179],
+                [-1.903955, 52.480237],
+              ],
+            ],
+          ],
+        },
+        type: "Feature",
+        properties: {
+          "entry-date": "2024-05-06",
+          "start-date": "2021-03-25",
+          "end-date": "",
+          entity: 12001049997,
+          name: "",
+          dataset: "title-boundary",
+          typology: "geography",
+          reference: "61385289",
+          prefix: "title-boundary",
+          "organisation-entity": "13",
+        },
+      },
+      "property.boundary.title.area": 8242.37,
+      "property.boundary.title.area.hectares": 0.8242370000000001,
+      "findProperty.action": "Selected an existing address",
+    },
+  },
+};

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SimpleExpand.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SimpleExpand.tsx
@@ -48,7 +48,7 @@ const SimpleExpand: React.FC<PropsWithChildren<Props>> = ({
           />
         </StyledButton>
       </Box>
-      <Collapse in={show} id={id}>
+      <Collapse in={show} id={id} data-testid={id}>
         {children}
       </Collapse>
     </>

--- a/editor.planx.uk/src/components/Error/ErrorFallback.tsx
+++ b/editor.planx.uk/src/components/Error/ErrorFallback.tsx
@@ -15,7 +15,7 @@ const ErrorFallback: React.FC<{ error: Error }> = ({ error }) => {
     <Card>
       <ErrorSummaryContainer role="alert">
         <Typography variant="h4" component="h1" gutterBottom>
-          Something went wrong
+          {(props.error.cause as string) || "Something went wrong"}
         </Typography>
         <Typography>
           {error.message && (

--- a/editor.planx.uk/src/components/Error/ErrorFallback.tsx
+++ b/editor.planx.uk/src/components/Error/ErrorFallback.tsx
@@ -15,7 +15,7 @@ const ErrorFallback: React.FC<{ error: Error }> = ({ error }) => {
     <Card>
       <ErrorSummaryContainer role="alert">
         <Typography variant="h4" component="h1" gutterBottom>
-          {(props.error.cause as string) || "Something went wrong"}
+          Something went wrong
         </Typography>
         <Typography>
           {error.message && (


### PR DESCRIPTION
## What?
Sets up very basic coverage of the public interface of the `PlanningConstraints` component.

## Why?
 - Follow up to https://github.com/theopensystemslab/planx-new/pull/3689#discussion_r1764504784
 - Upcoming work may focus on the Editor interface, it's worth having a good test setup here which can be expanded alongside this work