### PR TITLE
chore: update Metabase to v0.50.26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   metabase:
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.50.22
+    image: metabase/metabase:v0.50.26
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -184,7 +184,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.50.22",
+        image: "metabase/metabase:v0.50.26",
         portMappings: [metabaseListenerHttp],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
Updates Metabase to [v0.50.26](https://github.com/metabase/metabase/releases/tag/v0.50.26).

I know we [just updated Metabase](https://github.com/theopensystemslab/planx-new/pull/3579) but there was a minor change in [v0.50.23](https://discourse.metabase.com/t/cant-access-to-api-docs/150971) that should make life working with the API a lot easier. 