### PR TITLE
fix: remove assertion from e2e helper to fix regression tests

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow/create-flow.spec.ts
@@ -260,6 +260,9 @@ test.describe("Flow creation, publish and preview", () => {
     ).toBeVisible();
     await clickContinue({ page });
 
+    await expect(
+      page.locator("h1", { hasText: "Find the property" }),
+    ).toBeVisible();
     await answerFindProperty(page);
     await clickContinue({ page });
   });

--- a/e2e/tests/ui-driven/src/helpers/userActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/userActions.ts
@@ -196,9 +196,6 @@ export async function submitCardDetails(page: Page) {
 
 export async function answerFindProperty(page: Page) {
   await setupOSMockResponse(page);
-  await expect(
-    page.locator("h1", { hasText: "Find the property" }),
-  ).toBeVisible();
   await page.getByLabel("Postcode").fill("SW1 1AA");
   await page.getByLabel("Select an address").click();
   await page.getByRole("option").first().click();


### PR DESCRIPTION
Hopefully should fix the recent failing regression test runs e.g. https://github.com/theopensystemslab/planx-new/actions/runs/10923566442/job/30320494144

I've replaced the assertion in the one test case where I needed it, rather than assuming that it works for all places that the helper is used.