### PR TITLE
fix: add flow name to S3 Slack notifications & webhook message

### DIFF
--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -49,6 +49,7 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
 
     const session = await $api.session.find(sessionId);
     const passport = session?.data?.passport as Passport;
+    const flowName = session?.flow?.name;
 
     // Generate the ODP Schema JSON, skipping validation if not a supported application type
     const doValidation = isApplicationTypeSupported(passport);
@@ -73,6 +74,7 @@ const sendToS3 = async (req: Request, res: Response, next: NextFunction) => {
       },
       data: {
         message: "New submission from PlanX",
+        service: flowName,
         environment: env,
         file: fileUrl,
         payload: doValidation ? "Validated ODP Schema" : "Discretionary",

--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
@@ -351,6 +351,15 @@ describe("Send Slack notifications endpoint", () => {
           new: {
             session_id: "s3-pa-123",
             team_slug: "test-team",
+            webhook_request: {
+              data: {
+                service: "Test flow",
+                message: "New submission from PlanX",
+                payload: "Discretionary",
+                environment: "Staging",
+                file: "api.editor.planx.dev/private/file/test",
+              },
+            },
           },
         },
       },

--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -44,8 +44,8 @@ const getMessageForEventType = (data: EventData, type: EventType) => {
   }
 
   if (type === "s3-submission") {
-    const { session_id, team_slug } = data as S3EventData;
-    return `New S3 + Power Automate submission *${session_id}* [${team_slug}]`;
+    const { session_id, team_slug, webhook_request } = data as S3EventData;
+    return `New S3 + Power Automate submission "${webhook_request.data.service}" *${session_id}* [${team_slug}]`;
   }
 };
 

--- a/api.planx.uk/modules/webhooks/service/sendNotification/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/schema.ts
@@ -66,6 +66,15 @@ export const s3SubmissionSchema = z.object({
         new: z.object({
           session_id: z.string(),
           team_slug: z.string(),
+          webhook_request: z.object({
+            data: z.object({
+              message: z.string(),
+              service: z.string(),
+              environment: z.string(),
+              file: z.string(),
+              payload: z.string(),
+            }),
+          }),
         }),
       }),
     }),


### PR DESCRIPTION
Barnet is expanding their use of the S3/Power Automate webhook "Send" method to more services, but our logging for this method isn't currently easily filter-able on flow name.

**Two quick changes:** 
- Add `service` (aka flow name) property to the message we send to the webhook
- Access that `service` name again (from the audit table record) for the Slack message so it's more consistent with other notifications like send to email 
  - Before: ` New S3 + Power Automate submission 3ec46727-88b4-4f39-bb95-a89ee33f0b52 [barnet] [Exempt]`
  - After:  ` New S3 + Power Automate submission "Apply for a Lawful Development Certificate" 3ec46727-88b4-4f39-bb95-a89ee33f0b52 [barnet] [Exempt]`

**Testing:**
I've tested locally & confirmed with Kev. Please do _not_ send an S3 test submission on this pizza because it's just a single environment on Barnet's side (so we want to track & flag any local or pizza session IDs to them).

Here's local confirmation:
![Screenshot from 2024-09-19 10-43-56](https://github.com/user-attachments/assets/10f7a2c7-9233-4f4b-b2c3-b9389db15e67)
