### PR TITLE
fix: hide "Add a new editor" button from non-admin users

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -148,7 +148,7 @@ export const MembersTable = ({
               </StyledTableRow>
             ))}
             {showAddMemberButton && (
-              <Permission.IsNotPlatformAdmin>
+              <Permission.IsPlatformAdmin>
                 <TableRow>
                   <TableCell colSpan={3}>
                     <AddButton
@@ -161,7 +161,7 @@ export const MembersTable = ({
                     </AddButton>
                   </TableCell>
                 </TableRow>
-              </Permission.IsNotPlatformAdmin>
+              </Permission.IsPlatformAdmin>
             )}
           </TableBody>
         </Table>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -148,18 +148,20 @@ export const MembersTable = ({
               </StyledTableRow>
             ))}
             {showAddMemberButton && (
-              <TableRow>
-                <TableCell colSpan={3}>
-                  <AddButton
-                    onClick={() => {
-                      setInitialValues(undefined);
-                      setShowAddModal(true);
-                    }}
-                  >
-                    Add a new editor
-                  </AddButton>
-                </TableCell>
-              </TableRow>
+              <Permission.IsNotPlatformAdmin>
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <AddButton
+                      onClick={() => {
+                        setInitialValues(undefined);
+                        setShowAddModal(true);
+                      }}
+                    >
+                      Add a new editor
+                    </AddButton>
+                  </TableCell>
+                </TableRow>
+              </Permission.IsNotPlatformAdmin>
             )}
           </TableBody>
         </Table>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.errors.serverSide.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.errors.serverSide.test.tsx
@@ -5,7 +5,7 @@ import { vi } from "vitest";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
 import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
-import { alreadyExistingUser } from "./mocks/mockUsers";
+import { alreadyExistingUser, mockPlatformAdminUser } from "./mocks/mockUsers";
 
 let initialState: FullStore;
 vi.mock(
@@ -22,6 +22,7 @@ describe("when a user fills in the 'add a new editor' form correctly but there i
   beforeEach(async () => {
     useStore.setState({
       teamMembers: [...mockTeamMembersData, alreadyExistingUser],
+      user: mockPlatformAdminUser,
     });
 
     const { user } = await setupTeamMembersScreen();

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.errors.userAlreadyExists.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.errors.userAlreadyExists.test.tsx
@@ -5,7 +5,7 @@ import { vi } from "vitest";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
 import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
-import { alreadyExistingUser } from "./mocks/mockUsers";
+import { alreadyExistingUser, mockPlatformAdminUser } from "./mocks/mockUsers";
 
 vi.mock(
   "pages/FlowEditor/components/Team/queries/createAndAddUserToTeam.tsx",
@@ -23,6 +23,7 @@ describe("when a user fills in the 'add a new editor' form correctly but the use
   beforeEach(async () => {
     useStore.setState({
       teamMembers: [...mockTeamMembersData, alreadyExistingUser],
+      user: mockPlatformAdminUser,
     });
 
     const { user } = await setupTeamMembersScreen();

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.noExistingMembers.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.noExistingMembers.test.tsx
@@ -3,6 +3,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 
 import { TeamMember } from "../types";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
+import { mockPlatformAdminUser } from "./mocks/mockUsers";
 
 const mockTeamMembersDataWithNoTeamEditors: TeamMember[] = [
   {
@@ -16,7 +17,10 @@ const mockTeamMembersDataWithNoTeamEditors: TeamMember[] = [
 
 describe("when a user views the 'Team members' screen but there are no existing team editors listed", () => {
   beforeEach(async () => {
-    useStore.setState({ teamMembers: mockTeamMembersDataWithNoTeamEditors });
+    useStore.setState({
+      teamMembers: mockTeamMembersDataWithNoTeamEditors,
+      user: mockPlatformAdminUser,
+    });
     const { getByText } = await setupTeamMembersScreen();
     getByText("No members found");
   });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.test.tsx
@@ -11,7 +11,11 @@ import { EditorUpsertModal } from "../components/EditorUpsertModal";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
 import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
-import { emptyTeamMemberObj } from "./mocks/mockUsers";
+import {
+  emptyTeamMemberObj,
+  mockPlainUser,
+  mockPlatformAdminUser,
+} from "./mocks/mockUsers";
 
 vi.mock(
   "pages/FlowEditor/components/Team/queries/createAndAddUserToTeam.tsx",
@@ -27,7 +31,11 @@ let initialState: FullStore;
 
 describe("when a user presses 'add a new editor'", () => {
   beforeEach(async () => {
-    useStore.setState({ teamMembers: mockTeamMembersData, teamSlug: "planx" });
+    useStore.setState({
+      teamMembers: mockTeamMembersData,
+      user: mockPlatformAdminUser,
+      teamSlug: "planx",
+    });
     const { user } = await setupTeamMembersScreen();
 
     const teamEditorsTable = screen.getByTestId("team-editors");
@@ -45,8 +53,13 @@ describe("when a user presses 'add a new editor'", () => {
 
 describe("when a user fills in the 'add a new editor' form correctly", () => {
   afterAll(() => useStore.setState(initialState));
+
   beforeEach(async () => {
-    useStore.setState({ teamMembers: mockTeamMembersData, teamSlug: "planx" });
+    useStore.setState({
+      teamMembers: mockTeamMembersData,
+      user: mockPlatformAdminUser,
+      teamSlug: "planx",
+    });
     const { user } = await setupTeamMembersScreen();
     await userTriesToAddNewEditor(user);
   });
@@ -97,11 +110,30 @@ describe("'add a new editor' button is hidden from Templates team", () => {
   beforeEach(async () => {
     useStore.setState({
       teamMembers: mockTeamMembersData,
+      user: mockPlatformAdminUser,
       teamSlug: "templates",
     });
   });
 
   it("hides the button on the Templates team", async () => {
+    const { user: _user } = await setupTeamMembersScreen();
+    const teamEditorsTable = screen.getByTestId("team-editors");
+    const addEditorButton =
+      within(teamEditorsTable).queryByText("Add a new editor");
+    expect(addEditorButton).not.toBeInTheDocument();
+  });
+});
+
+describe("when a user is not a platform admin", () => {
+  beforeEach(async () => {
+    useStore.setState({
+      teamMembers: mockTeamMembersData,
+      user: mockPlainUser,
+      teamSlug: "templates",
+    });
+  });
+
+  it("hides the button from non-admin users", async () => {
     const { user: _user } = await setupTeamMembersScreen();
     const teamEditorsTable = screen.getByTestId("team-editors");
     const addEditorButton =

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.updateEditor.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.updateEditor.test.tsx
@@ -192,6 +192,7 @@ describe("when a user is not a platform admin", () => {
 
     await setupTeamMembersScreen();
   });
+
   it("does not show an edit button", async () => {
     const teamEditorsTable = screen.getByTestId("team-editors");
     const addEditorButton =


### PR DESCRIPTION
It's the second planning meeting in a row where Ian G has asked about / been a bit confused by adding and editing users and I think it's because he can see the add button as a `teamEditor`, but doesn't have permission to actually use it. 

This change hides the "Add a new editor" from non-`platformAdmins` similar to the "Edit" button. Database-level permissions already look correct (eg only `platformAdmin` role has "insert" permission on `team_members` table).

We've thrown this previous error: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1725542317058179
![Screenshot from 2024-09-19 15-38-11](https://github.com/user-attachments/assets/bc3e39ca-4060-49a4-87d4-00121aac0b60)

Good reminder to ourselves to trigger our own `platformAdmin` status "off" sometimes when testing/code reviewing pizzas!