### PR TITLE
feat: Add tags to Node data (take 2)

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -7,9 +7,9 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { PASSPORT_REQUESTED_FILES_KEY } from "../FileUploadAndLabel/model";
 import { PrivateFileUpload } from "../shared/PrivateFileUpload/PrivateFileUpload";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
-import { FileUploadSlot, Props, slotsSchema } from "./model";
+import { FileUpload, FileUploadSlot, slotsSchema } from "./model";
 
-const FileUpload: React.FC<Props> = (props) => {
+const FileUploadComponent: React.FC<FileUpload> = (props) => {
   const recoveredSlots = getPreviouslySubmittedData(props)?.map(
     (slot: FileUploadSlot) => slot.cachedSlot,
   );
@@ -96,4 +96,4 @@ const FileUpload: React.FC<Props> = (props) => {
   );
 };
 
-export default FileUpload;
+export default FileUploadComponent;

--- a/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -4,7 +4,7 @@ import type { HandleSubmit } from "pages/Preview/Node";
 import { FileWithPath } from "react-dropzone";
 import { array } from "yup";
 
-export interface Props extends MoreInformation {
+export interface FileUpload extends MoreInformation {
   id?: string;
   title?: string;
   fn: string;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -3,12 +3,12 @@ import {
   GovUKPayment,
   PaymentStatus,
 } from "@opensystemslab/planx-core/types";
+import { PublicProps } from "@planx/components/ui";
 import { logger } from "airbrake";
 import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import { setLocalFlow } from "lib/local.new";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { HandleSubmit } from "pages/Preview/Node";
 import React, { useEffect, useReducer } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import type { Session } from "types";
@@ -18,9 +18,7 @@ import { createPayload, GOV_UK_PAY_URL, Pay, toDecimal } from "../model";
 import Confirm from "./Confirm";
 
 export default Component;
-interface Props extends Pay {
-  handleSubmit: HandleSubmit;
-}
+export type Props = PublicProps<Pay>;
 
 type ComponentState =
   | { status: "indeterminate"; displayText?: string }
@@ -119,7 +117,7 @@ function Component(props: Props) {
   useEffect(() => {
     // Auto-skip component when fee=0
     if (fee <= 0) {
-      return props.handleSubmit({ auto: true });
+      return props.handleSubmit && props.handleSubmit({ auto: true });
     }
 
     // If props.fn is undefined, display & log an error
@@ -144,7 +142,8 @@ function Component(props: Props) {
 
   const handleSuccess = () => {
     dispatch(Action.Success);
-    props.handleSubmit(makeData(props, govUkPayment, GOV_PAY_PASSPORT_KEY));
+    props.handleSubmit &&
+      props.handleSubmit(makeData(props, govUkPayment, GOV_PAY_PASSPORT_KEY));
   };
 
   const normalizePaymentResponse = (responseData: any): GovUKPayment => {
@@ -282,7 +281,7 @@ function Component(props: Props) {
           onConfirm={() => {
             if (props.hidePay || state.status === "unsupported_team") {
               // Show "Continue" button to proceed
-              props.handleSubmit({ auto: false });
+              props.handleSubmit && props.handleSubmit({ auto: false });
             } else if (state.status === "init") {
               startNewPayment();
             } else if (state.status === "retry") {

--- a/editor.planx.uk/src/@planx/components/Question/model.ts
+++ b/editor.planx.uk/src/@planx/components/Question/model.ts
@@ -11,7 +11,7 @@ export interface Question {
   definitionImg?: string;
   img?: string;
   responses: {
-    id: string;
+    id?: string;
     responseKey: string | number;
     title: string;
     description?: string;

--- a/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Public/ResultReason.tsx
@@ -149,9 +149,9 @@ const ResultReason: React.FC<IResultReason> = ({
     }
   }, [summaryRef]);
 
-  const hasMoreInfo = question.data.info ?? question.data.policyRef;
+  const hasMoreInfo = question.data?.info ?? question.data?.policyRef;
 
-  const ariaLabel = `${question.data.text}: Your answer was: ${response}. ${
+  const ariaLabel = `${question.data?.text}: Your answer was: ${response}. ${
     hasMoreInfo
       ? "Click to expand for more information about this question."
       : ""
@@ -194,22 +194,22 @@ const ResultReason: React.FC<IResultReason> = ({
                 color="textPrimary"
                 id={`questionText-${id}`}
               >
-                {question.data.text} <br />
+                {question.data?.text} <br />
                 <strong>{response}</strong>
               </Typography>
             </SummaryWrap>
           </StyledAccordionSummary>
           <AccordionDetails sx={{ py: 1, px: 0 }}>
             <MoreInfo>
-              {question.data.info && (
+              {question.data?.info && (
                 <ReactMarkdownOrHtml
-                  source={question.data.info}
+                  source={question.data?.info}
                   openLinksOnNewTab
                 />
               )}
-              {question.data.policyRef && (
+              {question.data?.policyRef && (
                 <ReactMarkdownOrHtml
-                  source={question.data.policyRef}
+                  source={question.data?.policyRef}
                   openLinksOnNewTab
                 />
               )}
@@ -223,7 +223,7 @@ const ResultReason: React.FC<IResultReason> = ({
             color="textPrimary"
             id={`questionText-${id}`}
           >
-            {question.data.text} <br />
+            {question.data?.text} <br />
             <strong>{response}</strong>
           </Typography>
         </NonExpandingSummary>
@@ -239,7 +239,7 @@ const ResultReason: React.FC<IResultReason> = ({
           >
             Change
             <span style={visuallyHidden}>
-              your response to {question.data.text || "this question"}
+              your response to {question.data?.text || "this question"}
             </span>
           </Link>
         )}

--- a/editor.planx.uk/src/@planx/components/TaskList/model.ts
+++ b/editor.planx.uk/src/@planx/components/TaskList/model.ts
@@ -5,6 +5,12 @@ export interface TaskList extends MoreInformation {
   title: string;
   description?: string;
   tasks: Array<Task>;
+  /**
+   * @deprecated Remove once migrated
+   */
+  taskList?: {
+    tasks: Array<Task>;
+  };
 }
 
 export interface Task {
@@ -15,7 +21,7 @@ export interface Task {
 export const parseTaskList = (
   data: Record<string, any> | undefined,
 ): TaskList => ({
-  tasks: /* remove once migrated */ data?.taskList?.tasks || data?.tasks || [],
+  tasks: data?.taskList?.tasks || data?.tasks || [],
   title: data?.title || "",
   description: data?.description || "",
   ...parseMoreInformation(data),

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -385,7 +385,7 @@ function Question(props: ComponentProps) {
   function getNodeText() {
     try {
       const answerId = getAnswers(props)[0];
-      return props.flow[answerId].data.text;
+      return props.flow[answerId].data?.text;
     } catch (err) {
       return "";
     }
@@ -393,11 +393,11 @@ function Question(props: ComponentProps) {
 }
 
 function FindProperty(props: ComponentProps) {
-  const { source } = props.passport.data?._address;
+  const { source } = props.passport.data?._address || {};
 
   if (source === "os") {
     const { postcode, single_line_address, town } =
-      props.passport.data?._address;
+      props.passport.data?._address || {};
     return (
       <>
         <Box component="dt">{FIND_PROPERTY_DT}</Box>
@@ -432,7 +432,7 @@ function Checklist(props: ComponentProps) {
       <Box component="dd">
         <ul>
           {getAnswers(props).map((nodeId, i: number) => (
-            <li key={i}>{props.flow[nodeId].data.text}</li>
+            <li key={i}>{props.flow[nodeId].data?.text}</li>
           ))}
         </ul>
       </Box>

--- a/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio.tsx
@@ -6,7 +6,7 @@ import Radio from "@mui/material/Radio";
 import React from "react";
 
 export interface Props {
-  id: string;
+  id?: string;
   title: string;
   onChange: FormControlLabelProps["onChange"];
   variant?: "default" | "compact";

--- a/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio.tsx
@@ -8,7 +8,7 @@ import Typography from "@mui/material/Typography";
 import React, { useLayoutEffect, useRef, useState } from "react";
 
 export interface Props {
-  id: string;
+  id?: string;
   title: string;
   description?: string;
   responseKey?: string | number;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -149,7 +149,7 @@ const Node: React.FC<any> = (props) => {
   }
 };
 
-const getSetValueText = ({ operation, fn, val }: Store.Node["data"]) => {
+const getSetValueText = ({ operation, fn, val }: Store.Node["data"] = {}) => {
   switch (operation) {
     case "append":
       return `Append ${val} to ${fn}`;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/DataDisplayMap.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/DataDisplayMap.tsx
@@ -37,7 +37,7 @@ const DISPLAY_DATA: Partial<ComponentMap> = {
       displayKey: "Option (data)",
       getTitle: ({ item }) => {
         const parentNode = useStore.getState().flow[item.parentId];
-        return parentNode.data.text;
+        return parentNode.data?.text;
       },
       getHeadline: ({ item, key }) => get(item, key)?.toString(),
     },

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
@@ -34,7 +34,7 @@ const HeaderRoot = styled(Box)(({ theme }) => ({
 }));
 
 const InternalPortalHeader: React.FC<{ portalId: string }> = ({ portalId }) => {
-  const portalName = useStore((state) => state.flow)[portalId].data.text;
+  const portalName = useStore((state) => state.flow)[portalId].data?.text;
   const Icon = ICONS[ComponentType.InternalPortal];
 
   return (

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -14,7 +14,7 @@ import {
  * Generate meaningful title for content analytic log
  */
 export function getContentTitle(node: Store.Node): string {
-  const dom = new DOMParser().parseFromString(node.data.content, "text/html");
+  const dom = new DOMParser().parseFromString(node.data?.content, "text/html");
   const h1 = dom.body.getElementsByTagName("h1")[0]?.textContent;
   const text = h1 || dom.body.textContent;
   if (!text) return `Content: ${node.id}`;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -1,6 +1,7 @@
 import {
   Node as PlanXCoreNode,
   NodeId,
+  NodeTags,
 } from "@opensystemslab/planx-core/types";
 import { isPreviewOnlyDomain } from "routes/utils";
 import { create, StoreApi, UseBoundStore } from "zustand";
@@ -36,7 +37,7 @@ export declare namespace Store {
    * @deprecated Should share type with PlanX core once `Value` is retired and Flow Graph is typed
    */
   export interface Node extends PlanXCoreNode {
-    data?: any;
+    data?: Record<string, any> & NodeTags;
   }
   export interface Passport {
     data?: Record<string, any>;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -468,13 +468,15 @@ export const previewStore: StateCreator<
                 passportValues = [passportValues];
 
               passportValues = (passportValues || []).filter((pv: any) =>
-                sortedResponses.some((r) => pv.startsWith(r.data.val)),
+                sortedResponses.some((r) => pv.startsWith(r.data?.val)),
               );
 
               if (passportValues.length > 0) {
                 responsesThatCanBeAutoAnswered = (sortedResponses || []).filter(
                   (r) => {
-                    const responseValues = String(r.data.val).split(",").sort();
+                    const responseValues = String(r.data?.val)
+                      .split(",")
+                      .sort();
                     return String(responseValues) === String(passportValues);
                   },
                 );
@@ -483,7 +485,9 @@ export const previewStore: StateCreator<
                   responsesThatCanBeAutoAnswered = (
                     sortedResponses || []
                   ).filter((r) => {
-                    const responseValues = String(r.data.val).split(",").sort();
+                    const responseValues = String(r.data?.val)
+                      .split(",")
+                      .sort();
 
                     for (const responseValue of responseValues) {
                       return passportValues.some((passportValue: any) =>
@@ -594,7 +598,6 @@ export const previewStore: StateCreator<
     // Temporarily always returns false until upcomingCardIds is optimised
     // OSL Slack explanation: https://bit.ly/3x38IRY
     return false;
-
   },
 
   restore: false,

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -1,34 +1,60 @@
-import {
-  ComponentType as TYPES,
-} from "@opensystemslab/planx-core/types";
-import AddressInput from "@planx/components/AddressInput/Public";
-import Calculate from "@planx/components/Calculate/Public";
-import Checklist from "@planx/components/Checklist/Public";
-import Confirmation from "@planx/components/Confirmation/Public";
-import ContactInput from "@planx/components/ContactInput/Public";
-import Content from "@planx/components/Content/Public";
-import DateInput from "@planx/components/DateInput/Public";
-import DrawBoundary from "@planx/components/DrawBoundary/Public";
-import FileUpload from "@planx/components/FileUpload/Public";
-import FileUploadAndLabel from "@planx/components/FileUploadAndLabel/Public";
-import FindProperty from "@planx/components/FindProperty/Public";
-import List from "@planx/components/List/Public";
-import MapAndLabel from "@planx/components/MapAndLabel/Public";
-import NextSteps from "@planx/components/NextSteps/Public";
-import Notice from "@planx/components/Notice/Public";
-import NumberInput from "@planx/components/NumberInput/Public";
-import Page from "@planx/components/Page/Public";
-import Pay from "@planx/components/Pay/Public";
-import PlanningConstraints from "@planx/components/PlanningConstraints/Public";
-import PropertyInformation from "@planx/components/PropertyInformation/Public";
-import Question from "@planx/components/Question/Public";
-import Result from "@planx/components/Result/Public";
-import Review from "@planx/components/Review/Public";
-import Section from "@planx/components/Section/Public";
-import Send from "@planx/components/Send/Public";
-import SetValue from "@planx/components/SetValue/Public";
-import TaskList from "@planx/components/TaskList/Public";
-import TextInput from "@planx/components/TextInput/Public";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import type { AddressInput } from "@planx/components/AddressInput/model";
+import AddressInputComponent from "@planx/components/AddressInput/Public";
+import type { Calculate } from "@planx/components/Calculate/model";
+import CalculateComponent from "@planx/components/Calculate/Public";
+import type { Checklist } from "@planx/components/Checklist/model";
+import ChecklistComponent from "@planx/components/Checklist/Public";
+import type { Confirmation } from "@planx/components/Confirmation/model";
+import ConfirmationComponent from "@planx/components/Confirmation/Public";
+import type { ContactInput } from "@planx/components/ContactInput/model";
+import ContactInputComponent from "@planx/components/ContactInput/Public";
+import type { Content } from "@planx/components/Content/model";
+import ContentComponent from "@planx/components/Content/Public";
+import type { DateInput } from "@planx/components/DateInput/model";
+import DateInputComponent from "@planx/components/DateInput/Public";
+import type { DrawBoundary } from "@planx/components/DrawBoundary/model";
+import DrawBoundaryComponent from "@planx/components/DrawBoundary/Public";
+import type { FileUpload } from "@planx/components/FileUpload/model";
+import FileUploadComponent from "@planx/components/FileUpload/Public";
+import type { FileUploadAndLabel } from "@planx/components/FileUploadAndLabel/model";
+import FileUploadAndLabelComponent from "@planx/components/FileUploadAndLabel/Public";
+import type { FindProperty } from "@planx/components/FindProperty/model";
+import FindPropertyComponent from "@planx/components/FindProperty/Public";
+import type { List } from "@planx/components/List/model";
+import ListComponent from "@planx/components/List/Public";
+import type { MapAndLabel } from "@planx/components/MapAndLabel/model";
+import MapAndLabelComponent from "@planx/components/MapAndLabel/Public";
+import type { NextSteps } from "@planx/components/NextSteps/model";
+import NextStepsComponent from "@planx/components/NextSteps/Public";
+import type { Notice } from "@planx/components/Notice/model";
+import NoticeComponent from "@planx/components/Notice/Public";
+import type { NumberInput } from "@planx/components/NumberInput/model";
+import NumberInputComponent from "@planx/components/NumberInput/Public";
+import type { Page } from "@planx/components/Page/model";
+import PageComponent from "@planx/components/Page/Public";
+import type { Pay } from "@planx/components/Pay/model";
+import PayComponent from "@planx/components/Pay/Public";
+import type { PlanningConstraints } from "@planx/components/PlanningConstraints/model";
+import PlanningConstraintsComponent from "@planx/components/PlanningConstraints/Public";
+import type { PropertyInformation } from "@planx/components/PropertyInformation/model";
+import PropertyInformationComponent from "@planx/components/PropertyInformation/Public";
+import type { Question } from "@planx/components/Question/model";
+import QuestionComponent from "@planx/components/Question/Public";
+import { Result } from "@planx/components/Result/model";
+import ResultComponent from "@planx/components/Result/Public";
+import type { Review } from "@planx/components/Review/model";
+import ReviewComponent from "@planx/components/Review/Public";
+import type { Section } from "@planx/components/Section/model";
+import SectionComponent from "@planx/components/Section/Public";
+import type { Send } from "@planx/components/Send/model";
+import SendComponent from "@planx/components/Send/Public";
+import type { SetValue } from "@planx/components/SetValue/model";
+import SetValueComponent from "@planx/components/SetValue/Public";
+import type { TaskList } from "@planx/components/TaskList/model";
+import TaskListComponent from "@planx/components/TaskList/Public";
+import type { TextInput } from "@planx/components/TextInput/model";
+import TextInputComponent from "@planx/components/TextInput/Public";
 import mapAccum from "ramda/src/mapAccum";
 import React from "react";
 import { exhaustiveCheck } from "utils";
@@ -41,47 +67,49 @@ export type HandleSubmit = (userData?: Store.UserData | Event) => void;
 interface Props {
   handleSubmit: HandleSubmit;
   node: Store.Node;
-  data?: any;
+  data?: Store.Node["data"];
 }
 
 const Node: React.FC<Props> = (props) => {
-  const [
-    childNodesOf,
-    isFinalCard,
-    resetPreview,
-    cachedBreadcrumbs,
-  ] = useStore((state) => [
-    state.childNodesOf,
-    state.isFinalCard(),
-    state.resetPreview,
-    state.cachedBreadcrumbs,
-  ]);
+  const [childNodesOf, isFinalCard, resetPreview, cachedBreadcrumbs] = useStore(
+    (state) => [
+      state.childNodesOf,
+      state.isFinalCard(),
+      state.resetPreview,
+      state.cachedBreadcrumbs,
+    ],
+  );
 
   const handleSubmit = isFinalCard ? undefined : props.handleSubmit;
 
   const nodeId = props.node.id;
   const previouslySubmittedData =
     nodeId && cachedBreadcrumbs ? cachedBreadcrumbs[nodeId] : undefined;
-  const allProps = {
+
+  const getComponentProps = <T extends object>() => ({
     id: nodeId,
-    ...props.node.data,
     previouslySubmittedData,
     resetPreview,
     handleSubmit,
-  };
+    ...(props.node.data as T),
+  });
 
   switch (props.node.type) {
     case TYPES.Calculate:
-      return <Calculate {...allProps} />;
+      return <CalculateComponent {...getComponentProps<Calculate>()} />;
 
     case TYPES.Checklist: {
-      const childNodes = childNodesOf(props.node.id);
+      const checklistProps = getComponentProps<Checklist>();
+      const childNodes = childNodesOf(
+        props.node.id,
+      ) as (typeof checklistProps)["options"];
+
       return (
-        <Checklist
-          {...allProps}
-          options={allProps.categories ? undefined : childNodes}
+        <ChecklistComponent
+          {...checklistProps}
+          options={checklistProps.categories ? undefined : childNodes}
           groupedOptions={
-            !allProps.categories
+            !checklistProps.categories
               ? undefined
               : mapAccum(
                   (
@@ -91,11 +119,12 @@ const Node: React.FC<Props> = (props) => {
                     index + category.count,
                     {
                       title: category.title,
-                      children: childNodes.slice(index, index + category.count),
+                      children:
+                        childNodes?.slice(index, index + category.count) || [],
                     },
                   ],
                   0,
-                  allProps.categories,
+                  checklistProps.categories,
                 )[1]
           }
         />
@@ -103,66 +132,70 @@ const Node: React.FC<Props> = (props) => {
     }
 
     case TYPES.Confirmation:
-      return <Confirmation {...allProps} />;
+      return <ConfirmationComponent {...getComponentProps<Confirmation>()} />;
 
     case TYPES.Content:
-      return <Content {...allProps} />;
+      return <ContentComponent {...getComponentProps<Content>()} />;
 
     case TYPES.DateInput:
-      return <DateInput {...allProps} />;
+      return <DateInputComponent {...getComponentProps<DateInput>()} />;
 
     case TYPES.DrawBoundary:
-      return <DrawBoundary {...allProps} />;
+      return <DrawBoundaryComponent {...getComponentProps<DrawBoundary>()} />;
 
     case TYPES.FileUpload:
-      return <FileUpload {...allProps} />;
+      return <FileUploadComponent {...getComponentProps<FileUpload>()} />;
 
     case TYPES.FileUploadAndLabel:
-      return <FileUploadAndLabel {...allProps} />;
+      return (
+        <FileUploadAndLabelComponent
+          {...getComponentProps<FileUploadAndLabel>()}
+        />
+      );
 
     case TYPES.FindProperty:
-      return <FindProperty {...allProps} />;
+      return <FindPropertyComponent {...getComponentProps<FindProperty>()} />;
 
     case TYPES.List:
-      return <List {...allProps} />;
+      return <ListComponent {...getComponentProps<List>()} />;
 
     case TYPES.MapAndLabel:
-      return <MapAndLabel {...allProps} />;
+      return <MapAndLabelComponent {...getComponentProps<MapAndLabel>()} />;
 
     case TYPES.NextSteps:
-      return <NextSteps {...allProps} />;
+      return <NextStepsComponent {...getComponentProps<NextSteps>()} />;
 
     case TYPES.Notice:
-      return <Notice {...allProps} />;
+      return <NoticeComponent {...getComponentProps<Notice>()} />;
 
     case TYPES.NumberInput:
-      return <NumberInput {...allProps} />;
+      return <NumberInputComponent {...getComponentProps<NumberInput>()} />;
 
     case TYPES.Page:
-      return <Page {...allProps} />;
+      return <PageComponent {...getComponentProps<Page>()} />;
 
     case TYPES.Pay:
-      return <Pay {...allProps} />;
+      return <PayComponent {...getComponentProps<Pay>()} />;
 
     case TYPES.Result:
-      return <Result {...allProps} />;
+      return <ResultComponent {...getComponentProps<Result>()} />;
 
     case TYPES.Review:
-      return <Review {...allProps} />;
+      return <ReviewComponent {...getComponentProps<Review>()} />;
 
     case TYPES.Section:
-      return <Section {...allProps} />;
+      return <SectionComponent {...getComponentProps<Section>()} />;
 
     case TYPES.Send:
-      return <Send {...allProps} />;
+      return <SendComponent {...getComponentProps<Send>()} />;
 
     case TYPES.SetValue:
-      return <SetValue {...allProps} />;
+      return <SetValueComponent {...getComponentProps<SetValue>()} />;
 
     case TYPES.Question:
       return (
-        <Question
-          {...allProps}
+        <QuestionComponent
+          {...getComponentProps<Question>()}
           responses={childNodesOf(props.node.id).map((n, i) => ({
             id: n.id,
             responseKey: i + 1,
@@ -172,31 +205,39 @@ const Node: React.FC<Props> = (props) => {
         />
       );
 
-    case TYPES.TaskList:
+    case TYPES.TaskList: {
+      const taskListProps = getComponentProps<TaskList>();
+
       return (
-        <TaskList
-          {...allProps}
-          tasks={
-            // Remove once migrated
-            allProps.taskList?.tasks || allProps.tasks
-          }
+        <TaskListComponent
+          {...taskListProps}
+          tasks={taskListProps.taskList?.tasks || taskListProps.tasks}
+        />
+      );
+    }
+
+    case TYPES.TextInput:
+      return <TextInputComponent {...getComponentProps<TextInput>()} />;
+
+    case TYPES.AddressInput:
+      return <AddressInputComponent {...getComponentProps<AddressInput>()} />;
+
+    case TYPES.ContactInput:
+      return <ContactInputComponent {...getComponentProps<ContactInput>()} />;
+
+    case TYPES.PlanningConstraints:
+      return (
+        <PlanningConstraintsComponent
+          {...getComponentProps<PlanningConstraints>()}
         />
       );
 
-    case TYPES.TextInput:
-      return <TextInput {...allProps} />;
-
-    case TYPES.AddressInput:
-      return <AddressInput {...allProps} />;
-
-    case TYPES.ContactInput:
-      return <ContactInput {...allProps} />;
-
-    case TYPES.PlanningConstraints:
-      return <PlanningConstraints {...allProps} />;
-
     case TYPES.PropertyInformation:
-      return <PropertyInformation {...allProps} />;
+      return (
+        <PropertyInformationComponent
+          {...getComponentProps<PropertyInformation>()}
+        />
+      );
 
     case TYPES.ExternalPortal:
     case TYPES.Filter:


### PR DESCRIPTION
## What does this PR do?
- Adds `NodeTags` to `Store.Node["data"]`
- Final batch of TS updates in order to use NodeTags across all component types (I believe!)

Most of this is type updates, the two actual changes are highlighted below - 

https://github.com/theopensystemslab/planx-new/blob/0a1cbc68da8a5f3867b41756083aecd2dda7bd31/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts#L39-L41

https://github.com/theopensystemslab/planx-new/blob/0a1cbc68da8a5f3867b41756083aecd2dda7bd31/editor.planx.uk/src/pages/Preview/Node.tsx#L67-L71

## Next steps...
- Add form field for tags to each component (hopefully via `EditorProps<T>` or similar)
- Placeholder UI to add tag in-Editor