### PR TITLE
feat: Environment dependant header chip styling

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -2,6 +2,7 @@ import Edit from "@mui/icons-material/Edit";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
 import Person from "@mui/icons-material/Person";
 import Visibility from "@mui/icons-material/Visibility";
 import AppBar from "@mui/material/AppBar";
@@ -432,15 +433,25 @@ const PublicToolbar: React.FC<{
 
 const ServiceTitle: React.FC = () => {
   const flowName = useStore((state) => state.flowName);
+  const route = useCurrentRoute();
+  const path = route.url.pathname.split("/").slice(-1)[0];
 
   return (
     <ServiceTitleRoot data-testid="service-title">
-      <Chip
-        label="Preview"
-        variant="notApplicableTag"
-        size="medium"
-        icon={<OpenInNewIcon />}
-      />
+      {(path === "preview" || path === "draft") && (
+        <Chip
+          label={capitalize(path)}
+          variant="notApplicableTag"
+          size="medium"
+          icon={
+            path === "preview" ? (
+              <OpenInNewIcon fontSize="small" />
+            ) : (
+              <OpenInNewOffIcon fontSize="small" />
+            )
+          }
+        />
+      )}
       <Typography component="span" variant="h4">
         {flowName}
       </Typography>

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -444,11 +444,10 @@ const ServiceTitle: React.FC = () => {
           variant="notApplicableTag"
           size="medium"
           icon={
-            path === "preview" ? (
-              <OpenInNewIcon fontSize="small" />
-            ) : (
-              <OpenInNewOffIcon fontSize="small" />
-            )
+            {
+              preview: <OpenInNewIcon fontSize="small" />,
+              draft: <OpenInNewOffIcon fontSize="small" />,
+            }[path]
           }
         />
       )}

--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -1,11 +1,13 @@
 import Edit from "@mui/icons-material/Edit";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import MenuOpenIcon from "@mui/icons-material/MenuOpen";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Person from "@mui/icons-material/Person";
 import Visibility from "@mui/icons-material/Visibility";
 import AppBar from "@mui/material/AppBar";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
 import { grey } from "@mui/material/colors";
 import Container from "@mui/material/Container";
 import IconButton from "@mui/material/IconButton";
@@ -172,6 +174,8 @@ const SkipLink = styled("a")(({ theme }) => ({
 
 const ServiceTitleRoot = styled("span")(({ theme }) => ({
   display: "flex",
+  alignItems: "center",
+  gap: theme.spacing(1),
   flexGrow: 1,
   flexShrink: 1,
   lineHeight: LINE_HEIGHT_BASE,
@@ -431,6 +435,12 @@ const ServiceTitle: React.FC = () => {
 
   return (
     <ServiceTitleRoot data-testid="service-title">
+      <Chip
+        label="Preview"
+        variant="notApplicableTag"
+        size="medium"
+        icon={<OpenInNewIcon />}
+      />
       <Typography component="span" variant="h4">
         {flowName}
       </Typography>


### PR DESCRIPTION
## What does this PR do?

Adds a chip to the service title to flag whether a preview or draft service is being viewed.

Summary of changes:

- Chip is display depending on path being `draft` or `preview`
- Icon updated based on path
- Header height is not affected (except in cases of earlier text-wrap for longer titles on smaller screens)

**Demo:**
[Draft environment](https://3717.planx.pizza/buckinghamshire/report-a-planning-breach/draft)
[Preview environment](https://3717.planx.pizza/buckinghamshire/report-a-planning-breach/preview)
[Published environment](https://3717.planx.pizza/buckinghamshire/report-a-planning-breach/published?analytics=false) (no change)

**Preview:**

![image](https://github.com/user-attachments/assets/acd1dad1-780e-47e1-be20-404dd909096a)
