### PR TITLE
feat: Add loading spinner to search bar

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -1,11 +1,12 @@
 import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { useSearch } from "hooks/useSearch";
 import { debounce } from "lodash";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import ChecklistItem from "ui/shared/ChecklistItem";
 import Input from "ui/shared/Input";
 
@@ -25,6 +26,8 @@ const Search: React.FC = () => {
     state.orderedFlow,
     state.setOrderedFlow,
   ]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [lastSearchedTerm, setLastSearchedTerm] = useState("");
 
   useEffect(() => {
     if (!orderedFlow) setOrderedFlow();
@@ -46,10 +49,18 @@ const Search: React.FC = () => {
     () =>
       debounce((pattern: string) => {
         console.debug("Search term: ", pattern);
-        return search(pattern);
+        search(pattern);
+        setLastSearchedTerm(pattern);
+        setIsSearching(false);
       }, DEBOUNCE_MS),
     [search],
   );
+
+  useEffect(() => {
+    if (formik.values.pattern !== lastSearchedTerm) {
+      setIsSearching(true);
+    }
+  }, [formik.values.pattern, lastSearchedTerm]);
 
   return (
     <Container component={Box} p={3}>
@@ -63,16 +74,30 @@ const Search: React.FC = () => {
         >
           Search this flow and internal portals
         </Typography>
-        <Input
-          id="pattern"
-          name="pattern"
-          value={formik.values.pattern}
-          onChange={(e) => {
-            formik.setFieldValue("pattern", e.target.value);
-            formik.handleSubmit();
-          }}
-          inputProps={{ spellCheck: false }}
-        />
+        <Box
+          sx={{ display: "flex", position: "relative", alignItems: "center" }}
+        >
+          <Input
+            id="pattern"
+            name="pattern"
+            value={formik.values.pattern}
+            onChange={(e) => {
+              formik.setFieldValue("pattern", e.target.value);
+              formik.handleSubmit();
+            }}
+            inputProps={{ spellCheck: false }}
+          />
+          {isSearching && (
+            <CircularProgress
+              size={25}
+              sx={(theme) => ({
+                position: "absolute",
+                right: theme.spacing(1.5),
+                zIndex: 1,
+              })}
+            />
+          )}
+        </Box>
         <ChecklistItem
           label="Search only data fields"
           id={"search-data-field-facet"}


### PR DESCRIPTION
## What does this PR do?
 - Adds a loading spinner to the search bar whilst the debounce is happening, to provider better user feedback
 - Follow up to https://github.com/theopensystemslab/planx-new/pull/3703

No strong feelings about the UI, the logic here to capture `isSearching` could be used to add opacity to the current search results, or anything else to indicate staleness also.

https://github.com/user-attachments/assets/2307e86e-bf77-42d8-9357-fe614cca3e86

