### PR TITLE
feat: add "Save" button to MapAndLabel tabs

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -34,6 +34,7 @@ interface MapAndLabelContextValue {
   addInitialFeaturesToMap: (features: Feature[]) => void;
   editFeature: (index: number) => void;
   copyFeature: (sourceIndex: number, destinationIndex: number) => void;
+  saveFeature: (index: number) => void;
   removeFeature: (index: number) => void;
   mapAndLabelProps: PresentationalProps;
   errors: {
@@ -218,6 +219,11 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     setActiveIndex((features && features.length - 2) || 0);
   };
 
+  const saveFeature = (index: number) => {
+    // TODO separate schema field validation from "Continue"
+    formik.handleSubmit();
+  };
+
   return (
     <MapAndLabelContext.Provider
       value={{
@@ -231,6 +237,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
         addInitialFeaturesToMap,
         editFeature,
         copyFeature,
+        saveFeature,
         removeFeature,
         isFeatureInvalid,
         errors: {

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -64,6 +64,7 @@ const VerticalFeatureTabs: React.FC = () => {
     editFeature,
     isFeatureInvalid,
     removeFeature,
+    saveFeature,
   } = useMapAndLabelContext();
 
   if (!features) {
@@ -165,17 +166,23 @@ const VerticalFeatureTabs: React.FC = () => {
               activeIndex={activeIndex}
               formik={formik}
             />
-            <Button
-              onClick={() => removeFeature(activeIndex)}
-              sx={{
-                fontWeight: FONT_WEIGHT_SEMI_BOLD,
-                gap: (theme) => theme.spacing(2),
-                marginTop: 2,
-              }}
-            >
-              <DeleteIcon color="warning" fontSize="medium" />
-              Remove
-            </Button>
+            <Box display="flex" gap={2} mt={2}>
+              <Button
+                variant="contained"
+                color="primary"
+                data-testid="save-item-button"
+                onClick={() => saveFeature(activeIndex)}
+              >
+                Save
+              </Button>
+              <Button
+                onClick={() => removeFeature(activeIndex)}
+                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+              >
+                <DeleteIcon color="warning" fontSize="medium" />
+                Remove
+              </Button>
+            </Box>
           </TabPanel>
         ))}
       </TabContext>


### PR DESCRIPTION
Adds an explicit "Save" button to each tab per user research feedback.

Intention is that "Save" will run schema validation for the active tab only and display field errors.

![Screenshot from 2024-09-22 21-59-57](https://github.com/user-attachments/assets/68ad8d81-520f-48cc-979e-197aae75d06e)

Open questions:
- "List" uses "Save"/"Cancel" for active items, and "Edit"/"Remove" for inactive items - but we _only_ have a single state of each tab here, is it okay to present "Save" & "Remove" _without_ "Cancel" ? 
- Similarly, is "Save" actually too misleading here - eg do you expect your progress to be saved _before_ "Continuing" if you were to "Save & resume" midway through filling out trees tabs because you "Saved" individual tabs?