### PR TITLE
chore: Create shared `Category` type

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -25,16 +25,16 @@ import InputRowItem from "ui/shared/InputRowItem";
 import { Option, parseMoreInformation } from "../shared";
 import PermissionSelect from "../shared/PermissionSelect";
 import { ICONS, InternalNotes, MoreInformation } from "../ui";
-import type { Checklist, Group } from "./model";
+import type { Category, Checklist, Group } from "./model";
 import { toggleExpandableChecklist } from "./model";
 
-interface ChecklistProps extends Checklist {
+export interface ChecklistProps extends Checklist {
   text: string;
   handleSubmit?: Function;
   node?: {
     data?: {
       allRequired?: boolean;
-      categories?: any;
+      categories?: Array<Category>;
       definitionImg?: string;
       description?: string;
       fn?: string;

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -8,6 +8,11 @@ export interface Group<T> {
   children: Array<T>;
 }
 
+export interface Category {
+  title: string;
+  count: number;
+}
+
 export interface Checklist extends MoreInformation {
   fn?: string;
   description?: string;
@@ -16,6 +21,7 @@ export interface Checklist extends MoreInformation {
   groupedOptions?: Array<Group<Option>>;
   img?: string;
   allRequired?: boolean;
+  categories?: Array<Category>;
 }
 
 interface ChecklistExpandableProps {


### PR DESCRIPTION
## What?
 - Creates a shared `Category` type, which is shared within the `Checklist` component

## Why?
https://github.com/theopensystemslab/planx-new/pull/3716 has slightly descended into a large messy type fixing PR which I was trying to avoid. I'm splitting it up into smaller, more atomic, PRs in order to better highlight and track the actual important changes.