### PR TITLE
chore: Create model file for `Question`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
@@ -4,9 +4,10 @@ import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
-import Question, { IQuestion, QuestionLayout } from "./Public";
+import type { Question } from "./model";
+import QuestionComponent, { QuestionLayout } from "./Public";
 
-const responses: { [key in QuestionLayout]: IQuestion["responses"] } = {
+const responses: { [key in QuestionLayout]: Question["responses"] } = {
   [QuestionLayout.Basic]: [
     {
       id: "pizza_id",
@@ -59,7 +60,7 @@ describe("Question component", () => {
         const handleSubmit = vi.fn();
 
         const { user, getByTestId, getByRole, getByText } = setup(
-          <Question
+          <QuestionComponent
             text="Best food"
             responses={responses[type]}
             handleSubmit={handleSubmit}
@@ -82,7 +83,7 @@ describe("Question component", () => {
       it(`should display previously selected answer on back or change`, async () => {
         const handleSubmit = vi.fn();
         const { user, getByRole, getByTestId } = setup(
-          <Question
+          <QuestionComponent
             text="Best food"
             responses={responses[type]}
             previouslySubmittedData={{
@@ -112,7 +113,7 @@ describe("Question component", () => {
       it(`should not have any accessibility violations`, async () => {
         const handleSubmit = vi.fn();
         const { container } = setup(
-          <Question
+          <QuestionComponent
             text="Best food"
             responses={responses[type]}
             handleSubmit={handleSubmit}
@@ -127,7 +128,7 @@ describe("Question component", () => {
         const errorMessage = /Select your answer before continuing/;
 
         const { user, getByTestId, getByText, queryByText } = setup(
-          <Question
+          <QuestionComponent
             text="Best food"
             responses={responses[type]}
             handleSubmit={handleSubmit}

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -9,33 +9,13 @@ import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
 import DescriptionRadio from "@planx/components/shared/Radio/DescriptionRadio";
 import ImageRadio from "@planx/components/shared/Radio/ImageRadio";
 import { useFormik } from "formik";
-import { Store } from "pages/FlowEditor/lib/store";
-import { HandleSubmit } from "pages/Preview/Node";
 import React from "react";
 import FormWrapper from "ui/public/FormWrapper";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { mixed, object, string } from "yup";
 
-export interface IQuestion {
-  id?: string;
-  text?: string;
-  description?: string;
-  info?: string;
-  policyRef?: string;
-  howMeasured?: string;
-  definitionImg?: string;
-  img?: string;
-  responses: {
-    id: string;
-    responseKey: string | number;
-    title: string;
-    description?: string;
-    img?: string;
-  }[];
-  previouslySubmittedData?: Store.UserData;
-  handleSubmit: HandleSubmit;
-}
+import { Question } from "../model";
 
 export enum QuestionLayout {
   Basic,
@@ -43,7 +23,7 @@ export enum QuestionLayout {
   Descriptions,
 }
 
-const Question: React.FC<IQuestion> = (props) => {
+const QuestionComponent: React.FC<Question> = (props) => {
   const previousResponseId = props?.previouslySubmittedData?.answers?.[0];
   const previousResponseKey = props.responses.find(
     (response) => response.id === previousResponseId,
@@ -170,4 +150,4 @@ const Question: React.FC<IQuestion> = (props) => {
   );
 };
 
-export default Question;
+export default QuestionComponent;

--- a/editor.planx.uk/src/@planx/components/Question/model.ts
+++ b/editor.planx.uk/src/@planx/components/Question/model.ts
@@ -1,0 +1,22 @@
+import { Store } from "pages/FlowEditor/lib/store";
+import { HandleSubmit } from "pages/Preview/Node";
+
+export interface Question {
+  id?: string;
+  text?: string;
+  description?: string;
+  info?: string;
+  policyRef?: string;
+  howMeasured?: string;
+  definitionImg?: string;
+  img?: string;
+  responses: {
+    id: string;
+    responseKey: string | number;
+    title: string;
+    description?: string;
+    img?: string;
+  }[];
+  previouslySubmittedData?: Store.UserData;
+  handleSubmit: HandleSubmit;
+}


### PR DESCRIPTION
## What?
 - Moves `Question` to its own `model.ts` file

## Why?
https://github.com/theopensystemslab/planx-new/pull/3716 has slightly descended into a large messy type fixing PR which I was trying to avoid. I'm splitting it up into smaller, more atomic, PRs in order to better highlight and track the actual important changes.