### PR TITLE
fix: Set `flowId` in `flowEditorView`

### DIFF
--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -8,6 +8,7 @@ import { client } from "../lib/graphql";
 import { useStore } from "../pages/FlowEditor/lib/store";
 import Team from "../pages/Team";
 import { makeTitle } from "./utils";
+import { getFlowEditorData } from "./views/flowEditor";
 import { teamView } from "./views/team";
 
 let cached: { flowSlug?: string; teamSlug?: string } = {
@@ -17,7 +18,9 @@ let cached: { flowSlug?: string; teamSlug?: string } = {
 
 const setFlowAndLazyLoad = (importComponent: Parameters<typeof lazy>[0]) => {
   return map(async (request) => {
-    useStore.getState().setFlowSlug(request.params.flow);
+    const data = await getFlowEditorData(request.params.flow, request.params.team);
+    useStore.setState({ ...data, flowSlug: request.params.flow });
+    
     return lazy(importComponent);
   });
 };

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -7,13 +7,15 @@ import { View } from "react-navi";
 import { client } from "../../lib/graphql";
 import { useStore } from "../../pages/FlowEditor/lib/store";
 
-interface FlowMetadata {
+interface FlowEditorData {
+  id: string,
   flowAnalyticsLink: string;
   isFlowPublished: boolean;
 }
 
-interface GetFlowMetadata {
+interface GetFlowEditorData {
   flows: {
+    id: string,
     flowAnalyticsLink: string;
     publishedFlowsAggregate: {
       aggregate: {
@@ -23,13 +25,13 @@ interface GetFlowMetadata {
   }[];
 }
 
-const getFlowMetadata = async (
+export const getFlowEditorData = async (
   flowSlug: string,
   team: string,
-): Promise<FlowMetadata> => {
+): Promise<FlowEditorData> => {
   const {
     data: { flows },
-  } = await client.query<GetFlowMetadata>({
+  } = await client.query<GetFlowEditorData>({
     query: gql`
       query GetFlowMetadata($slug: String!, $team_slug: String!) {
         flows(
@@ -55,11 +57,13 @@ const getFlowMetadata = async (
   const flow = flows[0];
   if (!flows) throw new NotFoundError(`Flow ${flowSlug} not found for ${team}`);
 
-  const metadata = {
+  const flowEditorData: FlowEditorData = {
+    id: flow.id,
     flowAnalyticsLink: flow.flowAnalyticsLink,
     isFlowPublished: flow.publishedFlowsAggregate?.aggregate.count > 0,
   };
-  return metadata;
+
+  return flowEditorData;
 };
 
 /**
@@ -67,11 +71,11 @@ const getFlowMetadata = async (
  */
 export const flowEditorView = async (req: NaviRequest) => {
   const [flow] = req.params.flow.split(",");
-  const { flowAnalyticsLink, isFlowPublished } = await getFlowMetadata(
+  const { id, flowAnalyticsLink, isFlowPublished } = await getFlowEditorData(
     flow,
     req.params.team,
   );
-  useStore.setState({ flowAnalyticsLink, isFlowPublished });
+  useStore.setState({ id, flowAnalyticsLink, isFlowPublished });
 
   return (
     <FlowEditorLayout>


### PR DESCRIPTION
## What?
Sets the `flowId` variable in the store when the `flowEditorView` is loaded.

## Why?
This fixes a small bug I just hit. To recreate - 
 - Navigate to a team > flow > settings
 - Turning flow online/offline works fine as we've set the flowId on the main flow page
 - Refresh page
 - `flowId` not set as we've gone directly to the settings page
 - Turning flow online/offline fails as there's no `flowId` set

Still going to look into why the GraphQL error that's thrown in not being caught correctly!