### PR TITLE
refactor: Simplify and improve description radio layout

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -108,7 +108,7 @@ const Question: React.FC<IQuestion> = (props) => {
             >
               <Grid
                 container
-                spacing={layout === QuestionLayout.Basic ? 0 : 2}
+                spacing={layout === QuestionLayout.Images ? 2 : 0}
                 alignItems="stretch"
               >
                 {props.responses?.map((response) => {
@@ -136,16 +136,16 @@ const Question: React.FC<IQuestion> = (props) => {
                       );
                     case QuestionLayout.Descriptions:
                       return (
-                        <Grid
-                          item
-                          xs={12}
-                          sm={6}
-                          contentWrap={4}
-                          key={response.id}
-                          data-testid="description-radio"
-                        >
-                          <DescriptionRadio {...buttonProps} {...response} />
-                        </Grid>
+                        <FormWrapper key={`wrapper-${response.id}`}>
+                          <Grid
+                            item
+                            xs={12}
+                            key={`grid-${response.id}`}
+                            data-testid="description-radio"
+                          >
+                            <DescriptionRadio {...buttonProps} {...response} />
+                          </Grid>
+                        </FormWrapper>
                       );
                     case QuestionLayout.Images:
                       return (

--- a/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio.tsx
@@ -23,7 +23,13 @@ const BasicRadio: React.FC<Props> = ({
     onChange={onChange}
     control={<Radio variant={variant} />}
     label={title}
-    sx={variant === "default" ? { pb: 1 } : {}}
+    sx={(theme) => ({
+      mb: variant === "default" ? 1 : 0,
+      alignItems: "flex-start",
+      ".MuiFormControlLabel-label": {
+        paddingTop: theme.spacing(0.95),
+      },
+    })}
   />
 );
 

--- a/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio.tsx
@@ -1,6 +1,7 @@
 import FormControlLabel, {
   FormControlLabelProps,
 } from "@mui/material/FormControlLabel";
+import { formControlLabelClasses } from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import React from "react";
 
@@ -26,7 +27,7 @@ const BasicRadio: React.FC<Props> = ({
     sx={(theme) => ({
       mb: variant === "default" ? 1 : 0,
       alignItems: "flex-start",
-      ".MuiFormControlLabel-label": {
+      [`& .${formControlLabelClasses.label}`]: {
         paddingTop: theme.spacing(0.95),
       },
     })}

--- a/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import FormLabel from "@mui/material/FormLabel";
 import Radio, { RadioProps } from "@mui/material/Radio";
-import { useRadioGroup } from "@mui/material/RadioGroup";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
@@ -13,25 +12,10 @@ export interface Props {
   onChange: RadioProps["onChange"];
 }
 
-interface StyledFormLabelProps {
-  isSelected: boolean;
-}
-
-const StyledFormLabel = styled(FormLabel, {
-  shouldForwardProp: (prop) => prop !== "isSelected",
-})<StyledFormLabelProps>(({ theme, isSelected }) => ({
-  border: "2px solid",
-  borderColor: isSelected
-    ? theme.palette.primary.main
-    : theme.palette.border.main,
-  padding: theme.spacing(1.5),
+const StyledFormLabel = styled(FormLabel)(({ theme }) => ({
+  display: "flex",
+  marginBottom: theme.spacing(1),
   cursor: "pointer",
-  display: "block",
-  height: "100%",
-  color: theme.palette.text.primary,
-  "& > p": {
-    color: theme.palette.text.secondary,
-  },
 }));
 
 const DescriptionRadio: React.FC<Props> = ({
@@ -40,16 +24,17 @@ const DescriptionRadio: React.FC<Props> = ({
   onChange,
   id,
 }) => {
-  const radioGroupState = useRadioGroup();
-  const isSelected = radioGroupState?.value === id;
-
   return (
-    <StyledFormLabel focused={false} isSelected={isSelected}>
-      <Box sx={{ paddingBottom: 1, display: "flex", alignItems: "center" }}>
-        <Radio value={id} onChange={onChange} />
-        <Typography variant="body1">{title}</Typography>
+    <StyledFormLabel focused={false}>
+      <Radio value={id} onChange={onChange} />
+      <Box>
+        <Typography color="text.primary" variant="body1" pt={0.95}>
+          {title}
+        </Typography>
+        <Typography variant="body2" pt={0.5}>
+          {description}
+        </Typography>
       </Box>
-      <Typography variant="body2">{description}</Typography>
     </StyledFormLabel>
   );
 };


### PR DESCRIPTION
## What does this PR do?

An overdue change — simplifies questions/radios so that they are no longer placed in a 3 column-grid with border when a description is present. Follows the GOV.UK pattern: https://design-system.service.gov.uk/components/radios/#radio-items-with-hints

Image radios are still gridded for now (to be explored as a further design challenge as we are not following a GOV.UK content pattern).

**Preview:**
https://3729.planx.pizza/testing/question-layouts/preview

**Before:**
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/601de6b8-0d8a-4cd9-a5bf-8abeebf1d6dd">

**After:**
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/f925d64f-dfe2-4e92-8b42-df52d52345cf">
