### PR TITLE
fix: `computePassport()` bug which prevents Save & Return, or a "resume" journey after GovPay

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/computePassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/computePassport.test.ts
@@ -1,0 +1,67 @@
+import { FullStore, useStore } from "../store";
+import { flowWithDuplicatePassportVars } from "./mocks/computePassport/flowWithDuplicatePassportVars";
+
+const { getState, setState } = useStore;
+
+const { computePassport } = getState();
+
+let initialState: FullStore;
+
+beforeEach(() => {
+  initialState = getState();
+});
+
+afterEach(() => setState(initialState));
+
+describe("breadcrumbs where multiple nodes set the same passport value", () => {
+  const breadcrumbs = {
+    sIipiCHueb: {
+      auto: false,
+      data: {
+        "application.information.sensitive": "test",
+      },
+    },
+    "4oH6eI9TMm": {
+      auto: false,
+      answers: ["XZlpeuJt9o"],
+    },
+  };
+
+  it("returns an array of both values", () => {
+    setState({ flow: flowWithDuplicatePassportVars, breadcrumbs });
+    const duplicateKey = "application.information.sensitive";
+
+    const output = computePassport();
+    expect(output.data).toHaveProperty(duplicateKey);
+    expect(output.data?.[duplicateKey]).toEqual(expect.arrayContaining(["test", "true"]));
+  });
+
+  it.skip("returns an array of both values, irrespective of the order of the breadcrumbs", () => {
+    const breadcrumbs = {
+      "4oH6eI9TMm": {
+        auto: false,
+        answers: ["XZlpeuJt9o"],
+      },
+      sIipiCHueb: {
+        auto: false,
+        data: {
+          "application.information.sensitive": "test",
+        },
+      },
+    };
+
+    setState({ flow: flowWithDuplicatePassportVars, breadcrumbs });
+    const duplicateKey = "application.information.sensitive";
+
+    const output = computePassport();
+    expect(output.data).toHaveProperty(duplicateKey);
+
+    // Currently returning this value
+    expect(output.data?.[duplicateKey]).toEqual("test")
+
+    // But I think we should expect this?
+    expect(output.data?.[duplicateKey]).toEqual(
+      expect.arrayContaining(["test", "true"])
+    );
+  });
+});

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/computePassport/flowWithDuplicatePassportVars.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/computePassport/flowWithDuplicatePassportVars.ts
@@ -1,0 +1,54 @@
+import { Store } from "pages/FlowEditor/lib/store"
+
+export const flowWithDuplicatePassportVars: Store.Flow = {
+  _root: {
+    edges: [
+      "4oH6eI9TMm",
+      "CTW66QO1Aq"
+    ]
+  },
+  "4oH6eI9TMm": {
+    data: {
+      fn: "application.information.sensitive",
+      text: "Is any of the information you have provided sensitive?"
+    },
+    type: 100,
+    edges: [
+      "XZlpeuJt9o",
+      "5fh40KCyTJ"
+    ]
+  },
+  "5fh40KCyTJ": {
+    data: {
+      val: "false",
+      text: "No"
+    },
+    type: 200
+  },
+  CTW66QO1Aq: {
+    data: {
+      color: "#EFEFEF",
+      title: "The end",
+      resetButton: false
+    },
+    type: 8
+  },
+  XZlpeuJt9o: {
+    data: {
+      val: "true",
+      text: "Yes"
+    },
+    type: 200,
+    edges: [
+      "sIipiCHueb"
+    ]
+  },
+  sIipiCHueb: {
+    data: {
+      fn: "application.information.sensitive",
+      type: "long",
+      title: "What is it about the information that makes it sensitive?"
+    },
+    type: 110
+  }
+};

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -231,8 +231,8 @@ export const previewStore: StateCreator<
           if (passportValue.length > 0) {
             const existingValue = acc.data?.[key] ?? [];
 
-            const combined = existingValue
-              .concat(passportValue)
+            const combined = passportValue
+              .concat(existingValue)
               .reduce(
                 (acc: string[], curr: string, _i: number, arr: string[]) => {
                   if (!arr.some((x) => x !== curr && x.startsWith(curr))) {


### PR DESCRIPTION
## What's the problem?
This bug has been seen a number of times in Airbrake, but most noticeably has appeared as an issue here (OSL Slack) - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1726739984279969

Here's how the bug appears - 
 - A flow has multiple questions which use the same data variables, across different component types
   - One is a text node, which outputs a `string` to the passport
   - One is a question node, which outputs a `string[]` to the passport
 - In the flow, these appear in the correct order (guard question + more info text, see example linked below)
 - One a user resumes (e.g. after pay, or after save & return), their breadcrumbs have done a round trip to the database and are no longer stored locally. This means they go from the key order being insertion based, to alphabetically sorted keys (see `stringifyWithRootKeysSortedAlphabetically()`)
 - After breadcrumb keys are re-ordered, `computePassport()` fails to generate a passport after this

## What's the solution?
- Please see comment on code!

## Questions / Next steps...
- Do we still need to be using `stringifyWithRootKeysSortedAlphabetically()`? Is there a better solution?
- This wasn't caught by TS as the graph and data are still untyped - we need to get to grips with this one sooner rather than later I think.
- Do we need a validation check for repeated variables, across different component types? Would this even work?
- What is the desired behaviour here? New unit tests describe what currently happens, which is a different passports based on the order of breadcrumbs - I don't think this is what we ever want, but I've prioritised the actual fix over a wider look at how `computePassport()` looks.