### PR TITLE
fix: Flow slug in header breadcrumbs

### DIFF
--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -17,12 +17,21 @@ let cached: { flowSlug?: string; teamSlug?: string } = {
 };
 
 const setFlowAndLazyLoad = (importComponent: Parameters<typeof lazy>[0]) => {
-  return map(async (request) => {
-    const data = await getFlowEditorData(request.params.flow, request.params.team);
-    useStore.setState({ ...data, flowSlug: request.params.flow });
-    
-    return lazy(importComponent);
-  });
+  return compose(
+    withData((req) => ({
+      flow: req.params.flow.split(",")[0],
+    })),
+
+    map(async (request) => {
+      const data = await getFlowEditorData(
+        request.params.flow,
+        request.params.team,
+      );
+      useStore.setState({ ...data, flowSlug: request.params.flow });
+
+      return lazy(importComponent);
+    }),
+  );
 };
 
 const routes = compose(


### PR DESCRIPTION
## What does this PR do?
 - Ensures that the flow slug always displays in the header breadcrumbs when on a settings page
 - Regression introduced as part of recent route refactors (sorry!)

<img width="714" alt="image" src="https://github.com/user-attachments/assets/8b5bca21-85b7-45db-9a13-a2fa525a5e4c">
