### PR TITLE
feat(search): Add word break after special characters in search cards

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/Headline.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/Headline.tsx
@@ -15,17 +15,21 @@ export const Headline: React.FC<Props> = ({ text, matchIndices, variant }) => {
   return (
     <>
       {text.split("").map((char, index) => (
-        <Typography
-          component="span"
-          variant={variant}
-          key={`headline-character-${index}`}
-          sx={(theme) => ({
-            fontWeight: isHighlighted(index) ? FONT_WEIGHT_BOLD : "regular",
-            fontSize: theme.typography.body2.fontSize,
-          })}
-        >
-          {char}
-        </Typography>
+        <>
+          <Typography
+            component="span"
+            variant={variant}
+            key={`headline-character-${index}`}
+            sx={(theme) => ({
+              fontWeight: isHighlighted(index) ? FONT_WEIGHT_BOLD : "regular",
+              fontSize: theme.typography.body2.fontSize,
+            })}
+          >
+            {char}
+          </Typography>
+          {/* Add wordbreak after special characters */}
+          {char.match(/\W/) && <wbr />}
+        </>
       ))}
     </>
   );


### PR DESCRIPTION
## What does this PR do?
Adds a `<wbr/>` element ([docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)) after a headline character if it's a special character.

## Why?
The headline element is split into a series of spans (one per character), so applying a regular word break css rule to the parent won't work. By inserting a `<wbr/>` each time we hit a non-alphanumeric character, we allow the browser to break where it sees fit.

| Before | After |
|--------|--------|
|<img width="395" alt="image" src="https://github.com/user-attachments/assets/d6430233-5362-4273-93e5-d37f3042974b">|<img width="369" alt="image" src="https://github.com/user-attachments/assets/0d021873-4634-4e9c-8b17-8196e9944880">| 