### PR TITLE
feat(search): Enable data-only checkbox

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.tsx
@@ -8,6 +8,7 @@ import ChecklistItem from "ui/shared/ChecklistItem";
 import Input from "ui/shared/Input";
 
 import { Context, Data } from ".";
+import { ALL_FACETS, DATA_FACETS } from "./facets";
 
 export const SearchHeader: Components<Data, Context>["Header"] = ({
   context,
@@ -22,6 +23,14 @@ export const SearchHeader: Components<Data, Context>["Header"] = ({
       setIsSearching(true);
     }
   }, [formik.values.pattern, lastPattern, setIsSearching]);
+
+  // Use "data.title" as proxy for all facets
+  const isDataOnly = () => !formik.values.facets.includes("data.title");
+
+  const toggleDataOnly = () =>
+    isDataOnly()
+      ? formik.setFieldValue("facets", ALL_FACETS)
+      : formik.setFieldValue("facets", DATA_FACETS);
 
   return (
     <Box mx={3} pt={3} component="form" onSubmit={formik.handleSubmit}>
@@ -56,14 +65,24 @@ export const SearchHeader: Components<Data, Context>["Header"] = ({
           />
         )}
       </Box>
-      <ChecklistItem
-        label="Search only data fields"
-        id={"search-data-field-facet"}
-        checked
-        inputProps={{ disabled: !hasFeatureFlag("DATA_ONLY_SEARCH") }}
-        onChange={() => {}}
-        variant="compact"
-      />
+      {hasFeatureFlag("DATA_ONLY_SEARCH") ? (
+        <ChecklistItem
+          label="Search only data fields"
+          id={"search-data-field-facet"}
+          checked={isDataOnly()}
+          onChange={toggleDataOnly}
+          variant="compact"
+        />
+      ) : (
+        <ChecklistItem
+          label="Search only data fields"
+          id={"search-data-field-facet"}
+          inputProps={{ disabled: true }}
+          checked={true}
+          onChange={toggleDataOnly}
+          variant="compact"
+        />
+      )}
       {formik.values.pattern && (
         <Typography variant="h3" mt={2} mb={1}>
           {context?.results.length === 0 && "No matches found"}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.tsx
@@ -25,10 +25,11 @@ export const SearchHeader: Components<Data, Context>["Header"] = ({
   }, [formik.values.pattern, lastPattern, setIsSearching]);
 
   // Use "data.title" as proxy for all facets
-  const isDataOnly = () => !formik.values.facets.includes("data.title");
+  const isCurrentlyDataOnlySearch = () =>
+    !formik.values.facets.includes("data.title");
 
   const toggleDataOnly = () =>
-    isDataOnly()
+    isCurrentlyDataOnlySearch()
       ? formik.setFieldValue("facets", ALL_FACETS)
       : formik.setFieldValue("facets", DATA_FACETS);
 
@@ -69,7 +70,7 @@ export const SearchHeader: Components<Data, Context>["Header"] = ({
         <ChecklistItem
           label="Search only data fields"
           id={"search-data-field-facet"}
-          checked={isDataOnly()}
+          checked={isCurrentlyDataOnlySearch()}
           onChange={toggleDataOnly}
           variant="compact"
         />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -69,7 +69,6 @@ const schemaComponents: SearchFacets = [
   "data.schema.fields.data.description",
   "data.schema.fields.data.options.description",
   "data.schema.fields.data.options.text",
-  "data.schema.fields.data.options.data.val",
 ];
 
 const taskList: SearchFacets = ["data.tasks.title", "data.tasks.description"];

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -1,7 +1,7 @@
 import { IndexedNode } from "@opensystemslab/planx-core/types";
 import { FuseOptionKey } from "fuse.js";
 
-type SearchFacets = Array<FuseOptionKey<IndexedNode>>;
+export type SearchFacets = Array<FuseOptionKey<IndexedNode>>;
 
 const generalData: SearchFacets = ["data.fn", "data.val"];
 
@@ -26,10 +26,29 @@ const drawBoundaryData: SearchFacets = [
 ];
 
 /** Data fields used across PlanX components */
-export const DATA_FACETS = [
+export const DATA_FACETS: SearchFacets = [
   ...generalData,
   ...fileUploadAndLabelData,
   ...calculateData,
   ...listData,
   ...drawBoundaryData,
+];
+
+const basicFields: SearchFacets = [
+  "data.text",
+  "data.title",
+  "data.description",
+];
+
+const moreInformation: SearchFacets = [
+  "data.notes",
+  "data.howMeasured",
+  "data.policyRef",
+  "data.info",
+];
+
+export const ALL_FACETS: SearchFacets = [
+  ...basicFields,
+  ...moreInformation,
+  ...DATA_FACETS,
 ];

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -1,4 +1,4 @@
-import { IndexedNode } from "@opensystemslab/planx-core/types";
+import { flatFlags, IndexedNode } from "@opensystemslab/planx-core/types";
 import { FuseOptionKey } from "fuse.js";
 
 export type SearchFacets = Array<FuseOptionKey<IndexedNode>>;
@@ -47,8 +47,89 @@ const moreInformation: SearchFacets = [
   "data.info",
 ];
 
+const checklist: SearchFacets = ["data.categories.title"];
+
+const nextSteps: SearchFacets = [
+  "data.steps.title",
+  "data.steps.description",
+  "data.steps.url",
+];
+
+const fileUploadAndLabel: SearchFacets = [
+  "data.fileTypes.name",
+  "data.fileTypes.notes",
+  "data.fileTypes.howMeasured",
+  "data.fileTypes.policyRef",
+  "data.fileTypes.info",
+];
+
+/** List, Page, and MapAndLabel components share this structure */
+const schemaComponents: SearchFacets = [
+  "data.schema.fields.data.title",
+  "data.schema.fields.data.description",
+  "data.schema.fields.data.options.description",
+  "data.schema.fields.data.options.text",
+  "data.schema.fields.data.options.data.val",
+];
+
+const taskList: SearchFacets = ["data.tasks.title", "data.tasks.description"];
+
+const result: SearchFacets = [
+  ...flatFlags.flatMap(({ value }) => [
+    `data.overrides.${value}.heading`,
+    `data.overrides.${value}.description`,
+  ]),
+];
+
+const content: SearchFacets = ["data.content"];
+
+const confirmation: SearchFacets = [
+  "data.heading",
+  "data.moreInfo",
+  "data.contactInfo",
+  "data.nextSteps.title",
+  "data.nextSteps.description",
+];
+
+const findProperty: SearchFacets = [
+  "data.newAddressTitle",
+  "data.newAddressDescription",
+  "data.newAddressDescriptionLabel",
+];
+
+const drawBoundary: SearchFacets = [
+  "data.titleForUploading",
+  "data.descriptionForUploading",
+];
+
+const planningConstraints: SearchFacets = ["data.disclaimer"];
+
+const pay: SearchFacets = [
+  "data.bannerTitle",
+  "data.instructionsTitle",
+  "data.instructionsDescription",
+  "data.secondaryPageTitle",
+  "data.nomineeTitle",
+  "data.nomineeDescription",
+  "data.yourDetailsTitle",
+  "data.yourDetailsDescription",
+  "data.yourDetailsLabel",
+];
+
 export const ALL_FACETS: SearchFacets = [
   ...basicFields,
   ...moreInformation,
+  ...checklist,
+  ...nextSteps,
+  ...fileUploadAndLabel,
+  ...schemaComponents,
+  ...taskList,
+  ...result,
+  ...content,
+  ...confirmation,
+  ...findProperty,
+  ...drawBoundary,
+  ...planningConstraints,
+  ...pay,
   ...DATA_FACETS,
 ];

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Components, Virtuoso } from "react-virtuoso";
 
 import { ExternalPortalList } from "./ExternalPortalList";
-import { DATA_FACETS } from "./facets";
+import { ALL_FACETS, SearchFacets } from "./facets";
 import { SearchHeader } from "./SearchHeader";
 import { SearchResultCard } from "./SearchResultCard";
 
@@ -21,7 +21,7 @@ const DEBOUNCE_MS = 500;
 
 interface SearchNodes {
   pattern: string;
-  facets: typeof DATA_FACETS;
+  facets: SearchFacets;
 }
 
 // Types for Virtuoso
@@ -64,7 +64,7 @@ const Search: React.FC = () => {
 
   // Set up search input form
   const formik = useFormik<SearchNodes>({
-    initialValues: { pattern: "", facets: DATA_FACETS },
+    initialValues: { pattern: "", facets: ALL_FACETS },
     onSubmit: ({ pattern }) => {
       debouncedSearch(pattern);
     },


### PR DESCRIPTION
## What does this PR do?
 - Enables "data-only" checkbox to be toggled, which controls if the search uses `DATA_FACETS` or `ALL_FACETS`
 - Lists out all text node data values, across all component types, as `ALL_FACETS`
 - Still behind a feature flag so I'll pick up the tasks below as follow ups


https://github.com/user-attachments/assets/285f87b3-a71c-4bf1-93e1-a2878cb8fe3c



## Next steps...
 - Tests (?) - some thoughts here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1727949098464409
 - Display all matches in search result cards
 - Unpack HTML to string
 - Truncate long headlines
 - Toggle style of search result cards from "data" to something else