### PR TITLE
feat: Handle editor sidebar visibility toggle on sidebar

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -464,8 +464,7 @@ const EditorToolbar: React.FC<{
 }> = ({ headerRef, route }) => {
   const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
-  const [togglePreview, user] = useStore((state) => [
-    state.togglePreview,
+  const [user] = useStore((state) => [
     state.getUser(),
     state.getTeam(),
     state.canUserEditTeam,
@@ -490,16 +489,6 @@ const EditorToolbar: React.FC<{
             <RightBox>
               {user && (
                 <ProfileSection disableGutters>
-                  {route.data.flow && (
-                    <IconButton
-                      color="inherit"
-                      onClick={togglePreview}
-                      aria-label="Toggle Preview"
-                      size="large"
-                    >
-                      <MenuOpenIcon />
-                    </IconButton>
-                  )}
                   <Box mr={1}></Box>
                   <IconButton
                     edge="end"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -11,7 +11,7 @@ import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { rootFlowPath } from "routes/utils";
 import Permission from "ui/editor/Permission";
 import Reset from "ui/icons/Reset";
@@ -136,7 +136,12 @@ const Sidebar: React.FC = React.memo(() => {
   ]);
 
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
-  const [isSidebarMinimised, setIsSidebarMinimised] = useState(false);
+  const [isSidebarMinimised, setIsSidebarMinimised] = useState<boolean>(
+    () => {
+      const savedState = localStorage.getItem("isSidebarMinimised");
+      return savedState === 'true';
+    }
+  );
 
   const handleChange = (
     _event: React.SyntheticEvent,
@@ -146,7 +151,11 @@ const Sidebar: React.FC = React.memo(() => {
   };
 
   const togglePreview = () => {
-    setIsSidebarMinimised(!isSidebarMinimised);
+    setIsSidebarMinimised((prev) => {
+      const newState = !prev;
+      localStorage.setItem("isSidebarMinimised", JSON.stringify(newState));
+      return newState;
+    });
   };
 
   const baseUrl = `${window.location.origin}${rootFlowPath(false)}`;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,17 +1,17 @@
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import LanguageIcon from "@mui/icons-material/Language";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
-import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import ToggleButton from "@mui/material/ToggleButton";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Tabs from "@mui/material/Tabs";
+import ToggleButton from "@mui/material/ToggleButton";
 import Tooltip from "@mui/material/Tooltip";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { rootFlowPath } from "routes/utils";
 import Permission from "ui/editor/Permission";
 import Reset from "ui/icons/Reset";
@@ -26,26 +26,28 @@ import StyledTab from "./StyledTab";
 
 type SidebarTabs = "PreviewBrowser" | "History" | "Search" | "Console";
 
-const SIDEBAR_WIDTH = 500;
-const SIDEBAR_WIDTH_MINIMISED = 20;
+const SIDEBAR_WIDTH = "500px";
+const SIDEBAR_WIDTH_MINIMISED = "20px";
 
-const Root = styled(Box)<{ isMinimised: boolean }>(({ theme, isMinimised }) => ({
-  position: "relative",
-  top: "0",
-  right: "0",
-  bottom: "0",
-  width: isMinimised ? `${SIDEBAR_WIDTH_MINIMISED}px` : `${SIDEBAR_WIDTH}px`,
-  display: "flex",
-  flexShrink: 0,
-  flexDirection: "column",
-  borderLeft: `1px solid ${theme.palette.border.main}`,
-  background: theme.palette.background.paper,
-  zIndex: 1,
-  transition: "width 200ms ease-in-out",
-  "& iframe": {
-    flex: 1,
-  },
-}));
+const Root = styled(Box)<{ isMinimised: boolean }>(
+  ({ theme, isMinimised }) => ({
+    position: "relative",
+    top: "0",
+    right: "0",
+    bottom: "0",
+    width: isMinimised ? SIDEBAR_WIDTH_MINIMISED : SIDEBAR_WIDTH,
+    display: "flex",
+    flexShrink: 0,
+    flexDirection: "column",
+    borderLeft: `1px solid ${theme.palette.border.main}`,
+    background: theme.palette.background.paper,
+    zIndex: 1,
+    transition: "width 200ms ease-in-out",
+    "& iframe": {
+      flex: 1,
+    },
+  }),
+);
 
 const SidebarContainer = styled(Box)(() => ({
   overflow: "auto",
@@ -136,12 +138,10 @@ const Sidebar: React.FC = React.memo(() => {
   ]);
 
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
-  const [isSidebarMinimised, setIsSidebarMinimised] = useState<boolean>(
-    () => {
-      const savedState = localStorage.getItem("isSidebarMinimised");
-      return savedState === 'true';
-    }
-  );
+  const [isSidebarMinimised, setIsSidebarMinimised] = useState<boolean>(() => {
+    const savedState = localStorage.getItem("isSidebarMinimised");
+    return savedState === "true";
+  });
 
   const handleChange = (
     _event: React.SyntheticEvent,
@@ -170,11 +170,7 @@ const Sidebar: React.FC = React.memo(() => {
     <Root isMinimised={isSidebarMinimised}>
       <SidebarWrapper>
         <StyledToggleButton onClick={togglePreview} value="toggleSidebar">
-          {isSidebarMinimised ? (
-            <ChevronLeftIcon />
-          ) : (
-            <ChevronRightIcon />
-          )}
+          {isSidebarMinimised ? <ChevronLeftIcon /> : <ChevronRightIcon />}
         </StyledToggleButton>
         <Header>
           <Box width="100%" display="flex">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -1,6 +1,9 @@
 import LanguageIcon from "@mui/icons-material/Language";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ToggleButton from "@mui/material/ToggleButton";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
@@ -23,19 +26,24 @@ import StyledTab from "./StyledTab";
 
 type SidebarTabs = "PreviewBrowser" | "History" | "Search" | "Console";
 
-const Root = styled(Box)(({ theme }) => ({
+const SIDEBAR_WIDTH = 500;
+const SIDEBAR_WIDTH_MINIMISED = 20;
+
+const Root = styled(Box)<{ isMinimised: boolean }>(({ theme, isMinimised }) => ({
   position: "relative",
   top: "0",
   right: "0",
   bottom: "0",
-  width: "500px",
+  width: isMinimised ? `${SIDEBAR_WIDTH_MINIMISED}px` : `${SIDEBAR_WIDTH}px`,
   display: "flex",
   flexShrink: 0,
   flexDirection: "column",
   borderLeft: `1px solid ${theme.palette.border.main}`,
   background: theme.palette.background.paper,
+  zIndex: 1,
+  transition: "width 200ms ease-in-out",
   "& iframe": {
-    flex: "1",
+    flex: 1,
   },
 }));
 
@@ -46,8 +54,37 @@ const SidebarContainer = styled(Box)(() => ({
   position: "relative",
 }));
 
+const SidebarWrapper = styled(Box)(() => ({
+  width: SIDEBAR_WIDTH,
+  display: "flex",
+  flexDirection: "column",
+  flexShrink: 0,
+  flexGrow: 1,
+  maxHeight: "100%",
+}));
+
+const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
+  background: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.border.main}`,
+  borderImage: `linear-gradient(to right, ${theme.palette.border.main} 50%, transparent 50%) 30% 1`,
+  position: "absolute",
+  width: "40px",
+  height: "40px",
+  left: "-20px",
+  top: theme.spacing(0.5),
+  boxShadow: "none",
+  color: theme.palette.text.primary,
+  "& > svg": {
+    fontSize: "1.875rem",
+  },
+  "&:hover": {
+    background: theme.palette.background.paper,
+    boxShadow: "none",
+  },
+}));
+
 const Header = styled("header")(({ theme }) => ({
-  padding: theme.spacing(1, 1.5),
+  padding: theme.spacing(1, 2),
   "& input": {
     flex: "1",
     padding: "5px",
@@ -74,7 +111,6 @@ const ResetToggle = styled(Button)(({ theme }) => ({
 
 const TabList = styled(Box)(({ theme }) => ({
   position: "relative",
-  // Use a pseudo element as border to allow for tab border overlap without excessive MUI overrides
   "&::after": {
     content: "''",
     position: "absolute",
@@ -86,9 +122,8 @@ const TabList = styled(Box)(({ theme }) => ({
   },
   "& .MuiTabs-root": {
     minHeight: "0",
-    padding: theme.spacing(0, 1.5),
+    padding: theme.spacing(0, 1.75),
   },
-  // Hide default MUI indicator as we're using custom styling
   "& .MuiTabs-indicator": {
     display: "none",
   },
@@ -101,12 +136,17 @@ const Sidebar: React.FC = React.memo(() => {
   ]);
 
   const [activeTab, setActiveTab] = useState<SidebarTabs>("PreviewBrowser");
+  const [isSidebarMinimised, setIsSidebarMinimised] = useState(false);
 
   const handleChange = (
     _event: React.SyntheticEvent,
     newValue: SidebarTabs,
   ) => {
     setActiveTab(newValue);
+  };
+
+  const togglePreview = () => {
+    setIsSidebarMinimised(!isSidebarMinimised);
   };
 
   const baseUrl = `${window.location.origin}${rootFlowPath(false)}`;
@@ -118,97 +158,106 @@ const Sidebar: React.FC = React.memo(() => {
   };
 
   return (
-    <Root>
-      <Header>
-        <Box width="100%" display="flex">
-          <input type="text" disabled value={urls.preview} />
-
-          <Permission.IsPlatformAdmin>
-            <Tooltip arrow title="Open draft service">
-              <Link
-                href={urls.draft}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <OpenInNewOffIcon />
-              </Link>
-            </Tooltip>
-          </Permission.IsPlatformAdmin>
-
-          <Tooltip arrow title="Open preview of changes to publish">
-            <Link
-              href={urls.preview}
-              target="_blank"
-              rel="noopener noreferrer"
-              color="inherit"
-            >
-              <OpenInNewIcon />
-            </Link>
-          </Tooltip>
-
-          {isFlowPublished ? (
-            <Tooltip arrow title="Open published service">
-              <Link
-                href={urls.analytics}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="inherit"
-              >
-                <LanguageIcon />
-              </Link>
-            </Tooltip>
+    <Root isMinimised={isSidebarMinimised}>
+      <SidebarWrapper>
+        <StyledToggleButton onClick={togglePreview} value="toggleSidebar">
+          {isSidebarMinimised ? (
+            <ChevronLeftIcon />
           ) : (
-            <Tooltip arrow title="Flow not yet published">
-              <Box>
-                <Link component={"button"} disabled aria-disabled={true}>
+            <ChevronRightIcon />
+          )}
+        </StyledToggleButton>
+        <Header>
+          <Box width="100%" display="flex">
+            <input type="text" disabled value={urls.preview} />
+
+            <Permission.IsPlatformAdmin>
+              <Tooltip arrow title="Open draft service">
+                <Link
+                  href={urls.draft}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  color="inherit"
+                >
+                  <OpenInNewOffIcon />
+                </Link>
+              </Tooltip>
+            </Permission.IsPlatformAdmin>
+
+            <Tooltip arrow title="Open preview of changes to publish">
+              <Link
+                href={urls.preview}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                <OpenInNewIcon />
+              </Link>
+            </Tooltip>
+
+            {isFlowPublished ? (
+              <Tooltip arrow title="Open published service">
+                <Link
+                  href={urls.analytics}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  color="inherit"
+                >
                   <LanguageIcon />
                 </Link>
-              </Box>
-            </Tooltip>
-          )}
-        </Box>
-        <PublishFlowButton previewURL={urls.preview} />
-      </Header>
-      <TabList>
-        <Tabs onChange={handleChange} value={activeTab} aria-label="">
-          <StyledTab value="PreviewBrowser" label="Preview" />
-          <StyledTab value="History" label="History" />
-          <StyledTab value="Search" label="Search" />
-          <StyledTab value="Console" label="Console" />
-        </Tabs>
-      </TabList>
-      {activeTab === "PreviewBrowser" && (
-        <SidebarContainer>
-          <ResetToggle
-            variant="link"
-            onClick={() => {
-              resetPreview();
-            }}
-          >
-            <Reset fontSize="small" />
-            Restart
-          </ResetToggle>
-          <Questions previewEnvironment="editor" />
-        </SidebarContainer>
-      )}
-      {activeTab === "History" && (
-        <SidebarContainer py={3}>
-          <Container>
-            <EditHistory />
-          </Container>
-        </SidebarContainer>
-      )}
-      {activeTab === "Search" && (
-        <SidebarContainer>
-          <Search />
-        </SidebarContainer>
-      )}
-      {activeTab === "Console" && (
-        <SidebarContainer>
-          <DebugConsole />
-        </SidebarContainer>
-      )}
+              </Tooltip>
+            ) : (
+              <Tooltip arrow title="Flow not yet published">
+                <Box>
+                  <Link component={"button"} disabled aria-disabled={true}>
+                    <LanguageIcon />
+                  </Link>
+                </Box>
+              </Tooltip>
+            )}
+          </Box>
+          <PublishFlowButton previewURL={urls.preview} />
+        </Header>
+        <TabList>
+          <Tabs onChange={handleChange} value={activeTab} aria-label="">
+            <StyledTab value="PreviewBrowser" label="Preview" />
+            <StyledTab value="History" label="History" />
+            <StyledTab value="Search" label="Search" />
+            <StyledTab value="Console" label="Console" />
+          </Tabs>
+        </TabList>
+        {activeTab === "PreviewBrowser" && (
+          <SidebarContainer>
+            <ResetToggle
+              variant="link"
+              onClick={() => {
+                resetPreview();
+              }}
+            >
+              <Reset fontSize="small" />
+              Restart
+            </ResetToggle>
+            <Questions previewEnvironment="editor" />
+          </SidebarContainer>
+        )}
+        {activeTab === "History" && (
+          <SidebarContainer py={3}>
+            <Container>
+              <EditHistory />
+            </Container>
+          </SidebarContainer>
+        )}
+        {activeTab === "Search" && (
+          <SidebarContainer>
+            <Search />
+          </SidebarContainer>
+        )}
+        {activeTab === "Console" && (
+          <SidebarContainer>
+            <DebugConsole />
+          </SidebarContainer>
+        )}
+      </SidebarWrapper>
     </Root>
   );
 });


### PR DESCRIPTION
## What does this PR do?

Moves toggle for show/hiding the editor sidebar to be placed on the sidebar itself.

Also stores the toggle position in localStorage so that the position is maintained when opening graph nodes or switching screens.

Example:
https://3747.planx.pizza/barking-and-dagenham/retrofit-guide