### PR TITLE
feat: Use `BaseNodeData` to add `tags` property to all component types

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7712ff7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5781880",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7712ff7
-    version: github.com/theopensystemslab/planx-core/7712ff7
+    specifier: git+https://github.com/theopensystemslab/planx-core#5781880
+    version: github.com/theopensystemslab/planx-core/5781880
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6244,8 +6244,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/7712ff7:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7712ff7}
+  github.com/theopensystemslab/planx-core/5781880:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5781880}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7712ff7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5781880",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7712ff7
-    version: github.com/theopensystemslab/planx-core/7712ff7
+    specifier: git+https://github.com/theopensystemslab/planx-core#5781880
+    version: github.com/theopensystemslab/planx-core/5781880
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2932,8 +2932,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/7712ff7:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7712ff7}
+  github.com/theopensystemslab/planx-core/5781880:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5781880}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7712ff7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5781880",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7712ff7
-    version: github.com/theopensystemslab/planx-core/7712ff7
+    specifier: git+https://github.com/theopensystemslab/planx-core#5781880
+    version: github.com/theopensystemslab/planx-core/5781880
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2686,8 +2686,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/7712ff7:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7712ff7}
+  github.com/theopensystemslab/planx-core/5781880:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5781880}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/docs/adding-a-new-component.md
+++ b/editor.planx.uk/docs/adding-a-new-component.md
@@ -17,9 +17,9 @@ SetValue = 380,
 3. `model.ts`
 
 ```typescript
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface SetValue extends MoreInformation {
+export interface SetValue extends BaseNodeData {
   fn: string;
 }
 
@@ -27,7 +27,7 @@ export const parseContent = (
   data: Record<string, any> | undefined,
 ): SetValue => ({
   fn: data?.fn || "",
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 ```
 

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#7712ff7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5781880",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.3
     version: 1.0.0-alpha.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#7712ff7
-    version: github.com/theopensystemslab/planx-core/7712ff7(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#5781880
+    version: github.com/theopensystemslab/planx-core/5781880(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15352,9 +15352,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/7712ff7(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/7712ff7}
-    id: github.com/theopensystemslab/planx-core/7712ff7
+  github.com/theopensystemslab/planx-core/5781880(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5781880}
+    id: github.com/theopensystemslab/planx-core/5781880
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -1,7 +1,7 @@
 import type { SchemaOf } from "yup";
 import { object, string } from "yup";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export type Address = {
   line1: string;
@@ -21,7 +21,7 @@ export const userDataSchema: SchemaOf<Address> = object({
   country: string(),
 });
 
-export interface AddressInput extends MoreInformation {
+export interface AddressInput extends BaseNodeData {
   title: string;
   description?: string;
   fn?: string;
@@ -33,5 +33,5 @@ export const parseAddressInput = (
   title: data?.title || "",
   description: data?.description,
   fn: data?.fn || "",
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/Calculate/model.ts
+++ b/editor.planx.uk/src/@planx/components/Calculate/model.ts
@@ -1,8 +1,8 @@
 import * as math from "mathjs";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface Calculate extends MoreInformation {
+export interface Calculate extends BaseNodeData {
   title?: string;
   output: string;
   defaults: Record<string, number>;
@@ -19,7 +19,7 @@ export interface Input {
 export const parseCalculate = (
   data: Record<string, any> | undefined,
 ): Calculate => ({
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
   output: data?.output || "",
   defaults: data?.defaults || {},
   formula: data?.formula || "",

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -22,7 +22,7 @@ import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
-import { Option, parseMoreInformation } from "../shared";
+import { Option, parseBaseNodeData } from "../shared";
 import PermissionSelect from "../shared/PermissionSelect";
 import { ICONS, InternalNotes, MoreInformation } from "../ui";
 import type { Category, Checklist, Group } from "./model";
@@ -295,7 +295,7 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
       img: props.node?.data?.img || "",
       options: props.options,
       text: props.node?.data?.text || "",
-      ...parseMoreInformation(props.node?.data),
+      ...parseBaseNodeData(props.node?.data),
     },
     onSubmit: ({ options, groupedOptions, ...values }) => {
       const sourceOptions = options?.length

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -22,7 +22,7 @@ import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
-import { Option, parseBaseNodeData } from "../shared";
+import { BaseNodeData, Option, parseBaseNodeData } from "../shared";
 import PermissionSelect from "../shared/PermissionSelect";
 import { ICONS, InternalNotes, MoreInformation } from "../ui";
 import type { Category, Checklist, Group } from "./model";
@@ -35,16 +35,11 @@ export interface ChecklistProps extends Checklist {
     data?: {
       allRequired?: boolean;
       categories?: Array<Category>;
-      definitionImg?: string;
       description?: string;
       fn?: string;
-      howMeasured?: string;
       img?: string;
-      info?: string;
-      notes?: string;
-      policyRef?: string;
       text: string;
-    };
+    } & BaseNodeData;
   };
 }
 

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -1,6 +1,6 @@
 import { array } from "yup";
 
-import { MoreInformation, Option } from "../shared";
+import { BaseNodeData, Option } from "../shared";
 import { ChecklistLayout } from "./Public";
 
 export interface Group<T> {
@@ -13,7 +13,7 @@ export interface Category {
   count: number;
 }
 
-export interface Checklist extends MoreInformation {
+export interface Checklist extends BaseNodeData {
   fn?: string;
   description?: string;
   text?: string;

--- a/editor.planx.uk/src/@planx/components/Confirmation/model.ts
+++ b/editor.planx.uk/src/@planx/components/Confirmation/model.ts
@@ -1,9 +1,11 @@
+import { BaseNodeData } from "../shared";
+
 export interface Step {
   title: string;
   description: string;
 }
 
-export interface Confirmation {
+export interface Confirmation extends BaseNodeData {
   heading?: string;
   description?: string;
   color?: { text: string; background: string };

--- a/editor.planx.uk/src/@planx/components/ContactInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/ContactInput/model.ts
@@ -1,7 +1,7 @@
 import type { SchemaOf } from "yup";
 import { object, string } from "yup";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export type Contact = {
   title?: string;
@@ -41,7 +41,7 @@ export const userDataSchema: SchemaOf<Contact> = object({
   },
 });
 
-export interface ContactInput extends MoreInformation {
+export interface ContactInput extends BaseNodeData {
   title: string;
   description?: string;
   fn?: string;
@@ -53,5 +53,5 @@ export const parseContactInput = (
   title: data?.title || "",
   description: data?.description,
   fn: data?.fn || "",
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/Content/model.ts
+++ b/editor.planx.uk/src/@planx/components/Content/model.ts
@@ -1,6 +1,6 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface Content extends MoreInformation {
+export interface Content extends BaseNodeData {
   content: string;
   color?: string;
 }
@@ -10,5 +10,5 @@ export const parseContent = (
 ): Content => ({
   content: data?.content || "",
   color: data?.color,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -1,12 +1,12 @@
 import { isValid, parseISO } from "date-fns";
 import { object, SchemaOf, string } from "yup";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 // Expected format: YYYY-MM-DD
 export type UserData = string;
 
-export interface DateInput extends MoreInformation {
+export interface DateInput extends BaseNodeData {
   title: string;
   description?: string;
   fn?: string;
@@ -129,7 +129,7 @@ export const parseDateInput = (
   fn: data?.fn,
   min: data?.min,
   max: data?.max,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 export const editorValidationSchema = () =>

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -15,10 +15,6 @@ export interface DrawBoundary extends BaseNodeData {
   hideFileUpload?: boolean;
   dataFieldBoundary: string;
   dataFieldArea: string;
-  info?: string;
-  policyRef?: string;
-  howMeasured?: string;
-  definitionImg?: string;
 }
 
 export const parseDrawBoundary = (

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -1,4 +1,4 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export enum DrawBoundaryUserAction {
   Accept = "Accepted the title boundary",
@@ -7,7 +7,7 @@ export enum DrawBoundaryUserAction {
   Upload = "Uploaded a location plan",
 }
 
-export interface DrawBoundary extends MoreInformation {
+export interface DrawBoundary extends BaseNodeData {
   title: string;
   description: string;
   titleForUploading: string;
@@ -24,7 +24,7 @@ export interface DrawBoundary extends MoreInformation {
 export const parseDrawBoundary = (
   data: Record<string, any> | undefined,
 ): DrawBoundary => ({
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
   title: data?.title || defaultContent?.["title"],
   description: data?.description || defaultContent?.["description"],
   titleForUploading:

--- a/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -1,10 +1,10 @@
-import { MoreInformation } from "@planx/components/shared";
+import { BaseNodeData } from "@planx/components/shared";
 import { Store } from "pages/FlowEditor/lib/store";
 import type { HandleSubmit } from "pages/Preview/Node";
 import { FileWithPath } from "react-dropzone";
 import { array } from "yup";
 
-export interface FileUpload extends MoreInformation {
+export interface FileUpload extends BaseNodeData {
   id?: string;
   title?: string;
   fn: string;

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -5,7 +5,7 @@ import { Store, useStore } from "pages/FlowEditor/lib/store";
 import { FileWithPath } from "react-dropzone";
 
 import { FileUploadSlot } from "../FileUpload/model";
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, MoreInformation, parseBaseNodeData } from "../shared";
 
 export const PASSPORT_REQUESTED_FILES_KEY = "_requestedFiles" as const;
 
@@ -67,7 +67,7 @@ export interface FileType {
   moreInformation?: MoreInformation;
 }
 
-export interface FileUploadAndLabel extends MoreInformation {
+export interface FileUploadAndLabel extends BaseNodeData {
   title: string;
   description?: string;
   fn?: string;
@@ -83,7 +83,7 @@ export const parseContent = (
   fn: data?.fn || "",
   fileTypes: cloneDeep(data?.fileTypes) || [newFileType()],
   hideDropZone: data?.hideDropZone || false,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 const DEFAULT_TITLE = "Upload and label";

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -10,7 +10,7 @@ import {
 } from "yup";
 
 import { FileUploadSlot } from "../FileUpload/model";
-import { MoreInformation } from "../shared";
+import { BaseNodeData, MoreInformation } from "../shared";
 import {
   checkIfConditionalRule,
   Condition,
@@ -30,6 +30,10 @@ const moreInformationSchema: SchemaOf<MoreInformation> = object({
   notes: string(),
   definitionImg: string(),
 });
+
+const baseNodeDataSchema: SchemaOf<BaseNodeData> = object({
+  tags: array(mixed().oneOf(["placeholder"])),
+}).concat(moreInformationSchema);
 
 const valFnSchema = mixed().when("condition", {
   is: checkIfConditionalRule,
@@ -63,7 +67,7 @@ export const fileUploadAndLabelSchema: SchemaOf<FileUploadAndLabel> = object({
   fn: string(),
   fileTypes: array().of(fileTypeSchema).required().min(1),
   hideDropZone: boolean(),
-}).concat(moreInformationSchema);
+}).concat(baseNodeDataSchema);
 
 interface SlotsSchemaTestContext extends TestContext {
   fileList: FileList;

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -1,3 +1,4 @@
+import { NODE_TAGS } from "@opensystemslab/planx-core/types";
 import {
   array,
   boolean,
@@ -32,7 +33,7 @@ const moreInformationSchema: SchemaOf<MoreInformation> = object({
 });
 
 const baseNodeDataSchema: SchemaOf<BaseNodeData> = object({
-  tags: array(mixed().oneOf(["placeholder"])),
+  tags: array(mixed().oneOf(NODE_TAGS)),
 }).concat(moreInformationSchema);
 
 const valFnSchema = mixed().when("condition", {

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -1,4 +1,4 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export enum FindPropertyUserAction {
   Existing = "Selected an existing address",
@@ -7,7 +7,7 @@ export enum FindPropertyUserAction {
 
 export const PASSPORT_COMPONENT_ACTION_KEY = "findProperty.action";
 
-export interface FindProperty extends MoreInformation {
+export interface FindProperty extends BaseNodeData {
   title: string;
   description: string;
   allowNewAddresses?: boolean;
@@ -27,7 +27,7 @@ export const parseFindProperty = (
     data?.newAddressDescription || DEFAULT_NEW_ADDRESS_DESCRIPTION,
   newAddressDescriptionLabel:
     data?.newAddressDescriptionLabel || DEFAULT_NEW_ADDRESS_LABEL,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 // Addresses can come from two sources:

--- a/editor.planx.uk/src/@planx/components/List/model.ts
+++ b/editor.planx.uk/src/@planx/components/List/model.ts
@@ -1,11 +1,11 @@
 import { cloneDeep } from "lodash";
 import { number, object } from "yup";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 import { Schema } from "../shared/Schema/model";
 import { SCHEMAS } from "./Editor";
 
-export interface List extends MoreInformation {
+export interface List extends BaseNodeData {
   fn: string;
   title: string;
   description?: string;
@@ -19,11 +19,16 @@ export const parseContent = (data: Record<string, any> | undefined): List => ({
   description: data?.description,
   schemaName: data?.schemaName || SCHEMAS[0].name,
   schema: cloneDeep(data?.schema) || SCHEMAS[0].schema,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 export const validationSchema = object({
   schema: object({
-    max: number().optional().min(2, "The maximum must be greater than 1 - a Page component should be used when max is equal to 1"),
+    max: number()
+      .optional()
+      .min(
+        2,
+        "The maximum must be greater than 1 - a Page component should be used when max is equal to 1",
+      ),
   }),
 });

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/model.ts
@@ -1,10 +1,10 @@
 import cloneDeep from "lodash/cloneDeep";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 import { Schema } from "../shared/Schema/model";
 import { SCHEMAS } from "./Editor";
 
-export interface MapAndLabel extends MoreInformation {
+export interface MapAndLabel extends BaseNodeData {
   fn: string;
   title: string;
   description?: string;
@@ -26,5 +26,5 @@ export const parseContent = (
   drawType: data?.drawType || "Polygon",
   schemaName: data?.schemaName || SCHEMAS[0].name,
   schema: cloneDeep(data?.schema) || SCHEMAS[0].schema,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/NextSteps/model.ts
+++ b/editor.planx.uk/src/@planx/components/NextSteps/model.ts
@@ -1,6 +1,6 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface NextSteps extends MoreInformation {
+export interface NextSteps extends BaseNodeData {
   title: string;
   description: string;
   steps: Array<Step>;
@@ -18,7 +18,7 @@ export const parseNextSteps = (
   steps: data?.steps || [],
   title: data?.title || DEFAULT_TITLE,
   description: data?.description || "",
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 const DEFAULT_TITLE = "What would you like to do next?";

--- a/editor.planx.uk/src/@planx/components/Notice/model.ts
+++ b/editor.planx.uk/src/@planx/components/Notice/model.ts
@@ -1,6 +1,6 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface Notice extends MoreInformation {
+export interface Notice extends BaseNodeData {
   title: string;
   description: string;
   color: string;
@@ -13,5 +13,5 @@ export const parseNotice = (data: Record<string, any> | undefined) => ({
   description: data?.description || "",
   color: data?.color || "#EFEFEF",
   resetButton: data?.resetButton || false,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/Notice/model.ts
+++ b/editor.planx.uk/src/@planx/components/Notice/model.ts
@@ -4,7 +4,6 @@ export interface Notice extends BaseNodeData {
   title: string;
   description: string;
   color: string;
-  notes?: string;
   resetButton?: boolean;
 }
 

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -1,8 +1,8 @@
 import { object, string } from "yup";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface NumberInput extends MoreInformation {
+export interface NumberInput extends BaseNodeData {
   title: string;
   description?: string;
   fn?: string;
@@ -28,7 +28,7 @@ export const parseNumberInput = (
   fn: data?.fn || "",
   units: data?.units,
   allowNegatives: data?.allowNegatives || false,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 export const numberInputValidationSchema = (input: NumberInput) =>

--- a/editor.planx.uk/src/@planx/components/Page/model.ts
+++ b/editor.planx.uk/src/@planx/components/Page/model.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from "lodash";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 import { Schema } from "../shared/Schema/model";
 import { PAGE_SCHEMAS } from "./Editor";
 
@@ -9,7 +9,7 @@ export interface PageSchema extends Schema {
   max: 1;
 }
 
-export interface Page extends MoreInformation {
+export interface Page extends BaseNodeData {
   fn: string;
   title: string;
   description?: string;
@@ -23,5 +23,5 @@ export const parsePage = (data: Record<string, any> | undefined): Page => ({
   description: data?.description,
   schemaName: data?.schemaName || PAGE_SCHEMAS[0].name,
   schema: cloneDeep(data?.schema) || PAGE_SCHEMAS[0].schema,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -13,7 +13,7 @@ import {
   REQUIRED_GOVPAY_METADATA,
   validationSchema,
 } from "@planx/components/Pay/model";
-import { parseMoreInformation } from "@planx/components/shared";
+import { parseBaseNodeData } from "@planx/components/shared";
 import {
   EditorProps,
   ICONS,
@@ -180,7 +180,7 @@ const Component: React.FC<Props> = (props: Props) => {
         value: "@paidViaInviteToPay",
       },
     ],
-    ...parseMoreInformation(props.node?.data),
+    ...parseBaseNodeData(props.node?.data),
   };
 
   const onSubmit = (newValues: Pay) => {

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -8,9 +8,9 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { ApplicationPath, Passport } from "types";
 import { array, boolean, object, string } from "yup";
 
-import type { MoreInformation } from "../shared";
+import type { BaseNodeData } from "../shared";
 
-export interface Pay extends MoreInformation {
+export interface Pay extends BaseNodeData {
   title: string;
   bannerTitle?: string;
   description?: string;

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/model.ts
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/model.ts
@@ -1,6 +1,6 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface PlanningConstraints extends MoreInformation {
+export interface PlanningConstraints extends BaseNodeData {
   title: string;
   description: string;
   fn: string;
@@ -16,7 +16,7 @@ export const parseContent = (
     "Planning constraints might limit how you can develop or use the property",
   fn: data?.fn || DEFAULT_FN,
   disclaimer: data?.disclaimer || DEFAULT_PLANNING_CONDITIONS_DISCLAIMER,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 export type IntersectingConstraints = Record<string, string[]>;

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/model.ts
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/model.ts
@@ -1,6 +1,6 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface PropertyInformation extends MoreInformation {
+export interface PropertyInformation extends BaseNodeData {
   title: string;
   description: string;
   showPropertyTypeOverride?: boolean;
@@ -14,5 +14,5 @@ export const parseContent = (
     data?.description ||
     "This is the information we currently have about the property, including its title boundary shown in blue from the Land Registry",
   showPropertyTypeOverride: data?.showPropertyTypeOverride || false,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -11,24 +11,19 @@ import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
-import { Option, parseBaseNodeData } from "../shared";
+import { BaseNodeData, Option, parseBaseNodeData } from "../shared";
 import PermissionSelect from "../shared/PermissionSelect";
 import { ICONS, InternalNotes, MoreInformation } from "../ui";
 
 interface Props {
   node: {
     data?: {
-      definitionImg?: string;
       description?: string;
       fn?: string;
-      howMeasured?: string;
       img?: string;
-      info?: string;
-      notes?: string;
-      policyRef?: string;
       text: string;
       type?: string;
-    };
+    } & BaseNodeData;
   };
   options?: Option[];
   handleSubmit?: Function;

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -11,7 +11,7 @@ import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
-import { Option, parseMoreInformation } from "../shared";
+import { Option, parseBaseNodeData } from "../shared";
 import PermissionSelect from "../shared/PermissionSelect";
 import { ICONS, InternalNotes, MoreInformation } from "../ui";
 
@@ -135,7 +135,7 @@ export const Question: React.FC<Props> = (props) => {
       img: props.node?.data?.img || "",
       options: props.options || [],
       text: props.node?.data?.text || "",
-      ...parseMoreInformation(props.node?.data),
+      ...parseBaseNodeData(props.node?.data),
     },
     onSubmit: ({ options, ...values }) => {
       const children = options

--- a/editor.planx.uk/src/@planx/components/Question/model.ts
+++ b/editor.planx.uk/src/@planx/components/Question/model.ts
@@ -1,14 +1,12 @@
 import { Store } from "pages/FlowEditor/lib/store";
 import { HandleSubmit } from "pages/Preview/Node";
 
-export interface Question {
+import { BaseNodeData } from "../shared";
+
+export interface Question extends BaseNodeData {
   id?: string;
   text?: string;
   description?: string;
-  info?: string;
-  policyRef?: string;
-  howMeasured?: string;
-  definitionImg?: string;
   img?: string;
   responses: {
     id?: string;

--- a/editor.planx.uk/src/@planx/components/Result/model.ts
+++ b/editor.planx.uk/src/@planx/components/Result/model.ts
@@ -4,12 +4,14 @@ import { Response } from "pages/FlowEditor/lib/store/preview";
 import type { HandleSubmit } from "pages/Preview/Node";
 import type { TextContent } from "types";
 
+import { BaseNodeData } from "../shared";
+
 export interface FlagDisplayText {
   heading?: string;
   description?: string;
 }
 
-export interface Result {
+export interface Result extends BaseNodeData {
   flagSet: FlagSet;
   overrides?: { [flagId: string]: FlagDisplayText };
 }

--- a/editor.planx.uk/src/@planx/components/Review/model.ts
+++ b/editor.planx.uk/src/@planx/components/Review/model.ts
@@ -1,7 +1,8 @@
-export interface Review {
+import { BaseNodeData } from "../shared";
+
+export interface Review extends BaseNodeData {
   title: string;
   description: string;
-  notes: string;
 }
 
 export const parseContent = (

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -1,9 +1,9 @@
 import type { Store } from "pages/FlowEditor/lib/store";
 import { SectionNode, SectionStatus } from "types";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface Section extends MoreInformation {
+export interface Section extends BaseNodeData {
   title: string;
   description?: string;
 }
@@ -13,7 +13,7 @@ export const parseSection = (
 ): Section => ({
   title: data?.title || "",
   description: data?.description,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });
 
 export function computeSectionStatuses({

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -1,5 +1,5 @@
 import type { Store } from "../../../pages/FlowEditor/lib/store";
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export enum Destination {
   BOPS = "bops",
@@ -16,7 +16,7 @@ interface EventPayload {
   };
 }
 
-export interface Send extends MoreInformation {
+export interface Send extends BaseNodeData {
   title: string;
   destinations: Destination[];
 }
@@ -25,7 +25,7 @@ export const DEFAULT_TITLE = "Send";
 export const DEFAULT_DESTINATION = Destination.Email;
 
 export const parseContent = (data: Record<string, any> | undefined): Send => ({
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
   title: data?.title || DEFAULT_TITLE,
   destinations: data?.destinations || [DEFAULT_DESTINATION],
 });

--- a/editor.planx.uk/src/@planx/components/SetValue/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/model.ts
@@ -1,6 +1,6 @@
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
-export interface BaseSetValue extends MoreInformation {
+export interface BaseSetValue extends BaseNodeData {
   fn: string;
 }
 
@@ -22,5 +22,5 @@ export const parseSetValue = (
   fn: data?.fn || "",
   val: data?.val || "",
   operation: data?.operation || "replace",
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/TaskList/model.ts
+++ b/editor.planx.uk/src/@planx/components/TaskList/model.ts
@@ -1,7 +1,7 @@
-import type { MoreInformation } from "../shared";
-import { parseMoreInformation } from "../shared";
+import type { BaseNodeData } from "../shared";
+import { parseBaseNodeData } from "../shared";
 
-export interface TaskList extends MoreInformation {
+export interface TaskList extends BaseNodeData {
   title: string;
   description?: string;
   tasks: Array<Task>;
@@ -24,5 +24,5 @@ export const parseTaskList = (
   tasks: data?.taskList?.tasks || data?.tasks || [],
   title: data?.title || "",
   description: data?.description || "",
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -1,6 +1,6 @@
 import { SchemaOf, string } from "yup";
 
-import { MoreInformation, parseMoreInformation } from "../shared";
+import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export type UserData = string;
 
@@ -64,7 +64,7 @@ export const userDataSchema = ({ type }: TextInput): SchemaOf<UserData> =>
       },
     });
 
-export interface TextInput extends MoreInformation {
+export interface TextInput extends BaseNodeData {
   title: string;
   description?: string;
   fn?: string;
@@ -78,5 +78,5 @@ export const parseTextInput = (
   description: data?.description,
   fn: data?.fn,
   type: data?.type,
-  ...parseMoreInformation(data),
+  ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/shared/index.ts
+++ b/editor.planx.uk/src/@planx/components/shared/index.ts
@@ -1,4 +1,9 @@
+import { NodeTags } from "@opensystemslab/planx-core/types";
 import trim from "lodash/trim";
+import { Store } from "pages/FlowEditor/lib/store";
+
+/** Shared properties across all node types */
+export type BaseNodeData = NodeTags & MoreInformation;
 
 export interface MoreInformation {
   howMeasured?: string;
@@ -8,14 +13,15 @@ export interface MoreInformation {
   definitionImg?: string;
 }
 
-export const parseMoreInformation = (
-  data: Record<string, any> | undefined,
-): MoreInformation => ({
+export const parseBaseNodeData = (
+  data: Store.Node["data"] | undefined,
+): BaseNodeData => ({
   notes: data?.notes,
   definitionImg: data?.definitionImg,
   howMeasured: data?.howMeasured,
   policyRef: data?.policyRef,
   info: data?.info,
+  tags: data?.tags,
 });
 
 export interface Option {


### PR DESCRIPTION
## What does this PR do?
 - Replaces the `MoreInformation` interface with `BaseNodeData`
   - Most of this PR is then just type changes that follow along
   - Removes duplicate properties (where `MoreInformation` was previously not being used)

## Why?
 - Part of the work to add tags to nodes
 - This new interface serves as a base for all Node types - meaning we always get both `NodeTags` and `MoreInformation`
 - Hopefully this pattern can be followed up fairly shortly to also pull in and standardise other common fields (`title`, `description`, maybe `fn`)