### PR TITLE
feat: allow team editors to download a zip of application data from the editor submissions log

### DIFF
--- a/editor.planx.uk/src/lib/pay.ts
+++ b/editor.planx.uk/src/lib/pay.ts
@@ -2,7 +2,7 @@ import { addDays, format, subDays } from "date-fns";
 
 // Must value set in api.planx.uk/saveAndReturn/utils.ts
 // This ensures that dates will be aligned in the public interface and in emails
-const DAYS_UNTIL_EXPIRY = 28;
+export const DAYS_UNTIL_EXPIRY = 28;
 
 export const getExpiryDateForPaymentRequest = (createdAt: string) => {
   const expiryDate = addDays(Date.parse(createdAt), DAYS_UNTIL_EXPIRY);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -14,6 +14,7 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
@@ -141,20 +142,22 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
         <TableCell>{submission.sessionId}</TableCell>
         <TableCell>
           {showDownloadButton && (
-            <IconButton
-              aria-label="download application"
-              size="small"
-              onClick={() => {
-                const zipUrl = `${
-                  import.meta.env.VITE_APP_API_URL
-                }/download-application-files/${
-                  submission.sessionId
-                }?localAuthority=${teamSlug}&email=${submissionEmail}`;
-                window.open(zipUrl, "_blank");
-              }}
-            >
-              <CloudDownload />
-            </IconButton>
+            <Tooltip arrow title="Download application data">
+              <IconButton
+                aria-label="download application"
+                size="small"
+                onClick={() => {
+                  const zipUrl = `${
+                    import.meta.env.VITE_APP_API_URL
+                  }/download-application-files/${
+                    submission.sessionId
+                  }?localAuthority=${teamSlug}&email=${submissionEmail}`;
+                  window.open(zipUrl, "_blank");
+                }}
+              >
+                <CloudDownload />
+              </IconButton>
+            </Tooltip>
           )}
         </TableCell>
         <TableCell>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -108,6 +108,19 @@ export const teamStore: StateCreator<
             integrations {
               hasPlanningData: has_planning_data
             }
+            settings: team_settings {
+              boundaryUrl: boundary_url
+              boundaryBBox: boundary_bbox
+              referenceCode: reference_code
+              helpEmail: help_email
+              helpPhone: help_phone
+              helpOpeningHours: help_opening_hours
+              emailReplyToId: email_reply_to_id
+              homepage: homepage
+              externalPlanningSiteName: external_planning_site_name
+              externalPlanningSiteUrl: external_planning_site_url
+              submissionEmail: submission_email
+            }
           }
         }
       `,


### PR DESCRIPTION
Folks using the existing Uniform connector have been having issues accessing application files in their DMS and more often requesting that a zip be sent to them via Slack, etc - this should make application data easier to self-serve from the editor ! See this thread for more context: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1727791569016769

**Changes:**
- Shows a download button in the submissions log (_if_ it's a sucessful submission within last 28 days, you have team editor privileges to this team, a submission email has been set in team settings)
  - This button downloads the same zip that folks access if using "Send to email" - it includes standard PlanX documents (application.csv, application.json, overview.html, redactedOverview.html, locationPlan.html, locationPlan.geojson) as well as any user-uploaded files

**Test flow:**
- https://3750.planx.pizza/testing/submission-log-download-test/submissions-log

![Screenshot from 2024-10-01 20-23-48](https://github.com/user-attachments/assets/bc74ada1-7c8d-42c7-94ba-dab6de2fa069)
