### PR TITLE
fix: correct submissions log date comparison (hide download if > 28 days old)

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -18,7 +18,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
-import { addDays, format, isBefore } from "date-fns";
+import { addDays, format, isAfter, isBefore } from "date-fns";
 import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
@@ -105,12 +105,15 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
   ]);
 
   // Only show an application download button if certain conditions are met
-  const submissionDataExpirationDate = addDays(new Date(), DAYS_UNTIL_EXPIRY);
+  const submissionDataExpirationDate = addDays(
+    new Date(submission.createdAt),
+    DAYS_UNTIL_EXPIRY,
+  );
   const showDownloadButton =
     canUserEditTeam(teamSlug) &&
     submission.status === "Success" &&
     submissionEmail &&
-    isBefore(new Date(submission.createdAt), submissionDataExpirationDate);
+    isBefore(new Date(), submissionDataExpirationDate);
 
   return (
     <React.Fragment key={`${submission.eventId}-${submission.createdAt}`}>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -18,7 +18,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
-import { addDays, format, isAfter, isBefore } from "date-fns";
+import { addDays, format, isBefore } from "date-fns";
 import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";


### PR DESCRIPTION
Noticed when merged to staging - eg buttons should be hidden here because > 28 days old https://editor.planx.dev/southwark/apply-for-planning-permission/submissions-log (should help minimise prevalence of "cannot find published flow" error on staging, but that's another topic!)

Was my mistake - just a quick swap of comparison dates here so we're correctly calculating the expiry date _from_ the submission event, not now as before. 