### PR TITLE
fix: update Submission Logs description, hide button on Pay events

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -112,8 +112,8 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
   const showDownloadButton =
     canUserEditTeam(teamSlug) &&
     submission.status === "Success" &&
-    submissionEmail &&
-    isBefore(new Date(), submissionDataExpirationDate);
+    submission.eventType !== "Pay";
+  submissionEmail && isBefore(new Date(), submissionDataExpirationDate);
 
   return (
     <React.Fragment key={`${submission.eventId}-${submission.createdAt}`}>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/EventsLog.tsx
@@ -112,8 +112,9 @@ const CollapsibleRow: React.FC<Submission> = (submission) => {
   const showDownloadButton =
     canUserEditTeam(teamSlug) &&
     submission.status === "Success" &&
-    submission.eventType !== "Pay";
-  submissionEmail && isBefore(new Date(), submissionDataExpirationDate);
+    submission.eventType !== "Pay" &&
+    submissionEmail &&
+    isBefore(new Date(), submissionDataExpirationDate);
 
   return (
     <React.Fragment key={`${submission.eventId}-${submission.createdAt}`}>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -78,7 +78,9 @@ const Submissions: React.FC = () => {
           Submissions
         </Typography>
         <Typography variant="body1">
-          Feed of payment and submission events for this service
+          Feed of payment and submission events for this service. Successful
+          submission events within the last 28 days are availabe to download to
+          team editors.
         </Typography>
       </SettingsSection>
       <SettingsSection>


### PR DESCRIPTION
Two more minor tweaks to recent Submissions Logs changes - should clear up a bit of confusion based on questions that popped up at planning mtg ! 