### PR TITLE
[api] remove `/logout` route (do not implement front channel logout)

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -7,14 +7,6 @@ export const failedLogin: RequestHandler = (_req, _res, next) =>
     message: "User failed to authenticate",
   });
 
-export const logout: RequestHandler = (req, res) => {
-  // TODO: implement dual purpose as Microsoft frontend logout channel
-  req.logout(() => {
-    // do nothing
-  });
-  res.redirect(process.env.EDITOR_URL_EXT!);
-};
-
 export const handleSuccess = (req: Request, res: Response) => {
   if (!req.user) {
     return res.json({

--- a/api.planx.uk/modules/auth/docs.yaml
+++ b/api.planx.uk/modules/auth/docs.yaml
@@ -6,13 +6,6 @@ tags:
   - name: auth
     description: Authentication related requests
 paths:
-  /logout:
-    get:
-      summary: Logout from the PlanX service
-      tags: ["auth"]
-      responses:
-        "302":
-          description: Redirect to PlanX Editor
   /auth/login/failed:
     get:
       summary: Failed login
@@ -40,6 +33,22 @@ paths:
     get:
       summary: Generate a JWT for an authenticated user
       description: After authentication, Google will redirect the user back to this route which generates a JWT for the user
+      tags: ["auth"]
+      responses:
+        "200":
+          description: OK
+  /auth/microsoft:
+    get:
+      summary: Authenticate via Microsoft SSO
+      description: The first step in Microsoft authentication will involve redirecting the user to login.microsoftonline.com
+      tags: ["auth"]
+      responses:
+        "200":
+          description: OK
+  /auth/microsoft/callback:
+    get:
+      summary: Generate a JWT for an authenticated user
+      description: After authentication, Microsoft will redirect the user back to this route which generates a JWT for the user
       tags: ["auth"]
       responses:
         "200":

--- a/api.planx.uk/modules/auth/routes.ts
+++ b/api.planx.uk/modules/auth/routes.ts
@@ -6,8 +6,6 @@ import * as Controller from "./controller.js";
 export default (passport: Authenticator): Router => {
   const router = Router();
 
-  router.get("/logout", Controller.logout);
-  // router.get("/auth/frontchannel-logout", Controller.frontChannelLogout)
   router.get("/auth/login/failed", Controller.failedLogin);
   router.get("/auth/google", Middleware.getGoogleAuthHandler(passport));
   router.get(


### PR DESCRIPTION
Relates to [this Trello ticket](https://trello.com/c/0gYN7cdt) and follows on from #3453.

After some investigation, I came to the conclusion that implementing [front channel logout](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#single-sign-out) does not make sense in our context.

Before I realised that, and while trying to figure out how best to implement it, I realised that the API's `/logout` route is never hit, so serves no purpose. Therefore I have removed it in this PR.

## Some context

As per the Open ID Connect spec, a front channel logout is intended to log a user out of any server on which they are authenticated by a provider (e.g. Microsoft), when they log out of said provider centrally (or via another service).

For example, if I log out of my Microsoft account on Microsoft.com, I'd expect to be simultaneously logged out of PlanX, assuming I'd logged in via Microsoft SSO.

However, a PlanX user being 'logged in' is currently achieved by the presence of a `jwt` cookie stored on the browser, and does not relate to any session or state stored on the API server or in the database (this client-side session data is cleared when the user clicks `Logout` - see [here](https://github.com/theopensystemslab/planx-new/blob/main/editor.planx.uk/src/routes/index.tsx#L33)).

Therefore, there is no server to communicate a logout instruction to. The JWT on the user's browser cannot be revoked from without, will expire in due course (??), and cannot be renewed without signing in again.

I think this is a reasonable situation. If we wanted Microsoft to be able to log a user out, we'd have to keep session server-side, which would be a significant change.

## Further resources

- https://openid.net/specs/openid-connect-frontchannel-1_0.html#OPLogout