### PR TITLE
feat(ui): Node tags

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
@@ -2,11 +2,10 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -66,18 +65,7 @@ export default function AddressInputComponent(props: Props): FCReturn {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -6,12 +6,11 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import InputGroup from "ui/editor/InputGroup";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import Input from "ui/shared/Input";
@@ -195,18 +194,7 @@ export default function Component(props: Props) {
           </p>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -14,6 +14,7 @@ import { FormikHookReturn } from "types";
 import ImgInput from "ui/editor/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
 import ListManager from "ui/editor/ListManager";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -24,7 +25,7 @@ import InputRowItem from "ui/shared/InputRowItem";
 
 import { BaseNodeData, Option, parseBaseNodeData } from "../shared";
 import PermissionSelect from "../shared/PermissionSelect";
-import { ICONS, InternalNotes, MoreInformation } from "../ui";
+import { ICONS } from "../ui";
 import type { Category, Checklist, Group } from "./model";
 import { toggleExpandableChecklist } from "./model";
 
@@ -427,18 +428,7 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
         <Options formik={formik} />
       </ModalSection>
 
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        onChange={formik.handleChange}
-        value={formik.values.notes}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
@@ -2,11 +2,10 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -66,18 +65,7 @@ export default function ContactInputComponent(props: Props): FCReturn {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Content/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Editor.tsx
@@ -4,12 +4,11 @@ import { parseContent } from "@planx/components/Content/model";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import ColorPicker from "ui/editor/ColorPicker";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -49,18 +48,7 @@ const ContentComponent: React.FC<Props> = (props) => {
           />
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -9,11 +9,10 @@ import { parseDateInput } from "@planx/components/DateInput/model";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -97,18 +96,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
           </Box>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
@@ -4,12 +4,11 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import InputGroup from "ui/editor/InputGroup";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -119,18 +118,7 @@ function DrawBoundaryComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -1,7 +1,8 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { ICONS, InternalNotes, MoreInformation } from "@planx/components/ui";
+import { ICONS } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -72,18 +73,7 @@ function Component(props: any) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        onChange={formik.handleChange}
-        value={formik.values.notes}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -10,8 +10,6 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import { lowerCase, merge, upperFirst } from "lodash";
@@ -20,6 +18,7 @@ import ImgInput from "ui/editor/ImgInput";
 import ListManager, {
   EditorProps as ListManagerEditorProps,
 } from "ui/editor/ListManager";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import { ModalSubtitle } from "ui/editor/ModalSubtitle";
@@ -122,18 +121,7 @@ function FileUploadAndLabelComponent(props: Props) {
           />
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultipleFileTypes.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/SelectMultipleFileTypes.tsx
@@ -163,7 +163,7 @@ export const SelectMultipleFileTypes = (props: SelectMultipleProps) => {
   };
 
   return (
-    <SelectMultiple<Option>
+    <SelectMultiple
       getOptionLabel={(option) => option.name}
       groupBy={(option) => option.category}
       id={`select-multiple-file-tags-${uploadedFile.id}`}

--- a/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -4,12 +4,11 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import InputGroup from "ui/editor/InputGroup";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -114,18 +113,7 @@ function FindPropertyComponent(props: Props) {
           )}
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -2,6 +2,7 @@ import MenuItem from "@mui/material/MenuItem";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -12,7 +13,7 @@ import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
-import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
+import { EditorProps, ICONS } from "../ui";
 import { List, parseContent, validationSchema } from "./model";
 import { ProposedAdvertisements } from "./schemas/Adverts";
 import { NonResidentialFloorspace } from "./schemas/Floorspace";
@@ -153,18 +154,7 @@ function ListComponent(props: Props) {
           </ErrorWrapper>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -7,6 +7,7 @@ import { useFormik } from "formik";
 import React from "react";
 import ColorPicker from "ui/editor/ColorPicker";
 import InputGroup from "ui/editor/InputGroup";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -17,7 +18,7 @@ import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
 import BasicRadio from "../shared/Radio/BasicRadio";
-import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
+import { EditorProps, ICONS } from "../ui";
 import { MapAndLabel, parseContent } from "./model";
 import { Trees } from "./schemas/Trees";
 
@@ -177,18 +178,7 @@ function MapAndLabelComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -5,14 +5,13 @@ import { parseNextSteps } from "@planx/components/NextSteps/model";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React, { ChangeEvent } from "react";
 import ListManager, {
   EditorProps as ListManagerEditorProps,
 } from "ui/editor/ListManager";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -118,18 +117,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
           />
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        onChange={formik.handleChange}
-        value={formik.values.notes}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -7,6 +7,7 @@ import { ICONS, InternalNotes, MoreInformation } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import ColorPicker from "ui/editor/ColorPicker";
+import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -104,6 +105,13 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
           });
         }}
         value={props.value.notes}
+      />
+      <ComponentTagSelect
+        onChange={(value) => props.onChange({
+          ...props.value,
+          tags: value,
+        })}
+        value={props.value.tags}
       />
     </>
   );

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -6,11 +6,10 @@ import { parseNumberInput } from "@planx/components/NumberInput/model";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -94,18 +93,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -2,6 +2,7 @@ import MenuItem from "@mui/material/MenuItem";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -11,7 +12,7 @@ import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
-import { EditorProps, ICONS, InternalNotes, MoreInformation } from "../ui";
+import { EditorProps, ICONS } from "../ui";
 import { Page, parsePage } from "./model";
 import { ProposedAdvertisements } from "./schema/AdvertConsent";
 
@@ -89,18 +90,7 @@ function PageComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -23,6 +23,7 @@ import {
 import { Form, Formik, useFormikContext } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ListManager, {
   EditorProps as ListManagerEditorProps,
 } from "ui/editor/ListManager";
@@ -448,6 +449,10 @@ const Component: React.FC<Props> = (props: Props) => {
             name="notes"
             onChange={handleChange}
             value={values.notes}
+          />
+          <ComponentTagSelect
+            onChange={(value) => setFieldValue("tags", value)}
+            value={values.tags}
           />
         </Form>
       )}

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
@@ -8,11 +8,12 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { EditorProps, ICONS, InternalNotes } from "@planx/components/ui";
+import { EditorProps, ICONS } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
 import InputGroup from "ui/editor/InputGroup";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -166,11 +167,7 @@ function PlanningConstraintsComponent(props: Props) {
           </InputGroup>
         </ModalSectionContent>
       </ModalSection>
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} showMoreInformation={false}/>
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
@@ -4,11 +4,10 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -74,18 +73,7 @@ function PropertyInformationComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -1,6 +1,7 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React, { useEffect, useRef } from "react";
+import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ImgInput from "ui/editor/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
 import ListManager from "ui/editor/ListManager";
@@ -238,6 +239,10 @@ export const Question: React.FC<Props> = (props) => {
         name="notes"
         onChange={formik.handleChange}
         value={formik.values.notes}
+      />
+      <ComponentTagSelect
+        value={formik.values.tags}
+        onChange={(value) => formik.setFieldValue("tags", value)}
       />
     </form>
   );

--- a/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -1,13 +1,14 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 
-import { EditorProps, ICONS, InternalNotes } from "../ui";
+import { EditorProps, ICONS } from "../ui";
 import { parseContent, Review } from "./model";
 
 type Props = EditorProps<TYPES.Review, Review>;
@@ -46,11 +47,7 @@ function Component(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <InternalNotes
-        name="notes"
-        onChange={formik.handleChange}
-        value={formik.values.notes}
-      />
+      <ModalFooter formik={formik} showMoreInformation={false} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -1,7 +1,8 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { EditorProps, ICONS, InternalNotes } from "@planx/components/ui";
+import { EditorProps, ICONS } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -49,11 +50,7 @@ function SectionComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} showMoreInformation={false} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -3,9 +3,10 @@ import RadioGroup from "@mui/material/RadioGroup";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
-import { EditorProps, InternalNotes } from "@planx/components/ui";
+import { EditorProps } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import Input from "ui/shared/Input";
@@ -138,11 +139,7 @@ function SetValueComponent(props: Props) {
           </FormControl>
         </ModalSectionContent>
       </ModalSection>
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} showMoreInformation={false}/>
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -5,14 +5,13 @@ import { parseTaskList } from "@planx/components/TaskList/model";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React, { ChangeEvent } from "react";
 import ListManager, {
   EditorProps as ListManagerEditorProps,
 } from "ui/editor/ListManager";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -104,18 +103,7 @@ const TaskListComponent: React.FC<Props> = (props) => {
           />
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        onChange={formik.handleChange}
-        value={formik.values.notes}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -5,11 +5,10 @@ import BasicRadio from "@planx/components/shared/Radio/BasicRadio";
 import {
   EditorProps,
   ICONS,
-  InternalNotes,
-  MoreInformation,
 } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
+import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput";
@@ -21,7 +20,7 @@ import { parseTextInput, TextInput } from "./model";
 export type Props = EditorProps<TYPES.TextInput, TextInput>;
 
 const TextInputComponent: React.FC<Props> = (props) => {
-  const formik = useFormik({
+  const formik = useFormik<TextInput>({
     initialValues: parseTextInput(props.node?.data),
     onSubmit: (newValues) => {
       if (props.handleSubmit) {
@@ -95,18 +94,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
           </FormControl>
         </ModalSectionContent>
       </ModalSection>
-      <MoreInformation
-        changeField={formik.handleChange}
-        definitionImg={formik.values.definitionImg}
-        howMeasured={formik.values.howMeasured}
-        policyRef={formik.values.policyRef}
-        info={formik.values.info}
-      />
-      <InternalNotes
-        name="notes"
-        value={formik.values.notes}
-        onChange={formik.handleChange}
-      />
+      <ModalFooter formik={formik} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/shared/index.ts
+++ b/editor.planx.uk/src/@planx/components/shared/index.ts
@@ -21,7 +21,7 @@ export const parseBaseNodeData = (
   howMeasured: data?.howMeasured,
   policyRef: data?.policyRef,
   info: data?.info,
-  tags: data?.tags,
+  tags: data?.tags || [],
 });
 
 export interface Option {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -1,5 +1,8 @@
 import Box from "@mui/material/Box";
-import { ComponentType as TYPES,NodeTags } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  NodeTags,
+} from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/ui";
 import classNames from "classnames";
 import mapAccum from "ramda/src/mapAccum";
@@ -92,7 +95,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
             {Icon && <Icon />}
             <span>{props.text}</span>
           </Link>
-          { props.tags?.map((tag) => <Tag tag={tag} />)}
+          {props.tags?.map((tag) => <Tag tag={tag} key={tag} />)}
         </Box>
         {groupedOptions ? (
           <ol className="categories">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -1,4 +1,5 @@
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import Box from "@mui/material/Box";
+import { ComponentType as TYPES,NodeTags } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/ui";
 import classNames from "classnames";
 import mapAccum from "ramda/src/mapAccum";
@@ -10,12 +11,13 @@ import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
 import Hanger from "./Hanger";
 import Node from "./Node";
+import { Tag } from "./Tag";
 
 type Props = {
   type: TYPES;
   [key: string]: any;
   wasVisited?: boolean;
-};
+} & NodeTags;
 
 const Checklist: React.FC<Props> = React.memo((props) => {
   const [isClone, childNodes, copyNode] = useStore((state) => [
@@ -80,15 +82,18 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           wasVisited: props.wasVisited,
         })}
       >
-        <Link
-          href={href}
-          prefetch={false}
-          onContextMenu={handleContext}
-          ref={drag}
-        >
-          {Icon && <Icon />}
-          <span>{props.text}</span>
-        </Link>
+        <Box>
+          <Link
+            href={href}
+            prefetch={false}
+            onContextMenu={handleContext}
+            ref={drag}
+          >
+            {Icon && <Icon />}
+            <span>{props.text}</span>
+          </Link>
+          { props.tags?.map((tag) => <Tag tag={tag} />)}
+        </Box>
         {groupedOptions ? (
           <ol className="categories">
             {groupedOptions.map(({ title, children }, i) => (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -21,6 +21,7 @@ const Node: React.FC<any> = (props) => {
   const allProps = {
     ...props,
     wasVisited,
+    tags: node.data?.tags,
   };
 
   const type = props.type as TYPES;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -83,7 +83,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           {Icon && <Icon titleAccess={iconTitleAccess} />}
           <span>{props.text}</span>
         </Link>
-        { props.tags?.map(( tag ) => <Tag tag={tag} /> ) }
+        {props.tags?.map((tag) => <Tag tag={tag} key={tag} />)}
         <ol className="options">
           {childNodes.map((child: any) => (
             <Node key={child.id} {...child} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -1,5 +1,8 @@
 import ErrorIcon from "@mui/icons-material/Error";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  NodeTags,
+} from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/ui";
 import classNames from "classnames";
 import React from "react";
@@ -10,12 +13,13 @@ import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
 import Hanger from "./Hanger";
 import Node from "./Node";
+import { Tag } from "./Tag";
 
 type Props = {
   type: TYPES | "Error";
   [key: string]: any;
   wasVisited?: boolean;
-};
+} & NodeTags;
 
 const Question: React.FC<Props> = React.memo((props) => {
   const [isClone, childNodes, copyNode] = useStore((state) => [
@@ -79,6 +83,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           {Icon && <Icon titleAccess={iconTitleAccess} />}
           <span>{props.text}</span>
         </Link>
+        { props.tags?.map(( tag ) => <Tag tag={tag} /> ) }
         <ol className="options">
           {childNodes.map((child: any) => (
             <Node key={child.id} {...child} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,0 +1,28 @@
+import Box from "@mui/material/Box";
+import { NodeTag } from "@opensystemslab/planx-core/types";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+export const TAG_DISPLAY_VALUES: Record<NodeTag, { color: string, displayName: string }> = {
+  placeholder: {
+    color: "#FAE1B7",
+    displayName: "Placeholder"
+  }
+} as const;
+
+export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => (
+  <Box
+    sx={(theme) => ({
+      bgcolor: TAG_DISPLAY_VALUES[tag].color,
+      borderColor: theme.palette.common.black,
+      borderWidth: "0 1px 1px 1px",
+      borderStyle: "solid",
+      width: "100%",
+      p: 0.5,
+      textAlign: "center",
+      fontWeight: FONT_WEIGHT_SEMI_BOLD
+    })}
+  >
+    { TAG_DISPLAY_VALUES[tag].displayName }
+  </Box>
+);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,17 +1,24 @@
 import Box from "@mui/material/Box";
+import { visuallyHidden } from "@mui/utils";
 import { NodeTag } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-export const TAG_DISPLAY_VALUES: Record<NodeTag, { color: string, displayName: string }> = {
+export const TAG_DISPLAY_VALUES: Record<
+  NodeTag,
+  { color: string; displayName: string }
+> = {
   placeholder: {
     color: "#FAE1B7",
-    displayName: "Placeholder"
-  }
+    displayName: "Placeholder",
+  },
 } as const;
 
 export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => (
   <Box
+    // Temporarily hidden until we decide how this should appear in the graph
+    // Please see https://github.com/theopensystemslab/planx-new/pull/3762
+    style={visuallyHidden}
     sx={(theme) => ({
       bgcolor: TAG_DISPLAY_VALUES[tag].color,
       borderColor: theme.palette.common.black,
@@ -20,9 +27,9 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => (
       width: "100%",
       p: 0.5,
       textAlign: "center",
-      fontWeight: FONT_WEIGHT_SEMI_BOLD
+      fontWeight: FONT_WEIGHT_SEMI_BOLD,
     })}
   >
-    { TAG_DISPLAY_VALUES[tag].displayName }
+    {TAG_DISPLAY_VALUES[tag].displayName}
   </Box>
 );

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -137,6 +137,7 @@ $fontMonospace: "Source Code Pro", monospace;
     border: $nodeBorderWidth dashed red;
   }
 
+  & > div > a,
   & > a {
     position: relative;
     display: flex;

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -2,6 +2,7 @@ import BookmarksIcon from "@mui/icons-material/Bookmarks";
 import { AutocompleteProps } from "@mui/material/Autocomplete";
 import ListItem from "@mui/material/ListItem";
 import { NODE_TAGS, NodeTag } from "@opensystemslab/planx-core/types";
+import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -22,7 +23,7 @@ const renderOption: AutocompleteProps<
 >["renderOption"] = (props, tag, { selected }) => (
   <ListItem {...props}>
     <CustomCheckbox aria-hidden="true" className={selected ? "selected" : ""} />
-    {tag}
+    { TAG_DISPLAY_VALUES[tag].displayName }
   </ListItem>
 );
 
@@ -33,6 +34,7 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
         <InputRow>
           <SelectMultiple
             label="Tag this component"
+            getOptionLabel={(tag) => TAG_DISPLAY_VALUES[tag].displayName}
             options={NODE_TAGS}
             onChange={(_e, value) => onChange(value)}
             value={value}

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -1,0 +1,45 @@
+import BookmarksIcon from "@mui/icons-material/Bookmarks";
+import { AutocompleteProps } from "@mui/material/Autocomplete";
+import ListItem from "@mui/material/ListItem";
+import { NODE_TAGS, NodeTag } from "@opensystemslab/planx-core/types";
+import React from "react";
+import ModalSection from "ui/editor/ModalSection";
+import ModalSectionContent from "ui/editor/ModalSectionContent";
+import InputRow from "ui/shared/InputRow";
+import { CustomCheckbox, SelectMultiple } from "ui/shared/SelectMultiple";
+
+interface Props {
+  value?: NodeTag[];
+  onChange: (values: NodeTag[]) => void;
+};
+
+const renderOption: AutocompleteProps<
+  NodeTag,
+  true,
+  true,
+  false,
+  "div"
+>["renderOption"] = (props, tag, { selected }) => (
+  <ListItem {...props}>
+    <CustomCheckbox aria-hidden="true" className={selected ? "selected" : ""} />
+    {tag}
+  </ListItem>
+);
+
+export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
+  return (
+    <ModalSection>
+      <ModalSectionContent title="Tags" Icon={BookmarksIcon}>
+        <InputRow>
+          <SelectMultiple
+            label="Tag this component"
+            options={NODE_TAGS}
+            onChange={(_e, value) => onChange(value)}
+            value={value}
+            renderOption={renderOption}
+          />
+        </InputRow>
+      </ModalSectionContent>
+    </ModalSection>
+  )
+}

--- a/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -1,15 +1,15 @@
 import { BaseNodeData } from "@planx/components/shared";
-import { InternalNotes, MoreInformation } from "@planx/components/ui"
+import { InternalNotes, MoreInformation } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 
-import { ComponentTagSelect } from "./ComponentTagSelect"
+import { ComponentTagSelect } from "./ComponentTagSelect";
 
 interface Props<T extends BaseNodeData> {
-  formik: ReturnType<typeof useFormik<T>>
-  showMoreInformation?: boolean
-  showInternalNotes?: boolean
-  showTags?: boolean
+  formik: ReturnType<typeof useFormik<T>>;
+  showMoreInformation?: boolean;
+  showInternalNotes?: boolean;
+  showTags?: boolean;
 }
 
 export const ModalFooter = <T extends BaseNodeData>({
@@ -19,7 +19,7 @@ export const ModalFooter = <T extends BaseNodeData>({
   showTags = true,
 }: Props<T>) => (
   <>
-    {showMoreInformation &&
+    {showMoreInformation && (
       <MoreInformation
         changeField={formik.handleChange}
         definitionImg={formik.values.definitionImg}
@@ -27,19 +27,19 @@ export const ModalFooter = <T extends BaseNodeData>({
         policyRef={formik.values.policyRef}
         info={formik.values.info}
       />
-    }
-    {showInternalNotes &&
+    )}
+    {showInternalNotes && (
       <InternalNotes
-      name="notes"
-      onChange={formik.handleChange}
-      value={formik.values.notes}
+        name="notes"
+        onChange={formik.handleChange}
+        value={formik.values.notes}
       />
-    }
-    { showTags &&
+    )}
+    {showTags && (
       <ComponentTagSelect
         value={formik.values.tags}
         onChange={(value) => formik.setFieldValue("tags", value)}
       />
-    }
+    )}
   </>
-)
+);

--- a/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -1,0 +1,45 @@
+import { BaseNodeData } from "@planx/components/shared";
+import { InternalNotes, MoreInformation } from "@planx/components/ui"
+import { useFormik } from "formik";
+import React from "react";
+
+import { ComponentTagSelect } from "./ComponentTagSelect"
+
+interface Props<T extends BaseNodeData> {
+  formik: ReturnType<typeof useFormik<T>>
+  showMoreInformation?: boolean
+  showInternalNotes?: boolean
+  showTags?: boolean
+}
+
+export const ModalFooter = <T extends BaseNodeData>({
+  formik,
+  showMoreInformation = true,
+  showInternalNotes = true,
+  showTags = true,
+}: Props<T>) => (
+  <>
+    {showMoreInformation &&
+      <MoreInformation
+        changeField={formik.handleChange}
+        definitionImg={formik.values.definitionImg}
+        howMeasured={formik.values.howMeasured}
+        policyRef={formik.values.policyRef}
+        info={formik.values.info}
+      />
+    }
+    {showInternalNotes &&
+      <InternalNotes
+      name="notes"
+      onChange={formik.handleChange}
+      value={formik.values.notes}
+      />
+    }
+    { showTags &&
+      <ComponentTagSelect
+        value={formik.values.tags}
+        onChange={(value) => formik.setFieldValue("tags", value)}
+      />
+    }
+  </>
+)

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -64,6 +64,7 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   [`& .${outlinedInputClasses.root}, input`]: {
     cursor: "pointer",
+    backgroundColor: theme.palette.background.default,
   },
   [`& .${inputLabelClasses.root}`]: {
     textDecoration: "underline",


### PR DESCRIPTION
## What does this PR do?
 - Creates a `ComponentTagSelect` component, and adds this to all components which have more info and/or internal notes (I think just portals are excluded)
 - This is contained within a `ModalFooter` component, which now wraps internal notes, more information, and tags
 - Displays tags on the graph
 
<p align="center">
<img width="581" alt="image" src="https://github.com/user-attachments/assets/6043d79f-01db-4457-8d2d-21d58439fcd1">

<img width="666" alt="image" src="https://github.com/user-attachments/assets/bbc6e68a-8f35-463c-92eb-38278b3815a6">
</p>


## Next steps / questions
A few great comments and questions from show and tell which I've listed below, with my suggestions on how to approach them.

- Can we have more tags (e.g. automation, sensitive)?
  - It might be worthwhile adding a few extra initially here to make the most of this feature. I can compile a small list and add to PlanX core

- Should tags have an associated colour?
   - Probably! We can match them and then update chips within the modal to re-use this colour scheme - seems a change worth making

- Should tags display on graphs? Is this a templates only thing? How should more than one tag display?
  - Great question, this one might need some more input from @ianjon3s - I guess if we have multiple tags per component, we need an alternate display method. For now I can not display on the graph in order to progress this PR and we can come back here shortly

- Can I search by tags or view them any other way?
  - Yes, this will be added as a facet to search shortly