### PR TITLE
feat:

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -397,12 +397,12 @@ export const previewStore: StateCreator<
   upcomingCardIds() {
     const { flow, breadcrumbs, computePassport, collectedFlags } = get();
 
-    const knownNotVals = knownNots(
-      flow,
-      breadcrumbs,
-      // _nots is created by PlanningConstraints/Public
-      computePassport().data?._nots,
-    );
+    // const knownNotVals = knownNots(
+    //   flow,
+    //   breadcrumbs,
+    //   // _nots is created by PlanningConstraints/Public
+    //   computePassport().data?._nots,
+    // );
 
     const ids: Set<NodeId> = new Set();
     const visited: Set<NodeId> = new Set();
@@ -417,161 +417,160 @@ export const previewStore: StateCreator<
           const node = flow[id];
 
           return (
-            node &&
-            !breadcrumbs[id] &&
-            ((node.edges || []).length > 0 ||
-              (node.type && !SUPPORTED_DECISION_TYPES.includes(node.type)))
+            node && !breadcrumbs[id]
+            // ((node.edges || []).length > 0 ||
+            //   (node.type && !SUPPORTED_DECISION_TYPES.includes(node.type)))
           );
         })
         .forEach((id) => {
           const node = flow[id];
 
-          const passport = computePassport();
+          // const passport = computePassport();
 
           if (node.type === TYPES.InternalPortal) {
             return nodeIdsConnectedFrom(id);
           }
 
-          const fn = node.type === TYPES.Filter ? "flag" : node.data?.fn;
+          // const fn = node.type === TYPES.Filter ? "flag" : node.data?.fn;
 
-          const [globalFlag] = collectedFlags(id, Array.from(visited));
+          // const [globalFlag] = collectedFlags(id, Array.from(visited));
 
-          let passportValues = (() => {
-            try {
-              return fn === "flag" ? globalFlag : passport.data?.[fn]?.sort();
-            } catch (err) {
-              return [];
-            }
-          })();
+          // let passportValues = (() => {
+          //   try {
+          //     return fn === "flag" ? globalFlag : passport.data?.[fn]?.sort();
+          //   } catch (err) {
+          //     return [];
+          //   }
+          // })();
 
-          if (fn && (fn === "flag" || passportValues !== undefined)) {
-            const responses = node.edges?.map((id) => ({
-              id,
-              ...flow[id],
-            }));
+          // if (fn && (fn === "flag" || passportValues !== undefined)) {
+          //   const responses = node.edges?.map((id) => ({
+          //     id,
+          //     ...flow[id],
+          //   }));
 
-            let responsesThatCanBeAutoAnswered = [] as any[];
+          //   let responsesThatCanBeAutoAnswered = [] as any[];
 
-            const sortedResponses = responses
-              ? responses
-                  // sort by the most to least number of comma-separated items in data.val
-                  .sort(
-                    (a: any, b: any) =>
-                      String(b.data?.val).split(",").length -
-                      String(a.data?.val).split(",").length,
-                  )
-                  .filter((response) => response.data?.val)
-              : [];
+          //   const sortedResponses = responses
+          //     ? responses
+          //         // sort by the most to least number of comma-separated items in data.val
+          //         .sort(
+          //           (a: any, b: any) =>
+          //             String(b.data?.val).split(",").length -
+          //             String(a.data?.val).split(",").length,
+          //         )
+          //         .filter((response) => response.data?.val)
+          //     : [];
 
-            if (passportValues !== undefined) {
-              if (!Array.isArray(passportValues))
-                passportValues = [passportValues];
+          //   if (passportValues !== undefined) {
+          //     if (!Array.isArray(passportValues))
+          //       passportValues = [passportValues];
 
-              passportValues = (passportValues || []).filter((pv: any) =>
-                sortedResponses.some((r) => pv.startsWith(r.data?.val)),
-              );
+          //     passportValues = (passportValues || []).filter((pv: any) =>
+          //       sortedResponses.some((r) => pv.startsWith(r.data?.val)),
+          //     );
 
-              if (passportValues.length > 0) {
-                responsesThatCanBeAutoAnswered = (sortedResponses || []).filter(
-                  (r) => {
-                    const responseValues = String(r.data?.val)
-                      .split(",")
-                      .sort();
-                    return String(responseValues) === String(passportValues);
-                  },
-                );
+          //     if (passportValues.length > 0) {
+          //       responsesThatCanBeAutoAnswered = (sortedResponses || []).filter(
+          //         (r) => {
+          //           const responseValues = String(r.data?.val)
+          //             .split(",")
+          //             .sort();
+          //           return String(responseValues) === String(passportValues);
+          //         },
+          //       );
 
-                if (responsesThatCanBeAutoAnswered.length === 0) {
-                  responsesThatCanBeAutoAnswered = (
-                    sortedResponses || []
-                  ).filter((r) => {
-                    const responseValues = String(r.data?.val)
-                      .split(",")
-                      .sort();
+          //       if (responsesThatCanBeAutoAnswered.length === 0) {
+          //         responsesThatCanBeAutoAnswered = (
+          //           sortedResponses || []
+          //         ).filter((r) => {
+          //           const responseValues = String(r.data?.val)
+          //             .split(",")
+          //             .sort();
 
-                    for (const responseValue of responseValues) {
-                      return passportValues.some((passportValue: any) =>
-                        String(passportValue).startsWith(responseValue),
-                      );
-                    }
-                  });
-                }
-              }
-            }
+          //           for (const responseValue of responseValues) {
+          //             return passportValues.some((passportValue: any) =>
+          //               String(passportValue).startsWith(responseValue),
+          //             );
+          //           }
+          //         });
+          //       }
+          //     }
+          //   }
 
-            if (responsesThatCanBeAutoAnswered.length === 0) {
-              const _responses = (responses || []).filter(
-                (r) => !knownNotVals[fn]?.includes(r.data?.val),
-              );
+          //   if (responsesThatCanBeAutoAnswered.length === 0) {
+          //     const _responses = (responses || []).filter(
+          //       (r) => !knownNotVals[fn]?.includes(r.data?.val),
+          //     );
 
-              if (_responses.length === 1 && isNil(_responses[0].data?.val)) {
-                responsesThatCanBeAutoAnswered = _responses;
-              } else if (
-                !passport.data?.[fn] ||
-                passport.data?.[fn].length > 0
-              ) {
-                responsesThatCanBeAutoAnswered = (responses || []).filter(
-                  (r) => !r.data?.val,
-                );
-              }
-            }
+          //     if (_responses.length === 1 && isNil(_responses[0].data?.val)) {
+          //       responsesThatCanBeAutoAnswered = _responses;
+          //     } else if (
+          //       !passport.data?.[fn] ||
+          //       passport.data?.[fn].length > 0
+          //     ) {
+          //       responsesThatCanBeAutoAnswered = (responses || []).filter(
+          //         (r) => !r.data?.val,
+          //       );
+          //     }
+          //   }
 
-            if (responsesThatCanBeAutoAnswered.length > 0) {
-              if (node.type !== TYPES.Checklist) {
-                responsesThatCanBeAutoAnswered =
-                  responsesThatCanBeAutoAnswered.slice(0, 1);
-              }
+          //   if (responsesThatCanBeAutoAnswered.length > 0) {
+          //     if (node.type !== TYPES.Checklist) {
+          //       responsesThatCanBeAutoAnswered =
+          //         responsesThatCanBeAutoAnswered.slice(0, 1);
+          //     }
 
-              if (fn !== "flag") {
-                set({
-                  breadcrumbs: {
-                    ...breadcrumbs,
-                    [id]: {
-                      answers: responsesThatCanBeAutoAnswered.map((r) => r.id),
-                      auto: true,
-                    },
-                  },
-                });
-              }
+          //     if (fn !== "flag") {
+          //       set({
+          //         breadcrumbs: {
+          //           ...breadcrumbs,
+          //           [id]: {
+          //             answers: responsesThatCanBeAutoAnswered.map((r) => r.id),
+          //             auto: true,
+          //           },
+          //         },
+          //       });
+          //     }
 
-              return responsesThatCanBeAutoAnswered.forEach((r) =>
-                nodeIdsConnectedFrom(r.id),
-              );
-            }
-          } else if (
-            fn &&
-            knownNotVals[fn] &&
-            passportValues === undefined &&
-            Array.isArray(node.edges)
-          ) {
-            const data = node.edges.reduce(
-              (acc, edgeId) => {
-                if (flow[edgeId].data?.val === undefined) {
-                  acc.responseWithNoValueId = edgeId;
-                } else if (!knownNotVals[fn].includes(flow[edgeId].data?.val)) {
-                  acc.edges.push(edgeId);
-                }
-                return acc;
-              },
-              { edges: [] } as {
-                responseWithNoValueId?: NodeId;
-                edges: Array<NodeId>;
-              },
-            );
+          //     return responsesThatCanBeAutoAnswered.forEach((r) =>
+          //       nodeIdsConnectedFrom(r.id),
+          //     );
+          //   }
+          // } else if (
+          //   fn &&
+          //   knownNotVals[fn] &&
+          //   passportValues === undefined &&
+          //   Array.isArray(node.edges)
+          // ) {
+          //   const data = node.edges.reduce(
+          //     (acc, edgeId) => {
+          //       if (flow[edgeId].data?.val === undefined) {
+          //         acc.responseWithNoValueId = edgeId;
+          //       } else if (!knownNotVals[fn].includes(flow[edgeId].data?.val)) {
+          //         acc.edges.push(edgeId);
+          //       }
+          //       return acc;
+          //     },
+          //     { edges: [] } as {
+          //       responseWithNoValueId?: NodeId;
+          //       edges: Array<NodeId>;
+          //     },
+          //   );
 
-            if (data.responseWithNoValueId && data.edges.length === 0) {
-              set({
-                breadcrumbs: {
-                  ...breadcrumbs,
-                  [id]: {
-                    answers: [data.responseWithNoValueId],
-                    auto: true,
-                  },
-                },
-              });
-              return nodeIdsConnectedFrom(data.responseWithNoValueId);
-            }
-          }
+          //   if (data.responseWithNoValueId && data.edges.length === 0) {
+          //     set({
+          //       breadcrumbs: {
+          //         ...breadcrumbs,
+          //         [id]: {
+          //           answers: [data.responseWithNoValueId],
+          //           auto: true,
+          //         },
+          //       },
+          //     });
+          //     return nodeIdsConnectedFrom(data.responseWithNoValueId);
+          //   }
+          // }
 
           ids.add(id);
         });


### PR DESCRIPTION
**High-level goals here:**
- `upcomingCardIds` is responsible for graph navigation based on _visited_ nodes only and does not check future node's data values for automation potential or queue up nodes based on optimistic automations
- Question, Checklist, and Filter components are automated _when_ they are reached, not any earlier. Each should leave an `auto: true` breadcrumb (Filters don't leave any breadcrumb currently)

**Todo:**
- [x] `upcomingCardIds`
- [ ] new help method which takes current node & passport and outputs ids of responses that can be automated
- [x] Questions
- [ ] Checklists
- [ ] Filters
- [ ] Update tests

**Test flow:** `testing/auto-answer-next`