### PR TITLE
fix: React warning for `isMinimised` prop

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -29,7 +29,9 @@ type SidebarTabs = "PreviewBrowser" | "History" | "Search" | "Console";
 const SIDEBAR_WIDTH = "500px";
 const SIDEBAR_WIDTH_MINIMISED = "20px";
 
-const Root = styled(Box)<{ isMinimised: boolean }>(
+const Root = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "isMinimised",
+})<{ isMinimised: boolean }>(
   ({ theme, isMinimised }) => ({
     position: "relative",
     top: "0",


### PR DESCRIPTION
<img width="579" alt="image" src="https://github.com/user-attachments/assets/b26dd039-1b47-44a7-aecf-00b8e5064cec">
