### PR TITLE
chore: Remove `togglePreview()` method from store

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -45,7 +45,6 @@ const send = (ops: Array<any>) => {
 export interface EditorUIStore {
   flowLayout: FlowLayout;
   showSidebar: boolean;
-  togglePreview: () => void;
   isTestEnvBannerVisible: boolean;
   hideTestEnvBanner: () => void;
 }
@@ -59,10 +58,6 @@ export const editorUIStore: StateCreator<
   flowLayout: FlowLayout.TOP_DOWN,
 
   showSidebar: true,
-
-  togglePreview: () => {
-    set({ showSidebar: !get().showSidebar });
-  },
 
   isTestEnvBannerVisible: !window.location.href.includes(".uk"),
 


### PR DESCRIPTION
## What does this PR do?
 - Removes `togglePreview` method from `EditorUIStore`
 - Quick follow up to https://github.com/theopensystemslab/planx-new/pull/3747 as this variable is now handled in a single component