### PR TITLE
feat: Use zustand middleware to persist to local storage

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -29,7 +29,6 @@ const FlowEditor = () => {
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   useScrollControlsAndRememberPosition(scrollContainerRef);
-  const showSidebar = useStore((state) => state.showSidebar);
 
   const isTestEnvBannerVisible = useStore(
     (state) => state.isTestEnvBannerVisible,
@@ -52,7 +51,7 @@ const FlowEditor = () => {
           <Flow flow={flow} breadcrumbs={breadcrumbs} />
         </Box>
       </Box>
-      {showSidebar && <Sidebar />}
+      <Sidebar />
     </EditorContainer>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -26,6 +26,7 @@ import { customAlphabet } from "nanoid-good";
 import en from "nanoid-good/locale/en";
 import { type } from "ot-json0";
 import type { StateCreator } from "zustand";
+import { persist } from 'zustand/middleware'
 
 import { FlowLayout } from "../../components/Flow";
 import { connectToDB, getConnection } from "./../sharedb";
@@ -45,7 +46,7 @@ const send = (ops: Array<any>) => {
 export interface EditorUIStore {
   flowLayout: FlowLayout;
   showSidebar: boolean;
-  togglePreview: () => void;
+  toggleSidebar: () => void;
   isTestEnvBannerVisible: boolean;
   hideTestEnvBanner: () => void;
 }
@@ -53,21 +54,27 @@ export interface EditorUIStore {
 export const editorUIStore: StateCreator<
   SharedStore & EditorUIStore,
   [],
-  [],
+  [["zustand/persist", unknown]],
   EditorUIStore
-> = (set, get) => ({
-  flowLayout: FlowLayout.TOP_DOWN,
+> = persist(
+  (set, get) => ({
+    flowLayout: FlowLayout.TOP_DOWN,
 
-  showSidebar: true,
+    showSidebar: true,
 
-  togglePreview: () => {
-    set({ showSidebar: !get().showSidebar });
-  },
+    toggleSidebar: () => {
+      set({ showSidebar: !get().showSidebar });
+    },
 
-  isTestEnvBannerVisible: !window.location.href.includes(".uk"),
+    isTestEnvBannerVisible: !window.location.href.includes(".uk"),
 
-  hideTestEnvBanner: () => set({ isTestEnvBannerVisible: false }),
-});
+    hideTestEnvBanner: () => set({ isTestEnvBannerVisible: false }),
+  }),
+  {
+    name: "editorUIStore",
+    partialize: (state) => ({ showSidebar: state.showSidebar }),
+  }
+);
 
 interface PublishFlowResponse {
   alteredNodes: Store.Node[];


### PR DESCRIPTION
This PR is a rethink of two Friday quick fixes - 
 - https://github.com/theopensystemslab/planx-new/pull/3765
 - https://github.com/theopensystemslab/planx-new/pull/3766

Originally, I was just resolving a React error and then tidying up some unused store variables.

In this approach, I'm using Zustand's persist middleware pattern ([docs](https://zustand.docs.pmnd.rs/integrations/persisting-store-data)) to handle the variable stores in local storage. Here's the benefits to this approach as I see them - 

 - Less boilerplate in components that would need local or session storage - we set this up once in a store
 - An easy pattern to follow if we needs something like this elsewhere (e.g. the staging banner, session (!) or notifications when we get there)
 - Using a store means the variable could still be controlled by multiple React components
 - Less complex styled components (passing props, remembering to use `shouldForwardProp` etc)
   - I've also used a MUI Collapse component to save passing these variables into the styled component