### PR TITLE
chore: Fix React `:nth-child` warnings

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -30,7 +30,7 @@ const Content = styled(Box, {
   "& a": {
     color: getContrastTextColor(color || "#fff", theme.palette.link.main),
   },
-  "& *:nth-child(1)": {
+  "& *:nth-of-type(1)": {
     marginTop: 0,
   },
 }));

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -168,7 +168,7 @@ $fontMonospace: "Source Code Pro", monospace;
       opacity: 0.6;
     }
 
-    > span:not(:nth-child(1)) {
+    > span:not(:first-child) {
       margin-left: 6px;
     }
   }
@@ -476,7 +476,7 @@ $fontMonospace: "Source Code Pro", monospace;
           $lineWidth;
         background-repeat: no-repeat, repeat-x, repeat-x;
 
-        &:nth-child(1) {
+        &:nth-of-type(1) {
           background-position:
             top center,
             top right,
@@ -516,7 +516,7 @@ $fontMonospace: "Source Code Pro", monospace;
           $lineWidth 100%,
           2px 100%;
 
-        &:nth-child(1) {
+        &:nth-of-type(1) {
           background-position:
             left center,
             left bottom,

--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -97,7 +97,6 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
       },
     },
     // Styles for placeholder text, to match ui/Input.tsx
-    // "& p.is-editor-empty:nth-child(1)::before": {
     "& p.is-editor-empty:first-child::before": {
       color: theme.palette.text.placeholder,
       opacity: 1,

--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -96,6 +96,16 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
         fontWeight: "inherit",
       },
     },
+    // Styles for placeholder text, to match ui/Input.tsx
+    // "& p.is-editor-empty:nth-child(1)::before": {
+    "& p.is-editor-empty:first-child::before": {
+      color: theme.palette.text.placeholder,
+      opacity: 1,
+      content: `attr(data-placeholder)`,
+      float: "left",
+      height: 0,
+      pointerEvents: "none",
+    },
     // Focus styles
     "&.ProseMirror-focused": {
       ...inputFocusStyle,

--- a/editor.planx.uk/src/ui/editor/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput.tsx
@@ -96,15 +96,6 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
         fontWeight: "inherit",
       },
     },
-    // Styles for placeholder text, to match ui/Input.tsx
-    "& p.is-editor-empty:nth-child(1)::before": {
-      color: theme.palette.text.placeholder,
-      opacity: 1,
-      content: `attr(data-placeholder)`,
-      float: "left",
-      height: 0,
-      pointerEvents: "none",
-    },
     // Focus styles
     "&.ProseMirror-focused": {
       ...inputFocusStyle,

--- a/editor.planx.uk/src/ui/shared/InputRow.tsx
+++ b/editor.planx.uk/src/ui/shared/InputRow.tsx
@@ -13,7 +13,7 @@ const Root = styled(Box, {
   "& > *": {
     flexGrow: 1,
     marginRight: 5,
-    "&:nth-child(1)": {
+    "&:first:child": {
       marginLeft: 0,
     },
     "&:last-child": {

--- a/editor.planx.uk/src/ui/shared/InputRowLabel.tsx
+++ b/editor.planx.uk/src/ui/shared/InputRowLabel.tsx
@@ -7,9 +7,6 @@ const Label = styled(Typography)(({ theme }) => ({
   flexGrow: 0,
   paddingRight: theme.spacing(2),
   alignSelf: "center",
-  "&:not(:nth-child(1))": {
-    paddingLeft: theme.spacing(2),
-  },
 })) as typeof Typography;
 
 export default function InputRowLabel({ children }: { children: ReactNode }) {


### PR DESCRIPTION
Been meaning to get around to this one for a while!

<img width="579" alt="image" src="https://github.com/user-attachments/assets/35b7b682-afa8-46b3-9011-b43c8da836d3">