### PR TITLE
fix: Restore loading bar and `FlowEditor` state on Editor-only routes

### DIFF
--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -57,38 +57,48 @@ const editorRoutes = mount({
   ),
 });
 
-const mountPayRoutes = () =>
-  map(async () => {
-    compose(withView(loadingView));
-    return lazy(() => import("./pay"));
-  });
+const loadPayRoutes = () =>
+  compose(
+    withView(loadingView),
+    lazy(() => import("./pay")),
+  );
+
+const loadPublishedRoutes = () =>
+  compose(
+    withView(loadingView),
+    lazy(() => import("./published")),
+  );
+
+const loadPreviewRoutes = () =>
+  compose(
+    withView(loadingView),
+    lazy(() => import("./preview")),
+  );
+
+const loadDraftRoutes = () =>
+  compose(
+    withView(loadingView),
+    lazy(() => import("./draft")),
+  );
 
 export default isPreviewOnlyDomain
-  ? compose(
-      withView(loadingView),
-
-      mount({
-        "/:team/:flow/published": lazy(() => import("./published")), // XXX: keeps old URL working, but only for the team listed in the domain.
-        "/:flow": lazy(() => import("./published")),
-        "/:flow/pay": mountPayRoutes(),
-        // XXX: We're not sure where to redirect `/` to so for now we'll just return the default 404
-        // "/": redirect("somewhere?"),
-      }),
-    )
-  : compose(
-      withView(loadingView),
-
-      mount({
-        "/:team/:flow/published": lazy(() => import("./published")), // loads current published flow if exists, or throws Not Found if unpublished
-        "/canterbury/find-out-if-you-need-planning-permission/preview": map(
-          async (req) =>
-            redirect(
-              `/canterbury/find-out-if-you-need-planning-permission/published${req?.search}`,
-            ),
-        ), // temporary redirect while Canterbury works with internal IT to update advertised service links
-        "/:team/:flow/preview": lazy(() => import("./preview")), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
-        "/:team/:flow/draft": lazy(() => import("./draft")), // loads current draft flow and draft external portals
-        "/:team/:flow/pay": mountPayRoutes(),
-        "*": editorRoutes,
-      }),
-    );
+  ? mount({
+      "/:team/:flow/published": loadPublishedRoutes(), // XXX: keeps old URL working, but only for the team listed in the domain.
+      "/:flow": loadPublishedRoutes(),
+      "/:flow/pay": loadPayRoutes(),
+      // XXX: We're not sure where to redirect `/` to so for now we'll just return the default 404
+      // "/": redirect("somewhere?"),
+    })
+  : mount({
+      "/:team/:flow/published": loadPublishedRoutes(), // loads current published flow if exists, or throws Not Found if unpublished
+      "/canterbury/find-out-if-you-need-planning-permission/preview": map(
+        async (req) =>
+          redirect(
+            `/canterbury/find-out-if-you-need-planning-permission/published${req?.search}`,
+          ),
+      ), // temporary redirect while Canterbury works with internal IT to update advertised service links
+      "/:team/:flow/preview": loadPreviewRoutes(), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
+      "/:team/:flow/draft": loadDraftRoutes(), // loads current draft flow and draft external portals
+      "/:team/:flow/pay": loadPayRoutes(),
+      "*": editorRoutes,
+    });


### PR DESCRIPTION
## What does this PR do?
 - This is a belated follow up to https://github.com/theopensystemslab/planx-new/pull/3671 and https://github.com/theopensystemslab/planx-new/pull/3714
 - Re-ordered routes so that the loading progress bar is restored, and the public facing pages maintain their loading spinner
 - The previous fix (#3714) wrapped `"*": editorRoutes` in the `loadingView` in order to restore the loading spinner to public facing pages, here I'm (finally!) fixing this properly.

### How can I test this?
 - All Editor routes should have a loading progress bar, when navigating between routes. There is still an initial loading spinner on first load.
 - All non-Editor routes should have a loading spinner
 