### PR TITLE
fix: Correctly construct URL by re-ordering portals

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getURLForNode.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getURLForNode.test.ts
@@ -54,14 +54,14 @@ describe("constructing URLs for nodes", () => {
   test("a question node, deeply within internal portals", () => {
     const url = getURLForNode("tarantinoMovieQuestion");
     expect(url).toEqual(
-      "/testTeam/testFlow,tarantinoPortal,moviesPortal/nodes/tarantinoPortal/nodes/tarantinoMovieQuestion/edit",
+      "/testTeam/testFlow,moviesPortal,tarantinoPortal/nodes/tarantinoPortal/nodes/tarantinoMovieQuestion/edit",
     );
   });
 
   test("an answer node, deeply within internal portals", () => {
     const url = getURLForNode("reservoirDogsAnswer");
     expect(url).toEqual(
-      "/testTeam/testFlow,tarantinoPortal,moviesPortal/nodes/tarantinoPortal/nodes/tarantinoMovieQuestion/edit",
+      "/testTeam/testFlow,moviesPortal,tarantinoPortal/nodes/tarantinoPortal/nodes/tarantinoMovieQuestion/edit",
     );
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -3,6 +3,7 @@ import { getPathForNode, sortFlow } from "@opensystemslab/planx-core";
 import {
   ComponentType,
   FlowGraph,
+  IndexedNode,
   NodeId,
   OrderedFlow,
 } from "@opensystemslab/planx-core/types";
@@ -521,8 +522,14 @@ export const editorStore: StateCreator<
     const [node, parent, grandparent] = path;
 
     // Construct the internal portal path if applicable
+    const mapPortalsToURLPath = (portals: ReturnType<typeof getPathForNode>) =>
+      portals
+        .reverse()
+        .map(({ id }) => id)
+        .join(",");
+
     const portalPath = internalPortals.length
-      ? "," + internalPortals.map(({ id }) => id).join(",")
+      ? "," + mapPortalsToURLPath(internalPortals)
       : "";
 
     // Determine node path based on the node type


### PR DESCRIPTION
## What's the problem?
 - Identified here by @jessicamcinchak - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1727767192939239?thread_ts=1726217456.551129&cid=C5Q59R3HB (OSL Slack)
 - When constructing the URL for a node, and then exiting, the path was incorrect

## What's the solution?
 - The order of portals in the URL is hierarchical (grandparent → parent → child), but the path generated by `getPathForNode()` is in opposite order (current node → parent → grandparent).
 - This means just need to call `reverse()` on the list of internal portals 👌

## To test - 
 - Search for "mansard" in the following flow - https://3773.planx.pizza/opensystemslab/permitteddevelopment
 - Close modal
 - Your URL is now https://3773.planx.dev/opensystemslab/permitteddevelopment,7GeYLgmnm9,cw73eSHjy2
 - You should be able to see the "mansard" node

## Next steps...
It's a little unexpected that the navigation happens after you close the modal, I think I'd expect it on click of the result card when the modal is opened. This may not be an easy change, but I'll timebox a look into this one.

This really highlights to me how valuable it would be to locate your node in the X/Y space of the flow editor. I'll add a card to the backlog for this, and might try to pick it up before a Friday show + tell.