### PR TITLE
refactor: Better handling of print CSS styles

### DIFF
--- a/editor.planx.uk/src/components/Header.tsx
+++ b/editor.planx.uk/src/components/Header.tsx
@@ -141,16 +141,15 @@ const Logo = styled("img")(() => ({
   maxWidth: 140,
   maxHeight: HEADER_HEIGHT_PUBLIC - 20,
   objectFit: "contain",
+  "@media print": {
+    filter: "invert(1)",
+  },
 }));
 
-const LogoLink = styled(Link)(({ theme }) => ({
+const LogoLink = styled(Link)(() => ({
   display: "flex",
   alignItems: "center",
   "&:focus-visible": borderedFocusStyle,
-  "@media print": {
-    backgroundColor: theme.palette.common.black,
-    padding: "0.25em",
-  },
 }));
 
 const SkipLink = styled("a")(({ theme }) => ({

--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -29,6 +29,13 @@ const MainContainer = styled(Box)(({ theme }) => ({
   position: "relative",
 }));
 
+const OglLogo = styled("img")(({ theme }) => ({
+  paddingRight: theme.spacing(2),
+  "@media print": {
+    filter: "invert(1)",
+  },
+}));
+
 const PublicFooter: React.FC = () => {
   const { data } = useCurrentRoute();
   const [flowSettings, globalSettings] = useStore((state) => [
@@ -68,19 +75,7 @@ const PublicFooter: React.FC = () => {
       <Feedback />
       <Footer items={[...footerItems]}>
         <Box display="flex" alignItems="center">
-          <Box
-            pr={2}
-            display="flex"
-            sx={{
-              "@media print": {
-                backgroundColor: "black",
-                padding: "0.5em",
-                margin: "0.5em",
-              },
-            }}
-          >
-            <img src={Logo} alt="Open Government License Logo" />
-          </Box>
+          <OglLogo src={Logo} alt="Open Government License Logo" />
           <Typography variant="body2">
             All content is available under the{" "}
             <Link


### PR DESCRIPTION
## What does this PR do?

Prompted by the work by @jamdelion to add a print button.

I prototyped a few different approaches here (force background colours to remain, council name as pseudo content in place of logo), but have arrived at a solution that beats all others.

A previous print CSS update removed the large areas of solid header/footer background colour on print (particularly the black of the footer which could take up almost a whole page), and placed a small container with background colour behind the logos. As noted by @jessicamcinchak, removing background colours in print options rendered these invisible (white logo was still in place on white background).

Using `filter: invert(1)` on the images ensure they are still visible regardless of print settings for background graphics, and allows us to keep background colours out of the header + footer.

Open the print dialogue to see changes:

**Example with SVG council logo:**
https://3774.planx.pizza/buckinghamshire/report-a-high-hedge/preview

**Example with PNG council logo:**
https://3774.planx.pizza/birmingham/find-out-if-you-need-planning-permission/preview