### PR TITLE
feat: Setup additional node tags

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#5781880",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#c19c3be",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#c19c3be",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#0ade7fa",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.3
     version: 1.0.0-alpha.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#c19c3be
-    version: github.com/theopensystemslab/planx-core/c19c3be(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#0ade7fa
+    version: github.com/theopensystemslab/planx-core/0ade7fa(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15353,9 +15353,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/c19c3be(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c19c3be}
-    id: github.com/theopensystemslab/planx-core/c19c3be
+  github.com/theopensystemslab/planx-core/0ade7fa(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ade7fa}
+    id: github.com/theopensystemslab/planx-core/0ade7fa
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.3
     version: 1.0.0-alpha.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#5781880
-    version: github.com/theopensystemslab/planx-core/5781880(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#c19c3be
+    version: github.com/theopensystemslab/planx-core/c19c3be(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -8423,6 +8423,7 @@ packages:
   /eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
@@ -15352,9 +15353,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/5781880(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/5781880}
-    id: github.com/theopensystemslab/planx-core/5781880
+  github.com/theopensystemslab/planx-core/c19c3be(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/c19c3be}
+    id: github.com/theopensystemslab/planx-core/c19c3be
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/schema.ts
@@ -33,7 +33,7 @@ const moreInformationSchema: SchemaOf<MoreInformation> = object({
 });
 
 const baseNodeDataSchema: SchemaOf<BaseNodeData> = object({
-  tags: array(mixed().oneOf(NODE_TAGS)),
+  tags: array(mixed().oneOf([...NODE_TAGS])),
 }).concat(moreInformationSchema);
 
 const valFnSchema = mixed().when("condition", {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import { visuallyHidden } from "@mui/utils";
 import { NodeTag } from "@opensystemslab/planx-core/types";
 import React from "react";
+import { getContrastTextColor } from "styleUtils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
@@ -11,6 +12,22 @@ export const TAG_DISPLAY_VALUES: Record<
   placeholder: {
     color: "#FAE1B7",
     displayName: "Placeholder",
+  },
+  "to review": {
+    color: "#E9EDC9",
+    displayName: "To review",
+  },
+  "sensitive data": {
+    color: "#F4978E",
+    displayName: "Sensitive data",
+  },
+  analytics: {
+    color: "#D7C6E6",
+    displayName: "Analytics",
+  },
+  automation: {
+    color: "#B7D1DE",
+    displayName: "Automation",
   },
 } as const;
 
@@ -28,6 +45,7 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => (
       p: 0.5,
       textAlign: "center",
       fontWeight: FONT_WEIGHT_SEMI_BOLD,
+      color: getContrastTextColor(TAG_DISPLAY_VALUES[tag].color, "#FFF"),
     })}
   >
     {TAG_DISPLAY_VALUES[tag].displayName}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
-import { visuallyHidden } from "@mui/utils";
 import { NodeTag } from "@opensystemslab/planx-core/types";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -22,32 +22,34 @@ export const TAG_DISPLAY_VALUES: Record<
     displayName: "Sensitive data",
   },
   analytics: {
-    color: "#D7C6E6",
+    color: "#E9EDC9",
     displayName: "Analytics",
   },
   automation: {
-    color: "#B7D1DE",
+    color: "#E9EDC9",
     displayName: "Automation",
   },
 } as const;
 
-export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => (
-  <Box
-    // Temporarily hidden until we decide how this should appear in the graph
-    // Please see https://github.com/theopensystemslab/planx-new/pull/3762
-    style={visuallyHidden}
-    sx={(theme) => ({
-      bgcolor: TAG_DISPLAY_VALUES[tag].color,
-      borderColor: theme.palette.common.black,
-      borderWidth: "0 1px 1px 1px",
-      borderStyle: "solid",
-      width: "100%",
-      p: 0.5,
-      textAlign: "center",
-      fontWeight: FONT_WEIGHT_SEMI_BOLD,
-      color: getContrastTextColor(TAG_DISPLAY_VALUES[tag].color, "#FFF"),
-    })}
-  >
-    {TAG_DISPLAY_VALUES[tag].displayName}
-  </Box>
-);
+export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
+  const showTags = useStore((state) => state.showTags);
+  if (!showTags) return null;
+
+  return (
+    <Box
+      sx={(theme) => ({
+        bgcolor: TAG_DISPLAY_VALUES[tag].color,
+        borderColor: theme.palette.common.black,
+        borderWidth: "0 1px 1px 1px",
+        borderStyle: "solid",
+        width: "100%",
+        p: 0.5,
+        textAlign: "center",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+        color: getContrastTextColor(TAG_DISPLAY_VALUES[tag].color, "#FFF"),
+      })}
+    >
+      {TAG_DISPLAY_VALUES[tag].displayName}
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import { PaletteOptions, useTheme } from "@mui/material/styles";
 import { NodeTag } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -7,38 +8,42 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
-  { color: string; displayName: string }
+  { color: keyof PaletteOptions["nodeTag"]; displayName: string }
 > = {
   placeholder: {
-    color: "#FAE1B7",
+    color: "blocking",
     displayName: "Placeholder",
   },
-  "to review": {
-    color: "#E9EDC9",
+  toReview: {
+    color: "nonBlocking",
     displayName: "To review",
   },
-  "sensitive data": {
-    color: "#F4978E",
+  sensitiveData: {
+    color: "information",
     displayName: "Sensitive data",
   },
   analytics: {
-    color: "#E9EDC9",
+    color: "information",
     displayName: "Analytics",
   },
   automation: {
-    color: "#E9EDC9",
+    color: "information",
     displayName: "Automation",
   },
 } as const;
 
 export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
+  const theme = useTheme();
+
   const showTags = useStore((state) => state.showTags);
   if (!showTags) return null;
+
+  const tagBgColor = theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color];
 
   return (
     <Box
       sx={(theme) => ({
-        bgcolor: TAG_DISPLAY_VALUES[tag].color,
+        bgcolor: tagBgColor,
         borderColor: theme.palette.common.black,
         borderWidth: "0 1px 1px 1px",
         borderStyle: "solid",
@@ -46,7 +51,7 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
         p: 0.5,
         textAlign: "center",
         fontWeight: FONT_WEIGHT_SEMI_BOLD,
-        color: getContrastTextColor(TAG_DISPLAY_VALUES[tag].color, "#FFF"),
+        color: getContrastTextColor(tagBgColor, "#FFF"),
       })}
     >
       {TAG_DISPLAY_VALUES[tag].displayName}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,5 +1,5 @@
 import Box from "@mui/material/Box";
-import { PaletteOptions, useTheme } from "@mui/material/styles";
+import { Palette, useTheme } from "@mui/material/styles";
 import { NodeTag } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -8,7 +8,7 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
-  { color: keyof PaletteOptions["nodeTag"]; displayName: string }
+  { color: keyof Palette["nodeTag"]; displayName: string }
 > = {
   placeholder: {
     color: "blocking",

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
@@ -40,7 +40,6 @@ export const ToggleTagsButton: React.FC = () => {
     >
       <TooltipWrap title="Toggle tags">
         <IconButton
-          title="Toggle tags"
           aria-label="Toggle tags"
           onClick={toggleShowTags}
           size="large"

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
@@ -33,9 +33,12 @@ export const ToggleTagsButton: React.FC = () => {
     <Box
       sx={(theme) => ({
         position: "fixed",
-        bottom: theme.spacing(1),
+        bottom: theme.spacing(2),
         left: theme.spacing(7),
         zIndex: theme.zIndex.appBar,
+        border: `1px solid ${theme.palette.border.main}`,
+        borderRadius: "3px",
+        background: theme.palette.background.paper,
       })}
     >
       <TooltipWrap title="Toggle tags">
@@ -44,6 +47,7 @@ export const ToggleTagsButton: React.FC = () => {
           onClick={toggleShowTags}
           size="large"
           sx={(theme) => ({
+            padding: theme.spacing(1),
             color: showTags
               ? theme.palette.text.primary
               : theme.palette.text.disabled,

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
@@ -1,0 +1,58 @@
+import LabelIcon from "@mui/icons-material/Label";
+import LabelOffIcon from "@mui/icons-material/LabelOff";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import Tooltip, { tooltipClasses, TooltipProps } from "@mui/material/Tooltip";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+const TooltipWrap = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} arrow placement="right" classes={{ popper: className }} />
+))(() => ({
+  [`& .${tooltipClasses.arrow}`]: {
+    color: "#2c2c2c",
+  },
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "#2c2c2c",
+    left: "-5px",
+    fontSize: "0.8em",
+    borderRadius: 0,
+    fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  },
+}));
+
+export const ToggleTagsButton: React.FC = () => {
+  const [showTags, toggleShowTags] = useStore((state) => [
+    state.showTags,
+    state.toggleShowTags,
+  ]);
+
+  return (
+    <Box
+      sx={(theme) => ({
+        position: "fixed",
+        bottom: theme.spacing(1),
+        left: theme.spacing(7),
+        zIndex: theme.zIndex.appBar,
+      })}
+    >
+      <TooltipWrap title="Toggle tags">
+        <IconButton
+          title="Toggle tags"
+          aria-label="Toggle tags"
+          onClick={toggleShowTags}
+          size="large"
+          sx={(theme) => ({
+            color: showTags
+              ? theme.palette.text.primary
+              : theme.palette.text.disabled,
+          })}
+        >
+          {showTags ? <LabelIcon /> : <LabelOffIcon />}
+        </IconButton>
+      </TooltipWrap>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -7,6 +7,7 @@ import React, { useRef } from "react";
 import { useCurrentRoute } from "react-navi";
 
 import Flow from "./components/Flow";
+import { ToggleTagsButton } from "./components/FlowEditor/ToggleTagsButton";
 import Sidebar from "./components/Sidebar";
 import { useStore } from "./lib/store";
 import useScrollControlsAndRememberPosition from "./lib/useScrollControlsAndRememberPosition";
@@ -49,6 +50,7 @@ const FlowEditor = () => {
       >
         <Box id="editor" ref={scrollContainerRef} sx={{ position: "relative" }}>
           <Flow flow={flow} breadcrumbs={breadcrumbs} />
+          <ToggleTagsButton />
         </Box>
       </Box>
       <Sidebar />

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -26,7 +26,7 @@ import { customAlphabet } from "nanoid-good";
 import en from "nanoid-good/locale/en";
 import { type } from "ot-json0";
 import type { StateCreator } from "zustand";
-import { persist } from 'zustand/middleware'
+import { persist } from "zustand/middleware";
 
 import { FlowLayout } from "../../components/Flow";
 import { connectToDB, getConnection } from "./../sharedb";
@@ -49,6 +49,8 @@ export interface EditorUIStore {
   toggleSidebar: () => void;
   isTestEnvBannerVisible: boolean;
   hideTestEnvBanner: () => void;
+  showTags: boolean;
+  toggleShowTags: () => void;
 }
 
 export const editorUIStore: StateCreator<
@@ -69,11 +71,18 @@ export const editorUIStore: StateCreator<
     isTestEnvBannerVisible: !window.location.href.includes(".uk"),
 
     hideTestEnvBanner: () => set({ isTestEnvBannerVisible: false }),
+
+    showTags: false,
+
+    toggleShowTags: () => set({ showTags: !get().showTags }),
   }),
   {
     name: "editorUIStore",
-    partialize: (state) => ({ showSidebar: state.showSidebar }),
-  }
+    partialize: (state) => ({
+      showSidebar: state.showSidebar,
+      showTags: state.showTags,
+    }),
+  },
 );
 
 interface PublishFlowResponse {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -76,6 +76,11 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     input: "#0B0C0C",
     light: "#E0E0E0",
   },
+  nodeTag: {
+    blocking: "#F4978E",
+    nonBlocking: "#B7FAD7",
+    information: "#FAE1B7",
+  },
   tonalOffset: DEFAULT_TONAL_OFFSET,
 };
 

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -77,9 +77,10 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     light: "#E0E0E0",
   },
   nodeTag: {
-    blocking: "#F4978E",
-    nonBlocking: "#B7FAD7",
-    information: "#FAE1B7",
+    error: "#FFA8A1",
+    blocking: "#FAE1B7",
+    nonBlocking: "#FFFDB0",
+    information: "#B7FAD7",
   },
   tonalOffset: DEFAULT_TONAL_OFFSET,
 };

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -32,6 +32,7 @@ declare module "@mui/material/styles/createPalette" {
     border: { main: string; input: string; light: string };
     link: { main: string };
     prompt: { main: string; contrastText: string; light: string; dark: string };
+    nodeTag: { nonBlocking: string; blocking: string; information: string };
   }
 
   interface PaletteOptions {
@@ -43,6 +44,7 @@ declare module "@mui/material/styles/createPalette" {
       light: string;
       dark: string;
     };
+    nodeTag?: { nonBlocking: string; blocking: string; information: string };
   }
 
   interface TypeText {

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -32,7 +32,12 @@ declare module "@mui/material/styles/createPalette" {
     border: { main: string; input: string; light: string };
     link: { main: string };
     prompt: { main: string; contrastText: string; light: string; dark: string };
-    nodeTag: { nonBlocking: string; blocking: string; information: string };
+    nodeTag: {
+      error: string;
+      nonBlocking: string;
+      blocking: string;
+      information: string;
+    };
   }
 
   interface PaletteOptions {
@@ -44,7 +49,12 @@ declare module "@mui/material/styles/createPalette" {
       light: string;
       dark: string;
     };
-    nodeTag?: { nonBlocking: string; blocking: string; information: string };
+    nodeTag?: {
+      error: string;
+      nonBlocking: string;
+      blocking: string;
+      information: string;
+    };
   }
 
   interface TypeText {

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -1,9 +1,11 @@
 import BookmarksIcon from "@mui/icons-material/Bookmarks";
 import { AutocompleteProps } from "@mui/material/Autocomplete";
+import Chip from "@mui/material/Chip";
 import ListItem from "@mui/material/ListItem";
 import { NODE_TAGS, NodeTag } from "@opensystemslab/planx-core/types";
 import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
 import React from "react";
+import { getContrastTextColor } from "styleUtils";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import InputRow from "ui/shared/InputRow";
@@ -12,7 +14,7 @@ import { CustomCheckbox, SelectMultiple } from "ui/shared/SelectMultiple";
 interface Props {
   value?: NodeTag[];
   onChange: (values: NodeTag[]) => void;
-};
+}
 
 const renderOption: AutocompleteProps<
   NodeTag,
@@ -23,9 +25,28 @@ const renderOption: AutocompleteProps<
 >["renderOption"] = (props, tag, { selected }) => (
   <ListItem {...props}>
     <CustomCheckbox aria-hidden="true" className={selected ? "selected" : ""} />
-    { TAG_DISPLAY_VALUES[tag].displayName }
+    {TAG_DISPLAY_VALUES[tag].displayName}
   </ListItem>
 );
+
+const renderTags: AutocompleteProps<
+  NodeTag,
+  true,
+  true,
+  false,
+  "div"
+>["renderTags"] = (value, getTagProps) =>
+  value.map((tag, index) => (
+    <Chip
+      {...getTagProps({ index })}
+      key={tag}
+      label={TAG_DISPLAY_VALUES[tag].displayName}
+      sx={{
+        backgroundColor: TAG_DISPLAY_VALUES[tag].color,
+        color: getContrastTextColor(TAG_DISPLAY_VALUES[tag].color, "#FFF"),
+      }}
+    />
+  ));
 
 export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
   return (
@@ -39,9 +60,10 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
             onChange={(_e, value) => onChange(value)}
             value={value}
             renderOption={renderOption}
+            renderTags={renderTags}
           />
         </InputRow>
       </ModalSectionContent>
     </ModalSection>
-  )
-}
+  );
+};

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -41,10 +41,13 @@ const renderTags: AutocompleteProps<
       {...getTagProps({ index })}
       key={tag}
       label={TAG_DISPLAY_VALUES[tag].displayName}
-      sx={{
-        backgroundColor: TAG_DISPLAY_VALUES[tag].color,
-        color: getContrastTextColor(TAG_DISPLAY_VALUES[tag].color, "#FFF"),
-      }}
+      sx={(theme) => ({
+        backgroundColor: theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
+        color: getContrastTextColor(
+          theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
+          "#FFF",
+        ),
+      })}
     />
   ));
 


### PR DESCRIPTION
## What does this PR do?
 - Imports new tags from planx-core (will bump across all projects once https://github.com/theopensystemslab/planx-core/pull/528 merged to `main`)
 - Tags are coloured as per https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1728385666798109 (OSL Slack)
 - Adds toggle to view tags, peristed via local storage

<p align="center">

https://github.com/user-attachments/assets/d48e46ef-1cd6-49ae-9d8f-a792b4742dd3

<img width="623" alt="Screenshot 2024-10-08 at 14 14 42" src="https://github.com/user-attachments/assets/11e47b42-2eb7-4415-abe6-0eaee2f53008">


</p>