### PR TITLE
fix: Center align text env banner vertically

### DIFF
--- a/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
+++ b/editor.planx.uk/src/components/TestEnvironmentBanner.tsx
@@ -13,6 +13,7 @@ import { HEADER_HEIGHT_EDITOR } from "./Header";
 const TestEnvironmentWarning = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   color: theme.palette.text.primary,
+  display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
   padding: "0.2em 0",


### PR DESCRIPTION
## What does this PR do?
 - Ensures that the content of the test environment banner are vertically aligned correctly
 - It's always been off as `alignItems: "center"` was used without `display: "flex"`, it's just more noticeable now following https://github.com/theopensystemslab/planx-new/pull/3734  which made the banner taller

| Before | After |
|--------|--------|
|<img width="970" alt="image" src="https://github.com/user-attachments/assets/c91c8021-fc60-4990-82c4-07cf433aa466">|<img width="972" alt="image" src="https://github.com/user-attachments/assets/4e61c766-888a-4163-940e-cbfb9f7bc9ba">|