### PR TITLE
refactor: Toggle button style and tag colours update

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
@@ -33,9 +33,12 @@ export const ToggleTagsButton: React.FC = () => {
     <Box
       sx={(theme) => ({
         position: "fixed",
-        bottom: theme.spacing(1),
+        bottom: theme.spacing(2),
         left: theme.spacing(7),
         zIndex: theme.zIndex.appBar,
+        border: `1px solid ${theme.palette.border.main}`,
+        borderRadius: "3px",
+        background: theme.palette.background.paper,
       })}
     >
       <TooltipWrap title="Toggle tags">
@@ -44,6 +47,7 @@ export const ToggleTagsButton: React.FC = () => {
           onClick={toggleShowTags}
           size="large"
           sx={(theme) => ({
+            padding: theme.spacing(1),
             color: showTags
               ? theme.palette.text.primary
               : theme.palette.text.disabled,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -77,9 +77,10 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     light: "#E0E0E0",
   },
   nodeTag: {
-    blocking: "#F4978E",
-    nonBlocking: "#B7FAD7",
-    information: "#FAE1B7",
+    error: "#FFA8A1",
+    blocking: "#FAE1B7",
+    nonBlocking: "#FFFDB0",
+    information: "#B7FAD7",
   },
   tonalOffset: DEFAULT_TONAL_OFFSET,
 };

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -32,7 +32,12 @@ declare module "@mui/material/styles/createPalette" {
     border: { main: string; input: string; light: string };
     link: { main: string };
     prompt: { main: string; contrastText: string; light: string; dark: string };
-    nodeTag: { nonBlocking: string; blocking: string; information: string };
+    nodeTag: {
+      error: string;
+      nonBlocking: string;
+      blocking: string;
+      information: string;
+    };
   }
 
   interface PaletteOptions {
@@ -44,7 +49,12 @@ declare module "@mui/material/styles/createPalette" {
       light: string;
       dark: string;
     };
-    nodeTag?: { nonBlocking: string; blocking: string; information: string };
+    nodeTag?: {
+      error: string;
+      nonBlocking: string;
+      blocking: string;
+      information: string;
+    };
   }
 
   interface TypeText {


### PR DESCRIPTION
## Suggested changes

- Update styling of tag toggle to have a bit more visual prominence (less "floating") and mirror other page inputs
- Creation of an "error" tag state which the red error colour should be reserved for, we may not use this initially
- Nonblocking / to update colour mirror that of which currently used in "sticky note" styling for consistency