### PR TITLE
fix: Editor graph node link styling

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -50,8 +50,8 @@ $fontMonospace: "Source Code Pro", monospace;
     margin: 0 auto;
     width: max-content;
 
-    > a:focus,
-    > a:active {
+    a:focus,
+    a:active {
       outline: 4px solid $focus;
       outline-offset: 0;
     }
@@ -110,7 +110,7 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
-  &.wasVisited > a {
+  &.wasVisited a {
     span {
       opacity: 1;
     }
@@ -118,7 +118,7 @@ $fontMonospace: "Source Code Pro", monospace;
     outline-offset: 0;
   }
 
-  &.isClone > a {
+  &.isClone a {
     margin-top: 3px;
     ::before {
       content: "";
@@ -137,8 +137,7 @@ $fontMonospace: "Source Code Pro", monospace;
     border: $nodeBorderWidth dashed red;
   }
 
-  & > div > a,
-  & > a {
+  & a {
     position: relative;
     display: flex;
     align-items: flex-start;
@@ -404,13 +403,13 @@ $fontMonospace: "Source Code Pro", monospace;
   align-items: center;
 
   &.question.isNote {
-    > a {
+    a {
       background: #fffdb0 !important;
       position: relative;
       padding-right: 20px;
     }
     // Triangle shapes to simulate paper fold on sticky note
-    &:not(.isClone) > a {
+    &:not(.isClone) a {
       &::before {
         content: "";
         position: absolute;


### PR DESCRIPTION
## What does this PR do?

Fixes a number of styling regressions in the graph introduced by the wrapping div used for tags.

Addresses the following:
- Blank question sticky notes not appearing correctly
- Clones not showing correct dashed background
- Focus and visited states not showing correctly for certain nodes

**Preview of fixed graph:**
https://3782.planx.pizza/testing/graph-styling-fixed