### PR TITLE
fix(e2e): Ensure exact match for team slug

### DIFF
--- a/e2e/tests/ui-driven/src/refresh-page.spec.ts
+++ b/e2e/tests/ui-driven/src/refresh-page.spec.ts
@@ -73,6 +73,7 @@ test.describe("Refresh page", () => {
 
     const teamSlugInHeader = page.getByRole("link", {
       name: context.team.slug,
+      exact: true,
     });
     await expect(teamSlugInHeader).toBeVisible();
 


### PR DESCRIPTION
🚀 Regression tests running here on CI, passing locally - https://github.com/theopensystemslab/planx-new/actions/runs/11257964868

Best guess is that this was introduced by https://github.com/theopensystemslab/planx-new/pull/3772

The selector `page.getByRole("link", { name: context.team.slug })` is matching both the header and the team "card" in the list - I guess prior to the loading bar this was actually a false positive?