### PR TITLE
fix: Add permission guard to "Add a new Editor" button

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -194,17 +194,19 @@ export const MembersTable = ({
               </StyledTableRow>
             ))}
             {showAddMemberButton && (
-              <TableRow>
-                <TableCell colSpan={5}>
-                  <AddButton
-                    onClick={() => {
-                      addUser();
-                    }}
-                  >
-                    Add a new editor
-                  </AddButton>
-                </TableCell>
-              </TableRow>
+              <Permission.IsPlatformAdmin>
+                <TableRow>
+                  <TableCell colSpan={5}>
+                    <AddButton
+                      onClick={() => {
+                        addUser();
+                      }}
+                    >
+                      Add a new editor
+                    </AddButton>
+                  </TableCell>
+                </TableRow>
+              </Permission.IsPlatformAdmin>
             )}
           </TableBody>
         </Table>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewEditor.test.tsx
@@ -129,7 +129,7 @@ describe("when a user is not a platform admin", () => {
     useStore.setState({
       teamMembers: mockTeamMembersData,
       user: mockPlainUser,
-      teamSlug: "templates",
+      teamSlug: "trumptonshire",
     });
   });
 


### PR DESCRIPTION
## What's the problem?
- Airbrake caught the following error, which is a teamEditor failing to add a new user https://planx.airbrake.io/projects/329753/groups/3909794420521801267
- They aren't able to do this as they must be a platformAdmin for the action to work
- This means that the button must be visible

I've also messaged the user in question to see if we can help them add a user 👍 

## What's the solution?
- Add the correct permission guard wrapper to the button
- Update the test to use a non-template team to correctly catch this behaviour