### PR TITLE
fix: Missing personalisation details for `confirmation-agent` email template

### DIFF
--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
@@ -70,6 +70,7 @@ describe("sendAgentAndPayeeConfirmationEmail", () => {
         helpOpeningHours: "9-5",
         helpPhone: "123",
         serviceName: "Some Flow",
+        sessionId: "mockSessionId",
       },
     };
     await sendAgentAndPayeeConfirmationEmail("mockSessionId");

--- a/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -2,7 +2,10 @@ import { formatRawProjectTypes } from "@opensystemslab/planx-core";
 import { gql } from "graphql-request";
 import { $api } from "../../../../client/index.js";
 import { sendEmail } from "../../../../lib/notify/index.js";
-import type { AgentAndPayeeSubmissionNotifyConfig } from "../../../../types.js";
+import type {
+  AgentAndPayeeSubmissionNotifyConfig,
+  AgentAndPayeeSubmissionNotifyPersonalisation,
+} from "../../../../types.js";
 
 export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {
   const { personalisation, applicantEmail, payeeEmail, projectTypes } =
@@ -22,16 +25,10 @@ export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {
 }
 
 type PayeeAndAgentEmailData = {
-  personalisation: {
-    emailReplyToId: string;
-    helpEmail: string;
-    helpOpeningHours: string;
-    helpPhone: string;
-    serviceName: string;
-    payeeName: string;
-    address: string;
-    applicantName: string;
-  };
+  personalisation: Omit<
+    AgentAndPayeeSubmissionNotifyPersonalisation,
+    "projectType"
+  >;
   applicantEmail: string;
   payeeEmail: string;
   projectTypes: string[];
@@ -45,6 +42,7 @@ async function getDataForPayeeAndAgentEmails(
       lowcal_sessions(where: { id: { _eq: $sessionId } }, limit: 1) {
         email
         flow {
+          name
           slug
           team {
             notifyPersonalisation: team_settings {
@@ -109,6 +107,7 @@ async function getDataForPayeeAndAgentEmails(
       payeeName,
       address,
       applicantName,
+      sessionId,
     },
     applicantEmail,
     payeeEmail,

--- a/api.planx.uk/types.ts
+++ b/api.planx.uk/types.ts
@@ -137,6 +137,8 @@ export interface AgentAndPayeeSubmissionNotifyPersonalisation
   payeeName: string;
   address: string;
   projectType: string;
+  serviceName: string;
+  sessionId: string;
 }
 
 export interface AgentAndPayeeSubmissionNotifyConfig {


### PR DESCRIPTION
## What's the problem?
 - GovNotify is throwing the following error - `"Missing personalisation: serviceName, sessionId"` when trying to populate the `confirmation-agent` email template
 - Airbrake logs here - https://planx.airbrake.io/projects/329753/groups/3906275109563899218/notices/3908948747260993950?tab=notice-detail

## What's the solution?
 - Fix types and queries to make sure these variables are provided
 - Once this is merged to `production`, I'll manually re-trigger these messages so that the agents receive a confirmation that the application has been paid for