### PR TITLE
fix: Handle dynamic import error

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -33,6 +33,13 @@ if (!window.customElements.get("my-map")) {
   window.customElements.define("my-map", MyMap);
 }
 
+// Refresh window if user hits "Failed to fetch dynamically imported module" due to renamed assets following re-build after deploy
+// Docs: https://vite.dev/guide/build#load-error-handling
+window.addEventListener("vite:preloadError", (event) => {
+  event.preventDefault();
+  window.location.reload();
+});
+
 const hasJWT = (): boolean | void => {
   // This cookie indicates the presence of the secure httpOnly "jwt" cookie
   const authCookie = getCookie("auth");


### PR DESCRIPTION
## What's the problem?
 - After the app re-build and redeploys, assets are renamed (chunked `.js` files generated by `pnpm build`)
 - If a user is already using the app and needs a chunk which is no longer available post-deploy, this error is thrown
 - Fixes https://planx.airbrake.io/projects/329753/groups/3879282825748388260?tab=overview
 - We also faced a similar error pre-Vite which looked like this - `ChunkLoadError: Loading chunk 914 failed.`

## What's the solution?
- Catch the error and reload the page in order to access the required chunks
- I've seen some apps handle this more gracefully with a "Site is outdated, fetching new assets..." error - maybe we should consider something like this? Right now I think deploys are infrequent enough we can probably get away with a refresh. Thoughts welcome!
- Docs - https://vite.dev/guide/build#load-error-handling