### PR TITLE
fix: Remove redundant tooltip on URL copy

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/PublicLink.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/PublicLink.tsx
@@ -2,6 +2,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { FlowStatus } from "@opensystemslab/planx-core/types";
 import React, { useState } from "react";
@@ -10,25 +11,27 @@ import SettingsDescription from "ui/editor/SettingsDescription";
 const CopyButton = (props: { link: string; isActive: boolean }) => {
   const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
   return (
-    <Button
-      disabled={!props.isActive}
-      variant="help"
-      onMouseLeave={() => {
-        setTimeout(() => {
-          setCopyMessage("copy");
-        }, 500);
-      }}
-      onClick={() => {
-        setCopyMessage("copied");
-        navigator.clipboard.writeText(props.link);
-      }}
-      sx={{ marginLeft: 0.5 }}
-    >
-      <ContentCopyIcon style={{ width: "18px", height: "18px" }} />
-      <Typography ml={0.5} variant="body3">
-        {copyMessage}
-      </Typography>
-    </Button>
+    <Tooltip title={copyMessage}>
+      <Button
+        disabled={!props.isActive}
+        variant="help"
+        onMouseLeave={() => {
+          setTimeout(() => {
+            setCopyMessage("copy");
+          }, 500);
+        }}
+        onClick={() => {
+          setCopyMessage("copied");
+          navigator.clipboard.writeText(props.link);
+        }}
+        sx={{ marginLeft: 0.5 }}
+      >
+        <ContentCopyIcon style={{ width: "18px", height: "18px" }} />
+        <Typography ml={0.5} variant="body3">
+          {copyMessage}
+        </Typography>
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/PublicLink.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/PublicLink.tsx
@@ -2,7 +2,6 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
-import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { FlowStatus } from "@opensystemslab/planx-core/types";
 import React, { useState } from "react";
@@ -11,27 +10,25 @@ import SettingsDescription from "ui/editor/SettingsDescription";
 const CopyButton = (props: { link: string; isActive: boolean }) => {
   const [copyMessage, setCopyMessage] = useState<"copy" | "copied">("copy");
   return (
-    <Tooltip title={copyMessage}>
-      <Button
-        disabled={!props.isActive}
-        variant="help"
-        onMouseLeave={() => {
-          setTimeout(() => {
-            setCopyMessage("copy");
-          }, 500);
-        }}
-        onClick={() => {
-          setCopyMessage("copied");
-          navigator.clipboard.writeText(props.link);
-        }}
-        sx={{ marginLeft: 0.5 }}
-      >
-        <ContentCopyIcon style={{ width: "18px", height: "18px" }} />
-        <Typography ml={0.5} variant="body3">
-          {copyMessage}
-        </Typography>
-      </Button>
-    </Tooltip>
+    <Button
+      disabled={!props.isActive}
+      variant="help"
+      onMouseLeave={() => {
+        setTimeout(() => {
+          setCopyMessage("copy");
+        }, 500);
+      }}
+      onClick={() => {
+        setCopyMessage("copied");
+        navigator.clipboard.writeText(props.link);
+      }}
+      sx={{ marginLeft: 0.5 }}
+    >
+      <ContentCopyIcon style={{ width: "18px", height: "18px" }} />
+      <Typography ml={0.5} variant="body3">
+        {copyMessage}
+      </Typography>
+    </Button>
   );
 };
 


### PR DESCRIPTION
## What does this PR do?

Removes tooltip wrapper from the URL copy function, as the tooltip content replicates that of the text link.

Replication:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/e27450f2-bcb1-49cd-93ee-d710ce6d7a59">
