### PR TITLE
chore: Rename add-data to sync-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ We'd love to hear what you're building on Planx, don't hesitate to get in touch 
 
 The root of the project has several scripts set up to help you manage your docker containers:
 
-- `pnpm run up` alias for `pnpm recreate && pnpm add-data`
+- `pnpm run up` alias for `pnpm recreate && pnpm sync-data`
 - `pnpm run down` alias for `pnpm destroy`
 - `pnpm run restart` alias for `pnpm stop && pnpm start`
 - `pnpm start` will (re)create docker containers without rebuilding them
 - `pnpm stop` will stop your docker containers without destroying them
 - `pnpm recreate` will build and (re)start your docker containers from scratch.
 - `pnpm destroy` will remove volumes (i.e. database data) and can be a useful hard reset when necessary.
-- `pnpm add-data` will sync production records with modified data in your database
+- `pnpm sync-data` will sync production records with modified data in your database
 - `pnpm clean-data` will sync production records and reset any modified data
 - `pnpm tests` will recreate your docker containers and include test services
 - `pnpm analytics` will recreate your docker containers and include [Metabase](https://www.metabase.com/)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "scripts": {
-    "up": "pnpm recreate && pnpm add-data",
+    "up": "pnpm recreate && pnpm sync-data",
     "down": "pnpm destroy",
     "restart": "pnpm stop && pnpm start",
     "start": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --quiet-pull",
     "stop": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services down",
     "recreate": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --quiet-pull --build --renew-anon-volumes --force-recreate",
     "destroy": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services down --remove-orphans -v",
-    "add-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database",
+    "sync-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database",
     "test-sync": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database reset_flows",
     "clean-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.seed.yml run seed-database reset_all",
     "tests": "./scripts/start-containers-for-tests.sh",


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1728553069239859 (OSL Slack)

Renames `pnpm add-data` to `pnpm sync-data` to avoid the typo `pnpm add data`