### PR TITLE
refactor: Result component multiline inputs

### DIFF
--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -7,6 +7,7 @@ import groupBy from "lodash/groupBy";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input";
 import InputRow from "ui/shared/InputRow";
 
@@ -30,33 +31,35 @@ const FlagEditor: React.FC<{
   const showEditedIndicator = Boolean(existingOverrides);
 
   return (
-    <Box padding={1} bgcolor={flag.bgColor} color={flag.color} mt={1}>
+    <Box px={1.5} py={2} bgcolor={flag.bgColor} color={flag.color} mt={1}>
       <Box>
-        <Typography variant="body2">
+        <Typography variant="h4">
           {flag.text}
           {showEditedIndicator && "*"}
         </Typography>
       </Box>
 
-      <Box display="flex" flexDirection="column" gap={0.5} mt={1.5}>
-        <Input
-          value={existingOverrides?.heading ?? ""}
-          placeholder="Heading"
-          onChange={(ev) =>
-            props.onChange({ ...existingOverrides, heading: ev.target.value })
-          }
-        />
-        <Input
-          multiline
-          value={existingOverrides?.description ?? ""}
-          placeholder={"Description"}
-          onChange={(ev) =>
-            props.onChange({
-              ...existingOverrides,
-              description: ev.target.value,
-            })
-          }
-        />
+      <Box display="flex" flexDirection="column" gap={2} mt={2}>
+        <InputLabel label="Heading">
+          <Input
+            value={existingOverrides?.heading ?? ""}
+            onChange={(ev) =>
+              props.onChange({ ...existingOverrides, heading: ev.target.value })
+            }
+          />
+        </InputLabel>
+        <InputLabel label="Description">
+          <Input
+            multiline
+            value={existingOverrides?.description ?? ""}
+            onChange={(ev) =>
+              props.onChange({
+                ...existingOverrides,
+                description: ev.target.value,
+              })
+            }
+          />
+        </InputLabel>
       </Box>
     </Box>
   );

--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -1,11 +1,10 @@
 import Box from "@mui/material/Box";
-import Collapse from "@mui/material/Collapse";
 import Typography from "@mui/material/Typography";
 import { Flag, flatFlags } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import groupBy from "lodash/groupBy";
-import React, { useState } from "react";
+import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import Input from "ui/shared/Input";
@@ -28,46 +27,37 @@ const FlagEditor: React.FC<{
 }> = (props) => {
   const { flag, existingOverrides } = props;
 
-  const [expanded, setExpanded] = useState(false);
-
   const showEditedIndicator = Boolean(existingOverrides);
 
   return (
-    <Box
-      sx={{ cursor: "pointer" }}
-      padding={1}
-      bgcolor={flag.bgColor}
-      color={flag.color}
-      mt={1}
-    >
-      <Box onClick={() => setExpanded((x) => !x)}>
+    <Box padding={1} bgcolor={flag.bgColor} color={flag.color} mt={1}>
+      <Box>
         <Typography variant="body2">
           {flag.text}
           {showEditedIndicator && "*"}
         </Typography>
       </Box>
-      <Collapse in={expanded}>
-        <Box display="flex" mt={1}>
-          <Input
-            value={existingOverrides?.heading ?? ""}
-            placeholder={"Heading"}
-            onChange={(ev) =>
-              props.onChange({ ...existingOverrides, heading: ev.target.value })
-            }
-          />
-          <Box width={10} />
-          <Input
-            value={existingOverrides?.description ?? ""}
-            placeholder={"Description"}
-            onChange={(ev) =>
-              props.onChange({
-                ...existingOverrides,
-                description: ev.target.value,
-              })
-            }
-          />
-        </Box>
-      </Collapse>
+
+      <Box display="flex" flexDirection="column" gap={0.5} mt={1.5}>
+        <Input
+          value={existingOverrides?.heading ?? ""}
+          placeholder="Heading"
+          onChange={(ev) =>
+            props.onChange({ ...existingOverrides, heading: ev.target.value })
+          }
+        />
+        <Input
+          multiline
+          value={existingOverrides?.description ?? ""}
+          placeholder={"Description"}
+          onChange={(ev) =>
+            props.onChange({
+              ...existingOverrides,
+              description: ev.target.value,
+            })
+          }
+        />
+      </Box>
     </Box>
   );
 };
@@ -85,7 +75,7 @@ const ResultComponent: React.FC<Props> = (props) => {
         props.handleSubmit({ type: TYPES.Result, data: newValues });
       }
     },
-    validate: () => { },
+    validate: () => {},
   });
 
   const allFlagsForSet = flags[formik.values.flagSet];

--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -28,15 +28,10 @@ const FlagEditor: React.FC<{
 }> = (props) => {
   const { flag, existingOverrides } = props;
 
-  const showEditedIndicator = Boolean(existingOverrides);
-
   return (
     <Box px={1.5} py={2} bgcolor={flag.bgColor} color={flag.color} mt={1}>
       <Box>
-        <Typography variant="h4">
-          {flag.text}
-          {showEditedIndicator && "*"}
-        </Typography>
+        <Typography variant="h4">{flag.text}</Typography>
       </Box>
 
       <Box display="flex" flexDirection="column" gap={2} mt={2}>


### PR DESCRIPTION
## What does this PR do?

- Updates result component flag descriptions to be multiline text inputs
- Adjusts layout to vertical
- Adds input labels in place of input placeholders
- Removes accordion functionality in favour of presenting a form-based interface

**Example empty form:**
https://3796.planx.pizza/testing/result-empty/nodes/_root/nodes/twngigiPHD/edit

**Example populated form:**
https://3796.planx.pizza/buckinghamshire/find-out-if-you-need-planning-permission/nodes/AVaOWQEwBD/nodes/yc1uC0Mwc7/edit

**Previous:**
<img width="797" alt="image" src="https://github.com/user-attachments/assets/47fcd9ff-3349-4d37-9dc5-c146feeff7bd">

**Updated:**
<img width="797" alt="image" src="https://github.com/user-attachments/assets/69bb941d-9f13-4afc-baa9-f8478460956c">