### PR TITLE
feat: Filters support choosing any flagset category

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -62,7 +62,7 @@ test.describe("Flow creation, publish and preview", () => {
     await expect(editor.nodeList).toContainText([
       "Find property",
       "an internal portalEdit Portal",
-      "(Flags Filter)ImmuneMissing informationPermission neededPrior approvalNoticePermitted developmentNot development(No Result)",
+      "Filter - Planning permissionImmuneMissing informationPermission neededPrior approvalNoticePermitted developmentNot developmentNo flag result",
       "Upload and label",
       "Confirm your location plan",
       "Planning constraints",

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
@@ -64,14 +64,13 @@ test("Adding a filter and selecting a flagset category", async () => {
   );
 });
 
-test.todo("Updating an existing filter to another category", async () => {
+test("Updating an existing filter to another category", async () => {
   const handleSubmit = vi.fn();
 
   setup(
     <Filter
       id="filterNodeId"
-      category="Listed building consent"
-      fn="flag"
+      node={mockExistingFilterNode}
       handleSubmit={handleSubmit}
     />,
   );
@@ -99,6 +98,15 @@ test.todo("Updating an existing filter to another category", async () => {
     ),
   );
 });
+
+const mockExistingFilterNode = {
+  data: {
+    fn: "flag",
+    category: "Listed building consent",
+  },
+  type: 500,
+  edges: ["flag1", "flag2", "flag3", "flag4", "blankFlag"],
+};
 
 const mockDefaultFlagOptions = [
   ...flatFlags.filter((flag) => flag.category === DEFAULT_FLAG_CATEGORY),

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
@@ -1,0 +1,3 @@
+test.todo("Adding a filter");
+
+test.todo("Updating a filter");

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
@@ -1,3 +1,55 @@
-test.todo("Adding a filter");
+import {
+  ComponentType as TYPES,
+  DEFAULT_FLAG_CATEGORY,
+  flatFlags,
+} from "@opensystemslab/planx-core/types";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { setup } from "testUtils";
+import { vi } from "vitest";
 
-test.todo("Updating a filter");
+import Filter from "./Editor";
+
+test("Adding a filter for the default flagset", async () => {
+  const handleSubmit = vi.fn();
+
+  setup(<Filter category="Planning Permssion" handleSubmit={handleSubmit} />);
+
+  expect(screen.getByTestId("flagset-category-select")).toHaveValue(
+    DEFAULT_FLAG_CATEGORY,
+  );
+
+  fireEvent.submit(screen.getByTestId("filter-component-form"));
+
+  await waitFor(() =>
+    expect(handleSubmit).toHaveBeenCalledWith(
+      {
+        type: TYPES.Filter,
+        data: {
+          fn: "flag",
+          category: DEFAULT_FLAG_CATEGORY,
+        },
+      },
+      mockDefaultFlagOptions,
+    ),
+  );
+});
+
+test.todo("Adding a filter and picking a non-default flagset category");
+
+test.todo("Updating an existing filter");
+
+const mockDefaultFlagOptions = [
+  ...flatFlags.filter((flag) => flag.category === DEFAULT_FLAG_CATEGORY),
+  {
+    category: DEFAULT_FLAG_CATEGORY,
+    text: "No flag result",
+    value: "",
+  },
+].map((flag) => ({
+  type: TYPES.Answer,
+  data: {
+    text: flag.text,
+    val: flag.value,
+  },
+}));

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
@@ -10,10 +10,10 @@ import { vi } from "vitest";
 
 import Filter from "./Editor";
 
-test("Adding a filter for the default flagset", async () => {
+test("Adding a filter without explicit props uses the default flagset", async () => {
   const handleSubmit = vi.fn();
 
-  setup(<Filter category="Planning Permssion" handleSubmit={handleSubmit} />);
+  setup(<Filter handleSubmit={handleSubmit} />);
 
   expect(screen.getByTestId("flagset-category-select")).toHaveValue(
     DEFAULT_FLAG_CATEGORY,
@@ -35,14 +35,92 @@ test("Adding a filter for the default flagset", async () => {
   );
 });
 
-test.todo("Adding a filter and picking a non-default flagset category");
+test("Adding a filter and selecting a flagset category", async () => {
+  const handleSubmit = vi.fn();
 
-test.todo("Updating an existing filter");
+  setup(<Filter handleSubmit={handleSubmit} />);
+
+  expect(screen.getByTestId("flagset-category-select")).toHaveValue(
+    DEFAULT_FLAG_CATEGORY,
+  );
+
+  fireEvent.change(screen.getByTestId("flagset-category-select"), {
+    target: { value: "Community infrastructure levy" },
+  });
+
+  fireEvent.submit(screen.getByTestId("filter-component-form"));
+
+  await waitFor(() =>
+    expect(handleSubmit).toHaveBeenCalledWith(
+      {
+        type: TYPES.Filter,
+        data: {
+          fn: "flag",
+          category: "Community infrastructure levy",
+        },
+      },
+      mockCILFlagOptions,
+    ),
+  );
+});
+
+test.todo("Updating an existing filter to another category", async () => {
+  const handleSubmit = vi.fn();
+
+  setup(
+    <Filter
+      id="filterNodeId"
+      category="Listed building consent"
+      fn="flag"
+      handleSubmit={handleSubmit}
+    />,
+  );
+
+  expect(screen.getByTestId("flagset-category-select")).toHaveValue(
+    "Listed building consent",
+  );
+
+  fireEvent.change(screen.getByTestId("flagset-category-select"), {
+    target: { value: "Community infrastructure levy" },
+  });
+
+  fireEvent.submit(screen.getByTestId("filter-component-form"));
+
+  await waitFor(() =>
+    expect(handleSubmit).toHaveBeenCalledWith(
+      {
+        type: TYPES.Filter,
+        data: {
+          fn: "flag",
+          category: "Community infrastructure levy",
+        },
+      },
+      mockCILFlagOptions,
+    ),
+  );
+});
 
 const mockDefaultFlagOptions = [
   ...flatFlags.filter((flag) => flag.category === DEFAULT_FLAG_CATEGORY),
   {
     category: DEFAULT_FLAG_CATEGORY,
+    text: "No flag result",
+    value: "",
+  },
+].map((flag) => ({
+  type: TYPES.Answer,
+  data: {
+    text: flag.text,
+    val: flag.value,
+  },
+}));
+
+const mockCILFlagOptions = [
+  ...flatFlags.filter(
+    (flag) => flag.category === "Community infrastructure levy",
+  ),
+  {
+    category: "Community infrastructure levy",
     text: "No flag result",
     value: "",
   },

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -1,20 +1,29 @@
+import Typography from "@mui/material/Typography";
 import {
+  ComponentType as TYPES,
   DEFAULT_FLAG_CATEGORY,
   flatFlags,
 } from "@opensystemslab/planx-core/types";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React from "react";
+import ModalSection from "ui/editor/ModalSection";
+import ModalSectionContent from "ui/editor/ModalSectionContent";
+
+import { ICONS } from "../ui";
 
 export interface Props {
   id?: string;
-  handleSubmit?: (d: any, c?: any) => void;
-  node?: any;
+  fn?: "flag";
+  category?: string;
+  handleSubmit?: (data: any, children?: any) => void;
 }
 
 const Filter: React.FC<Props> = (props) => {
   const formik = useFormik({
-    initialValues: {},
+    initialValues: {
+      fn: "flag",
+      category: DEFAULT_FLAG_CATEGORY,
+    },
     onSubmit: (newValues) => {
       if (props.handleSubmit) {
         const children = props.id
@@ -22,12 +31,12 @@ const Filter: React.FC<Props> = (props) => {
           : [
               ...flatFlags,
               {
-                category: DEFAULT_FLAG_CATEGORY,
-                text: "(No Result)",
+                category: formik.values.category,
+                text: "No flag result",
                 value: "",
               },
             ]
-              .filter((f) => f.category === DEFAULT_FLAG_CATEGORY)
+              .filter((f) => f.category === formik.values.category)
               .map((f) => ({
                 type: TYPES.Answer,
                 data: {
@@ -36,17 +45,37 @@ const Filter: React.FC<Props> = (props) => {
                 },
               }));
 
-        props.handleSubmit(
-          { type: TYPES.Filter, data: { newValues, fn: "flag" } },
-          children,
-        );
+        props.handleSubmit({ type: TYPES.Filter, data: newValues }, children);
       }
     },
-    validate: () => {},
   });
+
+  const categories = new Set(flatFlags.map((flag) => flag.category));
+
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
-      <h1>Filter Component</h1>
+      <ModalSection>
+        <ModalSectionContent title="Filter" Icon={ICONS[TYPES.Filter]}>
+          <Typography variant="body2">
+            Filters sort based on collected flags. Flags are heirarchical and
+            the filter will route through the left-most matching option only.
+          </Typography>
+        </ModalSectionContent>
+        <ModalSectionContent title="Pick a flagset category">
+          <select
+            data-testid="flagset-category-select"
+            name="category"
+            value={formik.values.category}
+            onChange={formik.handleChange}
+          >
+            {Array.from(categories).map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+        </ModalSectionContent>
+      </ModalSection>
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -21,12 +21,12 @@ export interface Props {
 const Filter: React.FC<Props> = (props) => {
   const formik = useFormik({
     initialValues: {
-      fn: "flag",
-      category: DEFAULT_FLAG_CATEGORY,
+      category: props?.category || DEFAULT_FLAG_CATEGORY,
+      fn: props?.fn || "flag",
     },
     onSubmit: (newValues) => {
-      if (props.handleSubmit) {
-        const children = props.id
+      if (props?.handleSubmit) {
+        const children = props?.id
           ? undefined
           : [
               ...flatFlags,
@@ -61,8 +61,9 @@ const Filter: React.FC<Props> = (props) => {
       <ModalSection>
         <ModalSectionContent title="Filter" Icon={ICONS[TYPES.Filter]}>
           <Typography variant="body2">
-            Filters sort based on collected flags. Flags are heirarchical and
-            the filter will route through the left-most matching option only.
+            Filters automatically sort based on collected flags. Flags within a
+            category are ordered heirarchically and the filter will route
+            through the left-most matching flag option only.
           </Typography>
         </ModalSectionContent>
         <ModalSectionContent title="Pick a flagset category">

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -53,7 +53,11 @@ const Filter: React.FC<Props> = (props) => {
   const categories = new Set(flatFlags.map((flag) => flag.category));
 
   return (
-    <form onSubmit={formik.handleSubmit} id="modal">
+    <form
+      onSubmit={formik.handleSubmit}
+      id="modal"
+      data-testid="filter-component-form"
+    >
       <ModalSection>
         <ModalSectionContent title="Filter" Icon={ICONS[TYPES.Filter]}>
           <Typography variant="body2">

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -63,12 +63,13 @@ const Filter: React.FC<Props> = (props) => {
             through the left-most matching flag option only.
           </Typography>
         </ModalSectionContent>
-        <ModalSectionContent title="Pick a flagset category">
+        <ModalSectionContent title="Pick a flagset category (coming soon)">
           <select
             data-testid="flagset-category-select"
             name="category"
             value={formik.values.category}
             onChange={formik.handleChange}
+            disabled
           >
             {Array.from(categories).map((category) => (
               <option key={category} value={category}>

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -13,37 +13,34 @@ import { ICONS } from "../ui";
 
 export interface Props {
   id?: string;
-  fn?: "flag";
-  category?: string;
   handleSubmit?: (data: any, children?: any) => void;
+  node?: any;
 }
 
 const Filter: React.FC<Props> = (props) => {
   const formik = useFormik({
     initialValues: {
-      category: props?.category || DEFAULT_FLAG_CATEGORY,
-      fn: props?.fn || "flag",
+      fn: "flag",
+      category: props?.node?.data?.category || DEFAULT_FLAG_CATEGORY,
     },
     onSubmit: (newValues) => {
       if (props?.handleSubmit) {
-        const children = props?.id
-          ? undefined
-          : [
-              ...flatFlags,
-              {
-                category: formik.values.category,
-                text: "No flag result",
-                value: "",
-              },
-            ]
-              .filter((f) => f.category === formik.values.category)
-              .map((f) => ({
-                type: TYPES.Answer,
-                data: {
-                  text: f.text,
-                  val: f.value,
-                },
-              }));
+        const children = [
+          ...flatFlags,
+          {
+            category: formik.values.category,
+            text: "No flag result",
+            value: "",
+          },
+        ]
+          .filter((f) => f.category === formik.values.category)
+          .map((f) => ({
+            type: TYPES.Answer,
+            data: {
+              text: f.text,
+              val: f.value,
+            },
+          }));
 
         props.handleSubmit({ type: TYPES.Filter, data: newValues }, children);
       }

--- a/editor.planx.uk/src/@planx/components/Filter/model.ts
+++ b/editor.planx.uk/src/@planx/components/Filter/model.ts
@@ -1,5 +1,0 @@
-export interface Filter {
-  id?: string;
-  handleSubmit?: (d: any, children: any) => void;
-  node?: any;
-}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -63,7 +63,14 @@ const Node: React.FC<any> = (props) => {
         />
       );
     case TYPES.Filter:
-      return <Filter {...allProps} text="(Flags Filter)" />;
+      return (
+        <Filter
+          {...allProps}
+          text={
+            node?.data?.category ? `Filter - ${node.data.category}` : "Filter"
+          }
+        />
+      );
     case TYPES.FindProperty:
       return <Question {...allProps} text="Find property" />;
     case TYPES.List:

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -1,4 +1,7 @@
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  DEFAULT_FLAG_CATEGORY,
+} from "@opensystemslab/planx-core/types";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { exhaustiveCheck } from "utils";
@@ -66,9 +69,7 @@ const Node: React.FC<any> = (props) => {
       return (
         <Filter
           {...allProps}
-          text={
-            node?.data?.category ? `Filter - ${node.data.category}` : "Filter"
-          }
+          text={`Filter - ${node?.data?.category || DEFAULT_FLAG_CATEGORY}`}
         />
       );
     case TYPES.FindProperty:


### PR DESCRIPTION
**Changes:**
- Filter component supports picking from any available flagset categories & renders it correctly on the graph
  - It defaults to the "Planning permission" category so existing components should work without needing an "Update"
  - Uses same bare bones `<select />` styling as External Portal and Result modals, let's revisit styles later
- I have NOT touched the `collectedFlags` store method here, which means that all non-"Planning permission" filters won't actually "work" yet - in that they aren't correctly reading collected flags and still exclusively route down the "No flag result" branch
  - This will be addressed once rebased into #3764 (trying to make small PRs for review!)

![Screenshot from 2024-10-10 13-43-02](https://github.com/user-attachments/assets/b888de54-fd98-4ff9-98b2-88b32fdcff50)

![Screenshot from 2024-10-10 13-32-27](https://github.com/user-attachments/assets/a1f3af51-08f2-46e4-8b06-7127a7c55fde)
