### PR TITLE
feat: Whole number option on Number Input

### DIFF
--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -92,12 +92,9 @@ export default function NumberInputComponent(props: Props): FCReturn {
             <FormControlLabel
               control={
                 <Switch
-                  checked={formik.values.onlyWholeNumbers}
+                  checked={formik.values.isInteger}
                   onChange={() =>
-                    formik.setFieldValue(
-                      "onlyWholeNumbers",
-                      !formik.values.onlyWholeNumbers,
-                    )
+                    formik.setFieldValue("isInteger", !formik.values.isInteger)
                   }
                 />
               }

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -80,7 +80,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
                   onChange={() =>
                     formik.setFieldValue(
                       "allowNegatives",
-                      !formik.values.allowNegatives
+                      !formik.values.allowNegatives,
                     )
                   }
                 />
@@ -96,7 +96,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
                   onChange={() =>
                     formik.setFieldValue(
                       "onlyWholeNumbers",
-                      !formik.values.onlyWholeNumbers
+                      !formik.values.onlyWholeNumbers,
                     )
                   }
                 />

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -3,10 +3,7 @@ import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { NumberInput } from "@planx/components/NumberInput/model";
 import { parseNumberInput } from "@planx/components/NumberInput/model";
-import {
-  EditorProps,
-  ICONS,
-} from "@planx/components/ui";
+import { EditorProps, ICONS } from "@planx/components/ui";
 import { useFormik } from "formik";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
@@ -83,12 +80,28 @@ export default function NumberInputComponent(props: Props): FCReturn {
                   onChange={() =>
                     formik.setFieldValue(
                       "allowNegatives",
-                      !formik.values.allowNegatives,
+                      !formik.values.allowNegatives
                     )
                   }
                 />
               }
               label="Allow negative numbers to be input"
+            />
+          </InputRow>
+          <InputRow>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={formik.values.onlyWholeNumbers}
+                  onChange={() =>
+                    formik.setFieldValue(
+                      "onlyWholeNumbers",
+                      !formik.values.onlyWholeNumbers
+                    )
+                  }
+                />
+              }
+              label="Only allow whole numbers"
             />
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -84,7 +84,7 @@ test("allows negative numbers to be input when toggled on by editor", async () =
   expect(handleSubmit).toHaveBeenCalledWith({ data: { fahrenheit: -10 } });
 });
 
-test("requires only whole numbers to be input when toggled on by editor", async () => {
+test("a clear error is shown if decimal value added when onlyWholeNumbers is toggled on", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
@@ -111,7 +111,7 @@ test("requires only whole numbers to be input when toggled on by editor", async 
   });
 });
 
-test("allows only whole numbers to be input when toggled on by editor", async () => {
+test("allows only whole numbers to be submitted when toggled on by editor", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -106,9 +106,7 @@ test("a clear error is shown if decimal value added when onlyWholeNumbers is tog
   await user.click(screen.getByTestId("continue-button"));
 
   expect(screen.getByText("Enter a whole number")).toBeInTheDocument();
-  expect(handleSubmit).not.toHaveBeenCalledWith({
-    data: { fahrenheit: 10.06 },
-  });
+  expect(handleSubmit).not.toHaveBeenCalled();
 });
 
 test("allows only whole numbers to be submitted when toggled on by editor", async () => {

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -92,7 +92,7 @@ test("a clear error is shown if decimal value added when onlyWholeNumbers is tog
       fn="fahrenheit"
       title="What's the temperature?"
       handleSubmit={handleSubmit}
-      onlyWholeNumbers={true}
+      isInteger={true}
     />,
   );
 
@@ -117,7 +117,7 @@ test("allows only whole numbers to be submitted when toggled on by editor", asyn
       fn="fahrenheit"
       title="What's the temperature?"
       handleSubmit={handleSubmit}
-      onlyWholeNumbers={true}
+      isInteger={true}
     />,
   );
 

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -11,7 +11,7 @@ test("renders correctly", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
@@ -26,7 +26,7 @@ test("allows 0 to be input as a valid number", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
@@ -45,16 +45,16 @@ test("requires a positive number to be input by default", async () => {
       fn="doors"
       title="How many doors are you adding?"
       handleSubmit={handleSubmit}
-    />
+    />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent(
-    "How many doors are you adding?"
+    "How many doors are you adding?",
   );
 
   await user.type(
     screen.getByLabelText("How many doors are you adding?"),
-    "-1"
+    "-1",
   );
   await user.click(screen.getByTestId("continue-button"));
 
@@ -71,11 +71,11 @@ test("allows negative numbers to be input when toggled on by editor", async () =
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       allowNegatives={true}
-    />
+    />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent(
-    "What's the temperature?"
+    "What's the temperature?",
   );
 
   await user.type(screen.getByLabelText("What's the temperature?"), "-10");
@@ -84,7 +84,7 @@ test("allows negative numbers to be input when toggled on by editor", async () =
   expect(handleSubmit).toHaveBeenCalledWith({ data: { fahrenheit: -10 } });
 });
 
-test.only("requires only whole numbers to be input when toggled on by editor", async () => {
+test("requires only whole numbers to be input when toggled on by editor", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
@@ -93,11 +93,11 @@ test.only("requires only whole numbers to be input when toggled on by editor", a
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       onlyWholeNumbers={true}
-    />
+    />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent(
-    "What's the temperature?"
+    "What's the temperature?",
   );
 
   const textArea = screen.getByLabelText("What's the temperature?");
@@ -120,11 +120,11 @@ test("allows only whole numbers to be input when toggled on by editor", async ()
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       onlyWholeNumbers={true}
-    />
+    />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent(
-    "What's the temperature?"
+    "What's the temperature?",
   );
 
   const textArea = screen.getByLabelText("What's the temperature?");
@@ -138,7 +138,7 @@ test("requires a value before being able to continue", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
   );
 
   await user.click(screen.getByTestId("continue-button"));
@@ -160,7 +160,7 @@ test("recovers previously submitted number when clicking the back button", async
           [componentId]: 43,
         },
       }}
-    />
+    />,
   );
 
   await user.click(screen.getByTestId("continue-button"));
@@ -184,7 +184,7 @@ test("recovers previously submitted number when clicking the back button even if
           [dataField]: 43,
         },
       }}
-    />
+    />,
   );
 
   await user.click(screen.getByTestId("continue-button"));

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -11,7 +11,7 @@ test("renders correctly", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
@@ -26,7 +26,7 @@ test("allows 0 to be input as a valid number", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
@@ -45,16 +45,16 @@ test("requires a positive number to be input by default", async () => {
       fn="doors"
       title="How many doors are you adding?"
       handleSubmit={handleSubmit}
-    />,
+    />
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent(
-    "How many doors are you adding?",
+    "How many doors are you adding?"
   );
 
   await user.type(
     screen.getByLabelText("How many doors are you adding?"),
-    "-1",
+    "-1"
   );
   await user.click(screen.getByTestId("continue-button"));
 
@@ -71,11 +71,11 @@ test("allows negative numbers to be input when toggled on by editor", async () =
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       allowNegatives={true}
-    />,
+    />
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent(
-    "What's the temperature?",
+    "What's the temperature?"
   );
 
   await user.type(screen.getByLabelText("What's the temperature?"), "-10");
@@ -84,11 +84,61 @@ test("allows negative numbers to be input when toggled on by editor", async () =
   expect(handleSubmit).toHaveBeenCalledWith({ data: { fahrenheit: -10 } });
 });
 
+test.only("requires only whole numbers to be input when toggled on by editor", async () => {
+  const handleSubmit = vi.fn();
+
+  const { user } = setup(
+    <NumberInput
+      fn="fahrenheit"
+      title="What's the temperature?"
+      handleSubmit={handleSubmit}
+      onlyWholeNumbers={true}
+    />
+  );
+
+  expect(screen.getByRole("heading")).toHaveTextContent(
+    "What's the temperature?"
+  );
+
+  const textArea = screen.getByLabelText("What's the temperature?");
+
+  await user.type(textArea, "10.06");
+  await user.click(screen.getByTestId("continue-button"));
+
+  expect(screen.getByText("Enter a whole number")).toBeInTheDocument();
+  expect(handleSubmit).not.toHaveBeenCalledWith({
+    data: { fahrenheit: 10.06 },
+  });
+});
+
+test("allows only whole numbers to be input when toggled on by editor", async () => {
+  const handleSubmit = vi.fn();
+
+  const { user } = setup(
+    <NumberInput
+      fn="fahrenheit"
+      title="What's the temperature?"
+      handleSubmit={handleSubmit}
+      onlyWholeNumbers={true}
+    />
+  );
+
+  expect(screen.getByRole("heading")).toHaveTextContent(
+    "What's the temperature?"
+  );
+
+  const textArea = screen.getByLabelText("What's the temperature?");
+
+  await user.type(textArea, "10");
+  await user.click(screen.getByTestId("continue-button"));
+  expect(handleSubmit).toHaveBeenCalledWith({ data: { fahrenheit: 10 } });
+});
+
 test("requires a value before being able to continue", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />
   );
 
   await user.click(screen.getByTestId("continue-button"));
@@ -110,7 +160,7 @@ test("recovers previously submitted number when clicking the back button", async
           [componentId]: 43,
         },
       }}
-    />,
+    />
   );
 
   await user.click(screen.getByTestId("continue-button"));
@@ -134,7 +184,7 @@ test("recovers previously submitted number when clicking the back button even if
           [dataField]: 43,
         },
       }}
-    />,
+    />
   );
 
   await user.click(screen.getByTestId("continue-button"));

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -22,7 +22,7 @@ export const parseNumber = (raw: string): number | null => {
 };
 
 export const parseNumberInput = (
-  data: Record<string, any> | undefined
+  data: Record<string, any> | undefined,
 ): NumberInput => ({
   title: data?.title || "",
   description: data?.description,
@@ -62,7 +62,7 @@ export const numberInputValidationSchema = (input: NumberInput) =>
         if (!value) {
           return false;
         }
-        if (!Number.isInteger(Number(value))) {
+        if (input.onlyWholeNumbers && !Number.isInteger(Number(value))) {
           return false;
         }
         return true;

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -8,7 +8,7 @@ export interface NumberInput extends BaseNodeData {
   fn?: string;
   units?: string;
   allowNegatives?: boolean;
-  onlyWholeNumbers?: boolean;
+  isInteger?: boolean;
 }
 
 export type UserData = number;
@@ -29,7 +29,7 @@ export const parseNumberInput = (
   fn: data?.fn || "",
   units: data?.units,
   allowNegatives: data?.allowNegatives || false,
-  onlyWholeNumbers: data?.onlyWholeNumbers || false,
+  isInteger: data?.isInteger || false,
   ...parseBaseNodeData(data),
 });
 
@@ -62,7 +62,7 @@ export const numberInputValidationSchema = (input: NumberInput) =>
         if (!value) {
           return false;
         }
-        if (input.onlyWholeNumbers && !Number.isInteger(Number(value))) {
+        if (input.isInteger && !Number.isInteger(Number(value))) {
           return false;
         }
         return true;

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -8,6 +8,7 @@ export interface NumberInput extends BaseNodeData {
   fn?: string;
   units?: string;
   allowNegatives?: boolean;
+  onlyWholeNumbers?: boolean;
 }
 
 export type UserData = number;
@@ -21,13 +22,14 @@ export const parseNumber = (raw: string): number | null => {
 };
 
 export const parseNumberInput = (
-  data: Record<string, any> | undefined,
+  data: Record<string, any> | undefined
 ): NumberInput => ({
   title: data?.title || "",
   description: data?.description,
   fn: data?.fn || "",
   units: data?.units,
   allowNegatives: data?.allowNegatives || false,
+  onlyWholeNumbers: data?.onlyWholeNumbers || false,
   ...parseBaseNodeData(data),
 });
 
@@ -51,6 +53,19 @@ export const numberInputValidationSchema = (input: NumberInput) =>
           return false;
         }
         return value === "0" ? true : Boolean(parseNumber(value));
+      },
+    })
+    .test({
+      name: "check for a whole number",
+      message: "Enter a whole number",
+      test: (value: string | undefined) => {
+        if (!value) {
+          return false;
+        }
+        if (!Number.isInteger(Number(value))) {
+          return false;
+        }
+        return true;
       },
     });
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a switch option to the `<NumberInput>` editor modal to only allow whole numbers. 

A `test()` has been added to the validation schema to test that when `onlyWholeNumbers` is true, then `value` can only be an integer.

```ts
    .test({
      name: "check for a whole number",
      message: "Enter a whole number",
      test: (value: string | undefined) => {
        if (!value) {
          return false;
        }
        if (input.onlyWholeNumbers && !Number.isInteger(Number(value))) {
          return false;
        }
        return true;
      },
    });
```

