### PR TITLE
fix: Visited node CSS

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -110,7 +110,8 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
-  &.wasVisited a {
+  &.wasVisited > div,
+  &.wasVisited > a {
     span {
       opacity: 1;
     }


### PR DESCRIPTION
## What's the problem?
- Regression to graph styling which highlights all children of `.wasVisited` class with a green highlight, not just specific ones
- Believed to have been introduced in https://github.com/theopensystemslab/planx-new/pull/3782

## What's the solution?
- Use the CSS child selector `>` to limit the styling to child `div` and `a` elements only, not all descendants

https://github.com/user-attachments/assets/91128970-9131-40ba-82e2-7cd5719f6fad

