### PR TITLE
refactor: change List Map comp to use Trash icon

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -278,7 +278,6 @@ const Root = () => {
               osProxyEndpoint={`${
                 import.meta.env.VITE_APP_API_URL
               }/proxy/ordnance-survey`}
-              resetControlImage="trash"
               osCopyright={
                 basemap === "OSVectorTile"
                   ? `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -278,6 +278,7 @@ const Root = () => {
               osProxyEndpoint={`${
                 import.meta.env.VITE_APP_API_URL
               }/proxy/ordnance-survey`}
+              resetControlImage="trash"
               osCopyright={
                 basemap === "OSVectorTile"
                   ? `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -87,6 +87,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               maxZoom={23}
               latitude={Number(passport?.data?._address?.latitude)}
               longitude={Number(passport?.data?._address?.longitude)}
+              resetControlImage="trash"
               osProxyEndpoint={`${
                 import.meta.env.VITE_APP_API_URL
               }/proxy/ordnance-survey`}


### PR DESCRIPTION
I have altered the props passed to the map component so the reset icon is now a Trash Icon on the List Map input.

```diff
<my-map
              id={id}
              // TODO
              // ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
              height={400}
              basemap={mapOptions?.basemap}
              drawMode
              drawGeojsonData={
                features &&
                JSON.stringify({
                  type: "FeatureCollection",
                  features: features,
                })
              }
              drawMany={mapOptions?.drawMany}
              drawColor={mapOptions?.drawColor}
              drawType={mapOptions?.drawType}
              drawPointer="crosshair"
              zoom={20}
              maxZoom={23}
              latitude={Number(passport?.data?._address?.latitude)}
              longitude={Number(passport?.data?._address?.longitude)}
++            resetControlImage="trash"
              osProxyEndpoint={`${
                import.meta.env.VITE_APP_API_URL
              }/proxy/ordnance-survey`}
              osCopyright={
                mapOptions?.basemap === "OSVectorTile"
                  ? `Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`
                  : ``
              }
              clipGeojsonData={
                teamSettings?.boundaryBBox &&
                JSON.stringify(teamSettings?.boundaryBBox)
              }
              mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
              collapseAttributions
            />
```

Following user research feedback outlined in the Trello Ticket: https://trello.com/c/tUPbevRQ/3095-list-switch-map-reset-icon-from-arrow-to-trash-bin-via-existing-web-component-prop