### PR TITLE
refactor: Simplify editor toggle button group

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleDataFieldsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleDataFieldsButton.tsx
@@ -1,6 +1,5 @@
 import DataFieldIcon from "@mui/icons-material/Code";
 import DataFieldOffIcon from "@mui/icons-material/CodeOff";
-import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -13,32 +12,24 @@ export const ToggleDataFieldsButton: React.FC = () => {
   ]);
 
   return (
-    <Box
-      sx={(theme) => ({
-        position: "fixed",
-        bottom: theme.spacing(6),
-        left: theme.spacing(7),
-        zIndex: theme.zIndex.appBar,
-        border: `1px solid ${theme.palette.border.main}`,
-        borderRadius: "3px",
-        background: theme.palette.background.paper,
-      })}
-    >
-      <Tooltip title="Toggle data fields" placement="right">
-        <IconButton
-          aria-label="Toggle data fields"
-          onClick={toggleShowDataFields}
-          size="large"
-          sx={(theme) => ({
-            padding: theme.spacing(1),
-            color: showDataFields
-              ? theme.palette.text.primary
-              : theme.palette.text.disabled,
-          })}
-        >
-          {showDataFields ? <DataFieldIcon /> : <DataFieldOffIcon />}
-        </IconButton>
-      </Tooltip>
-    </Box>
+    <Tooltip title="Toggle data fields" placement="right">
+      <IconButton
+        aria-label="Toggle data fields"
+        onClick={toggleShowDataFields}
+        size="large"
+        sx={(theme) => ({
+          background: theme.palette.background.paper,
+          padding: theme.spacing(1),
+          color: showDataFields
+            ? theme.palette.text.primary
+            : theme.palette.text.disabled,
+          "&:hover": {
+            background: theme.palette.common.white,
+          },
+        })}
+      >
+        {showDataFields ? <DataFieldIcon /> : <DataFieldOffIcon />}
+      </IconButton>
+    </Tooltip>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleImagesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleImagesButton.tsx
@@ -1,6 +1,5 @@
 import ImageOffIcon from "@mui/icons-material/HideImage";
 import ImageIcon from "@mui/icons-material/Image";
-import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -13,32 +12,24 @@ export const ToggleImagesButton: React.FC = () => {
   ]);
 
   return (
-    <Box
-      sx={(theme) => ({
-        position: "fixed",
-        bottom: theme.spacing(10),
-        left: theme.spacing(7),
-        zIndex: theme.zIndex.appBar,
-        border: `1px solid ${theme.palette.border.main}`,
-        borderRadius: "3px",
-        background: theme.palette.background.paper,
-      })}
-    >
-      <Tooltip title="Toggle images" placement="right">
-        <IconButton
-          aria-label="Toggle images"
-          onClick={toggleShowImages}
-          size="large"
-          sx={(theme) => ({
-            padding: theme.spacing(1),
-            color: showImages
-              ? theme.palette.text.primary
-              : theme.palette.text.disabled,
-          })}
-        >
-          {showImages ? <ImageIcon /> : <ImageOffIcon />}
-        </IconButton>
-      </Tooltip>
-    </Box>
+    <Tooltip title="Toggle images" placement="right">
+      <IconButton
+        aria-label="Toggle images"
+        onClick={toggleShowImages}
+        size="large"
+        sx={(theme) => ({
+          background: theme.palette.background.paper,
+          padding: theme.spacing(1),
+          color: showImages
+            ? theme.palette.text.primary
+            : theme.palette.text.disabled,
+          "&:hover": {
+            background: theme.palette.common.white,
+          },
+        })}
+      >
+        {showImages ? <ImageIcon /> : <ImageOffIcon />}
+      </IconButton>
+    </Tooltip>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
@@ -1,6 +1,5 @@
 import LabelIcon from "@mui/icons-material/Label";
 import LabelOffIcon from "@mui/icons-material/LabelOff";
-import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -13,32 +12,24 @@ export const ToggleTagsButton: React.FC = () => {
   ]);
 
   return (
-    <Box
-      sx={(theme) => ({
-        position: "fixed",
-        bottom: theme.spacing(2),
-        left: theme.spacing(7),
-        zIndex: theme.zIndex.appBar,
-        border: `1px solid ${theme.palette.border.main}`,
-        borderRadius: "3px",
-        background: theme.palette.background.paper,
-      })}
-    >
-      <Tooltip title="Toggle tags" placement="right">
-        <IconButton
-          aria-label="Toggle tags"
-          onClick={toggleShowTags}
-          size="large"
-          sx={(theme) => ({
-            padding: theme.spacing(1),
-            color: showTags
-              ? theme.palette.text.primary
-              : theme.palette.text.disabled,
-          })}
-        >
-          {showTags ? <LabelIcon /> : <LabelOffIcon />}
-        </IconButton>
-      </Tooltip>
-    </Box>
+    <Tooltip title="Toggle tags" placement="right">
+      <IconButton
+        aria-label="Toggle tags"
+        onClick={toggleShowTags}
+        size="large"
+        sx={(theme) => ({
+          background: theme.palette.background.paper,
+          padding: theme.spacing(1),
+          color: showTags
+            ? theme.palette.text.primary
+            : theme.palette.text.disabled,
+          "&:hover": {
+            background: theme.palette.common.white,
+          },
+        })}
+      >
+        {showTags ? <LabelIcon /> : <LabelOffIcon />}
+      </IconButton>
+    </Tooltip>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -27,6 +27,18 @@ const EditorContainer = styled(Box, {
     : `calc(100vh - ${HEADER_HEIGHT_EDITOR}px)`,
 }));
 
+const EditorVisualControls = styled(ButtonGroup)(({ theme }) => ({
+  position: "fixed",
+  bottom: theme.spacing(2.5),
+  left: theme.spacing(7.5),
+  zIndex: theme.zIndex.appBar,
+  border: `1px solid ${theme.palette.border.main}`,
+  borderRadius: "3px",
+  background: theme.palette.border.main,
+  gap: "1px",
+  overflow: "hidden",
+}));
+
 const FlowEditor = () => {
   const [flow, ...breadcrumbs] =
     useCurrentRoute().url.pathname.split("/").at(-1)?.split(",") || [];
@@ -53,14 +65,14 @@ const FlowEditor = () => {
       >
         <Box id="editor" ref={scrollContainerRef} sx={{ position: "relative" }}>
           <Flow flow={flow} breadcrumbs={breadcrumbs} />
-          <ButtonGroup
+          <EditorVisualControls
             orientation="vertical"
             aria-label="Toggle node attributes"
           >
             <ToggleImagesButton />
             <ToggleDataFieldsButton />
             <ToggleTagsButton />
-          </ButtonGroup>
+          </EditorVisualControls>
         </Box>
       </Box>
       <Sidebar />


### PR DESCRIPTION
## What does this PR do?

- Updates editor toggle button group to have a fixed position and contain inner buttons to prevent having to set a fixed bottom/left distance value and replicated styling for each button
- Allows further buttons to be added without needing specific styling
- Unifies heights for each button

**Before (left) vs after (right):**
![image](https://github.com/user-attachments/assets/e7c1cd47-5d9e-4c1d-958e-e430c7fcab67)
