### PR TITLE
feat: Description text for map schema date input

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
@@ -57,6 +57,7 @@ export const Trees: Schema = {
       type: "date",
       data: {
         title: "Expected completion date",
+        description: "For example, 16 04 2027",
         fn: "completionDate",
       },
     },

--- a/editor.planx.uk/src/@planx/components/List/schemas/TreesMapFirst.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/TreesMapFirst.ts
@@ -70,6 +70,7 @@ export const TreesMapFirst: Schema = {
       type: "date",
       data: {
         title: "Expected completion date",
+        description: "For example, 16 04 2027",
         fn: "completionDate",
       },
     },

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/Trees.ts
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/Trees.ts
@@ -57,6 +57,7 @@ export const Trees: Schema = {
       type: "date",
       data: {
         title: "Expected completion date",
+        description: "For example, 16 04 2027",
         fn: "completionDate",
       },
     },

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/dataFacetFlow.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/dataFacetFlow.ts
@@ -304,6 +304,7 @@ export const mockListRootResult: SearchResult<IndexedNode> = {
             data: {
               fn: "completionDate",
               title: "Expected completion date",
+              description: "For example, 16 04 2027",
             },
             type: "date",
           },


### PR DESCRIPTION
## What does this PR do?

- Adds a description/hint text to map date inputs `For example, 16 04 2027`, in line with [GOV.UK example](https://design-system.service.gov.uk/components/date-input/).

Identified in user-research, 2/5 householder participants tried to enter months using text (i.e. "Nov").

A first instinct was to add a script to insert an example date [for example] 6 months in the future, so that the suggested date would be relevant(ish) and never "expire". Seems like something that can be solved by setting a date well into the future to save unnecessary functionality. Interested to hear other opinions on this.

**Preview:**
<img width="402" alt="image" src="https://github.com/user-attachments/assets/e90db6a2-e0b4-453c-9000-778e3a98893d">
