### PR TITLE
fix: better styles for toggling images on questions

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -94,14 +94,22 @@ const Checklist: React.FC<Props> = React.memo((props) => {
             onContextMenu={handleContext}
             ref={drag}
           >
-            {props.data?.img && (
-              <Thumbnail
-                imageSource={props.data?.img}
-                imageAltText={props.data?.text}
-              />
-            )}
-            {Icon && <Icon />}
-            <span>{props.text}</span>
+            <Box sx={{ 
+              display: "flex", 
+              flexDirection: "column",
+              maxWidth: "220px"
+            }}>
+              {props.data?.img && (
+                <Thumbnail
+                  imageSource={props.data?.img}
+                  imageAltText={props.data?.text}
+                />
+              )}
+              <Box sx={{ display: "flex", flexDirection: "row" }}>
+                {Icon && <Icon />}
+                <span>{props.text}</span>
+              </Box>
+            </Box>
           </Link>
           {props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Thumbnail.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Thumbnail.tsx
@@ -12,8 +12,8 @@ export const Thumbnail: React.FC<{
   return (
     <Box
       sx={{
-        maxWidth: "220px",
-        maxHeight: "220px",
+        width: "220px",
+        height: "220px",
         margin: "auto",
       }}
       component="img"


### PR DESCRIPTION
See feedback & example flows in this thread: https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1729084076459039

**After:**
![Screenshot from 2024-10-16 17-26-57](https://github.com/user-attachments/assets/b6fa4e39-bcf8-4f16-bed3-499716729c3b)
&& 
![Screenshot from 2024-10-16 17-26-41](https://github.com/user-attachments/assets/eda8430d-9774-47ad-9d4f-f58905667645)
