### PR TITLE
fix: Editor graph styling snags

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -138,6 +138,11 @@ $fontMonospace: "Source Code Pro", monospace;
     border: $nodeBorderWidth dashed red;
   }
 
+  // Allow nodes to expand to width of data when toggled
+  &:not(.type-Section):not(.portal) > a {
+    width: 100%;
+  }
+
   & a {
     position: relative;
     display: flex;
@@ -150,6 +155,8 @@ $fontMonospace: "Source Code Pro", monospace;
     background: white;
     user-select: none;
     padding: 6px 12px;
+    overflow-wrap: break-word;
+    word-break: break-word;
 
     * {
       pointer-events: none;
@@ -161,16 +168,14 @@ $fontMonospace: "Source Code Pro", monospace;
       overflow-wrap: break-word;
     }
 
-    > svg {
+    // Component icon
+    & svg {
       margin-left: -6px;
-      margin-top: 0.5px;
-      width: 16px;
-      height: 16px;
-      opacity: 0.6;
-    }
-
-    > span:not(:first-child) {
-      margin-left: 6px;
+      margin-top: -1px;
+      margin-right: 6px;
+      width: 19px;
+      height: 19px;
+      opacity: 0.75;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Addresses identified styling snags in the graph following introduction of additional content (images, data, tags):

Nodes now expand to match data width:

<img width="342" alt="image" src="https://github.com/user-attachments/assets/065f2299-e04a-4f5b-919b-22de556512e9">

Standardised icon styles across nodes (also made a bit more prominent):

<img width="458" alt="image" src="https://github.com/user-attachments/assets/0687aad8-e038-423e-beee-08c5ad3fa42a">

(Existing snag fix) URLs now wrapping correctly:

<img width="342" alt="image" src="https://github.com/user-attachments/assets/5801ce5f-807c-495c-bf10-6d026a3c8ea2">