### PR TITLE
feat: add Boundary to Map and Label comp

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -240,6 +240,10 @@ const Root = () => {
       `You must plot at most ${schema.max} ${schema.type}(s) on the map`) ||
     "";
 
+  const [passport] = useStore((state) => [state.computePassport()]);
+
+  console.log(passport);
+
   return (
     <Card handleSubmit={validateAndSubmitForm} isValid>
       <CardHeader
@@ -258,6 +262,11 @@ const Root = () => {
               data-testid={MAP_ID}
               basemap={basemap}
               ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
+              geojsonData={JSON.stringify(
+                passport.data?.["property.boundary.site"],
+              )}
+              geojsonColor="#0010A4"
+              geojsonBuffer={30}
               drawMode
               drawGeojsonData={
                 features &&

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -242,8 +242,6 @@ const Root = () => {
 
   const [passport] = useStore((state) => [state.computePassport()]);
 
-  console.log(passport);
-
   return (
     <Card handleSubmit={validateAndSubmitForm} isValid>
       <CardHeader
@@ -263,7 +261,7 @@ const Root = () => {
               basemap={basemap}
               ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
               geojsonData={JSON.stringify(
-                passport.data?.["property.boundary.site"],
+                passport.data?.["property.boundary.title"],
               )}
               geojsonColor="#0010A4"
               geojsonBuffer={30}

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -261,9 +261,8 @@ const Root = () => {
               basemap={basemap}
               ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
               geojsonData={JSON.stringify(
-                passport.data?.["property.boundary.title"],
+                passport.data?.["property.boundary.site"],
               )}
-              geojsonColor="#0010A4"
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -227,6 +227,8 @@ const Root = () => {
     previouslySubmittedData,
   } = mapAndLabelProps;
 
+  const [passport] = useStore((state) => [state.computePassport()]);
+
   // If coming "back" or "changing", load initial features & tabs onto the map
   //   Pre-populating form fields within tabs is handled via formik.initialValues in Context.tsx
   if (previouslySubmittedData?.data?.[fn]?.features?.length > 0) {
@@ -239,8 +241,6 @@ const Root = () => {
     (errors.max &&
       `You must plot at most ${schema.max} ${schema.type}(s) on the map`) ||
     "";
-
-  const [passport] = useStore((state) => [state.computePassport()]);
 
   return (
     <Card handleSubmit={validateAndSubmitForm} isValid>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -227,7 +227,7 @@ const Root = () => {
     previouslySubmittedData,
   } = mapAndLabelProps;
 
-  const [passport] = useStore((state) => [state.computePassport()]);
+  const passport = useStore((state) => state.computePassport().data);
 
   // If coming "back" or "changing", load initial features & tabs onto the map
   //   Pre-populating form fields within tabs is handled via formik.initialValues in Context.tsx
@@ -260,9 +260,9 @@ const Root = () => {
               data-testid={MAP_ID}
               basemap={basemap}
               ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
-              geojsonData={JSON.stringify(
-                passport.data?.["property.boundary.site"],
-              )}
+              geojsonData={
+                passport && JSON.stringify(passport["property.boundary.site"])
+              }
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -31,6 +31,8 @@ function Component(props: PublicProps<PropertyInformation>) {
     client: publicClient,
   });
 
+  console.log(passport);
+
   if (!passport.data?._address)
     throw new GraphError("nodeMustFollowFindProperty");
 

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -31,8 +31,6 @@ function Component(props: PublicProps<PropertyInformation>) {
     client: publicClient,
   });
 
-  console.log(passport);
-
   if (!passport.data?._address)
     throw new GraphError("nodeMustFollowFindProperty");
 

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -72,9 +72,8 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               height={400}
               basemap={mapOptions?.basemap}
               geojsonData={JSON.stringify(
-                passport.data?.["property.boundary.title"],
+                passport.data?.["property.boundary.site"],
               )}
-              geojsonColor="#0010A4"
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -71,6 +71,11 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               // ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
               height={400}
               basemap={mapOptions?.basemap}
+              geojsonData={JSON.stringify(
+                passport.data?.["property.boundary.title"],
+              )}
+              geojsonColor="#0010A4"
+              geojsonBuffer={30}
               drawMode
               drawGeojsonData={
                 features &&


### PR DESCRIPTION
Coming from user feedback contained in the Trello Ticket: https://trello.com/c/liDbYC96/3094-both-options-show-static-boundary-or-address-point-for-reference-using-geojsondata-prop?filter=member:rorydoak2

We have added the boundary to map components so users can clearly see their property boundary when adding trees. 

Main changes are using the `geoJsonData` prop to populate a readonly boundary using passport data

https://github.com/user-attachments/assets/ad6067a3-24b4-4404-8c0c-13b7bfcddc53


