### PR TITLE
style: Refine history styling for legibility

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory.tsx
@@ -123,7 +123,7 @@ const EditHistory = () => {
                     sx={{
                       bgcolor: (theme) =>
                         inUndoScope(i)
-                          ? theme.palette.grey[400]
+                          ? theme.palette.grey[300]
                           : theme.palette.grey[900],
                     }}
                   />
@@ -132,8 +132,8 @@ const EditHistory = () => {
                       sx={{
                         bgcolor: (theme) =>
                           inUndoScope(i)
-                            ? theme.palette.grey[400]
-                            : theme.palette.grey[900],
+                            ? theme.palette.grey[200]
+                            : theme.palette.grey[300],
                       }}
                     />
                   )}
@@ -141,6 +141,8 @@ const EditHistory = () => {
                 <TimelineContent
                   sx={{
                     paddingRight: 0,
+                    paddingTop: 0.1,
+                    paddingBottom: 2,
                     minWidth: "100%",
                     maxWidth: "100%",
                   }}
@@ -158,16 +160,19 @@ const EditHistory = () => {
                         variant="body1"
                         sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
                         color={inUndoScope(i) ? "GrayText" : "inherit"}
+                        py={0.33}
                       >
                         {`${
                           op.actor
-                            ? `Edited by ${op.actor?.firstName} ${op.actor?.lastName}`
+                            ? `${op.actor?.firstName} ${op.actor?.lastName}`
                             : `Created flow`
                         }`}
                       </Typography>
                       <Typography
                         variant="body2"
-                        color={inUndoScope(i) ? "GrayText" : "inherit"}
+                        fontSize="small"
+                        pb={0.75}
+                        color={inUndoScope(i) ? "GrayText" : "text.secondary"}
                       >
                         {formatLastEditDate(op.createdAt)}
                       </Typography>
@@ -189,13 +194,13 @@ const EditHistory = () => {
                     )}
                   </Box>
                   {op.data && (
-                    <>
+                    <Box sx={{ bgcolor: "#F0F3F6", borderRadius: "8px" }}>
                       <Typography
                         variant="body2"
                         component="ul"
                         padding={2}
+                        paddingLeft={3.5}
                         color={inUndoScope(i) ? "GrayText" : "inherit"}
-                        style={{ paddingRight: "50px" }}
                       >
                         {[...new Set(formatOps(flow, op.data))]
                           .slice(0, OPS_TO_DISPLAY)
@@ -222,6 +227,7 @@ const EditHistory = () => {
                             variant="body2"
                             component="ul"
                             padding={2}
+                            paddingLeft={3.5}
                             color={inUndoScope(i) ? "GrayText" : "inherit"}
                             style={{ paddingRight: "50px" }}
                           >
@@ -235,7 +241,7 @@ const EditHistory = () => {
                           </Typography>
                         </SimpleExpand>
                       )}
-                    </>
+                    </Box>
                   )}
                 </TimelineContent>
               </TimelineItem>


### PR DESCRIPTION
## What does this PR do?

The combination of black text mixed with accordions and buttons in the history panel can be difficult to parse visually. This PR improves the legibility of the history view by creating visual hierarchy and grouping. Uses a familiar "chat history" style to create a greater boundary between actions.

I've also removed the repeated text "Edited by", open to be challenged on this, but I don't think it's needed.

**Before vs after:**
![image](https://github.com/user-attachments/assets/57c6f53d-7b0c-439c-b5d4-2ab3614156bb)