### PR TITLE
fix: Correctly set parent flow name in GovPayMetadata

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -67,14 +67,14 @@ function Component(props: Props) {
     state.flowSlug,
   ]);
   const fee = props.fn ? Number(passport.data?.[props.fn]) : 0;
+
   const defaultMetadata = [
     { key: "source", value: "PlanX" },
     { key: "flow", value: flowSlug },
     { key: "paidViaInviteToPay", value: "@paidViaInviteToPay" },
   ];
-  const metadata = props.govPayMetadata?.length
-    ? props.govPayMetadata
-    : defaultMetadata;
+
+  const metadata = [...(props.govPayMetadata || []), ...defaultMetadata];
 
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {


### PR DESCRIPTION
## What's the problem?
- The Editor interface of the Pay component only ever knows about its own context - `flowName` will always be the flow it's held within
- At runtime, as an applicant hits the public interface of the component, the context can be different - `flowName` is the root ("parent" flow)
- This means that we send the incorrect flow name to GovPay

## What's the solution?
- Be a bit more smart about setting the defaults at runtime in the Public interface
- Always overwrite with the _current_ flow name, which is always correct

## Testing
I didn't find a good way to test this (without setting up a new E2E test). Open to ideas!

You can test this manually here - 
 - Public interface - https://3826.planx.pizza/buckinghamshire/test-pay-metadata/published?analytics=false
 - Editor interface - https://3826.planx.pizza/buckinghamshire/test-pay-metadata