### PR TITLE
feat: add 'printed at' timestamp to print view

### DIFF
--- a/editor.planx.uk/src/components/PrintButton.tsx
+++ b/editor.planx.uk/src/components/PrintButton.tsx
@@ -1,17 +1,44 @@
 import PrintIcon from "@mui/icons-material/Print";
 import Button from "@mui/material/Button";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
 import React from "react";
+
+const StyledPrintButton = styled(Button)(() => ({
+  "@media print": {
+    display: "none",
+  },
+}));
+
+const StyledTimestamp = styled(Typography)(() => ({
+  display: "none",
+  "@media print": {
+    display: "block",
+  },
+}));
+
+const PrintedAt = () => {
+  return (
+    <StyledTimestamp>
+      Printed at {new Date().toLocaleString("en-GB")}
+    </StyledTimestamp>
+  );
+};
 
 export const PrintButton = () => {
   return (
-    <Button
-      variant="contained"
-      color="secondary"
-      startIcon={<PrintIcon />}
-      size="large"
-      onClick={() => window.print()}
-    >
-      Print this page
-    </Button>
+    <>
+      <StyledPrintButton
+        variant="contained"
+        color="secondary"
+        startIcon={<PrintIcon />}
+        size="large"
+        onClick={() => window.print()}
+      >
+        Print this page
+      </StyledPrintButton>
+
+      <PrintedAt />
+    </>
   );
 };


### PR DESCRIPTION
Trello ticket: https://trello.com/c/4fhbFPFw/3097-can-we-force-a-timestamp-on-the-new-print-button-regardless-of-browsers-settings-for-the-upload-and-label-review-component

I've simply added some `@media print` CSS so that the 'Print this page' button turns into a line of text saying 'Printed at `<timestamp>`.

Open to wording and styling opinions!

![Screenshot 2024-10-22 at 12 58 54](https://github.com/user-attachments/assets/37e9b97a-604b-47d9-8a0b-3fa552a35dc1)
