### PR TITLE
chore: Add `VERBOSITY=terse` flag to db sync script in CI

### DIFF
--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -36,7 +36,15 @@ jobs:
       - name: Run sync script
         run: | 
           {
-            docker run --rm -v "$(pwd)/scripts/seed-database:/app" --workdir="/app" postgis/postgis:12-3.0-alpine "./container.sh" "${STAGING_PG_URL}" "${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}" "reset_flows"
+            # Create temp .psqlrc file to hold config
+            echo '\set VERBOSITY terse' > /tmp/.psqlrc
+
+            docker run --rm \
+              -v /tmp/.psqlrc:/root/.psqlrc \
+              -v "$(pwd)/scripts/seed-database:/app" \
+              --workdir="/app" \
+              postgis/postgis:12-3.0-alpine \
+              "./container.sh" "${STAGING_PG_URL}" "${PRODUCTION_PG_URL_FOR_USER_GITHUB_ACTIONS}" "reset_flows"
           } || {
             echo "Database sync failed!"
             exit 1


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C01EVPXFU7K/p1729769117634399 for context (OSL Slack)

Using the psql flag `VERBOSITY=terse` will prevent error `DETAILS` being caught in CI logs, but would still appear when running locally ([docs](https://www.postgresql.org/docs/current/runtime-config-logging.html#:~:text=TERSE%20excludes%20the%20logging%20of,number%20that%20generated%20the%20error.)).