### PR TITLE
fix: adjust string matching conditions for summarising external portal changes on publish

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -142,7 +142,7 @@ export const AlteredNodesSummaryContent = (props: {
     } else if (node.id && Object.keys(node).length === 1) {
       changeSummary["deleted"] += 1;
     } else if (node.type === TYPES.InternalPortal) {
-      if (node.data?.text?.includes("/")) {
+      if (node.data?.text?.includes("/") && !node.data?.text?.includes(" ")) {
         changeSummary["portals"].push({ ...node.data, flowId: node.id });
       }
     } else if (node.type) {


### PR DESCRIPTION
Flagged by August here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1729858933090839

A couple tricky factors at play here:
- When we flatten flows on publish, external portal node types are converted to internal portal node types, which means we can't filter on node type and instead filter on the "name" of the external or internal portal
- In this particular example, the name of the internal portal is `LDCe & LDCp s.191b/s.191a` which includes a `/` and matched our previous string matching logic which assumed every internal portal name including a `/` must be originally an external portal (eg `{team-slug}/{flow-slug}`) 

This isn't a particularly robust for future-proof fix, but should do the trick for now! External portals names will never have spaces because they are slugs.