### PR TITLE
feat: add demoUser role to Hasura with permissions

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -252,6 +252,24 @@
       using:
         foreign_key_constraint_on: team_id
   insert_permissions:
+    - role: demoUser
+      permission:
+        check: {}
+        columns:
+          - created_at
+          - device
+          - feedback_type
+          - flow_id
+          - id
+          - node_data
+          - node_id
+          - node_type
+          - status
+          - team_id
+          - user_comment
+          - user_context
+          - user_data
+      comment: Allow users who want to leave feedback on their experience to write to the table
     - role: public
       permission:
         check: {}
@@ -301,6 +319,39 @@
             name: teams
             schema: public
   select_permissions:
+    - role: demoUser
+      permission:
+        columns:
+          - feedback_id
+          - device
+          - node_data
+          - address
+          - feedback_type
+          - help_definition
+          - help_sources
+          - help_text
+          - intersecting_constraints
+          - node_id
+          - node_text
+          - node_title
+          - node_type
+          - project_type
+          - service_slug
+          - status
+          - team_slug
+          - uprn
+          - user_comment
+          - user_context
+          - created_at
+        filter:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -455,6 +506,22 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
+    - role: demoUser
+      permission:
+        check: {}
+        columns:
+          - copied_from
+          - created_at
+          - creator_id
+          - data
+          - id
+          - name
+          - settings
+          - slug
+          - team_id
+          - updated_at
+          - version
+      comment: ""
     - role: platformAdmin
       permission:
         check: {}
@@ -479,6 +546,22 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
+    - role: public
+      permission:
+        check: {}
+        columns:
+          - copied_from
+          - created_at
+          - creator_id
+          - data
+          - id
+          - name
+          - settings
+          - slug
+          - team_id
+          - updated_at
+          - version
+      comment: ""
     - role: teamEditor
       permission:
         check:
@@ -530,6 +613,39 @@
           - data_merged
         filter: {}
         allow_aggregations: true
+    - role: demoUser
+      permission:
+        columns:
+          - created_at
+          - creator_id
+          - data
+          - id
+          - name
+          - settings
+          - slug
+          - status
+          - team_id
+          - updated_at
+          - version
+        computed_fields:
+          - data_merged
+        filter:
+          _or:
+            - _and:
+                - creator_id:
+                    _eq: x-hasura-user-id
+                - team:
+                    id:
+                      _eq: 32
+            - team:
+                _or:
+                  - id:
+                      _eq: 1
+                  - id:
+                      _eq: 29
+                  - id:
+                      _eq: 30
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -566,7 +682,7 @@
         computed_fields:
           - data_merged
         filter: {}
-        allow_aggregations: true
+      comment: ""
     - role: teamEditor
       permission:
         columns:
@@ -613,6 +729,23 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
+    - role: demoUser
+      permission:
+        columns:
+          - copied_from
+          - created_at
+          - creator_id
+          - data
+          - id
+          - name
+          - settings
+          - slug
+          - team_id
+          - updated_at
+          - version
+        filter: {}
+        check: null
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -633,6 +766,23 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
+    - role: public
+      permission:
+        columns:
+          - copied_from
+          - created_at
+          - creator_id
+          - data
+          - id
+          - name
+          - settings
+          - slug
+          - team_id
+          - updated_at
+          - version
+        filter: {}
+        check: null
+      comment: ""
     - role: teamEditor
       permission:
         columns:
@@ -661,9 +811,17 @@
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   delete_permissions:
+    - role: demoUser
+      permission:
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         filter: {}
+    - role: public
+      permission:
+        filter: {}
+      comment: ""
     - role: teamEditor
       permission:
         filter:
@@ -694,6 +852,11 @@
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   select_permissions:
+    - role: demoUser
+      permission:
+        columns:
+          - footer_content
+        filter: {}
     - role: platformAdmin
       permission:
         columns:
@@ -946,6 +1109,14 @@
       using:
         foreign_key_constraint_on: flow_id
   insert_permissions:
+    - role: demoUser
+      permission:
+        check:
+          flow:
+            creator_id:
+              _eq: x-hausra-user-id
+        columns: []
+      comment: ""
     - role: platformAdmin
       permission:
         check: {}
@@ -977,6 +1148,18 @@
           - updated_at
           - flow_id
   select_permissions:
+    - role: demoUser
+      permission:
+        columns:
+          - id
+          - actor_id
+          - version
+          - data
+          - created_at
+          - updated_at
+          - flow_id
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -1000,6 +1183,15 @@
           - updated_at
         filter: {}
   update_permissions:
+    - role: demoUser
+      permission:
+        columns: []
+        filter:
+          flow:
+            creator_id:
+              _eq: x-hausra-user-id
+        check: null
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -1344,6 +1536,17 @@
           - data
         filter: {}
         allow_aggregations: true
+    - role: demoUser
+      permission:
+        columns:
+          - created_at
+          - data
+          - flow_id
+          - id
+          - publisher_id
+          - summary
+        filter: {}
+        allow_aggregations: true
     - role: platformAdmin
       permission:
         columns:
@@ -1532,6 +1735,19 @@
     name: submission_services_log
     schema: public
   select_permissions:
+    - role: demoUser
+      permission:
+        columns:
+          - retry
+          - response
+          - event_id
+          - event_type
+          - status
+          - created_at
+          - flow_id
+          - session_id
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -1562,6 +1778,38 @@
     name: submission_services_summary
     schema: public
   select_permissions:
+    - role: demoUser
+      permission:
+        columns:
+          - number_times_resumed
+          - sent_to_bops
+          - sent_to_email
+          - sent_to_s3_power_automate
+          - sent_to_uniform
+          - user_clicked_save
+          - user_invited_to_pay
+          - session_length_days
+          - bops_applications
+          - email_applications
+          - payment_requests
+          - payment_status
+          - s3_applications
+          - uniform_applications
+          - allow_list_answers
+          - application_declaration_connection
+          - draw_boundary_action
+          - find_property_action
+          - property_constraints_planning
+          - property_type
+          - proposal_project_type
+          - user_role
+          - service_slug
+          - session_id
+          - team_slug
+          - created_at
+          - submitted_at
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -1672,6 +1920,14 @@
           - staging_govpay_secret
           - power_automate_webhook_url
         filter: {}
+    - role: demoUser
+      permission:
+        columns:
+          - has_planning_data
+          - id
+          - team_id
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -1929,6 +2185,18 @@
           - team_id
         filter: {}
       comment: ""
+    - role: demoUser
+      permission:
+        columns:
+          - action_colour
+          - favicon
+          - id
+          - link_colour
+          - logo
+          - primary_colour
+          - team_id
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -2048,6 +2316,16 @@
           - updated_at
   select_permissions:
     - role: api
+      permission:
+        columns:
+          - created_at
+          - domain
+          - id
+          - name
+          - slug
+          - updated_at
+        filter: {}
+    - role: demoUser
       permission:
         columns:
           - created_at
@@ -2240,6 +2518,17 @@
           - id
           - is_platform_admin
           - is_staging_only
+          - last_name
+          - updated_at
+        filter: {}
+    - role: demoUser
+      permission:
+        columns:
+          - created_at
+          - email
+          - first_name
+          - id
+          - is_platform_admin
           - last_name
           - updated_at
         filter: {}

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -327,8 +327,8 @@
           - created_at
         filter:
           team:
-            members:
-              user_id:
+            flows:
+              creator_id:
                 _eq: x-hasura-user-id
       comment: ""
     - role: platformAdmin
@@ -502,7 +502,7 @@
           - team_id
           - updated_at
           - version
-      comment: ""
+      comment: They can only insert into Demo team [id = 32]
     - role: platformAdmin
       permission:
         check: {}
@@ -610,7 +610,7 @@
                       _eq: 29
                   - id:
                       _eq: 30
-      comment: ""
+      comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
         columns:
@@ -1450,6 +1450,25 @@
           - created_at
           - flow_id
           - data
+    - role: demoUser
+      permission:
+        check:
+          _and:
+            - flow:
+                creator_id:
+                  _eq: x-hasura-user-id
+            - flow:
+                team:
+                  id:
+                    _eq: 32
+        columns:
+          - id
+          - publisher_id
+          - summary
+          - created_at
+          - flow_id
+          - data
+      comment: A demoUser can only insert a published flow for their own flows and for flows inside the Demo team [id = 32]
     - role: platformAdmin
       permission:
         check: {}
@@ -1763,7 +1782,7 @@
           - created_at
           - submitted_at
         filter: {}
-      comment: ""
+      comment: 'For future, if this moves outside of the Flow to somewhere like Team, we should update "demoUser" to only see submission data related to only their flows. '
     - role: platformAdmin
       permission:
         columns:
@@ -2298,6 +2317,7 @@
                 _eq: 30
             - id:
                 _eq: 32
+      comment: 'For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
         columns:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -603,13 +603,11 @@
                     id:
                       _eq: 32
             - team:
-                _or:
-                  - id:
-                      _eq: 1
-                  - id:
-                      _eq: 29
-                  - id:
-                      _eq: 30
+                id:
+                  _in:
+                    - 1
+                    - 29
+                    - 30
       comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
@@ -2308,15 +2306,12 @@
           - slug
           - updated_at
         filter:
-          _or:
-            - id:
-                _eq: 1
-            - id:
-                _eq: 29
-            - id:
-                _eq: 30
-            - id:
-                _eq: 32
+          id:
+            _in:
+              - 1
+              - 29
+              - 30
+              - 32
       comment: 'For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -252,24 +252,6 @@
       using:
         foreign_key_constraint_on: team_id
   insert_permissions:
-    - role: demoUser
-      permission:
-        check: {}
-        columns:
-          - created_at
-          - device
-          - feedback_type
-          - flow_id
-          - id
-          - node_data
-          - node_id
-          - node_type
-          - status
-          - team_id
-          - user_comment
-          - user_context
-          - user_data
-      comment: Allow users who want to leave feedback on their experience to write to the table
     - role: public
       permission:
         check: {}
@@ -784,7 +766,12 @@
   delete_permissions:
     - role: demoUser
       permission:
-        filter: {}
+        filter:
+          _and:
+            - team_id:
+                _eq: 32
+            - creator_id:
+                _eq: x-hasura-user-id
       comment: ""
     - role: platformAdmin
       permission:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -346,11 +346,8 @@
         filter:
           team:
             members:
-              _and:
-                - user_id:
-                    _eq: x-hasura-user-id
-                - role:
-                    _eq: teamEditor
+              user_id:
+                _eq: x-hasura-user-id
       comment: ""
     - role: platformAdmin
       permission:
@@ -508,7 +505,9 @@
           type: http
     - role: demoUser
       permission:
-        check: {}
+        check:
+          team_id:
+            _eq: 32
         columns:
           - copied_from
           - created_at
@@ -727,7 +726,12 @@
           - team_id
           - updated_at
           - version
-        filter: {}
+        filter:
+          _and:
+            - team_id:
+                _eq: 32
+            - creator_id:
+                _eq: x-hasura-user-id
         check: null
       comment: ""
     - role: platformAdmin
@@ -2297,7 +2301,16 @@
           - name
           - slug
           - updated_at
-        filter: {}
+        filter:
+          _or:
+            - id:
+                _eq: 1
+            - id:
+                _eq: 29
+            - id:
+                _eq: 30
+            - id:
+                _eq: 32
     - role: platformAdmin
       permission:
         columns:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -157,7 +157,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -171,7 +171,7 @@
         query_params:
           type: bops-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: document_template
@@ -225,7 +225,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -239,7 +239,7 @@
         query_params:
           type: email-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: feedback
@@ -481,9 +481,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: demoUser
       permission:
@@ -523,9 +523,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: teamEditor
       permission:
@@ -554,9 +554,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   select_permissions:
     - role: api
@@ -608,7 +608,7 @@
                     - 1
                     - 29
                     - 30
-      comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
+      comment: "For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
     - role: platformAdmin
       permission:
         columns:
@@ -645,6 +645,7 @@
         computed_fields:
           - data_merged
         filter: {}
+        allow_aggregations: true
       comment: ""
     - role: teamEditor
       permission:
@@ -688,9 +689,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: demoUser
       permission:
@@ -730,9 +731,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: teamEditor
       permission:
@@ -757,9 +758,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   delete_permissions:
     - role: demoUser
@@ -799,9 +800,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   select_permissions:
     - role: demoUser
@@ -839,9 +840,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
 - table:
     name: lowcal_sessions
@@ -988,7 +989,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/send-email/confirmation'
+        url: "{{$base_url}}/send-email/confirmation"
         version: 2
     - name: setup_lowcal_expiry_events
       definition:
@@ -1018,7 +1019,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
+        url: "{{$base_url}}/webhooks/hasura/create-expiry-event"
         version: 2
     - name: setup_lowcal_reminder_events
       definition:
@@ -1048,7 +1049,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
+        url: "{{$base_url}}/webhooks/hasura/create-reminder-event"
         version: 2
 - table:
     name: operations
@@ -1254,7 +1255,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1276,13 +1277,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-expiry-events"
         version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1304,13 +1305,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-invitation-events"
         version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1332,7 +1333,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-reminder-events"
         version: 2
     - name: setup_payment_send_events
       definition:
@@ -1361,7 +1362,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-send-events"
         version: 2
 - table:
     name: payment_status
@@ -1623,12 +1624,12 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
         timeout_sec: 60
-      webhook: '{{HASURA_PLANX_API_URL}}'
+      webhook: "{{HASURA_PLANX_API_URL}}"
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
@@ -1637,7 +1638,7 @@
         query_params:
           type: s3-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: sessions
@@ -2312,7 +2313,7 @@
               - 29
               - 30
               - 32
-      comment: 'For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
+      comment: "For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
     - role: platformAdmin
       permission:
         columns:
@@ -2429,7 +2430,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -2443,7 +2444,7 @@
         query_params:
           type: uniform-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: user_roles

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -546,22 +546,6 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
-    - role: public
-      permission:
-        check: {}
-        columns:
-          - copied_from
-          - created_at
-          - creator_id
-          - data
-          - id
-          - name
-          - settings
-          - slug
-          - team_id
-          - updated_at
-          - version
-      comment: ""
     - role: teamEditor
       permission:
         check:
@@ -766,23 +750,6 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
-    - role: public
-      permission:
-        columns:
-          - copied_from
-          - created_at
-          - creator_id
-          - data
-          - id
-          - name
-          - settings
-          - slug
-          - team_id
-          - updated_at
-          - version
-        filter: {}
-        check: null
-      comment: ""
     - role: teamEditor
       permission:
         columns:
@@ -818,10 +785,6 @@
     - role: platformAdmin
       permission:
         filter: {}
-    - role: public
-      permission:
-        filter: {}
-      comment: ""
     - role: teamEditor
       permission:
         filter:

--- a/hasura.planx.uk/migrations/1729675271585_insert_into_public_user_roles/down.sql
+++ b/hasura.planx.uk/migrations/1729675271585_insert_into_public_user_roles/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."user_roles" WHERE "value" = 'demoUser';

--- a/hasura.planx.uk/migrations/1729675271585_insert_into_public_user_roles/up.sql
+++ b/hasura.planx.uk/migrations/1729675271585_insert_into_public_user_roles/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."user_roles"("value") VALUES (E'demoUser');

--- a/hasura.planx.uk/tests/analytics.test.js
+++ b/hasura.planx.uk/tests/analytics.test.js
@@ -76,6 +76,21 @@ describe("analytics and analytics_logs", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query analytics_logs", () => {
+      expect(i.queries).not.toContain("analytics_logs");
+    });
+
+    test("cannot create, update, or delete analytics_logs", () => {
+      expect(i).toHaveNoMutationsFor("analytics_logs");
+    });
+  });
+
   describe("api", () => {
     beforeAll(async () => {
       i = await introspectAs("api");

--- a/hasura.planx.uk/tests/blpu_codes.test.js
+++ b/hasura.planx.uk/tests/blpu_codes.test.js
@@ -59,6 +59,21 @@ describe("blpu_codes", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query blpu_codes", () => {
+      expect(i.queries).not.toContain("blpu_codes");
+    });
+
+    test("cannot create, update, or delete blpu_codes", () => {
+      expect(i).toHaveNoMutationsFor("blpu_codes");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/bops_applications.test.js
+++ b/hasura.planx.uk/tests/bops_applications.test.js
@@ -60,6 +60,21 @@ describe("bops_applications", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query bops applications", () => {
+      expect(i.queries).not.toContain("bops_applications");
+    });
+
+    test("cannot create, update, or delete bops applications", () => {
+      expect(i).toHaveNoMutationsFor("bops_applications");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/email_applications.test.js
+++ b/hasura.planx.uk/tests/email_applications.test.js
@@ -60,6 +60,7 @@ describe("email_applications", () => {
       expect(i).toHaveNoMutationsFor("email_applications");
     });
   });
+  
   describe("demoUser", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/email_applications.test.js
+++ b/hasura.planx.uk/tests/email_applications.test.js
@@ -60,6 +60,20 @@ describe("email_applications", () => {
       expect(i).toHaveNoMutationsFor("email_applications");
     });
   });
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query email_applications", () => {
+      expect(i.queries).not.toContain("email_applications");
+    });
+
+    test("cannot create, update, or delete email_applications", () => {
+      expect(i).toHaveNoMutationsFor("email_applications");
+    });
+  });
 
   describe("api", () => {
     let i;

--- a/hasura.planx.uk/tests/feedback.test.js
+++ b/hasura.planx.uk/tests/feedback.test.js
@@ -8,21 +8,21 @@ describe("feedback", () => {
     });
 
     test("cannot query feedback", () => {
-        expect(i.queries).not.toContain("feedback");
-      });
-  
-      test("cannot update feedback", () => {
-        expect(i.mutations).not.toContain("update_feedback");
-        expect(i.mutations).not.toContain("update_feedback_by_pk");
-      });
-  
-      test("cannot delete feedback", async () => {
-        expect(i.mutations).not.toContain("delete_feedback");
-      });
-  
-      test("can insert feedback", async () => {
-        expect(i.mutations).toContain("insert_feedback");
-      });
+      expect(i.queries).not.toContain("feedback");
+    });
+
+    test("cannot update feedback", () => {
+      expect(i.mutations).not.toContain("update_feedback");
+      expect(i.mutations).not.toContain("update_feedback_by_pk");
+    });
+
+    test("cannot delete feedback", async () => {
+      expect(i.mutations).not.toContain("delete_feedback");
+    });
+
+    test("can insert feedback", async () => {
+      expect(i.mutations).toContain("insert_feedback");
+    });
   });
 
   describe("admin", () => {
@@ -32,13 +32,13 @@ describe("feedback", () => {
     });
 
     test("has full access to query and mutate feedback", () => {
-        expect(i.mutations).toContain("insert_feedback");
-        expect(i.mutations).toContain("insert_feedback_one");
-        expect(i.mutations).toContain("update_feedback");
-        expect(i.mutations).toContain("update_feedback_by_pk");
-        expect(i.mutations).toContain("update_feedback_many");
-        expect(i.mutations).toContain("delete_feedback");
-        expect(i.mutations).toContain("delete_feedback_by_pk");
+      expect(i.mutations).toContain("insert_feedback");
+      expect(i.mutations).toContain("insert_feedback_one");
+      expect(i.mutations).toContain("update_feedback");
+      expect(i.mutations).toContain("update_feedback_by_pk");
+      expect(i.mutations).toContain("update_feedback_many");
+      expect(i.mutations).toContain("delete_feedback");
+      expect(i.mutations).toContain("delete_feedback_by_pk");
     });
   });
 
@@ -50,11 +50,10 @@ describe("feedback", () => {
 
     test("cannot query feedback", () => {
       expect(i.queries).not.toContain("feedback");
-
     });
 
     test("cannot mutate feedback", async () => {
-      expect(i).toHaveNoMutationsFor("feedback")
+      expect(i).toHaveNoMutationsFor("feedback");
     });
   });
 
@@ -66,11 +65,25 @@ describe("feedback", () => {
 
     test("cannot query feedback", () => {
       expect(i.queries).not.toContain("feedback");
-
     });
 
     test("cannot mutate feedback", async () => {
-      expect(i).toHaveNoMutationsFor("feedback")
+      expect(i).toHaveNoMutationsFor("feedback");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query feedback", () => {
+      expect(i.queries).not.toContain("feedback");
+    });
+
+    test("cannot mutate feedback", async () => {
+      expect(i).toHaveNoMutationsFor("feedback");
     });
   });
 
@@ -92,7 +105,7 @@ describe("feedback", () => {
     test("can delete feedback", async () => {
       expect(i.mutations).toContain("delete_feedback");
     });
-    
+
     test("cannot insert feedback", async () => {
       expect(i.mutations).not.toContain("insert_feedback");
     });

--- a/hasura.planx.uk/tests/feedback_status.test.js
+++ b/hasura.planx.uk/tests/feedback_status.test.js
@@ -66,6 +66,7 @@ describe("feedback_status_enum", () => {
       expect(i).toHaveNoMutationsFor("feedback_status_enum");
     });
   });
+  
   describe("demoUser", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/feedback_status.test.js
+++ b/hasura.planx.uk/tests/feedback_status.test.js
@@ -1,92 +1,106 @@
 const { introspectAs } = require("./utils");
 
 describe("feedback_status_enum", () => {
-    describe("public", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("public");
-        });
-    
-        test("cannot INSERT records", () => {
-          expect(i.mutations).not.toContain("insert_feedback_status_enum");
-        });
-    
-        test("cannot QUERY records", () => {
-          expect(i.queries).not.toContain("feedback_status_enum");
-        });
-    
-        test("cannot DELETE records", () => {
-          expect(i.mutations).not.toContain("delete_feedback_status_enum");
-        });
-    
-        test("cannot UPDATE records", () => {
-          expect(i.mutations).not.toContain("update_feedback_status_enum");
-        });
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
     });
 
-    describe("admin", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("admin");
-        });
-    
-        test("has full access to query and mutate feedback_status_enum", async () => {
-          expect(i.queries).toContain("feedback_status_enum");
-          expect(i.mutations).toContain("insert_feedback_status_enum");
-          expect(i.mutations).toContain("delete_feedback_status_enum");
-        });
+    test("cannot INSERT records", () => {
+      expect(i.mutations).not.toContain("insert_feedback_status_enum");
     });
 
-    describe("platformAdmin", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("platformAdmin");
-        });
-    
-        test("cannot query feedback_status_enum", () => {
-          expect(i.queries).not.toContain("feedback_status_enum");
-        });
-    
-        test("cannot create, update, or delete feedback_status_enum", () => {
-          expect(i).toHaveNoMutationsFor("feedback_status_enum");
-        });
-      });
-
-      describe("teamEditor", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("teamEditor");
-        });
-    
-        test("cannot query feedback_status_enum", () => {
-          expect(i.queries).not.toContain("feedback_status_enum");
-        });
-    
-        test("cannot create, update, or delete feedback_status_enum", () => {
-          expect(i).toHaveNoMutationsFor("feedback_status_enum");
-        });
-      });
-
-      describe("api", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("api");
-        });
-    
-        test("cannot INSERT records", () => {
-          expect(i.mutations).not.toContain("insert_feedback_status_enum");
-        });
-    
-        test("cannot QUERY records", () => {
-          expect(i.queries).not.toContain("feedback_status_enum");
-        });
-    
-        test("cannot DELETE records", () => {
-          expect(i.mutations).not.toContain("delete_feedback_status_enum");
-        });
-    
-        test("cannot UPDATE records", () => {
-          expect(i.mutations).not.toContain("update_feedback_status_enum");
-        });
+    test("cannot QUERY records", () => {
+      expect(i.queries).not.toContain("feedback_status_enum");
     });
- });
+
+    test("cannot DELETE records", () => {
+      expect(i.mutations).not.toContain("delete_feedback_status_enum");
+    });
+
+    test("cannot UPDATE records", () => {
+      expect(i.mutations).not.toContain("update_feedback_status_enum");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate feedback_status_enum", async () => {
+      expect(i.queries).toContain("feedback_status_enum");
+      expect(i.mutations).toContain("insert_feedback_status_enum");
+      expect(i.mutations).toContain("delete_feedback_status_enum");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query feedback_status_enum", () => {
+      expect(i.queries).not.toContain("feedback_status_enum");
+    });
+
+    test("cannot create, update, or delete feedback_status_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_status_enum");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query feedback_status_enum", () => {
+      expect(i.queries).not.toContain("feedback_status_enum");
+    });
+
+    test("cannot create, update, or delete feedback_status_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_status_enum");
+    });
+  });
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query feedback_status_enum", () => {
+      expect(i.queries).not.toContain("feedback_status_enum");
+    });
+
+    test("cannot create, update, or delete feedback_status_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_status_enum");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot INSERT records", () => {
+      expect(i.mutations).not.toContain("insert_feedback_status_enum");
+    });
+
+    test("cannot QUERY records", () => {
+      expect(i.queries).not.toContain("feedback_status_enum");
+    });
+
+    test("cannot DELETE records", () => {
+      expect(i.mutations).not.toContain("delete_feedback_status_enum");
+    });
+
+    test("cannot UPDATE records", () => {
+      expect(i.mutations).not.toContain("update_feedback_status_enum");
+    });
+  });
+});

--- a/hasura.planx.uk/tests/feedback_type_enum.test.js
+++ b/hasura.planx.uk/tests/feedback_type_enum.test.js
@@ -1,92 +1,107 @@
 const { introspectAs } = require("./utils");
 
 describe("feedback_type_enum", () => {
-    describe("public", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("public");
-        });
-    
-        test("cannot INSERT records", () => {
-          expect(i.mutations).not.toContain("insert_feedback_type_enum");
-        });
-    
-        test("cannot QUERY records", () => {
-          expect(i.queries).not.toContain("feedback_type_enum");
-        });
-    
-        test("cannot DELETE records", () => {
-          expect(i.mutations).not.toContain("delete_feedback_type_enum");
-        });
-    
-        test("cannot UPDATE records", () => {
-          expect(i.mutations).not.toContain("update_feedback_type_enum");
-        });
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
     });
 
-    describe("admin", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("admin");
-        });
-    
-        test("has full access to query and mutate feedback_type_enum", async () => {
-          expect(i.queries).toContain("feedback_type_enum");
-          expect(i.mutations).toContain("insert_feedback_type_enum");
-          expect(i.mutations).toContain("delete_feedback_type_enum");
-        });
+    test("cannot INSERT records", () => {
+      expect(i.mutations).not.toContain("insert_feedback_type_enum");
     });
 
-    describe("platformAdmin", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("platformAdmin");
-        });
-    
-        test("cannot query feedback_type_enum", () => {
-          expect(i.queries).not.toContain("feedback_type_enum");
-        });
-    
-        test("cannot create, update, or delete feedback_type_enum", () => {
-          expect(i).toHaveNoMutationsFor("feedback_type_enum");
-        });
-      });
-
-      describe("teamEditor", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("teamEditor");
-        });
-    
-        test("cannot query feedback_type_enum", () => {
-          expect(i.queries).not.toContain("feedback_type_enum");
-        });
-    
-        test("cannot create, update, or delete feedback_type_enum", () => {
-          expect(i).toHaveNoMutationsFor("feedback_type_enum");
-        });
-      });
-
-      describe("api", () => {
-        let i;
-        beforeAll(async () => {
-          i = await introspectAs("api");
-        });
-    
-        test("cannot INSERT records", () => {
-          expect(i.mutations).not.toContain("insert_feedback_type_enum");
-        });
-    
-        test("cannot QUERY records", () => {
-          expect(i.queries).not.toContain("feedback_type_enum");
-        });
-    
-        test("cannot DELETE records", () => {
-          expect(i.mutations).not.toContain("delete_feedback_type_enum");
-        });
-    
-        test("cannot UPDATE records", () => {
-          expect(i.mutations).not.toContain("update_feedback_type_enum");
-        });
+    test("cannot QUERY records", () => {
+      expect(i.queries).not.toContain("feedback_type_enum");
     });
- });
+
+    test("cannot DELETE records", () => {
+      expect(i.mutations).not.toContain("delete_feedback_type_enum");
+    });
+
+    test("cannot UPDATE records", () => {
+      expect(i.mutations).not.toContain("update_feedback_type_enum");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate feedback_type_enum", async () => {
+      expect(i.queries).toContain("feedback_type_enum");
+      expect(i.mutations).toContain("insert_feedback_type_enum");
+      expect(i.mutations).toContain("delete_feedback_type_enum");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query feedback_type_enum", () => {
+      expect(i.queries).not.toContain("feedback_type_enum");
+    });
+
+    test("cannot create, update, or delete feedback_type_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_type_enum");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query feedback_type_enum", () => {
+      expect(i.queries).not.toContain("feedback_type_enum");
+    });
+
+    test("cannot create, update, or delete feedback_type_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_type_enum");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query feedback_type_enum", () => {
+      expect(i.queries).not.toContain("feedback_type_enum");
+    });
+
+    test("cannot create, update, or delete feedback_type_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_type_enum");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot INSERT records", () => {
+      expect(i.mutations).not.toContain("insert_feedback_type_enum");
+    });
+
+    test("cannot QUERY records", () => {
+      expect(i.queries).not.toContain("feedback_type_enum");
+    });
+
+    test("cannot DELETE records", () => {
+      expect(i.mutations).not.toContain("delete_feedback_type_enum");
+    });
+
+    test("cannot UPDATE records", () => {
+      expect(i.mutations).not.toContain("update_feedback_type_enum");
+    });
+  });
+});

--- a/hasura.planx.uk/tests/flow_document_templates.test.js
+++ b/hasura.planx.uk/tests/flow_document_templates.test.js
@@ -64,6 +64,7 @@ describe("flow_document_templates", () => {
       expect(i).toHaveNoMutationsFor("flow_document_templates");
     });
   });
+  
   describe("demoUser", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/flow_document_templates.test.js
+++ b/hasura.planx.uk/tests/flow_document_templates.test.js
@@ -64,6 +64,20 @@ describe("flow_document_templates", () => {
       expect(i).toHaveNoMutationsFor("flow_document_templates");
     });
   });
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query flow_document_templates", () => {
+      expect(i.queries).not.toContain("flow_document_templates");
+    });
+
+    test("cannot create, update, or delete flow_document_templates", () => {
+      expect(i).toHaveNoMutationsFor("flow_document_templates");
+    });
+  });
 
   describe("api", () => {
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/flow_status_history.test.js
+++ b/hasura.planx.uk/tests/flow_status_history.test.js
@@ -61,6 +61,21 @@ describe("flows status history", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query flow_status_history", () => {
+      expect(i.queries).not.toContain("flow_status_history");
+    });
+
+    test("cannot create, update, or delete flows or their associated operations", () => {
+      expect(i).toHaveNoMutationsFor("flow_status_history");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -140,6 +140,57 @@ describe("flows and operations", () => {
       expect(i.mutations).not.toContain("update_published_flows");
     });
   });
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query flows and their associated operations", () => {
+      expect(i.queries).toContain("flows");
+      expect(i.queries).toContain("operations");
+    });
+
+    test("can update flows and their associated operations", () => {
+      expect(i.mutations).toContain("update_flows_by_pk");
+      expect(i.mutations).toContain("update_flows");
+      expect(i.mutations).toContain("update_operations_by_pk");
+      expect(i.mutations).toContain("update_operations");
+    });
+
+    test("can create flows and their associated operations", () => {
+      expect(i.mutations).toContain("insert_flows_one");
+      expect(i.mutations).toContain("insert_flows");
+      expect(i.mutations).toContain("insert_operations_one");
+      expect(i.mutations).toContain("insert_operations");
+    });
+
+    test("can delete flows", () => {
+      expect(i.mutations).toContain("delete_flows_by_pk");
+      expect(i.mutations).toContain("delete_flows");
+    });
+
+    test("cannot delete operations", () => {
+      expect(i.mutations).not.toContain("delete_operations_by_pk");
+      expect(i.mutations).not.toContain("delete_operations");
+    });
+
+    test("can query published flows", () => {
+      expect(i.queries).toContain("published_flows");
+    });
+
+    test("can create published_flows", () => {
+      expect(i.mutations).toContain("insert_published_flows_one");
+      expect(i.mutations).toContain("insert_published_flows");
+    });
+
+    test("cannot update or delete published_flows", () => {
+      expect(i.mutations).not.toContain("delete_published_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_published_flows");
+      expect(i.mutations).not.toContain("update_published_flows_by_pk");
+      expect(i.mutations).not.toContain("update_published_flows");
+    });
+  });
 
   describe("api", () => {
     let i;

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -140,6 +140,7 @@ describe("flows and operations", () => {
       expect(i.mutations).not.toContain("update_published_flows");
     });
   });
+  
   describe("demoUser", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/global_settings.test.js
+++ b/hasura.planx.uk/tests/global_settings.test.js
@@ -64,6 +64,21 @@ describe("global_settings", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query global_settings view", () => {
+      expect(i.queries).toContain("global_settings");
+    });
+
+    test("cannot create, update, or delete global_settings", () => {
+      expect(i).toHaveNoMutationsFor("global_settings");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -1,7 +1,6 @@
 const { introspectAs, gqlAdmin, gqlPublic } = require("./utils");
-const { v4: uuidV4 } = require('uuid');
+const { v4: uuidV4 } = require("uuid");
 const assert = require("assert");
-
 
 describe("lowcal_sessions", () => {
   describe("public role introspection", () => {
@@ -23,15 +22,9 @@ describe("lowcal_sessions", () => {
   describe("public role queries and mutations", () => {
     let ids;
     const flowId = uuidV4();
-    const [
-      alice1,
-      alice2,
-      bob1,
-      bob2,
-      mallory1,
-      robert1,
-      anon1
-    ] = [...Array(7)].map(() => uuidV4());
+    const [alice1, alice2, bob1, bob2, mallory1, robert1, anon1] = [
+      ...Array(7),
+    ].map(() => uuidV4());
 
     const insertSession = `
       mutation InsertLowcalSession(
@@ -123,12 +116,12 @@ describe("lowcal_sessions", () => {
             }
           }
         }
-      `
+      `;
       let res = await gqlAdmin(query);
       ids = res.data.insert_lowcal_sessions.returning.map((row) => row.id);
       assert.strictEqual(ids.length, 5);
     });
-  
+
     afterAll(async () => {
       const res = await gqlAdmin(`
         mutation {
@@ -137,20 +130,23 @@ describe("lowcal_sessions", () => {
           }
         }
       `);
-      assert.strictEqual(res.data.delete_lowcal_sessions.affected_rows, ids.length);
+      assert.strictEqual(
+        res.data.delete_lowcal_sessions.affected_rows,
+        ids.length
+      );
     });
 
     describe("INSERT without permission", () => {
       test("Anonymous users can insert a session with an empty email", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": anon1,
-          "x-hasura-lowcal-email": ""
+          "x-hasura-lowcal-email": "",
         };
         const payload = {
           email: "",
           sessionId: anon1,
-          data: { x: 1 }
-        }
+          data: { x: 1 },
+        };
         const res = await gqlPublic(insertSession, payload, headers);
         ids.push(res.data.insert_lowcal_sessions_one.id); // add the email to ids for teardown
         expect(res).not.toHaveProperty("errors");
@@ -162,89 +158,133 @@ describe("lowcal_sessions", () => {
       test("Alice cannot insert a session with an email that doesn't match headers", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice2,
-          "x-hasura-lowcal-email": "helloalice@opensystemslab.io"
+          "x-hasura-lowcal-email": "helloalice@opensystemslab.io",
         };
         const payload = {
           email: "alice@opensystemslab.io", // not the same as in header
           sessionId: alice2,
-          data: { x: 1 }
-        }
+          data: { x: 1 },
+        };
         const res = await gqlPublic(insertSession, payload, headers);
         expect(res).toHaveProperty("errors");
-        expect(res.errors[0].message).toContain('check constraint of an insert/update permission has failed');
+        expect(res.errors[0].message).toContain(
+          "check constraint of an insert/update permission has failed"
+        );
       });
-    })
+    });
 
     describe("UPDATE without permission", () => {
       test("cannot update without 'x-hasura-lowcal-session-id' header", async () => {
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, { "x-hasura-lowcal-email": "alice@opensystemslab.io" });
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          { "x-hasura-lowcal-email": "alice@opensystemslab.io" }
+        );
         expect(res).toHaveProperty("errors");
-        expect(res.errors[0].message).toContain('missing session variable: "x-hasura-lowcal-session-id"');
+        expect(res.errors[0].message).toContain(
+          'missing session variable: "x-hasura-lowcal-session-id"'
+        );
       });
-  
+
       test("cannot update without 'x-hasura-lowcal-email' header", async () => {
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, { "x-hasura-lowcal-session-id": uuidV4() });
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          { "x-hasura-lowcal-session-id": uuidV4() }
+        );
         expect(res).toHaveProperty("errors");
-        expect(res.errors[0].message).toContain('missing session variable: "x-hasura-lowcal-email"');
+        expect(res.errors[0].message).toContain(
+          'missing session variable: "x-hasura-lowcal-email"'
+        );
       });
 
       test("'x-hasura-lowcal-session-id' header must have value", async () => {
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, { "x-hasura-lowcal-session-id": null, "x-hasura-lowcal-email": "alice@opensystemslab.io"});
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          {
+            "x-hasura-lowcal-session-id": null,
+            "x-hasura-lowcal-email": "alice@opensystemslab.io",
+          }
+        );
         expect(res).toHaveProperty("errors");
-        expect(res.errors[0].message).toContain("invalid input syntax for type uuid: \"null\"");
+        expect(res.errors[0].message).toContain(
+          'invalid input syntax for type uuid: "null"'
+        );
       });
 
       test("Alice cannot update her own session with invalid sessionId", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": uuidV4(),
-          "x-hasura-lowcal-email": "alice@opensystemslab.io"
+          "x-hasura-lowcal-email": "alice@opensystemslab.io",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
       test("Alice cannot update her own session with invalid email", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": "not-alice@opensystemslab.io"
+          "x-hasura-lowcal-email": "not-alice@opensystemslab.io",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
       test("Alice cannot update her own session with a missing email", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": null
+          "x-hasura-lowcal-email": null,
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
       test("Alice cannot update her own existing session with an empty email ", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": ""
+          "x-hasura-lowcal-email": "",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
       test("Mallory cannot update Alice's session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": uuidV4(),
-          "x-hasura-lowcal-email": "random@opensystemslab.io"
+          "x-hasura-lowcal-email": "random@opensystemslab.io",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
 
       test("Mallory cannot update multiple sessions which do not belong to them", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": uuidV4(),
-          "x-hasura-lowcal-email": "random@opensystemslab.io"
+          "x-hasura-lowcal-email": "random@opensystemslab.io",
         };
-        const res = await gqlPublic(`
+        const res = await gqlPublic(
+          `
           mutation UpdateMultipleSessionsWithoutWhereClause {
             update_lowcal_sessions(where: {}, _set: { data: "{ x: 1 }" }) {
               returning {
@@ -252,16 +292,20 @@ describe("lowcal_sessions", () => {
               }
             }
           }
-        `, null, headers);
+        `,
+          null,
+          headers
+        );
         expect(res.data.update_lowcal_sessions.returning).toHaveLength(0);
       });
 
       test("Bob cannot update multiple sessions which do belong to them", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": bob1,
-          "x-hasura-lowcal-email": "bob@opensystemslab.io"
+          "x-hasura-lowcal-email": "bob@opensystemslab.io",
         };
-        const res = await gqlPublic(`
+        const res = await gqlPublic(
+          `
           mutation UpdateMultipleSessionsWithoutWhereClause {
             update_lowcal_sessions(where: {}, _set: { data: "{ x: 1 }" }) {
               returning {
@@ -269,7 +313,10 @@ describe("lowcal_sessions", () => {
               }
             }
           }
-        `, null, headers);
+        `,
+          null,
+          headers
+        );
         expect(res.data.update_lowcal_sessions.returning).toHaveLength(1);
         expect(res.data.update_lowcal_sessions.returning[0].id).toEqual(bob1);
       });
@@ -277,46 +324,75 @@ describe("lowcal_sessions", () => {
       test("Anonymous users can upsert their own session with an empty email", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": anon1,
-          "x-hasura-lowcal-email": ""
+          "x-hasura-lowcal-email": "",
         };
 
         // initial insert (upsert)
-        const res1 = await gqlPublic(updateByPK, { sessionId: anon1, data: { x: 1 } }, headers);
+        const res1 = await gqlPublic(
+          updateByPK,
+          { sessionId: anon1, data: { x: 1 } },
+          headers
+        );
         expect(res1.data.update_lowcal_sessions_by_pk).not.toBeNull();
         expect(res1.data.update_lowcal_sessions_by_pk.id).toEqual(anon1);
-        expect(res1.data.update_lowcal_sessions_by_pk.data).toHaveProperty("x", 1);
+        expect(res1.data.update_lowcal_sessions_by_pk.data).toHaveProperty(
+          "x",
+          1
+        );
 
         // update 1
-        const res2 = await gqlPublic(updateByPK, { sessionId: anon1, data: { y: 2 } }, headers);
+        const res2 = await gqlPublic(
+          updateByPK,
+          { sessionId: anon1, data: { y: 2 } },
+          headers
+        );
         expect(res2.data.update_lowcal_sessions_by_pk).not.toBeNull();
         expect(res2.data.update_lowcal_sessions_by_pk.id).toEqual(anon1);
-        expect(res2.data.update_lowcal_sessions_by_pk.data).toHaveProperty("y", 2);
+        expect(res2.data.update_lowcal_sessions_by_pk.data).toHaveProperty(
+          "y",
+          2
+        );
 
         // update 2
-        const res3 = await gqlPublic(updateByPK, { sessionId: anon1, data: {} }, headers);
+        const res3 = await gqlPublic(
+          updateByPK,
+          { sessionId: anon1, data: {} },
+          headers
+        );
         expect(res3.data.update_lowcal_sessions_by_pk).not.toBeNull();
         expect(res3.data.update_lowcal_sessions_by_pk.data).toEqual({});
       });
     });
-    
+
     describe("UPDATE with permission", () => {
       test("Alice can update her session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": "alice@opensystemslab.io"
+          "x-hasura-lowcal-email": "alice@opensystemslab.io",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res.data.update_lowcal_sessions_by_pk).not.toBeNull();
         expect(res.data.update_lowcal_sessions_by_pk.id).toEqual(alice1);
-        expect(res.data.update_lowcal_sessions_by_pk.data).toHaveProperty("x", 1);
+        expect(res.data.update_lowcal_sessions_by_pk.data).toHaveProperty(
+          "x",
+          1
+        );
       });
 
       test("Alice cannot update her session with an empty email", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": ""
+          "x-hasura-lowcal-email": "",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: alice1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: alice1, data: { x: 1 } },
+          headers
+        );
         expect(res).not.toHaveProperty("errors");
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
@@ -324,9 +400,13 @@ describe("lowcal_sessions", () => {
       test("Robert cannot update his read-only session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": robert1,
-          "x-hasura-lowcal-email": "robert@opensystemslab.io"
+          "x-hasura-lowcal-email": "robert@opensystemslab.io",
         };
-        const res = await gqlPublic(updateByPK, { sessionId: robert1, data: { x: 1 } }, headers);
+        const res = await gqlPublic(
+          updateByPK,
+          { sessionId: robert1, data: { x: 1 } },
+          headers
+        );
         expect(res).not.toHaveProperty("errors");
         expect(res.data.update_lowcal_sessions_by_pk).toBeNull();
       });
@@ -336,19 +416,27 @@ describe("lowcal_sessions", () => {
       test("cannot select without 'x-hasura-lowcal-session-id' header", async () => {
         const res = await gqlPublic(selectByPK, { sessionId: alice1 });
         expect(res).toHaveProperty("errors");
-        expect(res.errors[0].message).toContain('missing session variable: "x-hasura-lowcal-session-id"');
+        expect(res.errors[0].message).toContain(
+          'missing session variable: "x-hasura-lowcal-session-id"'
+        );
       });
 
       test("cannot select without 'x-hasura-lowcal-email' header", async () => {
-        const res = await gqlPublic(selectByPK, { sessionId: alice1 }, { "x-hasura-lowcal-session-id": uuidV4() });
+        const res = await gqlPublic(
+          selectByPK,
+          { sessionId: alice1 },
+          { "x-hasura-lowcal-session-id": uuidV4() }
+        );
         expect(res).toHaveProperty("errors");
-        expect(res.errors[0].message).toContain('missing session variable: "x-hasura-lowcal-email"');
+        expect(res.errors[0].message).toContain(
+          'missing session variable: "x-hasura-lowcal-email"'
+        );
       });
 
       test("Mallory cannot select Alice's session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": uuidV4(),
-          "x-hasura-lowcal-email": "random@opensystemslab.io"
+          "x-hasura-lowcal-email": "random@opensystemslab.io",
         };
         const res = await gqlPublic(selectByPK, { sessionId: alice1 }, headers);
         expect(res.data.lowcal_sessions_by_pk).toBeNull();
@@ -357,43 +445,51 @@ describe("lowcal_sessions", () => {
       test("Mallory cannot select all sessions", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": uuidV4(),
-          "x-hasura-lowcal-email": "random@opensystemslab.io"
+          "x-hasura-lowcal-email": "random@opensystemslab.io",
         };
-        const res = await gqlPublic(`
+        const res = await gqlPublic(
+          `
           query SelectAllLowcalSessions {
             lowcal_sessions {
               id
             }
           }
-        `, null, headers);
+        `,
+          null,
+          headers
+        );
         expect(res.data.lowcal_sessions).toHaveLength(0);
       });
 
       test("Bob cannot select multiple sessions which belong to him", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": bob1,
-          "x-hasura-lowcal-email": "bob@opensystemslab.io"
+          "x-hasura-lowcal-email": "bob@opensystemslab.io",
         };
-        const res = await gqlPublic(`
+        const res = await gqlPublic(
+          `
           query SelectAllLowcalSessions {
             lowcal_sessions {
               id
             }
           }
-        `, null, headers);
+        `,
+          null,
+          headers
+        );
         expect(res.data.lowcal_sessions).toHaveLength(1);
-        expect(res.data.lowcal_sessions[0].id).toEqual(bob1)
+        expect(res.data.lowcal_sessions[0].id).toEqual(bob1);
       });
-
     });
 
     describe("SELECT with permission", () => {
       test("Alice can select her session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": alice1,
-          "x-hasura-lowcal-email": "alice@opensystemslab.io"
+          "x-hasura-lowcal-email": "alice@opensystemslab.io",
         };
-        const res = await gqlPublic(`
+        const res = await gqlPublic(
+          `
           query SelectAllLowcalSessions {
             lowcal_sessions {
               created_at
@@ -403,17 +499,21 @@ describe("lowcal_sessions", () => {
               updated_at
             }
           }
-        `, null, headers);
+        `,
+          null,
+          headers
+        );
         expect(res.data.lowcal_sessions).toHaveLength(1);
-        expect(res.data.lowcal_sessions[0].id).toEqual(alice1)
+        expect(res.data.lowcal_sessions[0].id).toEqual(alice1);
       });
 
       test("Anonymous users cannot select their own session", async () => {
         const headers = {
           "x-hasura-lowcal-session-id": anon1,
-          "x-hasura-lowcal-email": ""
+          "x-hasura-lowcal-email": "",
         };
-        const res = await gqlPublic(`
+        const res = await gqlPublic(
+          `
           query SelectAllLowcalSessions {
             lowcal_sessions {
               created_at
@@ -423,7 +523,10 @@ describe("lowcal_sessions", () => {
               updated_at
             }
           }
-        `, null, headers);
+        `,
+          null,
+          headers
+        );
         expect(res.data.lowcal_sessions).toHaveLength(0);
       });
     });
@@ -448,6 +551,21 @@ describe("lowcal_sessions", () => {
     let i;
     beforeAll(async () => {
       i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query lowcal_sessions", () => {
+      expect(i.queries).not.toContain("lowcal_sessions");
+    });
+
+    test("cannot create, update, or delete lowcal_sessions", () => {
+      expect(i).toHaveNoMutationsFor("lowcal_sessions");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
     });
 
     test("cannot query lowcal_sessions", () => {

--- a/hasura.planx.uk/tests/payment_status.test.js
+++ b/hasura.planx.uk/tests/payment_status.test.js
@@ -67,6 +67,21 @@ describe("payment_status", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query payment_status", () => {
+      expect(i.queries).not.toContain("payment_status");
+    });
+
+    test("cannot create, update, or delete payment_status", () => {
+      expect(i).toHaveNoMutationsFor("payment_status");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {
@@ -84,6 +99,6 @@ describe("payment_status", () => {
     test("cannot delete or update payment_status", () => {
       expect(i.mutations).not.toContain("update_payment_status");
       expect(i.mutations).not.toContain("delete_payment_status");
-    })
+    });
   });
 });

--- a/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -25,7 +25,9 @@ describe("planning_constraints_requests", () => {
     test("has full access to query and mutate planning constraints requests", () => {
       expect(i.queries).toContain("planning_constraints_requests");
       expect(i.mutations).toContain("insert_planning_constraints_requests");
-      expect(i.mutations).toContain("update_planning_constraints_requests_by_pk");
+      expect(i.mutations).toContain(
+        "update_planning_constraints_requests_by_pk"
+      );
       expect(i.mutations).toContain("delete_planning_constraints_requests");
     });
   });
@@ -60,6 +62,21 @@ describe("planning_constraints_requests", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query planning_constraints_requests", () => {
+      expect(i.queries).not.toContain("planning_constraints_requests");
+    });
+
+    test("cannot create, update, or delete planning_constraints_requests", () => {
+      expect(i).toHaveNoMutationsFor("planning_constraints_requests");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {
@@ -68,15 +85,17 @@ describe("planning_constraints_requests", () => {
 
     test("can query planning_constraints_requests", () => {
       expect(i.queries).toContain("planning_constraints_requests");
-    })
+    });
 
     test("can insert planning_constraints_requests", () => {
       expect(i.mutations).toContain("insert_planning_constraints_requests");
     });
 
     test("cannot update or delete planning_constriants_requests", () => {
-      expect(i.mutations).not.toContain("update_planning_constraints_requests_by_pk");
+      expect(i.mutations).not.toContain(
+        "update_planning_constraints_requests_by_pk"
+      );
       expect(i.mutations).not.toContain("delete_planning_constraints_requests");
-    })
+    });
   });
 });

--- a/hasura.planx.uk/tests/reconciliation_requests.test.js
+++ b/hasura.planx.uk/tests/reconciliation_requests.test.js
@@ -64,6 +64,21 @@ describe("reconciliation_requests", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query reconciliation_requests", () => {
+      expect(i.queries).not.toContain("reconciliation_requests");
+    });
+
+    test("cannot create, update, or delete reconciliation_requests", () => {
+      expect(i).toHaveNoMutationsFor("reconciliation_requests");
+    });
+  });
+
   describe("api", () => {
     beforeAll(async () => {
       i = await introspectAs("api");

--- a/hasura.planx.uk/tests/sessions.test.js
+++ b/hasura.planx.uk/tests/sessions.test.js
@@ -564,7 +564,7 @@ describe("sessions", () => {
           headers
         );
         expect(res.data.sessions).toHaveLength(1);
-        const session = res.data.sessions[0]
+        const session = res.data.sessions[0];
         expect(session.id).toEqual(alice1);
         expect(session).toHaveProperty(["created_at"]);
         expect(session).toHaveProperty(["breadcrumbs"]);
@@ -629,6 +629,21 @@ describe("sessions", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query sessions", () => {
+      expect(i.queries).not.toContain("sessions");
+    });
+
+    test("cannot create, update, or delete sessions", () => {
+      expect(i).toHaveNoMutationsFor("sessions");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {
@@ -645,5 +660,4 @@ describe("sessions", () => {
       expect(i.mutations).not.toContain("delete_sessions");
     });
   });
-  
 });

--- a/hasura.planx.uk/tests/team_integrations.test.js
+++ b/hasura.planx.uk/tests/team_integrations.test.js
@@ -61,6 +61,21 @@ describe("team_integrations", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query team_integrations", () => {
+      expect(i.queries).toContain("team_integrations");
+    });
+
+    test("cannot create, update, or delete team_integrations", () => {
+      expect(i).toHaveNoMutationsFor("team_integrations");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/team_members.test.js
+++ b/hasura.planx.uk/tests/team_members.test.js
@@ -48,11 +48,26 @@ describe("team_members", () => {
     beforeAll(async () => {
       i = await introspectAs("teamEditor");
     });
-    
+
     // Row-level permissions tested in e2e/tests/api-driven
     // teamEditors can only query their own record
     test("can query teams", () => {
       expect(i.queries).toContain("team_members");
+    });
+
+    test("cannot create, update, or delete team_members", () => {
+      expect(i).toHaveNoMutationsFor("team_members");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query teams", () => {
+      expect(i.queries).not.toContain("team_members");
     });
 
     test("cannot create, update, or delete team_members", () => {

--- a/hasura.planx.uk/tests/team_themes.test.js
+++ b/hasura.planx.uk/tests/team_themes.test.js
@@ -82,6 +82,21 @@ describe("team_themes", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query team_themes", () => {
+      expect(i.queries).toContain("team_themes");
+    });
+
+    test("cannot create, update, or delete team_themes", () => {
+      expect(i).toHaveNoMutationsFor("team_themes");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -72,6 +72,21 @@ describe("teams", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query teams", () => {
+      expect(i.queries).toContain("teams");
+    });
+
+    test("cannot create, update, or delete teams", () => {
+      expect(i).toHaveNoMutationsFor("teams");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/hasura.planx.uk/tests/uniform_applications.test.js
+++ b/hasura.planx.uk/tests/uniform_applications.test.js
@@ -60,6 +60,21 @@ describe("uniform_applications", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query uniform applications", () => {
+      expect(i.queries).not.toContain("uniform_applications");
+    });
+
+    test("cannot create, update, or delete uniform applications", () => {
+      expect(i).toHaveNoMutationsFor("uniform_applications");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {
@@ -74,6 +89,6 @@ describe("uniform_applications", () => {
 
     test("cannot delete uniform applications", () => {
       expect(i.mutations).not.toContain("delete_uniform_applications");
-    })
+    });
   });
 });

--- a/hasura.planx.uk/tests/users.test.js
+++ b/hasura.planx.uk/tests/users.test.js
@@ -67,6 +67,21 @@ describe("users", () => {
     });
   });
 
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("can query users", async () => {
+      expect(i.queries).toContain("users");
+    });
+
+    test("cannot create, update, or delete users", async () => {
+      expect(i).toHaveNoMutationsFor("users");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {


### PR DESCRIPTION
## What does this PR do? 

For the Demo Workspace, a `demoUser` may only see flows created by them, or flows within the Open Systems Lab, Open Digital Planning, or Templates team. Also, they cannot see team settings or any other setting outwith flow settings for their own flows.

I have treated them as a `teamEditor` within their flows, and restricted data they can see outwith this. 

### Introspection testing

Introspection testing has been added to help communicate the relevant permissions changes and ensure future maintainability. 

