### PR TITLE
bump: planx-core for demoUser type

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#24b6656",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#54be9e0",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#24b6656
-    version: github.com/theopensystemslab/planx-core/24b6656
+    specifier: git+https://github.com/theopensystemslab/planx-core#54be9e0
+    version: github.com/theopensystemslab/planx-core/54be9e0
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6265,8 +6265,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/24b6656:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/24b6656}
+  github.com/theopensystemslab/planx-core/54be9e0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/54be9e0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#24b6656",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#54be9e0",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#24b6656
-    version: github.com/theopensystemslab/planx-core/24b6656
+    specifier: git+https://github.com/theopensystemslab/planx-core#54be9e0
+    version: github.com/theopensystemslab/planx-core/54be9e0
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2956,8 +2956,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/24b6656:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/24b6656}
+  github.com/theopensystemslab/planx-core/54be9e0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/54be9e0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#24b6656",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#54be9e0",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#24b6656
-    version: github.com/theopensystemslab/planx-core/24b6656
+    specifier: git+https://github.com/theopensystemslab/planx-core#54be9e0
+    version: github.com/theopensystemslab/planx-core/54be9e0
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2695,8 +2695,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/24b6656:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/24b6656}
+  github.com/theopensystemslab/planx-core/54be9e0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/54be9e0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.3",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#24b6656",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#54be9e0",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.3
     version: 1.0.0-alpha.3
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#24b6656
-    version: github.com/theopensystemslab/planx-core/24b6656(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#54be9e0
+    version: github.com/theopensystemslab/planx-core/54be9e0(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15359,9 +15359,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/24b6656(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/24b6656}
-    id: github.com/theopensystemslab/planx-core/24b6656
+  github.com/theopensystemslab/planx-core/54be9e0(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/54be9e0}
+    id: github.com/theopensystemslab/planx-core/54be9e0
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
Updating planx-core refs to start using the demoUser type in editor features for demo workspaces