### PR TITLE
chore: Turn off `no-empty-function` lint rule in Storybook files

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -97,6 +97,12 @@
       "extends": [
         "plugin:testing-library/react"
       ]
+    },
+    {
+      "files": [ "*.stories.tsx" ],
+      "rules": {
+        "@typescript-eslint/no-empty-function": "off"
+      }
     }
   ]
 }


### PR DESCRIPTION
Quick fix which resolves about 20 warnings in the codebase. It's a pretty common (and required) pattern to have empty functions in Storybook files (see screenshot below). This change turns off this check.

<img width="815" alt="image" src="https://github.com/user-attachments/assets/76f3b8ed-6b00-44b8-93a0-70ff58182e85">
