### PR TITLE
fix: Make routes reactive to change of user

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -94,28 +94,28 @@ const Layout: React.FC<{
   );
 };
 
-const App = () => {
-  const user = useStore(state => state.user);
-  
-  return (
-    <ToastContextProvider>
-      <ApolloProvider client={client}>
-        <AnalyticsProvider>
-          <Router context={{ currentUser: hasJWT(), user }} navigation={navigation}>
-            <HelmetProvider>
-              <Layout>
-                <CssBaseline />
-                <Suspense fallback={null}>
-                  <View />
-                </Suspense>
-              </Layout>
-            </HelmetProvider>
-          </Router>
-        </AnalyticsProvider>
-      </ApolloProvider>
-      <ToastContainer icon={false} theme="colored" />
-    </ToastContextProvider>
-  )
-}
-
-root.render(<App/>)
+root.render(
+  <ToastContextProvider>
+    <ApolloProvider client={client}>
+      <AnalyticsProvider>
+        <Router
+          context={{
+            currentUser: hasJWT(),
+            user: useStore.getState().user
+          }}
+          navigation={navigation}
+        >
+          <HelmetProvider>
+            <Layout>
+              <CssBaseline />
+              <Suspense fallback={null}>
+                <View />
+              </Suspense>
+            </Layout>
+          </HelmetProvider>
+        </Router>
+      </AnalyticsProvider>
+    </ApolloProvider>
+    <ToastContainer icon={false} theme="colored" />
+  </ToastContextProvider>,
+);

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -10,6 +10,7 @@ import { ToastContextProvider } from "contexts/ToastContext";
 import { getCookie, setCookie } from "lib/cookie";
 import ErrorPage from "pages/ErrorPage";
 import { AnalyticsProvider } from "pages/FlowEditor/lib/analytics/provider";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { Suspense, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { NotFoundBoundary, Router, View } from "react-navi";
@@ -93,22 +94,28 @@ const Layout: React.FC<{
   );
 };
 
-root.render(
-  <ToastContextProvider>
-    <ApolloProvider client={client}>
-      <AnalyticsProvider>
-        <Router context={{ currentUser: hasJWT() }} navigation={navigation}>
-          <HelmetProvider>
-            <Layout>
-              <CssBaseline />
-              <Suspense fallback={null}>
-                <View />
-              </Suspense>
-            </Layout>
-          </HelmetProvider>
-        </Router>
-      </AnalyticsProvider>
-    </ApolloProvider>
-    <ToastContainer icon={false} theme="colored" />
-  </ToastContextProvider>,
-);
+const App = () => {
+  const user = useStore(state => state.user);
+  
+  return (
+    <ToastContextProvider>
+      <ApolloProvider client={client}>
+        <AnalyticsProvider>
+          <Router context={{ currentUser: hasJWT(), user }} navigation={navigation}>
+            <HelmetProvider>
+              <Layout>
+                <CssBaseline />
+                <Suspense fallback={null}>
+                  <View />
+                </Suspense>
+              </Layout>
+            </HelmetProvider>
+          </Router>
+        </AnalyticsProvider>
+      </ApolloProvider>
+      <ToastContainer icon={false} theme="colored" />
+    </ToastContextProvider>
+  )
+}
+
+root.render(<App/>)

--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -94,28 +94,28 @@ const Layout: React.FC<{
   );
 };
 
-root.render(
-  <ToastContextProvider>
-    <ApolloProvider client={client}>
-      <AnalyticsProvider>
-        <Router
-          context={{
-            currentUser: hasJWT(),
-            user: useStore.getState().user
-          }}
-          navigation={navigation}
-        >
-          <HelmetProvider>
-            <Layout>
-              <CssBaseline />
-              <Suspense fallback={null}>
-                <View />
-              </Suspense>
-            </Layout>
-          </HelmetProvider>
-        </Router>
-      </AnalyticsProvider>
-    </ApolloProvider>
-    <ToastContainer icon={false} theme="colored" />
-  </ToastContextProvider>,
-);
+const App = () => {
+  const user = useStore(state => state.user);
+  
+  return (
+    <ToastContextProvider>
+      <ApolloProvider client={client}>
+        <AnalyticsProvider>
+          <Router context={{ currentUser: hasJWT(), user }} navigation={navigation}>
+            <HelmetProvider>
+              <Layout>
+                <CssBaseline />
+                <Suspense fallback={null}>
+                  <View />
+                </Suspense>
+              </Layout>
+            </HelmetProvider>
+          </Router>
+        </AnalyticsProvider>
+      </ApolloProvider>
+      <ToastContainer icon={false} theme="colored" />
+    </ToastContextProvider>
+  )
+}
+
+root.render(<App/>)


### PR DESCRIPTION
## What's the problem?
 - Routes with a route guard behave in a flakey manner, due to a race condition between `initUserStore()` and the route resolving. 
 - This means that we can navigate to `/global-settings` after landing on the homepage, but if we refresh once on this page the route guard will block us incorrectly.
 - This is particularly noticeable on team settings and flow setting and has come up as an issue quite a few times. It's also super frustrating when working on any of these pages as a refresh of the dev environment throws a `NotFound` error

## What's the solution?
- Following the pattern outlined [here in the react-navi docs](https://frontarm.com/navi/en/guides/authenticated-routes/), we ensure that the `Route` component is subscribed to changes in the user
- This means, when Zustand changes the `user`, react-navi is aware (and is re-rendering). This avoids the race condition.

### To test...
The following pages demonstrate examples of the race condition described above. On staging, a refresh (or a few) will give non-deterministic results. On the Pizza, we can refresh and reload the pages reliably.

| Staging ❌  | Pizza ✅  |
|--------|--------|
| [Global Settings](https://editor.planx.dev/global-settings) | Cell |
| [Admin Panel](https://editor.planx.dev/admin-panel) | Cell | 
| [Barnet / Team Members](https://editor.planx.dev/barnet/members) | Cell | 

### Next steps...
 - I'd like to move the `hasJWT()` logic into the user store and tie it into the current `initUserStore()` method - should be a quick follow on PR
 - A helper function to actually act as an auth guard on routes would be nice - we currently have repeated blocks of the following code which can be refactored - 
 
 ```ts
const isAuthorised = useStore.getState().user?.isPlatformAdmin;
if (!isAuthorised)
  throw new NotFoundError(
    `User does not have access to ${req.originalUrl}`,
  );
```