### PR TITLE
feat: populate `creator_id` when creating a flow

### DIFF
--- a/e2e/tests/api-driven/src/flowStatusHistory/helpers.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/helpers.ts
@@ -1,12 +1,13 @@
 import { FlowStatus } from "@opensystemslab/planx-core/types";
 import { $admin } from "../client";
-import { createTeam } from "../globalHelpers";
+import { createTeam, createUser } from "../globalHelpers";
 import gql from "graphql-tag";
 
 export const setup = async () => {
   const teamId = await createTeam();
+  const userId = await createUser();
 
-  const world = { teamId };
+  const world = { teamId, userId };
 
   return world;
 };
@@ -34,7 +35,7 @@ export const getFlowStatus = async (flowId: string) => {
         }
       }
     `,
-    { flowId },
+    { flowId }
   );
 
   return status;
@@ -65,7 +66,7 @@ export const getFlowStatusHistory = async (flowId: string) => {
           }
         }
       `,
-      { flowId },
+      { flowId }
     );
 
   return flowStatusHistory;

--- a/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
@@ -6,6 +6,7 @@ import { $admin } from "../client";
 
 export class CustomWorld extends World {
   teamId!: number;
+  userId!: number;
   flowId!: string;
 }
 
@@ -14,8 +15,9 @@ After("@flow-status-history", async function () {
 });
 
 Before<CustomWorld>("@flow-status-history", async function () {
-  const { teamId } = await setup();
+  const { teamId, userId } = await setup();
   this.teamId = teamId;
+  this.userId = userId;
 });
 
 Given<CustomWorld>("a flow exists", async function () {
@@ -23,6 +25,7 @@ Given<CustomWorld>("a flow exists", async function () {
     teamId: this.teamId,
     slug: "test-flow",
     name: "Test Flow",
+    userId: this.userId,
   });
 
   assert.ok(flowId, "flowId is not defined");
@@ -36,7 +39,7 @@ Then("the status of the flow is offline by default", async function () {
   assert.equal(
     status,
     "offline",
-    `Flow status is ${status} - it should be "offline"`,
+    `Flow status is ${status} - it should be "offline"`
   );
 });
 
@@ -46,28 +49,28 @@ Then("a flow_status_history record is created", async function () {
   assert.notEqual(
     flowStatusHistory.length,
     0,
-    "No records found for flow_status_history",
+    "No records found for flow_status_history"
   );
   assert.equal(
     flowStatusHistory.length,
     1,
-    "Multiple records found for flow_status_history",
+    "Multiple records found for flow_status_history"
   );
   assert.ok(flowStatusHistory[0], "flow_status_history record not created");
   assert.equal(
     flowStatusHistory[0].status,
     "offline",
-    `Flow status is ${flowStatusHistory[0].status} - it should be "offline"`,
+    `Flow status is ${flowStatusHistory[0].status} - it should be "offline"`
   );
   assert.notEqual(
     flowStatusHistory[0].eventStart,
     null,
-    "Event start should be set on INSERT",
+    "Event start should be set on INSERT"
   );
   assert.equal(
     flowStatusHistory[0].eventEnd,
     null,
-    "Event end should not be set on INSERT",
+    "Event end should not be set on INSERT"
   );
 });
 
@@ -80,7 +83,7 @@ When("the flow status is changed to online", async function () {
   assert.equal(
     flow.status,
     "online",
-    `Flow status is ${flow.status} - it should be "online`,
+    `Flow status is ${flow.status} - it should be "online`
   );
 });
 
@@ -88,7 +91,7 @@ Then("the open flow_status_history record is updated", async function () {
   const flowStatusHistory = await getFlowStatusHistory(this.flowId);
   assert.ok(
     flowStatusHistory[0].eventEnd,
-    "Event end should be set on update to status column",
+    "Event end should be set on update to status column"
   );
 });
 
@@ -99,16 +102,16 @@ Then("a new flow_status_history record is created", async function () {
   assert.equal(
     flowStatusHistory[1].status,
     "online",
-    `Flow status is ${flowStatusHistory[1].status} - it should be "online"`,
+    `Flow status is ${flowStatusHistory[1].status} - it should be "online"`
   );
   assert.notEqual(
     flowStatusHistory[1].eventStart,
     null,
-    "Event start should be set on INSERT",
+    "Event start should be set on INSERT"
   );
   assert.equal(
     flowStatusHistory[1].eventEnd,
     null,
-    "Event end should not be set on INSERT",
+    "Event end should not be set on INSERT"
   );
 });

--- a/e2e/tests/api-driven/src/permissions/helpers.ts
+++ b/e2e/tests/api-driven/src/permissions/helpers.ts
@@ -36,6 +36,7 @@ export const setup = async () => {
     teamId: teamId1,
     slug: "team-1-flow",
     name: "Team 1 Flow",
+    userId: user1Id,
   });
 
   const user2Id = await createUser({
@@ -46,6 +47,7 @@ export const setup = async () => {
     teamId: teamId2,
     slug: "team-2-flow",
     name: "Team 2 Flow",
+    userId: user2Id,
   });
 
   const world = {
@@ -72,7 +74,7 @@ export const performGQLQuery = async ({
   const client = (await getClient(world.activeUserEmail)).client;
   const { result } = await client.request<Record<"result", GQLQueryResult>>(
     query,
-    variables,
+    variables
   );
   return result;
 };
@@ -90,7 +92,7 @@ const buildVariables = (query: DocumentNode, world: CustomWorld) => {
 
   Object.keys(world).forEach((key) => {
     const isVariableUsedInQuery = definitionNode.variableDefinitions!.find(
-      (varDef) => varDef.variable.name.value === key,
+      (varDef) => varDef.variable.name.value === key
     );
     if (isVariableUsedInQuery) {
       variables[key] = world[key];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -110,7 +110,12 @@ export interface EditorStore extends Store.Store {
   connectTo: (id: NodeId) => void;
   copyFlow: (flowId: string) => Promise<any>;
   copyNode: (id: NodeId) => void;
-  createFlow: (teamId: any, newSlug: any, newName: string) => Promise<string>;
+  createFlow: (
+    teamId: any,
+    newSlug: any,
+    newName: string,
+    userId: number,
+  ) => Promise<string>;
   deleteFlow: (teamId: number, flowSlug: string) => Promise<object>;
   validateAndDiffFlow: (flowId: string) => Promise<any>;
   getFlows: (teamId: number) => Promise<any>;
@@ -237,17 +242,24 @@ export const editorStore: StateCreator<
     localStorage.setItem("clipboard", id);
   },
 
-  createFlow: async (teamId, newSlug, newName) => {
+  createFlow: async (teamId, newSlug, newName, userId) => {
     let response = (await client.mutate({
       mutation: gql`
         mutation CreateFlow(
           $data: jsonb
           $slug: String
           $teamId: Int
+          $userId: Int
           $name: String
         ) {
           insert_flows_one(
-            object: { slug: $slug, team_id: $teamId, version: 1, name: $name }
+            object: {
+              slug: $slug
+              team_id: $teamId
+              version: 1
+              name: $name
+              creator_id: $userId
+            }
           ) {
             id
             data
@@ -258,6 +270,7 @@ export const editorStore: StateCreator<
         name: newName,
         slug: newSlug,
         teamId,
+        userId,
       },
     })) as any;
 

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -280,7 +280,11 @@ const FlowItem: React.FC<FlowItemProps> = ({
 };
 
 const Team: React.FC = () => {
-  const { id: teamId, slug } = useStore((state) => state.getTeam());
+  const [{ id: teamId, slug }, user] = useStore((state) => [
+    state.getTeam(),
+    state.getUser(),
+  ]);
+
   const [flows, setFlows] = useState<any[] | null>(null);
   const navigation = useNavigation();
 
@@ -303,6 +307,7 @@ const Team: React.FC = () => {
     fetchFlows();
   }, [fetchFlows]);
 
+  console.log(user);
   return (
     <Container maxWidth="formWrap">
       <Box
@@ -343,7 +348,7 @@ const Team: React.FC = () => {
                 !duplicateFlowName
                   ? useStore
                       .getState()
-                      .createFlow(teamId, newFlowSlug, newFlowName)
+                      .createFlow(teamId, newFlowSlug, newFlowName, user.id)
                       .then((newId: string) => {
                         navigation.navigate(`/${slug}/${newId}`);
                       })


### PR DESCRIPTION
Found this wee missing element when working on the demo workspace ticket: https://trello.com/c/EfaEQRzK/2441-create-a-demo-workspace

In order for us to use row validation in Hasura to enable demo users to only see flows they have created, we need to ensure the `creator_id` is populated when a flow is created. Currently, it only gets populated when copying a flow.

This change is connected with changes made in `planx-core` : https://github.com/theopensystemslab/planx-core/pull/546

Changes have been made to the Team flowEditor page and also api 