### PR TITLE
fix: Persist portal state behind node modal

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -5,7 +5,7 @@ import ButtonGroup from "@mui/material/ButtonGroup";
 import { styled } from "@mui/material/styles";
 import { HEADER_HEIGHT_EDITOR } from "components/Header/Header";
 import React, { useRef } from "react";
-import { useCurrentRoute } from "react-navi";
+import { rootFlowPath } from "routes/utils";
 
 import Flow from "./components/Flow";
 import { ToggleDataFieldsButton } from "./components/FlowEditor/ToggleDataFieldsButton";
@@ -40,8 +40,8 @@ const EditorVisualControls = styled(ButtonGroup)(({ theme }) => ({
 }));
 
 const FlowEditor = () => {
-  const [flow, ...breadcrumbs] =
-    useCurrentRoute().url.pathname.split("/").at(-1)?.split(",") || [];
+  const flowPath = rootFlowPath(true).split("/")[2];
+  const [flow, ...breadcrumbs] = flowPath.split(",");
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   useScrollControlsAndRememberPosition(scrollContainerRef);


### PR DESCRIPTION
Fixes issue raised here - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1730126400538669 (OSL Slack)

The PR ensures that the URL is correctly deconstructed when we're within a portal root. Previously, it was incorrectly deconstructed leading to the fallback `ROOT_NODE_KEY` being relied on in `editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx`