### PR TITLE
feat: Use Hasura column presets to populate `creator_id`

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -157,7 +157,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -171,7 +171,7 @@
         query_params:
           type: bops-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: document_template
@@ -225,7 +225,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -239,7 +239,7 @@
         query_params:
           type: email-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: feedback
@@ -483,9 +483,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: demoUser
       permission:
@@ -529,9 +529,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: teamEditor
       permission:
@@ -562,9 +562,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   select_permissions:
     - role: api
@@ -616,7 +616,7 @@
                     - 1
                     - 29
                     - 30
-      comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
+      comment: "For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
     - role: platformAdmin
       permission:
         columns:
@@ -697,9 +697,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: demoUser
       permission:
@@ -739,9 +739,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
     - role: teamEditor
       permission:
@@ -766,9 +766,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   delete_permissions:
     - role: demoUser
@@ -808,9 +808,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
   select_permissions:
     - role: demoUser
@@ -848,9 +848,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: '{{HASURA_PLANX_API_KEY}}'
+                value: "{{HASURA_PLANX_API_KEY}}"
             timeout: 10
-            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
           type: http
 - table:
     name: lowcal_sessions
@@ -997,7 +997,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/send-email/confirmation'
+        url: "{{$base_url}}/send-email/confirmation"
         version: 2
     - name: setup_lowcal_expiry_events
       definition:
@@ -1027,7 +1027,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
+        url: "{{$base_url}}/webhooks/hasura/create-expiry-event"
         version: 2
     - name: setup_lowcal_reminder_events
       definition:
@@ -1057,7 +1057,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
+        url: "{{$base_url}}/webhooks/hasura/create-reminder-event"
         version: 2
 - table:
     name: operations
@@ -1263,7 +1263,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1285,13 +1285,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-expiry-events"
         version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1313,13 +1313,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-invitation-events"
         version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1341,7 +1341,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-reminder-events"
         version: 2
     - name: setup_payment_send_events
       definition:
@@ -1370,7 +1370,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
+        url: "{{$base_url}}/webhooks/hasura/create-payment-send-events"
         version: 2
 - table:
     name: payment_status
@@ -1632,12 +1632,12 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
         timeout_sec: 60
-      webhook: '{{HASURA_PLANX_API_URL}}'
+      webhook: "{{HASURA_PLANX_API_URL}}"
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
@@ -1646,7 +1646,7 @@
         query_params:
           type: s3-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: sessions
@@ -1789,7 +1789,7 @@
           - created_at
           - submitted_at
         filter: {}
-      comment: 'For future, if this moves outside of the Flow to somewhere like Team, we should update "demoUser" to only see submission data related to only their flows. '
+      comment: "For future, if this moves outside of the Flow to somewhere like Team, we should update 'demoUser' to only see submission data related to only their flows. "
     - role: platformAdmin
       permission:
         columns:
@@ -2321,7 +2321,7 @@
               - 29
               - 30
               - 32
-      comment: 'For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
+      comment: "For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
     - role: platformAdmin
       permission:
         columns:
@@ -2438,7 +2438,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: '*'
+          columns: "*"
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -2452,7 +2452,7 @@
         query_params:
           type: uniform-submission
         template_engine: Kriti
-        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
+        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
         version: 2
 - table:
     name: user_roles

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -490,6 +490,8 @@
         check:
           team_id:
             _eq: 32
+        set:
+          creator_id: x-hasura-user-id
         columns:
           - copied_from
           - created_at
@@ -506,6 +508,8 @@
     - role: platformAdmin
       permission:
         check: {}
+        set:
+          creator_id: x-hasura-user-id
         columns:
           - copied_from
           - created_at
@@ -537,6 +541,8 @@
                     _eq: x-hasura-user-id
                 - role:
                     _eq: teamEditor
+        set:
+          creator_id: x-hasura-user-id
         columns:
           - copied_from
           - created_at

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -157,7 +157,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -171,7 +171,7 @@
         query_params:
           type: bops-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: document_template
@@ -225,7 +225,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -239,7 +239,7 @@
         query_params:
           type: email-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: feedback
@@ -464,6 +464,8 @@
     - role: api
       permission:
         check: {}
+        set:
+          creator_id: x-hasura-user-id
         columns:
           - copied_from
           - created_at
@@ -481,9 +483,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: demoUser
       permission:
@@ -527,9 +529,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: teamEditor
       permission:
@@ -560,9 +562,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   select_permissions:
     - role: api
@@ -614,7 +616,7 @@
                     - 1
                     - 29
                     - 30
-      comment: "For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
+      comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
         columns:
@@ -695,9 +697,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: demoUser
       permission:
@@ -737,9 +739,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: teamEditor
       permission:
@@ -764,9 +766,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   delete_permissions:
     - role: demoUser
@@ -806,9 +808,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   select_permissions:
     - role: demoUser
@@ -846,9 +848,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
 - table:
     name: lowcal_sessions
@@ -995,7 +997,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/send-email/confirmation"
+        url: '{{$base_url}}/send-email/confirmation'
         version: 2
     - name: setup_lowcal_expiry_events
       definition:
@@ -1025,7 +1027,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-expiry-event"
+        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
         version: 2
     - name: setup_lowcal_reminder_events
       definition:
@@ -1055,7 +1057,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-reminder-event"
+        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
         version: 2
 - table:
     name: operations
@@ -1261,7 +1263,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1283,13 +1285,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-expiry-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
         version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1311,13 +1313,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-invitation-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
         version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1339,7 +1341,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-reminder-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
         version: 2
     - name: setup_payment_send_events
       definition:
@@ -1368,7 +1370,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-send-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
         version: 2
 - table:
     name: payment_status
@@ -1630,12 +1632,12 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
         timeout_sec: 60
-      webhook: "{{HASURA_PLANX_API_URL}}"
+      webhook: '{{HASURA_PLANX_API_URL}}'
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
@@ -1644,7 +1646,7 @@
         query_params:
           type: s3-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: sessions
@@ -2319,7 +2321,7 @@
               - 29
               - 30
               - 32
-      comment: "For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
+      comment: 'For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
         columns:
@@ -2436,7 +2438,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -2450,7 +2452,7 @@
         query_params:
           type: uniform-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: user_roles


### PR DESCRIPTION
This follows work on the demo workspace ticket: https://trello.com/c/EfaEQRzK/2441-create-a-demo-workspace

We found that the `creator_id` was not populating when we create a flow in the editor. To fix this, we decided to use Hasura Column Presets to reduce the number of places the change had to be made, and to make it more maintainable in the future.

We do sacrifice readability in the code base, but we found it was a better win for maintainability for a data field most people would expect to be populated by the user creating it. 

[Column Preset Docs](https://hasura.io/docs/2.0/auth/authorization/permissions/column-presets/)