### PR TITLE
fix: Update publishing details on flow change

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishFlowButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishFlowButton.tsx
@@ -96,14 +96,14 @@ export const PublishFlowButton: React.FC<{ previewURL: string }> = ({
     const user = await lastPublisher(flowId);
 
     setLastPublishedTitle(formatLastPublishMessage(date, user));
-  });
+  }, [flowId]);
 
   const _validateAndDiffRequest = useAsync(async () => {
     const newChanges = await validateAndDiffFlow(flowId);
     setAlteredNodes(
       newChanges?.data.alteredNodes ? newChanges.data.alteredNodes : [],
     );
-  });
+  }, [flowId]);
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1730197158271359

## What's the problem?
- The "last published" text does not update on flow change
- The diff count badge does not update on flow change

## What's the solution
- Add `flowId` to the dependency arrays of the functions responsible for updating these values
- This likely wasn't an issue in the past pre-route fixes and the component was always re-rendering - now that's not the case