### PR TITLE
fix: eslint errors from auto-answering changes

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -87,7 +87,15 @@
         }
       }
     ],
-    "no-nested-ternary": "error"
+    "no-nested-ternary": "error",
+    "@vitest/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": [
+          "expect"
+        ]
+      }
+    ]
   },
   "overrides": [
     {

--- a/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public.tsx
@@ -39,13 +39,13 @@ function toggleInArray<T>(value: T, arr: Array<T>): Array<T> {
 }
 
 const ChecklistComponent: React.FC<Props> = (props) => {
-  if (props.neverAutoAnswer) {
-    return <VisibleChecklist {...props} />;
-  }
-
   const autoAnswerableOptions = useStore(
     (state) => state.autoAnswerableOptions,
   );
+  
+  if (props.neverAutoAnswer) {
+    return <VisibleChecklist {...props} />;
+  }
   
   let idsThatCanBeAutoAnswered: string[] | undefined;
   if (props.id) idsThatCanBeAutoAnswered = autoAnswerableOptions(props.id);

--- a/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Public/Question.tsx
@@ -26,14 +26,14 @@ export enum QuestionLayout {
 }
 
 const QuestionComponent: React.FC<Question> = (props) => {
-  if (props.neverAutoAnswer) {
-    return <VisibleQuestion {...props} />;
-  }
-
   const [flow, autoAnswerableOptions] = useStore((state) => [
     state.flow,
     state.autoAnswerableOptions,
   ]);
+  
+  if (props.neverAutoAnswer) {
+    return <VisibleQuestion {...props} />;
+  }
 
   // Questions without edges act like "sticky notes" in the graph for editors only & can be immediately auto-answered
   let edges: Edges | undefined;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/automations.blanks.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/automations.blanks.test.ts
@@ -35,7 +35,7 @@ describe("Auto-answering blanks", () => {
 
     // The second blank is put to the user because we do not have a passport value and we have NOT seen all options before
     expect(computePassport()?.data).not.toHaveProperty("option");
-    expect(autoAnswerableOptions("Path2Checklist2")).toBeUndefined;
+    expect(autoAnswerableOptions("Path2Checklist2")).toBeUndefined();
   });
 
   test("Questions with the same options auto-answer the blank", () => {
@@ -63,7 +63,7 @@ describe("Auto-answering blanks", () => {
 
     // The second blank is put to the user because we do not have a passport value and we have NOT seen all options before
     expect(computePassport()?.data).not.toHaveProperty("option");
-    expect(autoAnswerableOptions("Path4Question2")).toBeUndefined;
+    expect(autoAnswerableOptions("Path4Question2")).toBeUndefined();
 
     // Manually proceed through the second blank
     clickContinue("Path4Question2", { answers: ["Path4Question2Blank"], auto: false });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/autoAnswerableFlag.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/autoAnswerableFlag.test.ts
@@ -18,7 +18,7 @@ describe("Returns undefined and does not auto-answer any flag paths", () => {
       }
     });
 
-    expect(autoAnswerableFlag("SetValue")).not.toBeDefined();
+    expect(autoAnswerableFlag("SetValue")).toBeUndefined();
   });
 
   test("If the node does not set a `fn`", () => {
@@ -26,15 +26,16 @@ describe("Returns undefined and does not auto-answer any flag paths", () => {
     delete alteredFlow["Filter"].data?.fn;
     setState({ flow: alteredFlow });
 
-    expect(autoAnswerableFlag("Filter")).not.toBeDefined();
+    expect(autoAnswerableFlag("Filter")).toBeUndefined();
   });
 
-  test("If the node does not have any flag paths (aka options)");
-  const alteredFlow = structuredClone(flowWithFilter);
-  delete alteredFlow["Filter"].edges;
-  setState({ flow: alteredFlow });
-
-  expect(autoAnswerableFlag("Filter")).not.toBeDefined();
+  test("If the node does not have any flag paths (aka options)", () => {
+    const alteredFlow = structuredClone(flowWithFilter);
+    delete alteredFlow["Filter"].edges;
+    setState({ flow: alteredFlow });
+  
+    expect(autoAnswerableFlag("Filter")).toBeUndefined();
+  });
 });
 
 const flowWithFilter: Store.Flow = {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -470,7 +470,7 @@ export const previewStore: StateCreator<
     let optionsThatCanBeAutoAnswered: Array<NodeId> = [];
 
     // Get existing passport value(s) for this node's fn
-    let passportValues = passportData?.[data.fn];
+    const passportValues = passportData?.[data.fn];
 
     // If we have existing passport value(s) for this fn in an eligible automation format (eg not numbers or plain strings), 
     //   then proceed through the matching option(s) or the blank option independent if other vals have been seen before
@@ -549,7 +549,7 @@ export const previewStore: StateCreator<
       id: edgeId,
       ...flow[edgeId],
     }));
-    let optionsThatCanBeAutoAnswered: Array<NodeId> = [];
+    const optionsThatCanBeAutoAnswered: Array<NodeId> = [];
 
     // "New" Filters will have a category prop, but existing ones may still be relying on DEFAULT category
     const filterCategory = data?.category || DEFAULT_FLAG_CATEGORY;


### PR DESCRIPTION
Follows on from #3764 

Running `pnpm check` in the editor subdirectory now returns 0 errors for me, sorry I missed these on initial merge ! 