### PR TITLE
chore: Update copy on "Team Members" page to be less Editor specific

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -41,12 +41,12 @@ export const TeamMembers = () => {
 
   return (
     <Container maxWidth="contentWrap">
-      <SettingsSection data-testid="team-editors">
+      <SettingsSection data-testid="team-members">
         <Typography variant="h2" component="h3" gutterBottom>
-          Team editors
+          Team members
         </Typography>
         <Typography variant="body1">
-          Editors have access to edit your services.
+          Editors have access to edit your services, whilst viewers can only browse your services.
         </Typography>
         <MembersTable
           members={activeMembers}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -102,7 +102,7 @@ export const MembersTable = ({
                       addUser();
                     }}
                   >
-                    Add a new editor
+                    Add a new member
                   </AddButton>
                 </TableCell>
               </TableRow>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
-import Dialog from "@mui/material/Dialog";
 import { styled } from "@mui/material/styles";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -9,15 +8,15 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import { Role, UserRole } from "@opensystemslab/planx-core/types";
+import { Role } from "@opensystemslab/planx-core/types";
 import { AddButton } from "pages/Team";
 import React, { useState } from "react";
 import Permission from "ui/editor/Permission";
 
 import { StyledAvatar, StyledTableRow } from "./../styles";
 import { ActionType, MembersTableProps, TeamMember } from "./../types";
-import { EditorUpsertModal } from "./EditorUpsertModal";
 import { RemoveUserModal } from "./RemoveUserModal";
+import { UserUpsertModal } from "./UserUpsertModal";
 
 const TableRowButton = styled(Button)(({ theme }) => ({
   textDecoration: "underline",
@@ -28,12 +27,14 @@ const TableRowButton = styled(Button)(({ theme }) => ({
     backgroundColor: theme.palette.action.hover,
   },
 }));
+
 const EditUserButton = styled(TableRowButton)(({ theme }) => ({
   color: theme.palette.primary.light,
   "&:hover": {
     color: theme.palette.primary.dark,
   },
 }));
+
 const RemoveUserButton = styled(TableRowButton)(({ theme }) => ({
   color: theme.palette.text.secondary,
   "&:hover": {
@@ -64,11 +65,13 @@ export const MembersTable = ({
     setShowModal(true);
     setInitialValues(member);
   };
+
   const removeUser = (member: TeamMember) => {
     setActionType("remove");
     setShowModal(true);
     setInitialValues(member);
   };
+
   const addUser = () => {
     setActionType("add");
     setShowModal(true);
@@ -107,7 +110,7 @@ export const MembersTable = ({
           )}
         </Table>
         {showModal && (
-          <EditorUpsertModal
+          <UserUpsertModal
             showModal={showModal}
             setShowModal={setShowModal}
             initialValues={initialValues}
@@ -141,7 +144,7 @@ export const MembersTable = ({
             </StyledTableRow>
           </TableHead>
           <TableBody
-            data-testid={`members-table${showAddMemberButton && "-add-editor"}`}
+            data-testid={`members-table${showAddMemberButton && "-add-member"}`}
           >
             {members.map((member) => (
               <StyledTableRow key={member.id}>
@@ -207,7 +210,7 @@ export const MembersTable = ({
                         addUser();
                       }}
                     >
-                      Add a new editor
+                      Add a new member
                     </AddButton>
                   </TableCell>
                 </TableRow>
@@ -225,7 +228,7 @@ export const MembersTable = ({
             actionType={actionType}
           />
         ) : (
-          <EditorUpsertModal
+          <UserUpsertModal
             setShowModal={setShowModal}
             showModal={showModal}
             initialValues={initialValues}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/UserUpsertModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/UserUpsertModal.tsx
@@ -13,10 +13,10 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 
 import {
-  AddNewEditorErrors,
+  AddNewMemberErrors,
   isUserAlreadyExistsError,
 } from "../errors/addNewEditorErrors";
-import { upsertEditorSchema } from "../formSchema";
+import { upsertMemberSchema } from "../formSchema";
 import { createAndAddUserToTeam } from "../queries/createAndAddUserToTeam";
 import { updateTeamMember } from "../queries/updateUser";
 import { SettingsDialog } from "../styles";
@@ -28,7 +28,7 @@ import {
 
 export const DEMO_TEAM_ID = 32;
 
-export const EditorUpsertModal = ({
+export const UserUpsertModal = ({
   setShowModal,
   showModal,
   initialValues,
@@ -117,7 +117,7 @@ export const EditorUpsertModal = ({
       // Users within the Demo team are granted a role with a restricted permission set
       role: isDemoTeam ? "demoUser" : "teamEditor",
     },
-    validationSchema: upsertEditorSchema,
+    validationSchema: upsertMemberSchema,
     onSubmit: handleSubmit,
   });
 
@@ -136,7 +136,7 @@ export const EditorUpsertModal = ({
         >
           <Box sx={{ mt: 1, mb: 4 }}>
             <Typography variant="h3" component="h2" id="dialog-heading">
-              Add a new editor
+              Add a new { isDemoTeam ? "demo user" : "editor" }
             </Typography>
           </Box>
           <InputGroup flowSpacing>
@@ -191,7 +191,7 @@ export const EditorUpsertModal = ({
           <ErrorWrapper
             error={
               showUserAlreadyExistsError
-                ? AddNewEditorErrors.USER_ALREADY_EXISTS.errorMessage
+                ? AddNewMemberErrors.USER_ALREADY_EXISTS.errorMessage
                 : undefined
             }
           >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/UserUpsertModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/UserUpsertModal.tsx
@@ -136,7 +136,7 @@ export const UserUpsertModal = ({
         >
           <Box sx={{ mt: 1, mb: 4 }}>
             <Typography variant="h3" component="h2" id="dialog-heading">
-              Add a new { isDemoTeam ? "demo user" : "editor" }
+              Add a new member
             </Typography>
           </Box>
           <InputGroup flowSpacing>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/errors/addNewEditorErrors.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/errors/addNewEditorErrors.tsx
@@ -1,8 +1,8 @@
-export const AddNewEditorErrors = {
+export const AddNewMemberErrors = {
   USER_ALREADY_EXISTS: {
     regex: /violates unique constraint "users_email_key"/i,
     errorMessage: "User already exists",
   },
 };
 export const isUserAlreadyExistsError = (error: string) =>
-  AddNewEditorErrors.USER_ALREADY_EXISTS.regex.test(error);
+  AddNewMemberErrors.USER_ALREADY_EXISTS.regex.test(error);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/formSchema.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/formSchema.tsx
@@ -1,6 +1,6 @@
 import * as Yup from "yup";
 
-export const upsertEditorSchema = Yup.object({
+export const upsertMemberSchema = Yup.object({
   firstName: Yup.string().required("Enter a first name"),
   lastName: Yup.string().required("Enter a last name"),
   email: Yup.string()

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.demoTeam.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.demoTeam.test.tsx
@@ -2,9 +2,9 @@ import { waitFor, within } from "@testing-library/react";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { vi } from "vitest";
 
-import { DEMO_TEAM_ID } from "../components/EditorUpsertModal";
+import { DEMO_TEAM_ID } from "../components/UserUpsertModal";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
-import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
+import { userTriesToAddNewMember } from "./helpers/userTriesToAddNewMember";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
 import { mockPlatformAdminUser } from "./mocks/mockUsers";
 
@@ -34,9 +34,9 @@ describe("adding a new user to the Demo team", () => {
     expect(currentUsers).toHaveLength(3);
 
     const { user, getByTestId } = await setupTeamMembersScreen();
-    await userTriesToAddNewEditor(user);
+    await userTriesToAddNewMember(user);
 
-    const membersTable = getByTestId("members-table-add-editor");
+    const membersTable = getByTestId("members-table-add-member");
 
     await waitFor(() => {
       expect(

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.errors.serverSide.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.errors.serverSide.test.tsx
@@ -3,7 +3,7 @@ import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import { vi } from "vitest";
 
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
-import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
+import { userTriesToAddNewMember } from "./helpers/userTriesToAddNewMember";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
 import { alreadyExistingUser, mockPlatformAdminUser } from "./mocks/mockUsers";
 
@@ -17,7 +17,7 @@ vi.mock(
   }),
 );
 
-describe("when a user fills in the 'add a new editor' form correctly but there is a server-side error", () => {
+describe("when a user fills in the 'add a new member' form correctly but there is a server-side error", () => {
   afterAll(() => useStore.setState(initialState));
   beforeEach(async () => {
     useStore.setState({
@@ -26,7 +26,7 @@ describe("when a user fills in the 'add a new editor' form correctly but there i
     });
 
     const { user } = await setupTeamMembersScreen();
-    await userTriesToAddNewEditor(user);
+    await userTriesToAddNewMember(user);
   });
 
   it("shows an appropriate error message", async () => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.errors.userAlreadyExists.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.errors.userAlreadyExists.test.tsx
@@ -3,7 +3,7 @@ import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import { vi } from "vitest";
 
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
-import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
+import { userTriesToAddNewMember } from "./helpers/userTriesToAddNewMember";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
 import { alreadyExistingUser, mockPlatformAdminUser } from "./mocks/mockUsers";
 
@@ -18,7 +18,7 @@ vi.mock(
 );
 let initialState: FullStore;
 
-describe("when a user fills in the 'add a new editor' form correctly but the user already exists", () => {
+describe("when a user fills in the 'add a new member' form correctly but the user already exists", () => {
   afterAll(() => useStore.setState(initialState));
   beforeEach(async () => {
     useStore.setState({
@@ -27,7 +27,7 @@ describe("when a user fills in the 'add a new editor' form correctly but the use
     });
 
     const { user } = await setupTeamMembersScreen();
-    await userTriesToAddNewEditor(user);
+    await userTriesToAddNewMember(user);
   });
 
   it("shows an appropriate error message", async () => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.noExistingMembers.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.noExistingMembers.test.tsx
@@ -15,7 +15,7 @@ const mockTeamMembersDataWithNoTeamEditors: TeamMember[] = [
   },
 ];
 
-describe("when a user views the 'Team members' screen but there are no existing team editors listed", () => {
+describe("when a user views the 'Team members' screen but there are no existing team members listed", () => {
   beforeEach(async () => {
     useStore.setState({
       teamMembers: mockTeamMembersDataWithNoTeamEditors,
@@ -25,10 +25,10 @@ describe("when a user views the 'Team members' screen but there are no existing 
     getByText("No members found");
   });
 
-  it("shows the 'add a new editor' button", async () => {
-    const teamEditorsTable = screen.getByTestId("team-editors");
+  it("shows the 'add a new member' button", async () => {
+    const teamMembersTable = screen.getByTestId("team-members");
     expect(
-      await within(teamEditorsTable).findByText("Add a new editor"),
+      await within(teamMembersTable).findByText("Add a new member"),
     ).toBeVisible();
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
@@ -7,9 +7,9 @@ import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
 import { setup } from "../../../../../testUtils";
-import { EditorUpsertModal } from "../components/EditorUpsertModal";
+import { UserUpsertModal } from "../components/UserUpsertModal";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
-import { userTriesToAddNewEditor } from "./helpers/userTriesToAddNewEditor";
+import { userTriesToAddNewMember } from "./helpers/userTriesToAddNewMember";
 import { mockTeamMembersData } from "./mocks/mockTeamMembersData";
 import {
   emptyTeamMemberObj,
@@ -29,7 +29,7 @@ vi.mock(
 
 let initialState: FullStore;
 
-describe("when a user presses 'add a new editor'", () => {
+describe("when a user presses 'add a new member'", () => {
   beforeEach(async () => {
     useStore.setState({
       teamMembers: mockTeamMembersData,
@@ -39,11 +39,11 @@ describe("when a user presses 'add a new editor'", () => {
     });
     const { user } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton = await within(teamEditorsTable).findByText(
-      "Add a new editor",
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton = await within(teamMembersTable).findByText(
+      "Add a new member",
     );
-    user.click(addEditorButton);
+    user.click(addMemberButton);
   });
 
   it("opens the modal and displays the input fields", async () => {
@@ -52,7 +52,7 @@ describe("when a user presses 'add a new editor'", () => {
   });
 });
 
-describe("when a user fills in the 'add a new editor' form correctly", () => {
+describe("when a user fills in the 'add a new member' form correctly", () => {
   afterAll(() => useStore.setState(initialState));
 
   beforeEach(async () => {
@@ -63,11 +63,11 @@ describe("when a user fills in the 'add a new editor' form correctly", () => {
       teamId: 1,
     });
     const { user } = await setupTeamMembersScreen();
-    await userTriesToAddNewEditor(user);
+    await userTriesToAddNewMember(user);
   });
 
-  it("adds the new user row to the Team Editors table", async () => {
-    const membersTable = screen.getByTestId("members-table-add-editor");
+  it("adds the new user row to the Team Members table", async () => {
+    const membersTable = screen.getByTestId("members-table-add-member");
 
     await waitFor(() => {
       expect(
@@ -89,7 +89,7 @@ describe("when a user fills in the 'add a new editor' form correctly", () => {
   });
 });
 
-describe("when the addNewEditor modal is rendered", () => {
+describe("when the addNewMember modal is rendered", () => {
   beforeEach(async () => {
     useStore.setState({
       teamSlug: "planx",
@@ -100,7 +100,7 @@ describe("when the addNewEditor modal is rendered", () => {
   it("should not have any accessibility issues", async () => {
     const { container } = setup(
       <DndProvider backend={HTML5Backend}>
-        <EditorUpsertModal
+        <UserUpsertModal
           showModal={true}
           setShowModal={() => {}}
           initialValues={emptyTeamMemberObj}
@@ -115,7 +115,7 @@ describe("when the addNewEditor modal is rendered", () => {
   });
 });
 
-describe("'add a new editor' button is hidden from Templates team", () => {
+describe("'add a new member' button is hidden from Templates team", () => {
   beforeEach(async () => {
     useStore.setState({
       teamMembers: mockTeamMembersData,
@@ -126,11 +126,11 @@ describe("'add a new editor' button is hidden from Templates team", () => {
   });
 
   it("hides the button on the Templates team", async () => {
-    const { user: _user } = await setupTeamMembersScreen();
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton =
-      within(teamEditorsTable).queryByText("Add a new editor");
-    expect(addEditorButton).not.toBeInTheDocument();
+    await setupTeamMembersScreen();
+    const teamMembers = screen.getByTestId("team-members");
+    const addMemberButton =
+      within(teamMembers).queryByText("Add a new member");
+    expect(addMemberButton).not.toBeInTheDocument();
   });
 });
 
@@ -145,10 +145,10 @@ describe("when a user is not a platform admin", () => {
   });
 
   it("hides the button from non-admin users", async () => {
-    const { user: _user } = await setupTeamMembersScreen();
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton =
-      within(teamEditorsTable).queryByText("Add a new editor");
-    expect(addEditorButton).not.toBeInTheDocument();
+    await setupTeamMembersScreen();
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton =
+      within(teamMembersTable).queryByText("Add a new member");
+    expect(addMemberButton).not.toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.removeUser.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.removeUser.test.tsx
@@ -29,8 +29,8 @@ describe("when a user presses 'remove' button", () => {
     });
     const { user, container } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const removeRowButton = await within(teamEditorsTable).findByTestId(
+    const teamMembersTable = screen.getByTestId("team-members");
+    const removeRowButton = await within(teamMembersTable).findByTestId(
       "remove-button-3",
     );
     axeContainer = container;
@@ -79,10 +79,10 @@ describe("when a user clicks 'Remove user' button", () => {
     });
     const { user } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
+    const teamMembersTable = screen.getByTestId("team-members");
 
     const removeRowButton =
-      within(teamEditorsTable).getByTestId("remove-button-3");
+      within(teamMembersTable).getByTestId("remove-button-3");
 
     await user.click(removeRowButton);
 
@@ -127,9 +127,9 @@ describe("'remove' button is hidden from Templates team", () => {
 
   it("hides the button on the Templates team", async () => {
     const { user: _user } = await setupTeamMembersScreen();
-    const teamEditorsTable = screen.getByTestId("team-editors");
+    const teamMembersTable = screen.getByTestId("team-members");
     const editButton =
-      within(teamEditorsTable).queryByTestId("remove-button-3");
+      within(teamMembersTable).queryByTestId("remove-button-3");
     expect(editButton).not.toBeInTheDocument();
   });
 });
@@ -146,9 +146,9 @@ describe("when a user is not a platform admin", () => {
     await setupTeamMembersScreen();
   });
   it("does not show a remove button", async () => {
-    const teamEditorsTable = screen.getByTestId("team-editors");
+    const teamMembersTable = screen.getByTestId("team-members");
     const addEditorButton =
-      within(teamEditorsTable).queryByTestId("remove-button-0");
+      within(teamMembersTable).queryByTestId("remove-button-0");
 
     expect(addEditorButton).not.toBeInTheDocument();
   });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.updateEditor.test.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.updateEditor.test.tsx
@@ -23,12 +23,12 @@ describe("when a user presses 'edit button'", () => {
 
     const { user } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton = await within(teamEditorsTable).findByTestId(
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton = await within(teamMembersTable).findByTestId(
       "edit-button-3",
     );
 
-    user.click(addEditorButton);
+    user.click(addMemberButton);
     // Start each test with an open modal
   });
 
@@ -60,14 +60,15 @@ describe("when a user deletes an input value", () => {
   beforeEach(async () => {
     useStore.setState({ teamMembers: mockTeamMembersData, teamSlug: "planx" });
   });
+
   it("displays an error message when clicking away", async () => {
     const { user } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton = await within(teamEditorsTable).findByTestId(
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton = await within(teamMembersTable).findByTestId(
       "edit-button-3",
     );
-    await user.click(addEditorButton);
+    await user.click(addMemberButton);
 
     const modal = await screen.findByRole("dialog");
     const firstNameInput = await screen.findByLabelText("First name");
@@ -97,11 +98,11 @@ describe("when a user updates a field correctly", () => {
     useStore.setState({ teamMembers: mockTeamMembersData, teamSlug: "planx" });
     const { user } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton = await within(teamEditorsTable).findByTestId(
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton = await within(teamMembersTable).findByTestId(
       "edit-button-3",
     );
-    await user.click(addEditorButton);
+    await user.click(addMemberButton);
 
     const modal = await screen.findByRole("dialog");
     const firstNameInput = await screen.findByLabelText("First name");
@@ -110,12 +111,14 @@ describe("when a user updates a field correctly", () => {
 
     await user.click(modal);
   });
+
   it("updates the field", async () => {
     const firstNameInput = await screen.findByLabelText("First name");
     expect(firstNameInput).toHaveDisplayValue(
       mockTeamMembersData[2].firstName + "bo",
     );
   });
+
   it("enables the update user button", async () => {
     const updateUserButton = await screen.findByRole("button", {
       name: "Update user",
@@ -129,11 +132,11 @@ describe("when a user correctly updates an Editor", () => {
     useStore.setState({ teamMembers: mockTeamMembersData, teamSlug: "planx" });
     const { user } = await setupTeamMembersScreen();
 
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton = await within(teamEditorsTable).findByTestId(
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton = await within(teamMembersTable).findByTestId(
       "edit-button-3",
     );
-    await user.click(addEditorButton);
+    await user.click(addMemberButton);
 
     const firstNameInput = await screen.findByLabelText("First name");
 
@@ -145,8 +148,9 @@ describe("when a user correctly updates an Editor", () => {
 
     await user.click(updateUserButton);
   });
+
   it("updates the member table with new details", async () => {
-    const membersTable = await screen.findByTestId("members-table-add-editor");
+    const membersTable = await screen.findByTestId("members-table-add-member");
     await waitFor(() => {
       expect(within(membersTable).getByText(/Bilbobo/)).toBeInTheDocument();
     });
@@ -154,11 +158,13 @@ describe("when a user correctly updates an Editor", () => {
       await screen.findByText(/Successfully updated a user/),
     ).toBeInTheDocument();
   });
+
   it("closes the modal", async () => {
     await waitFor(() => {
       expect(screen.queryByTestId("modal-edit-user")).not.toBeInTheDocument();
     });
   });
+
   it("shows a success message", async () => {
     expect(
       await screen.findByText(/Successfully updated a user/),
@@ -178,8 +184,8 @@ describe("'edit' button is hidden from Templates team", () => {
 
   it("hides the button on the Templates team", async () => {
     const { user: _user } = await setupTeamMembersScreen();
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const editButton = within(teamEditorsTable).queryByTestId("edit-button-0");
+    const teamMembersTable = screen.getByTestId("team-members");
+    const editButton = within(teamMembersTable).queryByTestId("edit-button-0");
     expect(editButton).not.toBeInTheDocument();
   });
 });
@@ -197,10 +203,10 @@ describe("when a user is not a platform admin", () => {
   });
 
   it("does not show an edit button", async () => {
-    const teamEditorsTable = screen.getByTestId("team-editors");
-    const addEditorButton =
-      within(teamEditorsTable).queryByTestId("edit-button-3");
+    const teamMembersTable = screen.getByTestId("team-members");
+    const addMemberButton =
+      within(teamMembersTable).queryByTestId("edit-button-3");
 
-    expect(addEditorButton).not.toBeInTheDocument();
+    expect(addMemberButton).not.toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/setupTeamMembersScreen.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/setupTeamMembersScreen.tsx
@@ -15,6 +15,6 @@ export const setupTeamMembersScreen = async () => {
       </ToastContextProvider>
     </DndProvider>,
   );
-  await screen.findByTestId("team-editors");
+  await screen.findByTestId("team-members");
   return setupResult;
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/userTriesToAddNewMember.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/userTriesToAddNewMember.tsx
@@ -3,12 +3,12 @@ import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 
 import { userEntersInput } from "./userEntersInput";
 
-export const userTriesToAddNewEditor = async (user: UserEvent) => {
-  const teamEditorsTable = screen.getByTestId("team-editors");
-  const addEditorButton = await within(teamEditorsTable).findByText(
-    "Add a new editor",
+export const userTriesToAddNewMember = async (user: UserEvent) => {
+  const teamMembersTable = screen.getByTestId("team-members");
+  const addMemberButton = await within(teamMembersTable).findByText(
+    "Add a new member",
   );
-  user.click(addEditorButton);
+  user.click(addMemberButton);
   const addNewEditorModal = await screen.findByTestId("modal-create-user");
   await userEntersInput("First name", "Mickey", addNewEditorModal, user);
   await userEntersInput("Last name", "Mouse", addNewEditorModal, user);


### PR DESCRIPTION
## What does this PR do?
- Update copy on "Team Members" page to be less Editor specific, for example changing the titles from "Team Editors" to "Team Members"
- Updates language used to code to also reflect this 