### PR TITLE
feat: add demo user to api hasura roles

### DIFF
--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -56,16 +56,15 @@ const getAllowedRolesForUser = (user: User): Role[] => {
  * This is the role of least privilege for the user
  */
 const getDefaultRoleForUser = (user: User): Role => {
-  
-  if(user.isPlatformAdmin) return "platformAdmin"
+  if (user.isPlatformAdmin) return "platformAdmin";
 
-  const isTeamEditor = user.teams.find((team)=> team.role === "teamEditor")
-  if(isTeamEditor) return "teamEditor"
+  const isTeamEditor = user.teams.find((team) => team.role === "teamEditor");
+  if (isTeamEditor) return "teamEditor";
 
-  const isTeamViewer = user.teams.find((team)=> team.role === "teamViewer")
-  if(isTeamViewer) return "teamViewer"
-  
-  return "demoUser"
+  const isTeamViewer = user.teams.find((team) => team.role === "teamViewer");
+  if (isTeamViewer) return "teamViewer";
+
+  return "demoUser";
 };
 
 /**

--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -41,7 +41,6 @@ const getAllowedRolesForUser = (user: User): Role[] => {
   const teamRoles = user.teams.map((teamRole) => teamRole.role);
   const allowedRoles: Role[] = [
     "public", // Allow public access
-    "teamEditor", // Least privileged role for authenticated users - required for Editor access
     ...teamRoles, // User specific roles
   ];
   if (user.isPlatformAdmin) allowedRoles.push("platformAdmin");
@@ -57,7 +56,16 @@ const getAllowedRolesForUser = (user: User): Role[] => {
  * This is the role of least privilege for the user
  */
 const getDefaultRoleForUser = (user: User): Role => {
-  return user.isPlatformAdmin ? "platformAdmin" : "teamEditor";
+  
+  if(user.isPlatformAdmin) return "platformAdmin"
+
+  const isTeamEditor = user.teams.find((team)=> team.role === "teamEditor")
+  if(isTeamEditor) return "teamEditor"
+
+  const isTeamViewer = user.teams.find((team)=> team.role === "teamViewer")
+  if(isTeamViewer) return "teamViewer"
+  
+  return "demoUser"
 };
 
 /**


### PR DESCRIPTION
Altered the JWT token builder in the api to set the correct role rather than falling back to only `teamEditor`.

Now it will correctly select `platformAdmin | teamEditor | teamViewer | demoUser`