### PR TITLE
fix: Grant additional permissions to demoUser role

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1960,6 +1960,17 @@
           - role
           - id
         filter: {}
+    - role: demoUser
+      permission:
+        columns:
+          - team_id
+          - user_id
+          - role
+          - id
+        filter:
+          user_id:
+            _eq: x-hasura-user-id
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -2035,6 +2046,24 @@
           - reference_code
           - submission_email
           - team_id
+        filter: {}
+      comment: ""
+    - role: demoUser
+      permission:
+        columns:
+          - id
+          - external_planning_site_name
+          - external_planning_site_url
+          - homepage
+          - help_email
+          - help_opening_hours
+          - help_phone
+          - email_reply_to_id
+          - team_id
+          - boundary_bbox
+          - submission_email
+          - reference_code
+          - boundary_url
         filter: {}
       comment: ""
     - role: platformAdmin

--- a/hasura.planx.uk/tests/team_members.test.js
+++ b/hasura.planx.uk/tests/team_members.test.js
@@ -66,8 +66,8 @@ describe("team_members", () => {
       i = await introspectAs("demoUser");
     });
 
-    test("cannot query teams", () => {
-      expect(i.queries).not.toContain("team_members");
+    test("can query teams", () => {
+      expect(i.queries).toContain("team_members");
     });
 
     test("cannot create, update, or delete team_members", () => {


### PR DESCRIPTION
A few issues when testing the `demoUser` role end-to-end - 
 - All users must be able to access their own record in the `team_members` table in order to log in
 - All users must have read access to the `team_settings` table