### PR TITLE
refactor: expand canUserEdit function to include all user roles

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -36,10 +36,10 @@ export const userStore: StateCreator<
     const user = get().getUser();
     if (!user) return false;
 
-    const hasTeamEditorRole = (team: UserTeams) =>
-      team.role === "teamEditor" && team.team.slug === teamSlug;
+    const canEditTeam = (team: UserTeams) =>
+      team.role !== "teamViewer" && team.team.slug === teamSlug;
 
-    return user.isPlatformAdmin || user.teams.some(hasTeamEditorRole);
+    return user.isPlatformAdmin || user.teams.some(canEditTeam);
   },
 
   async initUserStore() {


### PR DESCRIPTION
Continuing work of the demo workspaces: https://trello.com/c/EfaEQRzK/2441-create-a-demo-workspace

I have expanded the use of the `canUserEdit` store function to return `true` as long as the `role !== "teamViewer"` as the database will populate the `user.teams` array with all teams the user is a team member of. The only role that can be assigned where you wouldn't be able to edit is the `teamViewer` role thus, I went with this for the condition.

In other circumstances, a user may be a `teamEditor` or `demoUser` and in both cases this will be assigned only on the teams they can edit