### PR TITLE
fix: Use integer for userId in JWT

### DIFF
--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -33,7 +33,7 @@ export const buildJWTForAPIRole = () =>
 const generateHasuraClaimsForUser = (user: User): HasuraClaims => ({
   "x-hasura-allowed-roles": getAllowedRolesForUser(user),
   "x-hasura-default-role": getDefaultRoleForUser(user),
-  "x-hasura-user-id": user.id.toString(),
+  "x-hasura-user-id": user.id,
 });
 
 /**

--- a/api.planx.uk/modules/auth/types.ts
+++ b/api.planx.uk/modules/auth/types.ts
@@ -4,7 +4,7 @@ export type HasuraNamespace = "https://hasura.io/jwt/claims";
 export type HasuraClaims = {
   "x-hasura-allowed-roles": Role[];
   "x-hasura-default-role": Role;
-  "x-hasura-user-id": string;
+  "x-hasura-user-id": number;
 };
 export type HasuraJWT = Record<HasuraNamespace, HasuraClaims>;
 

--- a/api.planx.uk/tests/mockJWT.ts
+++ b/api.planx.uk/tests/mockJWT.ts
@@ -8,7 +8,7 @@ function getJWT({ role }: { role: Role }) {
     "https://hasura.io/jwt/claims": {
       "x-hasura-allowed-roles": [role],
       "x-hasura-default-role": role,
-      "x-hasura-user-id": "123",
+      "x-hasura-user-id": 123,
     },
   };
 

--- a/e2e/tests/api-driven/src/jwt.ts
+++ b/e2e/tests/api-driven/src/jwt.ts
@@ -20,7 +20,7 @@ export const buildJWT = async (email: string): Promise<string | undefined> => {
 const generateHasuraClaimsForUser = (user: User) => ({
   "x-hasura-allowed-roles": getAllowedRolesForUser(user),
   "x-hasura-default-role": getDefaultRoleForUser(user),
-  "x-hasura-user-id": user.id.toString(),
+  "x-hasura-user-id": user.id,
 });
 
 /**

--- a/e2e/tests/ui-driven/src/helpers/context.ts
+++ b/e2e/tests/ui-driven/src/helpers/context.ts
@@ -106,15 +106,15 @@ export async function tearDownTestContext(context: Context) {
   }
 }
 
-export function generateAuthenticationToken(userId: string) {
+export function generateAuthenticationToken(userId: number) {
   assert(process.env.JWT_SECRET);
   return sign(
     {
-      sub: `${userId}`,
+      sub: userId.toString(),
       "https://hasura.io/jwt/claims": {
         "x-hasura-allowed-roles": ["platformAdmin", "public"],
         "x-hasura-default-role": "platformAdmin",
-        "x-hasura-user-id": `${userId}`,
+        "x-hasura-user-id": userId,
       },
     },
     process.env.JWT_SECRET,

--- a/e2e/tests/ui-driven/src/helpers/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/helpers/globalHelpers.ts
@@ -51,7 +51,7 @@ export async function createAuthenticatedSession({
 }): Promise<Page> {
   const browserContext = await browser.newContext();
   const page = await browserContext.newPage();
-  const token = generateAuthenticationToken(`${userId}`);
+  const token = generateAuthenticationToken(userId);
   await browserContext.addCookies([
     {
       name: "jwt",

--- a/e2e/tests/ui-driven/src/utils.ts
+++ b/e2e/tests/ui-driven/src/utils.ts
@@ -25,13 +25,13 @@ export const gqlAdmin = async (query, variables = {}) => {
   return json;
 };
 
-export const getJWT = (userId) => {
+export const getJWT = (userId: number) => {
   const data = {
     sub: String(userId),
     "https://hasura.io/jwt/claims": {
       "x-hasura-allowed-roles": ["platformAdmin", "public"],
       "x-hasura-default-role": "platformAdmin",
-      "x-hasura-user-id": String(userId),
+      "x-hasura-user-id": userId,
     },
   };
 

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -67,7 +67,7 @@ function buildJWTForRole(role, userId = 1) {
   const hasura = {
     "x-hasura-allowed-roles": [role],
     "x-hasura-default-role": role,
-    "x-hasura-user-id": userId.toString(),
+    "x-hasura-user-id": userId,
   };
 
   const data = {


### PR DESCRIPTION
Regression tests running here - https://github.com/theopensystemslab/planx-new/actions/runs/11600394961