### PR TITLE
fix: Remove manual population of creator ID

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -4,6 +4,7 @@ import type { Flow, Node } from "./types.js";
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { $public, getClient } from "./client/index.js";
+import { userContext } from "./modules/auth/middleware.js";
 
 export interface FlowData {
   slug: string;
@@ -67,10 +68,11 @@ const insertFlow = async (
   slug: string,
   name: string,
   flowData: Flow["data"],
-  creatorId?: number,
   copiedFrom?: Flow["id"],
 ) => {
   const { client: $client } = getClient();
+  const userId = userContext.getStore()?.user?.sub;
+
   try {
     const {
       flow: { id },
@@ -81,7 +83,6 @@ const insertFlow = async (
           $slug: String!
           $name: String!
           $data: jsonb = {}
-          $creator_id: Int
           $copied_from: uuid
         ) {
           flow: insert_flows_one(
@@ -91,7 +92,6 @@ const insertFlow = async (
               name: $name
               data: $data
               version: 1
-              creator_id: $creator_id
               copied_from: $copied_from
             }
           ) {
@@ -104,7 +104,6 @@ const insertFlow = async (
         slug: slug,
         name: name,
         data: flowData,
-        creator_id: creatorId,
         copied_from: copiedFrom,
       },
     );
@@ -113,7 +112,7 @@ const insertFlow = async (
     return { id };
   } catch (error) {
     throw Error(
-      `User ${creatorId} failed to insert flow to teamId ${teamId}. Please check permissions. Error: ${error}`,
+      `User ${userId} failed to insert flow to teamId ${teamId}. Please check permissions. Error: ${error}`,
     );
   }
 };

--- a/api.planx.uk/modules/flows/copyFlow/service.ts
+++ b/api.planx.uk/modules/flows/copyFlow/service.ts
@@ -1,5 +1,4 @@
 import { makeUniqueFlow, getFlowData, insertFlow } from "../../../helpers.js";
-import { userContext } from "../../auth/middleware.js";
 
 const copyFlow = async (
   flowId: string,
@@ -16,18 +15,9 @@ const copyFlow = async (
   if (insert) {
     const newSlug = flow.slug + "-copy";
     const newName = flow.name + " (copy)";
-    const creatorId = userContext.getStore()?.user?.sub;
-    if (!creatorId) throw Error("User details missing from request");
 
     // Insert the flow and an associated operation
-    await insertFlow(
-      flow.team_id,
-      newSlug,
-      newName,
-      uniqueFlowData,
-      parseInt(creatorId),
-      flowId,
-    );
+    await insertFlow(flow.team_id, newSlug, newName, uniqueFlowData, flowId);
   }
 
   return { flow, uniqueFlowData };


### PR DESCRIPTION
## What's the problem?
 - The `/flows/:flowId/copy` endpoint is broken - throwing a permission error due to a missing field `creator_id`
 - All roles which write to this table have write permissions for this column
 
 ## What's the cause?
When we added a column preset for `creator_id` (https://github.com/theopensystemslab/planx-new/pull/3864) it removed the columns from the insert schema for the flows table.
 
 > The respective fields will also be removed from the generated GraphQL schema for that role.

Source: https://hasura.io/docs/2.0/auth/authorization/permissions/column-presets/

<img width="584" alt="image" src="https://github.com/user-attachments/assets/b804a34f-4a45-4122-be97-7d886421484e">

 
## What's the solution?
- Let Hasura handle this and populate it from the JWT, remove our custom code for fetch the user ID from the JWT
- It's actually a pretty nice solution / pattern imho!
- I've checked for other references to `creator_id` and `creatorId` - this is the only one in this repo and `planx-core`