### PR TITLE
feat: add demoUser to api user auth

### DIFF
--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -219,10 +219,11 @@ export const useRoleAuth: UseRoleAuth =
 // Convenience methods for role-based access
 export const useTeamViewerAuth = useRoleAuth([
   "teamViewer",
+  "demoUser",
   "teamEditor",
   "platformAdmin",
 ]);
-export const useTeamEditorAuth = useRoleAuth(["teamEditor", "platformAdmin"]);
+export const useTeamEditorAuth = useRoleAuth(["teamEditor", "platformAdmin", "demoUser"]);
 export const usePlatformAdminAuth = useRoleAuth(["platformAdmin"]);
 
 /**

--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -223,7 +223,11 @@ export const useTeamViewerAuth = useRoleAuth([
   "teamEditor",
   "platformAdmin",
 ]);
-export const useTeamEditorAuth = useRoleAuth(["teamEditor", "platformAdmin", "demoUser"]);
+export const useTeamEditorAuth = useRoleAuth([
+  "teamEditor",
+  "platformAdmin",
+  "demoUser",
+]);
 export const usePlatformAdminAuth = useRoleAuth(["platformAdmin"]);
 
 /**


### PR DESCRIPTION
A `demoUser` was forbidden from copying a flow due to the API running auth on if the user is a `teamEditor | platformAdmin` I have now added `demoUser` to this list