### PR TITLE
route Microsoft auth requests from pizzas to staging API

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -213,8 +213,9 @@ jobs:
           VITE_APP_HASURA_WEBSOCKET: wss://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
           VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           VITE_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
-          # needed because there's no API to change google's allowed OAuth URLs
+          # needed because there's no API to change google/microsoft's allowed redirect URIs
           VITE_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
+          VITE_APP_MICROSOFT_OAUTH_OVERRIDE: https://api.editor.planx.dev
           VITE_APP_ENV: pizza
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build-storybook
@@ -230,6 +231,7 @@ jobs:
           VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           VITE_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
           VITE_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
+          VITE_APP_MICROSOFT_OAUTH_OVERRIDE: https://api.editor.planx.dev
           VITE_APP_ENV: pizza
 
   pulumi_preview:


### PR DESCRIPTION
Ticket: https://trello.com/c/WdZicC3b

Resolves the problem in exactly the same way as we do for Google - we do the auth whole flow via the staging API (`api.editor.planx.dev`), and are returned to the pizza afterwards (rather than the staging client).