### PR TITLE
fix: ensure "no flag" band always displays if no flags are present

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -5,10 +5,10 @@ import { Link } from "react-navi";
 
 import { useStore } from "../../../lib/store";
 import { DataField } from "./DataField";
+import { FlagBand, NoFlagBand } from "./FlagBand";
 import Hanger from "./Hanger";
 import Node from "./Node";
 import { Thumbnail } from "./Thumbnail";
-import { FlagBand, NoFlagBand } from "./FlagBand";
 
 const Option: React.FC<any> = (props) => {
   const childNodes = useStore((state) => state.childNodesOf(props.id));
@@ -20,7 +20,9 @@ const Option: React.FC<any> = (props) => {
     // Question & Checklist Options set zero or many flag values under "data.flag"
     if (props.data?.flag) {
       if (Array.isArray(props.data?.flag)) {
-        flags = flatFlags.filter(({ value }) => props.data?.flag?.includes(value));
+        flags = flatFlags.filter(
+          ({ value }) => props.data?.flag?.includes(value),
+        );
       } else {
         flags = flatFlags.filter(({ value }) => props.data?.flag === value);
       }
@@ -46,9 +48,17 @@ const Option: React.FC<any> = (props) => {
             imageAltText={props.data.text}
           />
         )}
-        {flags ? flags.map((flag) => <FlagBand key={`${props.id}-${flag.value}`} flag={flag} />) : <NoFlagBand />}
+        {flags && flags.length > 0 ? (
+          flags.map((flag) => (
+            <FlagBand key={`${props.id}-${flag.value}`} flag={flag} />
+          ))
+        ) : (
+          <NoFlagBand />
+        )}
         <div className="text">{props.data.text}</div>
-        {props.data?.val && <DataField value={props.data.val} variant="child" />}
+        {props.data?.val && (
+          <DataField value={props.data.val} variant="child" />
+        )}
       </Link>
       <ol className="decisions">
         {childNodes.map((child: any) => (


### PR DESCRIPTION
Flagged here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1730462810086459

To recreate bug on staging/prod: 
- Add a question and assign flags to an option and another option without flags -> "create" -> color bands display as expected
- Update that node and remove the flags from the option -> "update" -> no color band displays on updated option
  - Fix is to explicitly check for `flags.length > 0` so that `flags = []` doesn't evaluate to `FlagBand` option