### PR TITLE
fix: ensure questions that set a data field with no option data values are not automated

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -5,7 +5,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { useFormik } from "formik";
+import { FormikErrors, FormikValues, useFormik } from "formik";
 import adjust from "ramda/src/adjust";
 import compose from "ramda/src/compose";
 import remove from "ramda/src/remove";
@@ -313,7 +313,7 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
       }
     },
     validate: ({ options, ...values }) => {
-      const errors: Record<string, string> = {};
+      const errors: FormikErrors<FormikValues> = {};
       if (values.fn && !options?.some((option) => option.data.val)) {
         errors.fn =
           "At least one option must set a data value when the checklist has a data field";

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -312,7 +312,14 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
         alert(JSON.stringify({ type, ...values, options }, null, 2));
       }
     },
-    validate: () => {},
+    validate: ({ options, ...values }) => {
+      const errors: Record<string, string> = {};
+      if (values.fn && !options?.some((option) => option.data.val)) {
+        errors.fn =
+          "At least one option must set a data value when the checklist has a data field";
+      }
+      return errors;
+    },
   });
 
   const focusRef = useRef<HTMLInputElement | null>(null);
@@ -365,6 +372,8 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
                 value={formik.values.fn}
                 placeholder="Data Field"
                 onChange={formik.handleChange}
+                error={Boolean(formik.errors?.fn)}
+                errorMessage={formik.errors?.fn}
               />
             </InputRow>
             <InputRow>

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -1,8 +1,7 @@
-import { errors } from "@airbrake/browser/dist/http_req/api";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { useFormik } from "formik";
+import { FormikErrors, FormikValues, useFormik } from "formik";
 import React, { useEffect, useRef } from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
@@ -157,12 +156,11 @@ export const Question: React.FC<Props> = (props) => {
       }
     },
     validate: ({ options, ...values }) => {
-      const errors: Record<string, string> = {};
+      const errors: FormikErrors<FormikValues> = {};
       if (values.fn && !options.some((option) => option.data.val)) {
         errors.fn =
           "At least one option must set a data value when the question has a data field";
       }
-
       return errors;
     },
   });

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -1,3 +1,4 @@
+import { errors } from "@airbrake/browser/dist/http_req/api";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
@@ -109,7 +110,11 @@ const OptionEditor: React.FC<{
       </InputRow>
     )}
     <FlagsSelect
-      value={Array.isArray(props.value.data.flag) ? props.value.data.flag : [props.value.data.flag]}
+      value={
+        Array.isArray(props.value.data.flag)
+          ? props.value.data.flag
+          : [props.value.data.flag]
+      }
       onChange={(ev) => {
         props.onChange({
           ...props.value,
@@ -151,7 +156,15 @@ export const Question: React.FC<Props> = (props) => {
         alert(JSON.stringify({ type, ...values, children }, null, 2));
       }
     },
-    validate: () => { },
+    validate: ({ options, ...values }) => {
+      const errors: Record<string, string> = {};
+      if (values.fn && !options.some((option) => option.data.val)) {
+        errors.fn =
+          "At least one option must set a data value when the question has a data field";
+      }
+
+      return errors;
+    },
   });
 
   const focusRef = useRef<HTMLInputElement | null>(null);
@@ -201,6 +214,8 @@ export const Question: React.FC<Props> = (props) => {
                 value={formik.values.fn}
                 placeholder="Data Field"
                 onChange={formik.handleChange}
+                error={Boolean(formik.errors?.fn)}
+                errorMessage={formik.errors?.fn}
               />
             </InputRow>
             <InputRow>
@@ -221,7 +236,6 @@ export const Question: React.FC<Props> = (props) => {
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
-
         <ModalSectionContent subtitle="Options">
           <ListManager
             values={formik.values.options}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -514,9 +514,10 @@ export const previewStore: StateCreator<
     )
       return;
 
-    // Only proceed if the user has seen at least one node with this fn before
+    // Only proceed if the user has seen at least one node with this fn (or `output` in case of Calculate nodes) before
     const visitedFns = Object.entries(breadcrumbs).filter(
-      ([nodeId, _breadcrumb]) => flow[nodeId].data?.fn === data.fn,
+      ([nodeId, _breadcrumb]) =>
+        [flow[nodeId].data?.fn, flow[nodeId].data?.output].includes(data.fn),
     );
     if (!visitedFns.length) return;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -518,7 +518,7 @@ export const previewStore: StateCreator<
     const visitedFns = Object.entries(breadcrumbs).filter(
       ([nodeId, _breadcrumb]) => flow[nodeId].data?.fn === data.fn,
     );
-    if (!visitedFns) return;
+    if (!visitedFns.length) return;
 
     // Get all options (aka edges or Answer nodes) for this node
     const options: Array<Store.Node> = edges.map((edgeId) => ({


### PR DESCRIPTION
Fixes edge case flagged here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1730455691984869

**Two changes:**
- `autoAnswerableOptions` condition is corrected so that _existing_ nodes will behave as expected (put to user)
- Formik validation added to editor modal for Questions & Checklists so that future nodes aren't allowed to do this at all 

![Screenshot from 2024-11-04 10-15-31](https://github.com/user-attachments/assets/73ab8a6c-1898-4942-b093-0d17838a1789)

**Testing:**
- Production https://editor.planx.uk/testing/self-automation
- Pizza https://3903.planx.pizza/testing/self-automation