### PR TITLE
fix: Add guard around add member button

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -94,19 +94,21 @@ export const MembersTable = ({
             </TableRow>
           </TableHead>
           {showAddMemberButton && (
-            <TableBody>
-              <TableRow>
-                <TableCell colSpan={3}>
-                  <AddButton
-                    onClick={() => {
-                      addUser();
-                    }}
-                  >
-                    Add a new member
-                  </AddButton>
-                </TableCell>
-              </TableRow>
-            </TableBody>
+            <Permission.IsPlatformAdmin>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <AddButton
+                      onClick={() => {
+                        addUser();
+                      }}
+                    >
+                      Add a new member
+                    </AddButton>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Permission.IsPlatformAdmin>
           )}
         </Table>
         {showModal && (


### PR DESCRIPTION
This now matches the button shown if there are members - the same guard and check wraps both instances of this button now.