### PR TITLE
fix: add missing postgres indexes 

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -157,7 +157,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -171,7 +171,7 @@
         query_params:
           type: bops-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: document_template
@@ -225,7 +225,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -239,7 +239,7 @@
         query_params:
           type: email-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: feedback
@@ -483,9 +483,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: demoUser
       permission:
@@ -529,9 +529,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: teamEditor
       permission:
@@ -562,9 +562,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   select_permissions:
     - role: api
@@ -617,7 +617,7 @@
                     - 1
                     - 29
                     - 30
-      comment: "For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
+      comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
         columns:
@@ -698,9 +698,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: demoUser
       permission:
@@ -740,9 +740,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
     - role: teamEditor
       permission:
@@ -767,9 +767,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   delete_permissions:
     - role: demoUser
@@ -809,9 +809,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
   select_permissions:
     - role: demoUser
@@ -849,9 +849,9 @@
             forward_client_headers: false
             headers:
               - name: authorization
-                value: "{{HASURA_PLANX_API_KEY}}"
+                value: '{{HASURA_PLANX_API_KEY}}'
             timeout: 10
-            url: "{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html"
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
 - table:
     name: lowcal_sessions
@@ -998,7 +998,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/send-email/confirmation"
+        url: '{{$base_url}}/send-email/confirmation'
         version: 2
     - name: setup_lowcal_expiry_events
       definition:
@@ -1028,7 +1028,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-expiry-event"
+        url: '{{$base_url}}/webhooks/hasura/create-expiry-event'
         version: 2
     - name: setup_lowcal_reminder_events
       definition:
@@ -1058,7 +1058,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-reminder-event"
+        url: '{{$base_url}}/webhooks/hasura/create-reminder-event'
         version: 2
 - table:
     name: operations
@@ -1278,7 +1278,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1300,13 +1300,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-expiry-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-expiry-events'
         version: 2
     - name: setup_payment_invitation_events
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1328,13 +1328,13 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-invitation-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-invitation-events'
         version: 2
     - name: setup_payment_reminder_events
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 3
@@ -1356,7 +1356,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-reminder-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-reminder-events'
         version: 2
     - name: setup_payment_send_events
       definition:
@@ -1385,7 +1385,7 @@
         method: POST
         query_params: {}
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/create-payment-send-events"
+        url: '{{$base_url}}/webhooks/hasura/create-payment-send-events'
         version: 2
 - table:
     name: payment_status
@@ -1647,12 +1647,12 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
         timeout_sec: 60
-      webhook: "{{HASURA_PLANX_API_URL}}"
+      webhook: '{{HASURA_PLANX_API_URL}}'
       headers:
         - name: authorization
           value_from_env: HASURA_PLANX_API_KEY
@@ -1661,7 +1661,7 @@
         query_params:
           type: s3-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: sessions
@@ -1804,7 +1804,7 @@
           - created_at
           - submitted_at
         filter: {}
-      comment: "For future, if this moves outside of the Flow to somewhere like Team, we should update 'demoUser' to only see submission data related to only their flows. "
+      comment: 'For future, if this moves outside of the Flow to somewhere like Team, we should update ''demoUser'' to only see submission data related to only their flows. '
     - role: platformAdmin
       permission:
         columns:
@@ -2365,7 +2365,7 @@
               - 29
               - 30
               - 32
-      comment: "For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team "
+      comment: 'For the demo user, we want to ensure they can only see their own team [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
         columns:
@@ -2482,7 +2482,7 @@
       definition:
         enable_manual: false
         insert:
-          columns: "*"
+          columns: '*'
       retry_conf:
         interval_sec: 30
         num_retries: 1
@@ -2496,7 +2496,7 @@
         query_params:
           type: uniform-submission
         template_engine: Kriti
-        url: "{{$base_url}}/webhooks/hasura/send-slack-notification"
+        url: '{{$base_url}}/webhooks/hasura/send-slack-notification'
         version: 2
 - table:
     name: user_roles

--- a/hasura.planx.uk/migrations/1730742914548_create_index_bops_applications_session_id/down.sql
+++ b/hasura.planx.uk/migrations/1730742914548_create_index_bops_applications_session_id/down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS "public"."bops_applications_session_id";
+DROP INDEX IF EXISTS "public"."uniform_applications_session_id_idx";
+DROP INDEX IF EXISTS "public"."email_applications_session_id_idx";
+DROP INDEX IF EXISTS "public"."s3_applications_session_id_idx";
+DROP INDEX IF EXISTS "public"."feedback_flow_id_team_id_idx";
+DROP INDEX IF EXISTS "public"."reconciliation_requests_session_id_idx";
+DROP INDEX IF EXISTS "public"."published_flows_created_at_idx";

--- a/hasura.planx.uk/migrations/1730742914548_create_index_bops_applications_session_id/up.sql
+++ b/hasura.planx.uk/migrations/1730742914548_create_index_bops_applications_session_id/up.sql
@@ -1,0 +1,14 @@
+CREATE  INDEX "bops_applications_session_id_idx" on
+  "public"."bops_applications" using hash ("session_id");
+CREATE  INDEX "uniform_applications_session_id_idx" on
+  "public"."uniform_applications" using hash ("submission_reference");
+CREATE  INDEX "email_applications_session_id_idx" on
+  "public"."email_applications" using hash ("session_id");
+CREATE  INDEX "s3_applications_session_id_idx" on
+  "public"."s3_applications" using hash ("session_id");
+CREATE  INDEX "feedback_flow_id_team_id_idx" on
+  "public"."feedback" using btree ("team_id", "flow_id");
+CREATE  INDEX "reconciliation_requests_session_id_idx" on
+  "public"."reconciliation_requests" using hash ("session_id");
+CREATE  INDEX "published_flows_created_at_idx" on
+  "public"."published_flows" using btree ("created_at");

--- a/hasura.planx.uk/migrations/1730742914548_create_index_bops_applications_session_id/up.sql
+++ b/hasura.planx.uk/migrations/1730742914548_create_index_bops_applications_session_id/up.sql
@@ -11,4 +11,4 @@ CREATE  INDEX "feedback_flow_id_team_id_idx" on
 CREATE  INDEX "reconciliation_requests_session_id_idx" on
   "public"."reconciliation_requests" using hash ("session_id");
 CREATE  INDEX "published_flows_created_at_idx" on
-  "public"."published_flows" using btree ("created_at");
+  "public"."published_flows" using btree ("created_at" DESC NULLS LAST);


### PR DESCRIPTION
Follows on from publishing debugging today: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1730715895034839

**Approached this from two directions:**
1. Which indexes are we missing? Where is postgres is doing more sequence scans than index scans?
  - This blog has a useful sample query: https://erikrw.hashnode.dev/how-to-identify-missing-indexes-in-postgresql
  - From these results, I then cross-checked with how we commonly query those tables (eg `where` params)
  - ![Screenshot from 2024-11-04 19-05-38](https://github.com/user-attachments/assets/a1366460-d325-4ece-9a49-d3aa6e06418c)
2. Which existing indexes are unused? Can any be removed?
  - Ran `select * from pg_stat_user_indexes where schemaname = 'public' order by idx_scan asc;` for this one
  - We do have multiple cases of existing indexes that have never been hit, but they're all direct remnants of "Primary keys" or "Unique keys" created via Hasura and therefore don't make sense to drop
  - ![Screenshot from 2024-11-04 18-45-36](https://github.com/user-attachments/assets/4dbf520b-3e06-4ffc-8e4c-71075d32c23f)

Wish that `published_flows` & `flows` would have come up higher on the "need to improve" checks, but the truth is they didn't !