### PR TITLE
Revert "fix: ensure questions that set a data field with no option data values are not automated"

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -5,7 +5,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { FormikErrors, FormikValues, useFormik } from "formik";
+import { useFormik } from "formik";
 import adjust from "ramda/src/adjust";
 import compose from "ramda/src/compose";
 import remove from "ramda/src/remove";
@@ -312,14 +312,7 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
         alert(JSON.stringify({ type, ...values, options }, null, 2));
       }
     },
-    validate: ({ options, ...values }) => {
-      const errors: FormikErrors<FormikValues> = {};
-      if (values.fn && !options?.some((option) => option.data.val)) {
-        errors.fn =
-          "At least one option must set a data value when the checklist has a data field";
-      }
-      return errors;
-    },
+    validate: () => {},
   });
 
   const focusRef = useRef<HTMLInputElement | null>(null);
@@ -372,8 +365,6 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
                 value={formik.values.fn}
                 placeholder="Data Field"
                 onChange={formik.handleChange}
-                error={Boolean(formik.errors?.fn)}
-                errorMessage={formik.errors?.fn}
               />
             </InputRow>
             <InputRow>

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -1,7 +1,7 @@
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { FormikErrors, FormikValues, useFormik } from "formik";
+import { useFormik } from "formik";
 import React, { useEffect, useRef } from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
@@ -109,11 +109,7 @@ const OptionEditor: React.FC<{
       </InputRow>
     )}
     <FlagsSelect
-      value={
-        Array.isArray(props.value.data.flag)
-          ? props.value.data.flag
-          : [props.value.data.flag]
-      }
+      value={Array.isArray(props.value.data.flag) ? props.value.data.flag : [props.value.data.flag]}
       onChange={(ev) => {
         props.onChange({
           ...props.value,
@@ -155,14 +151,7 @@ export const Question: React.FC<Props> = (props) => {
         alert(JSON.stringify({ type, ...values, children }, null, 2));
       }
     },
-    validate: ({ options, ...values }) => {
-      const errors: FormikErrors<FormikValues> = {};
-      if (values.fn && !options.some((option) => option.data.val)) {
-        errors.fn =
-          "At least one option must set a data value when the question has a data field";
-      }
-      return errors;
-    },
+    validate: () => { },
   });
 
   const focusRef = useRef<HTMLInputElement | null>(null);
@@ -212,8 +201,6 @@ export const Question: React.FC<Props> = (props) => {
                 value={formik.values.fn}
                 placeholder="Data Field"
                 onChange={formik.handleChange}
-                error={Boolean(formik.errors?.fn)}
-                errorMessage={formik.errors?.fn}
               />
             </InputRow>
             <InputRow>
@@ -234,6 +221,7 @@ export const Question: React.FC<Props> = (props) => {
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
+
         <ModalSectionContent subtitle="Options">
           <ListManager
             values={formik.values.options}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -514,12 +514,11 @@ export const previewStore: StateCreator<
     )
       return;
 
-    // Only proceed if the user has seen at least one node with this fn (or `output` in case of Calculate nodes) before
+    // Only proceed if the user has seen at least one node with this fn before
     const visitedFns = Object.entries(breadcrumbs).filter(
-      ([nodeId, _breadcrumb]) =>
-        [flow[nodeId].data?.fn, flow[nodeId].data?.output].includes(data.fn),
+      ([nodeId, _breadcrumb]) => flow[nodeId].data?.fn === data.fn,
     );
-    if (!visitedFns.length) return;
+    if (!visitedFns) return;
 
     // Get all options (aka edges or Answer nodes) for this node
     const options: Array<Store.Node> = edges.map((edgeId) => ({


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#3903

See thread here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1730884655361309

This is failing to automation `property.localAuthorityDistrict` & `property.region` questions because these data fields are not stored under `fn` in FindProperty.