### PR TITLE
chore: extract Public component wrappers for auto-answering into preview Node

### DIFF
--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -15,6 +15,7 @@ export interface Props {
   id?: string;
   handleSubmit?: (data: any, children?: any) => void;
   node?: any;
+  autoAnswers?: (string | undefined)[];
 }
 
 const Filter: React.FC<Props> = (props) => {

--- a/editor.planx.uk/src/@planx/components/Filter/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Public.tsx
@@ -1,4 +1,3 @@
-import { useStore } from "pages/FlowEditor/lib/store";
 import { useEffect } from "react";
 
 import { PublicProps } from "../shared/types";
@@ -8,14 +7,9 @@ export type Props = PublicProps<Filter>;
 
 // Filters are always auto-answered and never seen by a user, but should still leave a breadcrumb
 export default function Component(props: Props) {
-  const autoAnswerableFlag = useStore((state) => state.autoAnswerableFlag);
-
-  let idThatCanBeAutoAnswered: string | undefined;
-  if (props.id) idThatCanBeAutoAnswered = autoAnswerableFlag(props.id);
-
   useEffect(() => {
     props.handleSubmit?.({
-      answers: [idThatCanBeAutoAnswered],
+      answers: props.autoAnswers,
       auto: true,
     });
   }, []);

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -75,14 +75,19 @@ interface Props {
 }
 
 const Node: React.FC<Props> = (props) => {
-  const [childNodesOf, isFinalCard, resetPreview, cachedBreadcrumbs] = useStore(
-    (state) => [
-      state.childNodesOf,
-      state.isFinalCard(),
-      state.resetPreview,
-      state.cachedBreadcrumbs,
-    ],
-  );
+  const [
+    childNodesOf,
+    isFinalCard,
+    resetPreview,
+    cachedBreadcrumbs,
+    autoAnswerableFlag,
+  ] = useStore((state) => [
+    state.childNodesOf,
+    state.isFinalCard(),
+    state.resetPreview,
+    state.cachedBreadcrumbs,
+    state.autoAnswerableFlag,
+  ]);
 
   const handleSubmit = isFinalCard ? undefined : props.handleSubmit;
 
@@ -99,6 +104,9 @@ const Node: React.FC<Props> = (props) => {
   });
 
   switch (props.node.type) {
+    case TYPES.AddressInput:
+      return <AddressInputComponent {...getComponentProps<AddressInput>()} />;
+
     case TYPES.Calculate:
       return <CalculateComponent {...getComponentProps<Calculate>()} />;
 
@@ -138,6 +146,9 @@ const Node: React.FC<Props> = (props) => {
     case TYPES.Confirmation:
       return <ConfirmationComponent {...getComponentProps<Confirmation>()} />;
 
+    case TYPES.ContactInput:
+      return <ContactInputComponent {...getComponentProps<ContactInput>()} />;
+
     case TYPES.Content:
       return <ContentComponent {...getComponentProps<Content>()} />;
 
@@ -146,8 +157,10 @@ const Node: React.FC<Props> = (props) => {
 
     case TYPES.DrawBoundary:
       return <DrawBoundaryComponent {...getComponentProps<DrawBoundary>()} />;
+
     case TYPES.Feedback:
       return <FeedbackComponent {...getComponentProps<Feedback>()} />;
+
     case TYPES.FileUpload:
       return <FileUploadComponent {...getComponentProps<FileUpload>()} />;
 
@@ -157,6 +170,14 @@ const Node: React.FC<Props> = (props) => {
           {...getComponentProps<FileUploadAndLabel>()}
         />
       );
+
+    case TYPES.Filter: {
+      const filterProps = getComponentProps<Filter>();
+      let autoAnswers: (string | undefined)[] = [];
+      if (nodeId) autoAnswers = [autoAnswerableFlag(nodeId)];
+
+      return <FilterComponent {...filterProps} autoAnswers={autoAnswers} />;
+    }
 
     case TYPES.FindProperty:
       return <FindPropertyComponent {...getComponentProps<FindProperty>()} />;
@@ -182,6 +203,33 @@ const Node: React.FC<Props> = (props) => {
     case TYPES.Pay:
       return <PayComponent {...getComponentProps<Pay>()} />;
 
+    case TYPES.PlanningConstraints:
+      return (
+        <PlanningConstraintsComponent
+          {...getComponentProps<PlanningConstraints>()}
+        />
+      );
+
+    case TYPES.PropertyInformation:
+      return (
+        <PropertyInformationComponent
+          {...getComponentProps<PropertyInformation>()}
+        />
+      );
+
+    case TYPES.Question:
+      return (
+        <QuestionComponent
+          {...getComponentProps<Question>()}
+          responses={childNodesOf(props.node.id).map((n, i) => ({
+            id: n.id,
+            responseKey: i + 1,
+            title: n.data?.text,
+            ...n.data,
+          }))}
+        />
+      );
+
     case TYPES.Result:
       return <ResultComponent {...getComponentProps<Result>()} />;
 
@@ -197,19 +245,6 @@ const Node: React.FC<Props> = (props) => {
     case TYPES.SetValue:
       return <SetValueComponent {...getComponentProps<SetValue>()} />;
 
-    case TYPES.Question:
-      return (
-        <QuestionComponent
-          {...getComponentProps<Question>()}
-          responses={childNodesOf(props.node.id).map((n, i) => ({
-            id: n.id,
-            responseKey: i + 1,
-            title: n.data?.text,
-            ...n.data,
-          }))}
-        />
-      );
-
     case TYPES.TaskList: {
       const taskListProps = getComponentProps<TaskList>();
 
@@ -224,34 +259,11 @@ const Node: React.FC<Props> = (props) => {
     case TYPES.TextInput:
       return <TextInputComponent {...getComponentProps<TextInput>()} />;
 
-    case TYPES.AddressInput:
-      return <AddressInputComponent {...getComponentProps<AddressInput>()} />;
-
-    case TYPES.ContactInput:
-      return <ContactInputComponent {...getComponentProps<ContactInput>()} />;
-
-    case TYPES.PlanningConstraints:
-      return (
-        <PlanningConstraintsComponent
-          {...getComponentProps<PlanningConstraints>()}
-        />
-      );
-
-    case TYPES.PropertyInformation:
-      return (
-        <PropertyInformationComponent
-          {...getComponentProps<PropertyInformation>()}
-        />
-      );
-
-    case TYPES.Filter:
-      return <FilterComponent {...getComponentProps<Filter>()} />;
-
     // These types are never seen by users, nor do they leave their own breadcrumbs entry
+    case TYPES.Answer:
     case TYPES.ExternalPortal:
     case TYPES.Flow:
     case TYPES.InternalPortal:
-    case TYPES.Answer:
     case undefined:
       return null;
 


### PR DESCRIPTION
First step before moving onto auto-answering Input node types - this should be a more flexible, extensible pattern than per-`@planx/components` "visibility wrappers"

- [x] Filters
- [ ] Questions
- [ ] Checklists