### PR TITLE
fix: filter questions without responses out of generated docs

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dee2279",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dee2279
-    version: github.com/theopensystemslab/planx-core/dee2279
+    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
+    version: github.com/theopensystemslab/planx-core/72e7f7f
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6292,8 +6292,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dee2279:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dee2279}
+  github.com/theopensystemslab/planx-core/72e7f7f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
-    version: github.com/theopensystemslab/planx-core/30f4e8b
+    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
+    version: github.com/theopensystemslab/planx-core/839c7a0
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6292,8 +6292,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/30f4e8b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
+  github.com/theopensystemslab/planx-core/839c7a0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
-    version: github.com/theopensystemslab/planx-core/72e7f7f
+    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
+    version: github.com/theopensystemslab/planx-core/efa3bfe
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6292,8 +6292,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/72e7f7f:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
+  github.com/theopensystemslab/planx-core/efa3bfe:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
-    version: github.com/theopensystemslab/planx-core/efa3bfe
+    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
+    version: github.com/theopensystemslab/planx-core/30f4e8b
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6292,8 +6292,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/efa3bfe:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
+  github.com/theopensystemslab/planx-core/30f4e8b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dee2279",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
-    version: github.com/theopensystemslab/planx-core/efa3bfe
+    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
+    version: github.com/theopensystemslab/planx-core/30f4e8b
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2982,8 +2982,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/efa3bfe:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
+  github.com/theopensystemslab/planx-core/30f4e8b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dee2279
-    version: github.com/theopensystemslab/planx-core/dee2279
+    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
+    version: github.com/theopensystemslab/planx-core/72e7f7f
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2982,8 +2982,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dee2279:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dee2279}
+  github.com/theopensystemslab/planx-core/72e7f7f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
-    version: github.com/theopensystemslab/planx-core/72e7f7f
+    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
+    version: github.com/theopensystemslab/planx-core/efa3bfe
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2982,8 +2982,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/72e7f7f:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
+  github.com/theopensystemslab/planx-core/efa3bfe:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
-    version: github.com/theopensystemslab/planx-core/30f4e8b
+    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
+    version: github.com/theopensystemslab/planx-core/839c7a0
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2982,8 +2982,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/30f4e8b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
+  github.com/theopensystemslab/planx-core/839c7a0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dee2279",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dee2279
-    version: github.com/theopensystemslab/planx-core/dee2279
+    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
+    version: github.com/theopensystemslab/planx-core/72e7f7f
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2714,8 +2714,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dee2279:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dee2279}
+  github.com/theopensystemslab/planx-core/72e7f7f:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
-    version: github.com/theopensystemslab/planx-core/30f4e8b
+    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
+    version: github.com/theopensystemslab/planx-core/839c7a0
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2714,8 +2714,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/30f4e8b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
+  github.com/theopensystemslab/planx-core/839c7a0:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
-    version: github.com/theopensystemslab/planx-core/efa3bfe
+    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
+    version: github.com/theopensystemslab/planx-core/30f4e8b
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2714,8 +2714,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/efa3bfe:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
+  github.com/theopensystemslab/planx-core/30f4e8b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
-    version: github.com/theopensystemslab/planx-core/72e7f7f
+    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
+    version: github.com/theopensystemslab/planx-core/efa3bfe
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2714,8 +2714,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/72e7f7f:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
+  github.com/theopensystemslab/planx-core/efa3bfe:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dee2279",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#72e7f7f",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#efa3bfe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#30f4e8b",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
-    version: github.com/theopensystemslab/planx-core/72e7f7f(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
+    version: github.com/theopensystemslab/planx-core/efa3bfe(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15390,9 +15390,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/72e7f7f(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
-    id: github.com/theopensystemslab/planx-core/72e7f7f
+  github.com/theopensystemslab/planx-core/efa3bfe(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
+    id: github.com/theopensystemslab/planx-core/efa3bfe
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#efa3bfe
-    version: github.com/theopensystemslab/planx-core/efa3bfe(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
+    version: github.com/theopensystemslab/planx-core/30f4e8b(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15390,9 +15390,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/efa3bfe(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efa3bfe}
-    id: github.com/theopensystemslab/planx-core/efa3bfe
+  github.com/theopensystemslab/planx-core/30f4e8b(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
+    id: github.com/theopensystemslab/planx-core/30f4e8b
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#30f4e8b
-    version: github.com/theopensystemslab/planx-core/30f4e8b(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
+    version: github.com/theopensystemslab/planx-core/839c7a0(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15390,9 +15390,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/30f4e8b(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/30f4e8b}
-    id: github.com/theopensystemslab/planx-core/30f4e8b
+  github.com/theopensystemslab/planx-core/839c7a0(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
+    id: github.com/theopensystemslab/planx-core/839c7a0
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dee2279
-    version: github.com/theopensystemslab/planx-core/dee2279(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#72e7f7f
+    version: github.com/theopensystemslab/planx-core/72e7f7f(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -15390,9 +15390,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/dee2279(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dee2279}
-    id: github.com/theopensystemslab/planx-core/dee2279
+  github.com/theopensystemslab/planx-core/72e7f7f(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/72e7f7f}
+    id: github.com/theopensystemslab/planx-core/72e7f7f
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
See https://github.com/theopensystemslab/planx-core/pull/556 for context

**Testing notes:**
This flow has a sticky note question, put-to-user question, and auto-answered question https://3918.planx.pizza/testing/docs-test/published?analytics=false

Here's how each should be handled by the following components / documents:
- Result: put-to-user _and_ auto-answered questions may be included under "Reasons" depending on flags, only put-to-user questions should have a "change" link
- Review: only put-to-user questions are included, all have "change" link
- Submission docs:
  - overview.html: put-to-user _and_ auto-answered questions are included, with "auto-answered" annotation
  - application.csv: put-to-user _and_ auto-answered questions are included, with "auto" metadata
  - application.json (`responses`): put-to-user _and_ auto-answered questions are included, with "auto" metadata
 
 None of the above should ever include the sticky note question title/text with an empty answer! 