### PR TITLE
chore: Bump `planx-core`, update `_address` type in passport

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#134b20d",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
-    version: github.com/theopensystemslab/planx-core/839c7a0
+    specifier: git+https://github.com/theopensystemslab/planx-core#134b20d
+    version: github.com/theopensystemslab/planx-core/134b20d
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -6292,8 +6292,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/839c7a0:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
+  github.com/theopensystemslab/planx-core/134b20d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/134b20d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#134b20d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
-    version: github.com/theopensystemslab/planx-core/839c7a0
+    specifier: git+https://github.com/theopensystemslab/planx-core#134b20d
+    version: github.com/theopensystemslab/planx-core/134b20d
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2982,8 +2982,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/839c7a0:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
+  github.com/theopensystemslab/planx-core/134b20d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/134b20d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#134b20d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
-    version: github.com/theopensystemslab/planx-core/839c7a0
+    specifier: git+https://github.com/theopensystemslab/planx-core#134b20d
+    version: github.com/theopensystemslab/planx-core/134b20d
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2714,8 +2714,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/839c7a0:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
+  github.com/theopensystemslab/planx-core/134b20d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/134b20d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#839c7a0",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#134b20d",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#839c7a0
-    version: github.com/theopensystemslab/planx-core/839c7a0(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#134b20d
+    version: github.com/theopensystemslab/planx-core/134b20d(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -3385,8 +3385,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.25.7
       '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0)(react@18.2.0)
-      '@mui/types': 7.2.17(@types/react@18.2.45)
-      '@mui/utils': 5.15.11(@types/react@18.2.45)(react@18.2.0)
+      '@mui/types': 7.2.18(@types/react@18.2.45)
+      '@mui/utils': 5.16.6(@types/react@18.2.45)(react@18.2.0)
       '@popperjs/core': 2.11.8
       '@types/react': 18.2.45
       clsx: 2.1.1
@@ -3408,8 +3408,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.25.7
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.17(@types/react@18.2.45)
-      '@mui/utils': 5.15.11(@types/react@18.2.45)(react@18.3.1)
+      '@mui/types': 7.2.18(@types/react@18.2.45)
+      '@mui/utils': 5.16.6(@types/react@18.2.45)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 18.2.45
       clsx: 2.1.1
@@ -3689,7 +3689,7 @@ packages:
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.45)(react@18.2.0)
       '@mui/private-theming': 5.16.6(@types/react@18.2.45)(react@18.2.0)
       '@mui/styled-engine': 5.16.6(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/types': 7.2.17(@types/react@18.2.45)
+      '@mui/types': 7.2.18(@types/react@18.2.45)
       '@mui/utils': 5.16.6(@types/react@18.2.45)(react@18.2.0)
       '@types/react': 18.2.45
       clsx: 2.1.1
@@ -3719,7 +3719,7 @@ packages:
       '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.45)(react@18.3.1)
       '@mui/private-theming': 5.16.6(@types/react@18.2.45)(react@18.3.1)
       '@mui/styled-engine': 5.16.6(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(react@18.3.1)
-      '@mui/types': 7.2.17(@types/react@18.2.45)
+      '@mui/types': 7.2.18(@types/react@18.2.45)
       '@mui/utils': 5.16.6(@types/react@18.2.45)(react@18.3.1)
       '@types/react': 18.2.45
       clsx: 2.1.1
@@ -3797,7 +3797,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.25.7
-      '@mui/types': 7.2.17(@types/react@18.2.45)
+      '@mui/types': 7.2.18(@types/react@18.2.45)
       '@types/prop-types': 15.7.13
       '@types/react': 18.2.45
       clsx: 2.1.1
@@ -3817,7 +3817,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.25.7
-      '@mui/types': 7.2.17(@types/react@18.2.45)
+      '@mui/types': 7.2.18(@types/react@18.2.45)
       '@types/prop-types': 15.7.13
       '@types/react': 18.2.45
       clsx: 2.1.1
@@ -15390,9 +15390,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/839c7a0(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/839c7a0}
-    id: github.com/theopensystemslab/planx-core/839c7a0
+  github.com/theopensystemslab/planx-core/134b20d(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/134b20d}
+    id: github.com/theopensystemslab/planx-core/134b20d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -85,26 +85,26 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
             selectedAddress.SAO_TEXT, // populated in cases of building name only, no street number
           ]
             .filter(Boolean)
-            .join(""),
+            .join("") || undefined,
           saoEnd: [
             selectedAddress.SAO_END_NUMBER,
             selectedAddress.SAO_END_SUFFIX,
           ]
             .filter(Boolean)
-            .join(""),
+            .join("") || undefined,
           pao: [
             selectedAddress.PAO_START_NUMBER,
             selectedAddress.PAO_START_SUFFIX,
             selectedAddress.PAO_TEXT, // populated in cases of building name only, no street number
           ]
             .filter(Boolean)
-            .join(""),
+            .join("") || undefined,
           paoEnd: [
             selectedAddress.PAO_END_NUMBER,
             selectedAddress.PAO_END_SUFFIX,
           ]
             .filter(Boolean)
-            .join(""),
+            .join("") || undefined,
           street: selectedAddress.STREET_DESCRIPTION,
           town: selectedAddress.TOWN_NAME,
           postcode: selectedAddress.POSTCODE_LOCATOR,

--- a/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -52,8 +52,8 @@ export interface SiteAddress extends MinimumSiteAddress {
   usrn?: string;
   blpu_code?: string;
   organisation?: string | null;
-  sao?: string | null;
-  saoEnd?: string | null;
+  sao?: string;
+  saoEnd?: string;
   pao?: string;
   paoEnd?: string;
   street?: string;


### PR DESCRIPTION
## What does this PR do?
- Updates `planx-core` (see https://github.com/theopensystemslab/planx-core/pull/557)
- Update type for `_address` stored in passport to match schema - this should have a value of `string | undefined` and we're currently passing along `""`
 - This is both correct from a type POV and falsy (in JS), but I think the intention here is not to populate the field so `undefined` seems correct here to me

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c71fd0d4-193e-4135-8b3c-c4641f402a14) | ![image](https://github.com/user-attachments/assets/44ca50dc-34bc-4705-8709-e3f7be415e8a) | 