### PR TITLE
fix: Typo on FeedbackPage icon title

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -82,7 +82,7 @@ const feedbackTypeIcon = (type: FeedbackType) => {
         title: "Unhelpful (help text)",
       };
     default:
-      return { icon: <RuleIcon />, title: "inaccuracy" };
+      return { icon: <RuleIcon />, title: "Inaccuracy" };
   }
 };
 


### PR DESCRIPTION
Small issue I spotted when reviewing #3920 

![image](https://github.com/user-attachments/assets/c76629cf-c636-4d04-b055-fb07c64031be)
