### PR TITLE
style: Feedback component style refinement

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -6,13 +6,13 @@ import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHead
 import type { PublicProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
 import React from "react";
-import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import TerribleFace from "ui/images/feedback_filled-01.svg";
 import PoorFace from "ui/images/feedback_filled-02.svg";
 import NeutralFace from "ui/images/feedback_filled-03.svg";
 import GoodFace from "ui/images/feedback_filled-04.svg";
 import ExcellentFace from "ui/images/feedback_filled-05.svg";
 import InputLabel from "ui/public/InputLabel";
+import Input from "ui/shared/Input/Input";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 import { getPreviouslySubmittedData, makeData } from "../../shared/utils";
@@ -48,15 +48,17 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         id={"DESCRIPTION_TEXT"}
         openLinksOnNewTab
       />
-      <Box pt={2} mb={3}>
+      <Box pt={1} mb={2}>
         {props.ratingQuestion && (
           <InputLabel
             label={
-              <ReactMarkdownOrHtml
-                source={props.ratingQuestion}
-                id={"RATING_QUESTION"}
-                openLinksOnNewTab
-              />
+              <Typography component="span" fontWeight="700">
+                <ReactMarkdownOrHtml
+                  source={props.ratingQuestion}
+                  id={"RATING_QUESTION"}
+                  openLinksOnNewTab
+                />
+              </Typography>
             }
           />
         )}
@@ -67,7 +69,7 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
           onChange={handleFeedbackChange}
           aria-label="feedback score"
         >
-          <Grid container columnSpacing={15} component="fieldset">
+          <Grid container columnSpacing={2} sx={{ width: "100%" }} component="fieldset" direction={{ xs: "column", formWrap: "row" }}>
             <FaceBox
               value="1"
               testId="feedback-button-terrible"
@@ -104,22 +106,27 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         {props.freeformQuestion && (
           <InputLabel
             label={
-              <ReactMarkdownOrHtml
-                source={props.freeformQuestion}
-                id={"RATING_QUESTION"}
-                openLinksOnNewTab
-              />
+              <Typography component="span" fontWeight="700">
+                <ReactMarkdownOrHtml
+                  source={props.freeformQuestion}
+                  id={"RATING_QUESTION"}
+                  openLinksOnNewTab
+                />
+              </Typography>
             }
           />
         )}
-        <RichTextInput
+        <Input
+          type="text"
+          multiline
+          bordered
           name="feedback"
           value={formik.values.feedback}
           placeholder="What did you think?"
           onChange={formik.handleChange}
         />
       </Box>
-      <Typography variant="caption">
+      <Typography variant="body2">
         <ReactMarkdownOrHtml source={props?.disclaimer} id={"DISCLAIMER"} />
       </Typography>
     </Card>

--- a/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
@@ -20,28 +20,32 @@ export const FaceBox = ({
   value,
 }: FaceBoxProps): ReactElement => {
   return (
-    <Grid item xs={2} key={label}>
+    <Grid item xs={2.4} key={label}>
       <ToggleButton
         value={value}
         data-testid={testId}
         sx={{
-          px: 0,
+          px: 0, textTransform: "none", width: "100%",
+          "&[aria-pressed='true'] div": {
+            borderColor: (theme) => theme.palette.primary.dark,
+            background: (theme) => theme.palette.background.paper,
+          },
         }}
         disableRipple
       >
         <Box
           sx={(theme) => ({
-            p: theme.spacing(2),
+            p: theme.spacing(2, 1),
             border: `2px solid ${theme.palette.border.main} `,
-            width: "120px",
-            maxHeight: "120px",
             display: "flex",
+            gap: theme.spacing(0.25),
             flexDirection: "column",
             justifyContent: "center",
             alignItems: "center",
+            width: "100%",
           })}
         >
-          <img src={icon} width={50} alt={altText} />
+          <img src={icon} width={32} alt={altText} />
           <Typography variant="body2" pt={0.5}>
             {label}
           </Typography>

--- a/editor.planx.uk/src/@planx/components/Feedback/components/placeholders.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/placeholders.tsx
@@ -1,5 +1,5 @@
 export const freeformQuestionPlaceholder =
-  "Please tell us more about your experience.";
+  "Please tell us more about your experience";
 
 export const ratingQuestionPlaceholder =
   "How would you rate your experience with this service?";

--- a/editor.planx.uk/src/@planx/components/Feedback/styled.ts
+++ b/editor.planx.uk/src/@planx/components/Feedback/styled.ts
@@ -5,6 +5,7 @@ import ToggleButtonGroup, {
 
 export const StyledToggleButtonGroup = styled(ToggleButtonGroup)(
   ({ theme }) => ({
+    width: "100%",
     [`& .${toggleButtonGroupClasses.grouped}`]: {
       border: 0,
       padding: 0,


### PR DESCRIPTION
## What does this PR do?

Small styling refinements to @jamdelion's work on the feedback component:

- Updates feedback text input to be `textarea` rather than rich text (editor) input
- Updates rating buttons to be responsive to width
- Updates selected rating button to be consistent with styling of selected radio grid (blue border)
- Increases disclaimer text size to our minimum (16px) type size
- Small spacing refinements

**Preview:**
(feature flag required: `window.featureFlags.toggle("FEEDBACK_COMPONENT")`)

**Before:**
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/6409b0c7-6c23-4a0a-8af5-c37ac71428b5">

**After:**
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/b438aed3-ecda-4353-94a6-cc8ead19ac52">
