### PR TITLE
style: Feedback component style refinement 

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
 import { Disclaimer } from "@planx/components/shared/Disclaimer";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
@@ -83,15 +84,17 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         id={"DESCRIPTION_TEXT"}
         openLinksOnNewTab
       />
-      <Box pt={2} mb={3}>
+      <Box my={4}>
         {props.ratingQuestion && (
           <InputLabel
             label={
-              <ReactMarkdownOrHtml
-                source={props.ratingQuestion}
-                id={"RATING_QUESTION"}
-                openLinksOnNewTab
-              />
+              <Typography component="span" fontWeight="700">
+                <ReactMarkdownOrHtml
+                  source={props.ratingQuestion}
+                  id={"RATING_QUESTION"}
+                  openLinksOnNewTab
+                />
+              </Typography>
             }
           />
         )}
@@ -102,7 +105,12 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
           onChange={handleFeedbackChange}
           aria-label="feedback score"
         >
-          <Grid container columnSpacing={15} component="fieldset">
+          <Grid 
+            container 
+            columnSpacing={2} 
+            component="fieldset" 
+            direction={{ xs: "column", formWrap: "row" }}
+          >
             <FaceBox
               value="1"
               testId="feedback-button-terrible"
@@ -139,18 +147,19 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         {props.freeformQuestion && (
           <InputLabel
             label={
-              <ReactMarkdownOrHtml
-                source={props.freeformQuestion}
-                id={"RATING_QUESTION"}
-                openLinksOnNewTab
-              />
+              <Typography component="span" fontWeight="700">
+                <ReactMarkdownOrHtml
+                  source={props.freeformQuestion}
+                  id={"RATING_QUESTION"}
+                  openLinksOnNewTab
+                />
+              </Typography>
             }
           />
         )}
-
         <Input
           multiline={true}
-          rows={5}
+          rows={3}
           name="feedback"
           value={formik.values.feedback}
           bordered

--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -88,13 +88,11 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         {props.ratingQuestion && (
           <InputLabel
             label={
-              <Typography component="span" fontWeight="700">
-                <ReactMarkdownOrHtml
-                  source={props.ratingQuestion}
-                  id={"RATING_QUESTION"}
-                  openLinksOnNewTab
-                />
-              </Typography>
+              <ReactMarkdownOrHtml
+                source={props.ratingQuestion}
+                id={"RATING_QUESTION"}
+                openLinksOnNewTab
+              />
             }
           />
         )}
@@ -105,10 +103,10 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
           onChange={handleFeedbackChange}
           aria-label="feedback score"
         >
-          <Grid 
-            container 
-            columnSpacing={2} 
-            component="fieldset" 
+          <Grid
+            container
+            columnSpacing={2}
+            component="fieldset"
             direction={{ xs: "column", formWrap: "row" }}
           >
             <FaceBox
@@ -147,13 +145,11 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         {props.freeformQuestion && (
           <InputLabel
             label={
-              <Typography component="span" fontWeight="700">
-                <ReactMarkdownOrHtml
-                  source={props.freeformQuestion}
-                  id={"RATING_QUESTION"}
-                  openLinksOnNewTab
-                />
-              </Typography>
+              <ReactMarkdownOrHtml
+                source={props.freeformQuestion}
+                id={"RATING_QUESTION"}
+                openLinksOnNewTab
+              />
             }
           />
         )}

--- a/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
@@ -20,36 +20,37 @@ export const FaceBox = ({
   value,
 }: FaceBoxProps): ReactElement => {
   return (
-    <Grid item xs={2} key={label}>
+    <Grid item xs={2.4} key={label}>
       <ToggleButton
         value={value}
         data-testid={testId}
         sx={{
           px: 0,
+          width: "100%",
+          textTransform: "none",
+          "&[aria-pressed='true'] > div": {
+            borderColor: (theme) => theme.palette.primary.dark,
+            background: (theme) => theme.palette.background.paper,
+          },
         }}
         disableRipple
       >
         <Box
           sx={(theme) => ({
-            p: theme.spacing(2),
+            p: theme.spacing(2, 1),
+            width: "100%",
             border: `2px solid ${theme.palette.border.main} `,
-            width: "120px",
-            maxHeight: "120px",
             display: "flex",
             flexDirection: "column",
             justifyContent: "center",
             alignItems: "center",
+            gap: theme.spacing(0.5),
           })}
         >
-          <img src={icon} width={50} alt={altText} />
+          <img src={icon} width={32} alt={altText} />
           <Typography
             variant="body2"
-            pt={1}
             sx={(theme) => ({
-              textTransform: "lowercase",
-              "&::first-letter": {
-                textTransform: "uppercase",
-              },
               color: theme.palette.text.primary,
             })}
           >

--- a/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
-import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButton, { toggleButtonClasses } from "@mui/material/ToggleButton";
 import Typography from "@mui/material/Typography";
 import React, { ReactElement } from "react";
 
@@ -28,7 +28,7 @@ export const FaceBox = ({
           px: 0,
           width: "100%",
           textTransform: "none",
-          "&[aria-pressed='true'] > div": {
+          [`&.${toggleButtonClasses.selected}`]: {
             borderColor: (theme) => theme.palette.primary.dark,
             background: (theme) => theme.palette.background.paper,
           },

--- a/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
@@ -2,9 +2,11 @@ import { Feedback } from "../model";
 
 export const defaultContent: Feedback = {
   title: "Tell us what you think",
-  freeformQuestion: "Please tell us more about your experience.",
+  freeformQuestion:
+    "<strong>Please tell us more about your experience.</strong>",
 
-  ratingQuestion: "How would you rate your experience with this service?",
+  ratingQuestion:
+    "<strong>How would you rate your experience with this service?</strong>",
 
   description: `This service is a work in progress, any feedback you share about your experience will help us to improve it.
 <br>

--- a/editor.planx.uk/src/@planx/components/Feedback/styled.ts
+++ b/editor.planx.uk/src/@planx/components/Feedback/styled.ts
@@ -5,11 +5,12 @@ import ToggleButtonGroup, {
 
 export const StyledToggleButtonGroup = styled(ToggleButtonGroup)(
   ({ theme }) => ({
+    width: "100%",
     [`& .${toggleButtonGroupClasses.grouped}`]: {
       border: 0,
       padding: 0,
       marginTop: theme.spacing(1),
     },
-    paddingBottom: theme.spacing(3.5),
+    paddingBottom: theme.spacing(2.5),
   }),
 );

--- a/editor.planx.uk/src/@planx/components/shared/Disclaimer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Disclaimer.tsx
@@ -7,7 +7,7 @@ import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHt
 export const Disclaimer = ({ text }: { text: string }) => (
   <WarningContainer>
     <ErrorOutline />
-    <Typography variant="body1" component="div" ml={2} mb={1}>
+    <Typography variant="body2" component="div" ml={2} sx={{ "& p:first-of-type": { marginTop: 0, } }}>
       <ReactMarkdownOrHtml source={text} openLinksOnNewTab />
     </Typography>
   </WarningContainer>


### PR DESCRIPTION
Small styling refinements to @jamdelion's work on the feedback component:

- Updates rating buttons to be responsive to width
- Updates selected rating button to be consistent with styling of selected radio grid (blue border)
- Small type and spacing refinements

**Before:**
<img width="735" alt="image" src="https://github.com/user-attachments/assets/54ff82fc-68b7-4e3a-91a9-f426302ec8d8">

**After:**
<img width="735" alt="image" src="https://github.com/user-attachments/assets/414df5d7-4f33-404c-9ebd-2703870cd9b2">