### PR TITLE
feat: Hide label option for select multiple

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
@@ -72,7 +72,9 @@ export const FlagsSelect: React.FC<Props> = (props) => {
       <SelectMultiple
         id="select-multiple-flags"
         key="select-multiple-flags"
+        hideLabel
         label="Flags (up to one per category)"
+        placeholder="Flags (up to one per category)"
         options={flatFlags}
         getOptionLabel={(flag) => flag.text}
         groupBy={(flag) => flag.category}

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -38,7 +38,7 @@ export interface Props<T, EditorExtraProps = {}> {
 
 const Item = styled(Box)(({ theme }) => ({
   display: "flex",
-  marginBottom: theme.spacing(1),
+  marginBottom: theme.spacing(2),
 }));
 
 export default function ListManager<T, EditorExtraProps>(

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -8,6 +8,7 @@ import { inputLabelClasses } from "@mui/material/InputLabel";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 import { styled } from "@mui/material/styles";
 import TextField from "@mui/material/TextField";
+import { visuallyHidden } from "@mui/utils";
 import React from "react";
 import { borderedFocusStyle } from "theme";
 
@@ -29,23 +30,32 @@ type OptionalAutocompleteProps<T> = Partial<
 
 type Props<T> = {
   label: string;
+  hideLabel?: boolean;
+  placeholder?: string;
 } & RequiredAutocompleteProps<T> &
   OptionalAutocompleteProps<T>;
 
-const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
-  marginTop: theme.spacing(2),
-  "& > div > label": {
-    paddingRight: theme.spacing(3),
-  },
-  [`& .${autocompleteClasses.endAdornment}`]: {
-    top: "unset",
-  },
-  "&:focus-within": {
-    "& svg": {
-      color: "black",
+interface CustomAutocompleteProps<T>
+  extends AutocompleteProps<T, true, true, false, "div"> {
+  hideLabel?: boolean;
+}
+
+const StyledAutocomplete = styled(Autocomplete)<CustomAutocompleteProps<any>>(
+  ({ theme, hideLabel }) => ({
+    ...(hideLabel ? {} : { marginTop: theme.spacing(2) }),
+    "& > div > label": {
+      paddingRight: theme.spacing(3),
     },
-  },
-})) as typeof Autocomplete;
+    [`& .${autocompleteClasses.endAdornment}`]: {
+      top: "unset",
+    },
+    "&:focus-within": {
+      "& svg": {
+        color: "black",
+      },
+    },
+  }),
+) as typeof Autocomplete;
 
 const StyledTextField = styled(TextField)(({ theme }) => ({
   "&:focus-within": {
@@ -103,7 +113,13 @@ export const CustomCheckbox = styled("span")(({ theme }) => ({
   },
 }));
 
-export function SelectMultiple<T>(props: Props<T>) {
+export function SelectMultiple<T>({
+  label,
+  hideLabel = false,
+  placeholder,
+  value = [],
+  ...props
+}: Props<T> & { value?: T[] }) {
   return (
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
       <StyledAutocomplete<T, true, true, false, "div">
@@ -114,14 +130,21 @@ export function SelectMultiple<T>(props: Props<T>) {
         disableCloseOnSelect
         multiple
         popupIcon={PopupIcon}
+        value={value}
+        hideLabel={hideLabel}
         renderInput={(params) => (
           <StyledTextField
             {...params}
             InputProps={{
               ...params.InputProps,
               notched: false,
+              placeholder: value.length === 0 ? placeholder : "",
             }}
-            label={props.label}
+            label={hideLabel ? "" : label}
+            InputLabelProps={{
+              ...params.InputLabelProps,
+              sx: hideLabel ? visuallyHidden : {},
+            }}
           />
         )}
         ChipProps={{


### PR DESCRIPTION
[Jess] Jumped on this one to rebase to `main` and debug type issues causing React build to fail.

Design change per Ian as requested by August: 
- Abilty for multi-select to have placeholder only instead of label when used in editor modal context (only applied to flags select, editor component tags & public file tagging keep label)
![Screenshot from 2024-11-12 20-00-41](https://github.com/user-attachments/assets/a192c6ec-95b5-4534-a508-82560049f93e)

