### PR TITLE
fix: correct legal disclaimer description in service settings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -120,7 +120,7 @@ export const FooterLinksAndLegalDisclaimer = () => {
       <SettingsSection background>
         <TextInput
           title="Legal Disclaimer"
-          description="Displayed before a user submits their application"
+          description="Displayed on the 'Result' pages of the service (if it contains any)"
           switchProps={{
             name: "elements.legalDisclaimer.show",
             checked: elementsForm.values.elements?.legalDisclaimer?.show,


### PR DESCRIPTION
The current description of the Legal Disclaimer section in the service settings is incorrect. Legal Disclaimers are part of and displayed on the Result component, which 1. can sit in non-submission services, 2. can be absent from submission services, and 3. can (as in the current use case of LDCs) sit nowhere near the submission.