### PR TITLE
feat: Use shared `Switch` component instead of MUISwitch directly

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -53,6 +53,10 @@
               "styled"
             ],
             "message": "Please import styled from '@mui/material/styles'. Reason: https://mui.com/system/styled/#what-problems-does-it-solve"
+          },
+          {
+            "name": "@mui/material/Switch",
+            "message": "Please import shared Switch component from 'ui/shared/Switch' instead of the MUI Switch component directly"
           }
         ],
         "patterns": [

--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -1,6 +1,4 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
 import { styled } from "@mui/material/styles";
-import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
@@ -12,6 +10,7 @@ import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 import type { Calculate } from "./model";
@@ -135,20 +134,16 @@ export default function Component(props: Props) {
             />
           </InputRow>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.formatOutputForAutomations}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "formatOutputForAutomations",
-                      !formik.values.formatOutputForAutomations,
-                    )
-                  }
-                />
-              }
-              label="Format the output to automate a future Question or Checklist only"
-            />
+          <Switch            
+            checked={formik.values.formatOutputForAutomations}
+            onChange={() =>
+              formik.setFieldValue(
+                "formatOutputForAutomations",
+                !formik.values.formatOutputForAutomations
+              )
+            }
+            label="Format the output to automate a future Question or Checklist only"
+          />
           </InputRow>
         </ModalSectionContent>
         <ModalSectionContent title="Formula">

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -3,7 +3,6 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import adjust from "ramda/src/adjust";
@@ -22,6 +21,7 @@ import SimpleMenu from "ui/editor/SimpleMenu";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import { Switch } from "ui/shared/Switch";
 
 import { Option, parseBaseNodeData } from "../shared";
 import { FlagsSelect } from "../shared/FlagsSelect";
@@ -368,52 +368,40 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
               />
             </InputRow>
             <InputRow>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={!!formik.values.groupedOptions}
-                    onChange={() =>
-                      formik.setValues({
-                        ...formik.values,
-                        ...toggleExpandableChecklist({
-                          options: formik.values.options,
-                          groupedOptions: formik.values.groupedOptions,
-                        }),
-                      })
-                    }
-                  />
-                }
-                label="Expandable"
-              />
+            <Switch
+              checked={!!formik.values.groupedOptions}
+              onChange={() =>
+                formik.setValues({
+                  ...formik.values,
+                  ...toggleExpandableChecklist({
+                    options: formik.values.options,
+                    groupedOptions: formik.values.groupedOptions,
+                  }),
+                })
+              }
+              label="Expandable"
+            />
             </InputRow>
             <InputRow>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formik.values.allRequired}
-                    onChange={() =>
-                      formik.setFieldValue(
-                        "allRequired",
-                        !formik.values.allRequired,
-                      )
-                    }
-                  />
+              <Switch
+                checked={formik.values.allRequired}
+                onChange={() =>
+                  formik.setFieldValue(
+                    "allRequired",
+                    !formik.values.allRequired,
+                  )
                 }
-                label="All required"
-              />
+              label="All required"
+            />
             </InputRow>
             <InputRow>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formik.values.neverAutoAnswer}
-                    onChange={() =>
-                      formik.setFieldValue(
-                        "neverAutoAnswer",
-                        !formik.values.neverAutoAnswer,
-                      )
-                    }
-                  />
+              <Switch
+                checked={formik.values.neverAutoAnswer}
+                onChange={() => 
+                  formik.setFieldValue(
+                    "neverAutoAnswer",
+                    !formik.values.neverAutoAnswer
+                  )
                 }
                 label="Always put to user (forgo automation)"
               />

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
@@ -11,6 +9,7 @@ import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 import type { DrawBoundary } from "./model";
@@ -99,17 +98,13 @@ function DrawBoundaryComponent(props: Props) {
             />
           </InputRow>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.hideFileUpload}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "hideFileUpload",
-                      !formik.values.hideFileUpload,
-                    )
-                  }
-                />
+            <Switch
+              checked={formik.values.hideFileUpload}
+              onChange={() =>
+                formik.setFieldValue(
+                  "hideFileUpload",
+                  !formik.values.hideFileUpload,
+                )
               }
               label="Hide file upload and allow user to continue without data"
             />

--- a/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/shared/icons";
 import { EditorProps } from "@planx/components/shared/types";
@@ -13,6 +11,7 @@ import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import {
   descriptionPlaceholder,
@@ -96,17 +95,13 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
               </InputLabel>
             </InputRow>
             <InputRow>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formik.values.feedbackRequired}
-                    onChange={() =>
-                      formik.setFieldValue(
-                        "feedbackRequired",
-                        !formik.values.feedbackRequired,
-                      )
-                    }
-                  />
+              <Switch
+                checked={formik.values.feedbackRequired}
+                onChange={() =>
+                  formik.setFieldValue(
+                    "feedbackRequired",
+                    !formik.values.feedbackRequired,
+                  )
                 }
                 label="Feedback required"
               />

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -1,10 +1,8 @@
 import RuleIcon from "@mui/icons-material/Rule";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
-import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
@@ -24,6 +22,7 @@ import SelectInput from "ui/editor/SelectInput/SelectInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 import {
@@ -90,17 +89,13 @@ function FileUploadAndLabelComponent(props: Props) {
             />
           </InputRow>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.hideDropZone}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "hideDropZone",
-                      !formik.values.hideDropZone,
-                    )
-                  }
-                />
+            <Switch
+              checked={formik.values.hideDropZone}
+              onChange={() =>
+                formik.setFieldValue(
+                  "hideDropZone",
+                  !formik.values.hideDropZone,
+                )
               }
               label="Hide the drop zone and show files list for information only"
             />

--- a/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
@@ -12,6 +10,7 @@ import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 import type { FindProperty } from "./model";
@@ -58,17 +57,13 @@ function FindPropertyComponent(props: Props) {
         </ModalSectionContent>
         <ModalSectionContent>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.allowNewAddresses}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "allowNewAddresses",
-                      !formik.values.allowNewAddresses,
-                    )
-                  }
-                />
+            <Switch
+              checked={formik.values.allowNewAddresses}
+              onChange={() =>
+                formik.setFieldValue(
+                  "allowNewAddresses",
+                  !formik.values.allowNewAddresses,
+                )
               }
               label="Allow users to plot new addresses without a UPRN"
             />

--- a/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { Notice } from "@planx/components/Notice/model";
 import { parseNotice } from "@planx/components/Notice/model";
@@ -12,6 +10,7 @@ import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import { InternalNotes } from "../../../ui/editor/InternalNotes";
 import { MoreInformation } from "../../../ui/editor/MoreInformation/MoreInformation";
@@ -70,17 +69,13 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
             }}
           />
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={Boolean(props.value.resetButton)}
-                  onChange={() =>
-                    props.onChange({
-                      ...props.value,
-                      resetButton: !props.value.resetButton,
-                    })
-                  }
-                />
+            <Switch
+              checked={Boolean(props.value.resetButton)}
+              onChange={() =>
+                props.onChange({
+                  ...props.value,
+                  resetButton: !props.value.resetButton,
+                })
               }
               label="Reset to start of service"
             />

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { NumberInput } from "@planx/components/NumberInput/model";
 import { parseNumberInput } from "@planx/components/NumberInput/model";
@@ -14,6 +12,7 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 import InputRowLabel from "ui/shared/InputRowLabel";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 
@@ -75,30 +74,22 @@ export default function NumberInputComponent(props: Props): FCReturn {
             </InputRowItem>
           </InputRow>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.allowNegatives}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "allowNegatives",
-                      !formik.values.allowNegatives,
-                    )
-                  }
-                />
+            <Switch
+              checked={formik.values.allowNegatives}
+              onChange={() =>
+                formik.setFieldValue(
+                  "allowNegatives",
+                  !formik.values.allowNegatives,
+                )
               }
               label="Allow negative numbers to be input"
             />
           </InputRow>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.isInteger}
-                  onChange={() =>
-                    formik.setFieldValue("isInteger", !formik.values.isInteger)
-                  }
-                />
+            <Switch
+              checked={formik.values.isInteger}
+              onChange={() =>
+                formik.setFieldValue("isInteger", !formik.values.isInteger)
               }
               label="Only allow whole numbers"
             />

--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -2,7 +2,6 @@ import DataObjectIcon from "@mui/icons-material/DataObject";
 import Box from "@mui/material/Box";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Link from "@mui/material/Link";
-import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import {
   ComponentType as TYPES,
@@ -29,6 +28,7 @@ import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 import { EditorProps } from "../shared/types";
@@ -263,13 +263,9 @@ const Component: React.FC<Props> = (props: Props) => {
                 />
               </InputRow>
               <InputRow>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={values.hidePay}
-                      onChange={() => setFieldValue("hidePay", !values.hidePay)}
-                    />
-                  }
+                <Switch
+                  checked={values.hidePay}
+                  onChange={() => setFieldValue("hidePay", !values.hidePay)}
                   label="Hide the pay buttons and show fee for information only"
                 />
               </InputRow>
@@ -353,17 +349,13 @@ const Component: React.FC<Props> = (props: Props) => {
           <ModalSection>
             <ModalSectionContent title="Invite to Pay" Icon={ICONS[TYPES.Pay]}>
               <InputRow>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={values.allowInviteToPay}
-                      onChange={() =>
-                        setFieldValue(
-                          "allowInviteToPay",
-                          !values.allowInviteToPay,
-                        )
-                      }
-                    />
+                <Switch
+                  checked={values.allowInviteToPay}
+                  onChange={() =>
+                    setFieldValue(
+                      "allowInviteToPay",
+                      !values.allowInviteToPay,
+                    )
                   }
                   label="Allow applicants to invite someone else to pay"
                 />

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
@@ -10,6 +8,7 @@ import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../shared/icons";
 import { parseContent, PropertyInformation } from "./model";
@@ -54,17 +53,13 @@ function PropertyInformationComponent(props: Props) {
             />
           </InputRow>
           <InputRow>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formik.values.showPropertyTypeOverride}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "showPropertyTypeOverride",
-                      !formik.values.showPropertyTypeOverride,
-                    )
-                  }
-                />
+            <Switch
+              checked={formik.values.showPropertyTypeOverride}
+              onChange={() =>
+                formik.setFieldValue(
+                  "showPropertyTypeOverride",
+                  !formik.values.showPropertyTypeOverride,
+                )
               }
               label="Show users a 'change' link to override the property type"
             />

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -1,5 +1,3 @@
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import React, { useEffect, useRef } from "react";
@@ -13,6 +11,7 @@ import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import { Switch } from "ui/shared/Switch";
 
 import { InternalNotes } from "../../../ui/editor/InternalNotes";
 import { MoreInformation } from "../../../ui/editor/MoreInformation/MoreInformation";
@@ -204,17 +203,13 @@ export const Question: React.FC<Props> = (props) => {
               />
             </InputRow>
             <InputRow>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formik.values.neverAutoAnswer}
-                    onChange={() =>
-                      formik.setFieldValue(
-                        "neverAutoAnswer",
-                        !formik.values.neverAutoAnswer,
-                      )
-                    }
-                  />
+              <Switch
+                checked={formik.values.neverAutoAnswer}
+                onChange={() =>
+                  formik.setFieldValue(
+                    "neverAutoAnswer",
+                    !formik.values.neverAutoAnswer,
+                  )
                 }
                 label="Always put to user (forgo automation)"
               />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -1,9 +1,6 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import FormControlLabel, {
-  formControlLabelClasses,
-} from "@mui/material/FormControlLabel";
-import Switch from "@mui/material/Switch";
+import { formControlLabelClasses } from "@mui/material/FormControlLabel";
 import Typography from "@mui/material/Typography";
 import type { FlowStatus } from "@opensystemslab/planx-core/types";
 import axios from "axios";
@@ -14,6 +11,7 @@ import { rootFlowPath } from "routes/utils";
 import { FONT_WEIGHT_BOLD } from "theme";
 import SettingsDescription from "ui/editor/SettingsDescription";
 import SettingsSection from "ui/editor/SettingsSection";
+import { Switch } from "ui/shared/Switch";
 
 import { useStore } from "../../../../lib/store";
 import { PublicLink } from "./PublicLink";
@@ -104,28 +102,25 @@ const FlowStatus = () => {
         </Typography>
       </SettingsSection>
       <SettingsSection background>
-        <FormControlLabel
-          label={statusForm.values.status}
-          sx={{
-            marginBottom: 0.5,
-            [`& .${formControlLabelClasses.label}`]: {
-              fontWeight: FONT_WEIGHT_BOLD,
-              textTransform: "capitalize",
-              fontSize: 19,
+        <Switch
+          label={statusForm.values.status as Capitalize<string>}
+          formControlLabelProps={{
+            sx: {
+              marginBottom: 0.5,
+              [`& .${formControlLabelClasses.label}`]: {
+                fontWeight: FONT_WEIGHT_BOLD,
+                textTransform: "capitalize",
+                fontSize: 19,
+              },
             },
+            name: "service.status",
           }}
-          control={
-            <Switch
-              name="service.status"
-              color="primary"
-              checked={statusForm.values.status === "online"}
-              onChange={() =>
-                statusForm.setFieldValue(
-                  "status",
-                  statusForm.values.status === "online" ? "offline" : "online",
-                )
-              }
-            />
+          checked={statusForm.values.status === "online"}
+          onChange={() =>
+            statusForm.setFieldValue(
+              "status",
+              statusForm.values.status === "online" ? "offline" : "online",
+            )
           }
         />
         <SettingsDescription>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -1,10 +1,12 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Switch, { SwitchProps } from "@mui/material/Switch";
+import { formControlLabelClasses } from "@mui/material/FormControlLabel";
+import { SwitchProps } from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
 import React from "react";
+import { FONT_WEIGHT_BOLD } from "theme";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
@@ -13,12 +15,13 @@ import SettingsSection from "ui/editor/SettingsSection";
 import Input, { Props as InputProps } from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
+import { Switch } from "ui/shared/Switch";
 
 import type { FlowSettings } from "../../../../../types";
 import { useStore } from "../../../lib/store";
 
 const TextInput: React.FC<{
-  title: string;
+  title: Capitalize<string>;
   richText?: boolean;
   description?: string;
   switchProps?: SwitchProps;
@@ -35,10 +38,22 @@ const TextInput: React.FC<{
   return (
     <Box width="100%">
       <Box mb={0.5} display="flex" alignItems="center">
-        <Switch {...switchProps} color="primary" />
-        <Typography variant="h4" component="h5">
-          {title}
-        </Typography>
+        <Switch
+          label={title}
+          formControlLabelProps={{
+            sx: {
+            marginBottom: 0.5,
+            [`& .${formControlLabelClasses.label}`]: {
+                fontWeight: FONT_WEIGHT_BOLD,
+                textTransform: "capitalize",
+                fontSize: 19,
+              },
+            },
+            name: switchProps?.name,
+          }}
+          onChange={switchProps?.onChange}
+          checked={switchProps?.checked}
+        />
       </Box>
       <Box mb={1}>
         {description && (

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -1,0 +1,24 @@
+import Box from "@mui/material/Box";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
+import React from "react";
+
+interface Props {
+  checked?: boolean;
+  onChange: MuiSwitchProps["onChange"];
+  label: Capitalize<string>
+}
+
+export const Switch: React.FC<Props> = ({ checked, onChange, label }) => (
+  <Box>
+    <FormControlLabel
+      control={
+        <MuiSwitch
+          checked={checked}
+          onChange={onChange}
+        />
+      }
+      label={label}
+    />
+  </Box>
+)

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import FormControlLabel, { FormControlLabelProps } from "@mui/material/FormControlLabel";
+// eslint-disable-next-line no-restricted-imports
 import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
 import React from "react";
 

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -1,5 +1,5 @@
 import Box from "@mui/material/Box";
-import FormControlLabel from "@mui/material/FormControlLabel";
+import FormControlLabel, { FormControlLabelProps } from "@mui/material/FormControlLabel";
 import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
 import React from "react";
 
@@ -7,9 +7,10 @@ interface Props {
   checked?: boolean;
   onChange: MuiSwitchProps["onChange"];
   label: Capitalize<string>
+  formControlLabelProps?: Partial<FormControlLabelProps>;
 }
 
-export const Switch: React.FC<Props> = ({ checked, onChange, label }) => (
+export const Switch: React.FC<Props> = ({ checked, onChange, label, formControlLabelProps }) => (
   <Box>
     <FormControlLabel
       control={
@@ -19,6 +20,7 @@ export const Switch: React.FC<Props> = ({ checked, onChange, label }) => (
         />
       }
       label={label}
+      {...formControlLabelProps}
     />
   </Box>
 )


### PR DESCRIPTION
## What does this PR do?
 - Makes a single `Switch` component, with label, to be used across PlanX
 - This stops repetition, and should help with drift in other components in future
 - Ensures just switch and label is clickable, not entire row
 - Adds `.eslint` rule to enforce that the shared component should be imported