### PR TITLE
fix: safer destructuring in `autoAnswerableOptions` to prevent error on initial editor load

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -501,9 +501,11 @@ export const previewStore: StateCreator<
    */
   autoAnswerableOptions: (id: NodeId) => {
     const { breadcrumbs, flow, computePassport } = get();
-    const { type, data, edges } = flow[id];
-    const { data: passportData } = computePassport();
 
+    const node = flow[id];
+    if (!node) return;
+
+    const { type, data, edges } = node;
     // Only Question & Checklist nodes that have an fn & edges are eligible for auto-answering
     if (
       !type ||
@@ -514,12 +516,14 @@ export const previewStore: StateCreator<
     )
       return;
 
+    const passport = computePassport();
+
     // Only proceed if the user has seen at least one node with this fn before
     const visitedFns = Object.entries(breadcrumbs).filter(
       ([nodeId, _breadcrumb]) =>
         flow[nodeId].data?.fn === data.fn ||
         // Account for nodes like FindProperty that don't have `data.fn` prop but still set passport vars like `property.region` etc
-        Object.keys(passportData || {}).includes(data.fn),
+        Object.keys(passport?.data || {}).includes(data.fn),
     );
     if (!visitedFns.length) return;
 
@@ -541,7 +545,7 @@ export const previewStore: StateCreator<
     let optionsThatCanBeAutoAnswered: Array<NodeId> = [];
 
     // Get existing passport value(s) for this node's fn
-    const passportValues = passportData?.[data.fn];
+    const passportValues = passport.data?.[data.fn];
 
     // If we have existing passport value(s) for this fn in an eligible automation format (eg not numbers or plain strings),
     //   then proceed through the matching option(s) or the blank option independent if other vals have been seen before
@@ -598,7 +602,7 @@ export const previewStore: StateCreator<
             flow[nodeId].type === TYPES.PlanningConstraints,
         )
       ) {
-        const nots: string[] | undefined = passportData?.["_nots"]?.[data.fn];
+        const nots: string[] | undefined = passport.data?.["_nots"]?.[data.fn];
         if (nots) visitedOptionVals = visitedOptionVals.concat(nots);
       }
 


### PR DESCRIPTION
It appears that when we're loading flows, we're sometimes attempting to run `autoAnswerableOptions` before the whole flow has loaded (eg on `_root` node rather than true current card??) leading to errors like the one screenshot below & reported by Ian Grace in #help-issues here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1731336388546549

This tries destructuring the single `node` first before immediately assuming it has `{ type, data, edges }` too, similar with passport to account for cases where it's empty (eg no `data` yet)
![Screenshot from 2024-11-11 16-33-56](https://github.com/user-attachments/assets/8a4b110d-d6d0-4df5-b7a3-f8fca9b26d3b)
