### PR TITLE
feat: Add multiline to text inputs

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -41,6 +41,7 @@ const OptionEditor: React.FC<OptionEditorProps> = (props) => {
           <Input
             required
             format="bold"
+            multiline
             value={props.value.data.text || ""}
             onChange={(ev) => {
               props.onChange({

--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -32,6 +32,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
         <Input
           required
           name="title"
+          multiline
           value={props.value.title}
           onChange={(ev: ChangeEvent<HTMLInputElement>) => {
             props.onChange({

--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -46,6 +46,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
         <Input
           name="description"
           value={props.value.description}
+          multiline
           onChange={(ev: ChangeEvent<HTMLInputElement>) => {
             props.onChange({
               ...props.value,

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -49,6 +49,7 @@ const OptionEditor: React.FC<{
         <Input
           required
           format="bold"
+          multiline
           value={props.value.data.text || ""}
           onChange={(ev) => {
             props.onChange({

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -79,6 +79,7 @@ const OptionEditor: React.FC<{
       <Input
         value={props.value.data.description || ""}
         placeholder="Description"
+        multiline
         onChange={(ev) => {
           props.onChange({
             ...props.value,

--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -41,6 +41,7 @@ const FlagEditor: React.FC<{
       <Box display="flex" flexDirection="column" gap={2} mt={2}>
         <InputLabel label="Heading">
           <Input
+            multiline
             value={existingOverrides?.heading ?? ""}
             onChange={(ev) =>
               props.onChange({ ...existingOverrides, heading: ev.target.value })

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -41,12 +41,7 @@ const Option: React.FC<any> = (props) => {
     <li
       className={classNames("card", "option", { wasVisited: props.wasVisited })}
     >
-      <Link
-        style={{ width: "200px" }}
-        href={href}
-        prefetch={false}
-        onClick={(e) => e.preventDefault()}
-      >
+      <Link href={href} prefetch={false} onClick={(e) => e.preventDefault()}>
         {props.data?.img && (
           <Thumbnail
             imageSource={props.data?.img}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -41,7 +41,12 @@ const Option: React.FC<any> = (props) => {
     <li
       className={classNames("card", "option", { wasVisited: props.wasVisited })}
     >
-      <Link href={href} prefetch={false} onClick={(e) => e.preventDefault()}>
+      <Link
+        style={{ width: "200px" }}
+        href={href}
+        prefetch={false}
+        onClick={(e) => e.preventDefault()}
+      >
         {props.data?.img && (
           <Thumbnail
             imageSource={props.data?.img}

--- a/editor.planx.uk/src/ui/shared/Input/Input.tsx
+++ b/editor.planx.uk/src/ui/shared/Input/Input.tsx
@@ -79,9 +79,9 @@ const StyledInputBase = styled(InputBase, {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
   }),
   [`&.${classes.multiline}`]: {
-    height: "auto",
+    height: "100%",
     "& textarea": {
-      padding: theme.spacing(1.5, 0),
+      padding: theme.spacing(1, 0),
       lineHeight: 1.6,
     },
   },


### PR DESCRIPTION
I have added the `multiline` prop to certain text inputs to allow multiline text in things like Options in Checkboxes.

Adjustment had to me made with the `textarea` component as it used a `height: auto` rather than a `height: 100%` the change hasn't broken any styling I could find, so hope its okay!

Tested by August here: https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1730291082584539
