### PR TITLE
feat: demo team integrations to fail gracefully

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor.tsx
@@ -1,6 +1,5 @@
 import DataObjectIcon from "@mui/icons-material/DataObject";
 import Box from "@mui/material/Box";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import {
@@ -352,10 +351,7 @@ const Component: React.FC<Props> = (props: Props) => {
                 <Switch
                   checked={values.allowInviteToPay}
                   onChange={() =>
-                    setFieldValue(
-                      "allowInviteToPay",
-                      !values.allowInviteToPay,
-                    )
+                    setFieldValue("allowInviteToPay", !values.allowInviteToPay)
                   }
                   label="Allow applicants to invite someone else to pay"
                 />

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -8,6 +8,7 @@ import type {
   PaymentStatus,
 } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
+import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
 import SaveResumeButton from "@planx/components/shared/Preview/SaveResumeButton";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
@@ -86,7 +87,11 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   yourDetailsLabel,
   paymentStatus,
 }) => {
-  const [sessionId, path] = useStore((state) => [state.sessionId, state.path]);
+  const [sessionId, path, teamSlug] = useStore((state) => [
+    state.sessionId,
+    state.path,
+    state.teamSlug,
+  ]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
@@ -252,15 +257,16 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
             no longer be able to make changes.
           </Typography>
         </WarningContainer>
-        {error ? (
-          <ErrorWrapper
-            error={"Error generating payment request, please try again"}
-          >
+        {teamSlug !== "demo" &&
+          (error ? (
+            <ErrorWrapper
+              error={"Error generating payment request, please try again"}
+            >
+              <SubmitButton />
+            </ErrorWrapper>
+          ) : (
             <SubmitButton />
-          </ErrorWrapper>
-        ) : (
-          <SubmitButton />
-        )}
+          ))}
       </StyledForm>
       <Button
         variant="contained"
@@ -272,6 +278,18 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
       >
         {"I want to pay for this application myself"}
       </Button>
+
+      {teamSlug === "demo" && (
+        <ErrorSummaryContainer mt={2}>
+          <Typography variant="h4" ml={2} mb={1}>
+            GOV.UK Pay is not configured for the Demo team
+          </Typography>
+          <Typography variant="body2" ml={2}>
+            You can click "I want to pay for this application myself" to
+            continue your application
+          </Typography>
+        </ErrorSummaryContainer>
+      )}
       {isSaveReturn && <SaveResumeButton />}
     </Card>
   );

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -8,7 +8,6 @@ import type {
   PaymentStatus,
 } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
-import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
 import SaveResumeButton from "@planx/components/shared/Preview/SaveResumeButton";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
@@ -87,11 +86,7 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   yourDetailsLabel,
   paymentStatus,
 }) => {
-  const [sessionId, path, teamSlug] = useStore((state) => [
-    state.sessionId,
-    state.path,
-    state.teamSlug,
-  ]);
+  const [sessionId, path] = useStore((state) => [state.sessionId, state.path]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
@@ -257,16 +252,15 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
             no longer be able to make changes.
           </Typography>
         </WarningContainer>
-        {teamSlug !== "demo" &&
-          (error ? (
-            <ErrorWrapper
-              error={"Error generating payment request, please try again"}
-            >
-              <SubmitButton />
-            </ErrorWrapper>
-          ) : (
+        {error ? (
+          <ErrorWrapper
+            error={"Error generating payment request, please try again"}
+          >
             <SubmitButton />
-          ))}
+          </ErrorWrapper>
+        ) : (
+          <SubmitButton />
+        )}
       </StyledForm>
       <Button
         variant="contained"
@@ -278,18 +272,6 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
       >
         {"I want to pay for this application myself"}
       </Button>
-
-      {teamSlug === "demo" && (
-        <ErrorSummaryContainer mt={2}>
-          <Typography variant="h4" ml={2} mb={1}>
-            GOV.UK Pay is not configured for the Demo team
-          </Typography>
-          <Typography variant="body2" ml={2}>
-            You can click "I want to pay for this application myself" to
-            continue your application
-          </Typography>
-        </ErrorSummaryContainer>
-      )}
       {isSaveReturn && <SaveResumeButton />}
     </Card>
   );

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -450,3 +450,31 @@ describe("Confirm component in information-only mode", () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+describe("the demo user view", () => {
+  beforeEach(() => {
+    act(() =>
+      setState({
+        teamSlug: "demo",
+      }),
+    );
+  });
+  it("should render an error when teamSlug is demo", async () => {
+    const handleSubmit = vi.fn();
+    const { queryByText } = setup(
+      <Pay
+        title="Pay for your application"
+        fn="application.fee.typo"
+        handleSubmit={handleSubmit}
+        govPayMetadata={[]}
+      />,
+    );
+    const errorHeader = queryByText("GOV.UK Pay is not enabled for demo users");
+    const errorGuidance = queryByText(
+      "Click continue to skip payment and proceed with your application for testing.",
+    );
+
+    expect(errorGuidance).toBeInTheDocument();
+    expect(errorHeader).toBeInTheDocument();
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -75,11 +75,6 @@ function Component(props: Props) {
 
   const metadata = [...(props.govPayMetadata || []), ...defaultMetadata];
 
-  const errorMessage =
-    teamSlug !== "demo"
-      ? "GOV.UK Pay is not enabled for this local authority"
-      : "GOV.UK Pay is not enabled demo users";
-
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {
     switch (action) {
@@ -302,7 +297,10 @@ function Component(props: Props) {
               : "Retry payment"
           }
           error={
-            (state.status === "unsupported_team" && errorMessage) ||
+            (teamSlug === "demo" &&
+              "GOV.UK Pay is not enabled for demo users") ||
+            (state.status === "unsupported_team" &&
+              "GOV.UK Pay is not enabled for this local authority") ||
             (state.status === "undefined_fee" &&
               "We are unable to calculate your fee right now") ||
             undefined

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -78,7 +78,7 @@ function Component(props: Props) {
   const errorMessage =
     teamSlug !== "demo"
       ? "GOV.UK Pay is not enabled for this local authority"
-      : "GOV.UK Pay is not enabled for the Demo team";
+      : "GOV.UK Pay is not enabled for services created in the Demo team";
 
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -78,7 +78,7 @@ function Component(props: Props) {
   const errorMessage =
     teamSlug !== "demo"
       ? "GOV.UK Pay is not enabled for this local authority"
-      : "GOV.UK Pay is not enabled for services created in the Demo team";
+      : "GOV.UK Pay is not enabled demo users";
 
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -41,8 +41,7 @@ enum Action {
   Success,
 }
 
-export const PAY_API_ERROR_UNSUPPORTED_TEAM =
-  "GOV.UK Pay is not enabled for this local authority";
+export const PAY_API_ERROR_UNSUPPORTED_TEAM = "GOV.UK Pay is not enabled for";
 
 function Component(props: Props) {
   const [
@@ -75,6 +74,11 @@ function Component(props: Props) {
   ];
 
   const metadata = [...(props.govPayMetadata || []), ...defaultMetadata];
+
+  const errorMessage =
+    teamSlug !== "demo"
+      ? "GOV.UK Pay is not enabled for this local authority"
+      : "GOV.UK Pay is not enabled for the Demo team";
 
   // Handles UI states
   const reducer = (_state: ComponentState, action: Action): ComponentState => {
@@ -113,6 +117,10 @@ function Component(props: Props) {
   });
 
   const handleError = useErrorHandler();
+
+  const isTeamSupported =
+    state.status !== "unsupported_team" && teamSlug !== "demo";
+  const showPayOptions = props.allowInviteToPay && !props.hidePay;
 
   useEffect(() => {
     // Auto-skip component when fee=0
@@ -294,17 +302,12 @@ function Component(props: Props) {
               : "Retry payment"
           }
           error={
-            (state.status === "unsupported_team" &&
-              "GOV.UK Pay is not enabled for this local authority") ||
+            (state.status === "unsupported_team" && errorMessage) ||
             (state.status === "undefined_fee" &&
               "We are unable to calculate your fee right now") ||
             undefined
           }
-          showInviteToPay={
-            props.allowInviteToPay &&
-            !props.hidePay &&
-            state.status !== "unsupported_team"
-          }
+          showInviteToPay={showPayOptions && isTeamSupported}
           paymentStatus={govUkPayment?.state?.status}
           hidePay={props.hidePay}
         />

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
@@ -40,7 +40,7 @@ vi.mock("swr", () => ({
 }));
 
 describe("error state", () => {
-  it("renders an error if no addres is present in the passport", async () => {
+  it("renders an error if no address is present in the passport", async () => {
     const { getByRole, getByTestId } = setup(
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <PlanningConstraints
@@ -238,5 +238,49 @@ describe("following a FindProperty component", () => {
 
     expect(negativeConstraintsContainer).toBeVisible();
     expect(getByRole("heading", { name: /Ecology/ })).toBeVisible();
+  });
+});
+
+describe("demo state", () => {
+  beforeEach(() => {
+    act(() =>
+      setState({
+        breadcrumbs: simpleBreadcrumbs,
+        flow: simpleFlow,
+        teamIntegrations: {
+          hasPlanningData: false,
+        },
+        teamSlug: "demo",
+      }),
+    );
+  });
+  it("should render an error when teamSlug is demo", async () => {
+    const handleSubmit = vi.fn();
+    const { queryByText, queryByRole, user, getByTestId } = setup(
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <PlanningConstraints
+          title="Planning constraints"
+          description="Things that might affect your project"
+          fn="property.constraints.planning"
+          disclaimer="This page does not include information about historic planning conditions that may apply to this property."
+          handleSubmit={handleSubmit}
+        />
+      </ErrorBoundary>,
+    );
+
+    const errorMessage = queryByText(
+      "Planning Constraints are not enabled for demo users.",
+    );
+    expect(errorMessage).toBeVisible();
+
+    // Check planning constraints has not rendered
+    expect(
+      queryByRole("heading", { name: "Planning constraints" }),
+    ).not.toBeInTheDocument();
+
+    // Ensure a demo user can continue on in the application
+    await user.click(getByTestId("continue-button"));
+
+    expect(handleSubmit).toHaveBeenCalled();
   });
 });

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
@@ -269,13 +269,17 @@ describe("demo state", () => {
     );
 
     const errorMessage = queryByText(
-      "Planning Constraints are not enabled for demo users.",
+      "Planning Constraints are not enabled for demo users",
     );
     expect(errorMessage).toBeVisible();
 
     // Check planning constraints has not rendered
+    // reused positive constraints from basic layout test
     expect(
-      queryByRole("heading", { name: "Planning constraints" }),
+      queryByRole("heading", { name: /These are the planning constraints/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole("button", { name: /Parks and gardens/ }),
     ).not.toBeInTheDocument();
 
     // Ensure a demo user can continue on in the application

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -214,13 +214,17 @@ function Component(props: Props) {
   if (teamSlug === "demo") {
     return (
       <Card handleSubmit={props.handleSubmit}>
+        <CardHeader title={props.title} />
         <ErrorSummaryContainer role="status">
           <Typography variant="h4" ml={2} mb={1}>
-            Planning Constraints are not enabled for demo users.
+            Planning Constraints are not enabled for demo users
           </Typography>
           <Typography variant="body2" ml={2}>
-            Click continue to skip planning constraints and proceed with your
-            application for testing.
+            Since we cannot automatically check constraints, you might be asked
+            additional questions about your project.
+          </Typography>
+          <Typography variant="body2" ml={2} mt={0.5}>
+            Click continue to proceed with your application.
           </Typography>
         </ErrorSummaryContainer>
       </Card>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -216,12 +216,11 @@ function Component(props: Props) {
       <Card handleSubmit={props.handleSubmit}>
         <ErrorSummaryContainer role="status">
           <Typography variant="h4" ml={2} mb={1}>
-            Planning Constraints are not enabled for services created in the
-            Demo team
+            Planning Constraints are not enabled for demo users.
           </Typography>
           <Typography variant="body2" ml={2}>
             Click continue to skip planning constraints and proceed with your
-            application for testing
+            application for testing.
           </Typography>
         </ErrorSummaryContainer>
       </Card>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.tsx
@@ -1,3 +1,4 @@
+import Typography from "@mui/material/Typography";
 import type {
   EnhancedGISResponse,
   GISResponse,
@@ -13,6 +14,7 @@ import useSWR, { Fetcher } from "swr";
 import { stringify } from "wkt";
 
 import { SiteAddress } from "../FindProperty/model";
+import { ErrorSummaryContainer } from "../shared/Preview/ErrorSummaryContainer";
 import {
   type IntersectingConstraints,
   type PlanningConstraints,
@@ -208,6 +210,23 @@ function Component(props: Props) {
       data: passportData,
     });
   };
+
+  if (teamSlug === "demo") {
+    return (
+      <Card handleSubmit={props.handleSubmit}>
+        <ErrorSummaryContainer role="status">
+          <Typography variant="h4" ml={2} mb={1}>
+            Planning Constraints are not enabled for services created in the
+            Demo team
+          </Typography>
+          <Typography variant="body2" ml={2}>
+            Click continue to skip planning constraints and proceed with your
+            application for testing
+          </Typography>
+        </ErrorSummaryContainer>
+      </Card>
+    );
+  }
 
   const isLoading = isValidating || isValidatingRoads;
   if (isLoading)

--- a/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
@@ -210,3 +210,45 @@ it("should not have any accessibility violations", async () => {
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });
+
+describe("demo state", () => {
+  beforeEach(() => {
+    act(() =>
+      setState({
+        teamSlug: "demo",
+      }),
+    );
+  });
+  it("should render an error when teamSlug is demo", async () => {
+    const { queryByText } = setup(
+      <SendComponent title="Send" destinations={["bops", "uniform"]} />,
+    );
+
+    const errorHeader = queryByText(
+      "Send is not enabled for services created in the Demo team",
+    );
+    const errorGuidance = queryByText(
+      "Click continue to skip send and proceed with your application for testing.",
+    );
+
+    expect(errorHeader).toBeInTheDocument();
+    expect(errorGuidance).toBeInTheDocument();
+  });
+  it("should allow the user to continue with their application", async () => {
+    const handleSubmit = vi.fn();
+
+    const { findByRole, user } = setup(
+      <SendComponent
+        title="Send"
+        destinations={["bops", "uniform"]}
+        handleSubmit={handleSubmit}
+      />,
+    );
+
+    const continueButton = await findByRole("button", { name: "Continue" });
+    expect(continueButton).toBeInTheDocument();
+
+    await user.click(continueButton);
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -9,6 +9,7 @@ import { useAsync } from "react-use";
 import { AsyncState } from "react-use/lib/useAsyncFn";
 
 import Card from "../shared/Preview/Card";
+import { ErrorSummaryContainer } from "../shared/Preview/ErrorSummaryContainer";
 import { WarningContainer } from "../shared/Preview/WarningContainer";
 import { PublicProps } from "../shared/types";
 import { DEFAULT_DESTINATION, getCombinedEventsPayload, Send } from "./model";
@@ -31,6 +32,8 @@ const SendComponent: React.FC<Props> = ({
     window.location.pathname.endsWith("/preview")
   ) {
     return <SkipSendWarning {...fullProps} />;
+  } else if (window.location.pathname.split("/")[1] === "demo") {
+    return <DemoTeamWarning />;
   } else {
     return <CreateSendEvents {...fullProps} />;
   }
@@ -49,6 +52,20 @@ const SkipSendWarning: React.FC<Props> = (props) => (
         and skip submission.
       </Typography>
     </WarningContainer>
+  </Card>
+);
+
+const DemoTeamWarning: React.FC = () => (
+  <Card>
+    <ErrorSummaryContainer role="status">
+      <Typography variant="h4" ml={2} mb={1}>
+        The send component is not configured for the Demo team
+      </Typography>
+      <Typography variant="body2" ml={2}>
+        Integrations need to be configured to allow submissions to be sent from
+        PlanX
+      </Typography>
+    </ErrorSummaryContainer>
   </Card>
 );
 

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -26,13 +26,14 @@ const SendComponent: React.FC<Props> = ({
   destinations = [DEFAULT_DESTINATION],
   ...props
 }) => {
+  const teamSlug = useStore().teamSlug;
   const fullProps = { destinations: destinations, ...props };
   if (
     window.location.pathname.endsWith("/draft") ||
     window.location.pathname.endsWith("/preview")
   ) {
     return <SkipSendWarning {...fullProps} />;
-  } else if (window.location.pathname.split("/")[1] === "demo") {
+  } else if (teamSlug === "demo") {
     return <DemoTeamWarning {...fullProps} />;
   } else {
     return <CreateSendEvents {...fullProps} />;

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -33,7 +33,7 @@ const SendComponent: React.FC<Props> = ({
   ) {
     return <SkipSendWarning {...fullProps} />;
   } else if (window.location.pathname.split("/")[1] === "demo") {
-    return <DemoTeamWarning />;
+    return <DemoTeamWarning {...fullProps} />;
   } else {
     return <CreateSendEvents {...fullProps} />;
   }
@@ -55,15 +55,15 @@ const SkipSendWarning: React.FC<Props> = (props) => (
   </Card>
 );
 
-const DemoTeamWarning: React.FC = () => (
-  <Card>
+const DemoTeamWarning: React.FC<Props> = (props) => (
+  <Card handleSubmit={props.handleSubmit}>
     <ErrorSummaryContainer role="status">
       <Typography variant="h4" ml={2} mb={1}>
-        The send component is not configured for the Demo team
+        Send is disabled for the Demo team
       </Typography>
       <Typography variant="body2" ml={2}>
-        Integrations need to be configured to allow submissions to be sent from
-        PlanX
+        Team integrations need to be configured to allow submissions to be sent
+        from PlanX
       </Typography>
     </ErrorSummaryContainer>
   </Card>

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -59,7 +59,7 @@ const DemoTeamWarning: React.FC<Props> = (props) => (
   <Card handleSubmit={props.handleSubmit}>
     <ErrorSummaryContainer role="status">
       <Typography variant="h4" ml={2} mb={1}>
-        Send is disabled for the Demo team
+        Send is not enabled for services created in the Demo team
       </Typography>
       <Typography variant="body2" ml={2}>
         Team integrations need to be configured to allow submissions to be sent

--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -62,8 +62,8 @@ const DemoTeamWarning: React.FC<Props> = (props) => (
         Send is not enabled for services created in the Demo team
       </Typography>
       <Typography variant="body2" ml={2}>
-        Team integrations need to be configured to allow submissions to be sent
-        from PlanX
+        Click continue to skip send and proceed with your application for
+        testing.
       </Typography>
     </ErrorSummaryContainer>
   </Card>


### PR DESCRIPTION
Adding some failure screens with Send Components and Planning Constraints to gracefully catch errors and inform the `demoUsers` of certain restrictions in the Public interface, rather than the Editor one. Found this better as it would still show our range of components (things like Planning Constraints) while removing a potentially confusing experience for users.

For demoUsers, they may still see these components normally when in other teams, like ODP, but they just can't see them when they are within the Demo team.

This is because for the Public interface of the components, we don't have access to a User object which would help us manage it specifically for a `demoUser` role which sits within the `teams` section of a `user` object, as it is applied to the `team_members` table.

Feedback on this component has been given here: https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1731576342896299
