### PR TITLE
feat: Display feedback score in feedback log

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Editor/FeedbackEditor.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Editor/FeedbackEditor.stories.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { FeedbackEditor } from "./Editor";
 
 const meta = {
-  title: "Editor Components/Feedback",
+  title: "Editor Components/Feedback modal",
   component: FeedbackEditor,
 } satisfies Meta<typeof FeedbackEditor>;
 

--- a/editor.planx.uk/src/components/Feedback/types.ts
+++ b/editor.planx.uk/src/components/Feedback/types.ts
@@ -21,6 +21,7 @@ export type FeedbackCategory =
   | "comment"
   | "inaccuracy"
   | "component";
+
 export type FeedbackView = "banner" | "triage" | FeedbackCategory | "thanks";
 export type ClickEvents = "close" | "back" | "triage" | FeedbackCategory;
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -52,6 +52,9 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
                   <TableCell sx={{ width: 100 }}>
                     <strong>Date</strong>
                   </TableCell>
+                  <TableCell sx={{ width: 140 }}>
+                    <strong>Feedback score</strong>
+                  </TableCell>
                   <TableCell sx={{ width: 340 }}>
                     <strong>Comment</strong>
                   </TableCell>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -126,6 +126,17 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
     userContext: "What were you doing?",
   };
 
+  enum EmojiRating {
+    Terrible,
+    Poor,
+    Average,
+    Good,
+    Excellent,
+  }
+
+  const feedbackScore =
+    item.feedbackScore && EmojiRating[parseInt(item.feedbackScore) + 1]; // enums are 0-indexed
+
   const renderContent = (key: string, value: any) => {
     if (key === "combinedHelp" && value) {
       return <ReactMarkdownOrHtml source={value} openLinksOnNewTab />;
@@ -144,6 +155,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
         <TableCell>
           {format(new Date(item.createdAt), "dd/MM/yy hh:mm:ss")}
         </TableCell>
+        <TableCell sx={{ textAlign: "center" }}>{feedbackScore}</TableCell>
         <TableCell>{commentSummary}</TableCell>
         <TableCell sx={{ textAlign: "right" }}>
           <IconButton

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -135,7 +135,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
   }
 
   const feedbackScore =
-    item.feedbackScore && EmojiRating[parseInt(item.feedbackScore) + 1]; // enums are 0-indexed
+    item.feedbackScore && EmojiRating[item.feedbackScore + 1]; // enums are 0-indexed
 
   const renderContent = (key: string, value: any) => {
     if (key === "combinedHelp" && value) {

--- a/editor.planx.uk/src/routes/feedback.tsx
+++ b/editor.planx.uk/src/routes/feedback.tsx
@@ -18,6 +18,7 @@ export interface Feedback {
   nodeTitle: string | null;
   nodeType: keyof typeof ComponentType | null;
   userComment: string | null;
+  feedbackScore: string | null;
   userContext: string | null;
   createdAt: string;
   address: string | null;
@@ -43,7 +44,7 @@ const feedbackRoutes = compose(
         data: { feedback },
       } = await client.query<{ feedback: Feedback[] }>({
         query: gql`
-          query GetFeebackForFlow($teamSlug: String!, $flowSlug: String!) {
+          query GetFeedbackForFlow($teamSlug: String!, $flowSlug: String!) {
             feedback: feedback_summary(
               order_by: { created_at: asc }
               where: {
@@ -57,6 +58,7 @@ const feedbackRoutes = compose(
               nodeType: node_type
               userComment: user_comment
               userContext: user_context
+              feedbackScore: feedback_score
               createdAt: created_at
               address
             }

--- a/editor.planx.uk/src/routes/feedback.tsx
+++ b/editor.planx.uk/src/routes/feedback.tsx
@@ -18,7 +18,7 @@ export interface Feedback {
   nodeTitle: string | null;
   nodeType: keyof typeof ComponentType | null;
   userComment: string | null;
-  feedbackScore: string | null;
+  feedbackScore: number;
   userContext: string | null;
   createdAt: string;
   address: string | null;

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -305,15 +305,17 @@
     - role: demoUser
       permission:
         columns:
-          - feedback_id
-          - device
-          - node_data
           - address
+          - created_at
+          - device
+          - feedback_id
+          - feedback_score
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
+          - node_data
           - node_id
           - node_text
           - node_title
@@ -325,7 +327,6 @@
           - uprn
           - user_comment
           - user_context
-          - created_at
         filter:
           team:
             flows:
@@ -335,15 +336,17 @@
     - role: platformAdmin
       permission:
         columns:
-          - feedback_id
-          - device
-          - node_data
           - address
+          - created_at
+          - device
+          - feedback_id
+          - feedback_score
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
+          - node_data
           - node_id
           - node_text
           - node_title
@@ -355,21 +358,22 @@
           - uprn
           - user_comment
           - user_context
-          - created_at
         filter: {}
       comment: ""
     - role: teamEditor
       permission:
         columns:
-          - feedback_id
-          - device
-          - node_data
           - address
+          - created_at
+          - device
+          - feedback_id
+          - feedback_score
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
+          - node_data
           - node_id
           - node_text
           - node_title
@@ -381,7 +385,6 @@
           - uprn
           - user_comment
           - user_context
-          - created_at
         filter:
           team:
             members:

--- a/hasura.planx.uk/migrations/1730991162717_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1730991162717_run_sql_migration/down.sql
@@ -1,0 +1,29 @@
+-- Drop the existing feedback_summary view
+DROP VIEW IF EXISTS public.feedback_summary;
+
+-- Recreate the feedback_summary view without feedback_score
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS
+ SELECT fb.id AS feedback_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,
+    COALESCE((fb.node_data ->> 'title'::text), (fb.node_data ->> 'text'::text), (fb.node_data ->> 'flagSet'::text)) AS node_title,
+    (fb.node_data ->> 'description'::text) AS node_text,
+    (fb.node_data ->> 'info'::text) AS help_text,
+    (fb.node_data ->> 'policyRef'::text) AS help_sources,
+    (fb.node_data ->> 'howMeasured'::text) AS help_definition,
+    COALESCE(((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'uprn'::text) AS uprn,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'proposal.projectType'::text) AS project_type,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'property.constraints.planning'::text) AS intersecting_constraints
+   FROM ((feedback fb
+     LEFT JOIN flows f ON ((f.id = fb.flow_id)))
+     LEFT JOIN teams t ON ((t.id = fb.team_id)));

--- a/hasura.planx.uk/migrations/1730991162717_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1730991162717_run_sql_migration/up.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS 
+ SELECT fb.id AS feedback_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,
+    COALESCE((fb.node_data ->> 'title'::text), (fb.node_data ->> 'text'::text), (fb.node_data ->> 'flagSet'::text)) AS node_title,
+    (fb.node_data ->> 'description'::text) AS node_text,
+    (fb.node_data ->> 'info'::text) AS help_text,
+    (fb.node_data ->> 'policyRef'::text) AS help_sources,
+    (fb.node_data ->> 'howMeasured'::text) AS help_definition,
+    COALESCE(((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'uprn'::text) AS uprn,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'proposal.projectType'::text) AS project_type,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'property.constraints.planning'::text) AS intersecting_constraints,
+    fb.feedback_score
+   FROM ((feedback fb
+     LEFT JOIN flows f ON ((f.id = fb.flow_id)))
+     LEFT JOIN teams t ON ((t.id = fb.team_id)));


### PR DESCRIPTION
### In this PR:

- Added column in feedback log for feedback score
- Added 'feedback from component' as a feedback type that can be displayed in the log
- This involved updating the `feedback_summary` table to copy across the `feedbackScore` from the `feedback` table.

![Screenshot 2024-11-07 at 16 18 02](https://github.com/user-attachments/assets/3966e0bc-2a9a-49a3-a00a-941ffe801313)
