### PR TITLE
feat: Allow `SelectMultiple` to have either a `label` or `placeholder` prop

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
@@ -72,7 +72,7 @@ export const FlagsSelect: React.FC<Props> = (props) => {
       <SelectMultiple
         id="select-multiple-flags"
         key="select-multiple-flags"
-        label="Flags (up to one per category)"
+        placeholder="Flags (up to one per category)"
         options={flatFlags}
         getOptionLabel={(flag) => flag.text}
         groupBy={(flag) => flag.category}

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -38,7 +38,7 @@ export interface Props<T, EditorExtraProps = {}> {
 
 const Item = styled(Box)(({ theme }) => ({
   display: "flex",
-  marginBottom: theme.spacing(1),
+  marginBottom: theme.spacing(2),
 }));
 
 export default function ListManager<T, EditorExtraProps>(

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -27,10 +27,19 @@ type OptionalAutocompleteProps<T> = Partial<
   Omit<AutocompleteProps<T, true, true, false, "div">, "multiple">
 >;
 
-type Props<T> = {
+type WithLabel<T> = {
   label: string;
+  placeholder?: never;
 } & RequiredAutocompleteProps<T> &
   OptionalAutocompleteProps<T>;
+
+type WithPlaceholder<T> = {
+  label?: never;
+  placeholder: string;
+} & RequiredAutocompleteProps<T> &
+  OptionalAutocompleteProps<T>;
+
+type Props<T> = WithLabel<T> | WithPlaceholder<T>;
 
 const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
   marginTop: theme.spacing(2),
@@ -120,6 +129,7 @@ export function SelectMultiple<T>(props: Props<T>) {
             InputProps={{
               ...params.InputProps,
               notched: false,
+              placeholder: props?.placeholder
             }}
             label={props.label}
           />

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -42,7 +42,6 @@ type WithPlaceholder<T> = {
 type Props<T> = WithLabel<T> | WithPlaceholder<T>;
 
 const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
-  marginTop: theme.spacing(2),
   "& > div > label": {
     paddingRight: theme.spacing(3),
   },
@@ -113,9 +112,14 @@ export const CustomCheckbox = styled("span")(({ theme }) => ({
 }));
 
 export function SelectMultiple<T>(props: Props<T>) {
+  // MUI doesn't pass the Autocomplete value along to the TextField automatically
+  const isSelectEmpty = !props.value?.length;
+  const placeholder = isSelectEmpty ? props.placeholder : undefined
+
   return (
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
       <StyledAutocomplete<T, true, true, false, "div">
+        sx={{ mt: props.label ? 2 : 0 }}
         role="status"
         aria-atomic={true}
         aria-live="polite"
@@ -129,9 +133,9 @@ export function SelectMultiple<T>(props: Props<T>) {
             InputProps={{
               ...params.InputProps,
               notched: false,
-              placeholder: props?.placeholder
             }}
             label={props.label}
+            placeholder={placeholder}
           />
         )}
         ChipProps={{


### PR DESCRIPTION
Alternate implementation of https://github.com/theopensystemslab/planx-new/pull/3927

Visually the same, but relies on more simplified and strict type checking in the component to allow either `label` or `placeholder` to be passed as props.

https://github.com/user-attachments/assets/5a36014a-a5f4-402a-9e25-d41d4c93fced

