### PR TITLE
fix: Always center flows on load

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/EndPoint.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/EndPoint.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import {
-  Link,
-  useCurrentRoute,
-  useLoadingRoute,
-  useNavigation,
-} from "react-navi";
+import { Link, useLoadingRoute } from "react-navi";
 import scrollIntoView from "scroll-into-view-if-needed";
 
 import { rootFlowPath } from "../../../../../routes/utils";

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/EndPoint.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/EndPoint.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useRef } from "react";
-import { Link } from "react-navi";
+import {
+  Link,
+  useCurrentRoute,
+  useLoadingRoute,
+  useNavigation,
+} from "react-navi";
 import scrollIntoView from "scroll-into-view-if-needed";
 
 import { rootFlowPath } from "../../../../../routes/utils";
@@ -14,24 +19,29 @@ const EndPoint: React.FC<{ text: string }> = ({ text }) => {
 
   const href = rootFlowPath(false);
 
+  const currentPath = rootFlowPath(true);
+  const isLoading = useLoadingRoute();
+
   useEffect(() => {
     if (isStart && el.current) {
+      if (isLoading) return;
+
       scrollIntoView(
         el.current,
         flowLayout === FlowLayout.TOP_DOWN
           ? {
-              scrollMode: "if-needed",
+              scrollMode: "always",
               block: "nearest",
               inline: "center",
             }
           : {
-              scrollMode: "if-needed",
+              scrollMode: "always",
               block: "center",
               inline: "nearest",
             },
       );
     }
-  }, [flowLayout, isStart]);
+  }, [flowLayout, isStart, currentPath, isLoading]);
 
   return (
     <li


### PR DESCRIPTION
## What does this PR do?
 - Ensures flow is always centered, after load
 - Alternate implementation of https://github.com/theopensystemslab/planx-new/pull/3854/files#r1816927924
 - This does not change or remove the current session storage of x and y values, looking at this separately 

Following https://github.com/theopensystemslab/planx-new/pull/3854 there was some valuable feedback on how this _should_ behave which I'll pick up in follow up PRs.