### PR TITLE
feat: add a flow description settings section

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@airbrake/node": "^2.1.8",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#706410d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccf9ac3",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "aws-sdk": "^2.1467.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -6308,8 +6308,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/706410d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/706410d}
+  github.com/theopensystemslab/planx-core/ccf9ac3:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccf9ac3}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^2.1.8
     version: 2.1.8
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#706410d
-    version: github.com/theopensystemslab/planx-core/706410d
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccf9ac3
+    version: github.com/theopensystemslab/planx-core/ccf9ac3
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#706410d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccf9ac3",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -2877,8 +2877,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/706410d:
-    resolution: {commit: 706410d, repo: git+ssh://git@github.com/theopensystemslab/planx-core.git, type: git}
+  github.com/theopensystemslab/planx-core/ccf9ac3:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccf9ac3}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#706410d
-    version: github.com/theopensystemslab/planx-core/706410d
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccf9ac3
+    version: github.com/theopensystemslab/planx-core/ccf9ac3
   axios:
     specifier: ^1.7.4
     version: 1.7.4

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#706410d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccf9ac3",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#706410d
-    version: github.com/theopensystemslab/planx-core/706410d
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccf9ac3
+    version: github.com/theopensystemslab/planx-core/ccf9ac3
   axios:
     specifier: ^1.7.4
     version: 1.7.4

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -2652,8 +2652,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/706410d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/706410d}
+  github.com/theopensystemslab/planx-core/ccf9ac3:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccf9ac3}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d9fc4a0",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ccf9ac3",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#706410d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d9fc4a0",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -15433,9 +15433,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/706410d(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/706410d}
-    id: github.com/theopensystemslab/planx-core/706410d
+  github.com/theopensystemslab/planx-core/ccf9ac3(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ccf9ac3}
+    id: github.com/theopensystemslab/planx-core/ccf9ac3
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -47,10 +47,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#706410d
-    version: github.com/theopensystemslab/planx-core/706410d(@types/react@18.2.45)
-    specifier: git+https://github.com/theopensystemslab/planx-core#d9fc4a0
-    version: github.com/theopensystemslab/planx-core/d9fc4a0(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#ccf9ac3
+    version: github.com/theopensystemslab/planx-core/ccf9ac3(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -49,6 +49,8 @@ dependencies:
   '@opensystemslab/planx-core':
     specifier: git+https://github.com/theopensystemslab/planx-core#706410d
     version: github.com/theopensystemslab/planx-core/706410d(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#d9fc4a0
+    version: github.com/theopensystemslab/planx-core/d9fc4a0(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowDescription/FlowDescription.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowDescription/FlowDescription.tsx
@@ -15,6 +15,7 @@ const FlowDescription = () => {
     state.flowDescription,
     state.updateFlowDescription,
   ]);
+
   const toast = useToast();
 
   const formik = useFormik<{ description: string }>({
@@ -34,6 +35,9 @@ const FlowDescription = () => {
         );
       }
     },
+    validateOnBlur: false,
+    validateOnChange: false,
+    enableReinitialize: true,
   });
 
   return (
@@ -59,6 +63,7 @@ const FlowDescription = () => {
           <>
             <InputLabel label="Description" htmlFor="description">
               <Input
+                multiline
                 name="description"
                 onChange={(event) => {
                   formik.setFieldValue("description", event.target.value);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowDescription/FlowDescription.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowDescription/FlowDescription.tsx
@@ -1,0 +1,78 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { useFormik } from "formik";
+import { useToast } from "hooks/useToast";
+import React from "react";
+import InputLabel from "ui/editor/InputLabel";
+import SettingsSection from "ui/editor/SettingsSection";
+import Input from "ui/shared/Input/Input";
+
+import { useStore } from "../../../../lib/store";
+import { SettingsForm } from "../../shared/SettingsForm";
+
+const FlowDescription = () => {
+  const [flowDescription, updateFlowDescription] = useStore((state) => [
+    state.flowDescription,
+    state.updateFlowDescription,
+  ]);
+  const toast = useToast();
+
+  const formik = useFormik<{ description: string }>({
+    initialValues: {
+      description: flowDescription || "",
+    },
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await updateFlowDescription(values.description);
+      if (isSuccess) {
+        toast.success("Description updated successfully");
+        resetForm({ values });
+      }
+      if (!isSuccess) {
+        formik.setFieldError(
+          "description",
+          "We are unable to update the service description, check your internet connection and try again",
+        );
+      }
+    },
+  });
+
+  return (
+    <Box mb={2}>
+      <SettingsSection>
+        <Typography variant="h2" component="h3" gutterBottom>
+          Service Information
+        </Typography>
+        <Typography variant="body1">
+          Useful information about this service.
+        </Typography>
+      </SettingsSection>
+      <SettingsForm
+        legend="Service Description"
+        formik={formik}
+        description={
+          <>
+            A short blurb on what this service is, how it should be used, and if
+            there are any dependencies related to this service.
+          </>
+        }
+        input={
+          <>
+            <InputLabel label="Description" htmlFor="description">
+              <Input
+                name="description"
+                onChange={(event) => {
+                  formik.setFieldValue("description", event.target.value);
+                }}
+                value={formik.values.description ?? ""}
+                errorMessage={formik.errors.description}
+                id="description"
+              />
+            </InputLabel>
+          </>
+        }
+      />
+    </Box>
+  );
+};
+
+export default FlowDescription;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import { formControlLabelClasses } from "@mui/material/FormControlLabel";
 import Typography from "@mui/material/Typography";
 import type { FlowStatus } from "@opensystemslab/planx-core/types";
 import axios from "axios";
@@ -8,7 +7,6 @@ import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
 import React from "react";
 import { rootFlowPath } from "routes/utils";
-import { FONT_WEIGHT_BOLD } from "theme";
 import SettingsDescription from "ui/editor/SettingsDescription";
 import SettingsSection from "ui/editor/SettingsSection";
 import { Switch } from "ui/shared/Switch";
@@ -92,7 +90,7 @@ const FlowStatus = () => {
   };
 
   return (
-    <Box component="form" onSubmit={statusForm.handleSubmit}>
+    <Box component="form" onSubmit={statusForm.handleSubmit} mb={2}>
       <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Status

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -1,12 +1,11 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import { formControlLabelClasses } from "@mui/material/FormControlLabel";
+// eslint-disable-next-line no-restricted-imports
 import { SwitchProps } from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
 import React from "react";
-import { FONT_WEIGHT_BOLD } from "theme";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
@@ -86,6 +85,8 @@ export const FooterLinksAndLegalDisclaimer = () => {
   ]);
   const toast = useToast();
 
+  console.log(flowSettings);
+
   const elementsForm = useFormik<FlowSettings>({
     initialValues: {
       elements: {
@@ -112,7 +113,7 @@ export const FooterLinksAndLegalDisclaimer = () => {
     },
     validate: () => {},
   });
-
+  console.log(elementsForm.values.elements);
   return (
     <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
       <SettingsSection>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -85,8 +85,6 @@ export const FooterLinksAndLegalDisclaimer = () => {
   ]);
   const toast = useToast();
 
-  console.log(flowSettings);
-
   const elementsForm = useFormik<FlowSettings>({
     initialValues: {
       elements: {
@@ -113,7 +111,6 @@ export const FooterLinksAndLegalDisclaimer = () => {
     },
     validate: () => {},
   });
-  console.log(elementsForm.values.elements);
   return (
     <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
       <SettingsSection>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
@@ -1,16 +1,32 @@
 import Container from "@mui/material/Container";
-import React from "react";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useEffect } from "react";
 
 import FlowDescription from "./FlowDescription/FlowDescription";
 import FlowStatus from "./FlowStatus";
 import { FooterLinksAndLegalDisclaimer } from "./FooterLinksAndLegalDisclaimer";
 
-const ServiceSettings: React.FC = () => (
-  <Container maxWidth="formWrap">
-    <FooterLinksAndLegalDisclaimer />
-    <FlowStatus />
-    <FlowDescription />
-  </Container>
-);
+const ServiceSettings: React.FC = () => {
+  const [flowSlug, teamSlug, getFlowSettings] = useStore((state) => [
+    state.flowSlug,
+    state.teamSlug,
+    state.getFlowSettings,
+  ]);
+
+  useEffect(() => {
+    const fetchFlowSettings = async () => {
+      await getFlowSettings(flowSlug, teamSlug);
+    };
+    fetchFlowSettings();
+  }, [flowSlug, teamSlug, getFlowSettings]);
+
+  return (
+    <Container maxWidth="formWrap">
+      <FooterLinksAndLegalDisclaimer />
+      <FlowStatus />
+      <FlowDescription />
+    </Container>
+  );
+};
 
 export default ServiceSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
@@ -1,6 +1,7 @@
 import Container from "@mui/material/Container";
 import React from "react";
 
+import FlowDescription from "./FlowDescription/FlowDescription";
 import FlowStatus from "./FlowStatus";
 import { FooterLinksAndLegalDisclaimer } from "./FooterLinksAndLegalDisclaimer";
 
@@ -8,6 +9,7 @@ const ServiceSettings: React.FC = () => (
   <Container maxWidth="formWrap">
     <FooterLinksAndLegalDisclaimer />
     <FlowStatus />
+    <FlowDescription />
   </Container>
 );
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
@@ -1,32 +1,16 @@
 import Container from "@mui/material/Container";
-import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect } from "react";
+import React from "react";
 
 import FlowDescription from "./FlowDescription/FlowDescription";
 import FlowStatus from "./FlowStatus";
 import { FooterLinksAndLegalDisclaimer } from "./FooterLinksAndLegalDisclaimer";
 
-const ServiceSettings: React.FC = () => {
-  const [flowSlug, teamSlug, getFlowSettings] = useStore((state) => [
-    state.flowSlug,
-    state.teamSlug,
-    state.getFlowSettings,
-  ]);
-
-  useEffect(() => {
-    const fetchFlowSettings = async () => {
-      await getFlowSettings(flowSlug, teamSlug);
-    };
-    fetchFlowSettings();
-  }, [flowSlug, teamSlug, getFlowSettings]);
-
-  return (
-    <Container maxWidth="formWrap">
-      <FooterLinksAndLegalDisclaimer />
-      <FlowStatus />
-      <FlowDescription />
-    </Container>
-  );
-};
+const ServiceSettings: React.FC = () => (
+  <Container maxWidth="formWrap">
+    <FooterLinksAndLegalDisclaimer />
+    <FlowStatus />
+    <FlowDescription />
+  </Container>
+);
 
 export default ServiceSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -19,6 +19,9 @@ export interface SettingsStore {
   flowStatus?: FlowStatus;
   setFlowStatus: (flowStatus: FlowStatus) => void;
   updateFlowStatus: (newStatus: FlowStatus) => Promise<boolean>;
+  flowDescription?: string;
+  setFlowDescription: (flowDescription: string) => void;
+  updateFlowDescription: (newDescription: string) => Promise<boolean>;
   globalSettings?: GlobalSettings;
   setGlobalSettings: (globalSettings: GlobalSettings) => void;
   updateFlowSettings: (newSettings: FlowSettings) => Promise<number>;
@@ -48,6 +51,20 @@ export const settingsStore: StateCreator<
       status: newStatus,
     });
     set({ flowStatus: newStatus });
+    return Boolean(result?.id);
+  },
+
+  flowDescription: "",
+
+  setFlowDescription: (flowDescription: string) => set({ flowDescription }),
+
+  updateFlowDescription: async (newDescription: string) => {
+    const { id, $client } = get();
+    const result = await $client.flow.setDescription({
+      flow: { id },
+      description: newDescription,
+    });
+    set({ flowDescription: newDescription });
     return Boolean(result?.id);
   },
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { FlowStatus } from "@opensystemslab/planx-core/types";
 import camelcaseKeys from "camelcase-keys";
 import { client } from "lib/graphql";
-import { FlowInformation, GetFlowSettings } from "pages/FlowEditor/utils";
+import { FlowInformation, GetFlowInformation } from "pages/FlowEditor/utils";
 import {
   AdminPanelData,
   FlowSettings,
@@ -15,7 +15,7 @@ import { SharedStore } from "./shared";
 import { TeamStore } from "./team";
 
 export interface SettingsStore {
-  getFlowSettings: (
+  getFlowInformation: (
     flowSlug: string,
     teamSlug: string,
   ) => Promise<FlowInformation>;
@@ -73,12 +73,12 @@ export const settingsStore: StateCreator<
     return Boolean(result?.id);
   },
 
-  getFlowSettings: async (flowSlug, teamSlug) => {
+  getFlowInformation: async (flowSlug, teamSlug) => {
     const {
       data: {
         flows: [{ settings, status, description }],
       },
-    } = await client.query<GetFlowSettings>({
+    } = await client.query<GetFlowInformation>({
       query: gql`
         query GetFlow($slug: String!, $team_slug: String!) {
           flows(
@@ -96,7 +96,7 @@ export const settingsStore: StateCreator<
         slug: flowSlug,
         team_slug: teamSlug,
       },
-      fetchPolicy: "network-only",
+      fetchPolicy: "no-cache",
     });
 
     set({

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -3,13 +3,13 @@ import { formatDistanceToNow } from "date-fns";
 import { FlowSettings } from "types";
 
 export interface FlowInformation {
-  id?: string;
   settings: FlowSettings;
   status: FlowStatus;
   description: string;
 }
 
-export interface GetFlowSettings {
+export interface GetFlowInformation {
+  id: string;
   flows: FlowInformation[];
 }
 

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -1,4 +1,17 @@
+import { FlowStatus } from "@opensystemslab/planx-core/types";
 import { formatDistanceToNow } from "date-fns";
+import { FlowSettings } from "types";
+
+export interface FlowInformation {
+  id?: string;
+  settings: FlowSettings;
+  status: FlowStatus;
+  description: string;
+}
+
+export interface GetFlowSettings {
+  flows: FlowInformation[];
+}
 
 export const formatLastEditDate = (date: string): string => {
   return formatDistanceToNow(new Date(date), {

--- a/editor.planx.uk/src/routes/serviceSettings.tsx
+++ b/editor.planx.uk/src/routes/serviceSettings.tsx
@@ -1,51 +1,7 @@
-import { gql } from "@apollo/client";
-import { FlowStatus } from "@opensystemslab/planx-core/types";
-import { compose, mount, NaviRequest, route, withData } from "navi";
+import { compose, mount, route, withData } from "navi";
 import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
 
-import { client } from "../lib/graphql";
-import { useStore } from "../pages/FlowEditor/lib/store";
-import type { FlowSettings } from "../types";
 import { makeTitle } from "./utils";
-
-interface GetFlowSettings {
-  flows: {
-    id: string;
-    settings: FlowSettings;
-    status: FlowStatus;
-    description: string;
-  }[];
-}
-
-export const getFlowSettings = async (req: NaviRequest) => {
-  const {
-    data: {
-      flows: [{ settings, status, description }],
-    },
-  } = await client.query<GetFlowSettings>({
-    query: gql`
-      query GetFlow($slug: String!, $team_slug: String!) {
-        flows(
-          limit: 1
-          where: { slug: { _eq: $slug }, team: { slug: { _eq: $team_slug } } }
-        ) {
-          id
-          settings
-          description
-          status
-        }
-      }
-    `,
-    variables: {
-      slug: req.params.flow,
-      team_slug: req.params.team,
-    },
-  });
-
-  useStore.getState().setFlowSettings(settings);
-  useStore.getState().setFlowStatus(status);
-  useStore.getState().setFlowDescription(description);
-};
 
 const serviceSettingsRoutes = compose(
   withData((req) => ({
@@ -56,7 +12,6 @@ const serviceSettingsRoutes = compose(
   mount({
     "/": compose(
       route(async (req) => ({
-        getData: await getFlowSettings(req),
         title: makeTitle(
           [req.params.team, req.params.flow, "service"].join("/"),
         ),

--- a/editor.planx.uk/src/routes/serviceSettings.tsx
+++ b/editor.planx.uk/src/routes/serviceSettings.tsx
@@ -4,7 +4,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 
 import { makeTitle } from "./utils";
 
-const { flowSlug, teamSlug, getFlowSettings } = useStore.getState();
+const getFlowInformation = useStore.getState().getFlowInformation;
 
 const serviceSettingsRoutes = compose(
   withData((req) => ({
@@ -15,7 +15,7 @@ const serviceSettingsRoutes = compose(
   mount({
     "/": compose(
       route(async (req) => ({
-        getData: await getFlowSettings(flowSlug, teamSlug),
+        getData: await getFlowInformation(req.params.flow, req.params.team),
         title: makeTitle(
           [req.params.team, req.params.flow, "service"].join("/"),
         ),

--- a/editor.planx.uk/src/routes/serviceSettings.tsx
+++ b/editor.planx.uk/src/routes/serviceSettings.tsx
@@ -13,13 +13,14 @@ interface GetFlowSettings {
     id: string;
     settings: FlowSettings;
     status: FlowStatus;
+    description: string;
   }[];
 }
 
 export const getFlowSettings = async (req: NaviRequest) => {
   const {
     data: {
-      flows: [{ settings, status }],
+      flows: [{ settings, status, description }],
     },
   } = await client.query<GetFlowSettings>({
     query: gql`
@@ -30,6 +31,7 @@ export const getFlowSettings = async (req: NaviRequest) => {
         ) {
           id
           settings
+          description
           status
         }
       }
@@ -42,6 +44,7 @@ export const getFlowSettings = async (req: NaviRequest) => {
 
   useStore.getState().setFlowSettings(settings);
   useStore.getState().setFlowStatus(status);
+  useStore.getState().setFlowDescription(description);
 };
 
 const serviceSettingsRoutes = compose(

--- a/editor.planx.uk/src/routes/serviceSettings.tsx
+++ b/editor.planx.uk/src/routes/serviceSettings.tsx
@@ -1,7 +1,10 @@
 import { compose, mount, route, withData } from "navi";
 import ServiceSettings from "pages/FlowEditor/components/Settings/ServiceSettings";
+import { useStore } from "pages/FlowEditor/lib/store";
 
 import { makeTitle } from "./utils";
+
+const { flowSlug, teamSlug, getFlowSettings } = useStore.getState();
 
 const serviceSettingsRoutes = compose(
   withData((req) => ({
@@ -12,6 +15,7 @@ const serviceSettingsRoutes = compose(
   mount({
     "/": compose(
       route(async (req) => ({
+        getData: await getFlowSettings(flowSlug, teamSlug),
         title: makeTitle(
           [req.params.team, req.params.flow, "service"].join("/"),
         ),


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new section in the **Service Settings** page of the Editor. This houses the flow `description` which was added to the `flows` table in a previous PR: https://github.com/theopensystemslab/planx-new/pull/3945

I have created relevant mutations and updated current queries to update, create, and select `description` in `planx-core` in this PR: https://github.com/theopensystemslab/planx-core/pull/564

This new section has been added to the bottom of the **Service Settings** page as not to disrupt the UI too much, although it may be worth reviewing how these things are structured, but I imagined this is most aligned with the "Rethinking the Editor" work rather than this wee PR. 

I've called the setting section "Service Information" in case we want to put anything else in there in the future, type of service, creator, templated dependency etc... and it also allowed me to stop constantly using the word "description"

>[!Note]
> The input structure follows the pattern of going for an Input Label over a placeholder due to the accessibility needs, I'll add a ticket to update the rest of the settings (Footer / Disclaimer) in line with this