### PR TITLE
fix: sync all columns in `flows` table

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -60,8 +60,8 @@ SET
   copied_from = EXCLUDED.copied_from,
   analytics_link = NULL,
   status = EXCLUDED.status,
-  name = EXCLUDED.name
-  templated_from = EXCLUDED.templated_from
+  name = EXCLUDED.name,
+  templated_from = EXCLUDED.templated_from,
   description = EXCLUDED.description;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail

--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -12,7 +12,9 @@ CREATE TEMPORARY TABLE sync_flows (
   copied_from uuid,
   analytics_link text,
   status text,
-  name text
+  name text,
+  templated_from uuid,
+  description text
 );
 
 \copy sync_flows FROM '/tmp/flows.csv' WITH (FORMAT csv, DELIMITER ';');
@@ -28,7 +30,9 @@ INSERT INTO flows (
   copied_from,
   analytics_link,
   status,
-  name
+  name,
+  templated_from,
+  description
 )
 SELECT
   id,
@@ -41,7 +45,9 @@ SELECT
   copied_from,
   NULL,
   status,
-  name
+  name,
+  templated_from,
+  description
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -54,7 +60,9 @@ SET
   copied_from = EXCLUDED.copied_from,
   analytics_link = NULL,
   status = EXCLUDED.status,
-  name = EXCLUDED.name;
+  name = EXCLUDED.name
+  templated_from = EXCLUDED.templated_from
+  description = EXCLUDED.description;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;


### PR DESCRIPTION
`pnpm run up` on a fresh database is currently failing with the following error message (because we `select * from flows` but are missing recently added column defs)
![Screenshot from 2024-11-14 15-19-47](https://github.com/user-attachments/assets/dd9b95dd-65b2-4f43-af2e-c0907b9d78a8)
