### PR TITLE
feat: remove `onDelete` for Placeholder tag for non Platform admiins

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -1,7 +1,6 @@
 import Delete from "@mui/icons-material/Delete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { FormikErrors, FormikValues, useFormik } from "formik";
@@ -378,19 +377,19 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
               />
             </InputRow>
             <InputRow>
-            <Switch
-              checked={!!formik.values.groupedOptions}
-              onChange={() =>
-                formik.setValues({
-                  ...formik.values,
-                  ...toggleExpandableChecklist({
-                    options: formik.values.options,
-                    groupedOptions: formik.values.groupedOptions,
-                  }),
-                })
-              }
-              label="Expandable"
-            />
+              <Switch
+                checked={!!formik.values.groupedOptions}
+                onChange={() =>
+                  formik.setValues({
+                    ...formik.values,
+                    ...toggleExpandableChecklist({
+                      options: formik.values.options,
+                      groupedOptions: formik.values.groupedOptions,
+                    }),
+                  })
+                }
+                label="Expandable"
+              />
             </InputRow>
             <InputRow>
               <Switch
@@ -401,16 +400,16 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
                     !formik.values.allRequired,
                   )
                 }
-              label="All required"
-            />
+                label="All required"
+              />
             </InputRow>
             <InputRow>
               <Switch
                 checked={formik.values.neverAutoAnswer}
-                onChange={() => 
+                onChange={() =>
                   formik.setFieldValue(
                     "neverAutoAnswer",
-                    !formik.values.neverAutoAnswer
+                    !formik.values.neverAutoAnswer,
                   )
                 }
                 label="Always put to user (forgo automation)"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -8,11 +8,12 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
-  { color: keyof Palette["nodeTag"]; displayName: string }
+  { color: keyof Palette["nodeTag"]; displayName: string; isEditable?: boolean }
 > = {
   placeholder: {
     color: "blocking",
     displayName: "Placeholder",
+    isEditable: useStore.getState().user?.isPlatformAdmin,
   },
   toReview: {
     color: "nonBlocking",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -8,12 +8,12 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
-  { color: keyof Palette["nodeTag"]; displayName: string; isEditable?: Role }
+  { color: keyof Palette["nodeTag"]; displayName: string; isEditable?: Role[] }
 > = {
   placeholder: {
     color: "blocking",
     displayName: "Placeholder",
-    isEditable: "platformAdmin", // if new roles are added, we should update the canEdit() in ComponentTagSelect.tsx
+    isEditable: ["platformAdmin"], // if new roles are added, we should update the canEdit() in ComponentTagSelect.tsx
   },
   toReview: {
     color: "nonBlocking",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -8,12 +8,12 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
-  { color: keyof Palette["nodeTag"]; displayName: string; isEditable?: Role[] }
+  { color: keyof Palette["nodeTag"]; displayName: string; editableBy?: Role[] }
 > = {
   placeholder: {
     color: "blocking",
     displayName: "Placeholder",
-    isEditable: ["platformAdmin"], // if new roles are added, we should update the canEdit() in ComponentTagSelect.tsx
+    editableBy: ["platformAdmin"], // if new roles are added, we should update the canEdit() in ComponentTagSelect.tsx
   },
   toReview: {
     color: "nonBlocking",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import { Palette, useTheme } from "@mui/material/styles";
-import { NodeTag } from "@opensystemslab/planx-core/types";
+import { NodeTag, Role } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
@@ -8,12 +8,12 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
-  { color: keyof Palette["nodeTag"]; displayName: string; isEditable?: boolean }
+  { color: keyof Palette["nodeTag"]; displayName: string; isEditable?: Role }
 > = {
   placeholder: {
     color: "blocking",
     displayName: "Placeholder",
-    isEditable: useStore.getState().user?.isPlatformAdmin,
+    isEditable: "platformAdmin", // if new roles are added, we should update the canEdit() in ComponentTagSelect.tsx
   },
   toReview: {
     color: "nonBlocking",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -13,7 +13,7 @@ export const TAG_DISPLAY_VALUES: Record<
   placeholder: {
     color: "blocking",
     displayName: "Placeholder",
-    editableBy: ["platformAdmin"], // if new roles are added, we should update the canEdit() in ComponentTagSelect.tsx
+    editableBy: ["platformAdmin"],
   },
   toReview: {
     color: "nonBlocking",

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -50,7 +50,7 @@ describe("Checklist Component for a Platform Admin", () => {
 
     expect(optionTexts).toEqual(expect.arrayContaining(tagDisplayNames));
   });
-  it.only("renders all tags with Placeholder selected as a button", async () => {
+  it("renders all tags with Placeholder selected as a button", async () => {
     const { queryByTestId, queryByRole } = setup(
       <DndProvider backend={HTML5Backend}>
         <ChecklistComponent

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -27,6 +27,7 @@ describe("Checklist Component for a Platform Admin", () => {
           ...mockUser,
           isPlatformAdmin: true,
         },
+        teamSlug: "team",
       }),
     ),
   );

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -30,6 +30,7 @@ describe("Checklist Component for a Platform Admin", () => {
       }),
     ),
   );
+
   it("renders all tags with none selected", async () => {
     const { getByRole, user } = setup(
       <DndProvider backend={HTML5Backend}>
@@ -50,6 +51,7 @@ describe("Checklist Component for a Platform Admin", () => {
 
     expect(optionTexts).toEqual(expect.arrayContaining(tagDisplayNames));
   });
+
   it("renders all tags with Placeholder selected as a button", async () => {
     const { queryByTestId, queryByRole } = setup(
       <DndProvider backend={HTML5Backend}>
@@ -79,6 +81,7 @@ describe("Checklist Component for a non Platform Admin", () => {
       }),
     ),
   );
+
   it("renders all tags except Placeholder with none selected", async () => {
     const { getByRole, user } = setup(
       <DndProvider backend={HTML5Backend}>
@@ -95,6 +98,7 @@ describe("Checklist Component for a non Platform Admin", () => {
 
     expect(optionTexts).not.toContain(/placeholder/i);
   });
+
   it("renders all tags with static Placeholder selected", async () => {
     const { getByTestId, queryByRole } = setup(
       <DndProvider backend={HTML5Backend}>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -1,0 +1,114 @@
+import ChecklistComponent from "@planx/components/Checklist/Editor";
+import { within } from "@testing-library/react";
+import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { act } from "react-dom/test-utils";
+import { setup } from "testUtils";
+import { it } from "vitest";
+
+const { setState } = useStore;
+
+const mockUser = {
+  id: 200,
+  firstName: "Testy",
+  lastName: "McTester",
+  email: "test@email.com",
+  teams: [],
+};
+
+describe("Checklist Component for a Platform Admin", () => {
+  beforeEach(() =>
+    act(() =>
+      setState({
+        user: {
+          ...mockUser,
+          isPlatformAdmin: true,
+        },
+      }),
+    ),
+  );
+  it("renders all tags with none selected", async () => {
+    const { getByRole, user } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistComponent text="" />
+      </DndProvider>,
+    );
+    const tagSelect = getByRole("combobox", { name: /tag this component/i });
+
+    await user.click(tagSelect);
+
+    const optionsList = getByRole("listbox", { name: /tag this component/i });
+    const options = within(optionsList).getAllByRole("option");
+
+    const tagDisplayNames = Object.values(TAG_DISPLAY_VALUES).map(
+      (tag) => tag.displayName,
+    );
+    const optionTexts = options.map((option) => option.textContent);
+
+    expect(optionTexts).toEqual(expect.arrayContaining(tagDisplayNames));
+  });
+  it.only("renders all tags with Placeholder selected as a button", async () => {
+    const { queryByTestId, queryByRole } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistComponent
+          text=""
+          node={{ data: { text: "", tags: ["placeholder"] } }}
+        />
+      </DndProvider>,
+    );
+
+    const placeholderChip = queryByTestId("placeholder-chip");
+    const placeholderButton = queryByRole("button", { name: /placeholder/i });
+
+    expect(placeholderChip).toBeInTheDocument();
+    expect(placeholderButton).toBeInTheDocument();
+  });
+});
+
+describe("Checklist Component for a non Platform Admin", () => {
+  beforeEach(() =>
+    act(() =>
+      setState({
+        user: {
+          ...mockUser,
+          isPlatformAdmin: false,
+        },
+      }),
+    ),
+  );
+  it("renders all tags except Placeholder with none selected", async () => {
+    const { getByRole, user } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistComponent text="" />
+      </DndProvider>,
+    );
+    const tagSelect = getByRole("combobox", { name: /tag this component/i });
+
+    await user.click(tagSelect);
+
+    const optionsList = getByRole("listbox", { name: /tag this component/i });
+    const options = within(optionsList).getAllByRole("option");
+    const optionTexts = options.map((option) => option.textContent);
+
+    expect(optionTexts).not.toContain(/placeholder/i);
+  });
+  it("renders all tags with static Placeholder selected", async () => {
+    const { getByTestId, queryByRole } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistComponent
+          text=""
+          node={{ data: { text: "", tags: ["placeholder"] } }}
+        />
+      </DndProvider>,
+    );
+
+    const placeholderChip = getByTestId("placeholder-chip");
+    const placeholderButton = queryByRole("button", { name: /placeholder/i });
+
+    expect(placeholderChip).toBeInTheDocument();
+    expect(placeholderButton).not.toBeInTheDocument();
+  });
+});

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -4,7 +4,6 @@ import Chip from "@mui/material/Chip";
 import ListItem from "@mui/material/ListItem";
 import { NODE_TAGS, NodeTag } from "@opensystemslab/planx-core/types";
 import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import ModalSection from "ui/editor/ModalSection";
@@ -17,65 +16,55 @@ interface Props {
   onChange: (values: NodeTag[]) => void;
 }
 
-export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
-  const isPlatformAdmin = useStore().user?.isPlatformAdmin;
+const renderOption: AutocompleteProps<
+  NodeTag,
+  true,
+  true,
+  false,
+  "div"
+>["renderOption"] = (props, tag, { selected }) => {
+  if (TAG_DISPLAY_VALUES[tag].isEditable) return null;
+  return (
+    <ListItem {...props}>
+      <CustomCheckbox
+        aria-hidden="true"
+        className={selected ? "selected" : ""}
+      />
+      {!TAG_DISPLAY_VALUES[tag].displayName}
+    </ListItem>
+  );
+};
 
-  const showPlaceholderTag = (tagName: string) =>
-    tagName.toLowerCase() === "placeholder" && !isPlatformAdmin ? true : false;
-
-  const renderOption: AutocompleteProps<
-    NodeTag,
-    true,
-    true,
-    false,
-    "div"
-  >["renderOption"] = (props, tag, { selected }) => {
-    const tagName = TAG_DISPLAY_VALUES[tag].displayName;
-
-    if (showPlaceholderTag(tagName)) return;
-
+const renderTags: AutocompleteProps<
+  NodeTag,
+  true,
+  true,
+  false,
+  "div"
+>["renderTags"] = (value, getTagProps) =>
+  value.map((tag, index) => {
     return (
-      <ListItem {...props}>
-        <CustomCheckbox
-          aria-hidden="true"
-          className={selected ? "selected" : ""}
-        />
-        {tagName}
-      </ListItem>
+      <Chip
+        {...getTagProps({ index })}
+        key={tag}
+        label={TAG_DISPLAY_VALUES[tag].displayName}
+        sx={(theme) => ({
+          backgroundColor: theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
+          color: getContrastTextColor(
+            theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
+            "#FFF",
+          ),
+        })}
+        onDelete={
+          TAG_DISPLAY_VALUES[tag].isEditable
+            ? undefined
+            : getTagProps({ index }).onDelete
+        }
+      />
     );
-  };
+  });
 
-  const renderTags: AutocompleteProps<
-    NodeTag,
-    true,
-    true,
-    false,
-    "div"
-  >["renderTags"] = (value, getTagProps) =>
-    value.map((tag, index) => {
-      const tagName = TAG_DISPLAY_VALUES[tag].displayName;
-      const isChipDisabled = showPlaceholderTag(tagName);
-
-      return (
-        <Chip
-          {...getTagProps({ index })}
-          key={tag}
-          label={tagName}
-          sx={(theme) => ({
-            backgroundColor:
-              theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
-            color: getContrastTextColor(
-              theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
-              "#FFF",
-            ),
-          })}
-          onDelete={
-            isChipDisabled ? undefined : getTagProps({ index }).onDelete
-          }
-        />
-      );
-    });
-
+export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
   return (
     <ModalSection>
       <ModalSectionContent title="Tags" Icon={BookmarksIcon}>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -2,8 +2,9 @@ import BookmarksIcon from "@mui/icons-material/Bookmarks";
 import { AutocompleteProps } from "@mui/material/Autocomplete";
 import Chip from "@mui/material/Chip";
 import ListItem from "@mui/material/ListItem";
-import { NODE_TAGS, NodeTag } from "@opensystemslab/planx-core/types";
+import { NODE_TAGS, NodeTag, Role } from "@opensystemslab/planx-core/types";
 import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import ModalSection from "ui/editor/ModalSection";
@@ -16,6 +17,17 @@ interface Props {
   onChange: (values: NodeTag[]) => void;
 }
 
+const canEdit = (role?: Role) => {
+  switch (role) {
+    case "platformAdmin":
+      return useStore.getState().user?.isPlatformAdmin;
+    case undefined:
+      return true;
+    default:
+      return true;
+  }
+};
+
 const renderOption: AutocompleteProps<
   NodeTag,
   true,
@@ -23,14 +35,14 @@ const renderOption: AutocompleteProps<
   false,
   "div"
 >["renderOption"] = (props, tag, { selected }) => {
-  if (TAG_DISPLAY_VALUES[tag].isEditable) return null;
+  if (!canEdit(TAG_DISPLAY_VALUES[tag].isEditable)) return null;
   return (
     <ListItem {...props}>
       <CustomCheckbox
         aria-hidden="true"
         className={selected ? "selected" : ""}
       />
-      {!TAG_DISPLAY_VALUES[tag].displayName}
+      {TAG_DISPLAY_VALUES[tag].displayName}
     </ListItem>
   );
 };
@@ -46,6 +58,9 @@ const renderTags: AutocompleteProps<
     return (
       <Chip
         {...getTagProps({ index })}
+        data-testid={
+          TAG_DISPLAY_VALUES[tag].displayName.toLowerCase() + "-chip"
+        }
         key={tag}
         label={TAG_DISPLAY_VALUES[tag].displayName}
         sx={(theme) => ({
@@ -56,9 +71,9 @@ const renderTags: AutocompleteProps<
           ),
         })}
         onDelete={
-          TAG_DISPLAY_VALUES[tag].isEditable
-            ? undefined
-            : getTagProps({ index }).onDelete
+          canEdit(TAG_DISPLAY_VALUES[tag].isEditable)
+            ? getTagProps({ index }).onDelete
+            : undefined
         }
       />
     );

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -17,14 +17,9 @@ interface Props {
   onChange: (values: NodeTag[]) => void;
 }
 
-const canEdit = (role?: Role) => {
-  // depending on the role, a different form of validation will happen
-  switch (role) {
-    case "platformAdmin":
-      return !useStore.getState().user?.isPlatformAdmin;
-    default:
-      return true;
-  }
+const skipTag = (role?: Role) => {
+  const userRole = useStore.getState().getUserRoleForCurrentTeam();
+  return role === userRole ? false : true;
 };
 
 const renderOption: AutocompleteProps<
@@ -34,7 +29,7 @@ const renderOption: AutocompleteProps<
   false,
   "div"
 >["renderOption"] = (props, tag, { selected }) => {
-  if (TAG_DISPLAY_VALUES[tag].editableBy?.some(canEdit)) return null;
+  if (TAG_DISPLAY_VALUES[tag].editableBy?.some(skipTag)) return null;
   return (
     <ListItem {...props}>
       <CustomCheckbox
@@ -70,7 +65,7 @@ const renderTags: AutocompleteProps<
           ),
         })}
         onDelete={
-          TAG_DISPLAY_VALUES[tag].editableBy?.some(canEdit)
+          TAG_DISPLAY_VALUES[tag].editableBy?.some(skipTag)
             ? undefined
             : getTagProps({ index }).onDelete
         }

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -34,7 +34,7 @@ const renderOption: AutocompleteProps<
   false,
   "div"
 >["renderOption"] = (props, tag, { selected }) => {
-  if (TAG_DISPLAY_VALUES[tag].isEditable?.some(canEdit)) return null;
+  if (TAG_DISPLAY_VALUES[tag].editableBy?.some(canEdit)) return null;
   return (
     <ListItem {...props}>
       <CustomCheckbox
@@ -70,7 +70,7 @@ const renderTags: AutocompleteProps<
           ),
         })}
         onDelete={
-          TAG_DISPLAY_VALUES[tag].isEditable?.some(canEdit)
+          TAG_DISPLAY_VALUES[tag].editableBy?.some(canEdit)
             ? undefined
             : getTagProps({ index }).onDelete
         }

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -4,6 +4,7 @@ import Chip from "@mui/material/Chip";
 import ListItem from "@mui/material/ListItem";
 import { NODE_TAGS, NodeTag } from "@opensystemslab/planx-core/types";
 import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import ModalSection from "ui/editor/ModalSection";
@@ -16,42 +17,64 @@ interface Props {
   onChange: (values: NodeTag[]) => void;
 }
 
-const renderOption: AutocompleteProps<
-  NodeTag,
-  true,
-  true,
-  false,
-  "div"
->["renderOption"] = (props, tag, { selected }) => (
-  <ListItem {...props}>
-    <CustomCheckbox aria-hidden="true" className={selected ? "selected" : ""} />
-    {TAG_DISPLAY_VALUES[tag].displayName}
-  </ListItem>
-);
-
-const renderTags: AutocompleteProps<
-  NodeTag,
-  true,
-  true,
-  false,
-  "div"
->["renderTags"] = (value, getTagProps) =>
-  value.map((tag, index) => (
-    <Chip
-      {...getTagProps({ index })}
-      key={tag}
-      label={TAG_DISPLAY_VALUES[tag].displayName}
-      sx={(theme) => ({
-        backgroundColor: theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
-        color: getContrastTextColor(
-          theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
-          "#FFF",
-        ),
-      })}
-    />
-  ));
-
 export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
+  const isPlatformAdmin = useStore().user?.isPlatformAdmin;
+
+  const renderOption: AutocompleteProps<
+    NodeTag,
+    true,
+    true,
+    false,
+    "div"
+  >["renderOption"] = (props, tag, { selected }) => {
+    const tagName = TAG_DISPLAY_VALUES[tag].displayName;
+
+    if (tagName === "Placeholder" && !isPlatformAdmin) {
+      return null;
+    }
+
+    return (
+      <ListItem {...props}>
+        <CustomCheckbox
+          aria-hidden="true"
+          className={selected ? "selected" : ""}
+        />
+        {TAG_DISPLAY_VALUES[tag].displayName}
+      </ListItem>
+    );
+  };
+
+  const renderTags: AutocompleteProps<
+    NodeTag,
+    true,
+    true,
+    false,
+    "div"
+  >["renderTags"] = (value, getTagProps) =>
+    value.map((tag, index) => {
+      const tagName = TAG_DISPLAY_VALUES[tag].displayName;
+      const isChipDisabled = tagName === "Placeholder" && !isPlatformAdmin;
+
+      return (
+        <Chip
+          {...getTagProps({ index })}
+          key={tag}
+          label={TAG_DISPLAY_VALUES[tag].displayName}
+          sx={(theme) => ({
+            backgroundColor:
+              theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
+            color: getContrastTextColor(
+              theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],
+              "#FFF",
+            ),
+          })}
+          onDelete={
+            isChipDisabled ? undefined : getTagProps({ index }).onDelete
+          }
+        />
+      );
+    });
+
   return (
     <ModalSection>
       <ModalSectionContent title="Tags" Icon={BookmarksIcon}>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -20,6 +20,9 @@ interface Props {
 export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
   const isPlatformAdmin = useStore().user?.isPlatformAdmin;
 
+  const showPlaceholderTag = (tagName: string) =>
+    tagName.toLowerCase() === "placeholder" && !isPlatformAdmin ? true : false;
+
   const renderOption: AutocompleteProps<
     NodeTag,
     true,
@@ -29,9 +32,7 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
   >["renderOption"] = (props, tag, { selected }) => {
     const tagName = TAG_DISPLAY_VALUES[tag].displayName;
 
-    if (tagName === "Placeholder" && !isPlatformAdmin) {
-      return null;
-    }
+    if (showPlaceholderTag(tagName)) return;
 
     return (
       <ListItem {...props}>
@@ -39,7 +40,7 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
           aria-hidden="true"
           className={selected ? "selected" : ""}
         />
-        {TAG_DISPLAY_VALUES[tag].displayName}
+        {tagName}
       </ListItem>
     );
   };
@@ -53,13 +54,13 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
   >["renderTags"] = (value, getTagProps) =>
     value.map((tag, index) => {
       const tagName = TAG_DISPLAY_VALUES[tag].displayName;
-      const isChipDisabled = tagName === "Placeholder" && !isPlatformAdmin;
+      const isChipDisabled = showPlaceholderTag(tagName);
 
       return (
         <Chip
           {...getTagProps({ index })}
           key={tag}
-          label={TAG_DISPLAY_VALUES[tag].displayName}
+          label={tagName}
           sx={(theme) => ({
             backgroundColor:
               theme.palette.nodeTag[TAG_DISPLAY_VALUES[tag].color],

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -18,11 +18,10 @@ interface Props {
 }
 
 const canEdit = (role?: Role) => {
+  // depending on the role, a different form of validation will happen
   switch (role) {
     case "platformAdmin":
-      return useStore.getState().user?.isPlatformAdmin;
-    case undefined:
-      return true;
+      return !useStore.getState().user?.isPlatformAdmin;
     default:
       return true;
   }
@@ -35,7 +34,7 @@ const renderOption: AutocompleteProps<
   false,
   "div"
 >["renderOption"] = (props, tag, { selected }) => {
-  if (!canEdit(TAG_DISPLAY_VALUES[tag].isEditable)) return null;
+  if (TAG_DISPLAY_VALUES[tag].isEditable?.some(canEdit)) return null;
   return (
     <ListItem {...props}>
       <CustomCheckbox
@@ -71,9 +70,9 @@ const renderTags: AutocompleteProps<
           ),
         })}
         onDelete={
-          canEdit(TAG_DISPLAY_VALUES[tag].isEditable)
-            ? getTagProps({ index }).onDelete
-            : undefined
+          TAG_DISPLAY_VALUES[tag].isEditable?.some(canEdit)
+            ? undefined
+            : getTagProps({ index }).onDelete
         }
       />
     );


### PR DESCRIPTION
## What does this PR do?

This PR adds a role access constraint to the `Placeholder` tag so only `PlatformAdmins` can edit it, but everyone can see it. 

To do this, I have restricted the `renderOption` function so it only shows `Placeholder` tag in the MultiSelect for `PlatformAdmin` users. I have also added the constraint to the `renderTags` function, so it removes the `onDelete` from the `Chip` component when a user is not a `PlatformAdmin`

With the changes to `TAG_DISPLAY_VALUES` we can now use `Role` types to add further permission layers in future if required. To ensure this happens, new logic would need to be introduced to the `canEdit()` in `ComponentTagSelect()`