### PR TITLE
adr: Single `applications` table

### DIFF
--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -27,7 +27,10 @@ We propose to consolidate all integration application audit tables into a single
 
 2. Add an `integration_name` column (ENUM) to identify the destination
 
-3. Implement the migration in phases:
+3. Use a foreign key relationship between `lowcal_session.id` and `submissions.session_id`
+  - As `submission` need to be retained, and `lowcal_session` deleted a constraint such as `ON DELETE SET NULL` for the foreign key would allow for the relationship to be maintained whilst the session record exists.
+
+4. Implement the migration in phases:
    - Create new consolidated table
    - For each integration:
      - Update application code to write to both old and new tables
@@ -35,7 +38,7 @@ We propose to consolidate all integration application audit tables into a single
      - Update `submissions_services_log` and `submissions_services_summary` view
      - Delete or archive old table
 
-4. Update data retention operations to sanitise new `submissions` table
+5. Update data retention operations to sanitise new `submissions` table
 
 ## Consequences
 

--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -30,7 +30,12 @@ We propose to consolidate all integration application audit tables into a single
 3. Use a foreign key relationship between `lowcal_session.id` and `submissions.session_id`
   - As `submission` need to be retained, and `lowcal_session` deleted a constraint such as `ON DELETE SET NULL` for the foreign key would allow for the relationship to be maintained whilst the session record exists.
 
-4. Implement the migration in phases:
+4. When submitting, the current `check<SEND_DESTINATION>AuditTable()` function will validate the following - 
+  - Is there a record for this combination of session ID and send destination, where the `submission_reference` is set to `NULL`
+  - If yes, this has not yet been successfully submitted, proceed
+  - If no, return early - this session has been submitted already
+
+1. Implement the migration in phases:
    - Create new consolidated table
    - For each integration:
      - Update application code to write to both old and new tables
@@ -38,7 +43,7 @@ We propose to consolidate all integration application audit tables into a single
      - Update `submissions_services_log` and `submissions_services_summary` view
      - Delete or archive old table
 
-5. Update data retention operations to sanitise new `submissions` table
+2. Update data retention operations to sanitise new `submissions` table
 
 ## Consequences
 

--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -50,9 +50,10 @@ We propose to consolidate all integration application audit tables into a single
    - Cross-integration reporting becomes simpler
    - Simplified analytics queries in Metabase
 
-3. Future workflow improvements
+3. Potential future workflow improvements
    - This would enable event-driven architecture via status transitions - the front end could insert a new record with `status = "new"`, which would trigger the `/send` API  endpoint
    - This would eliminate the need for manual Hasura event generation, and simplify our submission process
+   - Any changes here are outside the scope of this ADR and will changes will constitute a new propsal, in their own time
 
 ### Negative
 

--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -31,7 +31,7 @@ We propose to consolidate all integration application audit tables into a single
   - As `submission` need to be retained, and `lowcal_session` deleted a constraint such as `ON DELETE SET NULL` for the foreign key would allow for the relationship to be maintained whilst the session record exists.
 
 4. When submitting, the current `check<SEND_DESTINATION>AuditTable()` function will validate the following - 
-  - Is there a record for this combination of session ID and send destination, where the `submission_reference` is set to `NULL`
+  - Is there a record for this combination of session ID and send destination, where the `destination_reference` is set to `NULL`
   - If yes, this has not yet been successfully submitted, proceed
   - If no, return early - this session has been submitted already
 

--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -19,7 +19,7 @@ These tables:
 
 ## Decision
 
-We propose to consolidate all integration application audit tables into a single `applications` table with the following key changes:
+We propose to consolidate all integration application audit tables into a single `submissions` table with the following key changes:
 
 1. Replace integration-specific ID columns with a standardised `external_reference_id` column (TEXT)
    - This will store the identifier returned by the integration partner
@@ -35,7 +35,7 @@ We propose to consolidate all integration application audit tables into a single
      - Update `submissions_services_log` and `submissions_services_summary` view
      - Delete or archive old table
 
-4. Update data retention operations to sanitise new `applications` table
+4. Update data retention operations to sanitise new `submissions` table
 
 ## Consequences
 
@@ -63,7 +63,7 @@ We propose to consolidate all integration application audit tables into a single
 2. Current use of existing `submission_` views
    - Frontend code and models may need to be updated
    - Metabase queries may need to be updated
-   - We can mitigate this by planning to keep the existing structure of the views, but simplify their sources to read from a single `applications` table instead of multiple `x_applications` tables
+   - We can mitigate this by planning to keep the existing structure of the views, but simplify their sources to read from a single `submissions` table instead of multiple `x_applications` tables
 
 ### Questions
 

--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -1,10 +1,10 @@
 # 9. Single application audit table
 
-Date: 2024-11-15
+Date: 2024-11-20
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/doc/architecture/decisions/0009-single-application-audit-table.md
+++ b/doc/architecture/decisions/0009-single-application-audit-table.md
@@ -1,0 +1,74 @@
+# 9. Single application audit table
+
+Date: 2024-11-15
+
+## Status
+
+Proposed
+
+## Context
+
+We currently maintain separate audit tables (`bops_applications`, `uniform_applications`, and `s3_applications`) for each integration partner's submissions. 
+
+These tables:
+- Have largely similar structures and track fundamentally the same type of data
+- Create maintenance overhead as changes need to be replicated across multiple tables
+- Make cross-integration querying more complex (we have the `submissions_services_log` and `submissions_services_summary` views)
+- Results in more unique code per-integration
+- It's likely the number of integrations will grow as PlanX matures and grows
+
+## Decision
+
+We propose to consolidate all integration application audit tables into a single `applications` table with the following key changes:
+
+1. Replace integration-specific ID columns with a standardised `external_reference_id` column (TEXT)
+   - This will store the identifier returned by the integration partner
+   - `TEXT` is fine as we don't use the columns for foreign keys internally
+
+2. Add an `integration_name` column (ENUM) to identify the destination
+
+3. Implement the migration in phases:
+   - Create new consolidated table
+   - For each integration:
+     - Update application code to write to both old and new tables
+     - Migrate historical data
+     - Update `submissions_services_log` and `submissions_services_summary` view
+     - Delete or archive old table
+
+4. Update data retention operations to sanitise new `applications` table
+
+## Consequences
+
+### Positive
+
+1. Simplified data structure
+   - Single source of truth for application audit data
+   - Schema changes and permissions only need to be applied once
+   - Easier to ensure consistency across new and existing integrations
+
+2. Improved querying capabilities
+   - Cross-integration reporting becomes simpler
+   - Simplified analytics queries in Metabase
+
+3. Future workflow improvements
+   - This would enable event-driven architecture via status transitions - the front end could insert a new record with `status = "new"`, which would trigger the `/send` API  endpoint
+   - This would eliminate the need for manual Hasura event generation, and simplify our submission process
+
+### Negative
+
+1. Migration complexity
+   - Need to maintain dual writes during transition
+   - Requires careful validation of migrated data
+
+2. Current use of existing `submission_` views
+   - Frontend code and models may need to be updated
+   - Metabase queries may need to be updated
+   - We can mitigate this by planning to keep the existing structure of the views, but simplify their sources to read from a single `applications` table instead of multiple `x_applications` tables
+
+### Questions
+
+1. Timing - is this worth doing right now?
+   - Probably! Very open to comments here
+   - The number of integrations is likely to grow
+   - Earlier consolidation means less data to migrate
+   - Enables workflow improvements and simplification for submissions


### PR DESCRIPTION
Something to talk about at the next dev call - thought sooner would be most welcome though. 

Ideally, I'd like to forgo creating and migrating a `goss_applications` table unnecessarily - it would be nice to start working on this soon if there's no real issues and we agree it's worth doing this right now.