### PR TITLE
chore: finalise Barking and Dagenham subdomain setup

### DIFF
--- a/editor.planx.uk/src/airbrake.ts
+++ b/editor.planx.uk/src/airbrake.ts
@@ -17,6 +17,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.gateshead.gov.uk":
     case "planningservices.gloucester.gov.uk":
     case "planningservices.lambeth.gov.uk":
+    case "planningservices.lbbd.gov.uk":
     case "planningservices.medway.gov.uk":
     case "planningservices.newcastle.gov.uk":
     case "planningservices.southwark.gov.uk":

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -49,14 +49,15 @@ export const setPath = (flowData: Store.Flow, req: NaviRequest) => {
 //      So I've hard-coded these domain names until a better solution comes along.
 //
 const PREVIEW_ONLY_DOMAINS = [
-  "planningservices.epsom-ewell.gov.uk",
   "planningservices.barnet.gov.uk",
   "planningservices.buckinghamshire.gov.uk",
   "planningservices.camden.gov.uk",
   "planningservices.doncaster.gov.uk",
+  "planningservices.epsom-ewell.gov.uk",
   "planningservices.gateshead.gov.uk",
   "planningservices.gloucester.gov.uk",
   "planningservices.lambeth.gov.uk",
+  "planningservices.lbbd.gov.uk",
   "planningservices.medway.gov.uk",
   "planningservices.newcastle.gov.uk",
   "planningservices.southwark.gov.uk",


### PR DESCRIPTION
The council has confirmed that the CNAME record for https://planningservices.lbbd.gov.uk/ has been created.

### To Do
As per https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-subdomains.md :
- [ ] Populate `team.domain` column (post prod deploy)
- [ ] Setup Uptime Robot
- [ ] Update PlanX CRM