### PR TITLE
chore: remove feature flag for feedback component

### DIFF
--- a/doc/how-to/how-to-setup-custom-subdomains.md
+++ b/doc/how-to/how-to-setup-custom-subdomains.md
@@ -108,4 +108,9 @@ This guide will walk through the process of setting a custom domain for a new te
   
 11. **PlanX** - Add custom domain to UptimeRobot (create monitor & also select SSL reminders)
 
+> [!NOTE]
+> We do not have individual named logins for our UptimeRobot account. Instead we have one single shared one in the 1Password "root/admin" vault, which not everyone will have access to. 
+>
+> Therefore you might need to ask someone to do this step for you if you do not have access.
+
 12. **PlanX** - Add certificate expiry date to [PlanX CMS on Notion](https://www.notion.so/opensystemslab/Plan-Customers-dee2cdfb40c04b5fa88edc5a86989211)

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["FEEDBACK_COMPONENT"] as const;
+const AVAILABLE_FEATURE_FLAGS = [] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -126,16 +126,15 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
     userContext: "What were you doing?",
   };
 
-  enum EmojiRating {
-    Terrible,
-    Poor,
-    Average,
-    Good,
-    Excellent,
-  }
+  const EmojiRating: Record<number, string> = {
+    1: "Terrible",
+    2: "Poor",
+    3: "Neutral",
+    4: "Good",
+    5: "Excellent",
+  };
 
-  const feedbackScore =
-    item.feedbackScore && EmojiRating[item.feedbackScore + 1]; // enums are 0-indexed
+  const feedbackScore = EmojiRating[item.feedbackScore];
 
   const renderContent = (key: string, value: any) => {
     if (key === "combinedHelp" && value) {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -71,7 +71,7 @@ const feedbackTypeIcon = (type: FeedbackType): FeedbackTypeIcon => {
         title: "Unhelpful (help text)",
       };
     case "component":
-      return { icon: <RateReviewIcon />, title: "From feedback component" };
+      return { icon: <RateReviewIcon />, title: "User satisfaction" };
     default:
       return { icon: <RuleIcon />, title: "Inaccuracy" };
   }
@@ -155,7 +155,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
         <TableCell>
           {format(new Date(item.createdAt), "dd/MM/yy hh:mm:ss")}
         </TableCell>
-        <TableCell sx={{ textAlign: "center" }}>{feedbackScore}</TableCell>
+        <TableCell>{feedbackScore}</TableCell>
         <TableCell>{commentSummary}</TableCell>
         <TableCell sx={{ textAlign: "right" }}>
           <IconButton

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -10,7 +10,6 @@ import { styled } from "@mui/material/styles";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { parseFormValues } from "@planx/components/shared";
 import ErrorFallback from "components/Error/ErrorFallback";
-import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useNavigation } from "react-navi";
@@ -64,9 +63,7 @@ const NodeTypeSelect: React.FC<{
         <option value={TYPES.List}>List</option>
         <option value={TYPES.Page}>Page</option>
         <option value={TYPES.MapAndLabel}>Map and Label (Testing only)</option>
-        {hasFeatureFlag("FEEDBACK_COMPONENT") && (
-          <option value={TYPES.Feedback}>Feedback (Testing only)</option>
-        )}
+        <option value={TYPES.Feedback}>Feedback</option>
       </optgroup>
       <optgroup label="Information">
         <option value={TYPES.TaskList}>Task List</option>


### PR DESCRIPTION
### In this PR:

- Remove `FEEDBACK_COMPONENT` feature flag
- Add note to custom subdomains doc about UptimeRobot access.
- From feedback on pizza: change name of column in Feedback log to `User satisfaction` 🍕 
- Fix the ratings not showing by replacing the enum with a regular object `EmojiRating` 🐛 