### PR TITLE
fix: add default disclaimer text to shared component

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Presentational.tsx
@@ -10,6 +10,7 @@ import { Disclaimer } from "../shared/Disclaimer";
 import { ErrorSummaryContainer } from "../shared/Preview/ErrorSummaryContainer";
 import SimpleExpand from "../shared/Preview/SimpleExpand";
 import ConstraintsList from "./List";
+import { DEFAULT_PLANNING_CONDITIONS_DISCLAIMER } from "./model";
 import { InaccurateConstraints } from "./Public";
 
 export type PresentationalProps = {
@@ -80,7 +81,10 @@ export function Presentational(props: PresentationalProps) {
               />
             </SimpleExpand>
           )}
-          <Disclaimer text={disclaimer} />
+          <Disclaimer
+            text={disclaimer}
+            defaultText={DEFAULT_PLANNING_CONDITIONS_DISCLAIMER}
+          />
         </>
       )}
       {positiveConstraints.length === 0 && negativeConstraints.length > 0 && (
@@ -110,7 +114,10 @@ export function Presentational(props: PresentationalProps) {
               setInaccurateConstraints={setInaccurateConstraints}
             />
           </SimpleExpand>
-          <Disclaimer text={disclaimer} />
+          <Disclaimer
+            text={disclaimer}
+            defaultText={DEFAULT_PLANNING_CONDITIONS_DISCLAIMER}
+          />
         </>
       )}
     </Card>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
@@ -239,4 +239,21 @@ describe("following a FindProperty component", () => {
     expect(negativeConstraintsContainer).toBeVisible();
     expect(getByRole("heading", { name: /Ecology/ })).toBeVisible();
   });
+
+  test("default disclaimer text should render if none provided", async () => {
+    const { queryByText } = setup(
+      <PlanningConstraints
+        title="Planning constraints"
+        description="Things that might affect your project"
+        fn="property.constraints.planning"
+        disclaimer=""
+        handleSubmit={vi.fn()}
+      />,
+    );
+    expect(
+      queryByText(
+        "This page does not include information about historic planning conditions that may apply to this property.",
+      ),
+    ).toBeVisible();
+  });
 });

--- a/editor.planx.uk/src/@planx/components/shared/Disclaimer.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Disclaimer.tsx
@@ -4,11 +4,24 @@ import { WarningContainer } from "@planx/components/shared/Preview/WarningContai
 import React from "react";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
-export const Disclaimer = ({ text }: { text: string }) => (
-  <WarningContainer>
-    <ErrorOutline />
-    <Typography variant="body2" component="div" ml={2} sx={{ "& p:first-of-type": { marginTop: 0, } }}>
-      <ReactMarkdownOrHtml source={text} openLinksOnNewTab />
-    </Typography>
-  </WarningContainer>
-);
+export const Disclaimer = ({
+  text,
+  defaultText,
+}: {
+  text: string;
+  defaultText?: string;
+}) => {
+  return (
+    <WarningContainer>
+      <ErrorOutline />
+      <Typography
+        variant="body2"
+        component="div"
+        ml={2}
+        sx={{ "& p:first-of-type": { marginTop: 0 } }}
+      >
+        <ReactMarkdownOrHtml source={text || defaultText} openLinksOnNewTab />
+      </Typography>
+    </WarningContainer>
+  );
+};


### PR DESCRIPTION
As discussed in [this slack thread](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1732029167504329), the disclaimer component got slightly broken in [my refactor ](https://github.com/theopensystemslab/planx-new/pull/3900). Namely, I extracted out the `Disclaimer` component from `Planning Constraints` but accidentally removed the fallback string. 🤦 

This has been re-added as an optional prop `defaultText` in the shared `Disclaimer` component.