### PR TITLE
fix: Only scroll to start node on initial load of flow

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/EndPoint.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/EndPoint.tsx
@@ -19,6 +19,11 @@ const EndPoint: React.FC<{ text: string }> = ({ text }) => {
 
   useEffect(() => {
     if (isStart && el.current) {
+      // Only scroll to center on initial visit
+      const storageKey = ["scrollPos", currentPath].join(":");
+      const hasVisited = sessionStorage.getItem(storageKey);
+      if (hasVisited) return;
+
       if (isLoading) return;
 
       scrollIntoView(


### PR DESCRIPTION
I had something to this effect in place on a previous PR, but seem to have lost it in a merge/rebase somewhere.

Currently (on staging), the start node scrolls to the center top on each load - it should only happen on initial load.

**Staging - incorrect behaviour**
_Scroll position reset on each route change_

https://github.com/user-attachments/assets/6b348956-f378-4b98-9187-dc92d47ac33a

**This PR - correct behaviour**
_Scroll position retained_

https://github.com/user-attachments/assets/cf789540-187f-469b-a3b1-1ceb121b3e56



