### PR TITLE
chore: Remove `/draft` and `/preview` routes from indexing

### DIFF
--- a/editor.planx.uk/public/robots.txt
+++ b/editor.planx.uk/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /*draft
+Disallow: /*preview

--- a/editor.planx.uk/src/routes/draft.tsx
+++ b/editor.planx.uk/src/routes/draft.tsx
@@ -1,4 +1,4 @@
-import { compose, map, mount, route, withData, withView } from "navi";
+import { compose, map, mount, route, withData, withHead, withView } from "navi";
 import ContentPage from "pages/Preview/ContentPage";
 import Questions from "pages/Preview/Questions";
 import React from "react";
@@ -9,6 +9,11 @@ const routes = compose(
   withData(async (req) => ({
     mountpath: req.mountpath,
   })),
+
+  withHead([
+    <meta name="robots" content="noindex, nofollow" key="meta-robots" />,
+    <meta name="googlebot" content="noindex, nofollow" key="meta-googlebot" />
+  ]),
 
   withView(async (req) => await draftView(req)),
 

--- a/editor.planx.uk/src/routes/preview.tsx
+++ b/editor.planx.uk/src/routes/preview.tsx
@@ -1,4 +1,4 @@
-import { compose, map, mount, route, withData, withView } from "navi";
+import { compose, map, mount, route, withData, withHead, withView } from "navi";
 import ContentPage from "pages/Preview/ContentPage";
 import Questions from "pages/Preview/Questions";
 import React from "react";
@@ -9,6 +9,11 @@ const routes = compose(
   withData(async (req) => ({
     mountpath: req.mountpath,
   })),
+
+  withHead([
+    <meta name="robots" content="noindex, nofollow" key="meta-robots"/>,
+    <meta name="googlebot" content="noindex, nofollow" key="meta-googlebot"/>
+  ]),
 
   withView(async (req) => await previewView(req)),
 


### PR DESCRIPTION
## What does this PR do?
 - Excludes `/draft` and `/preview` routes from search-engine indexing
 - These routes should be accessible (e.g. for internal council testing) but not discoverable by members of the public - they will likely have a bad experience on these routes! (not able to submit, incomplete content, testing content etc)
 - Other routes either require authentication, or should be publicly accessible
 
## What's the motivation for this?
I accidentally entered `https://editor.planx.uk/buckinghamshire/notification-of-commencement/` into a Google search instead of the URL bar and landed [here](https://www.google.com/search?q=https%3A%2F%2Feditor.planx.uk%2Fbuckinghamshire%2Fnotification-of-commencement%2F&sca_esv=dfd2af4a0faad991&rlz=1C5CHFA_enGB981GB982&ei=Pl0-Z5WXIp2N9u8PvruosQs&ved=0ahUKEwiVrq_S9euJAxWdhv0HHb4dKrYQ4dUDCA8&uact=5&oq=https%3A%2F%2Feditor.planx.uk%2Fbuckinghamshire%2Fnotification-of-commencement%2F&gs_lp=Egxnd3Mtd2l6LXNlcnAiRWh0dHBzOi8vZWRpdG9yLnBsYW54LnVrL2J1Y2tpbmdoYW1zaGlyZS9ub3RpZmljYXRpb24tb2YtY29tbWVuY2VtZW50L0gAUABYAHAAeACQAQCYAQCgAQCqAQC4AQPIAQD4AQGYAgCgAgCYAwCSBwCgBwA&sclient=gws-wiz-serp) 

<img width="907" alt="image" src="https://github.com/user-attachments/assets/1d63acb5-92be-4ad2-b555-66138c540a06">

This links to a `/preview` link which members of the public shouldn't be able to discover.

## How can I test this?
There will now be additional HTML `meta` elements within the `head` of `/draft` and `/preview` pages - 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c69f70d4-de1d-4b30-8f22-aee9870e425d">



## Next steps...
I think there's a whole separate task here around SEO, page titles and descriptions and OpenGraph tags etc - very much not handling this here, but I'll add a ticket to the blue Trello for this so it's not lost 👍 