### PR TITLE
test: Add retry to flaky react unit test

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
@@ -5,7 +5,7 @@ import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
-import { vi } from "vitest";
+import { it,vi } from "vitest";
 import { axe } from "vitest-axe";
 
 import hasuraEventsResponseMock from "./mocks/hasuraEventsResponseMock";
@@ -179,29 +179,34 @@ describe("Uniform overrides for Buckinghamshire", () => {
   });
 });
 
-it("generates a valid breadcrumb", async () => {
-  const handleSubmit = vi.fn();
+it(
+  "generates a valid breadcrumb",
+  async () => {
+    const handleSubmit = vi.fn();
 
-  setup(
-    <SendComponent
-      title="Send"
-      destinations={["bops", "uniform"]}
-      handleSubmit={handleSubmit}
-    />,
-  );
+    setup(
+      <SendComponent
+        title="Send"
+        destinations={["bops", "uniform"]}
+        handleSubmit={handleSubmit}
+      />,
+    );
 
-  await waitFor(() => expect(mockAxios.post).toHaveBeenCalledTimes(1));
-  expect(handleSubmit).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockAxios.post).toHaveBeenCalledTimes(1));
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
 
-  const breadcrumb = handleSubmit.mock.calls[0][0];
+    const breadcrumb = handleSubmit.mock.calls[0][0];
 
-  expect(breadcrumb.data).toEqual(
-    expect.objectContaining({
-      bopsSendEventId: hasuraEventsResponseMock.bops.event_id,
-      uniformSendEventId: hasuraEventsResponseMock.uniform.event_id,
-    }),
-  );
-});
+    expect(breadcrumb.data).toEqual(
+      expect.objectContaining({
+        bopsSendEventId: hasuraEventsResponseMock.bops.event_id,
+        uniformSendEventId: hasuraEventsResponseMock.uniform.event_id,
+      }),
+    );
+    // Flaky test in CI
+  },
+  { retry: 1 },
+);
 
 it("should not have any accessibility violations", async () => {
   const { container } = setup(


### PR DESCRIPTION
This test has been failing on a number of CI runs, and then usually passes on a retry.


<img width="1018" alt="image" src="https://github.com/user-attachments/assets/f03fd100-12c5-494f-b5e1-cc1ac2f8383a">


I'm not able to recreate this locally, so I'm adding in a retry to see if this mitigates the issue.

Once this is up and running, I'll retry the react tests a bunch of time on CI to check that a single retry actually seems to resolve this.

Update: Ran this multiple times, no issues so far 🤞 

![image](https://github.com/user-attachments/assets/5530f9f7-6bb1-4603-9b07-2310757c35fb)

