### PR TITLE
fix: External Portal node graph styling

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -141,19 +141,22 @@ const InternalPortal: React.FC<any> = (props) => {
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
-      <li className={classNames("card", "portal", { isDragging })} ref={ref}>
-        <Link
-          href={href}
-          prefetch={false}
-          ref={drag}
-          onContextMenu={handleContext}
-        >
-          {Icon && <Icon />}
-          <span>{props.data.text}</span>
-        </Link>
-        <Link href={editHref} prefetch={false} className="portalMenu">
-          <MoreVert titleAccess="Edit Portal" />
-        </Link>
+      <li ref={ref}>
+        <Box className={classNames("card", "portal", { isDragging })}>
+          <Link
+            href={href}
+            prefetch={false}
+            ref={drag}
+            onContextMenu={handleContext}
+          >
+            {Icon && <Icon />}
+            <span>{props.data.text}</span>
+          </Link>
+          <Link href={editHref} prefetch={false} className="portalMenu">
+            <MoreVert titleAccess="Edit Portal" />
+          </Link>
+        </Box>
+        {props.tags?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
       </li>
     </>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -89,17 +89,17 @@ const ExternalPortal: React.FC<any> = (props) => {
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
-      <Box sx={{ width: "max-content" }}>
-        <li className={classNames("card", "portal", { isDragging })}>
+      <li ref={ref}>
+        <Box className={classNames("card", "portal", { isDragging })}>
           <Link href={`/${href}`} prefetch={false} ref={drag}>
             <span>{href}</span>
           </Link>
           <Link href={editHref} prefetch={false} className="portalMenu">
             <MoreVert titleAccess="Edit Portal" />
           </Link>
-        </li>
+        </Box>
         {props.tags?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
-      </Box>
+      </li>
     </>
   );
 };
@@ -141,7 +141,7 @@ const InternalPortal: React.FC<any> = (props) => {
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
-      <li className={classNames("card", "portal", { isDragging })}>
+      <li className={classNames("card", "portal", { isDragging })} ref={ref}>
         <Link
           href={href}
           prefetch={false}


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1732286143726329 (OSL Slack)

Fixed small visual regressions introduced in https://github.com/theopensystemslab/planx-new/pull/3975, and adds back missing `ref`s.

<img width="358" alt="image" src="https://github.com/user-attachments/assets/c6182d1b-f876-4b4a-9d38-0a382915f91e">
