### PR TITLE
feat: Initial fee breakdown public UI

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -22,6 +22,7 @@ import { ICONS } from "../../shared/icons";
 import { EditorProps } from "../../shared/types";
 import { GovPayMetadataSection } from "./GovPayMetadataSection";
 import { InviteToPaySection } from "./InviteToPaySection";
+import { FeeBreakdownSection } from "./FeeBreakdownSection";
 
 export type Props = EditorProps<TYPES.Pay, Pay>;
 
@@ -114,6 +115,7 @@ const Component: React.FC<Props> = (props: Props) => {
           </ModalSection>
           <GovPayMetadataSection/>
           <InviteToPaySection/>
+          <FeeBreakdownSection/>
           <MoreInformation
             changeField={handleChange}
             definitionImg={values.definitionImg}

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -1,11 +1,5 @@
-import {
-  ComponentType as TYPES,
-} from "@opensystemslab/planx-core/types";
-import {
-  parsePay,
-  Pay,
-  validationSchema,
-} from "@planx/components/Pay/model";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { parsePay, Pay, validationSchema } from "@planx/components/Pay/model";
 import { Form, Formik } from "formik";
 import React from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
@@ -20,14 +14,13 @@ import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../../shared/icons";
 import { EditorProps } from "../../shared/types";
+import { FeeBreakdownSection } from "./FeeBreakdownSection";
 import { GovPayMetadataSection } from "./GovPayMetadataSection";
 import { InviteToPaySection } from "./InviteToPaySection";
-import { FeeBreakdownSection } from "./FeeBreakdownSection";
 
 export type Props = EditorProps<TYPES.Pay, Pay>;
 
 const Component: React.FC<Props> = (props: Props) => {
-
   const onSubmit = (newValues: Pay) => {
     if (props.handleSubmit) {
       props.handleSubmit({ type: TYPES.Pay, data: newValues });
@@ -42,11 +35,7 @@ const Component: React.FC<Props> = (props: Props) => {
       validateOnChange={true}
       validateOnBlur={true}
     >
-      {({
-        values,
-        handleChange,
-        setFieldValue,
-      }) => (
+      {({ values, handleChange, setFieldValue }) => (
         <Form id="modal" name="modal">
           <ModalSection>
             <ModalSectionContent title="Payment" Icon={ICONS[TYPES.Pay]}>
@@ -113,9 +102,9 @@ const Component: React.FC<Props> = (props: Props) => {
               </InputRow>
             </ModalSectionContent>
           </ModalSection>
-          <GovPayMetadataSection/>
-          <InviteToPaySection/>
-          <FeeBreakdownSection/>
+          <GovPayMetadataSection />
+          <InviteToPaySection />
+          <FeeBreakdownSection />
           <MoreInformation
             changeField={handleChange}
             definitionImg={values.definitionImg}

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
@@ -1,11 +1,11 @@
+import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
+import { useFormikContext } from "formik";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
-import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 
-import { useFormikContext } from "formik";
 import { Pay } from "../model";
 
 export const FeeBreakdownSection: React.FC = () => {
@@ -24,9 +24,9 @@ export const FeeBreakdownSection: React.FC = () => {
           />
         </InputRow>
         <>
-        { Boolean(values.showFeeBreakdown) && <p>Fee breakdown fields here</p> }
+          {Boolean(values.showFeeBreakdown) && <p>Fee breakdown fields here</p>}
         </>
       </ModalSectionContent>
     </ModalSection>
-  )
-}
+  );
+};

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
@@ -26,9 +26,6 @@ export const FeeBreakdownSection: React.FC = () => {
             label="Display a breakdown of the fee to the applicant"
           />
         </InputRow>
-        <>
-          {Boolean(values.showFeeBreakdown) && <p>Fee breakdown fields here</p>}
-        </>
       </ModalSectionContent>
     </ModalSection>
   );

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import ModalSection from "ui/editor/ModalSection";
+import ModalSectionContent from "ui/editor/ModalSectionContent";
+import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+
+import { useFormikContext } from "formik";
+import { Pay } from "../model";
+
+export const FeeBreakdownSection: React.FC = () => {
+  const { values, setFieldValue } = useFormikContext<Pay>();
+
+  return (
+    <ModalSection>
+      <ModalSectionContent title="Fee breakdown" Icon={ReceiptLongIcon}>
+        <InputRow>
+          <Switch
+            checked={values.showFeeBreakdown}
+            onChange={() =>
+              setFieldValue("showFeeBreakdown", !values.showFeeBreakdown)
+            }
+            label="Display a breakdown of the fee to the applicant"
+          />
+        </InputRow>
+        <>
+        { Boolean(values.showFeeBreakdown) && <p>Fee breakdown fields here</p> }
+        </>
+      </ModalSectionContent>
+    </ModalSection>
+  )
+}

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
@@ -1,5 +1,6 @@
 import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
 import { useFormikContext } from "formik";
+import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -10,6 +11,8 @@ import { Pay } from "../model";
 
 export const FeeBreakdownSection: React.FC = () => {
   const { values, setFieldValue } = useFormikContext<Pay>();
+
+  if (!hasFeatureFlag("FEE_BREAKDOWN")) return null;
 
   return (
     <ModalSection>

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
@@ -1,8 +1,7 @@
-import React from "react";
 import Box from "@mui/material/Box";
-import {
-  ComponentType as TYPES,
-} from "@opensystemslab/planx-core/types";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { useFormikContext } from "formik";
+import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
@@ -11,7 +10,6 @@ import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../../shared/icons";
-import { useFormikContext } from "formik";
 import { Pay } from "../model";
 
 export const InviteToPaySection: React.FC = () => {
@@ -98,5 +96,5 @@ export const InviteToPaySection: React.FC = () => {
         )}
       </ModalSectionContent>
     </ModalSection>
-  )
-}
+  );
+};

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -19,6 +19,7 @@ import {
   getDefaultContent,
   Pay,
 } from "../model";
+import { FeeBreakdown } from "./FeeBreakdown";
 import InviteToPayForm, { InviteToPayFormProps } from "./InviteToPayForm";
 import { PAY_API_ERROR_UNSUPPORTED_TEAM } from "./Pay";
 
@@ -180,6 +181,7 @@ export default function Confirm(props: Props) {
                 />
               </Typography>
             </FormWrapper>
+            {props.showFeeBreakdown && <FeeBreakdown />}
           </Banner>
         )}
         {page === "Pay" ? (

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -14,30 +14,23 @@ import FormWrapper from "ui/public/FormWrapper";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
-import { formattedPriceWithCurrencySymbol, getDefaultContent } from "../model";
+import {
+  formattedPriceWithCurrencySymbol,
+  getDefaultContent,
+  Pay,
+} from "../model";
 import InviteToPayForm, { InviteToPayFormProps } from "./InviteToPayForm";
 import { PAY_API_ERROR_UNSUPPORTED_TEAM } from "./Pay";
 
-export interface Props {
+export interface Props extends Omit<Pay, "title" | "fn" | "govPayMetadata"> {
   title?: string;
-  bannerTitle?: string;
-  description?: string;
   fee: number;
-  instructionsTitle?: string;
-  instructionsDescription?: string;
   showInviteToPay?: boolean;
-  secondaryPageTitle?: string;
-  nomineeTitle?: string;
-  nomineeDescription?: string;
-  yourDetailsTitle?: string;
-  yourDetailsDescription?: string;
-  yourDetailsLabel?: string;
   paymentStatus?: PaymentStatus;
   buttonTitle?: string;
   onConfirm: () => void;
   error?: string;
   hideFeeBanner?: boolean;
-  hidePay?: boolean;
 }
 
 interface PayBodyProps extends Props {
@@ -86,7 +79,7 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
     <Card>
       <PayText>
         <Typography variant="h2" component={props.hideFeeBanner ? "h2" : "h3"}>
-          {props.instructionsTitle || defaults.instructionsTitle }
+          {props.instructionsTitle || defaults.instructionsTitle}
         </Typography>
         <ReactMarkdownOrHtml
           source={

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { setup } from "testUtils";
+import { vi } from "vitest";
+import { axe } from "vitest-axe";
+
+import { FeeBreakdown } from "./FeeBreakdown";
+
+vi.mock("lib/featureFlags", () => ({
+  hasFeatureFlag: () => true,
+}));
+
+it("should not have any accessibility violations", async () => {
+  const { container } = setup(<FeeBreakdown />);
+  const results = await axe(container);
+
+  expect(results).toHaveNoViolations();
+});
+
+// Placeholder tests and initial assumptions
+it.todo("displays a planning fee");
+
+it.todo("displays a total");
+
+it.todo("displays a service charge if applicable");
+it.todo("does not display a service charge if not applicable");
+
+it.todo("displays VAT if applicable");
+it.todo("does not display VAT if not applicable");
+
+it.todo("displays exemptions if applicable");
+it.todo("does not exemptions if not applicable");
+
+it.todo("displays reductions if applicable");
+it.todo("does not reductions if not applicable");
+
+it.todo("does not display if fee calculation values are invalid");
+it.todo("silently throws an error if fee calculations are invalid");

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
@@ -1,7 +1,8 @@
 import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
+import TableCell, { tableCellClasses } from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
@@ -12,6 +13,19 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { formattedPriceWithCurrencySymbol } from "../model";
 
+const StyledTable = styled(Table)(() => ({
+  [`& .${tableCellClasses.root}`]: {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
+}));
+
+const BoldTableRow = styled(TableRow)(() => ({
+  [`& .${tableCellClasses.root}`]: {
+    fontWeight: FONT_WEIGHT_SEMI_BOLD,
+  },
+}));
+
 const VAT_RATE = 20;
 
 const DESCRIPTION =
@@ -19,14 +33,10 @@ const DESCRIPTION =
 
 const Header = () => (
   <TableHead>
-    <TableRow>
-      <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
-        Description
-      </TableCell>
-      <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }} align="right">
-        Amount
-      </TableCell>
-    </TableRow>
+    <BoldTableRow>
+      <TableCell>Description</TableCell>
+      <TableCell align="right">Amount</TableCell>
+    </BoldTableRow>
   </TableHead>
 );
 
@@ -66,12 +76,10 @@ const VAT = () => (
 );
 
 const Total = () => (
-  <TableRow>
-    <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>Total</TableCell>
-    <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }} align="right">
-      {formattedPriceWithCurrencySymbol(80)}
-    </TableCell>
-  </TableRow>
+  <BoldTableRow>
+    <TableCell>Total</TableCell>
+    <TableCell align="right">{formattedPriceWithCurrencySymbol(80)}</TableCell>
+  </BoldTableRow>
 );
 
 export const FeeBreakdown: React.FC = () => {
@@ -86,7 +94,7 @@ export const FeeBreakdown: React.FC = () => {
         {DESCRIPTION}
       </Typography>
       <TableContainer>
-        <Table data-testid="fee-breakdown-table">
+        <StyledTable data-testid="fee-breakdown-table">
           <Header />
           <TableBody>
             <ApplicationFee />
@@ -96,7 +104,7 @@ export const FeeBreakdown: React.FC = () => {
             <VAT />
             <Total />
           </TableBody>
-        </Table>
+        </StyledTable>
       </TableContainer>
     </Box>
   );

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
@@ -1,0 +1,100 @@
+import Box from "@mui/material/Box";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+import { formattedPriceWithCurrencySymbol } from "../model";
+
+const VAT_RATE = 20;
+
+const DESCRIPTION =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
+
+const Header = () => (
+  <TableHead>
+    <TableRow>
+      <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+        Description
+      </TableCell>
+      <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }} align="right">
+        Amount
+      </TableCell>
+    </TableRow>
+  </TableHead>
+);
+
+const PlanningFee = () => (
+  <TableRow>
+    <TableCell>Planning fee</TableCell>
+    <TableCell align="right">{formattedPriceWithCurrencySymbol(100)}</TableCell>
+  </TableRow>
+);
+
+const Exemptions = () => (
+  <TableRow>
+    <TableCell>Exemptions</TableCell>
+    <TableCell align="right">{formattedPriceWithCurrencySymbol(-20)}</TableCell>
+  </TableRow>
+);
+
+const Reductions = () => (
+  <TableRow>
+    <TableCell>Reductions</TableCell>
+    <TableCell align="right">{formattedPriceWithCurrencySymbol(-30)}</TableCell>
+  </TableRow>
+);
+
+const ServiceCharge = () => (
+  <TableRow>
+    <TableCell>Service charge</TableCell>
+    <TableCell align="right">{formattedPriceWithCurrencySymbol(30)}</TableCell>
+  </TableRow>
+);
+
+const VAT = () => (
+  <TableRow>
+    <TableCell>{`VAT (${VAT_RATE}%)`}</TableCell>
+    <TableCell align="right">-</TableCell>
+  </TableRow>
+);
+
+const Total = () => (
+  <TableRow>
+    <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>Total</TableCell>
+    <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }} align="right">
+      {formattedPriceWithCurrencySymbol(50)}
+    </TableCell>
+  </TableRow>
+);
+
+export const FeeBreakdown: React.FC = () => {
+  return (
+    <Box mt={3}>
+      <Typography variant="h3" mb={1}>
+        Fee breakdown
+      </Typography>
+      <Typography variant="body1" mb={2}>
+        {DESCRIPTION}
+      </Typography>
+      <TableContainer>
+        <Table>
+          <Header />
+          <TableBody>
+            <PlanningFee />
+            <ServiceCharge />
+            <Exemptions />
+            <Reductions />
+            <VAT />
+            <Total />
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
@@ -30,9 +30,9 @@ const Header = () => (
   </TableHead>
 );
 
-const PlanningFee = () => (
+const ApplicationFee = () => (
   <TableRow>
-    <TableCell>Planning fee</TableCell>
+    <TableCell>Application fee</TableCell>
     <TableCell align="right">{formattedPriceWithCurrencySymbol(100)}</TableCell>
   </TableRow>
 );
@@ -69,7 +69,7 @@ const Total = () => (
   <TableRow>
     <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>Total</TableCell>
     <TableCell sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }} align="right">
-      {formattedPriceWithCurrencySymbol(50)}
+      {formattedPriceWithCurrencySymbol(80)}
     </TableCell>
   </TableRow>
 );
@@ -89,7 +89,7 @@ export const FeeBreakdown: React.FC = () => {
         <Table data-testid="fee-breakdown-table">
           <Header />
           <TableBody>
-            <PlanningFee />
+            <ApplicationFee />
             <ServiceCharge />
             <Exemptions />
             <Reductions />

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
@@ -86,7 +86,7 @@ export const FeeBreakdown: React.FC = () => {
         {DESCRIPTION}
       </Typography>
       <TableContainer>
-        <Table>
+        <Table data-testid="fee-breakdown-table">
           <Header />
           <TableBody>
             <PlanningFee />

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown.tsx
@@ -6,6 +6,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
+import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
@@ -74,6 +75,8 @@ const Total = () => (
 );
 
 export const FeeBreakdown: React.FC = () => {
+  if (!hasFeatureFlag("FEE_BREAKDOWN")) return null;
+
   return (
     <Box mt={3}>
       <Typography variant="h3" mb={1}>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
@@ -71,3 +71,20 @@ export const ForInformationOnly = {
     onConfirm: () => {},
   },
 } satisfies Story;
+
+// TODO: Setup fee breakdown amounts
+export const WithFeeBreakdown = {
+  args: {
+    title: "Pay for your application",
+    bannerTitle: "The fee is",
+    description: "The fee covers the cost of processing your application",
+    fee: 103,
+    instructionsTitle: "How to pay",
+    instructionsDescription: "Pay via GOV.UK Pay",
+    buttonTitle: "Pay",
+    onConfirm: () => {},
+    error: undefined,
+    showInviteToPay: false,
+    showFeeBreakdown: true,
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
@@ -17,6 +17,9 @@ const meta = {
       }),
     },
   },
+  loaders: [
+    () => window.localStorage.setItem("FEATURE_FLAGS", '["FEE_BREAKDOWN"]'),
+  ],
 } satisfies Meta<typeof Confirm>;
 
 type Story = StoryObj<typeof meta>;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -14,7 +14,13 @@ import { useErrorHandler } from "react-error-boundary";
 import type { Session } from "types";
 
 import { makeData } from "../../shared/utils";
-import { createPayload, getDefaultContent, GOV_UK_PAY_URL, Pay, toDecimal } from "../model";
+import {
+  createPayload,
+  getDefaultContent,
+  GOV_UK_PAY_URL,
+  Pay,
+  toDecimal,
+} from "../model";
 import Confirm from "./Confirm";
 
 export default Component;
@@ -53,7 +59,6 @@ function Component(props: Props) {
     passport,
     environment,
     teamSlug,
-    flowSlug,
   ] = useStore((state) => [
     state.id,
     state.sessionId,
@@ -63,7 +68,6 @@ function Component(props: Props) {
     state.computePassport(),
     state.previewEnvironment,
     state.teamSlug,
-    state.flowSlug,
   ]);
   const fee = props.fn ? Number(passport.data?.[props.fn]) : 0;
 
@@ -303,7 +307,6 @@ function Component(props: Props) {
           }
           showInviteToPay={showPayOptions && isTeamSupported}
           paymentStatus={govUkPayment?.state?.status}
-          hidePay={props.hidePay}
         />
       ) : (
         <DelayedLoadingIndicator text={state.displayText || state.status} />

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -8,7 +8,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { ApplicationPath, Passport } from "types";
 import { array, boolean, object, string } from "yup";
 
-import { parseBaseNodeData, type BaseNodeData } from "../shared";
+import { type BaseNodeData, parseBaseNodeData } from "../shared";
 
 export interface Pay extends BaseNodeData {
   title: string;
@@ -182,6 +182,7 @@ export const getDefaultContent = (): Pay => ({
   nomineeTitle: "Details of the person paying",
   yourDetailsTitle: "Your details",
   yourDetailsLabel: "Your name or organisation name",
+  showFeeBreakdown: false,
   govPayMetadata: [
     {
       key: "flow",

--- a/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -27,6 +27,7 @@ export interface Pay extends BaseNodeData {
   yourDetailsDescription?: string;
   yourDetailsLabel?: string;
   govPayMetadata: GovPayMetadata[];
+  showFeeBreakdown?: boolean;
 }
 
 export const toPence = (decimal: number) => Math.trunc(decimal * 100);

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = [] as const;
+const AVAILABLE_FEATURE_FLAGS = ["FEE_BREAKDOWN"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 


### PR DESCRIPTION
## What does this PR do?
 - Adds a `FEE_BREAKDOWN` feature flag
 - Allows fee breakdown to be toggled in the Editor
 - Displays a very basic fee breakdown table in the Public "Pay" component
   - This is _just_ UI initially - there's no data here at all, these are just dummy values and not read from the passport
   - I've got a few ideas of how this could work, but having a UI first will help hang a few discussions around this - planning to have some ideas to talk through and maybe demo at dev calls this week
 - Storybook link here - https://storybook.4006.planx.pizza/?path=/story/planx-components-pay--with-fee-breakdown


<img width="603" alt="image" src="https://github.com/user-attachments/assets/bd550088-7539-4602-bfd6-599c4da52a15">
