### PR TITLE
fix: Ensure `hasComponentType` checks `fn` value

### DIFF
--- a/api.planx.uk/modules/flows/validate/helpers.ts
+++ b/api.planx.uk/modules/flows/validate/helpers.ts
@@ -22,14 +22,12 @@ export const hasComponentType = (
   const nodeIds = Object.entries(flowGraph).filter(
     (entry): entry is [string, Node] => isComponentType(entry, type),
   );
+
   if (fn) {
-    nodeIds
-      ?.filter(([_nodeId, nodeData]) => nodeData?.data?.fn === fn)
-      ?.map(([nodeId, _nodeData]) => nodeId);
-  } else {
-    nodeIds?.map(([nodeId, _nodeData]) => nodeId);
+    return nodeIds.some(([, nodeData]) => nodeData?.data?.fn === fn);
   }
-  return Boolean(nodeIds?.length);
+
+  return Boolean(nodeIds.length);
 };
 
 export const numberOfComponentType = (

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -419,15 +419,9 @@ describe("invite to pay validation on diff", () => {
   });
 
   it("does not update if invite to pay is enabled, but there is not a Checklist that sets `proposal.projectType`", async () => {
-    const {
-      Checklist: _Checklist,
-      ChecklistOptionOne: _ChecklistOptionOne,
-      ChecklistOptionTwo: _ChecklistOptionTwo,
-      ...invalidatedFlow
-    } = flowWithInviteToPay;
-    invalidatedFlow["_root"].edges?.splice(
-      invalidatedFlow["_root"].edges?.indexOf("Checklist"),
-    );
+    const invalidatedFlow = flowWithInviteToPay;
+    // Remove proposal.projectType, set incorrect variable
+    invalidatedFlow!.Checklist!.data!.fn = "some.other.variable";
 
     queryMock.mockQuery({
       name: "GetFlowData",


### PR DESCRIPTION
## What's the problem?
Invite to pay validation is only checking for the presence of a checklist, not a checklist with `proposal.projectType` set.

This means than an invalid flow can be configured, for which payment requests cannot be sent. I hit this when working on a follow up to https://github.com/theopensystemslab/planx-new/pull/4010, see demo below.

**`main` - incorrect behaviour**

https://github.com/user-attachments/assets/7b5e8914-6b76-495e-ac27-641222699103

## What's the cause?
The logic within `hasComponentType()` does not actually update the `nodeIds` array - it just maps and filters without reference to the source. As a result the `fn` check never actually happens, allowing any `Checklist` to pass the test.

**Pizza - correct behaviour**
Flow: https://4014.planx.pizza/testing/test-itp-validation

https://github.com/user-attachments/assets/c556458b-d1a0-4266-97bd-8838c0f1fa90

