### PR TITLE
fix: Clone styling for Questions with data variables or tags

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -1,4 +1,5 @@
 import ErrorIcon from "@mui/icons-material/Error";
+import Box from "@mui/material/Box";
 import {
   ComponentType as TYPES,
   NodeTags,
@@ -76,25 +77,27 @@ const Question: React.FC<Props> = React.memo((props) => {
           },
         )}
       >
-        <Link
-          href={href}
-          prefetch={false}
-          onContextMenu={handleContext}
-          ref={drag}
-        >
-          {props.data?.img && (
-            <Thumbnail
-              imageSource={props.data?.img}
-              imageAltText={props.data?.text}
-            />
+        <Box>
+          <Link
+            href={href}
+            prefetch={false}
+            onContextMenu={handleContext}
+            ref={drag}
+          >
+            {props.data?.img && (
+              <Thumbnail
+                imageSource={props.data?.img}
+                imageAltText={props.data?.text}
+              />
+            )}
+            {Icon && <Icon titleAccess={iconTitleAccess} />}
+            <span>{props.text}</span>
+          </Link>
+          {props.type !== TYPES.SetValue && props.data?.fn && (
+            <DataField value={props.data.fn} variant="parent" />
           )}
-          {Icon && <Icon titleAccess={iconTitleAccess} />}
-          <span>{props.text}</span>
-        </Link>
-        {props.type !== TYPES.SetValue && props.data?.fn && (
-          <DataField value={props.data.fn} variant="parent" />
-        )}
-        {props.tags?.map((tag) => <Tag tag={tag} key={tag} />)}
+          {props.tags?.map((tag) => <Tag tag={tag} key={tag} />)}
+        </Box>
         <ol className="options">
           {childNodes.map((child: any) => (
             <Node key={child.id} {...child} />

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -119,8 +119,7 @@ $fontMonospace: "Source Code Pro", monospace;
     outline-offset: 0;
   }
 
-  &.isClone > div,
-  &.isClone > a {
+  &.isClone > div {
     margin-top: 3px;
     position: relative;
     ::before {


### PR DESCRIPTION
## What does this PR do?
Updates structure of graph nodes so that is the `isClone` class always targets all children within a single `div` element.

| Before | After |
|--------|--------|
| <img width="789" alt="image" src="https://github.com/user-attachments/assets/e6c0b925-4655-46c3-99e8-cc9cdfe5e414"> | <img width="781" alt="image" src="https://github.com/user-attachments/assets/f202ca95-139f-4068-b92d-bf1fb38ccbcb"> | 
| Border not applied to sibling data tag, 3px gap | Border applied to single parent div, 3px gap is correctly offsetting hanger above |