### PR TITLE
feat: visually indicate if a node has help text in the graph

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -114,9 +114,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
               )}
               <Box sx={{ display: "flex", flexDirection: "row" }}>
                 {Icon && <Icon />}
-                {showHelpText && hasHelpText && (
-                  <Help fontSize="small" color="primary" />
-                )}
+                {showHelpText && hasHelpText && <Help fontSize="small" />}
                 <span>{props.text}</span>
               </Box>
             </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -1,3 +1,4 @@
+import Help from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
 import {
   ComponentType as TYPES,
@@ -25,10 +26,11 @@ type Props = {
 } & NodeTags;
 
 const Checklist: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, copyNode] = useStore((state) => [
+  const [isClone, childNodes, copyNode, showHelpText] = useStore((state) => [
     state.isClone,
     state.childNodesOf(props.id),
     state.copyNode,
+    state.showHelpText,
   ]);
 
   const parent = getParentId(props.parent);
@@ -76,6 +78,9 @@ const Checklist: React.FC<Props> = React.memo((props) => {
 
   const Icon = ICONS[props.type];
 
+  const hasHelpText =
+    props.data.policyRef || props.data.info || props.data.howMeasured;
+
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
@@ -109,6 +114,9 @@ const Checklist: React.FC<Props> = React.memo((props) => {
               )}
               <Box sx={{ display: "flex", flexDirection: "row" }}>
                 {Icon && <Icon />}
+                {showHelpText && hasHelpText && (
+                  <Help fontSize="small" color="primary" />
+                )}
                 <span>{props.text}</span>
               </Box>
             </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -1,4 +1,5 @@
 import ErrorIcon from "@mui/icons-material/Error";
+import Help from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
 import {
   ComponentType as TYPES,
@@ -25,10 +26,11 @@ type Props = {
 } & NodeTags;
 
 const Question: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, copyNode] = useStore((state) => [
+  const [isClone, childNodes, copyNode, showHelpText] = useStore((state) => [
     state.isClone,
     state.childNodesOf(props.id),
     state.copyNode,
+    state.showHelpText,
   ]);
 
   const parent = getParentId(props.parent);
@@ -59,6 +61,9 @@ const Question: React.FC<Props> = React.memo((props) => {
   const Icon = props.type === "Error" ? ErrorIcon : ICONS[props.type];
   // If there is an error, the icon has a semantic meaning and needs a title
   const iconTitleAccess = props.type === "Error" ? "Error" : undefined;
+
+  const hasHelpText =
+    props.data.policyRef || props.data.info || props.data.howMeasured;
 
   return (
     <>
@@ -91,6 +96,9 @@ const Question: React.FC<Props> = React.memo((props) => {
               />
             )}
             {Icon && <Icon titleAccess={iconTitleAccess} />}
+            {showHelpText && hasHelpText && (
+              <Help fontSize="small" color="primary" />
+            )}
             <span>{props.text}</span>
           </Link>
           {props.type !== TYPES.SetValue && props.data?.fn && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -96,9 +96,7 @@ const Question: React.FC<Props> = React.memo((props) => {
               />
             )}
             {Icon && <Icon titleAccess={iconTitleAccess} />}
-            {showHelpText && hasHelpText && (
-              <Help fontSize="small" color="primary" />
-            )}
+            {showHelpText && hasHelpText && <Help fontSize="small" />}
             <span>{props.text}</span>
           </Link>
           {props.type !== TYPES.SetValue && props.data?.fn && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleHelpTextButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleHelpTextButton.tsx
@@ -1,5 +1,5 @@
-import HelpTextIcon from "@mui/icons-material/SpeakerNotes";
-import HelpTextOffIcon from "@mui/icons-material/SpeakerNotesOff";
+import HelpTextOffIcon from "@mui/icons-material/DoNotDisturbOff";
+import HelpTextIcon from "@mui/icons-material/Help";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleHelpTextButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleHelpTextButton.tsx
@@ -1,0 +1,35 @@
+import HelpTextIcon from "@mui/icons-material/SpeakerNotes";
+import HelpTextOffIcon from "@mui/icons-material/SpeakerNotesOff";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+export const ToggleHelpTextButton: React.FC = () => {
+  const [showHelpText, toggleShowHelpText] = useStore((state) => [
+    state.showHelpText,
+    state.toggleShowHelpText,
+  ]);
+
+  return (
+    <Tooltip title="Toggle help text" placement="right">
+      <IconButton
+        aria-label="Toggle help text"
+        onClick={toggleShowHelpText}
+        size="large"
+        sx={(theme) => ({
+          background: theme.palette.background.paper,
+          padding: theme.spacing(1),
+          color: showHelpText
+            ? theme.palette.text.primary
+            : theme.palette.text.disabled,
+          "&:hover": {
+            background: theme.palette.common.white,
+          },
+        })}
+      >
+        {showHelpText ? <HelpTextIcon /> : <HelpTextOffIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -9,6 +9,7 @@ import { rootFlowPath } from "routes/utils";
 
 import Flow from "./components/Flow";
 import { ToggleDataFieldsButton } from "./components/FlowEditor/ToggleDataFieldsButton";
+import { ToggleHelpTextButton } from "./components/FlowEditor/ToggleHelpTextButton";
 import { ToggleImagesButton } from "./components/FlowEditor/ToggleImagesButton";
 import { ToggleTagsButton } from "./components/FlowEditor/ToggleTagsButton";
 import Sidebar from "./components/Sidebar";
@@ -71,6 +72,7 @@ const FlowEditor = () => {
           >
             <ToggleImagesButton />
             <ToggleDataFieldsButton />
+            <ToggleHelpTextButton />
             <ToggleTagsButton />
           </EditorVisualControls>
         </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -71,8 +71,8 @@ const FlowEditor = () => {
             aria-label="Toggle node attributes"
           >
             <ToggleImagesButton />
-            <ToggleDataFieldsButton />
             <ToggleHelpTextButton />
+            <ToggleDataFieldsButton />
             <ToggleTagsButton />
           </EditorVisualControls>
         </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -56,6 +56,8 @@ export interface EditorUIStore {
   toggleShowImages: () => void;
   showDataFields: boolean;
   toggleShowDataFields: () => void;
+  showHelpText: boolean;
+  toggleShowHelpText: () => void;
   previousURL?: string;
   currentURL: string;
   initURLTracking: () => void;
@@ -91,6 +93,10 @@ export const editorUIStore: StateCreator<
     showDataFields: false,
 
     toggleShowDataFields: () => set({ showDataFields: !get().showDataFields }),
+
+    showHelpText: false,
+
+    toggleShowHelpText: () => set({ showHelpText: !get().showHelpText }),
 
     previousURL: undefined,
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -121,6 +121,7 @@ export const editorUIStore: StateCreator<
       showTags: state.showTags,
       showImages: state.showImages,
       showDataFields: state.showDataFields,
+      showHelpText: state.showHelpText,
     }),
   },
 );

--- a/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -18,7 +18,7 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
 }) => {
   return (
     <ModalSection>
-      <ModalSectionContent title="Internal Notes" Icon={BorderColorIcon}>
+      <ModalSectionContent title="Internal notes" Icon={BorderColorIcon}>
         <InputRow>
           <Input
             // required
@@ -26,7 +26,7 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
             value={value}
             onChange={onChange}
             multiline
-            placeholder="Internal Notes"
+            placeholder="Internal notes"
             rows={3}
           />
         </InputRow>

--- a/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
+++ b/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
@@ -1,4 +1,4 @@
-import InfoOutlined from "@mui/icons-material/InfoOutlined";
+import Help from "@mui/icons-material/Help";
 import React from "react";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
@@ -17,7 +17,7 @@ export const MoreInformation = ({
 }: MoreInformationProps) => {
   return (
     <ModalSection>
-      <ModalSectionContent title="More Information" Icon={InfoOutlined}>
+      <ModalSectionContent title="More information" Icon={Help}>
         <InputGroup flowSpacing>
           <InputLabel label="Why it matters">
             <RichTextInput


### PR DESCRIPTION
Adds a simple toggle & icon to indicate if a node has help text defined without having to open its' modal

![Screenshot from 2024-12-02 09-47-59](https://github.com/user-attachments/assets/f6bbe602-4409-42a9-9f49-b3be7ac76799)