### PR TITLE
fix: Handle nodes without more info fields

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -79,7 +79,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
   const Icon = ICONS[props.type];
 
   const hasHelpText =
-    props.data.policyRef || props.data.info || props.data.howMeasured;
+    props.data?.policyRef || props.data?.info || props.data?.howMeasured;
 
   return (
     <>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -63,7 +63,7 @@ const Question: React.FC<Props> = React.memo((props) => {
   const iconTitleAccess = props.type === "Error" ? "Error" : undefined;
 
   const hasHelpText =
-    props.data.policyRef || props.data.info || props.data.howMeasured;
+    props.data?.policyRef || props.data?.info || props.data?.howMeasured;
 
   return (
     <>


### PR DESCRIPTION
Quick fix following on from #4021 

This account for nodes which don't have the "More information" fields - currently hitting this here on staging https://editor.planx.dev/templates/apply-for-a-rights-of-way-order

![image](https://github.com/user-attachments/assets/68d95067-7b71-496b-937f-48dcf393c971)
