### PR TITLE
fix: `TypeError: R.startsWith is not a function` in `computePassport`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -226,7 +226,7 @@ export const previewStore: StateCreator<
               .concat(existingValue)
               .reduce(
                 (acc: string[], curr: string, _i: number, arr: string[]) => {
-                  if (!arr.some((x) => x !== curr && x.startsWith(curr))) {
+                  if (!arr.some((x) => x !== curr && x?.startsWith(curr))) {
                     acc.push(curr);
                   }
                   return acc;


### PR DESCRIPTION
Flagged in #help-issues here https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1733142123040579 & picked up by Airbrake - this should clear it up :crossed_fingers: 
![Screenshot from 2024-12-02 15-09-33](https://github.com/user-attachments/assets/5f55b5c4-fa57-4133-9f92-55d809b33bb2)

`computePassport` is definitely on my logic-refactor wishlist one of these days as it'd benefit a lot from tighter types and code comments, but this patch should ease user-facing errors in meantime.
