### PR TITLE
feat: conditionally show/hide "Continue" button on Confirmation using `isFinalCard`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -75,6 +75,7 @@ describe("Confirmation component", () => {
         ]}
         moreInfo="more info"
         contactInfo="contact info"
+        handleSubmit={handleSubmit}
       />,
     );
 

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -33,3 +33,9 @@ it("should not have any accessibility violations", async () => {
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });
+
+it.todo("should hide the 'Continue' button if it's the final card in the flow");
+
+it.todo(
+  "should show the 'Continue' button if it is not the final card in the flow",
+);

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -85,6 +85,7 @@ interface PresentationalProps extends Props {
 }
 
 export function Presentational(props: PresentationalProps) {
+  const isFinalCard = useStore().isFinalCard();
   return (
     <Box width="100%">
       <Banner
@@ -99,7 +100,7 @@ export function Presentational(props: PresentationalProps) {
           </Box>
         )}
       </Banner>
-      <Card>
+      <Card handleSubmit={isFinalCard ? undefined : props.handleSubmit}>
         <SummaryListTable>
           {Object.entries(props.applicableDetails).map(([k, v], i) => (
             <React.Fragment key={`detail-${i}`}>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.test.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.test.tsx
@@ -1,4 +1,5 @@
 import Button from "@mui/material/Button";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { act, screen, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -46,6 +47,29 @@ describe("Card component", () => {
     const children = <h1>Confirmation Page</h1>;
     setup(<Card children={children}></Card>);
 
+    expect(screen.queryByText(resumeButtonText)).not.toBeInTheDocument();
+    expect(screen.queryByText(saveButtonText)).not.toBeInTheDocument();
+  });
+
+  it("hides the Save/Resume option if the user has already passed Send", () => {
+    act(() =>
+      setState({
+        path: ApplicationPath.SaveAndReturn,
+        flow: {
+          _root: { edges: ["Send", "Confirmation", "Feedback", "Notice"] },
+          Send: { type: TYPES.Send },
+          Confirmation: { type: TYPES.Confirmation },
+          Feedback: { type: TYPES.Feedback },
+          Notice: { type: TYPES.Notice },
+        },
+        breadcrumbs: { Send: { auto: false } },
+      }),
+    );
+    const children = <h1>Confirmation Page</h1>;
+    setup(<Card handleSubmit={handleSubmit} children={children}></Card>);
+
+    expect(screen.queryByText("Confirmation Page")).toBeInTheDocument();
+    expect(screen.queryByText("Continue")).toBeInTheDocument();
     expect(screen.queryByText(resumeButtonText)).not.toBeInTheDocument();
     expect(screen.queryByText(saveButtonText)).not.toBeInTheDocument();
   });

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -3,6 +3,7 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Fade from "@mui/material/Fade";
 import { styled, Theme, useTheme } from "@mui/material/styles";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect } from "react";
@@ -52,8 +53,11 @@ const Card: React.FC<Props> = ({
     state.path,
     state.currentCard,
   ]);
+
   const showSaveResumeButton =
-    path === ApplicationPath.SaveAndReturn && handleSubmit;
+    path === ApplicationPath.SaveAndReturn &&
+    handleSubmit &&
+    visibleNode?.type !== TYPES.Confirmation;
   const { track } = useAnalyticsTracking();
 
   useEffect(() => {

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -49,15 +49,23 @@ const Card: React.FC<Props> = ({
   ...props
 }) => {
   const theme = useTheme();
-  const [path, visibleNode] = useStore((state) => [
+  const [path, visibleNode, breadcrumbs, flow] = useStore((state) => [
     state.path,
     state.currentCard,
+    state.breadcrumbs,
+    state.flow,
   ]);
 
+  // Check if we have a Send node in our breadcrumbs
+  //   In the frontend this is a better/more immediate proxy for "Submitted" because actual send events that populate lowcal_sessions.submitted_at are async
+  const hasSent = Object.keys(breadcrumbs)
+    .reverse()
+    .some(
+      (breadcrumbNodeId: string) => flow[breadcrumbNodeId]?.type === TYPES.Send,
+    );
+
   const showSaveResumeButton =
-    path === ApplicationPath.SaveAndReturn &&
-    handleSubmit &&
-    visibleNode?.type !== TYPES.Confirmation;
+    path === ApplicationPath.SaveAndReturn && handleSubmit && !hasSent;
   const { track } = useAnalyticsTracking();
 
   useEffect(() => {

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -57,7 +57,7 @@ const Card: React.FC<Props> = ({
   ]);
 
   // Check if we have a Send node in our breadcrumbs
-  //   In the frontend this is a better/more immediate proxy for "Submitted" because actual send events that populate lowcal_sessions.submitted_at are async
+  //   This is a better/more immediate proxy for "Submitted" because actual send events that populate lowcal_sessions.submitted_at are queued via Hasura
   const hasSent = Object.keys(breadcrumbs)
     .reverse()
     .some(

--- a/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/Card.tsx
@@ -57,12 +57,10 @@ const Card: React.FC<Props> = ({
   ]);
 
   // Check if we have a Send node in our breadcrumbs
-  //   This is a better/more immediate proxy for "Submitted" because actual send events that populate lowcal_sessions.submitted_at are queued via Hasura
-  const hasSent = Object.keys(breadcrumbs)
-    .reverse()
-    .some(
-      (breadcrumbNodeId: string) => flow[breadcrumbNodeId]?.type === TYPES.Send,
-    );
+  //   This is a better/more immediate proxy for "submitted" in the frontend because actual send events that populate lowcal_sessions.submitted_at are queued via Hasura
+  const hasSent = Object.keys(breadcrumbs).some(
+    (breadcrumbNodeId: string) => flow[breadcrumbNodeId]?.type === TYPES.Send,
+  );
 
   const showSaveResumeButton =
     path === ApplicationPath.SaveAndReturn && handleSubmit && !hasSent;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -670,9 +670,8 @@ export const previewStore: StateCreator<
   },
 
   isFinalCard: () => {
-    // Temporarily always returns false until upcomingCardIds is optimised
-    // OSL Slack explanation: https://bit.ly/3x38IRY
-    return false;
+    const { upcomingCardIds } = get();
+    return upcomingCardIds().length === 1;
   },
 
   restore: false,

--- a/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -75,16 +75,13 @@ interface Props {
 }
 
 const Node: React.FC<Props> = (props) => {
-  const [childNodesOf, isFinalCard, resetPreview, cachedBreadcrumbs] = useStore(
-    (state) => [
-      state.childNodesOf,
-      state.isFinalCard(),
-      state.resetPreview,
-      state.cachedBreadcrumbs,
-    ],
-  );
+  const [childNodesOf, resetPreview, cachedBreadcrumbs] = useStore((state) => [
+    state.childNodesOf,
+    state.resetPreview,
+    state.cachedBreadcrumbs,
+  ]);
 
-  const handleSubmit = isFinalCard ? undefined : props.handleSubmit;
+  const handleSubmit = props.handleSubmit;
 
   const nodeId = props.node.id;
   const previouslySubmittedData =


### PR DESCRIPTION
Per request here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1733157241528129

**Changes:**
- The Confirmation component now determines if it is the final node in the flow
  - If it is the final node, it will not display a "Continue" button
  - If it is _not_ the final node, it **will** display a "Continue" button and leave a basic breadcrumb
  - In either scenario, the Confirmation component still _never_ displays a "back" button - which I think is correct/intended behavior as we would not allow someone to change answers post-Confirmation
- Hides the "Save and return..." link beneath "Continue" if there's a Send component present in our breadcrumbs

**Todo:** 
- :white_check_mark: Add some tests (honestly a little unsettling that this hasn't broken any :sweat_smile:)
  
**Testing questions:**
- Does this work as expected? Is there any sluggishness introduced when navigating between cards? 
- Is it okay that any node that comes _after_ Confirmation will _not_ be included in a submission payload? Does this impact any of our existing feedback/analytics processes for tracking user satisfaction, etc? 
- Do we need to hide the "Save and resume this application later" link under "Continue" on all nodes _after_ Confirmation?
  - :white_check_mark: See note above, now hidden if breadcrumbs include a Send node
- Do we need to introduce any publish validation rules for types of components that are allowed to come after Confirmation, eg no Pay or Send?