### PR TITLE
fix: remove `alteredNodes` badge on publish button and `validateAndDiff` request on first flow load

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishFlowButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishFlowButton.tsx
@@ -1,4 +1,3 @@
-import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -98,35 +97,21 @@ export const PublishFlowButton: React.FC<{ previewURL: string }> = ({
     setLastPublishedTitle(formatLastPublishMessage(date, user));
   }, [flowId]);
 
-  const _validateAndDiffRequest = useAsync(async () => {
-    const newChanges = await validateAndDiffFlow(flowId);
-    setAlteredNodes(
-      newChanges?.data.alteredNodes ? newChanges.data.alteredNodes : [],
-    );
-  }, [flowId]);
-
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
 
   return (
     <Box width="100%" mt={2}>
       <Box display="flex" flexDirection="column" alignItems="flex-end">
-        <Badge
+        <Button
           sx={{ width: "100%" }}
-          badgeContent={alteredNodes && alteredNodes.length}
-          max={999}
-          color="warning"
+          variant="contained"
+          color="primary"
+          disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+          onClick={handleCheckForChangesToPublish}
         >
-          <Button
-            sx={{ width: "100%" }}
-            variant="contained"
-            color="primary"
-            disabled={!useStore.getState().canUserEditTeam(teamSlug)}
-            onClick={handleCheckForChangesToPublish}
-          >
-            CHECK FOR CHANGES TO PUBLISH
-          </Button>
-        </Badge>
+          CHECK FOR CHANGES TO PUBLISH
+        </Button>
         <Dialog
           open={dialogOpen}
           onClose={() => setDialogOpen(false)}


### PR DESCRIPTION
I've noticed that loading flows in the editor feels particularly sluggish lately and leads to more errors in the Preview side panel than usual (and therefore Airbrake too) - eg `Error: id "eMxQAgygE6" not found`, `TypeError: Cannot read properties of undefined (reading 'data')` and so on.

This PR proposes removing the "badge" on the publish button which displays how many altered nodes are currently un-published. This badge requires calling `validateAndDiff` on initial flow load which is fairly expensive and regularly timesout (therefore badge fails to display at all).

Feels like it's an easy win to remove this feature for now (doubt it'll be noticed or missed), _only_ call `validateAndDiff` when the "Check for cahnges to publish" modal is actually opened and _not_ on first flow load as before, and re-visit this when we talk about publishing designs later this phase. Hopeful it'll free up more space for other requests on first flow load to run and ease a bit of noise in the errors channel :crossed_fingers: 