### PR TITLE
fix: when next step is deleted, props.value doesn't update

### DIFF
--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -46,7 +46,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
       <InputRow>
         <Input
           name="description"
-          value={props.value.description}
+          value={props.value.description || ""}
           multiline
           onChange={(ev: ChangeEvent<HTMLInputElement>) => {
             props.onChange({
@@ -61,7 +61,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
         <Input
           name="url"
           type="url"
-          value={props.value.url}
+          value={props.value.url || ""}
           onChange={(ev: ChangeEvent<HTMLInputElement>) => {
             props.onChange({
               ...props.value,


### PR DESCRIPTION
Found that when you deleted a step from the NextSteps component, it wouldn't set `description` or `url` to "", but not set it at all. This meant previous values with the same index would persist until it is submitted then when it is reloaded, data would return to the formik saved values. 

Looked into trying to alter the data model, but got a bit caught up in the components and functions with the way they are passed down and back up. Open to suggestions on a more robust change, but this seemed to work. 

