### PR TITLE
fix: Reapply SetValue graph CSS

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -180,7 +180,7 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
-  &.type-SetValue > a {
+  &.type-SetValue > div > a {
     background: #f0f0f0;
     font-family: $fontMonospace;
   }


### PR DESCRIPTION
Fixes issue raised here (OSL Slack) - https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1733216868074849

Regression introduced here when an additional wrapping `Box` (HTML `div`) was added to the graph node - https://github.com/theopensystemslab/planx-new/pull/4017