### PR TITLE
feat(fee-breakdown): Calculate VAT using `useFeeBreakdown()`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -15,7 +15,6 @@ import { Switch } from "ui/shared/Switch";
 import { ICONS } from "../../shared/icons";
 import { EditorProps } from "../../shared/types";
 import { FeeBreakdownSection } from "./FeeBreakdownSection";
-import { FeeBreakdownSection } from "./FeeBreakdownSection";
 import { GovPayMetadataSection } from "./GovPayMetadataSection";
 import { InviteToPaySection } from "./InviteToPaySection";
 

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -15,6 +15,7 @@ import { Switch } from "ui/shared/Switch";
 import { ICONS } from "../../shared/icons";
 import { EditorProps } from "../../shared/types";
 import { FeeBreakdownSection } from "./FeeBreakdownSection";
+import { FeeBreakdownSection } from "./FeeBreakdownSection";
 import { GovPayMetadataSection } from "./GovPayMetadataSection";
 import { InviteToPaySection } from "./InviteToPaySection";
 
@@ -102,9 +103,9 @@ const Component: React.FC<Props> = (props: Props) => {
               </InputRow>
             </ModalSectionContent>
           </ModalSection>
-          <GovPayMetadataSection />
-          <InviteToPaySection />
-          <FeeBreakdownSection />
+          <GovPayMetadataSection/>
+          <InviteToPaySection/>
+          <FeeBreakdownSection/>
           <MoreInformation
             changeField={handleChange}
             definitionImg={values.definitionImg}

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/FeeBreakdownSection.tsx
@@ -1,5 +1,5 @@
 import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
-import { hasFeatureFlag } from 'lib/featureFlags';
+import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
 import ModalSection from "ui/editor/ModalSection";

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -49,16 +49,52 @@ const ApplicationFee: React.FC<{ amount: number }> = ({ amount }) => (
   </TableRow>
 );
 
-const Reductions: React.FC<{ amount?: number }> = ({ amount }) => {
+const Reductions: React.FC<{ amount?: number, reductions: string[] }> = ({ amount, reductions }) => {
   if (!amount) return null;
 
   return (
+    <>
     <TableRow>
       <TableCell>Reductions</TableCell>
       <TableCell align="right">
         {formattedPriceWithCurrencySymbol(-amount)}
       </TableCell>
     </TableRow>
+    {
+      reductions.map((reduction) => (
+        <TableRow>
+          <TableCell colSpan={2}>
+            <Box sx={{ pl: 2, color: "grey" }}>{reduction}</Box>
+          </TableCell>
+        </TableRow>
+      ))
+    }
+    </>
+  );
+};
+
+// TODO: This won't show as if a fee is 0, we hide the whole Pay component from the user
+const Exemptions: React.FC<{ amount: number, exemptions: string[] }> = ({ amount, exemptions }) => {
+  if (!exemptions.length) return null;
+
+  return (
+    <>
+    <TableRow>
+      <TableCell>Exemptions</TableCell>
+      <TableCell align="right">
+        {formattedPriceWithCurrencySymbol(-amount)}
+      </TableCell>
+    </TableRow>
+    {
+        exemptions.map((exemption) => (
+        <TableRow>
+          <TableCell colSpan={2}>
+            <Box sx={{ pl: 2, color: "grey" }}>{exemption}</Box>
+          </TableCell>
+        </TableRow>
+      ))
+    }
+    </>
   );
 };
 
@@ -90,7 +126,7 @@ export const FeeBreakdown: React.FC = () => {
   const breakdown = useFeeBreakdown();
   if (!breakdown) return null;
 
-  const { amount, exemptions: _exemptions, reductions: _reductions } = breakdown;
+  const { amount, reductions, exemptions } = breakdown;
 
   return (
     <Box mt={3}>
@@ -105,7 +141,8 @@ export const FeeBreakdown: React.FC = () => {
           <Header />
           <TableBody>
             <ApplicationFee amount={amount.applicationFee} />
-            <Reductions amount={amount.reduction} />
+            <Reductions amount={amount.reduction} reductions={reductions}/>
+            <Exemptions amount={amount.applicationFee} exemptions={exemptions}/>
             <Total amount={amount.total} />
             <VAT amount={amount.vat} />
           </TableBody>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -26,7 +26,7 @@ const BoldTableRow = styled(TableRow)(() => ({
   },
 }));
 
-const VAT_RATE = 0.2;
+export const VAT_RATE = 0.2;
 
 const DESCRIPTION =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -90,6 +90,8 @@ export const FeeBreakdown: React.FC = () => {
   const breakdown = useFeeBreakdown();
   if (!breakdown) return null;
 
+  const { amount, exemptions: _exemptions, reductions: _reductions } = breakdown;
+
   return (
     <Box mt={3}>
       <Typography variant="h3" mb={1}>
@@ -102,10 +104,10 @@ export const FeeBreakdown: React.FC = () => {
         <StyledTable data-testid="fee-breakdown-table">
           <Header />
           <TableBody>
-            <ApplicationFee amount={breakdown.applicationFee} />
-            <Reductions amount={breakdown.reduction} />
-            <Total amount={breakdown.total} />
-            <VAT amount={breakdown.vat} />
+            <ApplicationFee amount={amount.applicationFee} />
+            <Reductions amount={amount.reduction} />
+            <Total amount={amount.total} />
+            <VAT amount={amount.vat} />
           </TableBody>
         </StyledTable>
       </TableContainer>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
@@ -12,7 +12,7 @@ export interface FeeBreakdown {
 export interface PassportFeeFields {
   "application.fee.calculated": number;
   "application.fee.payable": number;
-  "application.fee.payable.vat": number;
+  "application.fee.payable.includesVAT": boolean;
   "application.fee.reduction.alternative": boolean;
   "application.fee.reduction.parishCouncil": boolean;
   "application.fee.reduction.sports": boolean;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
@@ -10,11 +10,12 @@ export interface FeeBreakdown {
 }
 
 export interface PassportFeeFields {
-  amount: {
-    "application.fee.calculated": number;
-    "application.fee.payable": number;
-    "application.fee.payable.vat": number;
-  },
-  reductions?: Record<string, boolean>
-  exemptions?: Record<string, boolean>
+  "application.fee.calculated": number;
+  "application.fee.payable": number;
+  "application.fee.payable.vat": number;
+  "application.fee.reduction.alternative": boolean;
+  "application.fee.reduction.parishCouncil": boolean;
+  "application.fee.reduction.sports": boolean;
+  "application.fee.exemption.disability": boolean;
+  "application.fee.exemption.resubmission": boolean;
 };

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
@@ -5,6 +5,8 @@ export interface FeeBreakdown {
     reduction: number;
     vat: number | undefined;
   };
+  reductions: string[];
+  exemptions: string[];
 }
 
 export interface PassportFeeFields {
@@ -13,4 +15,6 @@ export interface PassportFeeFields {
     "application.fee.payable": number;
     "application.fee.payable.vat": number;
   },
+  reductions?: Record<string, boolean>
+  exemptions?: Record<string, boolean>
 };

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/types.ts
@@ -1,12 +1,16 @@
 export interface FeeBreakdown {
-  applicationFee: number;
-  total: number;
-  reduction: number;
-  vat: number | undefined;
+  amount: {
+    applicationFee: number;
+    total: number;
+    reduction: number;
+    vat: number | undefined;
+  };
 }
 
 export interface PassportFeeFields {
-  "application.fee.calculated": number;
-  "application.fee.payable": number;
-  "application.fee.payable.vat": number;
-}
+  amount: {
+    "application.fee.calculated": number;
+    "application.fee.payable": number;
+    "application.fee.payable.vat": number;
+  },
+};

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
@@ -28,10 +28,12 @@ describe("useFeeBreakdown() hook", () => {
       const result = useFeeBreakdown();
 
       expect(result).toEqual({
-        applicationFee: 1000,
-        total: 800,
-        reduction: 200,
-        vat: 160,
+        amount: {
+          applicationFee: 1000,
+          total: 800,
+          reduction: 200,
+          vat: 160,
+        },
       });
     });
 
@@ -47,10 +49,12 @@ describe("useFeeBreakdown() hook", () => {
       const result = useFeeBreakdown();
 
       expect(result).toEqual({
-        applicationFee: 1000,
-        total: 800,
-        reduction: 200,
-        vat: 160,
+        amount: {
+          applicationFee: 1000,
+          total: 800,
+          reduction: 200,
+          vat: 160,
+        }
       });
     });
   });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
@@ -34,6 +34,8 @@ describe("useFeeBreakdown() hook", () => {
           reduction: 200,
           vat: 160,
         },
+        exemptions: [],
+        reductions: [],
       });
     });
 
@@ -54,8 +56,80 @@ describe("useFeeBreakdown() hook", () => {
           total: 800,
           reduction: 200,
           vat: 160,
-        }
+        },
+        exemptions: [],
+        reductions: [],
       });
+    });
+
+    it("parses 'true' reduction values to a list of keys", () => {
+      const mockPassportData = {
+        "application.fee.calculated": 1000,
+        "application.fee.payable": 800,
+        "application.fee.payable.vat": 160,
+        "application.fee.reduction.reasonOne": ["true"],
+        "application.fee.reduction.reasonTwo": ["true"],
+      };
+
+      vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
+
+      const result = useFeeBreakdown();
+
+      expect(result?.reductions).toHaveLength(2);
+      expect(result?.reductions).toEqual(
+        expect.arrayContaining(["reasonOne", "reasonTwo"])
+      );
+    });
+
+    it("does not parse 'false' reduction values to a list of keys", () => {
+      const mockPassportData = {
+        "application.fee.calculated": 1000,
+        "application.fee.payable": 800,
+        "application.fee.payable.vat": 160,
+        "application.fee.reduction.reasonOne": ["false"],
+        "application.fee.reduction.reasonTwo": ["false"],
+      };
+
+      vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
+
+      const result = useFeeBreakdown();
+
+      expect(result?.reductions).toHaveLength(0);
+    });
+
+    it("parses 'true' exemption values to a list of keys", () => {
+      const mockPassportData = {
+        "application.fee.calculated": 1000,
+        "application.fee.payable": 800,
+        "application.fee.payable.vat": 160,
+        "application.fee.exemption.reasonOne": ["true"],
+        "application.fee.exemption.reasonTwo": ["true"],
+      };
+
+      vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
+
+      const result = useFeeBreakdown();
+
+      expect(result?.exemptions).toHaveLength(2);
+      expect(result?.exemptions).toEqual(
+        expect.arrayContaining(["reasonOne", "reasonTwo"])
+      );
+    });
+
+    it("does not parse 'false' exemption values to a list of keys", () => {
+      const mockPassportData = {
+        "application.fee.calculated": 1000,
+        "application.fee.payable": 800,
+        "application.fee.payable.vat": 160,
+        "application.fee.exemption.reasonOne": ["false"],
+        "application.fee.exemption.reasonTwo": ["false"],
+      };
+
+      vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
+
+      const result = useFeeBreakdown();
+
+      expect(result?.exemptions).toHaveLength(0);
     });
   });
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
@@ -69,8 +69,8 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
         "application.fee.payable.vat": 160,
-        "application.fee.reduction.reasonOne": ["true"],
-        "application.fee.reduction.reasonTwo": ["true"],
+        "application.fee.reduction.alternative": ["true"],
+        "application.fee.reduction.parishCouncil": ["true"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -80,7 +80,7 @@ describe("useFeeBreakdown() hook", () => {
 
       expect(result?.reductions).toHaveLength(2);
       expect(result?.reductions).toEqual(
-        expect.arrayContaining(["reasonOne", "reasonTwo"])
+        expect.arrayContaining(["alternative", "parishCouncil"])
       );
     });
 
@@ -89,8 +89,8 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
         "application.fee.payable.vat": 160,
-        "application.fee.reduction.reasonOne": ["false"],
-        "application.fee.reduction.reasonTwo": ["false"],
+        "application.fee.reduction.alternative": ["false"],
+        "application.fee.reduction.parishCouncil": ["false"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -101,13 +101,36 @@ describe("useFeeBreakdown() hook", () => {
       expect(result?.reductions).toHaveLength(0);
     });
 
+    it("does not parse non-schema reduction values", () => {
+      const mockPassportData = {
+        "application.fee.calculated": 1000,
+        "application.fee.payable": 800,
+        "application.fee.payable.vat": 160,
+        "application.fee.reduction.alternative": ["true"],
+        "application.fee.reduction.parishCouncil": ["false"],
+        "application.fee.reduction.someReason": ["true"],
+        "application.fee.reduction.someOtherReason": ["false"],
+        "some.other.fields": ["abc", "xyz"],
+      };
+
+      vi.mocked(useStore).mockReturnValue([
+        mockPassportData,
+        "test-session",
+      ]);
+
+      const result = useFeeBreakdown();
+
+      expect(result?.reductions).toEqual(expect.not.arrayContaining(["someReason"]))
+      expect(result?.reductions).toEqual(expect.not.arrayContaining(["someOtherReason"]))
+    });
+
     it("parses 'true' exemption values to a list of keys", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
         "application.fee.payable.vat": 160,
-        "application.fee.exemption.reasonOne": ["true"],
-        "application.fee.exemption.reasonTwo": ["true"],
+        "application.fee.exemption.disability": ["true"],
+        "application.fee.exemption.resubmission": ["true"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -117,7 +140,7 @@ describe("useFeeBreakdown() hook", () => {
 
       expect(result?.exemptions).toHaveLength(2);
       expect(result?.exemptions).toEqual(
-        expect.arrayContaining(["reasonOne", "reasonTwo"])
+        expect.arrayContaining(["disability", "resubmission"])
       );
     });
 
@@ -126,8 +149,8 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
         "application.fee.payable.vat": 160,
-        "application.fee.exemption.reasonOne": ["false"],
-        "application.fee.exemption.reasonTwo": ["false"],
+        "application.fee.exemption.disability": ["false"],
+        "application.fee.exemption.resubmission": ["false"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -136,6 +159,33 @@ describe("useFeeBreakdown() hook", () => {
       const result = useFeeBreakdown();
 
       expect(result?.exemptions).toHaveLength(0);
+    });
+
+    it("does not parse non-schema exemption values", () => {
+      const mockPassportData = {
+        "application.fee.calculated": 1000,
+        "application.fee.payable": 800,
+        "application.fee.payable.vat": 160,
+        "application.fee.exemption.disability": ["false"],
+        "application.fee.exemption.resubmission": ["false"],
+        "application.fee.exemption.someReason": ["true"],
+        "application.fee.exemption.someOtherReason": ["false"],
+        "some.other.fields": ["abc", "xyz"],
+      };
+
+      vi.mocked(useStore).mockReturnValue([
+        mockPassportData,
+        "test-session",
+      ]);
+
+      const result = useFeeBreakdown();
+
+      expect(result?.exemption).toEqual(
+        expect.not.arrayContaining(["someReason"])
+      );
+      expect(result?.exemption).toEqual(
+        expect.not.arrayContaining(["someOtherReason"])
+      );
     });
   });
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
@@ -20,7 +20,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -33,7 +33,7 @@ describe("useFeeBreakdown() hook", () => {
           applicationFee: 1000,
           total: 800,
           reduction: 200,
-          vat: 160,
+          vat: 166.67,
         },
         exemptions: [],
         reductions: [],
@@ -44,7 +44,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": [1000],
         "application.fee.payable": [800],
-        "application.fee.payable.vat": [160],
+        "application.fee.payable.includesVAT": ["true"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -57,7 +57,7 @@ describe("useFeeBreakdown() hook", () => {
           applicationFee: 1000,
           total: 800,
           reduction: 200,
-          vat: 160,
+          vat: 166.67,
         },
         exemptions: [],
         reductions: [],
@@ -68,7 +68,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "application.fee.reduction.alternative": ["true"],
         "application.fee.reduction.parishCouncil": ["true"],
         "some.other.fields": ["abc", "xyz"],
@@ -88,7 +88,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "application.fee.reduction.alternative": ["false"],
         "application.fee.reduction.parishCouncil": ["false"],
         "some.other.fields": ["abc", "xyz"],
@@ -105,7 +105,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "application.fee.reduction.alternative": ["true"],
         "application.fee.reduction.parishCouncil": ["false"],
         "application.fee.reduction.someReason": ["true"],
@@ -128,7 +128,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "application.fee.exemption.disability": ["true"],
         "application.fee.exemption.resubmission": ["true"],
         "some.other.fields": ["abc", "xyz"],
@@ -148,7 +148,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "application.fee.exemption.disability": ["false"],
         "application.fee.exemption.resubmission": ["false"],
         "some.other.fields": ["abc", "xyz"],
@@ -165,7 +165,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
-        "application.fee.payable.vat": 160,
+        "application.fee.payable.includesVAT": ["true"],
         "application.fee.exemption.disability": ["false"],
         "application.fee.exemption.resubmission": ["false"],
         "application.fee.exemption.someReason": ["true"],
@@ -205,7 +205,7 @@ describe("useFeeBreakdown() hook", () => {
     it("returns undefined for partial data", () => {
       const mockPassportData = {
         "application.fee.calculated": [1000],
-        "application.fee.payable.vat": [160],
+        "application.fee.payable.includesVAT": ["true"],
         "some.other.fields": ["abc", "xyz"],
       };
 
@@ -220,7 +220,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": "some string",
         "application.fee.payable": [800, 700],
-        "application.fee.payable.vat": false,
+        "application.fee.payable.includesVAT": false,
         "some.other.fields": ["abc", "xyz"],
       };
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
@@ -180,10 +180,10 @@ describe("useFeeBreakdown() hook", () => {
 
       const result = useFeeBreakdown();
 
-      expect(result?.exemption).toEqual(
+      expect(result?.exemptions).toEqual(
         expect.not.arrayContaining(["someReason"])
       );
-      expect(result?.exemption).toEqual(
+      expect(result?.exemptions).toEqual(
         expect.not.arrayContaining(["someOtherReason"])
       );
     });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.test.ts
@@ -21,6 +21,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.calculated": 1000,
         "application.fee.payable": 800,
         "application.fee.payable.vat": 160,
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -44,6 +45,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.calculated": [1000],
         "application.fee.payable": [800],
         "application.fee.payable.vat": [160],
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -69,6 +71,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.payable.vat": 160,
         "application.fee.reduction.reasonOne": ["true"],
         "application.fee.reduction.reasonTwo": ["true"],
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -88,6 +91,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.payable.vat": 160,
         "application.fee.reduction.reasonOne": ["false"],
         "application.fee.reduction.reasonTwo": ["false"],
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -104,6 +108,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.payable.vat": 160,
         "application.fee.exemption.reasonOne": ["true"],
         "application.fee.exemption.reasonTwo": ["true"],
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -123,6 +128,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.payable.vat": 160,
         "application.fee.exemption.reasonOne": ["false"],
         "application.fee.exemption.reasonTwo": ["false"],
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -135,7 +141,9 @@ describe("useFeeBreakdown() hook", () => {
 
   describe("invalid inputs", () => {
     it("returns undefined for missing data", () => {
-      const mockPassportData = {};
+      const mockPassportData = {
+        "some.other.fields": ["abc", "xyz"],
+      };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
 
@@ -148,6 +156,7 @@ describe("useFeeBreakdown() hook", () => {
       const mockPassportData = {
         "application.fee.calculated": [1000],
         "application.fee.payable.vat": [160],
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -162,6 +171,7 @@ describe("useFeeBreakdown() hook", () => {
         "application.fee.calculated": "some string",
         "application.fee.payable": [800, 700],
         "application.fee.payable.vat": false,
+        "some.other.fields": ["abc", "xyz"],
       };
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, "test-session"]);
@@ -172,7 +182,9 @@ describe("useFeeBreakdown() hook", () => {
     });
 
     it("calls Airbrake if invalid inputs are provided", () => {
-      const mockPassportData = {};
+      const mockPassportData = {
+        "some.other.fields": ["abc", "xyz"],
+      };
       const mockSessionId = "test-session";
 
       vi.mocked(useStore).mockReturnValue([mockPassportData, mockSessionId]);

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.tsx
@@ -2,7 +2,7 @@ import { logger } from "airbrake";
 import { useStore } from "pages/FlowEditor/lib/store";
 
 import { FeeBreakdown } from "./types";
-import { createPassportSchema, preProcessPassport } from "./utils";
+import { createPassportSchema } from "./utils";
 
 /**
  * Parses the users's Passport for data variables associated with their fee
@@ -19,8 +19,7 @@ export const useFeeBreakdown = (): FeeBreakdown | undefined => {
   if (!passportData) return 
 
   const schema = createPassportSchema();
-  const processedPassport = preProcessPassport(passportData);
-  const result = schema.safeParse(processedPassport);
+  const result = schema.safeParse(passportData);
 
   if (!result.success) {
     logger.notify(

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.tsx
@@ -2,7 +2,7 @@ import { logger } from "airbrake";
 import { useStore } from "pages/FlowEditor/lib/store";
 
 import { FeeBreakdown } from "./types";
-import { createPassportSchema } from "./utils";
+import { createPassportSchema, preProcessPassport } from "./utils";
 
 /**
  * Parses the users's Passport for data variables associated with their fee
@@ -16,8 +16,11 @@ export const useFeeBreakdown = (): FeeBreakdown | undefined => {
     state.computePassport().data,
     state.sessionId,
   ]);
+  if (!passportData) return 
+
   const schema = createPassportSchema();
-  const result = schema.safeParse(passportData);
+  const processedPassport = preProcessPassport(passportData);
+  const result = schema.safeParse(processedPassport);
 
   if (!result.success) {
     logger.notify(

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.test.ts
@@ -20,11 +20,14 @@ describe("toNumber() helper function", () => {
 describe("calculateReduction() helper function", () => {
   it("correctly outputs the reduction when a calculated value is provided", () => {
     const input: PassportFeeFields = {
-      amount: {
-        "application.fee.calculated": 100,
-        "application.fee.payable": 50,
-        "application.fee.payable.vat": 0,
-      }
+      "application.fee.calculated": 100,
+      "application.fee.payable": 50,
+      "application.fee.payable.vat": 0,
+      "application.fee.reduction.alternative": false,
+      "application.fee.reduction.parishCouncil": false,
+      "application.fee.reduction.sports": false,
+      "application.fee.exemption.disability": false,
+      "application.fee.exemption.resubmission": false,
     };
     const reduction = calculateReduction(input);
 
@@ -33,11 +36,14 @@ describe("calculateReduction() helper function", () => {
 
   it("defaults to 0 when calculated is 0", () => {
     const input: PassportFeeFields = {
-      amount: {
-        "application.fee.calculated": 0,
-        "application.fee.payable": 100,
-        "application.fee.payable.vat": 0,
-      }
+      "application.fee.calculated": 0,
+      "application.fee.payable": 100,
+      "application.fee.payable.vat": 0,
+      "application.fee.reduction.alternative": false,
+      "application.fee.reduction.parishCouncil": false,
+      "application.fee.reduction.sports": false,
+      "application.fee.exemption.disability": false,
+      "application.fee.exemption.resubmission": false,
     };
     const reduction = calculateReduction(input);
 
@@ -48,32 +54,38 @@ describe("calculateReduction() helper function", () => {
 describe("toFeeBreakdown() helper function", () => {
   it("correctly maps fields", () => {
     const input: PassportFeeFields = {
-      amount: {
-        "application.fee.calculated": 100,
-        "application.fee.payable": 50,
-        "application.fee.payable.vat": 10,
-      }
+      "application.fee.calculated": 100,
+      "application.fee.payable": 50,
+      "application.fee.payable.vat": 10,
+      "application.fee.reduction.alternative": false,
+      "application.fee.reduction.parishCouncil": false,
+      "application.fee.reduction.sports": false,
+      "application.fee.exemption.disability": false,
+      "application.fee.exemption.resubmission": false,
     };
 
     const { amount } = toFeeBreakdown(input);
 
-    expect(amount.applicationFee).toEqual(input.amount["application.fee.calculated"]);
-    expect(amount.total).toEqual(input.amount["application.fee.payable"]);
-    expect(amount.vat).toEqual(input.amount["application.fee.payable.vat"]);
+    expect(amount.applicationFee).toEqual(input["application.fee.calculated"]);
+    expect(amount.total).toEqual(input["application.fee.payable"]);
+    expect(amount.vat).toEqual(input["application.fee.payable.vat"]);
     expect(amount.reduction).toEqual(50);
   });
 
   it("sets applicationFee to payable amount if no calculated value is provided", () => {
     const input: PassportFeeFields = {
-      amount : {
-        "application.fee.calculated": 0,
-        "application.fee.payable.vat": 10,
-        "application.fee.payable": 50,
-      }
+      "application.fee.calculated": 0,
+      "application.fee.payable.vat": 10,
+      "application.fee.payable": 50,
+      "application.fee.reduction.alternative": false,
+      "application.fee.reduction.parishCouncil": false,
+      "application.fee.reduction.sports": false,
+      "application.fee.exemption.disability": false,
+      "application.fee.exemption.resubmission": false,
     };
 
     const { amount } = toFeeBreakdown(input);
 
-    expect(amount.applicationFee).toEqual(input.amount["application.fee.payable"]);
+    expect(amount.applicationFee).toEqual(input["application.fee.payable"]);
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.test.ts
@@ -22,7 +22,7 @@ describe("calculateReduction() helper function", () => {
     const input: PassportFeeFields = {
       "application.fee.calculated": 100,
       "application.fee.payable": 50,
-      "application.fee.payable.vat": 0,
+      "application.fee.payable.includesVAT": false,
       "application.fee.reduction.alternative": false,
       "application.fee.reduction.parishCouncil": false,
       "application.fee.reduction.sports": false,
@@ -38,7 +38,7 @@ describe("calculateReduction() helper function", () => {
     const input: PassportFeeFields = {
       "application.fee.calculated": 0,
       "application.fee.payable": 100,
-      "application.fee.payable.vat": 0,
+      "application.fee.payable.includesVAT": false,
       "application.fee.reduction.alternative": false,
       "application.fee.reduction.parishCouncil": false,
       "application.fee.reduction.sports": false,
@@ -56,7 +56,7 @@ describe("toFeeBreakdown() helper function", () => {
     const input: PassportFeeFields = {
       "application.fee.calculated": 100,
       "application.fee.payable": 50,
-      "application.fee.payable.vat": 10,
+      "application.fee.payable.includesVAT": true,
       "application.fee.reduction.alternative": false,
       "application.fee.reduction.parishCouncil": false,
       "application.fee.reduction.sports": false,
@@ -68,14 +68,13 @@ describe("toFeeBreakdown() helper function", () => {
 
     expect(amount.applicationFee).toEqual(input["application.fee.calculated"]);
     expect(amount.total).toEqual(input["application.fee.payable"]);
-    expect(amount.vat).toEqual(input["application.fee.payable.vat"]);
     expect(amount.reduction).toEqual(50);
   });
 
   it("sets applicationFee to payable amount if no calculated value is provided", () => {
     const input: PassportFeeFields = {
       "application.fee.calculated": 0,
-      "application.fee.payable.vat": 10,
+      "application.fee.payable.includesVAT": true,
       "application.fee.payable": 50,
       "application.fee.reduction.alternative": false,
       "application.fee.reduction.parishCouncil": false,
@@ -87,5 +86,22 @@ describe("toFeeBreakdown() helper function", () => {
     const { amount } = toFeeBreakdown(input);
 
     expect(amount.applicationFee).toEqual(input["application.fee.payable"]);
+  });
+
+  it("correctly calculates the VAT", () => {
+    const input: PassportFeeFields = {
+      "application.fee.calculated": 100,
+      "application.fee.payable": 50,
+      "application.fee.payable.includesVAT": true,
+      "application.fee.reduction.alternative": false,
+      "application.fee.reduction.parishCouncil": false,
+      "application.fee.reduction.sports": false,
+      "application.fee.exemption.disability": false,
+      "application.fee.exemption.resubmission": false,
+    };
+
+    const { amount } = toFeeBreakdown(input);
+
+    expect(amount.vat).toEqual(16.67);
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.test.ts
@@ -20,9 +20,11 @@ describe("toNumber() helper function", () => {
 describe("calculateReduction() helper function", () => {
   it("correctly outputs the reduction when a calculated value is provided", () => {
     const input: PassportFeeFields = {
-      "application.fee.calculated": 100,
-      "application.fee.payable": 50,
-      "application.fee.payable.vat": 0,
+      amount: {
+        "application.fee.calculated": 100,
+        "application.fee.payable": 50,
+        "application.fee.payable.vat": 0,
+      }
     };
     const reduction = calculateReduction(input);
 
@@ -31,9 +33,11 @@ describe("calculateReduction() helper function", () => {
 
   it("defaults to 0 when calculated is 0", () => {
     const input: PassportFeeFields = {
-      "application.fee.calculated": 0,
-      "application.fee.payable": 100,
-      "application.fee.payable.vat": 0,
+      amount: {
+        "application.fee.calculated": 0,
+        "application.fee.payable": 100,
+        "application.fee.payable.vat": 0,
+      }
     };
     const reduction = calculateReduction(input);
 
@@ -44,28 +48,32 @@ describe("calculateReduction() helper function", () => {
 describe("toFeeBreakdown() helper function", () => {
   it("correctly maps fields", () => {
     const input: PassportFeeFields = {
-      "application.fee.calculated": 100,
-      "application.fee.payable": 50,
-      "application.fee.payable.vat": 10,
+      amount: {
+        "application.fee.calculated": 100,
+        "application.fee.payable": 50,
+        "application.fee.payable.vat": 10,
+      }
     };
 
-    const output = toFeeBreakdown(input);
+    const { amount } = toFeeBreakdown(input);
 
-    expect(output.applicationFee).toEqual(input["application.fee.calculated"]);
-    expect(output.total).toEqual(input["application.fee.payable"]);
-    expect(output.vat).toEqual(input["application.fee.payable.vat"]);
-    expect(output.reduction).toEqual(50);
+    expect(amount.applicationFee).toEqual(input.amount["application.fee.calculated"]);
+    expect(amount.total).toEqual(input.amount["application.fee.payable"]);
+    expect(amount.vat).toEqual(input.amount["application.fee.payable.vat"]);
+    expect(amount.reduction).toEqual(50);
   });
 
   it("sets applicationFee to payable amount if no calculated value is provided", () => {
     const input: PassportFeeFields = {
-      "application.fee.calculated": 0,
-      "application.fee.payable": 50,
-      "application.fee.payable.vat": 10,
+      amount : {
+        "application.fee.calculated": 0,
+        "application.fee.payable.vat": 10,
+        "application.fee.payable": 50,
+      }
     };
 
-    const output = toFeeBreakdown(input);
+    const { amount } = toFeeBreakdown(input);
 
-    expect(output.applicationFee).toEqual(input["application.fee.payable"]);
+    expect(amount.applicationFee).toEqual(input.amount["application.fee.payable"]);
   });
 });

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.ts
@@ -9,20 +9,29 @@ export const toNumber = (input: number | [number]) =>
  * A "reduction" is the sum of the difference between calculated and payable
  * This is not currently broken down further into component parts, or as exemptions or reductions
  */
-export const calculateReduction = (data: PassportFeeFields) =>
-  data["application.fee.calculated"]
-    ? data["application.fee.calculated"] - data["application.fee.payable"]
+export const calculateReduction = ({ amount }: PassportFeeFields) =>
+  amount["application.fee.calculated"]
+    ? amount["application.fee.calculated"] - amount["application.fee.payable"]
     : 0;
 
 /**
  * Transform Passport data to a FeeBreakdown shape
  */
 export const toFeeBreakdown = (data: PassportFeeFields): FeeBreakdown => ({
-  applicationFee:
-    data["application.fee.calculated"] || data["application.fee.payable"],
-  total: data["application.fee.payable"],
-  vat: data["application.fee.payable.vat"],
-  reduction: calculateReduction(data),
+  amount: {
+    applicationFee:
+      data.amount["application.fee.calculated"] || data.amount["application.fee.payable"],
+    total: data.amount["application.fee.payable"],
+    vat: data.amount["application.fee.payable.vat"],
+    reduction: calculateReduction(data),
+  }
+});
+
+const filterByKey = (data: Record<string, unknown>, key: string) => 
+  Object.fromEntries(Object.entries(data).filter(([k, _v]) => k.startsWith(key)))
+
+export const preProcessPassport = (data: Record<string, unknown>) => ({
+  amount: filterByKey(data, "application.fee"),
 });
 
 export const createPassportSchema = () => {
@@ -32,13 +41,18 @@ export const createPassportSchema = () => {
     .union([questionSchema, setValueSchema])
     .transform(toNumber);
 
-  const schema = z
+  const amountsSchema = z
     .object({
       "application.fee.calculated": feeSchema.optional().default(0),
       "application.fee.payable": feeSchema,
       "application.fee.payable.vat": feeSchema.optional().default(0),
-    })
-    .transform(toFeeBreakdown);
+    });
+
+  const schema = z
+    .object({
+      amount: amountsSchema,
+
+    }).transform(toFeeBreakdown);
 
   return schema;
 };

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/utils.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 
 import { FeeBreakdown, PassportFeeFields } from "./types";
 
+const reductionKeys = /^application\.fee\.reduction\..+$/;
+const exemptionKeys = /^application\.fee\.exemption\..+$/;
+
 export const toNumber = (input: number | [number]) =>
   Array.isArray(input) ? input[0] : input;
 
@@ -20,11 +23,18 @@ export const calculateReduction = ({ amount }: PassportFeeFields) =>
 export const toFeeBreakdown = (data: PassportFeeFields): FeeBreakdown => ({
   amount: {
     applicationFee:
-      data.amount["application.fee.calculated"] || data.amount["application.fee.payable"],
+      data.amount["application.fee.calculated"] ||
+      data.amount["application.fee.payable"],
     total: data.amount["application.fee.payable"],
     vat: data.amount["application.fee.payable.vat"],
     reduction: calculateReduction(data),
-  }
+  },
+  reductions: Object.entries(data.reductions || {})
+    .filter(([_key, value]) => value)
+    .map(([key, _value]) => key.replace("application.fee.reduction.", "")),
+  exemptions: Object.entries(data.exemptions || {})
+    .filter(([_key, value]) => value)
+    .map(([key, _value]) => key.replace("application.fee.exemption.", "")),
 });
 
 const filterByKey = (data: Record<string, unknown>, key: string) => 
@@ -32,6 +42,8 @@ const filterByKey = (data: Record<string, unknown>, key: string) =>
 
 export const preProcessPassport = (data: Record<string, unknown>) => ({
   amount: filterByKey(data, "application.fee"),
+  reductions: filterByKey(data, "application.fee.reduction"),
+  exemptions: filterByKey(data, "application.fee.exemption"),
 });
 
 export const createPassportSchema = () => {
@@ -48,10 +60,27 @@ export const createPassportSchema = () => {
       "application.fee.payable.vat": feeSchema.optional().default(0),
     });
 
+  const reductionsSchema = z.record(
+    z.string().regex(reductionKeys),
+    z.array(z.string())
+      .max(1)
+      .transform((val) => val[0].toLowerCase() === "true"),
+  ).optional();
+
+  const exemptionsSchema = z
+    .record(
+      z.string().regex(exemptionKeys),
+      z.array(z.string())
+        .max(1)
+        .transform((val) => val[0].toLowerCase() === "true")
+    )
+    .optional();
+
   const schema = z
     .object({
       amount: amountsSchema,
-
+      reductions: reductionsSchema,
+      exemptions: exemptionsSchema,
     }).transform(toFeeBreakdown);
 
   return schema;


### PR DESCRIPTION
## What does this PR do?
 - Changes logic to now rely on on `application.fee.includesVAT` (boolean) instead of `application.fee.vat` (number)
 - This means we are relying on Editors to tell us if the fee in inclusive of VAT, but does not rely on them to make the calculation themselves
 - Based on decision from Monday's fee breakdown show & tell

### Note
This doesn't cover the cases where teams require a VAT amount to be included within their GovUK Pay metadata. In these cases they will still need to calculate it as a passport variable, and add it to the metadata fields. It's probably worth getting teams to adopt this approach there as well but I'm intentionally avoiding this here in order to focus on the fee breakdown feature.