### PR TITLE
fix: account for expandable checklists in editor modal passport value validation

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
@@ -72,8 +72,11 @@ export const ChecklistComponent: React.FC<ChecklistProps> = (props) => {
         alert(JSON.stringify({ type, ...values, options }, null, 2));
       }
     },
-    validate: ({ options, ...values }) => {
+    validate: ({ options, groupedOptions, ...values }) => {
       const errors: FormikErrors<FormikValues> = {};
+      // Account for flat or expandable Checklist options
+      options =
+        options || groupedOptions?.map((group) => group.children)?.flat();
       if (values.fn && !options?.some((option) => option.data.val)) {
         errors.fn =
           "At least one option must set a data value when the checklist has a data field";


### PR DESCRIPTION
Flagged here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1733408598813289

We don't currently have an `Editor.test.tsx` file for Checklists but happy to revisit that as a follow-up PR so we don't miss this again ! Probably nice to merge now though to minimise rebases for Jo :slightly_smiling_face: 