### PR TITLE
fix: ensure empty JSON files aren't written to S3

### DIFF
--- a/api.planx.uk/modules/file/service/uploadFile.ts
+++ b/api.planx.uk/modules/file/service/uploadFile.ts
@@ -79,9 +79,9 @@ export function generateFileParams(
     ACL: "public-read",
     Bucket: process.env.AWS_S3_BUCKET,
     Key: key,
-    Body: file.buffer,
+    Body: file.buffer || JSON.stringify(file),
     ContentDisposition: `inline;filename="${filename}"`,
-    ContentType: file.mimetype,
+    ContentType: file.mimetype || "application/json",
   };
 
   return {


### PR DESCRIPTION
Thread with lots of context here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1733474436178079

We removed these `||` when recently upgrading to AWS-SDK v3 (#3989), but they're required for our current handling of the application JSON written to S3 for use in the Power Automate integrations (see this old comment https://github.com/theopensystemslab/planx-new/pull/3003/files#r1560594873) 