### PR TITLE
fix: CVE-2024-52798

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -25,7 +25,7 @@
     "csv-stringify": "^6.5.0",
     "date-fns": "^3.3.1",
     "dompurify": "^3.1.6",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "express-async-errors": "^3.1.1",
     "express-jwt": "^8.4.1",
     "express-pino-logger": "^7.0.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -57,11 +57,11 @@ dependencies:
     specifier: ^3.1.6
     version: 3.1.6
   express:
-    specifier: ^4.21.1
-    version: 4.21.1
+    specifier: ^4.21.2
+    version: 4.21.2
   express-async-errors:
     specifier: ^3.1.1
-    version: 3.1.1(express@4.21.1)
+    version: 3.1.1(express@4.21.2)
   express-jwt:
     specifier: ^8.4.1
     version: 8.4.1
@@ -70,7 +70,7 @@ dependencies:
     version: 7.0.0
   express-rate-limit:
     specifier: ^7.1.5
-    version: 7.1.5(express@4.21.1)
+    version: 7.1.5(express@4.21.2)
   form-data:
     specifier: ^4.0.0
     version: 4.0.0
@@ -142,7 +142,7 @@ dependencies:
     version: 6.2.8(openapi-types@12.1.3)
   swagger-ui-express:
     specifier: ^5.0.0
-    version: 5.0.0(express@4.21.1)
+    version: 5.0.0(express@4.21.2)
   type-fest:
     specifier: ^4.18.1
     version: 4.18.1
@@ -4335,12 +4335,12 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
-  /express-async-errors@3.1.1(express@4.21.1):
+  /express-async-errors@3.1.1(express@4.21.2):
     resolution: {integrity: sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==}
     peerDependencies:
       express: ^4.16.2
     dependencies:
-      express: 4.21.1
+      express: 4.21.2
     dev: false
 
   /express-jwt@8.4.1:
@@ -4359,21 +4359,21 @@ packages:
       pino-http: 6.6.0
     dev: false
 
-  /express-rate-limit@7.1.5(express@4.21.1):
+  /express-rate-limit@7.1.5(express@4.21.2):
     resolution: {integrity: sha512-/iVogxu7ueadrepw1bS0X0kaRC/U0afwiYRSLg68Ts+p4Dc85Q5QKsOnPS/QUjPMHvOJQtBDrZgvkOzf8ejUYw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: 4 || 5 || ^5.0.0-beta.1
     dependencies:
-      express: 4.21.1
+      express: 4.21.2
     dev: false
 
   /express-unless@2.1.3:
     resolution: {integrity: sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ==}
     dev: false
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -4395,7 +4395,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -5928,8 +5928,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
 
   /path-type@4.0.0:
@@ -6728,13 +6728,13 @@ packages:
       '@scarf/scarf': 1.4.0
     dev: false
 
-  /swagger-ui-express@5.0.0(express@4.21.1):
+  /swagger-ui-express@5.0.0(express@4.21.2):
     resolution: {integrity: sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==}
     engines: {node: '>= v0.10.32'}
     peerDependencies:
       express: '>=4.0.0 || >=5.0.0-beta'
     dependencies:
-      express: 4.21.1
+      express: 4.21.2
       swagger-ui-dist: 5.18.2
     dev: false
 


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/148

Express release notes why upgrade this dependency - https://github.com/expressjs/express/releases/tag/4.21.2

After this update `pnpm why path-to-regexp` gives the following result showing we're updated to a safe version - 

```
dependencies:
express 4.21.2
└── path-to-regexp 0.1.12
express-async-errors 3.1.1
└─┬ express 4.21.2 peer
  └── path-to-regexp 0.1.12
express-rate-limit 7.1.5
└─┬ express 4.21.2 peer
  └── path-to-regexp 0.1.12
swagger-ui-express 5.0.0
└─┬ express 4.21.2 peer
  └── path-to-regexp 0.1.12
  ```