### PR TITLE
extend Hasura service boot grace period from 0 to 180s

### DIFF
--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -110,6 +110,8 @@ export const createHasuraService = async ({
       },
     },
     desiredCount: 1,
+    // experiment with non-zero grace period to see if it resolves scale up failure
+    healthCheckGracePeriodSeconds: 180,
   });
   
   new cloudflare.Record("hasura", {


### PR DESCRIPTION
Related to [this ticket](https://trello.com/c/oRzedbmJ).

This PR introduces a 180s grace period for the Hasura service in an attempt to deal with a boot loop during scale up.

## Context

During load testing, even with relatively small numbers of users we immediately hit issues with Hasura.

When the service tries to scale up with a 2nd Task to deal with the load, the new task fails to boot to a healthy state (which the load balancer checks for before directing traffic to it), and AWS then has to deprovision them (usually within 2 minutes or so of boot).

![image](https://github.com/user-attachments/assets/7da375c0-fc09-426b-9b95-d342dd0137d1)

The issue seems to be with the `Hasura` container itself, since the `HasuraProxy` container reports the following in the logs for one of these failed task:

```json
{"level":"error","ts":1733444599.5636377,"logger":"http.log.error","msg":"dial tcp 127.0.0.1:8080: connect: connection refused","request":{"remote_ip":"10.0.69.213","remote_port":"35948","proto":"HTTP/1.1","method":"GET","host":"10.0.1.180","uri":"/healthz","headers":{"Connection":["close"],"User-Agent":["ELB-HealthChecker/2.0"],"Accept-Encoding":["gzip, compressed"]}},"duration":0.000346896,"status":502,"err_id":"swhm20qqn","err_trace":"reverseproxy.statusError (reverseproxy.go:1299)"}
```

Note the `502 Bad Gateway` status code, the `reverseproxy.statusError (reverseproxy.go:1299)` error trace ([source](https://github.com/caddyserver/caddy/blob/0db29e2ce9799f652f3d16fd5aed6e426d23bd0a/modules/caddyhttp/reverseproxy/reverseproxy.go#L1299)), and the very short duration of the request.

See [Notion doc for more detail](https://www.notion.so/opensystemslab/PlanX-Load-Testing-13735d469ad180b18c45f0d1db44511e?pvs=4#14b35d469ad18060a527e9c022d31050).