### PR TITLE
fix: add missing BOPS app type suffixes to Slack notification pilot criteria

### DIFF
--- a/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -36,7 +36,11 @@ export const sendSlackNotification = async (
   const pilotServices = [
     "uniform",
     "happ",
+    "hapr",
+    "hret",
     "ldc",
+    "minor",
+    "major",
     "apply for planning permission",
     "apply for a lawful development certificate",
   ];


### PR DESCRIPTION
Quick followup from this thread yesterday: https://opensystemslab.slack.com/archives/C0405SQDP8B/p1733407486961749

Should now add the apparently-very-relied-on :large_orange_diamond: to all BOPS app type alerts coming through #planx-notifications during the pilot testing