### PR TITLE
fix: correct editor link validation

### DIFF
--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -200,8 +200,8 @@ export const emptyContent = "<p></p>";
 const linkSelectionError = (selectionHtml: string): string | null => {
   if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
     const text = selectionHtml.slice(3, -4);
-    const lowercaseText = text.toLowerCase();
-    if (lowercaseText.includes("click") || lowercaseText.includes("here")) {
+    const lowercaseText = text.toLowerCase().trim().replace(/[.,]/g, "");
+    if (lowercaseText == "click here" || lowercaseText == "clicking here") {
       return "Links must be set over text that accurately describes what the link is for. Avoid generic language such as 'click here'.";
     }
     if (text[0] && text[0] !== text[0].toUpperCase() && text.length < 8) {

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -201,7 +201,7 @@ const linkSelectionError = (selectionHtml: string): string | null => {
   if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
     const text = selectionHtml.slice(3, -4);
     const lowercaseText = text.toLowerCase().trim().replace(/[.,]/g, "");
-    if (lowercaseText == "click here" || lowercaseText == "clicking here") {
+    if (lowercaseText === "click here" || lowercaseText === "clicking here") {
       return "Links must be set over text that accurately describes what the link is for. Avoid generic language such as 'click here'.";
     }
     if (text[0] && text[0] !== text[0].toUpperCase() && text.length < 8) {


### PR DESCRIPTION
Tightens editor link validation from any link text including ''click'' or ''here'' to links set solely over ''click here'' or ''clicking here''. Includes trimming of white space and punctuation.