### PR TITLE
fix: Convert Digital Planning payload to JSON file before upload

### DIFF
--- a/api.planx.uk/modules/file/service/uploadFile.ts
+++ b/api.planx.uk/modules/file/service/uploadFile.ts
@@ -7,7 +7,6 @@ import mime from "mime";
 import { customAlphabet } from "nanoid";
 import { isLiveEnv } from "../../../helpers.js";
 import { s3Factory } from "./utils.js";
-import { Readable } from "stream";
 const nanoid = customAlphabet("1234567890abcdefghijklmnopqrstuvwxyz", 8);
 
 export const uploadPublicFile = async (
@@ -29,14 +28,10 @@ export const uploadPublicFile = async (
 };
 
 export const uploadPrivateFile = async (
-  file: Express.Multer.File | Buffer,
+  file: Express.Multer.File,
   filename: string,
   filekey?: string,
 ) => {
-  if (file instanceof Buffer) {
-    file = convertToMulterFile(file);
-  }
-
   const s3 = s3Factory();
 
   const { params, key, fileType } = generateFileParams(file, filename, filekey);
@@ -67,19 +62,6 @@ const buildFileUrl = async (key: string, path: "public" | "private") => {
     s3Pathname = s3Pathname.replace(`/${process.env.AWS_S3_BUCKET}`, "");
   return `${process.env.API_URL_EXT}/file/${path}${s3Pathname}`;
 };
-
-const convertToMulterFile = (buffer: Buffer): Express.Multer.File => ({
-  buffer: buffer,
-  originalname: "${data.id}.json",
-  mimetype: "application/json",
-  size: buffer.length,
-  fieldname: "file",
-  encoding: "7bit",
-  stream: Readable.from(buffer),
-  destination: "",
-  filename: "",
-  path: "",
-});
 
 export function generateFileParams(
   file: Express.Multer.File,

--- a/api.planx.uk/modules/file/service/utils.ts
+++ b/api.planx.uk/modules/file/service/utils.ts
@@ -1,5 +1,6 @@
 import { S3 } from "@aws-sdk/client-s3";
 import { isLiveEnv } from "../../../helpers.js";
+import { Readable } from "stream";
 
 export function s3Factory() {
   return new S3({
@@ -40,3 +41,23 @@ export function getS3KeyFromURL(fileURL: string): string {
   const key = [folder, file].map(decodeURIComponent).join("/");
   return key;
 }
+
+export const convertObjectToMulterJSONFile = (
+  data: Record<string, unknown>,
+  fileName: string,
+): Express.Multer.File => {
+  const buffer = Buffer.from(JSON.stringify(data));
+
+  return {
+    buffer: buffer,
+    originalname: fileName,
+    mimetype: "application/json",
+    size: buffer.length,
+    fieldname: "file",
+    encoding: "7bit",
+    stream: Readable.from(buffer),
+    destination: "",
+    filename: "",
+    path: "",
+  };
+};

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -45,10 +45,10 @@ const sendToS3: SendIntegrationController = async (_req, res, next) => {
     const flowName = session?.flow?.name;
 
     // Generate the ODP Schema JSON, skipping validation if not a supported application type
-    const doValidation = isApplicationTypeSupported(passport);
+    const skipValidation = !isApplicationTypeSupported(passport);
     const exportData = await $api.export.digitalPlanningDataPayload(
       sessionId,
-      doValidation,
+      skipValidation,
     );
 
     // Create and upload the data as an S3 file
@@ -70,7 +70,7 @@ const sendToS3: SendIntegrationController = async (_req, res, next) => {
         service: flowName,
         environment: env,
         file: fileUrl,
-        payload: doValidation ? "Validated ODP Schema" : "Discretionary",
+        payload: skipValidation ? "Discretionary" : "Validated ODP Schema",
       },
     };
     const webhookResponse = await axios(webhookRequest)
@@ -126,7 +126,7 @@ const sendToS3: SendIntegrationController = async (_req, res, next) => {
 
     res.status(200).send({
       message: `Successfully uploaded submission to S3: ${fileUrl}`,
-      payload: doValidation ? "Validated ODP Schema" : "Discretionary",
+      payload: skipValidation ? "Discretionary" : "Validated ODP Schema",
       webhookResponse: webhookResponse.axiosResponse.status,
       auditEntryId: webhookResponse.id,
     });


### PR DESCRIPTION
## What does this PR do?
 - Convert a `DigitalPlanningPayload` to an `Express.Multer.File` for upload
 - Addresses issues discussed here - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1733474436178079 (OSL Slack)

### Comments
Trickier than expected! TypeScript isn't catching the mismatch between `DigitalPlanningPayload` and `Express.Multer.File` even when the type is imported and assigned. I think it's to do with the combination of the type complexity plus the `Awaited<>` utility type which has a depth limit I believe.

Next up is some tests here for the entire module (in another PR), will also check the Pizza to make this is working as expected once it's up.