### PR TITLE
fix: remove Invite to Pay `proposal.projectType` validation on publish

### DIFF
--- a/api.planx.uk/modules/flows/validate/service/inviteToPay.ts
+++ b/api.planx.uk/modules/flows/validate/service/inviteToPay.ts
@@ -44,21 +44,6 @@ const validateInviteToPay = (flowGraph: FlowGraph): FlowValidationResponse => {
       };
     }
 
-    if (
-      !hasComponentType(
-        flowGraph,
-        ComponentType.Checklist,
-        "proposal.projectType",
-      )
-    ) {
-      return {
-        title: "Invite to Pay",
-        status: "Fail",
-        message:
-          "When using Invite to Pay, your flow must have a Checklist that sets `proposal.projectType`",
-      };
-    }
-
     return {
       title: "Invite to Pay",
       status: "Pass",

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -447,65 +447,6 @@ describe("invite to pay validation on diff", () => {
         ]);
       });
   });
-
-  it("does not update if invite to pay is enabled, but there is not a Checklist that sets `proposal.projectType`", async () => {
-    const invalidatedFlow = flowWithInviteToPay;
-    // Remove proposal.projectType, set incorrect variable
-    invalidatedFlow!.Checklist!.data!.fn = "some.other.variable";
-
-    queryMock.mockQuery({
-      name: "GetFlowData",
-      matchOnVariables: false,
-      data: {
-        flow: {
-          data: invalidatedFlow,
-          slug: "invalidated-flow-name",
-          team_id: 1,
-          team: {
-            slug: "testing",
-          },
-          publishedFlows: [{ data: invalidatedFlow }],
-        },
-      },
-    });
-
-    await supertest(app)
-      .post("/flows/1/diff")
-      .set(auth)
-      .expect(200)
-      .then((res) => {
-        expect(res.body.message).toEqual("Changes queued to publish");
-        expect(res.body.validationChecks).toEqual([
-          {
-            title: "Invite to Pay",
-            status: "Fail",
-            message:
-              "When using Invite to Pay, your flow must have a Checklist that sets `proposal.projectType`",
-          },
-          {
-            title: "Sections",
-            status: "Not applicable",
-            message: "Your flow is not using Sections",
-          },
-          {
-            title: "File types",
-            status: "Not applicable",
-            message: "Your flow is not using FileUpload or UploadAndLabel",
-          },
-          {
-            title: "Project types",
-            status: "Not applicable",
-            message:
-              'Your flow is not using Checklists which set "proposal.projectType"',
-          },
-          {
-            title: "Planning Constraints",
-            status: "Not applicable",
-            message: "Your flow is not using Planning Constraints",
-          },
-        ]);
-      });
-  });
 });
 
 describe("ODP Schema file type validation on diff", () => {


### PR DESCRIPTION
Context here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1733846389249239

- The validation check that `proposal.projectType` needed to be set via a Checklist was too strict and preventing pre app services using SetValue components from publishing
- Since our email templates _already_ use a fallback value of "Project type not submitted", we can simply forgo this layer of ITP validation altogether - we _still_ validate there is exactly one Pay component, a Send component, and that an address is collected via a FindProperty component