### PR TITLE
fix: account for un-checked Article 4 values in GIS API

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -252,7 +252,7 @@ async function go(
     const a4s = planningConstraints["article4"]["records"] || undefined;
 
     // loop through any intersecting a4 data entities and set granular planx values based on this local authority's schema
-    if (a4s && formattedResult["article4"].value) {
+    if (a4s && formattedResult["article4"]?.value) {
       formattedResult["article4"]?.data?.forEach((entity: any) => {
         Object.keys(a4s)?.forEach((key) => {
           if (
@@ -280,8 +280,8 @@ async function go(
 
       // if caz is true, but parent a4 is false, sync a4 for accurate granularity
       if (
-        formattedResult[localCaz].value &&
-        !formattedResult["article4"].value
+        formattedResult[localCaz]?.value &&
+        !formattedResult["article4"]?.value
       ) {
         formattedResult["article4"] = {
           fn: "article4",

--- a/api.planx.uk/modules/gis/service/index.js
+++ b/api.planx.uk/modules/gis/service/index.js
@@ -18,6 +18,11 @@ const localAuthorities = { digitalLand };
  *        type: string
  *        required: true
  *        description: Well-Known Text (WKT) formatted polygon or point
+ *      - in: query
+ *        name: vals
+ *        type: string
+ *        required: false
+ *        description: Comma-separated list of planning constraint values (formatted using `fn` property names) that should be returned
  */
 export async function locationSearch(req, res, next) {
   // 'geom' param signals this localAuthority has data available via Planning Data


### PR DESCRIPTION
Niche edge case spotted by Jenna while testing constraints here (eg _not_ checking general `article4` but still selecting `article4.caz` :cyclone:): https://opendigitalplanning.slack.com/archives/CQWPPHQ2X/p1733911237161229?thread_ts=1733763841.300959&cid=CQWPPHQ2X

Example request before: https://api.editor.planx.dev/gis/doncaster?geom=MULTIPOLYGON+%28%28%28-1.116085+53.526454%2C+-1.115971+53.52638%2C+-1.115557+53.526611%2C+-1.115625+53.526654%2C+-1.115823+53.526545%2C+-1.115871+53.526576%2C+-1.116085+53.526454%29%29%29&vals=article4.caz%2CbrownfieldSite%2Cdesignated.AONB%2Cdesignated.conservationArea%2CgreenBelt%2Cdesignated.nationalPark%2Cdesignated.nationalPark.broads%2Cdesignated.WHS%2Cflood%2Clisted%2Cmonument%2Cnature.ASNW%2Cnature.ramsarSite%2Cnature.SAC%2Cnature.SPA%2Cnature.SSSI%2CregisteredPark%2Ctpo%2Croad.classified

After: https://api.4066.planx.pizza/gis/doncaster?geom=MULTIPOLYGON+%28%28%28-1.116085+53.526454%2C+-1.115971+53.52638%2C+-1.115557+53.526611%2C+-1.115625+53.526654%2C+-1.115823+53.526545%2C+-1.115871+53.526576%2C+-1.116085+53.526454%29%29%29&vals=article4.caz%2CbrownfieldSite%2Cdesignated.AONB%2Cdesignated.conservationArea%2CgreenBelt%2Cdesignated.nationalPark%2Cdesignated.nationalPark.broads%2Cdesignated.WHS%2Cflood%2Clisted%2Cmonument%2Cnature.ASNW%2Cnature.ramsarSite%2Cnature.SAC%2Cnature.SPA%2Cnature.SSSI%2CregisteredPark%2Ctpo%2Croad.classified

