### PR TITLE
feat: Display `Pay` component when fee is zero

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#467123d",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
-    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#467123d
+    version: github.com/theopensystemslab/planx-core/467123d(@types/react@19.0.7)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7723,9 +7723,9 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
-    id: github.com/theopensystemslab/planx-core/2fe8707
+  github.com/theopensystemslab/planx-core/467123d(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/467123d}
+    id: github.com/theopensystemslab/planx-core/467123d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/tests/mocks/inviteToPayData.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayData.ts
@@ -68,6 +68,7 @@ export const paymentRequestResponse: Partial<PaymentRequest> = {
       calculated: 123.45,
       vat: 0,
       reduction: 0,
+      exemption: 0,
     },
     reductions: [],
     exemptions: [],

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -140,6 +140,7 @@ export const createPaymentRequestQueryMock = {
         calculated: 123.45,
         vat: 0,
         reduction: 0,
+        exemption: 0,
       },
       reductions: [],
       exemptions: [],

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#467123d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
-    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#467123d
+    version: github.com/theopensystemslab/planx-core/467123d(@types/react@19.0.7)
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -1078,7 +1078,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /convert-source-map@1.9.0:
@@ -2989,9 +2989,9 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
-    id: github.com/theopensystemslab/planx-core/2fe8707
+  github.com/theopensystemslab/planx-core/467123d(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/467123d}
+    id: github.com/theopensystemslab/planx-core/467123d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#467123d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
-    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#467123d
+    version: github.com/theopensystemslab/planx-core/467123d(@types/react@19.0.7)
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2543,9 +2543,9 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
-    id: github.com/theopensystemslab/planx-core/2fe8707
+  github.com/theopensystemslab/planx-core/467123d(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/467123d}
+    id: github.com/theopensystemslab/planx-core/467123d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -24,6 +24,7 @@ export const mockPaymentRequest: Partial<PaymentRequest> = {
       payable: 123.45,
       vat: 0,
       reduction: 0,
+      exemption: 0,
     },
     reductions: [],
     exemptions: [],

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#467123d",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
-    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#467123d
+    version: github.com/theopensystemslab/planx-core/467123d(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14652,9 +14652,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/2fe8707(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
-    id: github.com/theopensystemslab/planx-core/2fe8707
+  github.com/theopensystemslab/planx-core/467123d(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/467123d}
+    id: github.com/theopensystemslab/planx-core/467123d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -55,6 +55,10 @@ const PayText = styled(Box)(({ theme }) => ({
   },
 }));
 
+/**
+ * Displayed when component is in an error state
+ * Relies on props.error being set
+ */
 const Error: React.FC<Props> = ({ onConfirm, error }) => {
   if (error?.startsWith(PAY_API_ERROR_UNSUPPORTED_TEAM)) {
     return (
@@ -79,6 +83,10 @@ const Error: React.FC<Props> = ({ onConfirm, error }) => {
   );
 };
 
+/**
+ * Main functionality
+ * Allows users to make a payment via GovUK Pay
+ */
 const PayBody: React.FC<PayBodyProps> = (props) => {
   const defaults = getDefaultContent();
 
@@ -117,6 +125,10 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
   );
 };
 
+/**
+ * Display information only - does not allow users to pay
+ * Generally used at the end of guidance services as an illustrative example of what you could pay
+ */
 const InformationOnly: React.FC<Props> = (props) => {
   const defaults = getDefaultContent();
 
@@ -143,6 +155,10 @@ const InformationOnly: React.FC<Props> = (props) => {
   );
 };
 
+/**
+ * Displayed if the fee is calculated as £0
+ * Still displays component and fee breakdown, but allows user to continue without making a payment
+ */
 const ZeroFee: React.FC<Props> = (props) => (
   <Button
     variant="contained"

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -24,6 +24,8 @@ import { FeeBreakdown } from "./FeeBreakdown/FeeBreakdown";
 import InviteToPayForm, { InviteToPayFormProps } from "./InviteToPayForm";
 import { PAY_API_ERROR_UNSUPPORTED_TEAM } from "./Pay";
 
+type State = "error" | "informationOnly" | "inviteToPay" | "zeroFee" | "pay";
+
 export interface Props extends Omit<Pay, "title" | "fn" | "govPayMetadata"> {
   title?: string;
   fee: number;
@@ -48,34 +50,34 @@ const PayText = styled(Box)(({ theme }) => ({
   },
 }));
 
+const Error: React.FC<Props> = ({ onConfirm, error }) => {
+  if (error?.startsWith(PAY_API_ERROR_UNSUPPORTED_TEAM)) {
+    return (
+      <Card handleSubmit={onConfirm} isValid>
+        <ErrorSummary
+          format="error"
+          heading={error}
+          message="Click continue to skip payment and proceed with your application for testing."
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <ErrorSummary
+        format="error"
+        heading={error}
+        message="This error has been logged and our team will see it soon. You can safely close this tab and try resuming again soon by returning to this URL."
+      />
+    </Card>
+  );
+};
+
 const PayBody: React.FC<PayBodyProps> = (props) => {
   const path = useStore((state) => state.path);
   const isSaveReturn = path === ApplicationPath.SaveAndReturn;
   const defaults = getDefaultContent();
-
-  if (props.error) {
-    if (props.error.startsWith(PAY_API_ERROR_UNSUPPORTED_TEAM)) {
-      return (
-        <Card handleSubmit={props.onConfirm} isValid>
-          <ErrorSummary
-            format="error"
-            heading={props.error}
-            message="Click continue to skip payment and proceed with your application for testing."
-          />
-        </Card>
-      );
-    } else {
-      return (
-        <Card>
-          <ErrorSummary
-            format="error"
-            heading={props.error}
-            message="This error has been logged and our team will see it soon. You can safely close this tab and try resuming again soon by returning to this URL."
-          />
-        </Card>
-      );
-    }
-  }
 
   return (
     <Card>
@@ -95,11 +97,9 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
           size="large"
           onClick={props.onConfirm}
         >
-          {props.hidePay
-            ? "Continue"
-            : props.buttonTitle || "Pay now using GOV.UK Pay"}
+          {props.buttonTitle || "Pay now using GOV.UK Pay"}
         </Button>
-        {!props.hidePay && props.showInviteToPay && (
+        {props.showInviteToPay && (
           <Button
             variant="contained"
             color="secondary"
@@ -117,17 +117,87 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
   );
 };
 
+const InformationOnly: React.FC<Props> = (props) => {
+  const path = useStore((state) => state.path);
+  const isSaveReturn = path === ApplicationPath.SaveAndReturn;
+  const defaults = getDefaultContent();
+
+  return (
+    <Card>
+      <PayText>
+        <Typography variant="h2" component={props.hideFeeBanner ? "h2" : "h3"}>
+          {props.instructionsTitle || defaults.instructionsTitle}
+        </Typography>
+        <ReactMarkdownOrHtml
+          source={
+            props.instructionsDescription || defaults.instructionsDescription
+          }
+          openLinksOnNewTab
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          onClick={props.onConfirm}
+        >
+          Continue
+        </Button>
+        {isSaveReturn && <SaveResumeButton />}
+      </PayText>
+    </Card>
+  );
+};
+
+const ZeroFee: React.FC<Props> = (props) => {
+  const path = useStore((state) => state.path);
+  const isSaveReturn = path === ApplicationPath.SaveAndReturn;
+  const defaults = getDefaultContent();
+
+  return (
+    <Card>
+      <PayText>
+        <Typography variant="h2" component="h3">
+          {props.instructionsTitle || defaults.instructionsTitle}
+        </Typography>
+        <ReactMarkdownOrHtml
+          source={
+            props.instructionsDescription || defaults.instructionsDescription
+          }
+          openLinksOnNewTab
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          onClick={props.onConfirm}
+        >
+          Continue
+        </Button>
+        {isSaveReturn && <SaveResumeButton />}
+      </PayText>
+    </Card>
+  );
+};
+
+const getInitialState = (props: Props): State => {
+  if (props.error) return "error";
+  if (props.hidePay) return "informationOnly";
+  if (props.fee === 0) return "zeroFee";
+
+  return "pay";
+};
+
 export default function Confirm(props: Props) {
   const theme = useTheme();
-  const [page, setPage] = useState<"Pay" | "InviteToPay">("Pay");
+  const [state, setState] = useState<State>(getInitialState(props));
 
   const defaults = getDefaultContent();
 
   const changePage = () => {
-    if (page === "Pay" && !props.paymentStatus) {
-      setPage("InviteToPay");
+    if (state === "pay" && !props.paymentStatus) {
+      setState("inviteToPay");
     } else {
-      setPage("Pay");
+      setState("pay");
     }
   };
 
@@ -146,10 +216,10 @@ export default function Confirm(props: Props) {
       <>
         <Container maxWidth="contentWrap">
           <Typography variant="h2" component="h1" align="left" pb={3}>
-            {page === "Pay" ? props.title : props.secondaryPageTitle}
+            {state === "inviteToPay" ? props.secondaryPageTitle : props.title}
           </Typography>
         </Container>
-        {page === "Pay" && !props.hideFeeBanner && (
+        {state !== "inviteToPay" && !props.hideFeeBanner && (
           <Banner
             color={{
               background: theme.palette.info.light,
@@ -185,11 +255,15 @@ export default function Confirm(props: Props) {
             {hasFeatureFlag("FEE_BREAKDOWN") && <FeeBreakdown />}
           </Banner>
         )}
-        {page === "Pay" ? (
-          <PayBody changePage={changePage} {...props} />
-        ) : (
-          <InviteToPayForm {...inviteToPayFormProps} />
-        )}
+        {
+          {
+            pay: <PayBody {...props} changePage={changePage} />,
+            informationOnly: <InformationOnly {...props} />,
+            inviteToPay: <InviteToPayForm {...inviteToPayFormProps} />,
+            error: <Error {...props} />,
+            zeroFee: <ZeroFee {...props} />,
+          }[state]
+        }
       </>
     </Box>
   );

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -29,9 +29,6 @@ const BoldTableRow = styled(TableRow)(() => ({
 
 const VAT_RATE = 0.2;
 
-const DESCRIPTION =
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
-
 type FeeBreakdownSection = React.FC<IFeeBreakdown>;
 
 const Header = () => (
@@ -131,25 +128,17 @@ export const FeeBreakdown: React.FC<{
   if (!breakdown) return null;
 
   return (
-    <Box mt={3}>
-      <Typography variant="h3" mb={1}>
-        Fee
-      </Typography>
-      <Typography variant="body1" mb={2}>
-        {DESCRIPTION}
-      </Typography>
-      <TableContainer>
-        <StyledTable data-testid="fee-breakdown-table">
-          <Header />
-          <TableBody>
-            <ApplicationFee {...breakdown} />
-            <Reductions {...breakdown} />
-            <Exemptions {...breakdown} />
-            <Total {...breakdown} />
-            <VAT {...breakdown} />
-          </TableBody>
-        </StyledTable>
-      </TableContainer>
-    </Box>
+    <TableContainer sx={{ mt: 3 }}>
+      <StyledTable data-testid="fee-breakdown-table">
+        <Header />
+        <TableBody>
+          <ApplicationFee {...breakdown} />
+          <Reductions {...breakdown} />
+          <Exemptions {...breakdown} />
+          <Total {...breakdown} />
+          <VAT {...breakdown} />
+        </TableBody>
+      </StyledTable>
+    </TableContainer>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -32,6 +32,8 @@ const VAT_RATE = 0.2;
 const DESCRIPTION =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
 
+type FeeBreakdownSection = React.FC<IFeeBreakdown>;
+
 const Header = () => (
   <TableHead>
     <BoldTableRow>
@@ -41,66 +43,64 @@ const Header = () => (
   </TableHead>
 );
 
-const ApplicationFee: React.FC<{ amount: number }> = ({ amount }) => (
+const ApplicationFee: FeeBreakdownSection = ({ amount }) => (
   <TableRow>
     <TableCell>Application fee</TableCell>
     <TableCell align="right">
-      {formattedPriceWithCurrencySymbol(amount)}
+      {formattedPriceWithCurrencySymbol(amount.calculated)}
     </TableCell>
   </TableRow>
 );
 
-const Reductions: React.FC<{ amount?: number, reductions: string[] }> = ({ amount, reductions }) => {
-  if (!amount) return null;
+const Reductions: FeeBreakdownSection = ({ amount, reductions }) => {
+  if (!amount.reduction) return null;
 
   return (
     <>
-    <TableRow>
-      <TableCell>Reductions</TableCell>
-      <TableCell align="right">
-        {formattedPriceWithCurrencySymbol(-amount)}
-      </TableCell>
-    </TableRow>
-    {
-      reductions.map((reduction) => (
+      <TableRow>
+        <TableCell>Reductions</TableCell>
+        <TableCell align="right">
+          {formattedPriceWithCurrencySymbol(-amount.reduction)}
+        </TableCell>
+      </TableRow>
+      {reductions.map((reduction) => (
         <TableRow>
           <TableCell colSpan={2}>
             <Box sx={{ pl: 2, color: "grey" }}>{reduction}</Box>
           </TableCell>
         </TableRow>
-      ))
-    }
+      ))}
     </>
   );
 };
 
-// TODO: This won't show as if a fee is 0, we hide the whole Pay component from the user
-const Exemptions: React.FC<{ amount: number, exemptions: string[] }> = ({ amount, exemptions }) => {
-  if (!exemptions.length) return null;
+/* TODO: Parse exemption descriptions from schema */
+const Exemptions: FeeBreakdownSection = ({ exemptions, amount }) => {
+  if (!amount.exemption) return null;
 
   return (
     <>
-    <TableRow>
-      <TableCell>Exemptions</TableCell>
-      <TableCell align="right">
-        {formattedPriceWithCurrencySymbol(-amount)}
-      </TableCell>
-    </TableRow>
-    {
-        exemptions.map((exemption) => (
+      <TableRow>
+        <TableCell>Exemptions</TableCell>
+        <TableCell align="right">
+          {formattedPriceWithCurrencySymbol(-amount.exemption)}
+        </TableCell>
+      </TableRow>
+      {exemptions.map((exemption) => (
         <TableRow>
           <TableCell colSpan={2}>
-            <Box sx={{ pl: 2, color: "grey" }}>{exemption}</Box>
+            <Box sx={{ pl: 2, color: "grey", textTransform: "capitalize" }}>
+              {exemption}
+            </Box>
           </TableCell>
         </TableRow>
-      ))
-    }
+      ))}
     </>
   );
 };
 
-const VAT: React.FC<{ amount?: number }> = ({ amount }) => {
-  if (!amount) return null;
+const VAT: FeeBreakdownSection = ({ amount }) => {
+  if (!amount.vat) return null;
 
   return (
     <TableRow>
@@ -108,27 +108,27 @@ const VAT: React.FC<{ amount?: number }> = ({ amount }) => {
         VAT_RATE * 100
       }%)`}</TableCell>
       <TableCell variant="footer" align="right">
-        {formattedPriceWithCurrencySymbol(amount)}
+        {formattedPriceWithCurrencySymbol(amount.vat)}
       </TableCell>
     </TableRow>
   );
 };
 
-const Total: React.FC<{ amount: number }> = ({ amount }) => (
+const Total: FeeBreakdownSection = ({ amount }) => (
   <BoldTableRow>
     <TableCell>Total</TableCell>
     <TableCell align="right">
-      {formattedPriceWithCurrencySymbol(amount)}
+      {formattedPriceWithCurrencySymbol(amount.payable)}
     </TableCell>
   </BoldTableRow>
 );
 
-export const FeeBreakdown: React.FC<{ inviteToPayFeeBreakdown?: IFeeBreakdown }> = ({ inviteToPayFeeBreakdown }) => {
+export const FeeBreakdown: React.FC<{
+  inviteToPayFeeBreakdown?: IFeeBreakdown;
+}> = ({ inviteToPayFeeBreakdown }) => {
   const passportFeeBreakdown = useFeeBreakdown();
   const breakdown = passportFeeBreakdown || inviteToPayFeeBreakdown;
   if (!breakdown) return null;
-
-  const { amount, reductions, exemptions } = breakdown;
 
   return (
     <Box mt={3}>
@@ -142,11 +142,11 @@ export const FeeBreakdown: React.FC<{ inviteToPayFeeBreakdown?: IFeeBreakdown }>
         <StyledTable data-testid="fee-breakdown-table">
           <Header />
           <TableBody>
-            <ApplicationFee amount={amount.calculated} />
-            <Reductions amount={amount.reduction} reductions={reductions}/>
-            <Exemptions amount={amount.payable} exemptions={exemptions}/>
-            <Total amount={amount.payable} />
-            <VAT amount={amount.vat} />
+            <ApplicationFee {...breakdown} />
+            <Reductions {...breakdown} />
+            <Exemptions {...breakdown} />
+            <Total {...breakdown} />
+            <VAT {...breakdown} />
           </TableBody>
         </StyledTable>
       </TableContainer>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -7,8 +7,6 @@ import type {
   PaymentRequest,
   PaymentStatus,
 } from "@opensystemslab/planx-core/types";
-import Card from "@planx/components/shared/Preview/Card";
-import SaveResumeButton from "@planx/components/shared/Preview/SaveResumeButton";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useFormik } from "formik";
@@ -164,7 +162,7 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   return isLoading ? (
     <DelayedLoadingIndicator />
   ) : (
-    <Card>
+    <>
       <StyledForm onSubmit={formik.handleSubmit}>
         <Typography variant="h2">{nomineeTitle}</Typography>
         {nomineeDescription && (
@@ -279,8 +277,7 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
       >
         {"I want to pay for this application myself"}
       </Button>
-      {isSaveReturn && <SaveResumeButton />}
-    </Card>
+    </>
   );
 };
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -22,6 +22,7 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 import { object, string } from "yup";
+
 import { getDefaultContent } from "../model";
 
 // Passport keys which will be used to display a preview of the session to the payee as part of their journey
@@ -229,7 +230,10 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
             />
           </Typography>
         )}
-        <InputLabel label={yourDetailsLabel || defaults.yourDetailsLabel } htmlFor="applicantName">
+        <InputLabel
+          label={yourDetailsLabel || defaults.yourDetailsLabel}
+          htmlFor="applicantName"
+        >
           <Input
             bordered
             name="applicantName"

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
@@ -90,3 +90,11 @@ export const WithFeeBreakdown = {
     showInviteToPay: false,
   },
 } satisfies Story;
+
+export const WithError = {
+  args: {
+    error: "GOV.UK Pay is not enabled for this local authority",
+    fee: 103,
+    onConfirm: () => {},
+  },
+} satisfies Story;

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -161,7 +161,7 @@ describe("Pay component when fee is undefined or £0", () => {
     expect(handleSubmit).toHaveBeenCalled();
   });
 
-  it("Skips pay if fee is negative", () => {
+  it("Displays an error if fee is negative", () => {
     const handleSubmit = vi.fn();
     const loggerSpy = vi.spyOn(logger, "notify");
 
@@ -192,8 +192,12 @@ describe("Pay component when fee is undefined or £0", () => {
       />,
     );
 
-    // handleSubmit is called to auto-answer Pay (aka "skip" in card sequence)
-    expect(handleSubmit).toHaveBeenCalled();
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("We are unable to calculate your fee right now"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Continue")).not.toBeInTheDocument();
+    
     expect(loggerSpy).toHaveBeenCalledWith(
       expect.stringMatching(/Negative fee calculated/),
     );

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -119,8 +119,9 @@ function Component(props: Props) {
     // Skip component when fee is negative
     // Log error silently - this was likely a content error that should be addressed
     if (fee < 0) {
+      dispatch(Action.NoFeeFound);
       logger.notify(`Negative fee calculated for session ${sessionId}`);
-      return props.handleSubmit && props.handleSubmit({ auto: true });
+      return;
     }
 
     // Do not contact GovPay at all if fee is 0, just show UI

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -118,8 +118,15 @@ function Component(props: Props) {
   const showPayOptions = props.allowInviteToPay && !props.hidePay;
 
   useEffect(() => {
+    // Skip component when fee is negative
+    // Log error silently - this was likely a content error that should be addressed
+    if (fee < 0) {
+      logger.notify(`Negative fee calculated for session ${sessionId}`);
+      return props.handleSubmit && props.handleSubmit({ auto: true });
+    }
+
     // Auto-skip component when fee=0
-    if (fee <= 0) {
+    if (fee === 0) {
       return props.handleSubmit && props.handleSubmit({ auto: true });
     }
 

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -307,7 +307,6 @@ function Component(props: Props) {
           }
           showInviteToPay={showPayOptions && isTeamSupported}
           paymentStatus={govUkPayment?.state?.status}
-          hidePay={fee === 0 || props.hidePay}
         />
       ) : (
         <DelayedLoadingIndicator text={state.displayText || state.status} />

--- a/editor.planx.uk/src/@planx/components/Pay/Public/utils.ts
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/utils.ts
@@ -1,0 +1,20 @@
+import { GOV_UK_PAY_URL } from "../model";
+
+export function getGovUkPayUrlForTeam({
+  sessionId,
+  flowId,
+  teamSlug,
+  paymentId,
+}: {
+  sessionId: string;
+  flowId: string;
+  teamSlug: string;
+  paymentId?: string;
+}): string {
+  const baseURL = `${GOV_UK_PAY_URL}/${teamSlug}`;
+  const queryString = `?sessionId=${sessionId}&flowId=${flowId}`;
+  if (paymentId) {
+    return `${baseURL}/${paymentId}${queryString}`;
+  }
+  return `${baseURL}${queryString}`;
+}

--- a/editor.planx.uk/src/lib/local.new.ts
+++ b/editor.planx.uk/src/lib/local.new.ts
@@ -28,3 +28,7 @@ export const setLocalFlow = async (sessionId: string, session: Session) => {
 export const clearLocalFlow = async (sessionId: string) => {
   await lowcalStorage.removeItem(`session:${sessionId}`);
 };
+
+export const saveSession = async (session: Session) => {
+  await setLocalFlow(session.sessionId, session);
+};


### PR DESCRIPTION
## What does this PR do?
- Refactors `Confirm` component to more explicitly handle various states
  - Before this PR, the logic for information only, pay, and invite to pay was quite tricky to manage and understand - adding a "zero fee" option into the mix would add to this confusion.
- Renders `Confirm` in instances where fee is £0
- Removes fee breakdown title and description - if we find we need these we can add them back. There's already a clear title and simple description here.
- Pulls in changes made in https://github.com/theopensystemslab/planx-core/pull/637 which also renders any exemptions

There's still scope here for a content pass through which I'm going to address once this feature is technically complete (e.g. the title "pay for your application" is not very meaningful when we know the fee is £0.)

Notion documentation to sit alongside this feature can be found here - https://www.notion.so/opensystemslab/How-displaying-the-fee-breakdown-works-19035d469ad180e3bcd2eab977a39a56