### PR TITLE
feat: analytics module gets and updates PlanX DB

### DIFF
--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -1,1 +1,92 @@
-test.todo("should test collection check and creation");
+import { $api } from "../../../../client/index.js";
+import { updateMetabaseId } from "./updateMetabaseId.js";
+import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
+
+describe("getTeamIdAndMetabaseId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("successfully gets team and existing metabase id", async () => {
+    vi.spyOn($api.client, "request").mockResolvedValue({
+      teams: [
+        {
+          id: 26,
+          name: "Barnet",
+          metabaseId: 20,
+        },
+      ],
+    });
+
+    const teamAndMetabaseId = await getTeamIdAndMetabaseId("Barnet");
+
+    expect(teamAndMetabaseId.id).toEqual(26);
+    expect(teamAndMetabaseId.metabaseId).toEqual(20);
+  });
+
+  test("handles team with null metabase id", async () => {
+    vi.spyOn($api.client, "request").mockResolvedValue({
+      teams: [
+        {
+          id: 26,
+          name: "Barnet",
+          metabaseId: null,
+        },
+      ],
+    });
+
+    const teamAndMetabaseId = await getTeamIdAndMetabaseId("Barnet");
+
+    expect(teamAndMetabaseId.id).toEqual(26);
+    expect(teamAndMetabaseId.metabaseId).toBeNull();
+  });
+});
+
+describe("updateMetabaseId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("successfully updates metabase ID", async () => {
+    // Mock the GraphQL request
+    vi.spyOn($api.client, "request").mockResolvedValue({
+      update_teams: {
+        returning: [
+          {
+            id: 1,
+            name: "Test Team",
+            metabase_id: 123,
+          },
+        ],
+      },
+    });
+
+    const result = await updateMetabaseId(1, 123);
+
+    expect(result).toEqual({
+      update_teams: {
+        returning: [
+          {
+            id: 1,
+            name: "Test Team",
+            metabase_id: 123,
+          },
+        ],
+      },
+    });
+
+    expect($api.client.request).toHaveBeenCalledWith(expect.any(String), {
+      id: 1,
+      metabaseId: 123,
+    });
+  });
+
+  test("handles GraphQL error", async () => {
+    // Mock a failed GraphQL request
+    vi.spyOn($api.client, "request").mockRejectedValue(
+      new Error("GraphQL error"),
+    );
+
+    await expect(updateMetabaseId(1, 123)).rejects.toThrow("GraphQL error");
+  });
+});

--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -12,13 +12,13 @@ describe("getTeamIdAndMetabaseId", () => {
       teams: [
         {
           id: 26,
-          name: "Barnet",
+          slug: "barnet",
           metabaseId: 20,
         },
       ],
     });
 
-    const teamAndMetabaseId = await getTeamIdAndMetabaseId("Barnet");
+    const teamAndMetabaseId = await getTeamIdAndMetabaseId("barnet");
 
     expect(teamAndMetabaseId.id).toEqual(26);
     expect(teamAndMetabaseId.metabaseId).toEqual(20);
@@ -29,7 +29,7 @@ describe("getTeamIdAndMetabaseId", () => {
       teams: [
         {
           id: 26,
-          name: "Barnet",
+          slug: "barnet",
           metabaseId: null,
         },
       ],
@@ -54,7 +54,7 @@ describe("updateMetabaseId", () => {
         returning: [
           {
             id: 1,
-            name: "Test Team",
+            slug: "testteam",
             metabase_id: 123,
           },
         ],
@@ -68,7 +68,7 @@ describe("updateMetabaseId", () => {
         returning: [
           {
             id: 1,
-            name: "Test Team",
+            slug: "testteam",
             metabase_id: 123,
           },
         ],

--- a/api.planx.uk/modules/analytics/metabase/collection/getTeamIdAndMetabaseId.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getTeamIdAndMetabaseId.ts
@@ -1,0 +1,38 @@
+import { gql } from "graphql-request";
+import { $api } from "../../../../client/index.js";
+
+interface GetMetabaseId {
+  teams: {
+    id: number;
+    name: string;
+    metabaseId: number | null;
+  }[];
+}
+
+export const getTeamIdAndMetabaseId = async (name: string) => {
+  try {
+    const response = await $api.client.request<GetMetabaseId>(
+      gql`
+        query GetTeamAndMetabaseId($name: String!) {
+          teams(where: { name: { _ilike: $name } }) {
+            id
+            name
+            metabaseId: metabase_id
+          }
+        }
+      `,
+      {
+        name: name,
+      },
+    );
+
+    const result = response.teams[0];
+    return result;
+  } catch (e) {
+    console.error(
+      "Error fetching team's ID / Metabase ID from PlanX DB:",
+      (e as Error).stack,
+    );
+    throw e;
+  }
+};

--- a/api.planx.uk/modules/analytics/metabase/collection/getTeamIdAndMetabaseId.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getTeamIdAndMetabaseId.ts
@@ -4,25 +4,25 @@ import { $api } from "../../../../client/index.js";
 interface GetMetabaseId {
   teams: {
     id: number;
-    name: string;
+    slug: string;
     metabaseId: number | null;
   }[];
 }
 
-export const getTeamIdAndMetabaseId = async (name: string) => {
+export const getTeamIdAndMetabaseId = async (slug: string) => {
   try {
     const response = await $api.client.request<GetMetabaseId>(
       gql`
-        query GetTeamAndMetabaseId($name: String!) {
-          teams(where: { name: { _ilike: $name } }) {
+        query GetTeamAndMetabaseId($slug: String!) {
+          teams(where: { slug: { _eq: $slug } }) {
             id
-            name
+            slug
             metabaseId: metabase_id
           }
         }
       `,
       {
-        name: name,
+        slug: slug,
       },
     );
 

--- a/api.planx.uk/modules/analytics/metabase/collection/updateMetabaseId.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/updateMetabaseId.ts
@@ -4,7 +4,7 @@ import { $api } from "../../../../client/index.js";
 interface UpdateMetabaseId {
   teams: {
     id: number;
-    name: string;
+    slug: string;
     metabaseId: number;
   };
 }
@@ -21,7 +21,7 @@ export const updateMetabaseId = async (teamId: number, metabaseId: number) => {
           ) {
             returning {
               id
-              name
+              slug
               metabase_id
             }
           }

--- a/api.planx.uk/modules/analytics/metabase/collection/updateMetabaseId.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/updateMetabaseId.ts
@@ -1,0 +1,43 @@
+import { gql } from "graphql-request";
+import { $api } from "../../../../client/index.js";
+
+interface UpdateMetabaseId {
+  teams: {
+    id: number;
+    name: string;
+    metabaseId: number;
+  };
+}
+
+/** Updates column `metabase_id` in the Planx DB `teams` table */
+export const updateMetabaseId = async (teamId: number, metabaseId: number) => {
+  try {
+    const response = await $api.client.request<UpdateMetabaseId>(
+      gql`
+        mutation UpdateTeamMetabaseId($id: Int!, $metabaseId: Int!) {
+          update_teams(
+            where: { id: { _eq: $id } }
+            _set: { metabase_id: $metabaseId }
+          ) {
+            returning {
+              id
+              name
+              metabase_id
+            }
+          }
+        }
+      `,
+      {
+        id: teamId,
+        metabaseId: metabaseId,
+      },
+    );
+    return response;
+  } catch (e) {
+    console.error(
+      "There's been an error while updating the Metabase ID for this team",
+      (e as Error).stack,
+    );
+    throw e;
+  }
+};

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2370,6 +2370,7 @@
           - created_at
           - domain
           - id
+          - metabase_id
           - name
           - slug
           - updated_at
@@ -2422,6 +2423,13 @@
           - updated_at
         filter: {}
   update_permissions:
+    - role: api
+      permission:
+        columns:
+          - metabase_id
+        filter: {}
+        check: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:

--- a/hasura.planx.uk/migrations/1733738650997_alter_table_public_teams_add_column_metabase_id/down.sql
+++ b/hasura.planx.uk/migrations/1733738650997_alter_table_public_teams_add_column_metabase_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."teams" drop column "metabase_id";

--- a/hasura.planx.uk/migrations/1733738650997_alter_table_public_teams_add_column_metabase_id/up.sql
+++ b/hasura.planx.uk/migrations/1733738650997_alter_table_public_teams_add_column_metabase_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."teams" add column "metabase_id" integer
+ null;

--- a/hasura.planx.uk/tests/teams.test.js
+++ b/hasura.planx.uk/tests/teams.test.js
@@ -98,8 +98,15 @@ describe("teams", () => {
       expect(i.queries).toContain("teams");
     });
 
-    test("cannot create, update, or delete teams", () => {
-      expect(i).toHaveNoMutationsFor("teams");
+    test("can update teams", () => { 
+      expect(i.mutations).toContain("update_teams");
+      expect(i.mutations).toContain("update_teams_by_pk"); 
+      expect(i.mutations).toContain("update_teams_many"); 
+    }); 
+
+    test("cannot create or delete teams", () => {
+      expect(i.mutations).not.toContain("insert_teams"); 
+      expect(i.mutations).not.toContain("delete_teams");
     });
   });
 });


### PR DESCRIPTION
# What's new in this PR
- Migration to add `metabase_id` column to `teams` in PlanX DB
- Update Hasura permissions for `api` to be able to read and update relevant values
- A `getTeamIdAndMetabaseId` function
- An `updateMetabaseId ` function
- Tests for the above

# Why
- Daf suggested that a better pattern than querying Metabase every time we want to check if a collection exists would be to store a `metabase_id` in the PlanX DB and check that instead
- This is the PlanX DB portion of big PR #3971