### PR TITLE
feat: Metabase module controller and service

### DIFF
--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -14,8 +14,8 @@ components:
   schemas:
     NewCollection:
       type: object
-      properties:  
-        description:  
+      properties:
+        description:
           type: string
           description: Optional description for the collection
         parentId:
@@ -43,19 +43,19 @@ paths:
         "204":
           $ref: "#/components/responses/AnalyticsResponse"
 
-  /metabase/collection/{slug}:  
+  /metabase/collection/{slug}:
     post:
       summary: Create new Metabase collection
       description: Creates a new collection in Metabase if it doesn't already exist
       tags:
         - metabase
-      parameters:  
-        - name: slug  
-          in: path  
-          required: true  
-          schema:  
-            type: string  
-          description: PlanX team slug  
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: PlanX team slug
       requestBody:
         required: true
         content:
@@ -71,8 +71,8 @@ paths:
                 type: object
                 properties:
                   data:
-                    type: integer  
-                    description: Metabase collection ID  
+                    type: integer
+                    description: Metabase collection ID
         "400":
           description: Bad request or collection creation failed
           content:

--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -2,12 +2,32 @@ openapi: 3.1.0
 info:
   title: Plan✕ API
   version: 0.1.0
+
 tags:
   - name: analytics
+  - name: metabase
+
 components:
   responses:
     AnalyticsResponse:
       description: Successful response with no content. Not awaited from server as endpoint is called via the Beacon API
+
+  schemas:
+    NewCollection:
+      type: object
+      required:
+        - slug
+      properties:
+        slug:
+          type: string
+          description: Name of the collection
+        description:
+          type: string
+          description: Optional description for the collection
+        parentId:
+          type: integer
+          description: Optional ID of the parent collection
+
 paths:
   /analytics/log-user-exit:
     post:
@@ -18,6 +38,7 @@ paths:
       responses:
         "204":
           $ref: "#/components/responses/AnalyticsResponse"
+
   /analytics/log-user-resume:
     post:
       summary: Log user resume
@@ -27,3 +48,36 @@ paths:
       responses:
         "204":
           $ref: "#/components/responses/AnalyticsResponse"
+
+  /metabase/collection:
+    post:
+      summary: Create new Metabase collection
+      description: Creates a new collection in Metabase if it doesn't already exist
+      tags:
+        - metabase
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewCollection"
+      responses:
+        "201":
+          description: Collection created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/NewCollection"
+        "400":
+          description: Bad request or collection creation failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message

--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -5,7 +5,6 @@ info:
 
 tags:
   - name: analytics
-  - name: metabase
 
 components:
   responses:

--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -15,13 +15,8 @@ components:
   schemas:
     NewCollection:
       type: object
-      required:
-        - slug
-      properties:
-        slug:
-          type: string
-          description: Name of the collection
-        description:
+      properties:  
+        description:  
           type: string
           description: Optional description for the collection
         parentId:
@@ -49,12 +44,19 @@ paths:
         "204":
           $ref: "#/components/responses/AnalyticsResponse"
 
-  /metabase/collection:
+  /metabase/collection/{slug}:  
     post:
       summary: Create new Metabase collection
       description: Creates a new collection in Metabase if it doesn't already exist
       tags:
         - metabase
+      parameters:  
+        - name: slug  
+          in: path  
+          required: true  
+          schema:  
+            type: string  
+          description: PlanX team slug  
       requestBody:
         required: true
         content:
@@ -70,7 +72,8 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: "#/components/schemas/NewCollection"
+                    type: integer  
+                    description: Metabase collection ID  
         "400":
           description: Bad request or collection creation failed
           content:

--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -18,7 +18,7 @@ describe("createTeamCollection", () => {
       teams: [
         {
           id: 26,
-          name: "Barnet",
+          slug: "barnet",
           metabase_id: null,
         },
       ],
@@ -27,15 +27,15 @@ describe("createTeamCollection", () => {
     // Mock Metabase API calls
     const metabaseMock = nock(process.env.METABASE_URL_EXT!)
       .post("/api/collection/", {
-        name: "Barnet",
+        slug: "barnet",
       })
       .reply(200, {
         id: 123,
-        name: "Barnet",
+        slug: "barnet",
       });
 
     const collectionId = await createCollection({
-      name: "Barnet",
+      slug: "barnet",
     });
 
     expect(collectionId).toBe(123);
@@ -49,37 +49,37 @@ describe("createTeamCollection", () => {
         returning: [
           {
             id: 26,
-            name: "Barnet",
+            slug: "barnet",
             metabase_id: 123,
           },
         ],
       },
     });
 
-    const testName = "Example council";
+    const testSlug = "example-council";
     const metabaseMock = nock(process.env.METABASE_URL_EXT!);
 
     // Mock collection creation endpoint
     metabaseMock
       .post("/api/collection/", {
-        name: testName,
+        slug: testSlug,
         parent_id: 100,
       })
       .reply(200, {
         id: 123,
-        name: testName,
+        slug: testSlug,
         parent_id: 100,
       });
 
     // Mock GET request for verifying the new collection
     metabaseMock.get("/api/collection/123").reply(200, {
       id: 123,
-      name: testName,
+      slug: testSlug,
       parent_id: 100,
     });
 
     const collectionId = await createCollection({
-      name: testName,
+      slug: testSlug,
       parentId: 100,
     });
 
@@ -92,12 +92,12 @@ describe("createTeamCollection", () => {
     expect(metabaseMock.isDone()).toBe(true);
   });
 
-  test("returns collection correctly no matter collection name case", async () => {
+  test("returns collection correctly no matter collection slug case", async () => {
     vi.spyOn($api.client, "request").mockResolvedValueOnce({
       teams: [
         {
           id: 26,
-          name: "barnet",
+          slug: "barnet",
           metabaseId: 20,
         },
       ],
@@ -114,7 +114,7 @@ describe("createTeamCollection", () => {
 
     await expect(
       createCollection({
-        name: "Test Collection",
+        slug: "test-collection",
       }),
     ).rejects.toThrow("Network error occurred");
   });
@@ -126,7 +126,7 @@ describe("createTeamCollection", () => {
 
     await expect(
       createCollection({
-        name: "Test Collection",
+        slug: "test-collection",
       }),
     ).rejects.toThrow(MetabaseError);
   });
@@ -228,50 +228,50 @@ describe("edge cases", () => {
     vi.resetAllMocks();
   });
 
-  test("handles missing name", async () => {
+  test("handles missing slug", async () => {
     await expect(
       createTeamCollection({
-        name: "",
+        slug: "",
       }),
     ).rejects.toThrow();
   });
 
-  test("handles names with special characters", async () => {
-    const specialName = "@#$%^&*";
+  test("handles slug with special characters", async () => {
+    const specialSlug = "@#$%^&*";
 
     nock(process.env.METABASE_URL_EXT!).get("/api/collection/").reply(200, []);
 
     nock(process.env.METABASE_URL_EXT!)
       .post("/api/collection/", {
-        name: specialName,
+        slug: specialSlug,
       })
       .reply(200, {
         id: 789,
-        name: specialName,
+        slug: specialSlug,
       });
 
     const collection = await createCollection({
-      name: specialName,
+      slug: specialSlug,
     });
     expect(collection).toBe(789);
   });
 
-  test("handles very long names", async () => {
-    const longName = "A".repeat(101);
+  test("handles very long slugs", async () => {
+    const longSlug = "A".repeat(101);
 
     nock(process.env.METABASE_URL_EXT!).get("/api/collection/").reply(200, []);
 
     nock(process.env.METABASE_URL_EXT!)
       .post("/api/collection/", {
-        name: longName,
+        slug: longSlug,
       })
       .reply(400, {
-        message: "Name too long",
+        message: "Slug too long",
       });
 
     await expect(
       createTeamCollection({
-        name: longName,
+        slug: longSlug,
       }),
     ).rejects.toThrow();
   });

--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -27,15 +27,15 @@ describe("createTeamCollection", () => {
     // Mock Metabase API calls
     const metabaseMock = nock(process.env.METABASE_URL_EXT!)
       .post("/api/collection/", {
-        slug: "barnet",
+        name: "Barnet",
       })
       .reply(200, {
         id: 123,
-        slug: "barnet",
+        name: "Barnet",
       });
 
     const collectionId = await createCollection({
-      slug: "barnet",
+      name: "Barnet",
     });
 
     expect(collectionId).toBe(123);
@@ -49,6 +49,7 @@ describe("createTeamCollection", () => {
         returning: [
           {
             id: 26,
+            name: "Barnet",
             slug: "barnet",
             metabase_id: 123,
           },
@@ -56,30 +57,30 @@ describe("createTeamCollection", () => {
       },
     });
 
-    const testSlug = "example-council";
+    const testName = "Example Council";
     const metabaseMock = nock(process.env.METABASE_URL_EXT!);
 
     // Mock collection creation endpoint
     metabaseMock
       .post("/api/collection/", {
-        slug: testSlug,
-        parent_id: 100,
+        name: testName,
+        parentId: 100,
       })
       .reply(200, {
         id: 123,
-        slug: testSlug,
-        parent_id: 100,
+        name: testName,
+        parentId: 100,
       });
 
     // Mock GET request for verifying the new collection
     metabaseMock.get("/api/collection/123").reply(200, {
       id: 123,
-      slug: testSlug,
-      parent_id: 100,
+      name: testName,
+      parentId: 100,
     });
 
     const collectionId = await createCollection({
-      slug: testSlug,
+      name: testName,
       parentId: 100,
     });
 
@@ -88,7 +89,8 @@ describe("createTeamCollection", () => {
 
     // Verify the collection details using the service function
     const collection = await getCollection(collectionId);
-    expect(collection.parent_id).toBe(100);
+    console.log({ collection });
+    expect(collection.parentId).toBe(100);
     expect(metabaseMock.isDone()).toBe(true);
   });
 
@@ -97,6 +99,7 @@ describe("createTeamCollection", () => {
       teams: [
         {
           id: 26,
+          name: "Barnet",
           slug: "barnet",
           metabaseId: 20,
         },
@@ -114,7 +117,7 @@ describe("createTeamCollection", () => {
 
     await expect(
       createCollection({
-        slug: "test-collection",
+        name: "Test Collection",
       }),
     ).rejects.toThrow("Network error occurred");
   });
@@ -126,7 +129,7 @@ describe("createTeamCollection", () => {
 
     await expect(
       createCollection({
-        slug: "test-collection",
+        name: "Test Collection",
       }),
     ).rejects.toThrow(MetabaseError);
   });
@@ -142,6 +145,7 @@ describe("getTeamIdAndMetabaseId", () => {
       teams: [
         {
           id: 26,
+          name: "Barnet",
           slug: "barnet",
           metabaseId: 20,
         },
@@ -236,22 +240,22 @@ describe("edge cases", () => {
     ).rejects.toThrow();
   });
 
-  test("handles slug with special characters", async () => {
-    const specialSlug = "@#$%^&*";
+  test("handles name with special characters", async () => {
+    const specialName = "@#$%^&*";
 
     nock(process.env.METABASE_URL_EXT!).get("/api/collection/").reply(200, []);
 
     nock(process.env.METABASE_URL_EXT!)
       .post("/api/collection/", {
-        slug: specialSlug,
+        name: specialName,
       })
       .reply(200, {
         id: 789,
-        slug: specialSlug,
+        name: specialName,
       });
 
     const collection = await createCollection({
-      slug: specialSlug,
+      name: specialName,
     });
     expect(collection).toBe(789);
   });

--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -89,7 +89,6 @@ describe("createTeamCollection", () => {
 
     // Verify the collection details using the service function
     const collection = await getCollection(collectionId);
-    console.log({ collection });
     expect(collection.parentId).toBe(100);
     expect(metabaseMock.isDone()).toBe(true);
   });

--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -1,6 +1,136 @@
+import { createCollectionIfDoesNotExist } from "./service.js";
+import { getCollection } from "./getCollection.js";
+import nock from "nock";
+import { MetabaseError } from "../shared/client.js";
 import { $api } from "../../../../client/index.js";
 import { updateMetabaseId } from "./updateMetabaseId.js";
 import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
+import { createCollection } from "./createCollection.js";
+
+describe("createCollectionIfDoesNotExist", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  test("creates new collection when metabase ID doesn't exist", async () => {
+    // Mock getTeamIdAndMetabaseId response with null metabase_id
+    vi.spyOn($api.client, "request").mockResolvedValueOnce({
+      teams: [
+        {
+          id: 26,
+          name: "Barnet",
+          metabase_id: null,
+        },
+      ],
+    });
+
+    // Mock Metabase API calls
+    const metabaseMock = nock(process.env.METABASE_URL_EXT!)
+      .post("/api/collection/", {
+        name: "Barnet",
+      })
+      .reply(200, {
+        id: 123,
+        name: "Barnet",
+      });
+
+    const collectionId = await createCollection({
+      name: "Barnet",
+    });
+
+    expect(collectionId).toBe(123);
+    expect(metabaseMock.isDone()).toBe(true);
+  });
+
+  test("successfully places new collection in parent", async () => {
+    // Mock updateMetabaseId response
+    vi.spyOn($api.client, "request").mockResolvedValueOnce({
+      update_teams: {
+        returning: [
+          {
+            id: 26,
+            name: "Barnet",
+            metabase_id: 123,
+          },
+        ],
+      },
+    });
+
+    const testName = "Example council";
+    const metabaseMock = nock(process.env.METABASE_URL_EXT!);
+
+    // Mock collection creation endpoint
+    metabaseMock
+      .post("/api/collection/", {
+        name: testName,
+        parent_id: 100,
+      })
+      .reply(200, {
+        id: 123,
+        name: testName,
+        parent_id: 100,
+      });
+
+    // Mock GET request for verifying the new collection
+    metabaseMock.get("/api/collection/123").reply(200, {
+      id: 123,
+      name: testName,
+      parent_id: 100,
+    });
+
+    const collectionId = await createCollection({
+      name: testName,
+      parentId: 100,
+    });
+
+    // Check the ID is returned correctly
+    expect(collectionId).toBe(123);
+
+    // Verify the collection details using the service function
+    const collection = await getCollection(collectionId);
+    expect(collection.parent_id).toBe(100);
+    expect(metabaseMock.isDone()).toBe(true);
+  });
+
+  test("returns collection correctly no matter collection name case", async () => {
+    vi.spyOn($api.client, "request").mockResolvedValueOnce({
+      teams: [
+        {
+          id: 26,
+          name: "barnet",
+          metabaseId: 20,
+        },
+      ],
+    });
+
+    const collection = await getTeamIdAndMetabaseId("BARNET");
+    expect(collection.metabaseId).toBe(20);
+  });
+
+  test("throws error if network failure", async () => {
+    nock(process.env.METABASE_URL_EXT!)
+      .get("/api/collection/")
+      .replyWithError("Network error occurred");
+
+    await expect(
+      createCollection({
+        name: "Test Collection",
+      }),
+    ).rejects.toThrow("Network error occurred");
+  });
+
+  test("throws error if API error", async () => {
+    nock(process.env.METABASE_URL_EXT!).get("/api/collection/").reply(400, {
+      message: "Bad request",
+    });
+
+    await expect(
+      createCollection({
+        name: "Test Collection",
+      }),
+    ).rejects.toThrow(MetabaseError);
+  });
+});
 
 describe("getTeamIdAndMetabaseId", () => {
   beforeEach(() => {
@@ -88,5 +218,61 @@ describe("updateMetabaseId", () => {
     );
 
     await expect(updateMetabaseId(1, 123)).rejects.toThrow("GraphQL error");
+  });
+});
+
+describe("edge cases", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+  });
+
+  test("handles missing name", async () => {
+    await expect(
+      createCollectionIfDoesNotExist({
+        name: "",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("handles names with special characters", async () => {
+    const specialName = "@#$%^&*";
+
+    nock(process.env.METABASE_URL_EXT!).get("/api/collection/").reply(200, []);
+
+    nock(process.env.METABASE_URL_EXT!)
+      .post("/api/collection/", {
+        name: specialName,
+      })
+      .reply(200, {
+        id: 789,
+        name: specialName,
+      });
+
+    const collection = await createCollection({
+      name: specialName,
+    });
+    expect(collection).toBe(789);
+  });
+
+  test("handles very long names", async () => {
+    const longName = "A".repeat(101);
+
+    nock(process.env.METABASE_URL_EXT!).get("/api/collection/").reply(200, []);
+
+    nock(process.env.METABASE_URL_EXT!)
+      .post("/api/collection/", {
+        name: longName,
+      })
+      .reply(400, {
+        message: "Name too long",
+      });
+
+    await expect(
+      createCollectionIfDoesNotExist({
+        name: longName,
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -1,4 +1,4 @@
-import { createCollectionIfDoesNotExist } from "./service.js";
+import { createTeamCollection } from "./service.js";
 import { getCollection } from "./getCollection.js";
 import nock from "nock";
 import { MetabaseError } from "../shared/client.js";
@@ -7,7 +7,7 @@ import { updateMetabaseId } from "./updateMetabaseId.js";
 import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
 import { createCollection } from "./createCollection.js";
 
-describe("createCollectionIfDoesNotExist", () => {
+describe("createTeamCollection", () => {
   beforeEach(() => {
     nock.cleanAll();
   });
@@ -230,7 +230,7 @@ describe("edge cases", () => {
 
   test("handles missing name", async () => {
     await expect(
-      createCollectionIfDoesNotExist({
+      createTeamCollection({
         name: "",
       }),
     ).rejects.toThrow();
@@ -270,7 +270,7 @@ describe("edge cases", () => {
       });
 
     await expect(
-      createCollectionIfDoesNotExist({
+      createTeamCollection({
         name: longName,
       }),
     ).rejects.toThrow();

--- a/api.planx.uk/modules/analytics/metabase/collection/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/controller.ts
@@ -1,0 +1,18 @@
+import { createCollectionIfDoesNotExist } from "./service.js";
+import type { NewCollectionRequestHandler } from "./types.js";
+
+export const MetabaseCollectionsController: NewCollectionRequestHandler =
+  async (_req, res) => {
+    try {
+      const params = res.locals.parsedReq.body;
+      const collection = await createCollectionIfDoesNotExist(params);
+      res.status(201).json({ data: collection });
+    } catch (error) {
+      res.status(400).json({
+        error:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred",
+      });
+    }
+  };

--- a/api.planx.uk/modules/analytics/metabase/collection/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/controller.ts
@@ -1,11 +1,11 @@
-import { createCollectionIfDoesNotExist } from "./service.js";
+import { createTeamCollection } from "./service.js";
 import type { NewCollectionRequestHandler } from "./types.js";
 
 export const metabaseCollectionsController: NewCollectionRequestHandler =
   async (_req, res) => {
     try {
       const params = res.locals.parsedReq.body;
-      const collection = await createCollectionIfDoesNotExist(params);
+      const collection = await createTeamCollection(params);
       res.status(201).json({ data: collection });
     } catch (error) {
       res.status(400).json({

--- a/api.planx.uk/modules/analytics/metabase/collection/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/controller.ts
@@ -1,7 +1,7 @@
 import { createCollectionIfDoesNotExist } from "./service.js";
 import type { NewCollectionRequestHandler } from "./types.js";
 
-export const MetabaseCollectionsController: NewCollectionRequestHandler =
+export const metabaseCollectionsController: NewCollectionRequestHandler =
   async (_req, res) => {
     try {
       const params = res.locals.parsedReq.body;

--- a/api.planx.uk/modules/analytics/metabase/collection/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/controller.ts
@@ -4,7 +4,10 @@ import type { NewCollectionRequestHandler } from "./types.js";
 export const metabaseCollectionsController: NewCollectionRequestHandler =
   async (_req, res) => {
     try {
-      const params = res.locals.parsedReq.body;
+      const params = {
+        ...res.locals.parsedReq.params,
+        ...res.locals.parsedReq.body,
+      };
       const collection = await createTeamCollection(params);
       res.status(201).json({ data: collection });
     } catch (error) {

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -7,14 +7,14 @@ export async function createCollection(
   params: NewCollectionParams,
 ): Promise<number> {
   const transformedParams = {
-    name: params.name,
+    slug: params.slug,
     parent_id: params.parentId,
   };
 
   const response = await client.post(`/api/collection/`, transformedParams);
-
+  const slug = response.data.slug;
   console.log(
-    `New collection: ${response.data.name}, new collection ID: ${response.data.id}`,
+    `New collection: ${response.data.slug}, new collection ID: ${response.data.id}`,
   );
   return response.data.id;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -5,7 +5,7 @@ const client = createMetabaseClient();
 
 export async function createCollection(
   params: NewCollectionParams,
-): Promise<any> {
+): Promise<number> {
   const transformedParams = {
     name: params.name,
     parent_id: params.parentId,

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -1,11 +1,9 @@
-import { createMetabaseClient } from "../shared/client.js";
-import type { MetabaseCollectionParams, NewCollectionParams } from "./types.js";
-
-const client = createMetabaseClient();
+import type { MetabaseCollectionParams } from "./types.js";
+import { $metabase } from "../shared/client.js";
 
 export async function createCollection(
   params: MetabaseCollectionParams,
 ): Promise<number> {
-  const response = await client.post(`/api/collection/`, params);
+  const response = await $metabase.post(`/api/collection/`, params);
   return response.data.id;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -1,18 +1,12 @@
 import { createMetabaseClient } from "../shared/client.js";
-import type { NewCollectionParams } from "./types.js";
+import type { MetabaseCollectionParams, NewCollectionParams } from "./types.js";
 
 const client = createMetabaseClient();
 
 export async function createCollection(
-  params: NewCollectionParams,
+  params: MetabaseCollectionParams,
 ): Promise<number> {
-  const transformedParams = {
-    slug: params.slug,
-    parent_id: params.parentId,
-  };
-
-  const response = await client.post(`/api/collection/`, transformedParams);
-  const slug = response.data.slug;
+  const response = await client.post(`/api/collection/`, params);
   console.log(
     `New collection: ${response.data.slug}, new collection ID: ${response.data.id}`,
   );

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -7,8 +7,5 @@ export async function createCollection(
   params: MetabaseCollectionParams,
 ): Promise<number> {
   const response = await client.post(`/api/collection/`, params);
-  console.log(
-    `New collection: ${response.data.slug}, new collection ID: ${response.data.id}`,
-  );
   return response.data.id;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -1,0 +1,20 @@
+import { createMetabaseClient } from "../shared/client.js";
+import type { NewCollectionParams } from "./types.js";
+
+const client = createMetabaseClient();
+
+export async function createCollection(
+  params: NewCollectionParams,
+): Promise<any> {
+  const transformedParams = {
+    name: params.name,
+    parent_id: params.parentId,
+  };
+
+  const response = await client.post(`/api/collection/`, transformedParams);
+
+  console.log(
+    `New collection: ${response.data.name}, new collection ID: ${response.data.id}`,
+  );
+  return response.data.id;
+}

--- a/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
@@ -3,8 +3,6 @@ import { $metabase } from "../shared/client.js";
 
 /**
  * Retrieves info on a collection from Metabase, use to check a parent. Currently only used in tests but could be useful for other Metabase functionality
- * @param id
- * @returns
  */
 export async function getCollection(
   id: number,

--- a/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
@@ -1,0 +1,15 @@
+import { createMetabaseClient } from "../shared/client.js";
+import type { GetCollectionResponse } from "./types.js";
+
+const client = createMetabaseClient();
+/**
+ * Retrieves info on a collection from Metabase, use to check a parent. Currently only used in tests but could be useful for other Metabase functionality
+ * @param id
+ * @returns
+ */
+export async function getCollection(
+  id: number,
+): Promise<GetCollectionResponse> {
+  const response = await client.get(`/api/collection/${id}`);
+  return response.data;
+}

--- a/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
@@ -1,7 +1,7 @@
 import { createMetabaseClient } from "../shared/client.js";
 import type { GetCollectionResponse } from "./types.js";
+import { $metabase } from "../shared/client.js";
 
-const client = createMetabaseClient();
 /**
  * Retrieves info on a collection from Metabase, use to check a parent. Currently only used in tests but could be useful for other Metabase functionality
  * @param id
@@ -10,6 +10,6 @@ const client = createMetabaseClient();
 export async function getCollection(
   id: number,
 ): Promise<GetCollectionResponse> {
-  const response = await client.get(`/api/collection/${id}`);
+  const response = await $metabase.get(`/api/collection/${id}`);
   return response.data;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
@@ -1,4 +1,3 @@
-import { createMetabaseClient } from "../shared/client.js";
 import type { GetCollectionResponse } from "./types.js";
 import { $metabase } from "../shared/client.js";
 

--- a/api.planx.uk/modules/analytics/metabase/collection/getTeamIdAndMetabaseId.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getTeamIdAndMetabaseId.ts
@@ -4,6 +4,7 @@ import { $api } from "../../../../client/index.js";
 interface GetMetabaseId {
   teams: {
     id: number;
+    name: string;
     slug: string;
     metabaseId: number | null;
   }[];
@@ -16,6 +17,7 @@ export const getTeamIdAndMetabaseId = async (slug: string) => {
         query GetTeamAndMetabaseId($slug: String!) {
           teams(where: { slug: { _eq: $slug } }) {
             id
+            name
             slug
             metabaseId: metabase_id
           }

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -1,0 +1,36 @@
+import { createMetabaseClient } from "../shared/client.js";
+import { updateMetabaseId } from "./updateMetabaseId.js";
+import type { NewCollectionParams } from "./types.js";
+import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
+import { createCollection } from "./createCollection.js";
+
+const client = createMetabaseClient();
+
+/**
+ * First uses name to get teams.id and .metabase_id, if present.
+ * If metabase_id is null, return an object that includes its id. If not, create the collection.
+ * @params `name` is required, but `description` and `parent_id` are optional.
+ * @returns `response.data`, so use dot notation to access `id` or `parent_id`.
+ */
+export async function createCollectionIfDoesNotExist(
+  params: NewCollectionParams,
+): Promise<number> {
+  try {
+    const { metabaseId, id: teamId } = await getTeamIdAndMetabaseId(
+      params.name,
+    );
+
+    if (metabaseId) {
+      return metabaseId;
+    }
+
+    // Create new Metabase collection if !metabaseId
+    const newMetabaseId = await createCollection(params);
+    await updateMetabaseId(teamId, newMetabaseId);
+    console.log({ newMetabaseId });
+    return newMetabaseId;
+  } catch (error) {
+    console.error("Error in createCollectionIfDoesNotExist:", error);
+    throw error;
+  }
+}

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -3,11 +3,6 @@ import type { NewCollectionParams } from "./types.js";
 import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
 import { createCollection } from "./createCollection.js";
 
-/**
- * The `getTeamIdAndMetabaseId()` function is run here to first get teams.id and .metabase_id from PlanX db, if present,
- * so that the service can figure out if it needs to run `createCollection()` or not.
- * Instead of running `getTeamIdAndMetabaseId()` first in the controller, it is encapsulated in `createTeamCollection` to keep business logic in `service.ts` instead of `controller.ts`.
- */
 export async function createTeamCollection({
   slug,
   parentId,

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -1,5 +1,5 @@
 import { updateMetabaseId } from "./updateMetabaseId.js";
-import type { NewCollectionParams, MetabaseCollectionParams } from "./types.js";
+import type { NewCollectionParams } from "./types.js";
 import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
 import { createCollection } from "./createCollection.js";
 
@@ -10,27 +10,23 @@ import { createCollection } from "./createCollection.js";
  * @params `slug` is required, but `description` and `parent_id` are optional.
  * @returns `response.data`, so use dot notation to access `id` or `parent_id`.
  */
-export async function createTeamCollection(
-  params: NewCollectionParams,
-): Promise<number> {
+export async function createTeamCollection({
+  slug,
+  parentId,
+  description,
+}: NewCollectionParams): Promise<number> {
   try {
-    const {
-      metabaseId,
-      name,
-      id: teamId,
-    } = await getTeamIdAndMetabaseId(params.slug);
+    const { metabaseId, name, id: teamId } = await getTeamIdAndMetabaseId(slug);
 
     if (metabaseId) {
       return metabaseId;
     }
 
-    const { slug, ...rest } = params;
-    const metabaseParams = {
+    const newMetabaseId = await createCollection({
       name,
-      ...rest,
-    } as const;
-
-    const newMetabaseId = await createCollection(metabaseParams);
+      parentId,
+      description,
+    });
 
     await updateMetabaseId(teamId, newMetabaseId);
     return newMetabaseId;

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -9,7 +9,7 @@ import { createCollection } from "./createCollection.js";
  * @params `name` is required, but `description` and `parent_id` are optional.
  * @returns `response.data`, so use dot notation to access `id` or `parent_id`.
  */
-export async function createCollectionIfDoesNotExist(
+export async function createTeamCollection(
   params: NewCollectionParams,
 ): Promise<number> {
   try {
@@ -27,7 +27,7 @@ export async function createCollectionIfDoesNotExist(
     console.log({ newMetabaseId });
     return newMetabaseId;
   } catch (error) {
-    console.error("Error in createCollectionIfDoesNotExist:", error);
+    console.error("Error in createTeamCollection:", error);
     throw error;
   }
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -1,5 +1,5 @@
 import { updateMetabaseId } from "./updateMetabaseId.js";
-import type { NewCollectionParams } from "./types.js";
+import type { NewCollectionParams, MetabaseCollectionParams } from "./types.js";
 import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
 import { createCollection } from "./createCollection.js";
 
@@ -14,15 +14,24 @@ export async function createTeamCollection(
   params: NewCollectionParams,
 ): Promise<number> {
   try {
-    const { metabaseId, id: teamId } = await getTeamIdAndMetabaseId(
-      params.slug,
-    );
+    const {
+      metabaseId,
+      name,
+      id: teamId,
+    } = await getTeamIdAndMetabaseId(params.slug);
 
     if (metabaseId) {
       return metabaseId;
     }
 
-    const newMetabaseId = await createCollection(params);
+    const { slug, ...rest } = params;
+    const metabaseParams = {
+      name,
+      ...rest,
+    } as const;
+
+    const newMetabaseId = await createCollection(metabaseParams);
+
     await updateMetabaseId(teamId, newMetabaseId);
     return newMetabaseId;
   } catch (error) {

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -4,9 +4,10 @@ import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
 import { createCollection } from "./createCollection.js";
 
 /**
- * First uses name to get teams.id and .metabase_id, if present.
- * If metabase_id is null, return an object that includes its id. If not, create the collection.
- * @params `name` is required, but `description` and `parent_id` are optional.
+ * The `getTeamIdAndMetabaseId()` function is run here to first get teams.id and .metabase_id from PlanX db, if present,
+ * so that the service can figure out if it needs to run `createCollection()` or not.
+ * Instead of running `getTeamIdAndMetabaseId()` first in the controller, it is encapsulated in `createTeamCollection` to keep business logic in `service.ts` instead of `controller.ts`.
+ * @params `slug` is required, but `description` and `parent_id` are optional.
  * @returns `response.data`, so use dot notation to access `id` or `parent_id`.
  */
 export async function createTeamCollection(
@@ -14,17 +15,15 @@ export async function createTeamCollection(
 ): Promise<number> {
   try {
     const { metabaseId, id: teamId } = await getTeamIdAndMetabaseId(
-      params.name,
+      params.slug,
     );
 
     if (metabaseId) {
       return metabaseId;
     }
 
-    // Create new Metabase collection if !metabaseId
     const newMetabaseId = await createCollection(params);
     await updateMetabaseId(teamId, newMetabaseId);
-    console.log({ newMetabaseId });
     return newMetabaseId;
   } catch (error) {
     console.error("Error in createTeamCollection:", error);

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -1,10 +1,7 @@
-import { createMetabaseClient } from "../shared/client.js";
 import { updateMetabaseId } from "./updateMetabaseId.js";
 import type { NewCollectionParams } from "./types.js";
 import { getTeamIdAndMetabaseId } from "./getTeamIdAndMetabaseId.js";
 import { createCollection } from "./createCollection.js";
-
-const client = createMetabaseClient();
 
 /**
  * First uses name to get teams.id and .metabase_id, if present.

--- a/api.planx.uk/modules/analytics/metabase/collection/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/service.ts
@@ -7,8 +7,6 @@ import { createCollection } from "./createCollection.js";
  * The `getTeamIdAndMetabaseId()` function is run here to first get teams.id and .metabase_id from PlanX db, if present,
  * so that the service can figure out if it needs to run `createCollection()` or not.
  * Instead of running `getTeamIdAndMetabaseId()` first in the controller, it is encapsulated in `createTeamCollection` to keep business logic in `service.ts` instead of `controller.ts`.
- * @params `slug` is required, but `description` and `parent_id` are optional.
- * @returns `response.data`, so use dot notation to access `id` or `parent_id`.
  */
 export async function createTeamCollection({
   slug,

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -15,11 +15,9 @@ export interface NewCollectionParams {
 }
 
 /** Interface for request after transforming to snake case (Metabase takes snake while PlanX API takes camel) */
-export interface MetabaseCollectionParams {
+export type MetabaseCollectionParams = Omit<NewCollectionParams, "slug"> & {
   name: string;
-  description?: string;
-  parent_id?: number;
-}
+};
 
 /** Metbase collection ID for the the "Council" collection **/
 // const COUNCILS_COLLECTION_ID = 58;
@@ -45,5 +43,5 @@ export interface NewCollectionResponse {
 export interface GetCollectionResponse {
   id: number;
   slug: string;
-  parent_id: number;
+  parentId: number;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -25,17 +25,11 @@ export interface MetabaseCollectionParams {
 // const COUNCILS_COLLECTION_ID = 58;
 
 export const createCollectionIfDoesNotExistSchema = z.object({
-  body: z
-    .object({
-      name: z.string(),
-      description: z.string().optional(),
-      parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
-    })
-    .transform((data) => ({
-      name: data.name,
-      description: data.description,
-      parent_id: data.parentId,
-    })),
+  body: z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
+  }),
 });
 
 export type NewCollectionRequestHandler = ValidatedRequestHandler<

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -23,8 +23,10 @@ export type MetabaseCollectionParams = Omit<NewCollectionParams, "slug"> & {
 // const COUNCILS_COLLECTION_ID = 58;
 
 export const createTeamCollectionSchema = z.object({
-  body: z.object({
+  params: z.object({
     slug: z.string(),
+  }),
+  body: z.object({
     description: z.string().optional(),
     parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
   }),

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -24,7 +24,7 @@ export interface MetabaseCollectionParams {
 /** Metbase collection ID for the the "Council" collection **/
 // const COUNCILS_COLLECTION_ID = 58;
 
-export const createCollectionIfDoesNotExistSchema = z.object({
+export const createTeamCollectionSchema = z.object({
   body: z.object({
     name: z.string(),
     description: z.string().optional(),
@@ -33,7 +33,7 @@ export const createCollectionIfDoesNotExistSchema = z.object({
 });
 
 export type NewCollectionRequestHandler = ValidatedRequestHandler<
-  typeof createCollectionIfDoesNotExistSchema,
+  typeof createTeamCollectionSchema,
   ApiResponse<number>
 >;
 

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+
+type ApiResponse<T> = {
+  data?: T;
+  error?: string;
+};
+
+/** Interface for incoming request, in camelCase */
+export interface NewCollectionParams {
+  name: string;
+  description?: string;
+  /** Optional; if the collection is a child of a parent, specify parent ID here */
+  parentId?: number;
+}
+
+/** Interface for request after transforming to snake case (Metabase takes snake while PlanX API takes camel) */
+export interface MetabaseCollectionParams {
+  name: string;
+  description?: string;
+  parent_id?: number;
+}
+
+/** Metbase collection ID for the the "Council" collection **/
+// const COUNCILS_COLLECTION_ID = 58;
+
+export const createCollectionIfDoesNotExistSchema = z.object({
+  body: z
+    .object({
+      name: z.string(),
+      description: z.string().optional(),
+      parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
+    })
+    .transform((data) => ({
+      name: data.name,
+      description: data.description,
+      parent_id: data.parentId,
+    })),
+});
+
+export type NewCollectionRequestHandler = ValidatedRequestHandler<
+  typeof createCollectionIfDoesNotExistSchema,
+  ApiResponse<NewCollectionResponse>
+>;
+
+export interface NewCollectionResponse {
+  id: number;
+  name: string;
+}
+
+export interface GetCollectionResponse {
+  id: number;
+  name: string;
+  parent_id: number;
+}

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
 import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
-
-type ApiResponse<T> = {
-  data?: T;
-  error?: string;
-};
+import type { ApiResponse } from "../shared/types.js";
 
 /** Interface for incoming request, in camelCase */
 export interface NewCollectionParams {

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -40,7 +40,7 @@ export const createCollectionIfDoesNotExistSchema = z.object({
 
 export type NewCollectionRequestHandler = ValidatedRequestHandler<
   typeof createCollectionIfDoesNotExistSchema,
-  ApiResponse<NewCollectionResponse>
+  ApiResponse<number>
 >;
 
 export interface NewCollectionResponse {

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -23,7 +23,7 @@ export type MetabaseCollectionParams = Omit<NewCollectionParams, "slug"> & {
 
 export const createTeamCollectionSchema = z.object({
   params: z.object({
-    slug: z.string(),
+    slug: z.string().min(1),
   }),
   body: z.object({
     description: z.string().optional(),

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -19,7 +19,10 @@ export type MetabaseCollectionParams = Omit<NewCollectionParams, "slug"> & {
   name: string;
 };
 
-/** Metbase collection ID for the the "Council" collection **/
+/** TODO: when running on production, turn below comment back into code
+ * the Metabase collection ID is for the "Council" collection
+ * see https://github.com/theopensystemslab/planx-new/pull/4072#discussion_r1892631692
+ **/
 // const COUNCILS_COLLECTION_ID = 58;
 
 export const createTeamCollectionSchema = z.object({

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -8,7 +8,7 @@ type ApiResponse<T> = {
 
 /** Interface for incoming request, in camelCase */
 export interface NewCollectionParams {
-  name: string;
+  slug: string;
   description?: string;
   /** Optional; if the collection is a child of a parent, specify parent ID here */
   parentId?: number;
@@ -26,7 +26,7 @@ export interface MetabaseCollectionParams {
 
 export const createTeamCollectionSchema = z.object({
   body: z.object({
-    name: z.string(),
+    slug: z.string(),
     description: z.string().optional(),
     parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
   }),
@@ -39,11 +39,11 @@ export type NewCollectionRequestHandler = ValidatedRequestHandler<
 
 export interface NewCollectionResponse {
   id: number;
-  name: string;
+  slug: string;
 }
 
 export interface GetCollectionResponse {
   id: number;
-  name: string;
+  slug: string;
   parent_id: number;
 }

--- a/api.planx.uk/modules/analytics/metabase/shared/client.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/shared/client.test.ts
@@ -1,12 +1,9 @@
-import axios from "axios";
 import {
   validateConfig,
   createMetabaseClient,
   MetabaseError,
 } from "./client.js";
 import nock from "nock";
-
-const axiosCreateSpy = vi.spyOn(axios, "create");
 
 describe("Metabase client", () => {
   beforeEach(() => {

--- a/api.planx.uk/modules/analytics/metabase/shared/client.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/shared/client.test.ts
@@ -4,6 +4,7 @@ import {
   MetabaseError,
 } from "./client.js";
 import nock from "nock";
+import { $metabase } from "./client.js";
 
 describe("Metabase client", () => {
   beforeEach(() => {
@@ -16,13 +17,12 @@ describe("Metabase client", () => {
   });
 
   test("returns configured client", async () => {
-    const client = createMetabaseClient();
-    expect(client.defaults.baseURL).toBe(process.env.METABASE_URL_EXT);
-    expect(client.defaults.headers["X-API-Key"]).toBe(
+    expect($metabase.defaults.baseURL).toBe(process.env.METABASE_URL_EXT);
+    expect($metabase.defaults.headers["X-API-Key"]).toBe(
       process.env.METABASE_API_KEY,
     );
-    expect(client.defaults.headers["Content-Type"]).toBe("application/json");
-    expect(client.defaults.timeout).toBe(30_000);
+    expect($metabase.defaults.headers["Content-Type"]).toBe("application/json");
+    expect($metabase.defaults.timeout).toBe(30_000);
   });
 
   describe("validates configuration", () => {
@@ -61,8 +61,7 @@ describe("Metabase client", () => {
         .get("/test")
         .reply(200, { data: "success" });
 
-      const client = createMetabaseClient();
-      const response = await client.get("/test");
+      const response = await $metabase.get("/test");
 
       expect(response.data).toEqual({ data: "success" });
       expect(metabaseScope.isDone()).toBe(true);
@@ -76,10 +75,10 @@ describe("Metabase client", () => {
         .times(4)
         .reply(500, { message: "Internal Server Error" });
 
-      const client = createMetabaseClient();
+      const $metabase = createMetabaseClient();
 
       try {
-        await client.get("/test");
+        await $metabase.get("/test");
         expect.fail("Should have thrown an error");
       } catch (error) {
         expect(error).toBeInstanceOf(MetabaseError);
@@ -93,8 +92,8 @@ describe("Metabase client", () => {
 
       metabaseScope.get("/test").once().reply(200, { data: "success" });
 
-      const client = createMetabaseClient();
-      const response = await client.get("/test");
+      const $metabase = createMetabaseClient();
+      const response = await $metabase.get("/test");
 
       expect(response.data).toEqual({ data: "success" });
 

--- a/api.planx.uk/modules/analytics/metabase/shared/client.ts
+++ b/api.planx.uk/modules/analytics/metabase/shared/client.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import assert from "assert";
 import type {
   AxiosInstance,
   AxiosError,

--- a/api.planx.uk/modules/analytics/metabase/shared/client.ts
+++ b/api.planx.uk/modules/analytics/metabase/shared/client.ts
@@ -121,10 +121,4 @@ export const createMetabaseClient = (): AxiosInstance => {
   return client;
 };
 
-// // Export both client and instance with delayed instantiation for test purposes
-// export let metabaseClient: AxiosInstance;
-
-// export const initializeMetabaseClient = () => {
-//   metabaseClient = createMetabaseClient();
-//   return metabaseClient;
-// };
+export const $metabase = createMetabaseClient();

--- a/api.planx.uk/modules/analytics/metabase/shared/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/shared/types.ts
@@ -1,0 +1,4 @@
+export type ApiResponse<T> = {
+  data?: T;
+  error?: string;
+};

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -21,7 +21,7 @@ router.post(
   logUserResumeController,
 );
 router.post(
-  "/metabase/collection",
+  "/metabase/collection/:slug",
   validate(createTeamCollectionSchema),
   metabaseCollectionsController,
 );

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -21,7 +21,7 @@ router.post(
   logUserResumeController,
 );
 router.post(
-  "/collection",
+  "/metabase/collection",
   validate(createTeamCollectionSchema),
   metabaseCollectionsController,
 );

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -6,7 +6,7 @@ import {
   logUserResumeController,
 } from "./analyticsLog/controller.js";
 import { metabaseCollectionsController } from "./metabase/collection/controller.js";
-import { createCollectionIfDoesNotExistSchema } from "./metabase/collection/types.js";
+import { createTeamCollectionSchema } from "./metabase/collection/types.js";
 
 const router = Router();
 
@@ -22,7 +22,7 @@ router.post(
 );
 router.post(
   "/collection",
-  validate(createCollectionIfDoesNotExistSchema),
+  validate(createTeamCollectionSchema),
   metabaseCollectionsController,
 );
 

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -5,6 +5,8 @@ import {
   logUserExitController,
   logUserResumeController,
 } from "./analyticsLog/controller.js";
+import { MetabaseCollectionsController } from "./metabase/collection/controller.js";
+import { createCollectionIfDoesNotExistSchema } from "./metabase/collection/types.js";
 
 const router = Router();
 
@@ -17,6 +19,11 @@ router.post(
   "/analytics/log-user-resume",
   validate(logAnalyticsSchema),
   logUserResumeController,
+);
+router.post(
+  "/collection",
+  validate(createCollectionIfDoesNotExistSchema),
+  MetabaseCollectionsController,
 );
 
 export default router;

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -5,7 +5,7 @@ import {
   logUserExitController,
   logUserResumeController,
 } from "./analyticsLog/controller.js";
-import { MetabaseCollectionsController } from "./metabase/collection/controller.js";
+import { metabaseCollectionsController } from "./metabase/collection/controller.js";
 import { createCollectionIfDoesNotExistSchema } from "./metabase/collection/types.js";
 
 const router = Router();
@@ -23,7 +23,7 @@ router.post(
 router.post(
   "/collection",
   validate(createCollectionIfDoesNotExistSchema),
-  MetabaseCollectionsController,
+  metabaseCollectionsController,
 );
 
 export default router;

--- a/api.planx.uk/modules/send/s3/index.test.ts
+++ b/api.planx.uk/modules/send/s3/index.test.ts
@@ -23,6 +23,11 @@ vi.mock("../../file/service/uploadFile.js", () => ({
 
 vi.mock("../../client/index.js");
 
+// Mock the Metabase client which also relies on Axios which these tests need to mock
+vi.mock("../../analytics/metabase/shared/client.js", () => ({
+  createMetabaseClient: vi.fn(),
+}));
+
 vi.mock("axios", () => ({
   default: vi.fn(),
 }));


### PR DESCRIPTION
# What does this PR do
- Creates `createCollectionIfDoesNotExist` service
- Creates `createCollection` Metabase API call
- Adds necessary types
- Adds necessary tests
- Creates new route for analytics module
- Fixes an import that was missing from the Metabase client (in order to get this working) [Maybe this should have gone in another PR..?]

# Why
This is the second PR that breaks up #3971 (follows #4071)