### PR TITLE
chore(iac): Configure lifecycle policy for AWS ECR

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -94,7 +94,17 @@ const CUSTOM_DOMAINS: CustomDomains =
 export = async () => {
   const DOMAIN: string = await certificates.requireOutputValue("domain");
 
-  const repo = new awsx.ecr.Repository("repo");
+  const repo = new awsx.ecr.Repository("repo", {
+    lifeCyclePolicyArgs: {
+      rules: [
+        {
+          description: "Keep last 100 images",
+          maximumNumberOfImages: 100,
+          selection: "any",
+        },
+      ],
+    },
+  });
 
   const vpc = awsx.ec2.Vpc.fromExistingIds("vpc", {
     vpcId: networking.requireOutput("vpcId"),


### PR DESCRIPTION
## What's the problem?
We recently hit the following error on a recent staging deploy - 

> `error: denied: The repository with name {NAME} in registry with id {ID} already has the maximum allowed number of images which is ‘10000’`

## What's the solution?
I manually removed the oldest images from ECR > Private registry > Repository > Repository ID via the AWS console (staging).

After I did this, I re-ran our CI process which succeeded ✅ 

This PR configures an ECR Lifecycle Policy (AWS docs: https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) via Pulumi. This should be applied automatically on the next staging deploy (I'll verify via the console when this has ran).