### PR TITLE
fix: Selected feedback styling

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
@@ -28,7 +28,7 @@ export const FaceBox = ({
           px: 0,
           width: "100%",
           textTransform: "none",
-          [`&.${toggleButtonClasses.selected}`]: {
+          [`&.${toggleButtonClasses.selected} > div`]: {
             borderColor: (theme) => theme.palette.primary.dark,
             background: (theme) => theme.palette.background.paper,
           },


### PR DESCRIPTION
## What does this PR do?

Quick one:
Fixes inheritance of selected class so that selected feedback is correctly highlighted.

**Before ('neutral' selected):**
<img width="738" alt="image" src="https://github.com/user-attachments/assets/c3fb25b3-8563-4bd9-a432-c28d3e23c6d5" />

**After:**
<img width="738" alt="image" src="https://github.com/user-attachments/assets/97e8da89-9600-4187-ad53-69aa8d4f5152" />
