### PR TITLE
boost hasura-proxy Fargate container CPU / memory (staging)

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -27,6 +27,8 @@ config:
     secure: AAABAHfDtVpAD8w32yINWTjgvuRQixWXYFf3/rEcyh59/pRSz+J4ZYCXNq5jqBiIXM2emB+7zOY=
   application:hasura-cpu: "512"
   application:hasura-memory: "2048"
+  application:hasura-proxy-cpu: "512"
+  application:hasura-proxy-memory: "2048"
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
   application:idox-nexus-client:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -28,6 +28,8 @@ config:
     secure: AAABAHsoh7ZNkr6ep3xXsUZpp/JIjshBX+tJ0KOFgGnJ4wxR0oIcB6VewVDuwSyFJRVix72YahM=
   application:hasura-cpu: "512"
   application:hasura-memory: "2048"
+  application:hasura-proxy-cpu: "512"
+  application:hasura-proxy-memory: "2048"
   application:hasura-planx-api-key:
     secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
   application:idox-nexus-client:

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -59,7 +59,8 @@ export const createHasuraService = async ({
       containers: {
         hasuraProxy: {
           image: repo.buildAndPushImage("../../hasura.planx.uk/proxy"),
-          memory: 1024 /*MB*/,
+          cpu: config.requireNumber("hasura-proxy-cpu"),
+          memory: config.requireNumber("hasura-proxy-memory"),
           portMappings: [hasuraListenerHttp],
           environment: [
             { name: "HASURA_PROXY_PORT", value: String(HASURA_PROXY_PORT) },


### PR DESCRIPTION
Related to [this ticket](https://trello.com/c/oRzedbmJ).

The 180s grace period introduced in #4051 didn't resolve the scaling issue, so trying a different tack. This PR boosts CPU and memory resources of the hasura-proxy container (and therefore of the Task overall).

Also moves the variables for controlling those resources to the Pulumi yaml (staging only for now).