### PR TITLE
extend timeout for Hasura migrations at boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ hasura.planx.uk/.env.test
 /playwright-report/
 /playwright/.cache/
 api.planx.uk/tmp/
+.python-version
+__pycache__
 
 # Ignore certificate files
 **/*.chain

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -98,6 +98,7 @@ export const createHasuraService = async ({
               name: "HASURA_GRAPHQL_DATABASE_URL",
               value: dbRootUrl,
             },
+            { name: "HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT", value: "300" },
             {
               name: "HASURA_PLANX_API_URL",
               value: `https://api.${DOMAIN}`,


### PR DESCRIPTION
Related to [this ticket](https://trello.com/c/oRzedbmJ).

Neither of the interventions in #4051 or #4076 resolved the Hasura boot loop issue on scale up.

This PR takes a different tack, based on a closer reading of the logs for the instances which are failing to boot (all of which follow a similar pattern). Essentially it allows the Hasura server 5 minutes to pull metadata and handle migrations from the RDS-hosted PostgreSQL database.

(includes bits for gitignore to ease my workflow with python)

See also #4081.

## Context

After a closer look at the logs ([example](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/hasura20230630103945001200000001/log-events/hasura%2Fhasura%2F15010cf0ad98493eb21ed11d2fbd4773)), I realised that the key might be in the final log from the `hasura` container:

```json
{"timestamp":"2024-12-12T17:06:11.000+0000","level":"info","type":"startup","detail":{"kind":"migrations-startup","info":"failed waiting for 9691, try increasing HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT (default: 30)"}}
```

That is, the Hasura server itself is failing to load the metadata which it requires for setup from the upstream database. So I’m drawn to the conclusion that it’s the underlying Postgres database (hosted on AWS RDS) which is the root of the issue.

Indeed, the staging instance (which is a T3 Micro, compared to a Medium on prod) will have a maximum of 104 or so connections with it’s 1GB of memory (i.e. `1x10^9 / 9531392` - see AWS [docs on RDS instance quotas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections) and [instance hardware specs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Summary.html#hardware-specifications.burstable-inst-classes)).

In practice the number of connections it can handle is less, because some memory must be reserved for running the database itself, e.g. the following grab suggests it tops out at ~ 78:

![image](https://github.com/user-attachments/assets/d3dc2959-e28f-4654-93ec-7ce591636e9c)

Hasura servers default to having 1 pool, with 1 'stripe' with at most 50 connections, so it might be that attempting to boot a 2nd server is simply overwhelming our database.

There are a few possible ways forward here (see [Notion doc](https://www.notion.so/opensystemslab/PlanX-Load-Testing-13735d469ad180b18c45f0d1db44511e?pvs=4#15a35d469ad180bf8bc4ea1cccd26d85)), of which this PR is the first and simplest.