### PR TITLE
bump staging RDS instance to T3 Small

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -16,7 +16,7 @@ const db = new aws.rds.Instance("app", {
   // $ aws rds describe-db-engine-versions --default-only --engine postgres
   engineVersion: "12.17",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
-  instanceClass: env === "production" ? "db.t3.medium" : "db.t3.micro",
+  instanceClass: env === "production" ? "db.t3.medium" : "db.t3.small",
   allocatedStorage: env === "production" ? 100 : 20,
   allowMajorVersionUpgrade: true,
   dbSubnetGroupName: networking.requireOutput("subnetId"),


### PR DESCRIPTION
Related to [this ticket](https://trello.com/c/oRzedbmJ).

This PR bumps the RDS PostgreSQL DB instance used on staging to `db.t3.small`, in order to increase the number of connections it can handle by doubling the memory (to 2GB).

Prod is still pinned to `db.t3.medium`, which has twice the memory again (4GB).

We only need to merge this if #4080 doesn't solve the scaling issue - also see that PR for further context and motivation for this change.

Also note that we'll have to manually roll out the upgrade on AWS via Pulumi CLI, since there is no CI setup for the `data` layer as there is for `application` (see the `push-main` workflow).