### PR TITLE
chore: update default description text for PropertyInformation

### DIFF
--- a/editor.planx.uk/src/@planx/components/PropertyInformation/model.ts
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/model.ts
@@ -10,9 +10,9 @@ export const parseContent = (
   data: Record<string, any> | undefined,
 ): PropertyInformation => ({
   title: data?.title || "About the property",
-  description:
-    data?.description ||
-    "This is the information we currently have about the property, including its title boundary shown in blue from the Land Registry",
+  description: data?.description || defaultDescription,
   showPropertyTypeOverride: data?.showPropertyTypeOverride || false,
   ...parseBaseNodeData(data),
 });
+
+const defaultDescription = "<p>This is the information we currently have about the property.</p><p>The blue line shows the <strong>outline</strong> of the property (known as the title boundary). If this looks incorrect, go back a step and <strong>check you have selected the correct address</strong>.</p><p>We use this outline to create the site boundary where the project will take place. If your project covers a different area, you can change or redraw the site boundary on the next page.</p>";


### PR DESCRIPTION
Per data migration plan here https://docs.google.com/spreadsheets/d/1Vtxp5BLweDPDooQoNhgOCYjCIBPRYIcOuyArGJRqOkI/edit?gid=1778589811#gid=1778589811

This one can merge anytime & will mean _new_ PropertyInformation components have correct text, then we'll run script separately to update _existing_ components.