### PR TITLE
fix: Feedback table alignment

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -167,7 +167,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
         </TableCell>
       </TableRow>
       <TableRow sx={{ background: (theme) => theme.palette.background.paper }}>
-        <TableCell sx={{ padding: 0, border: "none" }} colSpan={4}>
+        <TableCell sx={{ padding: 0, border: "none" }} colSpan={5}>
           <Collapse
             in={open}
             timeout="auto"


### PR DESCRIPTION
## What does this PR do?

Quick one: fixes alignment of the feedback table dropdown, as another header row has been added.

**Before:**
<img width="997" alt="image" src="https://github.com/user-attachments/assets/acecd5eb-773f-42af-b097-837c3dc9f0ec" />

**After:**
<img width="997" alt="image" src="https://github.com/user-attachments/assets/f775ec75-45ba-4343-aa7c-e64b0197dddd" />