### PR TITLE
fix: Spacing of review tables

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -32,14 +32,13 @@ export const SummaryListTable = styled("dl", {
   ({ theme, showChangeButton, dense }) => ({
     display: "grid",
     gridTemplateColumns: showChangeButton ? "1fr 2fr 100px" : "1fr 2fr",
-    gridRowGap: "10px",
     marginTop: dense ? theme.spacing(1) : theme.spacing(2),
     marginBottom: dense ? theme.spacing(2) : theme.spacing(4),
     fontSize: dense ? theme.typography.body2.fontSize : "inherit",
     "& > *": {
       borderBottom: `1px solid ${theme.palette.border.main}`,
-      paddingBottom: dense ? theme.spacing(1) : theme.spacing(2),
-      paddingTop: dense ? theme.spacing(1) : theme.spacing(2),
+      paddingBottom: dense ? theme.spacing(1) : theme.spacing(2.5),
+      paddingTop: dense ? theme.spacing(1) : theme.spacing(2.5),
       verticalAlign: "top",
       margin: 0,
     },
@@ -52,7 +51,7 @@ export const SummaryListTable = styled("dl", {
       // left column
       fontWeight: FONT_WEIGHT_SEMI_BOLD,
     },
-    "& dd:nth-of-type(n)": {
+    "& dd": {
       // middle column
       paddingLeft: "10px",
     },
@@ -65,20 +64,22 @@ export const SummaryListTable = styled("dl", {
       flexDirection: "column",
       "& dt": {
         // top row
-        paddingLeft: theme.spacing(1),
         paddingTop: dense ? theme.spacing(1) : theme.spacing(2),
-        marginTop: theme.spacing(1),
+        marginTop: theme.spacing(1.5),
+        paddingBottom: 0,
         borderTop: `1px solid ${theme.palette.border.main}`,
         borderBottom: "none",
         fontWeight: FONT_WEIGHT_SEMI_BOLD,
       },
-      "& dd:nth-of-type(n)": {
-        // middle row
+      "& dd": {
         textAlign: "left",
-        paddingTop: 0,
-        paddingBottom: 0,
+        padding: 0,
         margin: 0,
         borderBottom: "none",
+      },
+      "& dd:nth-of-type(2n-1)": {
+        // middle row
+        padding: theme.spacing(1, 0),
       },
       "& dd:nth-of-type(2n)": {
         // bottom row


### PR DESCRIPTION
## What does this PR do?

From mobile QA: the spacing of review tables is a bit loose, making it difficult to parse groups of information on smaller screens. Tightening up the spacing and removing gap spacing from the empty third table cell tidies this up.

**Preview:**
https://4093.planx.pizza/testing/summary-table-spacing/preview

Before (left) vs after (right):

**Property information:**
![image](https://github.com/user-attachments/assets/0dcde3aa-2199-4644-8aab-c8430042f59d)

**Review page:**
![image](https://github.com/user-attachments/assets/606b739f-9d48-4be3-b2bf-3014292ddcc8)

