### PR TITLE
feat: add audit table for data migration scripts

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2465,6 +2465,9 @@
         filter: {}
       comment: ""
 - table:
+    name: temp_data_migrations_audit
+    schema: public
+- table:
     name: uniform_applications
     schema: public
   insert_permissions:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2467,6 +2467,16 @@
 - table:
     name: temp_data_migrations_audit
     schema: public
+  object_relationships:
+    - name: flows
+      using:
+        manual_configuration:
+          column_mapping:
+            flow_id: id
+          insertion_order: null
+          remote_table:
+            name: flows
+            schema: public
 - table:
     name: uniform_applications
     schema: public

--- a/hasura.planx.uk/migrations/1734623060683_create_table_public_temp_data_migrations_audit/down.sql
+++ b/hasura.planx.uk/migrations/1734623060683_create_table_public_temp_data_migrations_audit/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."temp_data_migrations_audit";

--- a/hasura.planx.uk/migrations/1734623060683_create_table_public_temp_data_migrations_audit/up.sql
+++ b/hasura.planx.uk/migrations/1734623060683_create_table_public_temp_data_migrations_audit/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "public"."temp_data_migrations_audit" (
+  "flow_id" uuid NOT NULL, 
+  "team_id" integer NOT NULL, 
+  "updated" boolean NOT NULL DEFAULT false, 
+  "updated_at" timestamptz NOT NULL DEFAULT now(), 
+  PRIMARY KEY ("flow_id") 
+);
+COMMENT ON TABLE "public"."temp_data_migrations_audit" IS E'Basic table structure that we can use to track status of data migrations. Contents of this table are ephemeral and may be truncated between migrations';


### PR DESCRIPTION
Following on from data migration chat! This is a basic table structure that will help us both: queue up _which_ flows should be updated by a given data migration script and track which have been `updated` so far.

Exclusively the `platformAdmin` role can access and update this table.

I'm imagining: 
- We'll simply manually populate the table like so:
```psql
INSERT INTO temp_data_migrations_audit (flow_id, team_id)
SELECT id, team_id
FROM flows 
WHERE team_id IN (1,2,3); -- team_ids match councils that have "consented"
```
- Then kick off the migration script which will fetch/transform/update one flow/row at a time `where updated = false` until all records have been updated
- Finally after a successful migration, we can simply `TRUNCATE` the table and re-use the same structure for our next use-case (plus option to export as CSV like a receipt and store on gdrive before truncation if necessary)