### PR TITLE
fix: Responsive type sizes

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -156,11 +156,17 @@ const getThemeOptions = ({
         fontSize: "3rem",
         letterSpacing: SPACING_TIGHT,
         fontWeight: FONT_WEIGHT_BOLD,
+        "@media (max-width: 500px)": {
+          fontSize: "2.125rem",
+        },
       },
       h2: {
         fontSize: "2.25rem",
         letterSpacing: SPACING_TIGHT,
         fontWeight: FONT_WEIGHT_BOLD,
+        "@media (max-width: 500px)": {
+          fontSize: "1.65rem",
+        },
       },
       h3: {
         fontSize: "1.5rem",
@@ -169,6 +175,9 @@ const getThemeOptions = ({
       h4: {
         fontSize: "1.188rem",
         fontWeight: FONT_WEIGHT_SEMI_BOLD,
+        "@media (min-width: 500px) and (max-width: 768px)": {
+          fontSize: "1.15rem !important",
+        },
       },
       h5: {
         fontSize: "1rem",


### PR DESCRIPTION
## What does this PR do?

MUI responsive type sizes provides a one-value (`factor: x`) scale for resizing type which aims to provide a global function, but removes the ability to scale or fine-tune by a particular type property.

In PlanX we use h2 sizes for most page/question titles and h1 for headline/banners, MUI was resizing these to be too small comparatively to be effective.

I've tried a number of methods to work with MUI's automatic scale, ideally we'd use an up-to-date method (such as `fontSize: "clamp(2.125rem, 3rem, 5rem)",`, but MUI needs to see a hardcoded value for each property.

This PR introduces manual media queries to increase larger header sizes at the smallest (sub 500px wide) screens. There is also the reluctant use of an `!important` rule as MUI trumps any media queries defined in the theme with its own, and there is an apparent bug in `h4` resizes in which MUI does not scale this correctly between 500px – 768px.

Before changes, largest viewport (left) vs smallest viewport (right):
![image](https://github.com/user-attachments/assets/51e3b926-6e9e-47f3-893f-e2cff2c1fad8)


After changes, largest viewport (left) vs smallest viewport (right):
![image](https://github.com/user-attachments/assets/0a747812-0f2e-4006-8603-ab7afc9f9d46)
