### PR TITLE
fix: add metabase_id to database scripts

### DIFF
--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -5,7 +5,8 @@ CREATE TEMPORARY TABLE sync_teams (
   slug text,
   created_at timestamptz,
   updated_at timestamptz,
-  domain text
+  domain text,
+  metabase_id integer
 );
 
 \copy sync_teams FROM '/tmp/teams.csv' WITH (FORMAT csv, DELIMITER ';');


### PR DESCRIPTION
I couldn't successfully run `pnpm run up` and found `metabase_id` wasn't added to the `seed-database` scripts