### PR TITLE
chore: fix confirmation and invite to pay page default copy

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -42,10 +42,9 @@ export const Basic = {
     ## You will be contacted
     - if there is anything missing from the information you have provided so far
     - if any additional information is required
-    - to arrange a site visit, if required
-    - to inform you whether a certificate has been granted or not`,
+    - to arrange a site visit, if required`,
     contactInfo: `
-      You can contact us at <em>planning@lambeth.gov.uk</em>
+      You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
       <br/><br/>
       What did you think of this service? Please give us your feedback using the link in the footer below.
     `,

--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -46,7 +46,7 @@ export const Basic = {
     contactInfo: `
       You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
       <br/><br/>
-      What did you think of this service? Please give us your feedback using the link in the footer below.
+      <p><strong>What did you think of this service? Please give us your feedback on the next page.</strong></p>
     `,
     data: [],
   },

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -71,11 +71,10 @@ export default function ConfirmationEditor(props: Props) {
         <li>if there is anything missing from the information you have provided so far</li>
         <li>if any additional information is required</li>
         <li>to arrange a site visit, if required</li>
-        <li>to inform you whether a certificate has been granted or not</li>
         </ul>`,
       contactInfo:
         props.node?.data?.contactInfo ||
-        `You can contact us at <em>planning@lambeth.gov.uk</em>
+        `You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
           <br/><br/>
           What did you think of this service? Please give us your feedback using the link in the footer below.`,
       ...parseNextSteps(props.node?.data),

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -76,7 +76,7 @@ export default function ConfirmationEditor(props: Props) {
         props.node?.data?.contactInfo ||
         `You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
           <br/><br/>
-          What did you think of this service? Please give us your feedback using the link in the footer below.`,
+          <p><strong>What did you think of this service? Please give us your feedback on the next page.</strong></p>`,
       ...parseNextSteps(props.node?.data),
     },
     onSubmit: (values) => {

--- a/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
+++ b/editor.planx.uk/src/pages/Pay/InviteToPay.tsx
@@ -59,7 +59,6 @@ const InviteToPay: React.FC<PaymentRequest> = ({ createdAt }) => {
             </li>
             <li>if any additional information is required</li>
             <li>to arrange a site visit, if required</li>
-            <li>to inform you whether a certificate has been granted or not</li>
           </List>
           <Divider sx={{ mt: 4 }} />
           <Typography variant="h2" mt={4}>


### PR DESCRIPTION
Removes references to certificates from default More Information copy of confirmation and invite to pay page.

Updates default Contact Us copy of confirmation page to new feedback nudge and replaces Lambeth email with placeholder copy requesting the addition of contact details.