### PR TITLE
chore: Import planx-core as ESM

### DIFF
--- a/api.planx.uk/modules/send/bops/bops.test.ts
+++ b/api.planx.uk/modules/send/bops/bops.test.ts
@@ -1,6 +1,6 @@
 import nock from "nock";
 import supertest from "supertest";
-import type planxCore from "@opensystemslab/planx-core";
+import type * as planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import app from "../../../server.js";
 import { expectedPlanningPermissionPayload } from "../../../tests/mocks/digitalPlanningDataMocks.js";

--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -1,5 +1,5 @@
 import supertest from "supertest";
-import type planxCore from "@opensystemslab/planx-core";
+import type * as planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import app from "../../../server.js";
 

--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.test.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.test.ts
@@ -1,4 +1,4 @@
-import type planxCore from "@opensystemslab/planx-core";
+import type * as planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
 import {
   getSubmittedUnAnalyzedSessionIds,

--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.test.ts
@@ -1,4 +1,4 @@
-import type planxCore from "@opensystemslab/planx-core";
+import type * as planxCore from "@opensystemslab/planx-core";
 import { runSQL } from "../../../../lib/hasura/schema/index.js";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
 import {

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d004278",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a9848d4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a9848d4
-    version: github.com/theopensystemslab/planx-core/a9848d4
+    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
+    version: github.com/theopensystemslab/planx-core/f2f555b
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -1732,12 +1732,12 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.9.0):
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.10.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      graphql: 16.9.0
+      graphql: 16.10.0
     dev: false
 
   /@humanwhocodes/config-array@0.11.14:
@@ -4465,8 +4465,8 @@ packages:
       strnum: 1.0.5
     dev: false
 
-  /fast-xml-parser@4.5.0:
-    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+  /fast-xml-parser@4.5.1:
+    resolution: {integrity: sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -4757,14 +4757,14 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request@6.1.0(graphql@16.9.0):
+  /graphql-request@6.1.0(graphql@16.10.0):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       cross-fetch: 3.1.8
-      graphql: 16.9.0
+      graphql: 16.10.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -4775,6 +4775,11 @@ packages:
     dependencies:
       iterall: 1.3.0
     dev: true
+
+  /graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
 
   /graphql@16.9.0:
     resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
@@ -5480,8 +5485,8 @@ packages:
       semver: 7.6.3
     dev: true
 
-  /marked@15.0.3:
-    resolution: {integrity: sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==}
+  /marked@15.0.5:
+    resolution: {integrity: sha512-xN+kSuqHjxWg+Q47yhhZMUP+kO1qHobvXkkm6FX+7N6lDvanLDd8H7AQ0jWDDyq+fDt/cSrJaBGyWYHXy0KQWA==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -6892,8 +6897,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /type-fest@4.30.0:
-    resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
+  /type-fest@4.31.0:
+    resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -7303,8 +7308,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a9848d4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a9848d4}
+  github.com/theopensystemslab/planx-core/f2f555b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -7321,16 +7326,16 @@ packages:
       copyfiles: 2.4.1
       docx: 9.1.0
       eslint: 8.57.1
-      fast-xml-parser: 4.5.0
-      graphql: 16.9.0
-      graphql-request: 6.1.0(graphql@16.9.0)
+      fast-xml-parser: 4.5.1
+      graphql: 16.10.0
+      graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
       lodash: 4.17.21
-      marked: 15.0.3
+      marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.30.0
+      type-fest: 4.31.0
       uuid: 11.0.3
       zod: 3.24.0
     transitivePeerDependencies:

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
-    version: github.com/theopensystemslab/planx-core/f2f555b
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
+    version: github.com/theopensystemslab/planx-core/a7ec46d
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -5378,6 +5378,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: false
@@ -7308,8 +7312,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/f2f555b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
+  github.com/theopensystemslab/planx-core/a7ec46d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -7330,7 +7334,7 @@ packages:
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
-    version: github.com/theopensystemslab/planx-core/a7ec46d
+    specifier: git+https://github.com/theopensystemslab/planx-core#d004278
+    version: github.com/theopensystemslab/planx-core/d004278
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7308,12 +7308,12 @@ packages:
     resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
     dev: false
 
-  /zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
+  /zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ec46d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
+  github.com/theopensystemslab/planx-core/d004278:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d004278}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -7341,7 +7341,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.31.0
       uuid: 11.0.3
-      zod: 3.24.0
+      zod: 3.24.1
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/api.planx.uk/tests/mockJWT.ts
+++ b/api.planx.uk/tests/mockJWT.ts
@@ -1,5 +1,5 @@
 import type { Role } from "@opensystemslab/planx-core/types";
-import { sign } from "jsonwebtoken";
+import jwt from "jsonwebtoken";
 
 function getJWT({ role }: { role: Role }) {
   const data = {
@@ -12,7 +12,7 @@ function getJWT({ role }: { role: Role }) {
     },
   };
 
-  return sign(data, process.env.JWT_SECRET!);
+  return jwt.sign(data, process.env.JWT_SECRET!);
 }
 
 function authHeader({ role }: { role: Role }) {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,9 @@
     "test:debug": "DEBUG_LOG=true pnpm test",
     "lint": "eslint './tests/**/*.{js,ts}' && prettier -c ./tests",
     "lint:fix": "eslint --fix './tests/**/*.{js,ts}' && prettier -w ./tests",
-    "check": "tsc && pnpm lint",
+    "check": "pnpm check:api && pnpm check:ui && pnpm lint",
+    "check:api": "tsc --project './tests/api-driven/tsconfig.json' && pnpm lint",
+    "check:ui": "tsc --project './tests/ui-driven/tsconfig.json' && pnpm lint",
     "postinstall": "cd tests/ui-driven && pnpm install && cd ../api-driven && pnpm install",
     "prepare": "cd .. && husky install e2e/.husky"
   },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,9 +10,7 @@
     "test:debug": "DEBUG_LOG=true pnpm test",
     "lint": "eslint './tests/**/*.{js,ts}' && prettier -c ./tests",
     "lint:fix": "eslint --fix './tests/**/*.{js,ts}' && prettier -w ./tests",
-    "check": "pnpm check:api && pnpm check:ui && pnpm lint",
-    "check:api": "tsc --project './tests/api-driven/tsconfig.json' && pnpm lint",
-    "check:ui": "tsc --project './tests/ui-driven/tsconfig.json' && pnpm lint",
+    "check": "tsc && pnpm lint",
     "postinstall": "cd tests/ui-driven && pnpm install && cd ../api-driven && pnpm install",
     "prepare": "cd .. && husky install e2e/.husky"
   },
@@ -24,6 +22,7 @@
   },
   "packageManager": "pnpm@8.6.6",
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "22.10.5",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@types/jsonwebtoken':
+    specifier: ^9.0.7
+    version: 9.0.7
   '@types/node':
     specifier: 22.10.5
     version: 22.10.5
@@ -114,6 +117,12 @@ packages:
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+    dev: true
+
+  /@types/jsonwebtoken@9.0.7:
+    resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
+    dependencies:
+      '@types/node': 22.10.5
     dev: true
 
   /@types/node@22.10.5:

--- a/e2e/tests/api-driven/cucumber.json
+++ b/e2e/tests/api-driven/cucumber.json
@@ -1,10 +1,9 @@
 {
   "default": {
-    "requireModule": ["ts-node/register"],
-    "require": ["src/env.ts", "src/**/*.ts"],
+    "loader": ["ts-node/esm"],
+    "import": ["src/env.ts", "src/**/*.ts"],
     "paths": ["src/**/*.feature"],
     "format": ["summary"],
-    "publishQuiet": true,
     "formatOptions": {
       "snippetInterface": "async-await"
     }

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a9848d4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -4,9 +4,10 @@
     "test": "cucumber-js --tags 'not @regression'",
     "test:regression": "cucumber-js"
   },
+  "type": "module",
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
-    "@cucumber/cucumber": "^9.3.0",
+    "@cucumber/cucumber": "^11.1.1",
     "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
@@ -17,6 +18,7 @@
     "nock": "^13.3.1"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/lodash.zipobject": "^4.1.7",
     "@types/node": "22.10.5",
     "ts-node": "^10.9.1",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^9.3.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d004278",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a9848d4
-    version: github.com/theopensystemslab/planx-core/a9848d4
+    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
+    version: github.com/theopensystemslab/planx-core/f2f555b
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -506,12 +506,12 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.9.0):
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.10.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      graphql: 16.9.0
+      graphql: 16.10.0
     dev: false
 
   /@humanwhocodes/config-array@0.13.0:
@@ -1428,8 +1428,8 @@ packages:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
     dev: false
 
-  /fast-xml-parser@4.5.0:
-    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+  /fast-xml-parser@4.5.1:
+    resolution: {integrity: sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -1565,14 +1565,14 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: false
 
-  /graphql-request@6.1.0(graphql@16.9.0):
+  /graphql-request@6.1.0(graphql@16.10.0):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       cross-fetch: 3.1.8
-      graphql: 16.9.0
+      graphql: 16.10.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -1587,13 +1587,13 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /graphql@16.8.1:
-    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+  /graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
-  /graphql@16.9.0:
-    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
@@ -1954,8 +1954,8 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
-  /marked@15.0.3:
-    resolution: {integrity: sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==}
+  /marked@15.0.5:
+    resolution: {integrity: sha512-xN+kSuqHjxWg+Q47yhhZMUP+kO1qHobvXkkm6FX+7N6lDvanLDd8H7AQ0jWDDyq+fDt/cSrJaBGyWYHXy0KQWA==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -2606,8 +2606,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /type-fest@4.30.0:
-    resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
+  /type-fest@4.31.0:
+    resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2808,8 +2808,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a9848d4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a9848d4}
+  github.com/theopensystemslab/planx-core/f2f555b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2826,16 +2826,16 @@ packages:
       copyfiles: 2.4.1
       docx: 9.1.0
       eslint: 8.57.1
-      fast-xml-parser: 4.5.0
-      graphql: 16.9.0
-      graphql-request: 6.1.0(graphql@16.9.0)
+      fast-xml-parser: 4.5.1
+      graphql: 16.10.0
+      graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
       lodash: 4.17.21
-      marked: 15.0.3
+      marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.30.0
+      type-fest: 4.31.0
       uuid: 11.0.3
       zod: 3.24.0
     transitivePeerDependencies:

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@cucumber/cucumber':
-    specifier: ^9.3.0
-    version: 9.3.0
+    specifier: ^11.1.1
+    version: 11.1.1
   '@opensystemslab/planx-core':
     specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
     version: github.com/theopensystemslab/planx-core/a7ec46d
@@ -34,6 +34,9 @@ dependencies:
     version: 13.3.1
 
 devDependencies:
+  '@types/jsonwebtoken':
+    specifier: ^9.0.7
+    version: 9.0.7
   '@types/lodash.zipobject':
     specifier: ^4.1.7
     version: 4.1.7
@@ -159,30 +162,31 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@cucumber/ci-environment@9.2.0:
-    resolution: {integrity: sha512-jLzRtVwdtNt+uAmTwvXwW9iGYLEOJFpDSmnx/dgoMGKXUWRx1UHT86Q696CLdgXO8kyTwsgJY0c6n5SW9VitAA==}
+  /@cucumber/ci-environment@10.0.1:
+    resolution: {integrity: sha512-/+ooDMPtKSmvcPMDYnMZt4LuoipfFfHaYspStI4shqw8FyKcfQAmekz6G+QKWjQQrvM+7Hkljwx58MEwPCwwzg==}
     dev: false
 
-  /@cucumber/cucumber-expressions@16.1.2:
-    resolution: {integrity: sha512-CfHEbxJ5FqBwF6mJyLLz4B353gyHkoi6cCL4J0lfDZ+GorpcWw4n2OUAdxJmP7ZlREANWoTFlp4FhmkLKrCfUA==}
+  /@cucumber/cucumber-expressions@17.1.0:
+    resolution: {integrity: sha512-PCv/ppsPynniKPWJr5v566daCVe+pbxQpHGrIu/Ev57cCH9Rv+X0F6lio4Id3Z64TaG7btCRLUGewIgLwmrwOA==}
     dependencies:
       regexp-match-indices: 1.0.2
     dev: false
 
-  /@cucumber/cucumber@9.3.0:
-    resolution: {integrity: sha512-8QvcQVJzRra3pZpV0dITPcFuT2yYH0C1fEgzDlqe6+Zpz9k3z+ov9xUWEYgKp0VMx65JxNKAYYYWmG6cWOiYQQ==}
-    engines: {node: 14 || 16 || >=18}
+  /@cucumber/cucumber@11.1.1:
+    resolution: {integrity: sha512-4i2vk4R1Ffi1JXiNrVMLxLJFgZ7e0BHdoRN6QiWdz5EDPS+Qv9ld4wGZWeahBH5ncDygIrkkhtYxDhqOBXLPxQ==}
+    engines: {node: 18 || 20 || 22 || >=23}
     hasBin: true
     dependencies:
-      '@cucumber/ci-environment': 9.2.0
-      '@cucumber/cucumber-expressions': 16.1.2
-      '@cucumber/gherkin': 26.2.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.2.0)(@cucumber/message-streams@4.0.1)(@cucumber/messages@22.0.0)
-      '@cucumber/gherkin-utils': 8.0.2
-      '@cucumber/html-formatter': 20.4.0(@cucumber/messages@22.0.0)
-      '@cucumber/message-streams': 4.0.1(@cucumber/messages@22.0.0)
-      '@cucumber/messages': 22.0.0
-      '@cucumber/tag-expressions': 5.0.1
+      '@cucumber/ci-environment': 10.0.1
+      '@cucumber/cucumber-expressions': 17.1.0
+      '@cucumber/gherkin': 28.0.0
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1)(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-utils': 9.0.0
+      '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
+      '@cucumber/junit-xml-formatter': 0.6.0(@cucumber/messages@24.1.0)
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
+      '@cucumber/messages': 24.1.0
+      '@cucumber/tag-expressions': 6.1.1
       assertion-error-formatter: 3.0.0
       capital-case: 1.0.4
       chalk: 4.1.2
@@ -191,7 +195,7 @@ packages:
       debug: 4.4.0(supports-color@8.1.1)
       error-stack-parser: 2.1.4
       figures: 3.2.0
-      glob: 7.2.3
+      glob: 10.4.5
       has-ansi: 4.0.1
       indent-string: 4.0.0
       is-installed-globally: 0.4.0
@@ -200,23 +204,23 @@ packages:
       lodash.merge: 4.6.2
       lodash.mergewith: 4.6.2
       luxon: 3.2.1
+      mime: 3.0.0
       mkdirp: 2.1.6
       mz: 2.7.0
       progress: 2.0.3
+      read-pkg-up: 7.0.1
       resolve-pkg: 2.0.0
       semver: 7.5.3
-      string-argv: 0.3.2
-      strip-ansi: 6.0.1
+      string-argv: 0.3.1
       supports-color: 8.1.1
       tmp: 0.2.3
+      type-fest: 4.31.0
       util-arity: 1.1.0
-      verror: 1.10.1
-      xmlbuilder: 15.1.1
       yaml: 2.6.1
-      yup: 0.32.11
+      yup: 1.2.0
     dev: false
 
-  /@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.2.0)(@cucumber/message-streams@4.0.1)(@cucumber/messages@22.0.0):
+  /@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1)(@cucumber/messages@24.1.0):
     resolution: {integrity: sha512-/7VkIE/ASxIP/jd4Crlp4JHXqdNFxPGQokqWqsaCCiqBiu5qHoKMxcWNlp9njVL/n9yN4S08OmY3ZR8uC5x74Q==}
     hasBin: true
     peerDependencies:
@@ -224,72 +228,77 @@ packages:
       '@cucumber/message-streams': '>=4.0.0'
       '@cucumber/messages': '>=17.1.1'
     dependencies:
-      '@cucumber/gherkin': 26.2.0
-      '@cucumber/message-streams': 4.0.1(@cucumber/messages@22.0.0)
-      '@cucumber/messages': 22.0.0
+      '@cucumber/gherkin': 28.0.0
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
+      '@cucumber/messages': 24.1.0
       commander: 9.1.0
       source-map-support: 0.5.21
     dev: false
 
-  /@cucumber/gherkin-utils@8.0.2:
-    resolution: {integrity: sha512-aQlziN3r3cTwprEDbLEcFoMRQajb9DTOu2OZZp5xkuNz6bjSTowSY90lHUD2pWT7jhEEckZRIREnk7MAwC2d1A==}
+  /@cucumber/gherkin-utils@9.0.0:
+    resolution: {integrity: sha512-clk4q39uj7pztZuZtyI54V8lRsCUz0Y/p8XRjIeHh7ExeEztpWkp4ca9q1FjUOPfQQ8E7OgqFbqoQQXZ1Bx7fw==}
     hasBin: true
     dependencies:
-      '@cucumber/gherkin': 25.0.2
-      '@cucumber/messages': 19.1.4
-      '@teppeis/multimaps': 2.0.0
-      commander: 9.4.1
+      '@cucumber/gherkin': 28.0.0
+      '@cucumber/messages': 24.1.0
+      '@teppeis/multimaps': 3.0.0
+      commander: 12.0.0
       source-map-support: 0.5.21
     dev: false
 
-  /@cucumber/gherkin@25.0.2:
-    resolution: {integrity: sha512-EdsrR33Y5GjuOoe2Kq5Y9DYwgNRtUD32H4y2hCrT6+AWo7ibUQu7H+oiWTgfVhwbkHsZmksxHSxXz/AwqqyCRQ==}
+  /@cucumber/gherkin@28.0.0:
+    resolution: {integrity: sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==}
     dependencies:
-      '@cucumber/messages': 19.1.4
+      '@cucumber/messages': 24.1.0
     dev: false
 
-  /@cucumber/gherkin@26.2.0:
-    resolution: {integrity: sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==}
-    dependencies:
-      '@cucumber/messages': 22.0.0
-    dev: false
-
-  /@cucumber/html-formatter@20.4.0(@cucumber/messages@22.0.0):
-    resolution: {integrity: sha512-TnLSXC5eJd8AXHENo69f5z+SixEVtQIf7Q2dZuTpT/Y8AOkilGpGl1MQR1Vp59JIw+fF3EQSUKdf+DAThCxUNg==}
+  /@cucumber/html-formatter@21.6.0(@cucumber/messages@24.1.0):
+    resolution: {integrity: sha512-Qw1tdObBJrgXgXwVjKVjB3hFhFPI8WhIFb+ULy8g5lDl5AdnKDiyDXAMvAWRX+pphnRMMNdkPCt6ZXEfWvUuAA==}
     peerDependencies:
       '@cucumber/messages': '>=18'
     dependencies:
-      '@cucumber/messages': 22.0.0
+      '@cucumber/messages': 24.1.0
     dev: false
 
-  /@cucumber/message-streams@4.0.1(@cucumber/messages@22.0.0):
+  /@cucumber/junit-xml-formatter@0.6.0(@cucumber/messages@24.1.0):
+    resolution: {integrity: sha512-++PAuxliQhq7yr2Bn9P0fwBUo46OoKAK5f6M4PrwoHBqIsl/6pUS4mqpviuBrgZ8RD7BTrmASk4lUDJClAz/qA==}
+    peerDependencies:
+      '@cucumber/messages': '*'
+    dependencies:
+      '@cucumber/messages': 24.1.0
+      '@cucumber/query': 13.0.3(@cucumber/messages@24.1.0)
+      '@teppeis/multimaps': 3.0.0
+      xmlbuilder: 15.1.1
+    dev: false
+
+  /@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0):
     resolution: {integrity: sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==}
     peerDependencies:
       '@cucumber/messages': '>=17.1.1'
     dependencies:
-      '@cucumber/messages': 22.0.0
+      '@cucumber/messages': 24.1.0
     dev: false
 
-  /@cucumber/messages@19.1.4:
-    resolution: {integrity: sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==}
+  /@cucumber/messages@24.1.0:
+    resolution: {integrity: sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==}
     dependencies:
-      '@types/uuid': 8.3.4
+      '@types/uuid': 9.0.8
       class-transformer: 0.5.1
-      reflect-metadata: 0.1.13
-      uuid: 9.0.0
+      reflect-metadata: 0.2.1
+      uuid: 9.0.1
     dev: false
 
-  /@cucumber/messages@22.0.0:
-    resolution: {integrity: sha512-EuaUtYte9ilkxcKmfqGF9pJsHRUU0jwie5ukuZ/1NPTuHS1LxHPsGEODK17RPRbZHOFhqybNzG2rHAwThxEymg==}
+  /@cucumber/query@13.0.3(@cucumber/messages@24.1.0):
+    resolution: {integrity: sha512-OdGea9D9wIoCY2RvcdG5/b2FYASvOdsOIObtv8dU8/kwPXHPo/UxcF+fWElr8yciu+BQMBa8NCxDsoU3ijQqZg==}
+    peerDependencies:
+      '@cucumber/messages': '*'
     dependencies:
-      '@types/uuid': 9.0.1
-      class-transformer: 0.5.1
-      reflect-metadata: 0.1.13
-      uuid: 9.0.0
+      '@cucumber/messages': 24.1.0
+      '@teppeis/multimaps': 3.0.0
     dev: false
 
-  /@cucumber/tag-expressions@5.0.1:
-    resolution: {integrity: sha512-N43uWud8ZXuVjza423T9ZCIJsaZhFekmakt7S9bvogTxqdVGbRobjR663s0+uW0Rz9e+Pa8I6jUuWtoBLQD2Mw==}
+  /@cucumber/tag-expressions@6.1.1:
+    resolution: {integrity: sha512-0oj5KTzf2DsR3DhL3hYeI9fP3nyKzs7TQdpl54uJelJ3W3Hlyyet2Hib+8LK7kNnqJsXENnJg9zahRYyrtvNEg==}
     dev: false
 
   /@emotion/babel-plugin@11.13.5:
@@ -536,6 +545,18 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: false
 
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: false
+
   /@jridgewell/gen-mapping@0.3.5:
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -771,13 +792,20 @@ packages:
       fastq: 1.17.1
     dev: false
 
+  /@pkgjs/parseargs@0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@popperjs/core@2.11.8:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
-  /@teppeis/multimaps@2.0.0:
-    resolution: {integrity: sha512-TL1adzq1HdxUf9WYduLcQ/DNGYiz71U31QRgbnr0Ef1cPyOUOsBojxHVWpFeOSUucB6Lrs0LxFRA14ntgtkc9w==}
-    engines: {node: '>=10.17'}
+  /@teppeis/multimaps@3.0.0:
+    resolution: {integrity: sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==}
+    engines: {node: '>=14'}
     dev: false
 
   /@tsconfig/node10@1.0.11:
@@ -800,6 +828,12 @@ packages:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: false
 
+  /@types/jsonwebtoken@9.0.7:
+    resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
+    dependencies:
+      '@types/node': 22.10.5
+    dev: true
+
   /@types/lodash.zipobject@4.1.7:
     resolution: {integrity: sha512-bsFXX/ac3fFgW3l/yxwRx7NvTXryi4bMaNcsbSK2MJnTPn0nHvs7NdwfHtvOkNKxSQ0dXgnNwI5oEGLoMA1mug==}
     dependencies:
@@ -813,6 +847,10 @@ packages:
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
     dependencies:
       undici-types: 6.20.0
+
+  /@types/normalize-package-data@2.4.4:
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+    dev: false
 
   /@types/parse-json@4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -834,12 +872,8 @@ packages:
       csstype: 3.1.3
     dev: false
 
-  /@types/uuid@8.3.4:
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
-    dev: false
-
-  /@types/uuid@9.0.1:
-    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
+  /@types/uuid@9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
     dev: false
 
   /@ungap/structured-clone@1.2.1:
@@ -905,11 +939,21 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+    dev: false
+
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: false
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
     dev: false
 
   /any-promise@1.3.0:
@@ -922,11 +966,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: false
-
-  /assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
     dev: false
 
   /assertion-error-formatter@3.0.0:
@@ -973,6 +1012,12 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    dev: false
+
+  /brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
     dev: false
 
   /buffer-equal-constant-time@1.0.1:
@@ -1081,13 +1126,13 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /commander@9.1.0:
-    resolution: {integrity: sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==}
-    engines: {node: ^12.20.0 || >=14}
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
     dev: false
 
-  /commander@9.4.1:
-    resolution: {integrity: sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==}
+  /commander@9.1.0:
+    resolution: {integrity: sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==}
     engines: {node: ^12.20.0 || >=14}
     dev: false
 
@@ -1110,10 +1155,6 @@ packages:
       through2: 2.0.5
       untildify: 4.0.0
       yargs: 16.2.0
-    dev: false
-
-  /core-util-is@1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     dev: false
 
   /core-util-is@1.0.3:
@@ -1264,6 +1305,10 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: false
+
   /ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
@@ -1272,6 +1317,10 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: false
+
+  /emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: false
 
   /encoding-sniffer@0.2.0:
@@ -1407,11 +1456,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /extsprintf@1.4.1:
-    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
-    engines: {'0': node >=0.6.0}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -1470,6 +1514,14 @@ packages:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
     dev: false
 
+  /find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: false
+
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1501,6 +1553,14 @@ packages:
         optional: true
     dev: false
 
+  /foreground-child@3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+    dev: false
+
   /form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
@@ -1528,6 +1588,18 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
+    dev: false
+
+  /glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
     dev: false
 
   /glob@7.2.3:
@@ -1627,6 +1699,10 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
+    dev: false
+
+  /hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: false
 
   /htmlparser2@9.1.0:
@@ -1745,6 +1821,14 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: false
+
+  /jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
     dev: false
 
   /js-tokens@4.0.0:
@@ -1874,6 +1958,13 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: false
 
+  /locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-locate: 4.1.0
+    dev: false
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1938,6 +2029,10 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+    dev: false
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1972,6 +2067,12 @@ packages:
       mime-db: 1.52.0
     dev: false
 
+  /mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dev: false
+
   /minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
     dev: false
@@ -1982,8 +2083,20 @@ packages:
       brace-expansion: 1.1.11
     dev: false
 
+  /minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: false
+
+  /minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dev: false
 
   /mkdirp@1.0.4:
@@ -2008,10 +2121,6 @@ packages:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-    dev: false
-
-  /nanoclone@0.2.1:
-    resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
     dev: false
 
   /nanoid@5.0.9:
@@ -2062,6 +2171,15 @@ packages:
       readable-stream: 1.0.34
     dev: false
 
+  /normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.8
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+    dev: false
+
   /nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
@@ -2091,6 +2209,13 @@ packages:
       word-wrap: 1.2.5
     dev: false
 
+  /p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
+    dev: false
+
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2098,11 +2223,27 @@ packages:
       yocto-queue: 0.1.0
     dev: false
 
+  /p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: false
+
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
+    dev: false
+
+  /p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
     dev: false
 
   /pad-right@0.2.2:
@@ -2169,6 +2310,14 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: false
+
+  /path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
     dev: false
 
   /path-type@4.0.0:
@@ -2274,6 +2423,25 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
+  /read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+    dev: false
+
+  /read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+    dev: false
+
   /readable-stream@1.0.34:
     resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
     dependencies:
@@ -2295,8 +2463,9 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /reflect-metadata@0.1.13:
-    resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
+  /reflect-metadata@0.2.1:
+    resolution: {integrity: sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==}
+    deprecated: This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer.
     dev: false
 
   /regenerator-runtime@0.14.1:
@@ -2400,6 +2569,11 @@ packages:
     resolution: {integrity: sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==}
     dev: false
 
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: false
+
   /semver@7.5.3:
     resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
     engines: {node: '>=10'}
@@ -2430,6 +2604,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
@@ -2447,12 +2626,34 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.20
+    dev: false
+
+  /spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+    dev: false
+
+  /spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.20
+    dev: false
+
+  /spdx-license-ids@3.0.20:
+    resolution: {integrity: sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==}
+    dev: false
+
   /stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
     dev: false
 
-  /string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+  /string-argv@0.3.1:
+    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
     dev: false
 
@@ -2463,6 +2664,15 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+    dev: false
+
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
     dev: false
 
   /string_decoder@0.10.31:
@@ -2480,6 +2690,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+    dev: false
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.1.0
     dev: false
 
   /strip-json-comments@3.1.1:
@@ -2536,6 +2753,10 @@ packages:
     dependencies:
       readable-stream: 2.3.8
       xtend: 4.0.2
+    dev: false
+
+  /tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
     dev: false
 
   /tinyglobby@0.2.10:
@@ -2606,6 +2827,21 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+    dev: false
+
   /type-fest@4.31.0:
     resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
     engines: {node: '>=16'}
@@ -2655,8 +2891,8 @@ packages:
     hasBin: true
     dev: false
 
-  /uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
 
@@ -2664,13 +2900,11 @@ packages:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
-  /verror@1.10.1:
-    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
-    engines: {node: '>=0.6.0'}
+  /validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.4.1
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
     dev: false
 
   /webidl-conversions@3.0.1:
@@ -2716,6 +2950,15 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    dev: false
+
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
     dev: false
 
   /wrappy@1.0.2:
@@ -2791,17 +3034,13 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /yup@0.32.11:
-    resolution: {integrity: sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==}
-    engines: {node: '>=10'}
+  /yup@1.2.0:
+    resolution: {integrity: sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==}
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@types/lodash': 4.17.13
-      lodash: 4.17.21
-      lodash-es: 4.17.21
-      nanoclone: 0.2.1
       property-expr: 2.0.6
+      tiny-case: 1.0.3
       toposort: 2.0.2
+      type-fest: 2.19.0
     dev: false
 
   /zod@3.24.0:

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
-    version: github.com/theopensystemslab/planx-core/a7ec46d
+    specifier: git+https://github.com/theopensystemslab/planx-core#d004278
+    version: github.com/theopensystemslab/planx-core/d004278
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -3043,12 +3043,12 @@ packages:
       type-fest: 2.19.0
     dev: false
 
-  /zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
+  /zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ec46d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
+  github.com/theopensystemslab/planx-core/d004278:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d004278}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -3076,7 +3076,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.31.0
       uuid: 11.0.3
-      zod: 3.24.0
+      zod: 3.24.1
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
-    version: github.com/theopensystemslab/planx-core/f2f555b
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
+    version: github.com/theopensystemslab/planx-core/a7ec46d
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2808,8 +2808,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/f2f555b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
+  github.com/theopensystemslab/planx-core/a7ec46d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2830,7 +2830,7 @@ packages:
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1

--- a/e2e/tests/api-driven/src/client.ts
+++ b/e2e/tests/api-driven/src/client.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { CoreDomainClient } from "@opensystemslab/planx-core";
-import { buildJWT } from "./jwt";
+import { buildJWT } from "./jwt.js";
 
 // check env variables are defined
 assert(process.env.HASURA_GRAPHQL_ADMIN_SECRET);

--- a/e2e/tests/api-driven/src/demo-workspace/helper.ts
+++ b/e2e/tests/api-driven/src/demo-workspace/helper.ts
@@ -1,5 +1,5 @@
-import gql from "graphql-tag";
-import { $admin } from "../client";
+import { gql } from "graphql-tag";
+import { $admin } from "../client.js";
 import { Team, User } from "@opensystemslab/planx-core/types";
 import { UUID } from "crypto";
 

--- a/e2e/tests/api-driven/src/demo-workspace/steps/background_steps.ts
+++ b/e2e/tests/api-driven/src/demo-workspace/steps/background_steps.ts
@@ -9,8 +9,8 @@ import {
   DataTableArray,
   DataTableRecord,
   Flow,
-} from "../helper";
-import { $admin, getClient } from "../../client";
+} from "../helper.js";
+import { $admin, getClient } from "../../client.js";
 import { strict as assert } from "node:assert";
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { Team, User } from "@opensystemslab/planx-core/types";

--- a/e2e/tests/api-driven/src/demo-workspace/steps/navigation_steps.ts
+++ b/e2e/tests/api-driven/src/demo-workspace/steps/navigation_steps.ts
@@ -1,8 +1,8 @@
 import { When } from "@cucumber/cucumber";
-import { $admin } from "../../client";
+import { $admin } from "../../client.js";
 import { strict as assert } from "node:assert";
-import { getFlowBySlug, getTeamAndFlowsBySlug, getTeams } from "../helper";
-import { CustomWorld } from "./background_steps";
+import { getFlowBySlug, getTeamAndFlowsBySlug, getTeams } from "../helper.js";
+import { CustomWorld } from "./background_steps.js";
 
 When<CustomWorld>("I am in the {string} team", async function (this, teamSlug) {
   const team = await getTeamAndFlowsBySlug(this.demoClient, teamSlug);

--- a/e2e/tests/api-driven/src/demo-workspace/steps/verification_steps.ts
+++ b/e2e/tests/api-driven/src/demo-workspace/steps/verification_steps.ts
@@ -1,5 +1,5 @@
 import { Then } from "@cucumber/cucumber";
-import { CustomWorld } from "./background_steps";
+import { CustomWorld } from "./background_steps.js";
 import { strict as assert } from "node:assert";
 import {
   createFlow,
@@ -8,7 +8,7 @@ import {
   getFlowBySlug,
   updateFlow,
   updateTeamSettings,
-} from "../helper";
+} from "../helper.js";
 
 Then<CustomWorld>("I should only see my own flows", async function (this) {
   assert.equal(

--- a/e2e/tests/api-driven/src/flowStatusHistory/helpers.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/helpers.ts
@@ -1,7 +1,7 @@
 import { FlowStatus } from "@opensystemslab/planx-core/types";
-import { $admin } from "../client";
-import { createTeam } from "../globalHelpers";
-import gql from "graphql-tag";
+import { $admin } from "../client.js";
+import { createTeam } from "../globalHelpers.js";
+import { gql } from "graphql-tag";
 
 export const setup = async () => {
   const teamId = await createTeam();

--- a/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
@@ -1,8 +1,13 @@
 import { When, Then, World, After, Before, Given } from "@cucumber/cucumber";
 import assert from "assert";
-import { cleanup, getFlowStatus, getFlowStatusHistory, setup } from "./helpers";
-import { createFlow } from "../globalHelpers";
-import { $admin } from "../client";
+import {
+  cleanup,
+  getFlowStatus,
+  getFlowStatusHistory,
+  setup,
+} from "./helpers.js";
+import { createFlow } from "../globalHelpers.js";
+import { $admin } from "../client.js";
 
 export class CustomWorld extends World {
   teamId!: number;

--- a/e2e/tests/api-driven/src/globalHelpers.ts
+++ b/e2e/tests/api-driven/src/globalHelpers.ts
@@ -1,5 +1,9 @@
-import { TEST_EMAIL } from "../../ui-driven/src/helpers/globalHelpers";
-import { $admin } from "./client";
+import { $admin } from "./client.js";
+
+// Gov.uk Notify requests testing service use smoke test email addresses
+// see https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing
+export const TEST_EMAIL =
+  "simulate-delivered@notifications.service.gov.uk" as const;
 
 export function createTeam(
   args?: Partial<Parameters<typeof $admin.team.create>[0]>,

--- a/e2e/tests/api-driven/src/hasuraTriggers/helpers.ts
+++ b/e2e/tests/api-driven/src/hasuraTriggers/helpers.ts
@@ -1,7 +1,6 @@
-import { TEST_EMAIL } from "../../../ui-driven/src/helpers/globalHelpers";
-import { $admin } from "../client";
-import { safely } from "../globalHelpers";
-import gql from "graphql-tag";
+import { $admin } from "../client.js";
+import { safely, TEST_EMAIL } from "../globalHelpers.js";
+import { gql } from "graphql-tag";
 
 export const cleanup = async () => {
   await $admin.user._destroyAll();

--- a/e2e/tests/api-driven/src/hasuraTriggers/steps.ts
+++ b/e2e/tests/api-driven/src/hasuraTriggers/steps.ts
@@ -1,9 +1,9 @@
 import { After, Given, Then, When, World } from "@cucumber/cucumber";
-import { cleanup, createDemoUser } from "./helpers";
+import { cleanup, createDemoUser } from "./helpers.js";
 import { User } from "@opensystemslab/planx-core/types";
-import { $admin } from "../client";
+import { $admin } from "../client.js";
 import assert from "assert";
-import { createTeam, createUser } from "../globalHelpers";
+import { createTeam, createUser } from "../globalHelpers.js";
 
 export class CustomWorld extends World {
   user!: User;

--- a/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
@@ -3,18 +3,17 @@ import type {
   PaymentRequest,
 } from "@opensystemslab/planx-core/types";
 import axios from "axios";
-import gql from "graphql-tag";
+import { gql } from "graphql-tag";
 import { readFileSync } from "node:fs";
-import { TEST_EMAIL } from "../../../ui-driven/src/helpers/globalHelpers";
-import { $admin } from "../client";
-import { createTeam, createUser } from "../globalHelpers";
+import { $admin } from "../client.js";
+import { createTeam, createUser, TEST_EMAIL } from "../globalHelpers.js";
 import {
   inviteToPayFlowGraph,
   mockBreadcrumbs,
   mockPassport,
   sendNodeWithDestination,
-} from "./mocks";
-import { CustomWorld } from "./steps";
+} from "./mocks/index.js";
+import { CustomWorld } from "./steps.js";
 
 export async function setUpMocks() {
   const serverMockFile = readFileSync(`${__dirname}/mocks/server-mocks.yaml`);

--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/index.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/index.ts
@@ -5,14 +5,14 @@ import type {
   Node,
 } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
-import flow from "./flow.json";
-import session from "./session.json";
+import flow from "./flow.json" assert { type: "json" };
+import session from "./session.json" assert { type: "json" };
 
 export const mockBreadcrumbs = session.data?.breadcrumbs as Breadcrumbs;
 
 export const mockPassport = session.data?.passport as Passport;
 
-export const inviteToPayFlowGraph = flow.data as FlowGraph;
+export const inviteToPayFlowGraph = flow?.data as FlowGraph;
 
 export function sendNodeWithDestination(destination: string): Node {
   return {

--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/index.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/index.ts
@@ -5,8 +5,8 @@ import type {
   Node,
 } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
-import flow from "./flow.json" assert { type: "json" };
-import session from "./session.json" assert { type: "json" };
+import flow from "./flow.json" with { type: "json" };
+import session from "./session.json" with { type: "json" };
 
 export const mockBreadcrumbs = session.data?.breadcrumbs as Breadcrumbs;
 

--- a/e2e/tests/api-driven/src/invite-to-pay/steps.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/steps.ts
@@ -10,7 +10,7 @@ import {
   waitForResponse,
   cleanup,
   setup,
-} from "./helpers";
+} from "./helpers.js";
 
 export class CustomWorld extends World {
   teamId!: number;

--- a/e2e/tests/api-driven/src/jwt.ts
+++ b/e2e/tests/api-driven/src/jwt.ts
@@ -1,6 +1,6 @@
-import { sign } from "jsonwebtoken";
+import JWT from "jsonwebtoken";
 import { User, Role } from "@opensystemslab/planx-core/types";
-import { $admin } from "./client";
+import { $admin } from "./client.js";
 
 // This code is copied from api.planx.uk/modules/auth/service.ts
 
@@ -13,7 +13,7 @@ export const buildJWT = async (email: string): Promise<string | undefined> => {
     "https://hasura.io/jwt/claims": generateHasuraClaimsForUser(user),
   };
 
-  const jwt = sign(data, process.env.JWT_SECRET!);
+  const jwt = JWT.sign(data, process.env.JWT_SECRET!);
   return jwt;
 };
 

--- a/e2e/tests/api-driven/src/permissions/helpers.ts
+++ b/e2e/tests/api-driven/src/permissions/helpers.ts
@@ -1,8 +1,8 @@
-import { DocumentNode, Kind } from "graphql/language";
-import { $admin, getClient } from "../client";
-import { CustomWorld } from "./steps";
-import { queries } from "./queries";
-import { createFlow, createTeam, createUser } from "../globalHelpers";
+import { DocumentNode, Kind } from "graphql/language/index.js";
+import { $admin, getClient } from "../client.js";
+import { CustomWorld } from "./steps.js";
+import { queries } from "./queries/index.js";
+import { createFlow, createTeam, createUser } from "../globalHelpers.js";
 
 export type Action = "insert" | "update" | "delete" | "select";
 export type Table = keyof typeof queries;

--- a/e2e/tests/api-driven/src/permissions/queries/index.ts
+++ b/e2e/tests/api-driven/src/permissions/queries/index.ts
@@ -2,11 +2,14 @@ import {
   DELETE_FLOW_QUERY,
   INSERT_FLOW_QUERY,
   UPDATE_FLOW_QUERY,
-} from "./flows";
-import { INSERT_OPERATION_QUERY, UPDATE_OPERATION_QUERY } from "./operations";
-import { INSERT_PUBLISHED_FLOW_QUERY } from "./publishedFlows";
-import { SELECT_TEAM_MEMBERS_QUERY } from "./teamMembers";
-import { SELECT_USERS_QUERY } from "./users";
+} from "./flows.js";
+import {
+  INSERT_OPERATION_QUERY,
+  UPDATE_OPERATION_QUERY,
+} from "./operations.js";
+import { INSERT_PUBLISHED_FLOW_QUERY } from "./publishedFlows.js";
+import { SELECT_TEAM_MEMBERS_QUERY } from "./teamMembers.js";
+import { SELECT_USERS_QUERY } from "./users.js";
 
 export const queries = {
   flows: {

--- a/e2e/tests/api-driven/src/permissions/queries/publishedFlows.ts
+++ b/e2e/tests/api-driven/src/permissions/queries/publishedFlows.ts
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import { gql } from "graphql-tag";
 
 export const INSERT_PUBLISHED_FLOW_QUERY = gql`
   mutation InsertPublishedFlowsE2E($team1FlowId: uuid!, $activeUserId: Int) {

--- a/e2e/tests/api-driven/src/permissions/queries/teamMembers.ts
+++ b/e2e/tests/api-driven/src/permissions/queries/teamMembers.ts
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import { gql } from "graphql-tag";
 
 export const SELECT_TEAM_MEMBERS_QUERY = gql`
   query SelectTeamMembersE2E($user1Id: Int) {

--- a/e2e/tests/api-driven/src/permissions/queries/users.ts
+++ b/e2e/tests/api-driven/src/permissions/queries/users.ts
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import { gql } from "graphql-tag";
 
 export const SELECT_USERS_QUERY = gql`
   query SelectUsersE2E($user1Id: Int!) {

--- a/e2e/tests/api-driven/src/permissions/steps.ts
+++ b/e2e/tests/api-driven/src/permissions/steps.ts
@@ -1,6 +1,6 @@
 import { After, Before, Given, Then, When, World } from "@cucumber/cucumber";
 import { strict as assert } from "node:assert";
-import { getUser } from "../globalHelpers";
+import { getUser } from "../globalHelpers.js";
 import {
   Action,
   GQLQueryResult,
@@ -9,7 +9,7 @@ import {
   cleanup,
   performGQLQuery,
   setup,
-} from "./helpers";
+} from "./helpers.js";
 
 export class CustomWorld extends World {
   // A teamEditor for team1

--- a/e2e/tests/api-driven/tsconfig.json
+++ b/e2e/tests/api-driven/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "lib": ["DOM", "ESNext"],
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "rootDir": "./src"
-  }
-}

--- a/e2e/tests/api-driven/tsconfig.json
+++ b/e2e/tests/api-driven/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "rootDir": "./src"
+  }
+}

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a9848d4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -8,7 +8,7 @@
     "postinstall": "./install-dependencies.sh"
   },
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -12,7 +12,7 @@
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",
-    "graphql": "^16.9.0",
+    "graphql": "^16.10.0",
     "graphql-request": "^6.1.0",
     "isomorphic-fetch": "^3.0.0",
     "jsonwebtoken": "^9.0.2",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -7,8 +7,9 @@
     "ui": "serve ../../../editor.planx.uk/build --single --listen 3000",
     "postinstall": "./install-dependencies.sh"
   },
+  "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d004278",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",
@@ -21,7 +22,7 @@
   },
   "packageManager": "pnpm@8.6.6",
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "^1.49.1",
     "@types/geojson": "^7946.0.14",
     "@types/node": "22.10.5",
     "eslint-plugin-playwright": "^0.20.0"

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -18,11 +18,11 @@ dependencies:
     specifier: ^8.56.0
     version: 8.56.0
   graphql:
-    specifier: ^16.9.0
-    version: 16.9.0
+    specifier: ^16.10.0
+    version: 16.10.0
   graphql-request:
     specifier: ^6.1.0
-    version: 6.1.0(graphql@16.9.0)
+    version: 6.1.0(graphql@16.10.0)
   isomorphic-fetch:
     specifier: ^3.0.0
     version: 3.0.0
@@ -379,14 +379,6 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.10.0
-    dev: false
-
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.9.0):
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 16.9.0
     dev: false
 
   /@humanwhocodes/config-array@0.11.14:
@@ -1506,25 +1498,8 @@ packages:
       - encoding
     dev: false
 
-  /graphql-request@6.1.0(graphql@16.9.0):
-    resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
-    peerDependencies:
-      graphql: 14 - 16
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
-      cross-fetch: 3.1.8
-      graphql: 16.9.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /graphql@16.10.0:
     resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: false
-
-  /graphql@16.9.0:
-    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
-    version: github.com/theopensystemslab/planx-core/f2f555b
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
+    version: github.com/theopensystemslab/planx-core/a7ec46d
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -1796,6 +1796,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
     dev: false
@@ -2622,8 +2626,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/f2f555b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
+  github.com/theopensystemslab/planx-core/a7ec46d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2644,7 +2648,7 @@ packages:
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a9848d4
-    version: github.com/theopensystemslab/planx-core/a9848d4
+    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
+    version: github.com/theopensystemslab/planx-core/f2f555b
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -371,6 +371,14 @@ packages:
     resolution: {integrity: sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==}
     dependencies:
       tslib: 2.8.1
+    dev: false
+
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.10.0):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 16.10.0
     dev: false
 
   /@graphql-typed-document-node/core@3.2.0(graphql@16.9.0):
@@ -1360,8 +1368,8 @@ packages:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
     dev: false
 
-  /fast-xml-parser@4.5.0:
-    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+  /fast-xml-parser@4.5.1:
+    resolution: {integrity: sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -1486,6 +1494,18 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  /graphql-request@6.1.0(graphql@16.10.0):
+    resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
+    peerDependencies:
+      graphql: 14 - 16
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
+      cross-fetch: 3.1.8
+      graphql: 16.10.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /graphql-request@6.1.0(graphql@16.9.0):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
@@ -1496,6 +1516,11 @@ packages:
       graphql: 16.9.0
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
   /graphql@16.9.0:
@@ -1813,8 +1838,8 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /marked@15.0.3:
-    resolution: {integrity: sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==}
+  /marked@15.0.5:
+    resolution: {integrity: sha512-xN+kSuqHjxWg+Q47yhhZMUP+kO1qHobvXkkm6FX+7N6lDvanLDd8H7AQ0jWDDyq+fDt/cSrJaBGyWYHXy0KQWA==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -2430,8 +2455,8 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /type-fest@4.30.0:
-    resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
+  /type-fest@4.31.0:
+    resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2597,8 +2622,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a9848d4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a9848d4}
+  github.com/theopensystemslab/planx-core/f2f555b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2615,16 +2640,16 @@ packages:
       copyfiles: 2.4.1
       docx: 9.1.0
       eslint: 8.57.1
-      fast-xml-parser: 4.5.0
-      graphql: 16.9.0
-      graphql-request: 6.1.0(graphql@16.9.0)
+      fast-xml-parser: 4.5.1
+      graphql: 16.10.0
+      graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
       lodash: 4.17.21
-      marked: 15.0.3
+      marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.30.0
+      type-fest: 4.31.0
       uuid: 11.0.3
       zod: 3.24.0
     transitivePeerDependencies:

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
-    version: github.com/theopensystemslab/planx-core/a7ec46d
+    specifier: git+https://github.com/theopensystemslab/planx-core#d004278
+    version: github.com/theopensystemslab/planx-core/d004278
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -38,8 +38,8 @@ dependencies:
 
 devDependencies:
   '@playwright/test':
-    specifier: ^1.49.0
-    version: 1.49.0
+    specifier: ^1.49.1
+    version: 1.49.1
   '@types/geojson':
     specifier: ^7946.0.14
     version: 7946.0.14
@@ -639,12 +639,12 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  /@playwright/test@1.49.0:
-    resolution: {integrity: sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==}
+  /@playwright/test@1.49.1:
+    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.49.0
+      playwright: 1.49.1
     dev: true
 
   /@popperjs/core@2.11.8:
@@ -2055,18 +2055,18 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /playwright-core@1.49.0:
-    resolution: {integrity: sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==}
+  /playwright-core@1.49.1:
+    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.49.0:
-    resolution: {integrity: sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==}
+  /playwright@1.49.1:
+    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.49.0
+      playwright-core: 1.49.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -2597,12 +2597,12 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
+  /zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ec46d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
+  github.com/theopensystemslab/planx-core/d004278:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d004278}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2630,7 +2630,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.31.0
       uuid: 11.0.3
-      zod: 3.24.0
+      zod: 3.24.1
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -3,18 +3,18 @@ import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
-import { getTeamPage } from "./helpers/getPage";
-import { createAuthenticatedSession } from "./helpers/globalHelpers";
-import { answerQuestion, clickContinue } from "./helpers/userActions";
-import { PlaywrightEditor } from "./pages/Editor";
+} from "./helpers/context.js";
+import { getTeamPage } from "./helpers/getPage.js";
+import { createAuthenticatedSession } from "./helpers/globalHelpers.js";
+import { answerQuestion, clickContinue } from "./helpers/userActions.js";
+import { PlaywrightEditor } from "./pages/Editor.js";
 import {
   navigateToService,
   publishService,
   turnServiceOnline,
-} from "./helpers/navigateAndPublish";
-import { TestContext } from "./helpers/types";
-import { serviceProps } from "./helpers/serviceData";
+} from "./helpers/navigateAndPublish.js";
+import { TestContext } from "./helpers/types.js";
+import { serviceProps } from "./helpers/serviceData.js";
 import {
   alterDrawGeoJson,
   checkGeoJsonContent,
@@ -22,26 +22,26 @@ import {
   getMapProperties,
   resetMapBoundary,
   waitForMapComponent,
-} from "./helpers/geospatialChecks";
+} from "./helpers/geospatialChecks.js";
 import {
   GeoJsonChangeHandler,
   mockChangedMapGeoJson,
   mockPropertyTypeOptions,
   mockTitleBoundaryGeoJson,
-} from "./mocks/geospatialMocks";
+} from "./mocks/geospatialMocks.js";
 import {
   setupOSMapsStyles,
   setupOSMapsVectorTiles,
-} from "./mocks/osMapsResponse";
+} from "./mocks/osMapsResponse.js";
 import {
   planningConstraintHeadersMock,
   setupGISMockResponse,
   setupRoadsMockResponse,
-} from "./mocks/gisResponse";
+} from "./mocks/gisResponse.js";
 import {
   answerFindProperty,
   userChallengesPlanningConstraint,
-} from "./helpers/geoSpatialUserActions";
+} from "./helpers/geoSpatialUserActions.js";
 
 test.describe("Flow creation, publish and preview", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow.spec.ts
@@ -3,13 +3,13 @@ import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
-import { getTeamPage } from "./helpers/getPage";
+} from "./helpers/context.js";
+import { getTeamPage } from "./helpers/getPage.js";
 import {
   createAuthenticatedSession,
   filterFlags,
   selectedFlag,
-} from "./helpers/globalHelpers";
+} from "./helpers/globalHelpers.js";
 import {
   answerAddressInput,
   answerChecklist,
@@ -20,19 +20,19 @@ import {
   answerQuestion,
   answerTextInput,
   clickContinue,
-} from "./helpers/userActions";
-import { PlaywrightEditor } from "./pages/Editor";
-import { createExternalPortal } from "./helpers/addComponent";
+} from "./helpers/userActions.js";
+import { PlaywrightEditor } from "./pages/Editor.js";
+import { createExternalPortal } from "./helpers/addComponent.js";
 import {
   navigateToService,
   publishService,
   turnServiceOnline,
-} from "./helpers/navigateAndPublish";
-import { TestContext } from "./helpers/types";
+} from "./helpers/navigateAndPublish.js";
+import { TestContext } from "./helpers/types.js";
 import {
   externalPortalFlowData,
   externalPortalServiceProps,
-} from "./helpers/serviceData";
+} from "./helpers/serviceData.js";
 
 test.describe("Flow creation, publish and preview", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -1,9 +1,9 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { expect, Locator, Page } from "@playwright/test";
-import { contextDefaults } from "./context";
-import { externalPortalServiceProps } from "./serviceData";
-import { OptionWithDataValues } from "./types";
-import { selectedFlag } from "./globalHelpers";
+import { contextDefaults } from "./context.js";
+import { externalPortalServiceProps } from "./serviceData.js";
+import { OptionWithDataValues } from "./types.js";
+import { selectedFlag } from "./globalHelpers.js";
 
 const createBaseComponent = async (
   page: Page,

--- a/e2e/tests/ui-driven/src/helpers/context.ts
+++ b/e2e/tests/ui-driven/src/helpers/context.ts
@@ -1,8 +1,8 @@
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { GraphQLClient, gql } from "graphql-request";
-import { sign } from "jsonwebtoken";
+import jwt from "jsonwebtoken";
 import assert from "node:assert";
-import { TestContext } from "./types";
+import { TestContext } from "./types.js";
 
 export const contextDefaults: TestContext = {
   user: {
@@ -107,7 +107,7 @@ export async function tearDownTestContext() {
 
 export function generateAuthenticationToken(userId: string) {
   assert(process.env.JWT_SECRET);
-  return sign(
+  return jwt.sign(
     {
       sub: `${userId}`,
       "https://hasura.io/jwt/claims": {

--- a/e2e/tests/ui-driven/src/helpers/geoSpatialUserActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/geoSpatialUserActions.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from "@playwright/test";
-import { setupOSMockResponse } from "../mocks/osPlacesResponse";
+import { setupOSMockResponse } from "../mocks/osPlacesResponse.js";
 
 export async function answerFindProperty(page: Page) {
   await setupOSMockResponse(page);

--- a/e2e/tests/ui-driven/src/helpers/getPage.ts
+++ b/e2e/tests/ui-driven/src/helpers/getPage.ts
@@ -1,5 +1,5 @@
 import { Browser, Page } from "@playwright/test";
-import { createAuthenticatedSession } from "./globalHelpers";
+import { createAuthenticatedSession } from "./globalHelpers.js";
 
 export async function getAdminPage({
   browser,

--- a/e2e/tests/ui-driven/src/helpers/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/helpers/globalHelpers.ts
@@ -1,8 +1,8 @@
 import { FlowGraph } from "@opensystemslab/planx-core/types";
 import { type Browser, type Page, type Request } from "@playwright/test";
 import { gql } from "graphql-request";
-import { generateAuthenticationToken, getGraphQLClient } from "./context";
-import { TestContext } from "./types";
+import { generateAuthenticationToken, getGraphQLClient } from "./context.js";
+import { TestContext } from "./types.js";
 import { flatFlags } from "@opensystemslab/planx-core/types";
 
 // Test card numbers to be used in gov.uk sandbox environment

--- a/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
+++ b/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from "@playwright/test";
-import { contextDefaults } from "./context";
+import { contextDefaults } from "./context.js";
 
 export const navigateToService = async (page: Page, slug: string) => {
   await page.goto(`/${contextDefaults.team.slug}/${slug}`);

--- a/e2e/tests/ui-driven/src/helpers/types.ts
+++ b/e2e/tests/ui-driven/src/helpers/types.ts
@@ -1,5 +1,5 @@
 import { CoreDomainClient } from "@opensystemslab/planx-core";
-import { User } from "@opensystemslab/planx-core/dist/types";
+import { User } from "@opensystemslab/planx-core/types";
 
 type NewTeam = Parameters<CoreDomainClient["team"]["create"]>[0];
 

--- a/e2e/tests/ui-driven/src/helpers/userActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/userActions.ts
@@ -1,8 +1,8 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
-import { findSessionId, getGraphQLClient } from "./context";
-import { TEST_EMAIL, log, waitForDebugLog } from "./globalHelpers";
-import { TestContext } from "./types";
+import { findSessionId, getGraphQLClient } from "./context.js";
+import { TEST_EMAIL, log, waitForDebugLog } from "./globalHelpers.js";
+import { TestContext } from "./types.js";
 
 export async function saveSession({
   page,

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -4,22 +4,22 @@ import {
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
-} from "../helpers/context";
-import { addSessionToContext, modifyFlow } from "../helpers/globalHelpers";
+} from "../helpers/context.js";
+import { addSessionToContext, modifyFlow } from "../helpers/globalHelpers.js";
 import {
   clickContinue,
   returnToSession,
   saveSession,
-} from "../helpers/userActions";
-import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow";
+} from "../helpers/userActions.js";
+import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow.js";
 import {
   answerInviteToPayForm,
   getPaymentRequestBySessionId,
   makePaymentRequest,
   navigateToPayComponent,
-} from "./helpers";
-import { mockPaymentRequest, modifiedInviteToPayFlow } from "./mocks";
-import { TestContext } from "../helpers/types";
+} from "./helpers.js";
+import { mockPaymentRequest, modifiedInviteToPayFlow } from "./mocks.js";
+import { TestContext } from "../helpers/types.js";
 
 let context: TestContext = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
@@ -1,14 +1,18 @@
-import { PaymentRequest } from "@opensystemslab/planx-core/dist/types";
+import { PaymentRequest } from "@opensystemslab/planx-core/types";
 import { expect, type Page } from "@playwright/test";
 import { GraphQLClient, gql } from "graphql-request";
-import { TEST_EMAIL, addSessionToContext, log } from "../helpers/globalHelpers";
+import {
+  TEST_EMAIL,
+  addSessionToContext,
+  log,
+} from "../helpers/globalHelpers.js";
 import {
   answerChecklist,
   answerContactInput,
   fillInEmail,
-} from "../helpers/userActions";
-import { TestContext } from "../helpers/types";
-import { answerFindProperty } from "../helpers/geoSpatialUserActions";
+} from "../helpers/userActions.js";
+import { TestContext } from "../helpers/types.js";
+import { answerFindProperty } from "../helpers/geoSpatialUserActions.js";
 
 /**
  * Navigates to pay component whilst completing the minimum requirements for an Invite to Pay flow

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -4,8 +4,8 @@ import {
   PaymentRequest,
   SessionData,
 } from "@opensystemslab/planx-core/types";
-import { TEST_EMAIL } from "../helpers/globalHelpers";
-import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow";
+import { TEST_EMAIL } from "../helpers/globalHelpers.js";
+import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow.js";
 
 export const mockPaymentRequest: Partial<PaymentRequest> = {
   payeeEmail: TEST_EMAIL,

--- a/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
@@ -7,13 +7,13 @@ import {
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
-} from "../helpers/context";
-import { cards, setFeatureFlag } from "../helpers/globalHelpers";
-import { fillGovUkCardDetails } from "../helpers/userActions";
-import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow";
-import { getPaymentRequestBySessionId } from "./helpers";
-import { mockPaymentRequestDetails, mockSessionData } from "./mocks";
-import { TestContext } from "../helpers/types";
+} from "../helpers/context.js";
+import { cards, setFeatureFlag } from "../helpers/globalHelpers.js";
+import { fillGovUkCardDetails } from "../helpers/userActions.js";
+import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow.js";
+import { getPaymentRequestBySessionId } from "./helpers.js";
+import { mockPaymentRequestDetails, mockSessionData } from "./mocks.js";
+import { TestContext } from "../helpers/types.js";
 
 let context: TestContext = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/login.spec.ts
+++ b/e2e/tests/ui-driven/src/login.spec.ts
@@ -3,9 +3,9 @@ import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
-import { createAuthenticatedSession } from "./helpers/globalHelpers";
-import { TestContext } from "./helpers/types";
+} from "./helpers/context.js";
+import { createAuthenticatedSession } from "./helpers/globalHelpers.js";
+import { TestContext } from "./helpers/types.js";
 
 test.describe("Login", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/mocks/geospatialMocks.ts
+++ b/e2e/tests/ui-driven/src/mocks/geospatialMocks.ts
@@ -1,4 +1,4 @@
-import { OptionWithDataValues } from "../helpers/types";
+import { OptionWithDataValues } from "../helpers/types.js";
 import { Feature, Polygon } from "geojson";
 
 type ChangeHandlerProperties = {

--- a/e2e/tests/ui-driven/src/mocks/gisResponse.ts
+++ b/e2e/tests/ui-driven/src/mocks/gisResponse.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from "@playwright/test";
-import { mockRoadData } from "./geospatialMocks";
-import propertyConstraintsResponse from "./propertyConstraintResponse.json";
+import { mockRoadData } from "./geospatialMocks.js";
+import propertyConstraintsResponse from "./propertyConstraintResponse.json" with { type: "json" };
 
 export async function setupGISMockResponse(page: Page) {
   const gisDigitalLandEndpoint = "**/gis/E2E?geom*";

--- a/e2e/tests/ui-driven/src/mocks/osMapsResponse.ts
+++ b/e2e/tests/ui-driven/src/mocks/osMapsResponse.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { osMapsStylesResponse } from "./osMapsMockData";
+import { osMapsStylesResponse } from "./osMapsMockData.js";
 
 export async function setupOSMapsStyles(page: Page) {
   const ordnanceSurveyMapsStyles = new RegExp(

--- a/e2e/tests/ui-driven/src/pages/Editor.ts
+++ b/e2e/tests/ui-driven/src/pages/Editor.ts
@@ -28,9 +28,9 @@ import {
   createTaskList,
   createTextInput,
   createUploadAndLabel,
-} from "../helpers/addComponent";
-import { OptionWithDataValues } from "../helpers/types";
-import { selectedFlag } from "../helpers/globalHelpers";
+} from "../helpers/addComponent.js";
+import { OptionWithDataValues } from "../helpers/types.js";
+import { selectedFlag } from "../helpers/globalHelpers.js";
 
 export class PlaywrightEditor {
   readonly page: Page;

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -7,16 +7,19 @@ import {
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
+} from "./helpers/context.js";
 import {
   cards,
   getSessionId,
   log,
   waitForPaymentResponse,
-} from "./helpers/globalHelpers";
-import { fillGovUkCardDetails, submitCardDetails } from "./helpers/userActions";
-import payFlow from "./mocks/flows/pay-flow.json";
-import { TestContext } from "./helpers/types";
+} from "./helpers/globalHelpers.js";
+import {
+  fillGovUkCardDetails,
+  submitCardDetails,
+} from "./helpers/userActions.js";
+import payFlow from "./mocks/flows/pay-flow.json" with { type: "json" };
+import { TestContext } from "./helpers/types.js";
 
 let context: TestContext = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/refresh-page.spec.ts
+++ b/e2e/tests/ui-driven/src/refresh-page.spec.ts
@@ -3,12 +3,12 @@ import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
+} from "./helpers/context.js";
 import {
   createAuthenticatedSession,
   isGetUserRequest,
-} from "./helpers/globalHelpers";
-import { TestContext } from "./helpers/types";
+} from "./helpers/globalHelpers.js";
+import { TestContext } from "./helpers/types.js";
 
 test.describe("Refresh page", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/save-and-return.spec.ts
+++ b/e2e/tests/ui-driven/src/save-and-return.spec.ts
@@ -3,8 +3,8 @@ import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
-import { modifyFlow } from "./helpers/globalHelpers";
+} from "./helpers/context.js";
+import { modifyFlow } from "./helpers/globalHelpers.js";
 import {
   answerQuestion,
   clickContinue,
@@ -12,12 +12,12 @@ import {
   findQuestion,
   returnToSession,
   saveSession,
-} from "./helpers/userActions";
+} from "./helpers/userActions.js";
 import {
   modifiedSimpleSendFlow,
   simpleSendFlow,
-} from "./mocks/flows/save-and-return-flows";
-import { TestContext } from "./helpers/types";
+} from "./mocks/flows/save-and-return-flows.js";
+import { TestContext } from "./helpers/types.js";
 
 test.describe("Save and return", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/sections.spec.ts
+++ b/e2e/tests/ui-driven/src/sections.spec.ts
@@ -6,7 +6,7 @@ import {
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
-} from "./helpers/context";
+} from "./helpers/context.js";
 import {
   answerChecklist,
   answerQuestion,
@@ -18,9 +18,9 @@ import {
   fillInEmail,
   returnToSession,
   saveSession,
-} from "./helpers/userActions";
-import { flow, updatedQuestionAnswers } from "./mocks/flows/sections-flow";
-import { TestContext } from "./helpers/types";
+} from "./helpers/userActions.js";
+import { flow, updatedQuestionAnswers } from "./mocks/flows/sections-flow.js";
+import { TestContext } from "./helpers/types.js";
 
 // TODO: move this type to planx-core
 // also defined in editor.planx.uk/src/types.ts

--- a/e2e/tests/ui-driven/src/utils.ts
+++ b/e2e/tests/ui-driven/src/utils.ts
@@ -1,4 +1,4 @@
-import { sign } from "jsonwebtoken";
+import jwt from "jsonwebtoken";
 import Axios from "axios";
 
 export const gqlAdmin = async (query, variables = {}) => {
@@ -35,7 +35,7 @@ export const getJWT = (userId) => {
     },
   };
 
-  return sign(data, process.env.JWT_SECRET);
+  return jwt.sign(data, process.env.JWT_SECRET!);
 };
 
 export const insertTeam = async (teamName) => {

--- a/e2e/tests/ui-driven/tsconfig.json
+++ b/e2e/tests/ui-driven/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/e2e/tests/ui-driven/tsconfig.json
+++ b/e2e/tests/ui-driven/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "."
-  }
-}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,16 +3,19 @@
     "allowJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2021", "DOM"],
-    "module": "commonjs",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "rootDir": "tests",
     "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": false,
     "target": "es2021",
-    "noEmit": true
+    "noEmit": true,
+    "lib": [
+      "DOM",
+      "ESNext"
+    ],
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
   },
   "exclude": ["node_modules"]
 }

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a9848d4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d004278",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
-    version: github.com/theopensystemslab/planx-core/f2f555b(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
+    version: github.com/theopensystemslab/planx-core/a7ec46d(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14523,9 +14523,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/f2f555b(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
-    id: github.com/theopensystemslab/planx-core/f2f555b
+  github.com/theopensystemslab/planx-core/a7ec46d(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
+    id: github.com/theopensystemslab/planx-core/a7ec46d
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -14546,7 +14546,7 @@ packages:
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
-    version: github.com/theopensystemslab/planx-core/a7ec46d(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#d004278
+    version: github.com/theopensystemslab/planx-core/d004278(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14494,8 +14494,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  /zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
+  /zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
   /zstddec@0.1.0:
@@ -14523,9 +14523,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ec46d(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
-    id: github.com/theopensystemslab/planx-core/a7ec46d
+  github.com/theopensystemslab/planx-core/d004278(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d004278}
+    id: github.com/theopensystemslab/planx-core/d004278
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -14553,7 +14553,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.31.0
       uuid: 11.0.3
-      zod: 3.24.0
+      zod: 3.24.1
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a9848d4
-    version: github.com/theopensystemslab/planx-core/a9848d4(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
+    version: github.com/theopensystemslab/planx-core/f2f555b(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -2745,20 +2745,20 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.10.0):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 16.10.0
+    dev: false
+
   /@graphql-typed-document-node/core@3.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.8.1
-    dev: false
-
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.9.0):
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 16.9.0
     dev: false
 
   /@humanwhocodes/config-array@0.13.0:
@@ -3226,7 +3226,7 @@ packages:
       react-is: 17.0.2
     dev: true
 
-  /@mdx-js/react@3.1.0(@types/react@18.2.45)(react@18.2.0):
+  /@mdx-js/react@3.1.0(@types/react@18.2.45)(react@18.3.1):
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
       '@types/react': '>=16'
@@ -3234,7 +3234,7 @@ packages:
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 18.2.45
-      react: 18.2.0
+      react: 18.3.1
     dev: true
 
   /@microlink/react-json-view@1.23.1(@types/react@18.2.45)(react-dom@18.2.0)(react@18.2.0):
@@ -4105,15 +4105,15 @@ packages:
     peerDependencies:
       storybook: ^8.3.1
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@18.2.45)(react@18.2.0)
-      '@storybook/blocks': 8.3.1(react-dom@18.2.0)(react@18.2.0)(storybook@8.3.1)
+      '@mdx-js/react': 3.1.0(@types/react@18.2.45)(react@18.3.1)
+      '@storybook/blocks': 8.3.1(react-dom@18.3.1)(react@18.3.1)(storybook@8.3.1)
       '@storybook/csf-plugin': 8.3.1(storybook@8.3.1)
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 8.3.1(react-dom@18.2.0)(react@18.2.0)(storybook@8.3.1)
+      '@storybook/react-dom-shim': 8.3.1(react-dom@18.3.1)(react@18.3.1)(storybook@8.3.1)
       '@types/react': 18.2.45
       fs-extra: 11.2.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       rehype-external-links: 3.0.0
       rehype-slug: 6.0.0
       storybook: 8.3.1
@@ -4248,7 +4248,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/blocks@8.3.1(react-dom@18.2.0)(react@18.2.0)(storybook@8.3.1):
+  /@storybook/blocks@8.3.1(react-dom@18.3.1)(react@18.3.1)(storybook@8.3.1):
     resolution: {integrity: sha512-/wNLRVWR/edzHQAFvSW68VxHYmBcfXpL/XdO46I5Z1X/tXUd0rtgGZmliQ2jZ242FqxcT8guqqFGehbeYUns5w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -4262,17 +4262,17 @@ packages:
     dependencies:
       '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
-      '@storybook/icons': 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/icons': 1.3.0(react-dom@18.3.1)(react@18.3.1)
       '@types/lodash': 4.17.13
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
-      markdown-to-jsx: 7.7.1(react@18.2.0)
+      markdown-to-jsx: 7.7.1(react@18.3.1)
       memoizerific: 1.11.3
       polished: 4.3.1
-      react: 18.2.0
-      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
-      react-dom: 18.2.0(react@18.2.0)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.1
       telejson: 7.2.0
       ts-dedent: 2.2.0
@@ -4387,15 +4387,15 @@ packages:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
     dev: true
 
-  /@storybook/icons@1.3.0(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/icons@1.3.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Nz/UzeYQdUZUhacrPyfkiiysSjydyjgg/p0P9HxB4p/WaJUUjMAcaoaLgy3EXx61zZJ3iD36WPuDkZs5QYrA0A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: true
 
   /@storybook/instrumenter@8.3.1(storybook@8.3.1):
@@ -4442,6 +4442,18 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      storybook: 8.3.1
+    dev: true
+
+  /@storybook/react-dom-shim@8.3.1(react-dom@18.3.1)(react@18.3.1)(storybook@8.3.1):
+    resolution: {integrity: sha512-nHMhXkt3FAm8c08QTTU70vpYhsAu65RpCv/uhYZ89H5OWvmLFHn36iJQPzlpWFtJHJ5+bAV/bfgNODR3BV1gRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.3.1
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.1
     dev: true
 
@@ -8331,8 +8343,8 @@ packages:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
     dev: false
 
-  /fast-xml-parser@4.5.0:
-    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+  /fast-xml-parser@4.5.1:
+    resolution: {integrity: sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -8761,14 +8773,14 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  /graphql-request@6.1.0(graphql@16.9.0):
+  /graphql-request@6.1.0(graphql@16.10.0):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       cross-fetch: 3.1.8
-      graphql: 16.9.0
+      graphql: 16.10.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -8783,13 +8795,13 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /graphql@16.8.1:
-    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+  /graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
-  /graphql@16.9.0:
-    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
@@ -10452,17 +10464,17 @@ packages:
       uc.micro: 2.1.0
     dev: false
 
-  /markdown-to-jsx@7.7.1(react@18.2.0):
+  /markdown-to-jsx@7.7.1(react@18.3.1):
     resolution: {integrity: sha512-BjLkHb+fWCAH9gp7ndbgPrY+zeZlGFtCiQNTWk+PD+GKfLg9YsUPNonSsYXGw6nQ7eZqeR+i71X59PpWXlxc/w==}
     engines: {node: '>= 10'}
     peerDependencies:
       react: '>= 0.14.0'
     dependencies:
-      react: 18.2.0
+      react: 18.3.1
     dev: true
 
-  /marked@15.0.3:
-    resolution: {integrity: sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==}
+  /marked@15.0.5:
+    resolution: {integrity: sha512-xN+kSuqHjxWg+Q47yhhZMUP+kO1qHobvXkkm6FX+7N6lDvanLDd8H7AQ0jWDDyq+fDt/cSrJaBGyWYHXy0KQWA==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -11821,14 +11833,14 @@ packages:
       reactcss: 1.2.3(react@18.2.0)
       tinycolor2: 1.6.0
 
-  /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
+  /react-colorful@5.6.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: true
 
   /react-dnd-html5-backend@16.0.1:
@@ -11905,7 +11917,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-    dev: false
 
   /react-dropzone@14.2.3(react@18.2.0):
     resolution: {integrity: sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==}
@@ -12199,7 +12210,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /reactcss@1.2.3(react@18.2.0):
     resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
@@ -13548,6 +13558,11 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
+  /type-fest@4.31.0:
+    resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
+    engines: {node: '>=16'}
+    dev: false
+
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -14508,9 +14523,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/a9848d4(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a9848d4}
-    id: github.com/theopensystemslab/planx-core/a9848d4
+  github.com/theopensystemslab/planx-core/f2f555b(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
+    id: github.com/theopensystemslab/planx-core/f2f555b
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -14527,16 +14542,16 @@ packages:
       copyfiles: 2.4.1
       docx: 9.1.0
       eslint: 8.57.1
-      fast-xml-parser: 4.5.0
-      graphql: 16.9.0
-      graphql-request: 6.1.0(graphql@16.9.0)
+      fast-xml-parser: 4.5.1
+      graphql: 16.10.0
+      graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
       lodash: 4.17.21
-      marked: 15.0.3
+      marked: 15.0.5
       prettier: 3.4.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.30.0
+      type-fest: 4.31.0
       uuid: 11.0.3
       zod: 3.24.0
     transitivePeerDependencies:

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@8.6.6",
   "keywords": [],
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a9848d4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3"
   },

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@8.6.6",
   "keywords": [],
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d004278",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3"
   },

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@8.6.6",
   "keywords": [],
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#f2f555b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a7ec46d",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3"
   },

--- a/scripts/encrypt/pnpm-lock.yaml
+++ b/scripts/encrypt/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
-    version: github.com/theopensystemslab/planx-core/a7ec46d
+    specifier: git+https://github.com/theopensystemslab/planx-core#d004278
+    version: github.com/theopensystemslab/planx-core/d004278
   ts-node:
     specifier: ^10.9.2
     version: 10.9.2(@types/node@22.10.1)(typescript@5.4.3)
@@ -2092,12 +2092,12 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
+  /zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a7ec46d:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
+  github.com/theopensystemslab/planx-core/d004278:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d004278}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2125,7 +2125,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.30.2
       uuid: 11.0.3
-      zod: 3.24.0
+      zod: 3.24.1
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/scripts/encrypt/pnpm-lock.yaml
+++ b/scripts/encrypt/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a9848d4
-    version: github.com/theopensystemslab/planx-core/a9848d4
+    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
+    version: github.com/theopensystemslab/planx-core/f2f555b
   ts-node:
     specifier: ^10.9.2
     version: 10.9.2(@types/node@22.10.1)(typescript@5.4.3)
@@ -334,12 +334,12 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.9.0):
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.10.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      graphql: 16.9.0
+      graphql: 16.10.0
     dev: false
 
   /@humanwhocodes/config-array@0.13.0:
@@ -1114,8 +1114,8 @@ packages:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
     dev: false
 
-  /fast-xml-parser@4.5.0:
-    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+  /fast-xml-parser@4.5.1:
+    resolution: {integrity: sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -1218,20 +1218,20 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: false
 
-  /graphql-request@6.1.0(graphql@16.9.0):
+  /graphql-request@6.1.0(graphql@16.10.0):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
       graphql: 14 - 16
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       cross-fetch: 3.1.8
-      graphql: 16.9.0
+      graphql: 16.10.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /graphql@16.9.0:
-    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+  /graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: false
 
@@ -1467,8 +1467,8 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: false
 
-  /marked@15.0.3:
-    resolution: {integrity: sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==}
+  /marked@15.0.4:
+    resolution: {integrity: sha512-TCHvDqmb3ZJ4PWG7VEGVgtefA5/euFmsIhxtD0XsBxI39gUSKL81mIRFdt0AiNQozUahd4ke98ZdirExd/vSEw==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -1941,8 +1941,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /type-fest@4.30.0:
-    resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
+  /type-fest@4.30.2:
+    resolution: {integrity: sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==}
     engines: {node: '>=16'}
     dev: false
 
@@ -2092,8 +2092,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a9848d4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a9848d4}
+  github.com/theopensystemslab/planx-core/f2f555b:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2110,16 +2110,16 @@ packages:
       copyfiles: 2.4.1
       docx: 9.1.0
       eslint: 8.57.1
-      fast-xml-parser: 4.5.0
-      graphql: 16.9.0
-      graphql-request: 6.1.0(graphql@16.9.0)
+      fast-xml-parser: 4.5.1
+      graphql: 16.10.0
+      graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
       lodash: 4.17.21
-      marked: 15.0.3
+      marked: 15.0.4
       prettier: 3.4.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      type-fest: 4.30.0
+      type-fest: 4.30.2
       uuid: 11.0.3
       zod: 3.24.0
     transitivePeerDependencies:

--- a/scripts/encrypt/pnpm-lock.yaml
+++ b/scripts/encrypt/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#f2f555b
-    version: github.com/theopensystemslab/planx-core/f2f555b
+    specifier: git+https://github.com/theopensystemslab/planx-core#a7ec46d
+    version: github.com/theopensystemslab/planx-core/a7ec46d
   ts-node:
     specifier: ^10.9.2
     version: 10.9.2(@types/node@22.10.1)(typescript@5.4.3)
@@ -1448,6 +1448,10 @@ packages:
       p-locate: 5.0.0
     dev: false
 
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: false
@@ -2092,8 +2096,8 @@ packages:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/f2f555b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/f2f555b}
+  github.com/theopensystemslab/planx-core/a7ec46d:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a7ec46d}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2114,7 +2118,7 @@ packages:
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
       json-schema-to-typescript: 15.0.3
-      lodash: 4.17.21
+      lodash-es: 4.17.21
       marked: 15.0.4
       prettier: 3.4.2
       react: 18.3.1


### PR DESCRIPTION
## What does this PR do?
 - Updates to ESM planx-core - https://github.com/theopensystemslab/planx-core/pull/601
 - This required the E2E project to be converted to ESM also. Please see above PR for motivations here.
 
 ## Why?
Part of the process of getting the schema repo published as a library - https://github.com/theopensystemslab/planx-core/pull/600