### PR TITLE
refactor: Universal toggle button

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleDataFieldsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleDataFieldsButton.tsx
@@ -1,9 +1,7 @@
 import DataFieldIcon from "@mui/icons-material/Code";
-import DataFieldOffIcon from "@mui/icons-material/CodeOff";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import ToggleIconButton from "ui/editor/ToggleIconButton";
 
 export const ToggleDataFieldsButton: React.FC = () => {
   const [showDataFields, toggleShowDataFields] = useStore((state) => [
@@ -12,24 +10,12 @@ export const ToggleDataFieldsButton: React.FC = () => {
   ]);
 
   return (
-    <Tooltip title="Toggle data fields" placement="right">
-      <IconButton
-        aria-label="Toggle data fields"
-        onClick={toggleShowDataFields}
-        size="large"
-        sx={(theme) => ({
-          background: theme.palette.background.paper,
-          padding: theme.spacing(1),
-          color: showDataFields
-            ? theme.palette.text.primary
-            : theme.palette.text.disabled,
-          "&:hover": {
-            background: theme.palette.common.white,
-          },
-        })}
-      >
-        {showDataFields ? <DataFieldIcon /> : <DataFieldOffIcon />}
-      </IconButton>
-    </Tooltip>
+    <ToggleIconButton
+      isToggled={showDataFields}
+      onToggle={toggleShowDataFields}
+      icon={<DataFieldIcon />}
+      tooltip="Toggle data fields"
+      ariaLabel="Toggle data fields"
+    />
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleHelpTextButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleHelpTextButton.tsx
@@ -1,9 +1,7 @@
-import HelpTextOffIcon from "@mui/icons-material/DoNotDisturbOff";
 import HelpTextIcon from "@mui/icons-material/Help";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import ToggleIconButton from "ui/editor/ToggleIconButton";
 
 export const ToggleHelpTextButton: React.FC = () => {
   const [showHelpText, toggleShowHelpText] = useStore((state) => [
@@ -12,24 +10,12 @@ export const ToggleHelpTextButton: React.FC = () => {
   ]);
 
   return (
-    <Tooltip title="Toggle help text" placement="right">
-      <IconButton
-        aria-label="Toggle help text"
-        onClick={toggleShowHelpText}
-        size="large"
-        sx={(theme) => ({
-          background: theme.palette.background.paper,
-          padding: theme.spacing(1),
-          color: showHelpText
-            ? theme.palette.text.primary
-            : theme.palette.text.disabled,
-          "&:hover": {
-            background: theme.palette.common.white,
-          },
-        })}
-      >
-        {showHelpText ? <HelpTextIcon /> : <HelpTextOffIcon />}
-      </IconButton>
-    </Tooltip>
+    <ToggleIconButton
+      isToggled={showHelpText}
+      onToggle={toggleShowHelpText}
+      icon={<HelpTextIcon />}
+      tooltip="Toggle help text"
+      ariaLabel="Toggle help text"
+    />
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleImagesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleImagesButton.tsx
@@ -1,9 +1,7 @@
-import ImageOffIcon from "@mui/icons-material/HideImage";
 import ImageIcon from "@mui/icons-material/Image";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import ToggleIconButton from "ui/editor/ToggleIconButton";
 
 export const ToggleImagesButton: React.FC = () => {
   const [showImages, toggleShowImages] = useStore((state) => [
@@ -12,24 +10,12 @@ export const ToggleImagesButton: React.FC = () => {
   ]);
 
   return (
-    <Tooltip title="Toggle images" placement="right">
-      <IconButton
-        aria-label="Toggle images"
-        onClick={toggleShowImages}
-        size="large"
-        sx={(theme) => ({
-          background: theme.palette.background.paper,
-          padding: theme.spacing(1),
-          color: showImages
-            ? theme.palette.text.primary
-            : theme.palette.text.disabled,
-          "&:hover": {
-            background: theme.palette.common.white,
-          },
-        })}
-      >
-        {showImages ? <ImageIcon /> : <ImageOffIcon />}
-      </IconButton>
-    </Tooltip>
+    <ToggleIconButton
+      isToggled={showImages}
+      onToggle={toggleShowImages}
+      icon={<ImageIcon />}
+      tooltip="Toggle images"
+      ariaLabel="Toggle images"
+    />
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FlowEditor/ToggleTagsButton.tsx
@@ -1,9 +1,7 @@
 import LabelIcon from "@mui/icons-material/Label";
-import LabelOffIcon from "@mui/icons-material/LabelOff";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import ToggleIconButton from "ui/editor/ToggleIconButton";
 
 export const ToggleTagsButton: React.FC = () => {
   const [showTags, toggleShowTags] = useStore((state) => [
@@ -12,24 +10,12 @@ export const ToggleTagsButton: React.FC = () => {
   ]);
 
   return (
-    <Tooltip title="Toggle tags" placement="right">
-      <IconButton
-        aria-label="Toggle tags"
-        onClick={toggleShowTags}
-        size="large"
-        sx={(theme) => ({
-          background: theme.palette.background.paper,
-          padding: theme.spacing(1),
-          color: showTags
-            ? theme.palette.text.primary
-            : theme.palette.text.disabled,
-          "&:hover": {
-            background: theme.palette.common.white,
-          },
-        })}
-      >
-        {showTags ? <LabelIcon /> : <LabelOffIcon />}
-      </IconButton>
-    </Tooltip>
+    <ToggleIconButton
+      isToggled={showTags}
+      onToggle={toggleShowTags}
+      icon={<LabelIcon />}
+      tooltip="Toggle tags"
+      ariaLabel="Toggle tags"
+    />
   );
 };

--- a/editor.planx.uk/src/ui/editor/ToggleIconButton.tsx
+++ b/editor.planx.uk/src/ui/editor/ToggleIconButton.tsx
@@ -1,0 +1,59 @@
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import React from "react";
+import ToggleOverlayIcon from "ui/icons/ToggleOverlay";
+
+interface ToggleIconButtonProps {
+  isToggled: boolean;
+  onToggle: () => void;
+  icon: React.ReactNode;
+  tooltip: string;
+  ariaLabel: string;
+}
+
+const ToggleIconButton: React.FC<ToggleIconButtonProps> = ({
+  isToggled,
+  onToggle,
+  icon,
+  tooltip,
+  ariaLabel,
+}) => {
+  return (
+    <Tooltip title={tooltip} placement="right">
+      <IconButton
+        aria-label={ariaLabel}
+        onClick={onToggle}
+        size="large"
+        sx={(theme) => ({
+          position: "relative",
+          background: theme.palette.background.paper,
+          padding: theme.spacing(1),
+          color: isToggled
+            ? theme.palette.text.disabled
+            : theme.palette.text.primary,
+
+          "&:hover": {
+            background: theme.palette.common.white,
+          },
+        })}
+      >
+        {icon}
+        <Box
+          sx={{
+            position: "absolute",
+            top: "55%",
+            left: "48%",
+            transform: "translate(-50%, -50%)",
+            opacity: isToggled ? 1 : 0,
+            transition: "opacity 0.2s ease-in-out",
+          }}
+        >
+          <ToggleOverlayIcon />
+        </Box>
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ToggleIconButton;

--- a/editor.planx.uk/src/ui/icons/ToggleOverlay.tsx
+++ b/editor.planx.uk/src/ui/icons/ToggleOverlay.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 export default function EditorIcon(props: SvgIconProps) {
   const theme = useTheme();
   const inactiveColor = theme.palette.text.disabled;
+  const overlayColor = theme.palette.background.paper;
 
   return (
     <SvgIcon {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -12,7 +13,10 @@ export default function EditorIcon(props: SvgIconProps) {
         points="0 0 1.45 0 24 22.5 24 24 22.46 24 0 1.52 0 0"
         fill={inactiveColor}
       />
-      <polygon points="1.45 0 4.48 0 24 19.55 24 22.5 1.45 0" fill="#fff" />
+      <polygon
+        points="1.45 0 4.48 0 24 19.55 24 22.5 1.45 0"
+        fill={overlayColor}
+      />
     </SvgIcon>
   );
 }

--- a/editor.planx.uk/src/ui/icons/ToggleOverlay.tsx
+++ b/editor.planx.uk/src/ui/icons/ToggleOverlay.tsx
@@ -1,12 +1,16 @@
+import { useTheme } from "@mui/material/styles";
 import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
 import * as React from "react";
 
 export default function EditorIcon(props: SvgIconProps) {
+  const theme = useTheme();
+  const inactiveColor = theme.palette.text.disabled;
+
   return (
     <SvgIcon {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
       <polygon
         points="0 0 1.45 0 24 22.5 24 24 22.46 24 0 1.52 0 0"
-        fill="#68787D"
+        fill={inactiveColor}
       />
       <polygon points="1.45 0 4.48 0 24 19.55 24 22.5 1.45 0" fill="#fff" />
     </SvgIcon>

--- a/editor.planx.uk/src/ui/icons/ToggleOverlay.tsx
+++ b/editor.planx.uk/src/ui/icons/ToggleOverlay.tsx
@@ -1,0 +1,14 @@
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+import * as React from "react";
+
+export default function EditorIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <polygon
+        points="0 0 1.45 0 24 22.5 24 24 22.46 24 0 1.52 0 0"
+        fill="#68787D"
+      />
+      <polygon points="1.45 0 4.48 0 24 19.55 24 22.5 1.45 0" fill="#fff" />
+    </SvgIcon>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

- Simplifies toggle button setup so that styles are defined once in a shared component `ToggleIconButton.tsx`
- Adds a custom "strikethrough" icon overlay to remove reliance on active/inactive icon pairings when using toggle buttons

**Test:**
https://4115.planx.pizza/barnet/find-out-if-you-need-planning-permission

**Before change:**
![image](https://github.com/user-attachments/assets/07926034-e2b6-448b-adf0-70fc18ae6605)

**After change (small visual difference):**
![image](https://github.com/user-attachments/assets/34ea17f6-e5b1-4c5f-b039-4dc26e458ee1)