### PR TITLE
fix: ensure area is correctly displayed when navigating back to DrawBoundary

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -57,8 +57,9 @@ export default function Component(props: Props) {
     props.previouslySubmittedData?.data?.[props.fn] ||
     passport.data?.["property.boundary"];
   const previousArea =
-    props.previouslySubmittedData?.data?.[props.fn] ||
+    props.previouslySubmittedData?.data?.[`${props.fn}.area`] ||
     passport.data?.["property.boundary.area"];
+  
   const [boundary, setBoundary] = useState<Boundary>(previousBoundary);
   const [area, setArea] = useState<number | undefined>(previousArea);
   const [mapValidationError, setMapValidationError] = useState<string>();

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/model.ts
@@ -28,7 +28,7 @@ export const parseDrawBoundary = (
     data?.descriptionForUploading ||
     defaultContent?.["descriptionForUploading"],
   hideFileUpload: data?.hideFileUpload || defaultContent?.["hideFileUpload"],
-  fn: data?.fn || defaultContent?.["fn"],
+  fn: defaultContent?.["fn"], // input is disabled, no need to account for data?.fn
   info: data?.info || defaultContent?.["info"],
   policyRef: data?.policyRef || defaultContent?.["policyRef"],
   howMeasured: data?.howMeasured || defaultContent?.["howMeasured"],


### PR DESCRIPTION
Per data migraiton feedback here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1736347450892489?thread_ts=1736239726.670049&cid=C01E3AC0C03

When navigating "back" to a DrawBoundary it was incorrectly displaying this:
![Screenshot 2025-01-08 at 14 41 18](https://github.com/user-attachments/assets/0325229b-b37a-4924-aaf6-c1f66ad23583)
