### PR TITLE
chore: bump planx-core

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dc2386b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e126742",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dc2386b
-    version: github.com/theopensystemslab/planx-core/dc2386b
+    specifier: git+https://github.com/theopensystemslab/planx-core#e126742
+    version: github.com/theopensystemslab/planx-core/e126742
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7312,8 +7312,8 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dc2386b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dc2386b}
+  github.com/theopensystemslab/planx-core/e126742:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e126742}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dc2386b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e126742",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dc2386b
-    version: github.com/theopensystemslab/planx-core/dc2386b
+    specifier: git+https://github.com/theopensystemslab/planx-core#e126742
+    version: github.com/theopensystemslab/planx-core/e126742
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -1137,7 +1137,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: false
 
   /convert-source-map@1.9.0:
@@ -3047,8 +3047,8 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dc2386b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dc2386b}
+  github.com/theopensystemslab/planx-core/e126742:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e126742}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dc2386b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e126742",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dc2386b
-    version: github.com/theopensystemslab/planx-core/dc2386b
+    specifier: git+https://github.com/theopensystemslab/planx-core#e126742
+    version: github.com/theopensystemslab/planx-core/e126742
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2601,8 +2601,8 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/dc2386b:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dc2386b}
+  github.com/theopensystemslab/planx-core/e126742:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e126742}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
See https://github.com/theopensystemslab/planx-core/pull/614

**Testing notes:**
- I've copied an "old" session from Bucks RAB production into this pizza database to confirm that the overview document maps display correctly
- Login to the pizza editor to generate an auth token then open this admin endpoint in your browser: https://api.4121.planx.pizza/admin/session/12c48901-178d-445d-a550-783a36ba4bc1/html
  - Confirm that you have the subtext "The user accepted the title boundary" and a grey code block "boundary" populated
  - There's CORS errors in the console related the the OS maps display that are consistent with production that we can fix forward later (this seems to be specific to the admin endpoint and local downloads are fine)
  - But the presence of the subtext & "boundary" block are confirmation that variables are linking up again when compared to prod endpoint https://api.editor.planx.uk/admin/session/12c48901-178d-445d-a550-783a36ba4bc1/html

I've additionally confirmed that sessions started _and_ submitted today (so only new data fields present) are correctly displaying documents and maps - download `115c6638-f77a-40d4-a653-2dc1ea342214` from here to confirm https://editor.planx.uk/gateshead/report-a-planning-breach/submissions-log