### PR TITLE
chore: bump planx-core in Editor

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dc2386b",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e126742",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#dc2386b
-    version: github.com/theopensystemslab/planx-core/dc2386b(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#e126742
+    version: github.com/theopensystemslab/planx-core/e126742(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14523,9 +14523,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/dc2386b(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dc2386b}
-    id: github.com/theopensystemslab/planx-core/dc2386b
+  github.com/theopensystemslab/planx-core/e126742(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e126742}
+    id: github.com/theopensystemslab/planx-core/e126742
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
Bumped planx-core in line with the API and E2E here:

https://github.com/theopensystemslab/planx-new/pull/4121