### PR TITLE
feat: Read dbUrl from config file, not remote pulumi

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -4,6 +4,8 @@ config:
   application:airbrake-project-key:
     secure: AAABAPIGB+gWevPn0SzWnuSuV1RmdwpLOlWKnu8cM/kxLfslvdCIRcU0n0M0XNJ3jwj4EdFn7/llsL1Kg2XnDA==
   application:cloudflare-zone-id: a9b9933f28e786ec4cfd4bb596f5a519
+  application:db-url:
+    secure: AAABAFMl4J25TQyb+dAVA/8g5KR1aIP7cOZrrLqYzv4ScF4AGIDWnp6zC9wV+Odja2LZyy10cbUojs1mybg1EV82UAZfEX+HCcaNixJvTuoC0h4swDMdLXX9vvs1QqsC6Q+7qp96hQCT8CW81TbdDSVIu2mLbV8dnjyuD2R8o4tt5pBmXKCVJJ4zWI5LuukolIj3nw==
   application:encryption-key:
     secure: AAABAGbTpoRtazwoNFNmaPCW0RdeTqjhEzQuYR1kl4ft7EWNxqswAu8Dc9T+YBxkYr3uaHbu5obzyo8I4QuVgg==
   application:file-api-key:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -5,6 +5,8 @@ config:
     secure: AAABABujxMHxU8Abj4QpyQTz7bLt3AP2wBFaypVkDZ2khzc6eh6lHLljTEkzpLUncno3gNNDXnrmxzXvqKnQdQ==
   application:cloudflare-zone-id:
     secure: AAABAPZz/bzFCZEZd+jzPpYP4HXAOLYQmLGf2YLQE2YPfMBUtDC83KCo2l2DJ4AL4OKL+jFFx8wrrJc6DDwXJQ==
+  application:db-url:
+    secure: AAABAHaVuHg4NkZjMQv7N8hpKRJL13IW721pPo/ou6+itPn2PLYr8s8YjTbaxDGZg9LiB5QAgbihA1fSnIolokoZ/wJ7VzkHOI59Icci0CEoOgQrUfzDFevpgt3HaTmyrxIzemMbOPl/dGcJCTW0K9NkRADWE4z2OERcFwQBRUZuRSwIbV7teXpbY15IAW24FLNM+g==
   application:encryption-key:
     secure: AAABAFTW2eRwQnXJq/IboPWtStOWXiF9WcsUKEiuosmp7TLZt52uKE3L+NrEGgsThOl3NkvFW2HhFa2XL6aB5w==
   application:file-api-key:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -114,7 +114,7 @@ export = async () => {
     vpc,
   });
 
-  const dbRootUrl: string = await data.requireOutputValue("dbRootUrl");
+  const dbRootUrl: string = config.requireSecret("db-url");
 
   // ----------------------- Metabase
   const pgRoot = url.parse(dbRootUrl);

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -20,7 +20,7 @@ export const createHasuraService = async ({
 }: CreateService) => {
 
   const config = new pulumi.Config();
-  const dbRootUrl: string = await data.requireOutputValue("dbRootUrl");
+  const dbRootUrl: string = config.requireSecret("db-url");
   const DOMAIN: string = await certificates.requireOutputValue("domain");
 
   const lbHasura = new awsx.lb.ApplicationLoadBalancer("hasura", {


### PR DESCRIPTION
- After restoring the production db to a point in time 9/1/25, we need to point to a new db instance
- This is currently controlled via an output from the data layer (`dbRootUrl`)
- Rather than run this layer and try to get it to update and point to the new db, we're just statically importing the db root url from the pulumi config file now

This does not affect any workflows as we don't have an automated link between the data and application layer.