### PR TITLE
fix: Pulumi output syntax

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -114,7 +114,7 @@ export = async () => {
     vpc,
   });
 
-  const dbRootUrl: string = config.requireSecret("db-url");
+  const dbRootUrl = config.requireSecret("db-url").get();
 
   // ----------------------- Metabase
   const pgRoot = url.parse(dbRootUrl);

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -20,7 +20,7 @@ export const createHasuraService = async ({
 }: CreateService) => {
 
   const config = new pulumi.Config();
-  const dbRootUrl: string = config.requireSecret("db-url");
+  const dbRootUrl = config.requireSecret("db-url").get();
   const DOMAIN: string = await certificates.requireOutputValue("domain");
 
   const lbHasura = new awsx.lb.ApplicationLoadBalancer("hasura", {


### PR DESCRIPTION
Currently, we're returning an `Output<string>` instead of a `string` type - this should resolve it!