### PR TITLE
fix: explicitly use URLSearchParams when constructing send to email magic links

### DIFF
--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -34,13 +34,20 @@ export const sendToEmail: SendIntegrationController = async (
     const { email, flow } = await getSessionEmailDetailsById(sessionId);
     const flowName = flow.name;
 
+    // Make application files download magic link
+    const params = new URLSearchParams({
+      email: teamSettings.submissionEmail,
+      localAuthority: localAuthority,
+    });
+    const applicationFilesDownloadLink = `${process.env.API_URL_EXT}/download-application-files/${sessionId}?${params}`;
+
     // Prepare email template
     const config: EmailSubmissionNotifyConfig = {
       personalisation: {
         serviceName: flowName,
         sessionId,
         applicantEmail: email,
-        downloadLink: `${process.env.API_URL_EXT}/download-application-files/${sessionId}?email=${teamSettings.submissionEmail}&localAuthority=${localAuthority}`,
+        downloadLink: applicationFilesDownloadLink,
         ...teamSettings,
       },
     };


### PR DESCRIPTION
See #help-issues thread from Tewkesbury here: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1736501911947289

**Here's what's happening:**
- :heavy_check_mark: Our submissions log button downloads as expected
- :heavy_check_mark: The magic link saved in our `email_applications` audit table downloads as expected
- :x: The magic link when clicked directly from the body of a Gov Notify email does _not_ download as expected and instead throws error: `error: "Missing values required to access application files"` (email forwarded to `devops@`)
  - It appears Gov Notify has automatically wrapped the link (eg `https://linkprotect.cudasvc.com/url?a={our encoded URL}` which fails to properly decode the second query param in the request
  - Eg see `amp;localAuthority` when inspecting the network request here: 
![Screenshot from 2025-01-13 08-56-07](https://github.com/user-attachments/assets/5c72a09c-8438-4f8a-b6ba-ef02f7541556)

**Open questions:**
- Is this bug even on our side of the fence, is this a recent Gov Notify change ?? Can't find anything specific in the docs about this third party service! https://www.notifications.service.gov.uk/using-notify/links-and-URLs
- Is this isolated to Tewkesbury or their internal network/email applications, why haven't we heard from high-volume send to email teams like Bucks about same?

**Changes & testing:** 
- I'm hoping that explicitly calling `new URLSearchParams()` when constructing our magic link may fix this instead of the previous plain string template approach? Any other more robust ideas here?
- Use the pizza to send a Gov Notify email and check the URL in the email body
  - **The magic link downloads as expected for me on the pizza, but is notably NOT wrapped in the `linkprotect` URL, which likely confirms this is unqiue to Tewkesbury and _not_ Gov Notify as a whole** 
  - Likely not able to test this any further locally without deploying to prod & asking Tewkesbury to test _next_ live app received or on staging?
- Unfortunately any solution here is only going to apply to _new/future_ emails and not ones already received, so we'll want to continue pointing councils to the Submissions Logs for those if we hear of others with this issue
