### PR TITLE
fix: Add optional chaining to flag check

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -942,7 +942,7 @@ const collectedFlagValuesByCategory = (
     if (breadcrumb.answers) {
       breadcrumb.answers.forEach((answerId) => {
         const node = flow[answerId];
-        if (node.data?.flags) {
+        if (node?.data?.flags) {
           node.data.flags.forEach((flag: Flag["value"]) => {
             if (possibleFlagValues.includes(flag)) collectedFlags.push(flag);
           });


### PR DESCRIPTION
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/23377ce1-a7a7-41dd-b4cb-4d9c85ced608" />

This should address an error raised by Greg (via email).

I haven't actually worked out the underlying issue here yet (why there's a node without data) but I'm currently looking into this by working through the session's breadcrumbs.