### PR TITLE
feat: Metabase dashboard service and controller

### DIFF
--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -22,6 +22,33 @@ components:
           type: integer
           description: Optional ID of the parent collection
 
+    NewDashboard:
+      type: object
+      properties:
+        templateId:
+          type: integer
+          description: ID of the template dashboard to copy from
+        description:
+          type: string
+          description: Optional description for the dashboard
+        collectionId:
+          type: integer
+          description: Optional ID of the collection to place the dashboard in
+        collectionPosition:
+          type: integer
+          description: Optional position within the collection
+          minimum: 0
+        filter:
+          type: string
+          description: Filter parameter to update
+        value:
+          type: string
+          description: Value to set for the filter
+      required:
+        - templateId
+        - filter
+        - value
+
 paths:
   /analytics/log-user-exit:
     post:
@@ -75,6 +102,53 @@ paths:
                     description: Metabase collection ID
         "400":
           description: Bad request or collection creation failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+
+  /metabase/dashboard/{slug}/{service}:
+    post:
+      summary: Create new Metabase dashboard
+      description: Creates a new dashboard in Metabase by copying a template and updating filters
+      tags:
+        - metabase
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: PlanX team slug
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Service identifier
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewDashboard"
+      responses:
+        "201":
+          description: Dashboard created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+                    description: Public link to the created dashboard
+        "400":
+          description: Bad request or dashboard creation failed
           content:
             application/json:
               schema:

--- a/api.planx.uk/modules/analytics/metabase/dashboard/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/controller.ts
@@ -1,0 +1,21 @@
+import { createNewDashboard } from "./service.js";
+import type { NewDashboardHandler } from "./types.js";
+
+export const metabaseDashboardsController: NewDashboardHandler = async (
+  _req,
+  res,
+) => {
+  try {
+    const params = {
+      ...res.locals.parsedReq.params,
+      ...res.locals.parsedReq.body,
+    };
+    const dashboard = await createNewDashboard(params);
+    res.status(201).json({ data: dashboard });
+  } catch (error) {
+    res.status(400).json({
+      error:
+        error instanceof Error ? error.message : "An unexpected error occurred",
+    });
+  }
+};

--- a/api.planx.uk/modules/analytics/metabase/dashboard/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/controller.ts
@@ -10,10 +10,15 @@ export const metabaseDashboardsController: NewDashboardHandler = async (
       ...res.locals.parsedReq.params,
       ...res.locals.parsedReq.body,
     };
+    console.log("Received params:", params);
     const dashboard = await createNewDashboard(params);
-    res.status(201).json({ data: dashboard });
+    return res.status(201).json({ data: dashboard });
   } catch (error) {
-    res.status(400).json({
+    console.error("Controller error:", error);
+    if (error instanceof Error) {
+      console.error("Error stack:", error.stack);
+    }
+    return res.status(400).json({
       error:
         error instanceof Error ? error.message : "An unexpected error occurred",
     });

--- a/api.planx.uk/modules/analytics/metabase/dashboard/copyDashboard.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/copyDashboard.ts
@@ -1,13 +1,16 @@
 import type { CopyDashboardParams } from "./types.js";
 import { $metabase } from "../shared/client.js";
+import { toMetabaseParams } from "./types.js";
 
 /** Returns the ID of the copied dashboard. */
 export async function copyDashboard(
   params: CopyDashboardParams,
 ): Promise<number> {
+  const metabaseParams = toMetabaseParams(params);
+  console.log({ metabaseParams });
   const response = await $metabase.post(
     `/api/dashboard/${params.templateId}/copy`,
-    params,
+    metabaseParams,
   );
   return response.data.id;
 }

--- a/api.planx.uk/modules/analytics/metabase/dashboard/copyDashboard.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/copyDashboard.ts
@@ -1,0 +1,13 @@
+import type { CopyDashboardParams } from "./types.js";
+import { $metabase } from "../shared/client.js";
+
+/** Returns the ID of the copied dashboard. */
+export async function copyDashboard(
+  params: CopyDashboardParams,
+): Promise<number> {
+  const response = await $metabase.post(
+    `/api/dashboard/${params.templateId}/copy`,
+    params,
+  );
+  return response.data.id;
+}

--- a/api.planx.uk/modules/analytics/metabase/dashboard/dashboard.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/dashboard.test.ts
@@ -1,1 +1,243 @@
-test.todo("should test dashboard creation, filtering and link generation");
+import nock from "nock";
+import { copyDashboard } from "./copyDashboard.js";
+import { getDashboard } from "./getDashboard.js";
+import { updateFilter } from "./updateFilter.js";
+import { toMetabaseParams } from "./types.js";
+import { generatePublicLink } from "./generatePublicLink.js";
+
+describe("Dashboard Operations", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("getDashboard", () => {
+    test("gets dashboard name from Metabase", async () => {
+      const dashboardId = 7;
+      const metabaseMock = nock(process.env.METABASE_URL_EXT!)
+        .get(`/api/dashboard/${dashboardId}`)
+        .reply(200, {
+          name: "Template - Test Dashboard",
+        });
+
+      const dashboard = await getDashboard(dashboardId);
+      expect(dashboard.name).toBe("Template - Test Dashboard");
+      expect(metabaseMock.isDone()).toBe(true);
+    });
+  });
+
+  describe("copyDashboard", () => {
+    test("copies dashboard template", async () => {
+      const params = {
+        name: "Template - Test Dashboard",
+        templateId: 7,
+        description: "Here is a description.",
+        collectionId: 4,
+        isDeepCopy: false,
+      };
+
+      const metabaseMock = nock(process.env.METABASE_URL_EXT!)
+        .post("/api/dashboard/7/copy", {
+          name: params.name,
+          description: params.description,
+          collection_id: params.collectionId,
+          is_deep_copy: params.isDeepCopy,
+        })
+        .reply(200, {
+          id: 42,
+          name: params.name,
+          description: params.description,
+        });
+
+      const dashboard = await copyDashboard({
+        name: "Template - Test Dashboard",
+        templateId: 7,
+        description: "Here is a description.",
+        collectionId: 4,
+      });
+
+      expect(dashboard).toBe(42);
+      expect(metabaseMock.isDone()).toBe(true);
+    });
+
+    test("copies and renames dashboard", async () => {
+      const params = {
+        name: "New Dashboard Name",
+        templateId: 7,
+        description: "New dashboard description",
+        collectionId: 4,
+        isDeepCopy: false,
+      };
+
+      const metabaseMock = nock(process.env.METABASE_URL_EXT!)
+        .post("/api/dashboard/7/copy", {
+          name: params.name,
+          description: params.description,
+          collection_id: params.collectionId,
+          is_deep_copy: params.isDeepCopy,
+        })
+        .reply(200, {
+          id: 43,
+          name: params.name,
+          description: params.description,
+        });
+
+      const dashboard = await copyDashboard(params);
+      expect(dashboard).toBe(43);
+      expect(metabaseMock.isDone()).toBe(true);
+    });
+
+    test("transforms params to snake case for Metabase API", async () => {
+      const params = {
+        name: "Barnet",
+        templateId: 88,
+        collectionId: 4,
+        collectionPosition: 2,
+      };
+
+      const snakeCaseParams = toMetabaseParams(params);
+      expect(snakeCaseParams).toHaveProperty("collection_id");
+      expect(snakeCaseParams.collection_id).toBe(4);
+      expect(snakeCaseParams).toHaveProperty("collection_position");
+      expect(snakeCaseParams.collection_position).toBe(2);
+    });
+
+    test("places new dashboard into correct parent", async () => {
+      const params = {
+        name: "Template - Test Dashboard",
+        templateId: 7,
+        description: "Here is a description.",
+        collectionId: 4,
+        isDeepCopy: false,
+      };
+
+      const metabasePostMock = nock(process.env.METABASE_URL_EXT!)
+        .post("/api/dashboard/7/copy", {
+          name: params.name,
+          description: params.description,
+          collection_id: params.collectionId,
+          is_deep_copy: params.isDeepCopy,
+        })
+        .reply(200, {
+          id: 42,
+          name: params.name,
+          collectionId: 4,
+          description: params.description,
+        });
+
+      const metabaseGetMock = nock(process.env.METABASE_URL_EXT!)
+        .get("/api/dashboard/42")
+        .reply(200, {
+          name: params.name,
+          id: 42,
+          collection_id: 4,
+        });
+
+      const newDashboardId = await copyDashboard(params);
+      const checkDashboard = await getDashboard(newDashboardId);
+
+      expect(checkDashboard.collection_id).toBe(4);
+      expect(metabasePostMock.isDone()).toBe(true);
+      expect(metabaseGetMock.isDone()).toBe(true);
+    });
+  });
+
+  describe("updateFilter", () => {
+    const dashboardId = 123;
+    const filterName = "test_filter";
+    const filterValue = "new_value";
+
+    test("successfully updates string filter value", async () => {
+      nock(process.env.METABASE_URL_EXT!)
+        .get(`/api/dashboard/${dashboardId}`)
+        .reply(200, {
+          parameters: [
+            {
+              name: filterName,
+              type: "string/=",
+              default: ["old_value"],
+            },
+          ],
+        });
+
+      nock(process.env.METABASE_URL_EXT!)
+        .put(`/api/dashboard/${dashboardId}`, {
+          parameters: [
+            {
+              name: filterName,
+              type: "string/=",
+              default: [filterValue],
+            },
+          ],
+        })
+        .reply(200, {
+          parameters: [
+            {
+              name: filterName,
+              type: "string/=",
+              default: [filterValue],
+            },
+          ],
+          param_fields: {},
+        });
+
+      await expect(
+        updateFilter({
+          dashboardId: dashboardId,
+          filter: filterName,
+          value: filterValue,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    test("handles non-string filter type appropriately", async () => {
+      nock(process.env.METABASE_URL_EXT!)
+        .get(`/api/dashboard/${dashboardId}`)
+        .reply(200, {
+          parameters: [
+            {
+              name: filterName,
+              slug: "event",
+              id: "30a24538",
+              type: "number/=",
+              sectionId: "number",
+              default: [42],
+            },
+          ],
+        });
+
+      nock(process.env.METABASE_URL_EXT!)
+        .put(`/api/dashboard/${dashboardId}`)
+        .reply(400, {
+          message: "Invalid parameter type. Expected number, got string.",
+        });
+
+      await expect(
+        updateFilter({
+          dashboardId: dashboardId,
+          filter: filterName,
+          value: "not_a_number",
+        }),
+      ).rejects.toThrow(
+        "Filter type 'number/=' is not supported. Only string filters are currently supported.",
+      );
+    });
+  });
+
+  describe("generatePublicLink", () => {
+    test("generates public link", async () => {
+      const dashboardId = 8;
+      const testUuid = 1111111;
+
+      nock(process.env.METABASE_URL_EXT!)
+        .post(`/api/dashboard/${dashboardId}/public_link`)
+        .reply(200, {
+          uuid: testUuid,
+        });
+
+      const link = await generatePublicLink(dashboardId);
+      expect(link).toBe(
+        `${process.env.METABASE_URL_EXT}/public/dashboard/${testUuid}`,
+      );
+    });
+  });
+});

--- a/api.planx.uk/modules/analytics/metabase/dashboard/generatePublicLink.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/generatePublicLink.ts
@@ -1,0 +1,8 @@
+import { $metabase } from "../shared/client.js";
+
+/** Returns the ID of the copied dashboard. */
+export async function generatePublicLink(params: number): Promise<string> {
+  const response = await $metabase.post(`/api/dashboard/${params}/public_link`);
+  const url = `${process.env.METABASE_URL_EXT}/public/dashboard/${response.data.uuid}`;
+  return url;
+}

--- a/api.planx.uk/modules/analytics/metabase/dashboard/getDashboard.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/getDashboard.ts
@@ -1,0 +1,13 @@
+import { $metabase } from "../shared/client.js";
+
+/** Takes dashboard ID and returns dashboard name. */
+export async function getDashboard(dashboardId: number): Promise<any> {
+  try {
+    const response = await $metabase.get(`/api/dashboard/${dashboardId}`);
+    console.log("Original dashboard name: ", response.data.name);
+    return response.data.name;
+  } catch (error) {
+    console.error("Error in getDashboard:", error);
+    throw error;
+  }
+}

--- a/api.planx.uk/modules/analytics/metabase/dashboard/getDashboard.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/getDashboard.ts
@@ -1,11 +1,10 @@
 import { $metabase } from "../shared/client.js";
 
-/** Takes dashboard ID and returns dashboard name. */
+/** Takes dashboard ID and returns dashboard with name as param; it's useful to return `response.data` to access other properties in testing. */
 export async function getDashboard(dashboardId: number): Promise<any> {
   try {
     const response = await $metabase.get(`/api/dashboard/${dashboardId}`);
-    console.log("Original dashboard name: ", response.data.name);
-    return response.data.name;
+    return response.data;
   } catch (error) {
     console.error("Error in getDashboard:", error);
     throw error;

--- a/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
@@ -11,15 +11,14 @@ export async function createNewDashboard(
   params: CreateNewDashboardParams,
 ): Promise<string> {
   try {
-    const templateName = await getDashboard(params.templateId);
-    const newName = templateName.replace("Template", params.teamName);
+    const template = await getDashboard(params.templateId);
+    const newName = template.name.replace("Template", params.teamName);
     const copiedDashboardId = await copyDashboard({
       name: newName,
       templateId: params.templateId,
       description: params.description,
       collectionId: params.collectionId,
       collectionPosition: params.collectionPosition,
-      isDeepCopy: false,
     });
 
     // updateFilter() does not need to be saved to a variable because we don't need to access its output anywhere else

--- a/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
@@ -4,14 +4,17 @@ import { updateFilter } from "./updateFilter.js";
 import { generatePublicLink } from "./generatePublicLink.js";
 import type { CreateNewDashboardParams } from "./types.js";
 
+/**
+ * @returns The dashboard name (the Metabase API performs GETs with the dashboard ID, so we have to have that locally already--no need to return it here)
+ */
 export async function createNewDashboard(
   params: CreateNewDashboardParams,
 ): Promise<string> {
   try {
     const templateName = await getDashboard(params.templateId);
-    // TODO: string processing to pull template name and update it
+    const newName = templateName.replace("Template", params.teamName);
     const copiedDashboardId = await copyDashboard({
-      name: templateName,
+      name: newName,
       templateId: params.templateId,
       description: params.description,
       collectionId: params.collectionId,

--- a/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
@@ -1,0 +1,34 @@
+import { copyDashboard } from "./copyDashboard.js";
+import { getDashboard } from "./getDashboard.js";
+import { updateFilter } from "./updateFilter.js";
+import { generatePublicLink } from "./generatePublicLink.js";
+import type { CreateNewDashboardParams } from "./types.js";
+
+export async function createNewDashboard(
+  params: CreateNewDashboardParams,
+): Promise<string> {
+  try {
+    const templateName = await getDashboard(params.templateId);
+    // TODO: string processing to pull template name and update it
+    const copiedDashboardId = await copyDashboard({
+      name: templateName,
+      templateId: params.templateId,
+      description: params.description,
+      collectionId: params.collectionId,
+      collectionPosition: params.collectionPosition,
+      isDeepCopy: false,
+    });
+
+    // updateFilter() does not need to be saved to a variable because we don't need to access its output anywhere else
+    await updateFilter({
+      dashboardId: copiedDashboardId,
+      filter: params.filter,
+      value: params.value,
+    });
+    const publicLink = await generatePublicLink(copiedDashboardId);
+    return publicLink;
+  } catch (error) {
+    console.error("Error in createNewDashboard:", error);
+    throw error;
+  }
+}

--- a/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
@@ -5,7 +5,7 @@ export interface CreateNewDashboardParams {
   teamName: string;
   /** Original / template Metabase Dashboard ID, it is the number that follows /dashboard/ in the URL */
   templateId: number;
-  /**  What the copied dashboard should be named;
+  /** What the copied dashboard should be named;
    * should be the original dashboard name
    * but with 'Template' replaced with council name */
   // name?: string;
@@ -15,25 +15,18 @@ export interface CreateNewDashboardParams {
   collectionId: number;
   /** Optional number for the copied dashboard's placement within the collection */
   collectionPosition?: number | null;
-  /** Toggle whether or not the questions are copied as well;
-   * Metabase deep-copies by default, but we want shallow
-   * shallow = "Only duplicate the dashboard" */
-  isDeepCopy: boolean;
   /** A filter that should be automatically set, eg `Team slug` */
   filter: string;
   /** Default filter value, eg `council-name` */
   value: string;
 }
 
+/* We don't want users to be able to deep copy templates / dashboards because it will wreak Metabase havoc. This is why there is no isDeepCopy option here */
 export type CopyDashboardParams = {
   name: string;
 } & Pick<
   CreateNewDashboardParams,
-  | "templateId"
-  | "description"
-  | "collectionId"
-  | "collectionPosition"
-  | "isDeepCopy"
+  "templateId" | "description" | "collectionId" | "collectionPosition"
 >;
 
 // Version of CopyDashboardParams suitable for Metabase API
@@ -42,7 +35,7 @@ export type MetabaseCopyDashboardParams = {
   description?: string;
   collection_id?: number;
   collection_position?: number | null;
-  is_deep_copy: boolean;
+  is_deep_copy?: boolean;
 };
 
 // Convert to Metabase API structure
@@ -54,7 +47,8 @@ export function toMetabaseParams(
     description: params.description,
     collection_id: params.collectionId,
     collection_position: params.collectionPosition,
-    is_deep_copy: params.isDeepCopy,
+    /* Hard-coded false because deep copies will be messy in Metabase */
+    is_deep_copy: false,
   };
 }
 
@@ -78,7 +72,6 @@ export const createNewDashboardSchema = z.object({
     description: z.string().optional(),
     collectionId: z.coerce.number(),
     collectionPosition: z.coerce.number().nullable().optional(),
-    isDeepCopy: z.coerce.boolean().default(false),
     filter: z.string(),
     value: z.string(),
   }),

--- a/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
@@ -1,0 +1,66 @@
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import { z } from "zod";
+
+export interface CreateNewDashboardParams {
+  /** Original / template Metabase Dashboard ID, it is the number that follows /dashboard/ in the URL */
+  templateId: number;
+  /**  What the copied dashboard should be named;
+   * should be the original dashboard name
+   * but with 'Template' replaced with council name */
+  // name?: string;
+  /** Optional text to be displayed as the dashboard description */
+  description?: string;
+  /** Number for the copied dashboard's parent collection */
+  collectionId: number;
+  /** Optional number for the copied dashboard's placement within the collection */
+  collectionPosition?: number | null;
+  /** Toggle whether or not the questions are copied as well;
+   * Metabase deep-copies by default, but we want shallow
+   * shallow = "Only duplicate the dashboard" */
+  isDeepCopy: boolean;
+  /** A filter that should be automatically set, eg `Team slug` */
+  filter: string;
+  /** Default filter value, eg `council-name` */
+  value: string;
+}
+
+export type CopyDashboardParams = {
+  name: string;
+} & Pick<
+  CreateNewDashboardParams,
+  | "templateId"
+  | "description"
+  | "collectionId"
+  | "collectionPosition"
+  | "isDeepCopy"
+>;
+
+export type UpdateFilterParams = {
+  dashboardId: number;
+} & Pick<CreateNewDashboardParams, "filter" | "value">;
+
+type ApiResponse<T> = {
+  data?: T;
+  error?: string;
+};
+
+export const createNewDashboardSchema = z.object({
+  params: z.object({
+    templateId: z.number(),
+    description: z.string().optional(),
+    collectionId: z.number(),
+    collectionPosition: z.number().optional(),
+    isDeepCopy: z.boolean(),
+    filter: z.string(),
+    value: z.string(),
+  }),
+  body: z.object({
+    description: z.string().optional(),
+    parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
+  }),
+});
+
+export type NewDashboardHandler = ValidatedRequestHandler<
+  typeof createNewDashboardSchema,
+  ApiResponse<string>
+>;

--- a/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
@@ -2,6 +2,7 @@ import type { ValidatedRequestHandler } from "../../../../shared/middleware/vali
 import { z } from "zod";
 
 export interface CreateNewDashboardParams {
+  teamName: string;
   /** Original / template Metabase Dashboard ID, it is the number that follows /dashboard/ in the URL */
   templateId: number;
   /**  What the copied dashboard should be named;
@@ -73,6 +74,7 @@ export const createNewDashboardSchema = z.object({
     templateId: z.coerce.number(),
   }),
   body: z.object({
+    teamName: z.string(),
     description: z.string().optional(),
     collectionId: z.coerce.number(),
     collectionPosition: z.coerce.number().nullable().optional(),

--- a/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
@@ -35,6 +35,28 @@ export type CopyDashboardParams = {
   | "isDeepCopy"
 >;
 
+// Version of CopyDashboardParams suitable for Metabase API
+export type MetabaseCopyDashboardParams = {
+  name: string;
+  description?: string;
+  collection_id?: number;
+  collection_position?: number | null;
+  is_deep_copy: boolean;
+};
+
+// Convert to Metabase API structure
+export function toMetabaseParams(
+  params: CopyDashboardParams,
+): MetabaseCopyDashboardParams {
+  return {
+    name: params.name,
+    description: params.description,
+    collection_id: params.collectionId,
+    collection_position: params.collectionPosition,
+    is_deep_copy: params.isDeepCopy,
+  };
+}
+
 export type UpdateFilterParams = {
   dashboardId: number;
 } & Pick<CreateNewDashboardParams, "filter" | "value">;
@@ -46,17 +68,17 @@ type ApiResponse<T> = {
 
 export const createNewDashboardSchema = z.object({
   params: z.object({
-    templateId: z.number(),
-    description: z.string().optional(),
-    collectionId: z.number(),
-    collectionPosition: z.number().optional(),
-    isDeepCopy: z.boolean(),
-    filter: z.string(),
-    value: z.string(),
+    slug: z.string(),
+    service: z.string(),
+    templateId: z.coerce.number(),
   }),
   body: z.object({
     description: z.string().optional(),
-    parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
+    collectionId: z.coerce.number(),
+    collectionPosition: z.coerce.number().nullable().optional(),
+    isDeepCopy: z.coerce.boolean().default(false),
+    filter: z.string(),
+    value: z.string(),
   }),
 });
 

--- a/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
@@ -1,3 +1,4 @@
+import { error } from "console";
 import { $metabase } from "../shared/client.js";
 import type { UpdateFilterParams } from "./types.js";
 
@@ -11,6 +12,12 @@ export async function updateFilter(params: UpdateFilterParams): Promise<any> {
   let updatedFilter;
   const updatedParameters = response.data.parameters.map((param: any) => {
     if (param.name === params.filter) {
+      // Check if the filter is a string type
+      if (!param.type.startsWith("string/")) {
+        throw new Error(
+          `Filter type '${param.type}' is not supported. Only string filters are currently supported.`,
+        );
+      }
       updatedFilter = param.name;
       return { ...param, default: [params.value] };
     }
@@ -18,7 +25,9 @@ export async function updateFilter(params: UpdateFilterParams): Promise<any> {
   });
 
   if (!updatedFilter) {
-    console.warn(`Filter "${params.filter}" not found in dashboard parameters`);
+    throw new Error(
+      `Filter "${params.filter}" not found in dashboard parameters`,
+    );
   }
 
   // Prepare the update payload
@@ -32,10 +41,6 @@ export async function updateFilter(params: UpdateFilterParams): Promise<any> {
     updatePayload,
   );
 
-  const updatedResponseDataParamFields = updatedResponse.data.param_fields;
-  console.log({ updatedResponseDataParamFields });
-  const updatePayloadParams = updatePayload.parameters;
-  console.log({ updatePayloadParams });
   console.log(
     `Updated dashboard ${params.dashboardId} filter "${updatedFilter}" with: ${params.value}`,
   );

--- a/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
@@ -8,16 +8,16 @@ export async function updateFilter(params: UpdateFilterParams): Promise<any> {
   const response = await $metabase.get(`/api/dashboard/${params.dashboardId}`);
 
   // Update filter default value parameter
-  let updatedParam;
+  let updatedFilter;
   const updatedParameters = response.data.parameters.map((param: any) => {
-    if (param.name === param.filter) {
-      updatedParam = param.name;
-      return { ...param, default: [param.value] };
+    if (param.name === params.filter) {
+      updatedFilter = param.name;
+      return { ...param, default: [params.value] };
     }
     return param;
   });
 
-  if (!updatedParam) {
+  if (!updatedFilter) {
     console.warn(`Filter "${params.filter}" not found in dashboard parameters`);
   }
 
@@ -31,7 +31,12 @@ export async function updateFilter(params: UpdateFilterParams): Promise<any> {
     `/api/dashboard/${params.dashboardId}`,
     updatePayload,
   );
+
+  const updatedResponseDataParamFields = updatedResponse.data.param_fields;
+  console.log({ updatedResponseDataParamFields });
+  const updatePayloadParams = updatePayload.parameters;
+  console.log({ updatePayloadParams });
   console.log(
-    `Updated dashboard ${params.dashboardId} filter "${updatedParam}" with: ${params.value}`,
+    `Updated dashboard ${params.dashboardId} filter "${updatedFilter}" with: ${params.value}`,
   );
 }

--- a/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
@@ -1,0 +1,37 @@
+import { $metabase } from "../shared/client.js";
+import type { UpdateFilterParams } from "./types.js";
+
+/** Takes the ID of the dashboard to be updated, the name of the filter (a string, must be an exact match), and the new value to be filtered on.
+ * Currently only works for strings. */
+export async function updateFilter(params: UpdateFilterParams): Promise<any> {
+  // Get existing dashboard data
+  const response = await $metabase.get(`/api/dashboard/${params.dashboardId}`);
+
+  // Update filter default value parameter
+  let updatedParam;
+  const updatedParameters = response.data.parameters.map((param: any) => {
+    if (param.name === param.filter) {
+      updatedParam = param.name;
+      return { ...param, default: [param.value] };
+    }
+    return param;
+  });
+
+  if (!updatedParam) {
+    console.warn(`Filter "${params.filter}" not found in dashboard parameters`);
+  }
+
+  // Prepare the update payload
+  const updatePayload = {
+    parameters: updatedParameters,
+  };
+
+  // Send the updated data back using PUT
+  const updatedResponse = await $metabase.put(
+    `/api/dashboard/${params.dashboardId}`,
+    updatePayload,
+  );
+  console.log(
+    `Updated dashboard ${params.dashboardId} filter "${updatedParam}" with: ${params.value}`,
+  );
+}

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -6,7 +6,9 @@ import {
   logUserResumeController,
 } from "./analyticsLog/controller.js";
 import { metabaseCollectionsController } from "./metabase/collection/controller.js";
+import { metabaseDashboardsController } from "./metabase/dashboard/controller.js";
 import { createTeamCollectionSchema } from "./metabase/collection/types.js";
+import { createNewDashboardSchema } from "./metabase/dashboard/types.js";
 
 const router = Router();
 
@@ -24,6 +26,11 @@ router.post(
   "/metabase/collection/:slug",
   validate(createTeamCollectionSchema),
   metabaseCollectionsController,
+);
+router.post(
+  "/metabase/dashboard/:slug/:service",
+  validate(createNewDashboardSchema),
+  metabaseDashboardsController,
 );
 
 export default router;

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -28,7 +28,7 @@ router.post(
   metabaseCollectionsController,
 );
 router.post(
-  "/metabase/dashboard/:slug/:service",
+  "/metabase/dashboard/:slug/:service/:templateId",
   validate(createNewDashboardSchema),
   metabaseDashboardsController,
 );


### PR DESCRIPTION
# What does this PR do?
- Creates services `getDashboard`, `copyDashboard`, `updateFilter` and `generatePublicLink`
- Adds necessary types and tests
- Creates new route for analytics module
- Exports the Metabase client as a singleton instance (this also happens in [8f12f20](https://github.com/theopensystemslab/planx-new/pull/4072/commits/8f12f205708fb03b802f8f9330fce54319a21f93) in #4072 but there were other changes in the same commit so I've isolated the change here)
- Updates Swagger yaml

# Why?
Following on from #4072, this should complete all the services we need to automate Metabase dashboard creation

This PR became a bit bigger than I'd anticipated... let me know if it'd be better to break it up! 