### PR TITLE
fix: never fully remove `_root` node via graph operations

### DIFF
--- a/editor.planx.uk/src/@planx/graph/__tests__/remove.test.ts
+++ b/editor.planx.uk/src/@planx/graph/__tests__/remove.test.ts
@@ -26,7 +26,7 @@ test("with clones", () => {
   ]);
 });
 
-test("with id", () => {
+test("final node with id", () => {
   const [graph, ops] = remove(
     "a",
     "_root",
@@ -43,9 +43,10 @@ test("with id", () => {
     },
     d: {},
   });
-  expect(graph).toEqual({});
+  // The `_root` node is never fully deleted, rather just "emptied out"
+  expect(graph).toEqual({ "_root": { edges: [] } });
   expect(ops).toEqual([
-    { od: { edges: ["a"] }, p: ["_root"] },
+    { ld: "a", p: ["_root", "edges", 0] },
     { od: {}, p: ["b"] },
     { od: { edges: ["b", "c"] }, p: ["a"] },
     { od: { edges: ["d"] }, p: ["c"] },

--- a/editor.planx.uk/src/@planx/graph/index.ts
+++ b/editor.planx.uk/src/@planx/graph/index.ts
@@ -307,13 +307,13 @@ const _remove = (draft: Graph, id: string, parent: string) => {
 
   const idx = parentNode.edges.indexOf(id);
   if (idx >= 0) {
-    if (parentNode.edges.length === 1) delete parentNode.edges;
+    if (parent !== ROOT_NODE_KEY && parentNode.edges.length === 1) delete parentNode.edges;
     else parentNode.edges.splice(idx, 1);
   } else {
     throw new Error("not found in parent");
   }
 
-  if (Object.keys(draft[parent]).length === 0) delete draft[parent];
+  if (parent !== ROOT_NODE_KEY && Object.keys(draft[parent]).length === 0) delete draft[parent];
 
   if (numberOfEdgesTo(id, draft) === 0) {
     const { edges } = draft[id];


### PR DESCRIPTION
Per bug spot by August https://opensystemslab.slack.com/archives/C01E3AC0C03/p1736354419439469

When removing the last/final node in the graph currently, the flow data will be set to `{}` - which then on next render will display a blank screen & fail to load because of type errors:
```
index-vd9rjCRb.js:614 
TypeError: Cannot read properties of undefined (reading 'edges')
    at Object.filterFlowByType (index-vd9rjCRb.js:1565:3082)
    at Object.initNavigationStore (index-vd9rjCRb.js:1565:2543)
    at Object.setFlow (index-vd9rjCRb.js:1610:741)
    at n (index-vd9rjCRb.js:1500:92956)
    at Object.connectTo (index-vd9rjCRb.js:1500:93024)
    at async team-BRe-K93g.js:107:189
```

This change ensures that removing the last node still preserves the original `{ "_root": { edges: [] } }` flow structure to prevent type errors and not disrupt the editing workflow.