### PR TITLE
feat(types): Stricter and more accurate Schema response types

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -8,7 +8,7 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import { MapField, ResponseValue } from "@planx/components/shared/Schema/model";
+import { isMapFieldResponse } from "@planx/components/shared/Schema/model";
 import { SchemaFields } from "@planx/components/shared/Schema/SchemaFields";
 import { PublicProps } from "@planx/components/shared/types";
 import React, { useEffect, useRef } from "react";
@@ -129,7 +129,17 @@ const InactiveListCard: React.FC<{
 }> = ({ index: i }) => {
   const { schema, formik, removeItem, editItem } = useListContext();
 
-  const mapPreview = schema.fields.find((field) => field.type === "map");
+  const formattedMapResponse = (() => {
+    const mapField = schema.fields.find((field) => field.type === "map");
+    if (!mapField) return null;
+
+    const mapResponse = formik.values.schemaData[i][mapField.data.fn];
+    if (!mapResponse) return null;
+
+    return isMapFieldResponse(mapResponse)
+      ? formatSchemaDisplayValue(mapResponse, mapField)
+      : null;
+  })();
 
   return (
     <ListCard data-testid={`list-card-${i}`}>
@@ -137,15 +147,8 @@ const InactiveListCard: React.FC<{
         {`${schema.type} ${i + 1}`}
       </Typography>
       <InactiveListCardLayout>
-        {mapPreview && (
-          <Box sx={{ flexBasis: "50%" }}>
-            {formatSchemaDisplayValue(
-              formik.values.schemaData[i][
-                mapPreview.data.fn
-              ] as ResponseValue<MapField>,
-              mapPreview,
-            )}
-          </Box>
+        {formattedMapResponse && (
+          <Box sx={{ flexBasis: "50%" }}>{formattedMapResponse}</Box>
         )}
         <Table>
           <TableBody>

--- a/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -8,6 +8,7 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
+import { MapField, ResponseValue } from "@planx/components/shared/Schema/model";
 import { SchemaFields } from "@planx/components/shared/Schema/SchemaFields";
 import { PublicProps } from "@planx/components/shared/types";
 import React, { useEffect, useRef } from "react";
@@ -139,7 +140,9 @@ const InactiveListCard: React.FC<{
         {mapPreview && (
           <Box sx={{ flexBasis: "50%" }}>
             {formatSchemaDisplayValue(
-              formik.values.schemaData[i][mapPreview.data.fn],
+              formik.values.schemaData[i][
+                mapPreview.data.fn
+              ] as ResponseValue<MapField>,
               mapPreview,
             )}
           </Box>

--- a/editor.planx.uk/src/@planx/components/List/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/List/utils.test.ts
@@ -1,4 +1,3 @@
-import { SchemaUserResponse } from "./../shared/Schema/model";
 import {
   flatten,
   sumIdenticalUnits,
@@ -63,7 +62,7 @@ describe("passport data shape", () => {
           identicalUnits: 2,
         },
       ],
-    } as unknown as Record<string, SchemaUserResponse[]>;
+    };
 
     expect(
       sumIdenticalUnits("proposal.units.residential", defaultPassportData),

--- a/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -1,7 +1,15 @@
 import { styled } from "@mui/material/styles";
 import React from "react";
 
-import { Field, SchemaUserResponse } from "./../shared/Schema/model";
+import {
+  ChecklistField,
+  DateField,
+  Field,
+  NumberField,
+  ResponseValue,
+  SchemaUserResponse,
+  TextField,
+} from "./../shared/Schema/model";
 
 const List = styled("ul")(() => ({
   listStylePosition: "inside",
@@ -15,19 +23,26 @@ const List = styled("ul")(() => ({
  * @param field - the Field object
  * @returns string | React.JSX.Element - the `text` for the given value `val`, or the original value
  */
-export function formatSchemaDisplayValue(
-  value: string | string[],
-  field: Field,
-) {
+export const formatSchemaDisplayValue = <T extends Field>(
+  value: ResponseValue<T>,
+  field: T,
+) => {
   switch (field.type) {
-    case "number":
-      return field.data.units ? `${value} ${field.data.units}` : value;
+    case "number": {
+      const numberValue = value as ResponseValue<NumberField>;
+      return field.data.units
+        ? `${numberValue} ${field.data.units}`
+        : numberValue;
+    }
     case "text":
-    case "date":
-      return value;
+    case "date": {
+      const textOrDataValue = value as ResponseValue<DateField | TextField>;
+      return textOrDataValue;
+    }
     case "checklist": {
+      const checklistValue = value as ResponseValue<ChecklistField>;
       const matchingOptions = field.data.options.filter((option) =>
-        (value as string[]).includes(option.id),
+        checklistValue.includes(option.id),
       );
       return (
         <List>
@@ -75,7 +90,7 @@ export function formatSchemaDisplayValue(
       );
     }
   }
-}
+};
 
 /**
  * If the schema includes a field that sets fn = "identicalUnits", sum of total units
@@ -89,6 +104,8 @@ export function sumIdenticalUnits(
 ): number {
   let sum = 0;
   passportData[`${fn}`].map((item) => {
+    // TODO: Remove this check?
+
     if (!Array.isArray(item?.identicalUnits)) {
       sum += parseInt(item?.identicalUnits);
     }
@@ -119,6 +136,7 @@ export function sumIdenticalUnitsByDevelopmentType(
     notKnown: 0,
   };
   passportData[`${fn}`].map((item) => {
+    // TODO: Remove this check?
     if (!Array.isArray(item?.identicalUnits)) {
       baseSums[`${item?.development}`] += parseInt(item?.identicalUnits);
     }

--- a/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -92,6 +92,21 @@ export const formatSchemaDisplayValue = <T extends Field>(
   }
 };
 
+const isIdenticalUnitsField = (
+  item: SchemaUserResponse,
+): item is Record<"identicalUnits", ResponseValue<NumberField>> =>
+  "identicalUnits" in item && typeof item.identicalUnits === "number";
+
+const isIdenticalUnitsDevelopmentField = (
+  item: SchemaUserResponse,
+): item is Record<
+  "identicalUnits" | "development",
+  ResponseValue<NumberField>
+> =>
+  "identicalUnits" in item &&
+  "development" in item &&
+  typeof item.identicalUnits === "number";
+
 /**
  * If the schema includes a field that sets fn = "identicalUnits", sum of total units
  * @param fn - passport key of current List
@@ -104,10 +119,8 @@ export function sumIdenticalUnits(
 ): number {
   let sum = 0;
   passportData[`${fn}`].map((item) => {
-    // TODO: Remove this check?
-
-    if (!Array.isArray(item?.identicalUnits)) {
-      sum += parseInt(item?.identicalUnits);
+    if (isIdenticalUnitsField(item)) {
+      sum += item.identicalUnits;
     }
   });
   return sum;
@@ -136,9 +149,8 @@ export function sumIdenticalUnitsByDevelopmentType(
     notKnown: 0,
   };
   passportData[`${fn}`].map((item) => {
-    // TODO: Remove this check?
-    if (!Array.isArray(item?.identicalUnits)) {
-      baseSums[`${item?.development}`] += parseInt(item?.identicalUnits);
+    if (isIdenticalUnitsDevelopmentField(item)) {
+      baseSums[`${item?.development}`] += item.identicalUnits;
     }
   });
 

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -17,7 +17,12 @@ import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-import { SchemaUserResponse } from "../Schema/model";
+import {
+  Field,
+  MapField,
+  ResponseValue,
+  SchemaUserResponse,
+} from "../Schema/model";
 
 export default SummaryListsBySections;
 
@@ -640,8 +645,13 @@ function Page(props: ComponentProps) {
             </Typography>
             <Typography>
               {field.type === "map"
-                ? `${answers[0][field.data.fn].length || 0} features`
-                : answers[0][field.data.fn]}
+                ? `${
+                    (answers[0][field.data.fn] as ResponseValue<MapField>)
+                      .length || 0
+                  } features`
+                : (answers[0][field.data.fn] as ResponseValue<
+                    Exclude<Field, MapField>
+                  >)}
             </Typography>
           </Box>
         ))}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -19,7 +19,9 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import {
   Field,
-  MapField,
+  isMapFieldResponse,
+  isNumberFieldResponse,
+  isTextResponse,
   ResponseValue,
   SchemaUserResponse,
 } from "../Schema/model";
@@ -631,6 +633,15 @@ function Page(props: ComponentProps) {
   const answers = getAnswersByNode(props) as SchemaUserResponse[];
   const fields = (props.node.data as Page).schema.fields;
 
+  const displayValue = (answer: ResponseValue<Field>) => {
+    if (isTextResponse(answer)) return answer;
+    if (isNumberFieldResponse(answer)) return answer.toString();
+    if (isMapFieldResponse(answer)) return `${answer.length || 0} features`;
+
+    // TODO: Handle other types more gracefully
+    return answer;
+  };
+
   return (
     <>
       <Box component="dt">{props.node.data.title}</Box>
@@ -644,14 +655,7 @@ function Page(props: ComponentProps) {
               {field.data.title}
             </Typography>
             <Typography>
-              {field.type === "map"
-                ? `${
-                    (answers[0][field.data.fn] as ResponseValue<MapField>)
-                      .length || 0
-                  } features`
-                : (answers[0][field.data.fn] as ResponseValue<
-                    Exclude<Field, MapField>
-                  >)}
+              <>{displayValue(answers[0][field.data.fn])}</>
             </Typography>
           </Box>
         ))}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/index.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/index.tsx
@@ -1,5 +1,6 @@
 import type {
   Field,
+  ResponseValue,
   SchemaUserData,
 } from "@planx/components/shared/Schema/model";
 import { FormikProps } from "formik";
@@ -31,7 +32,9 @@ export const getFieldProps = <T extends Field>(props: Props<T>) => ({
     props.data.fn,
   ]),
   name: `schemaData[${props.activeIndex}]['${props.data.fn}']`,
-  value: props.formik.values.schemaData[props.activeIndex][props.data.fn],
+  value: props.formik.values.schemaData[props.activeIndex][
+    props.data.fn
+  ] as ResponseValue<T>,
 });
 
 /**

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -141,6 +141,27 @@ export type SchemaUserData = {
   schemaData: SchemaUserResponse[];
 };
 
+// Type-guards to narrow the type of response values
+// Required as we often need to match a value with it's corresponding schema field
+export const isNumberFieldResponse = (
+  response: unknown,
+): response is ResponseValue<NumberField> => typeof response === "number";
+
+export const isTextResponse = (
+  response: unknown,
+): response is ResponseValue<TextField | DateField | QuestionField> =>
+  typeof response === "string";
+
+export const isMapFieldResponse = (
+  response: unknown,
+): response is ResponseValue<MapField> =>
+  Array.isArray(response) && response[0]?.type === "Feature";
+
+export const isChecklistFieldResponse = (
+  response: unknown,
+): response is ResponseValue<ChecklistField> =>
+  Array.isArray(response) && !isMapFieldResponse(response);
+
 /**
  * For each field in schema, return a map of Yup validation schema
  * Matches both the field type and data

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -125,6 +125,8 @@ export type ResponseValue<T extends Field> = T extends MapField
   ? Feature[]
   : T extends ChecklistField
   ? string[]
+  : T extends NumberField
+  ? number
   : string;
 
 export type SchemaUserResponse = Record<

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -118,10 +118,19 @@ export interface Schema {
   max?: number;
 }
 
+/**
+ * Value returned per field, based on field type
+ */
+export type ResponseValue<T extends Field> = T extends MapField
+  ? Feature[]
+  : T extends ChecklistField
+  ? string[]
+  : string;
+
 export type SchemaUserResponse = Record<
   Field["data"]["fn"],
-  string | string[] | any[]
->; // string | string[] | Feature[]
+  ResponseValue<Field>
+>;
 
 /**
  * Output data from a form using the useSchema hook
@@ -187,9 +196,15 @@ export const generateValidationSchema = (schema: Schema) => {
 export const generateInitialValues = (schema: Schema): SchemaUserResponse => {
   const initialValues: SchemaUserResponse = {};
   schema.fields.forEach((field) => {
-    ["checklist", "map"].includes(field.type)
-      ? (initialValues[field.data.fn] = [])
-      : (initialValues[field.data.fn] = "");
+    switch (field.type) {
+      case "checklist":
+      case "map":
+        initialValues[field.data.fn] = [];
+        break;
+      default:
+        initialValues[field.data.fn] = "";
+        break;
+    }
   });
   return initialValues;
 };


### PR DESCRIPTION
## What does this PR do?
 - Correctly defines output values of a schema field, based on it's field type. This is the `ResponseValue<T>` type.
   - Please see https://github.com/theopensystemslab/planx-new/pull/4153#discussion_r1919809762 for details on why this is the approach I've gone for
 - Updates code that was relying on type casting, or type checking via disparate means, to use a standard set of type guards defined in the model file

## Why?
- Overdue technical debt from the list/schema work
- A barrier for https://github.com/theopensystemslab/planx-new/pull/4020 which is introducing another field and response value. One this PR is merged I'll rebase the above branch to incorporate this and make the required type changes there.