### PR TITLE
demo: Council resources in the editor prototype

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
@@ -1,7 +1,12 @@
+import Box from "@mui/material/Box";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { DataFieldAutocomplete } from "@planx/components/shared/DataFieldAutocomplete";
 import { FormikErrors, FormikValues, useFormik } from "formik";
-import React, { useEffect, useRef } from "react";
+import { TabList } from "pages/FlowEditor/components/Sidebar";
+import StyledTab from "pages/FlowEditor/components/Sidebar/StyledTab";
+import React, { useEffect, useRef,useState } from "react";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
 import { ModalFooter } from "ui/editor/ModalFooter";
@@ -109,89 +114,128 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
     }, 50);
   }, []);
 
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue);
+  };
+
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
-      <ModalSection>
-        <ModalSectionContent title="Checklist" Icon={ICONS[type]}>
-          <InputGroup>
-            <InputRow>
-              <Input
-                format="large"
-                name="text"
-                value={formik.values.text}
-                placeholder="Text"
-                onChange={formik.handleChange}
-                inputRef={focusRef}
-                required
-              />
-              <ImgInput
-                img={formik.values.img}
-                onChange={(newUrl) => {
-                  formik.setFieldValue("img", newUrl);
-                }}
-              />
-            </InputRow>
-            <InputRow>
-              <RichTextInput
-                name="description"
-                value={formik.values.description}
-                placeholder="Description"
-                onChange={formik.handleChange}
-              />
-            </InputRow>
-            <ErrorWrapper error={formik.errors.fn}>
+      <TabList sx={{ marginLeft: "-24px", width: "calc(100% + 48px)" }}>
+        <Tabs value={activeTab} onChange={handleTabChange}>
+          <StyledTab label="Component settings" />
+          <StyledTab label="How to use this component" />
+        </Tabs>
+      </TabList>
+      <Box
+        style={{
+          display: activeTab === 0 ? "flex" : "none",
+          flexDirection: "column",
+          flex: 1,
+          overflow: "auto",
+        }}
+      >
+        <ModalSection>
+          <ModalSectionContent title="Checklist" Icon={ICONS[type]}>
+            <InputGroup>
+              <InputRow>
+                <Input
+                  format="large"
+                  name="text"
+                  value={formik.values.text}
+                  placeholder="Text"
+                  onChange={formik.handleChange}
+                  inputRef={focusRef}
+                  required
+                />
+                <ImgInput
+                  img={formik.values.img}
+                  onChange={(newUrl) => {
+                    formik.setFieldValue("img", newUrl);
+                  }}
+                />
+              </InputRow>
+              <InputRow>
+                <RichTextInput
+                  name="description"
+                  value={formik.values.description}
+                  placeholder="Description"
+                  onChange={formik.handleChange}
+                />
+              </InputRow>
               <DataFieldAutocomplete
                 value={formik.values.fn}
                 onChange={(value) => formik.setFieldValue("fn", value)}
               />
-            </ErrorWrapper>
-            <InputRow>
-              <Switch
-                checked={!!formik.values.groupedOptions}
-                onChange={() =>
-                  formik.setValues({
-                    ...formik.values,
-                    ...toggleExpandableChecklist({
-                      options: formik.values.options,
-                      groupedOptions: formik.values.groupedOptions,
-                    }),
-                  })
-                }
-                label="Expandable"
-              />
-            </InputRow>
-            <InputRow>
-              <Switch
-                checked={formik.values.allRequired}
-                onChange={() =>
-                  formik.setFieldValue(
-                    "allRequired",
-                    !formik.values.allRequired,
-                  )
-                }
-                label="All required"
-              />
-            </InputRow>
+              <InputRow>
+                <Switch
+                  checked={!!formik.values.groupedOptions}
+                  onChange={() =>
+                    formik.setValues({
+                      ...formik.values,
+                      ...toggleExpandableChecklist({
+                        options: formik.values.options,
+                        groupedOptions: formik.values.groupedOptions,
+                      }),
+                    })
+                  }
+                  label="Expandable"
+                />
+              </InputRow>
+              <InputRow>
+                <Switch
+                  checked={formik.values.allRequired}
+                  onChange={() =>
+                    formik.setFieldValue(
+                      "allRequired",
+                      !formik.values.allRequired,
+                    )
+                  }
+                  label="All required"
+                />
+              </InputRow>
 
-            <InputRow>
-              <Switch
-                checked={formik.values.neverAutoAnswer}
-                onChange={() =>
-                  formik.setFieldValue(
-                    "neverAutoAnswer",
-                    !formik.values.neverAutoAnswer,
-                  )
-                }
-                label="Always put to user (forgo automation)"
-              />
-            </InputRow>
-          </InputGroup>
-        </ModalSectionContent>
-        <ErrorWrapper error={formik.errors.options}>
-          <Options formik={formik} />
-        </ErrorWrapper>
-      </ModalSection>
-      <ModalFooter formik={formik} />
+              <InputRow>
+                <Switch
+                  checked={formik.values.neverAutoAnswer}
+                  onChange={() =>
+                    formik.setFieldValue(
+                      "neverAutoAnswer",
+                      !formik.values.neverAutoAnswer,
+                    )
+                  }
+                  label="Always put to user (forgo automation)"
+                />
+              </InputRow>
+            </InputGroup>
+          </ModalSectionContent>
+          <ErrorWrapper error={formik.errors.options}>
+            <Options formik={formik} />
+          </ErrorWrapper>
+        </ModalSection>
+        <ModalFooter formik={formik} />
+      </Box>
+      <Box
+        sx={{
+          display: activeTab === 1 ? "flex" : "none",
+          flexDirection: "column",
+          flex: 1,
+          padding: "16px",
+          overflow: "auto",
+        }}
+      >
+        <Box mt={1}>
+          <iframe
+            width="680"
+            height="680"
+            src="https://scribehow.com/shared/Creating_a_Checklist_in_PlanX_Editor__E-wF1ViORmm-ieO-V0mpMA"
+            title="Using the checklist component"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            style={{ border: "1px solid #DBDADA" }}
+          ></iframe>
+        </Box>
+      </Box>
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -1,11 +1,15 @@
+import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import RadioGroup from "@mui/material/RadioGroup";
+import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio/BasicRadio";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
-import React from "react";
+import { TabList } from "pages/FlowEditor/components/Sidebar";
+import StyledTab from "pages/FlowEditor/components/Sidebar/StyledTab";
+import React, { useState } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -16,8 +20,6 @@ import { DataFieldAutocomplete } from "../shared/DataFieldAutocomplete";
 import { parseSetValue, SetValue } from "./model";
 
 type Props = EditorProps<TYPES.SetValue, SetValue>;
-
-export default SetValueComponent;
 
 interface Option {
   value: SetValue["operation"];
@@ -77,7 +79,9 @@ const DescriptionText: React.FC<SetValue> = ({ fn, val, operation }) => {
   }
 };
 
-function SetValueComponent(props: Props) {
+const SetValueComponent: React.FC<Props> = (props) => {
+  const [activeTab, setActiveTab] = useState(0);
+
   const formik = useFormik({
     initialValues: parseSetValue(props.node?.data),
     onSubmit: (newValues) => {
@@ -93,49 +97,99 @@ function SetValueComponent(props: Props) {
     formik.setFieldValue("operation", target.value);
   };
 
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue);
+  };
+
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
-      <ModalSection>
-        <ModalSectionContent title="Passport field name">
-          <DataFieldAutocomplete
-            required
-            value={formik.values.fn}
-            onChange={(value) => formik.setFieldValue("fn", value)}
-          />
-        </ModalSectionContent>
-        {formik.values.operation !== "removeAll" && (
-          <ModalSectionContent title="Field value">
-            <InputRow>
-              <Input
-                required
-                format="data"
-                name="val"
-                value={formik.values.val}
-                placeholder="value"
-                onChange={formik.handleChange}
-              />
-            </InputRow>
+      <TabList sx={{ marginLeft: "-24px", width: "calc(100% + 48px)" }}>
+        <Tabs value={activeTab} onChange={handleTabChange}>
+          <StyledTab label="Component settings" />
+          <StyledTab label="How to use this component" />
+        </Tabs>
+      </TabList>
+      <Box
+        style={{
+          display: activeTab === 0 ? "flex" : "none",
+          flexDirection: "column",
+          flex: 1,
+          overflow: "auto",
+        }}
+      >
+        <ModalSection>
+          <ModalSectionContent title="Passport field name">
+            <DataFieldAutocomplete
+              required
+              value={formik.values.fn}
+              onChange={(value) => formik.setFieldValue("fn", value)}
+            />
           </ModalSectionContent>
-        )}
-        <ModalSectionContent title="Operation">
-          <DescriptionText {...formik.values} />
-          <FormControl component="fieldset">
-            <RadioGroup defaultValue="replace" value={formik.values.operation}>
-              {options.map((option) => (
-                <BasicRadio
-                  key={option.value}
-                  id={option.value}
-                  title={option.label}
-                  variant="compact"
-                  value={option.value}
-                  onChange={handleRadioChange}
+          {formik.values.operation !== "removeAll" && (
+            <ModalSectionContent title="Field value">
+              <InputRow>
+                <Input
+                  required
+                  format="data"
+                  name="val"
+                  value={formik.values.val}
+                  placeholder="value"
+                  onChange={formik.handleChange}
                 />
-              ))}
-            </RadioGroup>
-          </FormControl>
-        </ModalSectionContent>
-      </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+              </InputRow>
+            </ModalSectionContent>
+          )}
+          <ModalSectionContent title="Operation">
+            <DescriptionText {...formik.values} />
+            <FormControl component="fieldset">
+              <RadioGroup
+                defaultValue="replace"
+                value={formik.values.operation}
+              >
+                {options.map((option) => (
+                  <BasicRadio
+                    key={option.value}
+                    id={option.value}
+                    title={option.label}
+                    variant="compact"
+                    value={option.value}
+                    onChange={handleRadioChange}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          </ModalSectionContent>
+        </ModalSection>
+        <ModalFooter formik={formik} showMoreInformation={false} />
+      </Box>
+      <Box
+        sx={{
+          display: activeTab === 1 ? "flex" : "none",
+          flexDirection: "column",
+          flex: 1,
+          padding: "16px",
+          overflow: "auto",
+        }}
+      >
+        <Typography variant="body1" mt={2}>
+          The Set Value component allows you to modify the values of a specific
+          field in the Passport. You can choose an operation (e.g., replace,
+          append, remove) and specify the field name and value. Ensure you have
+          configured the appropriate field names and operations before saving
+          changes.
+        </Typography>
+        <Box mt={4}>
+          <iframe
+            width="680"
+            height="383"
+            src="https://www.youtube.com/embed/r3nXC0jgVIg"
+            title="10 Using the set component"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          ></iframe>
+        </Box>
+      </Box>
     </form>
   );
-}
+};
+
+export default SetValueComponent;

--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -42,7 +42,7 @@ describe("globalLayoutRoutes", () => {
 
     const { queryAllByRole } = setup(<EditorNavMenu />);
     const menuItems = queryAllByRole("listitem");
-    expect(menuItems).toHaveLength(0);
+    expect(menuItems).toHaveLength(2);
   });
 
   it("displays for platformAdmins", () => {

--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -42,7 +42,7 @@ describe("globalLayoutRoutes", () => {
 
     const { queryAllByRole } = setup(<EditorNavMenu />);
     const menuItems = queryAllByRole("listitem");
-    expect(menuItems).toHaveLength(2);
+    expect(menuItems).toHaveLength(4);
   });
 
   it("displays for platformAdmins", () => {
@@ -50,7 +50,7 @@ describe("globalLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(4);
+    expect(menuItems).toHaveLength(6);
     expect(within(menuItems[0]).getByText("Select a team")).toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -50,7 +50,7 @@ describe("globalLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(3);
+    expect(menuItems).toHaveLength(4);
     expect(within(menuItems[0]).getByText("Select a team")).toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -4,6 +4,7 @@ import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
 import Info from "@mui/icons-material/Info";
 import LeaderboardIcon from "@mui/icons-material/Leaderboard";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import PaletteIcon from "@mui/icons-material/Palette";
 import RateReviewIcon from "@mui/icons-material/RateReview";
 import TuneIcon from "@mui/icons-material/Tune";
@@ -137,6 +138,12 @@ function EditorNavMenu() {
       Icon: AdminPanelSettingsIcon,
       route: "admin-panel",
       accessibleBy: ["platformAdmin"],
+    },
+    {
+      title: "Resources",
+      Icon: MenuBookIcon,
+      route: "resources",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
     },
   ];
 

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -1,4 +1,5 @@
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
@@ -7,6 +8,7 @@ import LeaderboardIcon from "@mui/icons-material/Leaderboard";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
 import PaletteIcon from "@mui/icons-material/Palette";
 import RateReviewIcon from "@mui/icons-material/RateReview";
+import SchoolIcon from "@mui/icons-material/School";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
@@ -143,6 +145,18 @@ function EditorNavMenu() {
       title: "Resources",
       Icon: MenuBookIcon,
       route: "resources",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    },
+    {
+      title: "Onboarding",
+      Icon: AssignmentTurnedInIcon,
+      route: "onboarding",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    },
+    {
+      title: "Tutorials",
+      Icon: SchoolIcon,
+      route: "tutorials",
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
     },
   ];

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -33,30 +33,32 @@ const Flow = ({ breadcrumbs = [] }: any) => {
       <ol id="flow" data-layout={flowLayout} className="decisions">
         <EndPoint text="start" />
         {!(breadcrumbs.length > 0 || childNodes.length > 0) && (
+          // Example code for demo, would be ideal to make this kind of inline
+          // graph content into a component for production
           <Box
-            sx={{
+            sx={(theme) => ({
               display: "flex",
-              gap: "10px",
+              gap: theme.spacing(1),
               width: "266px",
-              padding: "20px",
-              background: "#F9F8F8",
-              border: `1px solid #B2B4B6`,
+              padding: theme.spacing(2),
+              background: theme.palette.background.paper,
+              border: `1px solid ${theme.palette.border.main}`,
               position: "relative",
-              marginTop: "10px",
-              borderRadius: "5px",
+              marginTop: theme.spacing(1),
+              borderRadius: "4px",
               "&::before": {
                 content: "''",
                 position: "absolute",
-                top: "-10px",
+                top: "-11px",
                 left: `calc(50% - 1px)`,
                 width: "2px",
-                height: "10px",
+                height: theme.spacing(1),
                 background: "#D0D0D0",
               },
-            }}
+            })}
           >
             <SchoolIcon />
-            <Box sx={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
               <Typography variant="body1">
                 <strong>New to Plan✕?</strong>
               </Typography>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -1,3 +1,7 @@
+import SchoolIcon from "@mui/icons-material/School";
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import React from "react";
 
@@ -28,7 +32,42 @@ const Flow = ({ breadcrumbs = [] }: any) => {
     <>
       <ol id="flow" data-layout={flowLayout} className="decisions">
         <EndPoint text="start" />
-
+        {!(breadcrumbs.length > 0 || childNodes.length > 0) && (
+          <Box
+            sx={{
+              display: "flex",
+              gap: "10px",
+              width: "266px",
+              padding: "20px",
+              background: "#F9F8F8",
+              border: `1px solid #B2B4B6`,
+              position: "relative",
+              marginTop: "10px",
+              borderRadius: "5px",
+              "&::before": {
+                content: "''",
+                position: "absolute",
+                top: "-10px",
+                left: `calc(50% - 1px)`,
+                width: "2px",
+                height: "10px",
+                background: "#D0D0D0",
+              },
+            }}
+          >
+            <SchoolIcon />
+            <Box sx={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+              <Typography variant="body1">
+                <strong>New to Plan✕?</strong>
+              </Typography>
+              <Typography variant="body2">
+                Visit the{" "}
+                <Link href="../../tutorials">guides and tutorials</Link> to get
+                started.
+              </Typography>
+            </Box>
+          </Box>
+        )}
         {breadcrumbs.map((bc: any) => (
           <Node key={bc.id} {...bc} />
         ))}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -106,7 +106,7 @@ const ResetToggle = styled(Button)(({ theme }) => ({
   color: theme.palette.text.primary,
 }));
 
-const TabList = styled(Box)(({ theme }) => ({
+export const TabList = styled(Box)(({ theme }) => ({
   position: "relative",
   "&::after": {
     content: "''",

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -19,6 +19,9 @@ import { fromSlug, SLUGS } from "../../data/types";
 import { useStore } from "../../lib/store";
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
+  "& .MuiPaper-elevation": {
+    height: "100%",
+  },
   // Target all modal sections (the direct child is the backdrop, hence the double child selector)
   "& > * > *": {
     backgroundColor: theme.palette.background.paper,

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -121,7 +121,33 @@ const editorRoutes = compose(
         view: (
           <iframe
             title="notion"
-            src="https://www.notioniframe.com/notion/23i4jzez4xn"
+            src="https://www.notioniframe.com/notion/28nuwlsxpaz"
+            style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+          />
+        ),
+      };
+    }),
+
+    "/onboarding": route(() => {
+      return {
+        title: makeTitle("Onboarding"),
+        view: (
+          <iframe
+            title="notion"
+            src="https://www.notioniframe.com/notion/1fjdisq3i73"
+            style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+          />
+        ),
+      };
+    }),
+
+    "/tutorials": route(() => {
+      return {
+        title: makeTitle("Tutorials"),
+        view: (
+          <iframe
+            title="notion"
+            src="https://www.notioniframe.com/notion/1wf4jidsdbv"
             style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
           />
         ),

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -115,6 +115,19 @@ const editorRoutes = compose(
       });
     }),
 
+    "/resources": route(() => {
+      return {
+        title: makeTitle("Resources"),
+        view: (
+          <iframe
+            title="notion"
+            src="https://www.notioniframe.com/notion/23i4jzez4xn"
+            style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+          />
+        ),
+      };
+    }),
+
     "/:team": lazy(() => import("./team")),
   }),
 );


### PR DESCRIPTION
## What does this PR do?

Related to: https://trello.com/c/YlthOxbW/3161-make-external-resources-eg-notion-links-accessible-from-the-editor

Initial ideas around sharing resources in the editor.

3 areas where resource links are introduced:

1. At the root level, resource links are added to the navigational menu for resources, onboarding and guides & tutorials: https://4154.planx.pizza/
2. When starting a new service, a prompt is displayed when no component nodes are added:
https://4154.planx.pizza/a-test-team/empty-service
3. In certain components (where videos/guides exist), we link to the guides within the component with tabs:
https://4154.planx.pizza/a-test-team/set-component/nodes/_root/nodes/DRJD2oA7RN/edit