### PR TITLE
chore: Throw Uniform error to Airbrake, don't pass to `next()`

### DIFF
--- a/api.planx.uk/modules/send/uniform/uniform.ts
+++ b/api.planx.uk/modules/send/uniform/uniform.ts
@@ -131,10 +131,10 @@ export const sendToUniform: SendIntegrationController = async (
     const errorMessage = isAxiosError(error)
       ? JSON.stringify(error.response?.data)
       : (error as Error).message;
-    return next({
-      error,
-      message: `Failed to send to Uniform (${localAuthority}): ${errorMessage}`,
-    });
+
+    throw Error(
+      `Failed to send to Uniform (${localAuthority}): ${errorMessage}`,
+    );
   }
 };
 


### PR DESCRIPTION
Quick change that came from a a double-submission failure - this now matches BOPS, which was caught by Airbrake.