### PR TITLE
feat: Allow optional fields in `List` and `Page` schemas

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/Checklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/Checklist.tsx
@@ -2,7 +2,7 @@ import Grid from "@mui/material/Grid";
 import { visuallyHidden } from "@mui/utils";
 import {
   ChecklistLayout,
-  checklistValidationSchema,
+  checklistInputValidationSchema,
 } from "@planx/components/Checklist/model";
 import { Option } from "@planx/components/shared";
 import Card from "@planx/components/shared/Preview/Card";
@@ -47,7 +47,7 @@ export const Checklist: React.FC<PublicChecklistProps> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      checked: checklistValidationSchema({ data: props, required: true }),
+      checked: checklistInputValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/Checklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/Checklist.tsx
@@ -47,7 +47,7 @@ export const Checklist: React.FC<PublicChecklistProps> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      checked: checklistValidationSchema(props),
+      checked: checklistValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/Checklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/Checklist.tsx
@@ -1,8 +1,8 @@
 import Grid from "@mui/material/Grid";
 import { visuallyHidden } from "@mui/utils";
 import {
-  ChecklistLayout,
   checklistInputValidationSchema,
+  ChecklistLayout,
 } from "@planx/components/Checklist/model";
 import { Option } from "@planx/components/shared";
 import Card from "@planx/components/shared/Preview/Card";

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
@@ -2,8 +2,8 @@ import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import { visuallyHidden } from "@mui/utils";
 import {
-  ChecklistLayout,
   checklistInputValidationSchema,
+  ChecklistLayout,
 } from "@planx/components/Checklist/model";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
@@ -3,7 +3,7 @@ import Grid from "@mui/material/Grid";
 import { visuallyHidden } from "@mui/utils";
 import {
   ChecklistLayout,
-  checklistValidationSchema,
+  checklistInputValidationSchema,
 } from "@planx/components/Checklist/model";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
@@ -46,7 +46,7 @@ export const GroupedChecklist: React.FC<PublicChecklistProps> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      checked: checklistValidationSchema({ data: props, required: true }),
+      checked: checklistInputValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
@@ -46,7 +46,7 @@ export const GroupedChecklist: React.FC<PublicChecklistProps> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      checked: checklistValidationSchema(props),
+      checked: checklistValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -1,8 +1,8 @@
-import { checklistValidationSchema } from "./model";
+import { checklistInputValidationSchema } from "./model";
 
 describe("Checklist - validation", () => {
   describe("optional fields", () => {
-    const validationSchema = checklistValidationSchema({
+    const validationSchema = checklistInputValidationSchema({
       data: {
         options: [
           { id: "test1", data: { text: "Test 1", val: "test1" } },

--- a/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -1,7 +1,7 @@
 import { checklistInputValidationSchema } from "./model";
 
 describe("Checklist - validation", () => {
-  describe("optional fields", () => {
+  describe("optional checklist fields in schema", () => {
     const validationSchema = checklistInputValidationSchema({
       data: {
         options: [
@@ -23,7 +23,7 @@ describe("Checklist - validation", () => {
 
     it("validates optional fields with a value", async () => {
       await expect(() => validationSchema.validate(["test1"])).rejects.toThrow(
-        /All options must be checked/,
+        /All options must be checked/
       );
     });
   });

--- a/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -1,0 +1,30 @@
+import { checklistValidationSchema } from "./model";
+
+describe("Checklist - validation", () => {
+  describe("optional fields", () => {
+    const validationSchema = checklistValidationSchema({
+      data: {
+        options: [
+          { id: "test1", data: { text: "Test 1", val: "test1" } },
+          { id: "test2", data: { text: "Test 2", val: "test2" } },
+        ],
+        allRequired: true,
+      },
+      required: false,
+    });
+
+    it("does not validate fields without a value", async () => {
+      const undefinedResult = await validationSchema.validate(undefined);
+      expect(undefinedResult).toBeUndefined();
+
+      const arrayResult = await validationSchema.validate([]);
+      expect(arrayResult).toHaveLength(0);
+    });
+
+    it("validates optional fields with a value", async () => {
+      await expect(() => validationSchema.validate(["test1"])).rejects.toThrow(
+        /All options must be checked/,
+      );
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -123,15 +123,14 @@ export const getLayout = ({
   return ChecklistLayout.Basic;
 };
 
-interface ValidationSchema {
-  data: Checklist;
-  required: boolean;
-}
-
 export const checklistValidationSchema = ({
   data: { allRequired, options, groupedOptions },
   required,
-}: ValidationSchema) => {
+}: {
+  // Cannot use FieldValidationSchema<ChecklistInput> as this is a simplified representation (i.e. no groups)
+  data: Checklist;
+  required: boolean;
+}) => {
   const flatOptions = getFlatOptions({ options, groupedOptions });
 
   return array()

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -123,7 +123,7 @@ export const getLayout = ({
   return ChecklistLayout.Basic;
 };
 
-export const checklistValidationSchema = ({
+export const checklistInputValidationSchema = ({
   data: { allRequired, options, groupedOptions },
   required,
 }: {

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -127,7 +127,7 @@ export const checklistInputValidationSchema = ({
   data: { allRequired, options, groupedOptions },
   required,
 }: {
-  // Cannot use FieldValidationSchema<ChecklistInput> as this is a simplified representation (i.e. no groups)
+  // Cannot use type FieldValidationSchema<ChecklistInput> as this is a simplified representation (i.e. no groups)
   data: Checklist;
   required: boolean;
 }) => {

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -136,23 +136,14 @@ export const checklistInputValidationSchema = ({
   return array()
     .when([], {
       is: () => required,
-      then: array().required(),
+      then: array().min(1, "Select at least one option"),
       otherwise: array().notRequired(),
-    })
-    .test({
-      name: "atLeastOneChecked",
-      message: "Select at least one option",
-      test: (checked?: Array<string>) => {
-        if (!required && !checked?.length) return true;
-
-        return Boolean(checked && checked.length > 0);
-      },
     })
     .test({
       name: "notAllChecked",
       message: "All options must be checked",
       test: (checked?: Array<string>) => {
-        if (!required && !checked?.length) return true;
+        if (!checked?.length) return true;
         if (!allRequired) return true;
 
         const allChecked = checked && checked.length === flatOptions.length;

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -144,7 +144,7 @@ export const checklistValidationSchema = ({
       name: "atLeastOneChecked",
       message: "Select at least one option",
       test: (checked?: Array<string>) => {
-        if (!required) return true;
+        if (!required && !checked?.length) return true;
 
         return Boolean(checked && checked.length > 0);
       },
@@ -153,7 +153,7 @@ export const checklistValidationSchema = ({
       name: "notAllChecked",
       message: "All options must be checked",
       test: (checked?: Array<string>) => {
-        if (!required) return true;
+        if (!required && !checked?.length) return true;
         if (!allRequired) return true;
 
         const allChecked = checked && checked.length === flatOptions.length;

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -30,7 +30,7 @@ const DateInputPublic: React.FC<Props> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      date: dateValidationSchema(props),
+      date: dateValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { visuallyHidden } from "@mui/utils";
 import {
   DateInput,
-  dateValidationSchema,
+  dateInputValidationSchema,
   paddedDate,
 } from "@planx/components/DateInput/model";
 import Card from "@planx/components/shared/Preview/Card";
@@ -30,7 +30,7 @@ const DateInputPublic: React.FC<Props> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      date: dateValidationSchema({ data: props, required: true }),
+      date: dateInputValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
@@ -43,23 +43,18 @@ describe("parseDate helper function", () => {
 
 describe("dateSchema", () => {
   test("basic validation", async () => {
-    expect(await dateSchema({ required: true }).isValid("2021-03-23")).toBe(
+    expect(await dateSchema().isValid("2021-03-23")).toBe(
       true,
     );
-    expect(await dateSchema({ required: true }).isValid("2021-23-03")).toBe(
+    expect(await dateSchema().isValid("2021-23-03")).toBe(
       false,
     );
   });
 
   const validate = async (date?: string) =>
-    await dateSchema({ required: true })
+    await dateSchema()
       .validate(date)
       .catch((err) => err.errors);
-
-  it("throws an error for an undefined value (empty form)", async () => {
-    const errors = await validate(undefined);
-    expect(errors[0]).toMatch(/Date must include a day/);
-  });
 
   it("throws an error for an nonsensical value", async () => {
     const errors = await validate("ab-cd-efgh");

--- a/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
@@ -43,12 +43,16 @@ describe("parseDate helper function", () => {
 
 describe("dateSchema", () => {
   test("basic validation", async () => {
-    expect(await dateSchema().isValid("2021-03-23")).toBe(true);
-    expect(await dateSchema().isValid("2021-23-03")).toBe(false);
+    expect(await dateSchema({ required: true }).isValid("2021-03-23")).toBe(
+      true,
+    );
+    expect(await dateSchema({ required: true }).isValid("2021-23-03")).toBe(
+      false,
+    );
   });
 
   const validate = async (date?: string) =>
-    await dateSchema()
+    await dateSchema({ required: true })
       .validate(date)
       .catch((err) => err.errors);
 
@@ -130,6 +134,28 @@ describe("dateValidationSchema", () => {
         required: true,
       }).isValid("1980-06-15"),
     ).toBe(false);
+  });
+
+  describe("optional fields", () => {
+    const validationSchema = dateRangeSchema({
+      data: {
+        title: "test",
+        min: "1990-01-01",
+        max: "1999-12-31",
+      },
+      required: false,
+    });
+
+    it("does not validate fields without a value", async () => {
+      const result = await validationSchema.validate(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("validates optional fields with a value", async () => {
+      await expect(() =>
+        validationSchema.validate("2023-02-29"),
+      ).rejects.toThrow(/Enter a valid date in DD.MM.YYYY format/);
+    });
   });
 });
 

--- a/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
@@ -1,4 +1,4 @@
-import { dateSchema, dateValidationSchema, paddedDate, parseDate } from "./model";
+import { dateInputValidationSchema, dateSchema, paddedDate, parseDate } from "./model";
 
 describe("parseDate helper function", () => {
   it("returns a day value", () => {
@@ -102,20 +102,20 @@ describe("dateSchema", () => {
   });
 });
 
-describe("dateValidationSchema", () => {
+describe("dateInputValidationSchema", () => {
   test("basic validation", async () => {
     expect(
-      await dateValidationSchema({
+      await dateInputValidationSchema({
         data: {
           title: "test",
           min: "1990-01-01",
           max: "1999-12-31",
         },
         required: true,
-      }).isValid("1995-06-15"),
+      }).isValid("1995-06-15")
     ).toBe(true);
     expect(
-      await dateValidationSchema({
+      await dateInputValidationSchema({
         data: {
           title: "test",
           min: "1990-01-01",
@@ -125,7 +125,7 @@ describe("dateValidationSchema", () => {
       }).isValid("2021-06-15"),
     ).toBe(false);
     expect(
-      await dateValidationSchema({
+      await dateInputValidationSchema({
         data: {
           title: "test",
           min: "1990-01-01",
@@ -137,7 +137,7 @@ describe("dateValidationSchema", () => {
   });
 
   describe("optional fields", () => {
-    const validationSchema = dateRangeSchema({
+    const validationSchema = dateInputValidationSchema({
       data: {
         title: "test",
         min: "1990-01-01",

--- a/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
@@ -1,10 +1,4 @@
-import {
-  DateInput,
-  dateSchema,
-  dateValidationSchema,
-  paddedDate,
-  parseDate,
-} from "./model";
+import { dateSchema, dateValidationSchema, paddedDate, parseDate } from "./model";
 
 describe("parseDate helper function", () => {
   it("returns a day value", () => {
@@ -108,21 +102,33 @@ describe("dateValidationSchema", () => {
   test("basic validation", async () => {
     expect(
       await dateValidationSchema({
-        min: "1990-01-01",
-        max: "1999-12-31",
-      } as DateInput).isValid("1995-06-15"),
+        data: {
+          title: "test",
+          min: "1990-01-01",
+          max: "1999-12-31",
+        },
+        required: true,
+      }).isValid("1995-06-15"),
     ).toBe(true);
     expect(
       await dateValidationSchema({
-        min: "1990-01-01",
-        max: "1999-12-31",
-      } as DateInput).isValid("2021-06-15"),
+        data: {
+          title: "test",
+          min: "1990-01-01",
+          max: "1999-12-31",
+        },
+        required: true,
+      }).isValid("2021-06-15"),
     ).toBe(false);
     expect(
       await dateValidationSchema({
-        min: "1990-01-01",
-        max: "1999-12-31",
-      } as DateInput).isValid("1980-06-15"),
+        data: {
+          title: "test",
+          min: "1990-01-01",
+          max: "1999-12-31",
+        },
+        required: true,
+      }).isValid("1980-06-15"),
     ).toBe(false);
   });
 });

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -116,7 +116,7 @@ export const dateSchema = ({ required }: { required: boolean }) => {
 /**
  * Validates that date is both valid and fits within the provided min/max
  */
-export const dateRangeSchema = ({
+export const dateInputValidationSchema = ({
   data,
   required,
 }: FieldValidationSchema<DateInput>) =>
@@ -124,7 +124,7 @@ export const dateRangeSchema = ({
     .when([], {
       is: () => required,
       then: dateSchema({ required }).required(
-        "Enter a valid date in DD.MM.YYYY format",
+        "Enter a valid date in DD.MM.YYYY format"
       ),
       otherwise: dateSchema({ required }).notRequired(),
     })

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -1,5 +1,5 @@
 import { isValid, parseISO } from "date-fns";
-import { object, SchemaOf, string } from "yup";
+import { object, string } from "yup";
 
 import { BaseNodeData, parseBaseNodeData } from "../shared";
 
@@ -100,30 +100,37 @@ export const dateSchema = () => {
     );
 };
 
+interface ValidationSchema {
+  data: DateInput;
+  required: boolean;
+}
+
 /**
  * Validates that date is both valid and fits within the provided min/max
  */
-export const dateValidationSchema: (input: DateInput) => SchemaOf<string> = (
-  params,
-) =>
+export const dateValidationSchema = ({ data, required }: ValidationSchema) =>
   dateSchema()
-    .required("Enter a valid date in DD.MM.YYYY format")
+    .when([], {
+      is: () => required,
+      then: string().required("Enter a valid date in DD.MM.YYYY format"),
+      otherwise: string().notRequired(),
+    })
     .test({
       name: "too soon",
-      message: `Enter a date later than ${
-        params.min && displayDate(params.min)
-      }`,
-      test: (date: string | undefined) => {
-        return Boolean(date && !(params.min && date < params.min));
+      message: `Enter a date later than ${data.min && displayDate(data.min)}`,
+      test: (date) => {
+        if (!required && !date) return true;
+
+        return Boolean(date && !(data.min && date < data.min));
       },
     })
     .test({
       name: "too late",
-      message: `Enter a date earlier than ${
-        params.max && displayDate(params.max)
-      }`,
-      test: (date: string | undefined) => {
-        return Boolean(date && !(params.max && date > params.max));
+      message: `Enter a date earlier than ${data.max && displayDate(data.max)}`,
+      test: (date) => {
+        if (!required && !date) return true;
+
+        return Boolean(date && !(data.max && date > data.max));
       },
     });
 

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -69,34 +69,34 @@ export const parseDate = (date?: string) => {
 /**
  * Validates that a given string is a date in the correct format
  */
-export const dateSchema = ({ required }: { required: boolean }) => {
+export const dateSchema = () => {
   return string()
     .test("missing day", "Date must include a day", (date?: string) => {
-      if (!required && !date) return true;
+      if (!date) return true;
 
       const { day } = parseDate(date);
       return day !== undefined;
     })
     .test("missing month", "Date must include a month", (date?: string) => {
-      if (!required && !date) return true;
+      if (!date) return true;
 
       const { month } = parseDate(date);
       return month !== undefined;
     })
     .test("missing year", "Date must include a year", (date?: string) => {
-      if (!required && !date) return true;
+      if (!date) return true;
 
       const { year } = parseDate(date);
       return year !== undefined;
     })
     .test("invalid day", "Day must be valid", (date?: string) => {
-      if (!required && !date) return true;
+      if (!date) return true;
 
       const { day } = parseDate(date);
       return Boolean(day && day <= 31);
     })
     .test("invalid month", "Month must be valid", (date?: string) => {
-      if (!required && !date) return true;
+      if (!date) return true;
 
       const { month } = parseDate(date);
       return Boolean(month && month <= 12);
@@ -105,7 +105,7 @@ export const dateSchema = ({ required }: { required: boolean }) => {
       "valid",
       "Enter a valid date in DD.MM.YYYY format",
       (date: string | undefined) => {
-        if (!required && !date) return true;
+        if (!date) return true;
 
         // test runs regardless of required status, so don't fail it if it's undefined
         return Boolean(!date || isDateValid(date));
@@ -120,19 +120,19 @@ export const dateInputValidationSchema = ({
   data,
   required,
 }: FieldValidationSchema<DateInput>) =>
-  dateSchema({ required })
+  dateSchema()
     .when([], {
       is: () => required,
-      then: dateSchema({ required }).required(
+      then: dateSchema().required(
         "Enter a valid date in DD.MM.YYYY format"
       ),
-      otherwise: dateSchema({ required }).notRequired(),
+      otherwise: dateSchema().notRequired(),
     })
     .test({
       name: "too soon",
       message: `Enter a date later than ${data.min && displayDate(data.min)}`,
       test: (date) => {
-        if (!required && !date) return true;
+        if (!date) return true;
 
         return Boolean(date && !(data.min && date < data.min));
       },
@@ -141,7 +141,7 @@ export const dateInputValidationSchema = ({
       name: "too late",
       message: `Enter a date earlier than ${data.max && displayDate(data.max)}`,
       test: (date) => {
-        if (!required && !date) return true;
+        if (!date) return true;
 
         return Boolean(date && !(data.max && date > data.max));
       },
@@ -160,7 +160,7 @@ export const parseDateInput = (
 
 export const editorValidationSchema = () =>
   object({
-    min: dateSchema({ required: true }).test({
+    min: dateSchema().test({
       name: "Min less than max",
       message: "Min must be less than max",
       test(date: string | undefined) {
@@ -168,7 +168,7 @@ export const editorValidationSchema = () =>
         return date < this.parent.max;
       },
     }),
-    max: dateSchema({ required: true }).test({
+    max: dateSchema().test({
       name: "Max greater than min",
       message: "Max must be greater than min",
       test(date: string | undefined) {

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -2,6 +2,7 @@ import { isValid, parseISO } from "date-fns";
 import { object, string } from "yup";
 
 import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { FieldValidationSchema } from "../shared/Schema/model";
 
 // Expected format: YYYY-MM-DD
 export type UserData = string;
@@ -112,15 +113,13 @@ export const dateSchema = ({ required }: { required: boolean }) => {
     );
 };
 
-interface ValidationSchema {
-  data: DateInput;
-  required: boolean;
-}
-
 /**
  * Validates that date is both valid and fits within the provided min/max
  */
-export const dateRangeSchema = ({ data, required }: ValidationSchema) =>
+export const dateRangeSchema = ({
+  data,
+  required,
+}: FieldValidationSchema<DateInput>) =>
   dateSchema({ required })
     .when([], {
       is: () => required,

--- a/editor.planx.uk/src/@planx/components/DateInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/DateInput/model.ts
@@ -68,25 +68,35 @@ export const parseDate = (date?: string) => {
 /**
  * Validates that a given string is a date in the correct format
  */
-export const dateSchema = () => {
+export const dateSchema = ({ required }: { required: boolean }) => {
   return string()
     .test("missing day", "Date must include a day", (date?: string) => {
+      if (!required && !date) return true;
+
       const { day } = parseDate(date);
       return day !== undefined;
     })
     .test("missing month", "Date must include a month", (date?: string) => {
+      if (!required && !date) return true;
+
       const { month } = parseDate(date);
       return month !== undefined;
     })
     .test("missing year", "Date must include a year", (date?: string) => {
+      if (!required && !date) return true;
+
       const { year } = parseDate(date);
       return year !== undefined;
     })
     .test("invalid day", "Day must be valid", (date?: string) => {
+      if (!required && !date) return true;
+
       const { day } = parseDate(date);
       return Boolean(day && day <= 31);
     })
     .test("invalid month", "Month must be valid", (date?: string) => {
+      if (!required && !date) return true;
+
       const { month } = parseDate(date);
       return Boolean(month && month <= 12);
     })
@@ -94,6 +104,8 @@ export const dateSchema = () => {
       "valid",
       "Enter a valid date in DD.MM.YYYY format",
       (date: string | undefined) => {
+        if (!required && !date) return true;
+
         // test runs regardless of required status, so don't fail it if it's undefined
         return Boolean(!date || isDateValid(date));
       },
@@ -108,12 +120,14 @@ interface ValidationSchema {
 /**
  * Validates that date is both valid and fits within the provided min/max
  */
-export const dateValidationSchema = ({ data, required }: ValidationSchema) =>
-  dateSchema()
+export const dateRangeSchema = ({ data, required }: ValidationSchema) =>
+  dateSchema({ required })
     .when([], {
       is: () => required,
-      then: string().required("Enter a valid date in DD.MM.YYYY format"),
-      otherwise: string().notRequired(),
+      then: dateSchema({ required }).required(
+        "Enter a valid date in DD.MM.YYYY format",
+      ),
+      otherwise: dateSchema({ required }).notRequired(),
     })
     .test({
       name: "too soon",
@@ -147,7 +161,7 @@ export const parseDateInput = (
 
 export const editorValidationSchema = () =>
   object({
-    min: dateSchema().test({
+    min: dateSchema({ required: true }).test({
       name: "Min less than max",
       message: "Min must be less than max",
       test(date: string | undefined) {
@@ -155,7 +169,7 @@ export const editorValidationSchema = () =>
         return date < this.parent.max;
       },
     }),
-    max: dateSchema().test({
+    max: dateSchema({ required: true }).test({
       name: "Max greater than min",
       message: "Max must be greater than min",
       test(date: string | undefined) {

--- a/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Public/index.test.tsx
@@ -597,7 +597,7 @@ describe("Form validation and error handling", () => {
       )[0];
 
       expect(dateInputErrorMessage).toHaveTextContent(
-        /Date must include a day/,
+        /Enter a valid date in DD.MM.YYYY format/,
       );
     });
 
@@ -622,7 +622,7 @@ describe("Form validation and error handling", () => {
 
   test(
     "an error displays if the minimum number of items is not met",
-    { timeout: 10_000 },
+    { timeout: 20_000 },
     async () => {
       const mockWithMinTwo = merge(cloneDeep(mockZooProps), {
         schema: { min: 2 },

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
@@ -31,7 +31,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
     },
     validateOnBlur: false,
     validateOnChange: false,
-    validationSchema: validationSchema(props),
+    validationSchema: validationSchema({ data: props, required: true }),
   });
 
   const inputRef = useRef<HTMLInputElement>(null);

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.test.ts
@@ -1,7 +1,7 @@
 import { numberInputValidationSchema } from "./model";
 
 describe("validation", () => {
-  describe("optional fields", () => {
+  describe("optional number fields in schema", () => {
     const validationSchema = numberInputValidationSchema({
       data: { title: "test", isInteger: true },
       required: false,
@@ -14,11 +14,11 @@ describe("validation", () => {
 
     it("validates optional fields with a value", async () => {
       await expect(() =>
-        validationSchema.validate("not a number"),
+        validationSchema.validate("not a number")
       ).rejects.toThrow(/Enter a positive number/);
 
       await expect(() => validationSchema.validate("12.34")).rejects.toThrow(
-        /Enter a whole number/,
+        /Enter a whole number/
       );
     });
   });

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.test.ts
@@ -1,0 +1,25 @@
+import { numberInputValidationSchema } from "./model";
+
+describe("validation", () => {
+  describe("optional fields", () => {
+    const validationSchema = numberInputValidationSchema({
+      data: { title: "test", isInteger: true },
+      required: false,
+    });
+
+    it("does not validate fields without a value", async () => {
+      const result = await validationSchema.validate(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("validates optional fields with a value", async () => {
+      await expect(() =>
+        validationSchema.validate("not a number"),
+      ).rejects.toThrow(/Enter a positive number/);
+
+      await expect(() => validationSchema.validate("12.34")).rejects.toThrow(
+        /Enter a whole number/,
+      );
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -54,8 +54,7 @@ export const numberInputValidationSchema = ({
         return "Enter a number";
       })(),
       test: (value?: string) => {
-        if (!value && !required) return true;
-        if (!value) return false;
+        if (!value) return true;
 
         if (!data.allowNegatives && value.startsWith("-")) {
           return false;
@@ -67,8 +66,7 @@ export const numberInputValidationSchema = ({
       name: "check for a whole number",
       message: "Enter a whole number",
       test: (value?: string) => {
-        if (!value && !required) return true;
-        if (!value) return false;
+        if (!value) return true;
 
         if (data.isInteger && !Number.isInteger(Number(value))) {
           return false;

--- a/editor.planx.uk/src/@planx/components/NumberInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/NumberInput/model.ts
@@ -1,6 +1,7 @@
 import { object, string } from "yup";
 
 import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { FieldValidationSchema } from "../shared/Schema/model";
 
 export interface NumberInput extends BaseNodeData {
   title: string;
@@ -33,15 +34,10 @@ export const parseNumberInput = (
   ...parseBaseNodeData(data),
 });
 
-type ValidationSchema = {
-  data: NumberInput;
-  required: boolean;
-};
-
 export const numberInputValidationSchema = ({
   data,
   required,
-}: ValidationSchema) =>
+}: FieldValidationSchema<NumberInput>) =>
   string()
     .when([], {
       is: () => required,
@@ -81,7 +77,7 @@ export const numberInputValidationSchema = ({
       },
     });
 
-export const validationSchema = (args: ValidationSchema) =>
+export const validationSchema = (args: FieldValidationSchema<NumberInput>) =>
   object({
     value: numberInputValidationSchema(args),
   });

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -28,7 +28,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: object({
-      text: textInputValidationSchema(props),
+      text: textInputValidationSchema({ data: props, required: true }),
     }),
   });
 

--- a/editor.planx.uk/src/@planx/components/TextInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.test.ts
@@ -1,0 +1,21 @@
+import { TextInputType, userDataSchema } from "./model";
+
+describe("validation", () => {
+  describe("optional fields", () => {
+    const validationSchema = userDataSchema({
+      data: { title: "test", type: TextInputType.Email },
+      required: false,
+    });
+
+    it("does not validate fields without a value", async () => {
+      const result = await validationSchema.validate(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("validates optional fields with a value", async () => {
+      await expect(() =>
+        validationSchema.validate("not a valid email address"),
+      ).rejects.toThrow(/Enter an email address in the correct format/);
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/TextInput/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.test.ts
@@ -1,8 +1,8 @@
-import { TextInputType, userDataSchema } from "./model";
+import { TextInputType, textInputValidationSchema } from "./model";
 
 describe("validation", () => {
   describe("optional fields", () => {
-    const validationSchema = userDataSchema({
+    const validationSchema = textInputValidationSchema({
       data: { title: "test", type: TextInputType.Email },
       required: false,
     });

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -1,4 +1,4 @@
-import { SchemaOf, string } from "yup";
+import { string } from "yup";
 
 import { BaseNodeData, parseBaseNodeData } from "../shared";
 
@@ -23,10 +23,18 @@ export const emailRegex =
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 export const textInputValidationSchema = ({
-  type,
-}: TextInput): SchemaOf<UserData> =>
+  data: { type },
+  required,
+}: {
+  data: TextInput;
+  required: boolean;
+}) =>
   string()
-    .required("Enter your answer before continuing")
+    .when([], {
+      is: () => required,
+      then: string().required("Enter your answer before continuing"),
+      otherwise: string().notRequired(),
+    })
     .test({
       name: "valid",
       message: (() => {
@@ -41,10 +49,10 @@ export const textInputValidationSchema = ({
         }
         return `Your answer must be ${TEXT_LIMITS[type]} characters or fewer.`;
       })(),
-      test: (value: string | undefined) => {
-        if (!type) {
-          return true;
-        }
+      test: (value?: string) => {
+        if (!required && !value) return true;
+        if (!type) return true;
+
         if (type === TextInputType.Email) {
           return Boolean(value && emailRegex.test(value));
         }

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -50,7 +50,7 @@ export const textInputValidationSchema = ({
         return `Your answer must be ${TEXT_LIMITS[type]} characters or fewer.`;
       })(),
       test: (value?: string) => {
-        if (!required && !value) return true;
+        if (!value) return true;
         if (!type) return true;
 
         if (type === TextInputType.Email) {

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/DateFieldInput.tsx
@@ -11,13 +11,14 @@ import { FieldInputDescription } from "./shared";
 
 export const DateFieldInput: React.FC<Props<DateField>> = (props) => {
   const { data, formik } = props;
-  const { id, errorMessage, name, value } = getFieldProps(props);
+  const { id, errorMessage, name, value, title, required } =
+    getFieldProps(props);
 
   return (
     <Box component="fieldset">
       <InputLegend>
         <Typography variant="body1" pb={1}>
-          <strong>{data.title}</strong>
+          <strong>{title}</strong>
         </Typography>
       </InputLegend>
       {data.description && (
@@ -31,6 +32,7 @@ export const DateFieldInput: React.FC<Props<DateField>> = (props) => {
         }}
         error={errorMessage}
         id={id}
+        required={required}
       />
     </Box>
   );

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -12,7 +12,6 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { getFieldProps, Props } from ".";
 import { FieldInputDescription } from "./shared";
 
-// TODO: Think about "required" here
 export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   // Ensure there's a FindProperty component preceding this field (eg address data in state to position map view)
   const { longitude, latitude } = useStore(

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -12,6 +12,7 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { getFieldProps, Props } from ".";
 import { FieldInputDescription } from "./shared";
 
+// TODO: Think about "required" here
 export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
   // Ensure there's a FindProperty component preceding this field (eg address data in state to position map view)
   const { longitude, latitude } = useStore(
@@ -24,9 +25,9 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
 
   const {
     formik,
-    data: { title, description, mapOptions },
+    data: { description, mapOptions },
   } = props;
-  const { id, errorMessage, name } = getFieldProps(props);
+  const { id, errorMessage, name, title } = getFieldProps(props);
 
   const teamSettings = useStore.getState().teamSettings;
   const passport = useStore((state) => state.computePassport());
@@ -49,7 +50,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
       }
     };
 
-    const map: any = document.getElementById(id);
+    const map: HTMLElement | null = document.getElementById(id);
 
     map?.addEventListener("geojsonChange", geojsonChangeHandler);
 
@@ -71,9 +72,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               // ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
               height={400}
               basemap={mapOptions?.basemap}
-              geojsonData={JSON.stringify(
-                passport.data?.["proposal.site"],
-              )}
+              geojsonData={JSON.stringify(passport.data?.["proposal.site"])}
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
@@ -12,10 +12,10 @@ import { FieldInputDescription } from "./shared";
 export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
   const fieldProps = getFieldProps(props);
   const { data, formik } = props;
-  const { id, errorMessage } = fieldProps;
+  const { id, errorMessage, required, title } = fieldProps;
 
   return (
-    <InputLabel label={data.title} htmlFor={id}>
+    <InputLabel label={title} htmlFor={id}>
       {data.description && (
         <FieldInputDescription description={data.description} />
       )}
@@ -23,7 +23,7 @@ export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
         <Input
           {...fieldProps}
           onChange={formik.handleChange}
-          required
+          required={required}
           bordered
           type="number"
           inputProps={{

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
@@ -22,7 +22,7 @@ export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
         <SelectInput
           bordered
           required={required}
-          title={data.title}
+          title={title}
           labelId={`select-label-${id}`}
           value={value}
           onChange={formik.handleChange}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/SelectInputField.tsx
@@ -10,17 +10,18 @@ import { FieldInputDescription } from "./shared";
 
 export const SelectFieldInput: React.FC<Props<QuestionField>> = (props) => {
   const { data, formik } = props;
-  const { id, errorMessage, name, value } = getFieldProps(props);
+  const { id, errorMessage, name, value, required, title } =
+    getFieldProps(props);
 
   return (
-    <InputLabel label={data.title} id={`select-label-${id}`}>
+    <InputLabel label={title} id={`select-label-${id}`}>
       {data.description && (
         <FieldInputDescription description={data.description} />
       )}
       <ErrorWrapper id={`${id}-error`} error={errorMessage}>
         <SelectInput
           bordered
-          required
+          required={required}
           title={data.title}
           labelId={`select-label-${id}`}
           value={value}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
@@ -12,11 +12,11 @@ import { FieldInputDescription } from "./shared";
 export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
   const fieldProps = getFieldProps(props);
   const { data, formik } = props;
-  const { id, errorMessage } = fieldProps;
+  const { id, errorMessage, required, title } = fieldProps;
 
   const characterCountLimit = data.type && isLongTextType(data.type);
   return (
-    <InputLabel label={data.title} htmlFor={id}>
+    <InputLabel label={title} htmlFor={id}>
       {data.description && (
         <FieldInputDescription description={data.description} />
       )}
@@ -33,7 +33,7 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
         rows={
           data.type && ["long", "extraLong"].includes(data.type) ? 5 : undefined
         }
-        required
+        required={required}
         inputProps={{
           "aria-describedby": [
             data.description

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/index.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/index.tsx
@@ -23,6 +23,14 @@ export type Props<T extends Field> = {
 } & T;
 
 /**
+ * Apply "(optional)" suffix to optional fields
+ */
+export const formatTitle = ({
+  required = true,
+  data: { title },
+}: Props<Field>): string => (required ? title : (title += " (optional)"));
+
+/**
  * Helper function to get shared props derived from `Field` and `props.formik`
  */
 export const getFieldProps = <T extends Field>(props: Props<T>) => ({
@@ -36,6 +44,8 @@ export const getFieldProps = <T extends Field>(props: Props<T>) => ({
   value: props.formik.values.schemaData[props.activeIndex][
     props.data.fn
   ] as ResponseValue<T>,
+  title: formatTitle(props),
+  required: props.required ?? true,
 });
 
 /**

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
@@ -1,4 +1,7 @@
-import { mapValidationSchema, questionInputValidationSchema } from "./model";
+import {
+  mapInputValidationSchema,
+  questionInputValidationSchema,
+} from "./model";
 
 describe("QuestionField - validation", () => {
   describe("optional fields", () => {
@@ -28,7 +31,7 @@ describe("QuestionField - validation", () => {
 
 describe("MapField - validation", () => {
   describe("optional fields", () => {
-    const validationSchema = mapValidationSchema({
+    const validationSchema = mapInputValidationSchema({
       data: {
         title: "test",
         fn: "test",

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
@@ -23,7 +23,7 @@ describe("QuestionField - validation", () => {
 
     it("validates optional fields with a value", async () => {
       await expect(() =>
-        validationSchema.validate("not a valid options"),
+        validationSchema.validate("not a valid option"),
       ).rejects.toThrow(/Invalid selection/);
     });
   });

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
@@ -46,8 +46,8 @@ describe("MapField - validation", () => {
 
     it("validates optional fields with a value", async () => {
       await expect(() =>
-        validationSchema.validate(["not a valid feature"]),
-      ).rejects.toThrow(/Draw at least one feature on the map/);
+        validationSchema.validate(["not a valid feature"])
+      ).rejects.toThrow(/Input must be valid GeoJSON/);
     });
   });
 });

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.test.ts
@@ -1,0 +1,50 @@
+import { mapValidationSchema, questionInputValidationSchema } from "./model";
+
+describe("QuestionField - validation", () => {
+  describe("optional fields", () => {
+    const validationSchema = questionInputValidationSchema({
+      data: {
+        title: "test",
+        options: [
+          { id: "test1", data: { text: "Test 1", val: "test1" } },
+          { id: "test2", data: { text: "Test 2", val: "test2" } },
+        ],
+      },
+      required: false,
+    });
+
+    it("does not validate fields without a value", async () => {
+      const result = await validationSchema.validate(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("validates optional fields with a value", async () => {
+      await expect(() =>
+        validationSchema.validate("not a valid options"),
+      ).rejects.toThrow(/Invalid selection/);
+    });
+  });
+});
+
+describe("MapField - validation", () => {
+  describe("optional fields", () => {
+    const validationSchema = mapValidationSchema({
+      data: {
+        title: "test",
+        fn: "test",
+      },
+      required: false,
+    });
+
+    it("does not validate fields without a value", async () => {
+      const result = await validationSchema.validate(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("validates optional fields with a value", async () => {
+      await expect(() =>
+        validationSchema.validate(["not a valid feature"]),
+      ).rejects.toThrow(/Draw at least one feature on the map/);
+    });
+  });
+});

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -7,8 +7,8 @@ import { Feature } from "geojson";
 import { exhaustiveCheck } from "utils";
 import { array, BaseSchema, object, ObjectSchema, string } from "yup";
 
-import { checklistValidationSchema } from "../../Checklist/model";
-import { DateInput, dateValidationSchema } from "../../DateInput/model";
+import { checklistInputValidationSchema } from "../../Checklist/model";
+import { DateInput, dateInputValidationSchema } from "../../DateInput/model";
 import {
   NumberInput,
   numberInputValidationSchema,
@@ -63,7 +63,7 @@ export interface FieldValidationSchema<T extends Omit<Field["data"], "fn">> {
   required: boolean;
 }
 
-export const mapValidationSchema = ({
+export const mapInputValidationSchema = ({
   data: { mapOptions },
   required,
 }: FieldValidationSchema<MapInput>) =>
@@ -237,16 +237,19 @@ const generateValidationSchemaForFields = (
         });
         break;
       case "checklist":
-        fieldSchemas[data.fn] = checklistValidationSchema({ data, required });
+        fieldSchemas[data.fn] = checklistInputValidationSchema({
+          data,
+          required,
+        });
         break;
       case "date":
-        fieldSchemas[data.fn] = dateValidationSchema({ data, required });
+        fieldSchemas[data.fn] = dateInputValidationSchema({ data, required });
         break;
       case "address":
         fieldSchemas[data.fn] = addressValidationSchema();
         break;
       case "map":
-        fieldSchemas[data.fn] = mapValidationSchema({ data, required });
+        fieldSchemas[data.fn] = mapInputValidationSchema({ data, required });
         break;
       default:
         return exhaustiveCheck(type);

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -37,7 +37,7 @@ interface ChecklistInput {
  * As above, we need a simplified validation schema for QuestionsInputs
  */
 
-const questionInputValidationSchema = ({
+export const questionInputValidationSchema = ({
   data,
   required,
 }: {
@@ -63,7 +63,7 @@ interface ValidationSchema {
   required: boolean;
 }
 
-const mapValidationSchema = ({
+export const mapValidationSchema = ({
   data: { mapOptions },
   required,
 }: ValidationSchema) =>
@@ -79,9 +79,12 @@ const mapValidationSchema = ({
         mapOptions?.drawType?.toLocaleLowerCase() || "feature"
       } on the map`,
       test: (features?: Array<Feature>) => {
-        if (!required) return true;
+        if (!required && !features?.length) return true;
+        if (!features || !features.length) return false;
 
-        return Boolean(features && features?.length > 0);
+        const isGeoJSON = (input: Feature) => input?.type === "Feature";
+
+        return features.every(isGeoJSON);
       },
     });
 

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -40,17 +40,14 @@ interface ChecklistInput {
 export const questionInputValidationSchema = ({
   data,
   required,
-}: {
-  data: QuestionInput;
-  required: boolean;
-}) =>
+}: FieldValidationSchema<QuestionInput>) =>
   string()
     .when([], {
       is: () => required,
       then: string().required("Select your answer before continuing"),
       otherwise: string().notRequired(),
     })
-    .test("is-valid-option", "Invalid selection", (value) => {
+    .test("isValidOption", "Invalid selection", (value) => {
       if (!required && !value) return true;
 
       return data.options.some(
@@ -58,15 +55,18 @@ export const questionInputValidationSchema = ({
       );
     });
 
-interface ValidationSchema {
-  data: MapInput;
+/**
+ * Describes the input of function which returns a Yup validation schema for a field
+ */
+export interface FieldValidationSchema<T extends Omit<Field["data"], "fn">> {
+  data: T;
   required: boolean;
 }
 
 export const mapValidationSchema = ({
   data: { mapOptions },
   required,
-}: ValidationSchema) =>
+}: FieldValidationSchema<MapInput>) =>
   array()
     .when([], {
       is: () => required,

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -54,51 +54,50 @@ const mapValidationSchema = ({ mapOptions }: MapField["data"]) =>
       },
     });
 
-export type TextField = {
+type BaseField<T> = {
+  required?: boolean;
+  data: T & { fn: string };
+};
+
+export interface TextField extends BaseField<TextInput> {
   type: "text";
-  data: TextInput & { fn: string };
-};
+}
 
-export type NumberField = {
+export interface NumberField extends BaseField<NumberInput> {
   type: "number";
-  data: NumberInput & { fn: string };
-};
+}
 
-export type QuestionField = {
+export interface QuestionField extends BaseField<QuestionInput> {
   type: "question";
-  data: QuestionInput & { fn: string };
-};
+}
 
-export type ChecklistField = {
+export interface ChecklistField extends BaseField<ChecklistInput> {
   type: "checklist";
-  required?: true;
-  data: ChecklistInput & { fn: string };
-};
+}
 
-export type DateField = {
+export interface DateField extends BaseField<DateInput> {
   type: "date";
-  data: DateInput & { fn: string };
-};
+}
 
-export type AddressField = {
+export interface AddressField extends BaseField<AddressInput> {
   type: "address";
-  data: AddressInput & { fn: string };
 };
 
-export type MapField = {
-  type: "map";
-  data: {
-    title: string;
-    description?: string;
-    fn: string;
-    mapOptions?: {
-      basemap?: "OSVectorTile" | "OSRaster" | "MapboxSatellite" | "OSM";
-      drawType?: "Point" | "Polygon";
-      drawColor?: string;
-      drawMany?: boolean;
-    };
+type MapInput = {
+  title: string;
+  description?: string;
+  fn: string;
+  mapOptions?: {
+    basemap?: "OSVectorTile" | "OSRaster" | "MapboxSatellite" | "OSM";
+    drawType?: "Point" | "Polygon";
+    drawColor?: string;
+    drawMany?: boolean;
   };
 };
+
+export interface MapField extends BaseField<MapInput> {
+  type: "map";
+}
 
 /**
  * Represents the input types available in the List component

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -71,17 +71,16 @@ export const mapInputValidationSchema = ({
   array()
     .when([], {
       is: () => required,
-      then: array().required(),
+      then: array().min(1, `Draw at least one ${
+        mapOptions?.drawType?.toLocaleLowerCase() || "feature"
+      } on the map`,),
       otherwise: array().notRequired(),
     })
     .test({
-      name: "atLeastOneFeature",
-      message: `Draw at least one ${
-        mapOptions?.drawType?.toLocaleLowerCase() || "feature"
-      } on the map`,
+      name: "validGeoJSON",
+      message: "Input must be valid GeoJSON",
       test: (features?: Array<Feature>) => {
-        if (!required && !features?.length) return true;
-        if (!features || !features.length) return false;
+        if (!features?.length) return true;
 
         const isGeoJSON = (input: Feature) => input?.type === "Feature";
 

--- a/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/model.ts
@@ -48,8 +48,9 @@ export const questionInputValidationSchema = ({
       otherwise: string().notRequired(),
     })
     .test("isValidOption", "Invalid selection", (value) => {
-      if (!required && !value) return true;
+      if (!value) return true;
 
+      // Check validity regardless of "required" status
       return data.options.some(
         (option) => value === (option.data.val || option.data.text),
       );

--- a/editor.planx.uk/src/ui/shared/DateInput/DateInput.tsx
+++ b/editor.planx.uk/src/ui/shared/DateInput/DateInput.tsx
@@ -13,6 +13,7 @@ export interface Props {
   bordered?: boolean;
   id?: string;
   onChange: (newDate: string, eventType: string) => void;
+  required?: boolean;
 }
 
 const INPUT_DATE_WIDTH = "65px";
@@ -71,6 +72,7 @@ export default function DateInput(props: Props): FCReturn {
                 ev.type,
               );
             }}
+            required={props.required}
           />
         </Box>
         <Box sx={{ width: INPUT_DATE_WIDTH }}>
@@ -98,6 +100,7 @@ export default function DateInput(props: Props): FCReturn {
                 ev.type,
               );
             }}
+            required={props.required}
           />
         </Box>
         <Box sx={{ width: INPUT_YEAR_WIDTH }}>
@@ -119,6 +122,7 @@ export default function DateInput(props: Props): FCReturn {
                 ev.type,
               );
             }}
+            required={props.required}
           />
         </Box>
       </Root>


### PR DESCRIPTION
## What does this PR do?
- Introduced a new `required` property for all schema fields
- Based on this prop, makes the input conditionally optional or required. Required is the default and fallback value if not set.
- Standardises validation schema names to `${field}InputValidationSchema` (see https://github.com/theopensystemslab/planx-new/pull/4020#discussion_r1923853166)
- Test coverage for new functionality

## To test...
 - Pull down branch
 - Make schema changes to make fields required or not (Zoo schema has examples of each field type)
 - See `" (optional)" title appended to optional fields
 - Optional fields get validated correctly