### PR TITLE
chore: bump planx-core (ODP Schema v0.7.2)

### DIFF
--- a/api.planx.uk/modules/flows/publish/publish.test.ts
+++ b/api.planx.uk/modules/flows/publish/publish.test.ts
@@ -106,7 +106,7 @@ describe("publish", () => {
         data: {
           flagSet: "Planning permission",
           overrides: {
-            NO_APP_REQUIRED: {
+            "flag.pp.permittedDevelopment": {
               heading: "Some Other Heading",
             },
           },
@@ -155,7 +155,7 @@ describe("publish", () => {
               data: {
                 flagSet: "Planning permission",
                 overrides: {
-                  NO_APP_REQUIRED: {
+                  "flag.pp.permittedDevelopment": {
                     heading: "Some Other Heading",
                   },
                 },

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ae6e7f4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#90601e1",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ae6e7f4
-    version: github.com/theopensystemslab/planx-core/ae6e7f4
+    specifier: git+https://github.com/theopensystemslab/planx-core#90601e1
+    version: github.com/theopensystemslab/planx-core/90601e1
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -5217,8 +5217,8 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: false
 
-  /json-schema-to-typescript@15.0.3:
-    resolution: {integrity: sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==}
+  /json-schema-to-typescript@15.0.4:
+    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -7312,8 +7312,8 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/ae6e7f4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ae6e7f4}
+  github.com/theopensystemslab/planx-core/90601e1:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/90601e1}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -7333,7 +7333,7 @@ packages:
       fast-xml-parser: 4.5.1
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
-      json-schema-to-typescript: 15.0.3
+      json-schema-to-typescript: 15.0.4
       lodash-es: 4.17.21
       marked: 15.0.6
       prettier: 3.4.2

--- a/api.planx.uk/tests/mocks/validateAndPublishMocks.ts
+++ b/api.planx.uk/tests/mocks/validateAndPublishMocks.ts
@@ -26,7 +26,7 @@ export const mockFlowData: FlowGraph = {
     data: {
       flagSet: "Planning permission",
       overrides: {
-        NO_APP_REQUIRED: {
+        "flag.pp.permittedDevelopment": {
           heading: "Congratulations!",
         },
       },

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ae6e7f4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#90601e1",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ae6e7f4
-    version: github.com/theopensystemslab/planx-core/ae6e7f4
+    specifier: git+https://github.com/theopensystemslab/planx-core#90601e1
+    version: github.com/theopensystemslab/planx-core/90601e1
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -1856,8 +1856,8 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: false
 
-  /json-schema-to-typescript@15.0.3:
-    resolution: {integrity: sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==}
+  /json-schema-to-typescript@15.0.4:
+    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -3052,8 +3052,8 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/ae6e7f4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ae6e7f4}
+  github.com/theopensystemslab/planx-core/90601e1:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/90601e1}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -3073,7 +3073,7 @@ packages:
       fast-xml-parser: 4.5.1
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
-      json-schema-to-typescript: 15.0.3
+      json-schema-to-typescript: 15.0.4
       lodash-es: 4.17.21
       marked: 15.0.6
       prettier: 3.4.2

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ae6e7f4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#90601e1",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ae6e7f4
-    version: github.com/theopensystemslab/planx-core/ae6e7f4
+    specifier: git+https://github.com/theopensystemslab/planx-core#90601e1
+    version: github.com/theopensystemslab/planx-core/90601e1
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -1677,8 +1677,8 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: false
 
-  /json-schema-to-typescript@15.0.3:
-    resolution: {integrity: sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==}
+  /json-schema-to-typescript@15.0.4:
+    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -2601,8 +2601,8 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/ae6e7f4:
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ae6e7f4}
+  github.com/theopensystemslab/planx-core/90601e1:
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/90601e1}
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2622,7 +2622,7 @@ packages:
       fast-xml-parser: 4.5.1
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
-      json-schema-to-typescript: 15.0.3
+      json-schema-to-typescript: 15.0.4
       lodash-es: 4.17.21
       marked: 15.0.6
       prettier: 3.4.2

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ae6e7f4",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#90601e1",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#ae6e7f4
-    version: github.com/theopensystemslab/planx-core/ae6e7f4(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#90601e1
+    version: github.com/theopensystemslab/planx-core/90601e1(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -10076,8 +10076,8 @@ packages:
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  /json-schema-to-typescript@15.0.3:
-    resolution: {integrity: sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==}
+  /json-schema-to-typescript@15.0.4:
+    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -14560,9 +14560,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/ae6e7f4(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ae6e7f4}
-    id: github.com/theopensystemslab/planx-core/ae6e7f4
+  github.com/theopensystemslab/planx-core/90601e1(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/90601e1}
+    id: github.com/theopensystemslab/planx-core/90601e1
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -14582,7 +14582,7 @@ packages:
       fast-xml-parser: 4.5.1
       graphql: 16.10.0
       graphql-request: 6.1.0(graphql@16.10.0)
-      json-schema-to-typescript: 15.0.3
+      json-schema-to-typescript: 15.0.4
       lodash-es: 4.17.21
       marked: 15.0.6
       prettier: 3.4.2

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
@@ -76,7 +76,7 @@ test("Updating an existing filter to another category", async () => {
   );
 
   expect(screen.getByTestId("flagset-category-select")).toHaveValue(
-    "Listed building consent",
+    "Works to listed buildings",
   );
 
   fireEvent.change(screen.getByTestId("flagset-category-select"), {
@@ -102,7 +102,7 @@ test("Updating an existing filter to another category", async () => {
 const mockExistingFilterNode = {
   data: {
     fn: "flag",
-    category: "Listed building consent",
+    category: "Works to listed buildings",
   },
   type: 500,
   edges: ["flag1", "flag2", "flag3", "flag4", "blankFlag"],

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -172,7 +172,7 @@ function ConstraintListItem({ children, ...props }: ConstraintListItemProps) {
   // Whether to show the button to the override modal
   const showOverrideButton =
     hasPlanningData && // skip teams that don't publish via Planning Data eg Braintree
-    !props.fn.startsWith("article4") && // skip A4s (and therefore CAZs) because we can't confidently update granular passport vars based on entity data
+    !props.fn.startsWith("articleFour") && // skip A4s (and therefore CAZs) because we can't confidently update granular passport vars based on entity data
     props.value && // skip negative constraints that don't apply to this property
     Boolean(props.data?.length); // skip any positive constraints that don't have individual linked entities
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/allFacets.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/allFacets.test.ts
@@ -756,12 +756,12 @@ describe("result fields", () => {
   it("renders the heading", () => {
     const output = getDisplayDetailsForResult({
       ...mockResultResult,
-      key: "data.overrides.IMMUNE.heading",
+      key: "data.overrides.flag.pp.immune.heading",
       matchValue: "Squid",
     });
 
     expect(output).toStrictEqual<Output>({
-      key: "Heading (IMMUNE flag)",
+      key: "Heading (flag.pp.immune flag)",
       iconKey: ComponentType.Result,
       componentType: "Result",
       title: "",
@@ -772,12 +772,12 @@ describe("result fields", () => {
   it("renders the description", () => {
     const output = getDisplayDetailsForResult({
       ...mockResultResult,
-      key: "data.overrides.IMMUNE.description",
+      key: "data.overrides.flag.pp.immune.description",
       matchValue: "Eagle",
     });
 
     expect(output).toStrictEqual<Output>({
-      key: "Description (IMMUNE flag)",
+      key: "Description (flag.pp.immune flag)",
       iconKey: ComponentType.Result,
       componentType: "Result",
       title: "",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
@@ -249,7 +249,7 @@ export const mockFlow: FlowGraph = {
     data: {
       flagSet: "Planning permission",
       overrides: {
-        IMMUNE: {
+        "flag.pp.immune": {
           heading: "Squid",
           description: "Eagle",
         },
@@ -647,14 +647,14 @@ export const mockResultResult: SearchResult<IndexedNode> = {
     data: {
       flagSet: "Planning permission",
       overrides: {
-        IMMUNE: {
+        "flag.pp.immune": {
           heading: "Squid",
           description: "Eagle",
         },
       },
     },
   },
-  key: "data.overrides.IMMUNE.heading",
+  key: "data.overrides.flag.pp.immune.heading",
   matchIndices: [[0, 4]],
   refIndex: 0,
   matchValue: "Squid",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -228,14 +228,14 @@ const flowWithFilters: Store.Flow = {
   SecondQuestionYesAnswer: {
     data: {
       val: "alter.landscaping",
-      flags: ["MCOU_TRUE"],
+      flags: ["flag.mcou.true"],
       text: "Yes",
     },
     type: 200,
   },
   FirstQuestionNoAnswer: {
     data: {
-      flags: ["MCOU_FALSE"],
+      flags: ["flag.mcou.false"],
       text: "No",
     },
     type: 200,
@@ -251,7 +251,7 @@ const flowWithFilters: Store.Flow = {
   },
   RootFilterYes: {
     data: {
-      val: "MCOU_TRUE",
+      val: "flag.mcou.true",
       text: "Material change of use",
     },
     type: 200,
@@ -288,7 +288,7 @@ const flowWithFilters: Store.Flow = {
   },
   BranchFilterNo: {
     data: {
-      val: "MCOU_FALSE",
+      val: "flag.mcou.false",
       text: "Not material change of use",
     },
     type: 200,
@@ -302,7 +302,7 @@ const flowWithFilters: Store.Flow = {
   },
   RootFilterNo: {
     data: {
-      val: "MCOU_FALSE",
+      val: "flag.mcou.false",
       text: "Not material change of use",
     },
     type: 200,
@@ -336,14 +336,14 @@ const flowWithFilters: Store.Flow = {
   FirstQuestionYesAnswer: {
     data: {
       val: "alter.facade",
-      flags: ["MCOU_TRUE"],
+      flags: ["flag.mcou.true"],
       text: "Yes",
     },
     type: 200,
   },
   BranchFilterYes: {
     data: {
-      val: "MCOU_TRUE",
+      val: "flag.mcou.true",
       text: "Material change of use",
     },
     type: 200,
@@ -371,7 +371,7 @@ const flowWithFilters: Store.Flow = {
   },
   SecondQuestionNoAnswer: {
     data: {
-      flags: ["MCOU_FALSE"],
+      flags: ["flag.mcou.false"],
       text: "No",
     },
     type: 200,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getFlowSchema.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/getFlowSchema.test.ts
@@ -1,5 +1,6 @@
-import { Store, useStore } from "../store";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+
+import { Store, useStore } from "../store";
 
 const { getState, setState } = useStore;
 const { getFlowSchema } = getState();
@@ -44,27 +45,23 @@ describe("generating the schema for a flow", () => {
 });
 
 const flow: Store.Flow = {
-  "_root": {
-    "edges": [
-      "PropertyQuestion",
-      "ProjectQuestion",
-      "DateInput"
-    ]
+  _root: {
+    edges: ["PropertyQuestion", "ProjectQuestion", "DateInput"],
   },
   "0mUjzeoySp": {
-    "data": {
-      "val": "residential.dwelling.flat",
-      "text": "Flat"
+    data: {
+      val: "residential.dwelling.flat",
+      text: "Flat",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "ProjectQuestion": {
-    "data": {
-      "fn": "proposal.projectType",
-      "text": "Do you have any supported project?"
+  ProjectQuestion: {
+    data: {
+      fn: "proposal.projectType",
+      text: "Do you have any supported project?",
     },
-    "type": TYPES.Question,
-    "edges": [
+    type: TYPES.Question,
+    edges: [
       "TtjHD8V5Z9",
       "FPHuxFvNmb",
       "lOtvc52uBR",
@@ -72,184 +69,173 @@ const flow: Store.Flow = {
       "X1YhLhqImI",
       "hWyONP37gE",
       "7TBRnmE54E",
-      "NWR7GMCibW"
-    ]
+      "NWR7GMCibW",
+    ],
   },
   "7TBRnmE54E": {
-    "data": {
-      "val": "unit",
-      "text": "Unit conversion"
+    data: {
+      val: "unit",
+      text: "Unit conversion",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "GranularPropertyQuestion": {
-    "data": {
-      "fn": "property.type",
-      "text": "What type of property is it?"
+  GranularPropertyQuestion: {
+    data: {
+      fn: "property.type",
+      text: "What type of property is it?",
     },
-    "type": TYPES.Question,
-    "edges": [
-      "vNV3AeoySp",
-      "0mUjzeoySp",
-      "r3dAheoySp"
-    ]
+    type: TYPES.Question,
+    edges: ["vNV3AeoySp", "0mUjzeoySp", "r3dAheoySp"],
   },
-  "FPHuxFvNmb": {
-    "data": {
-      "val": "alter",
-      "text": "Alteration"
+  FPHuxFvNmb: {
+    data: {
+      val: "alter",
+      text: "Alteration",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "NWR7GMCibW": {
-    "data": {
-      "val": "other",
-      "text": "No"
+  NWR7GMCibW: {
+    data: {
+      val: "other",
+      text: "No",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "PropertyQuestion": {
-    "data": {
-      "fn": "property.type",
-      "text": "What type of property is it?",
-      "neverAutoAnswer": false,
-      "tags": []
+  PropertyQuestion: {
+    data: {
+      fn: "property.type",
+      text: "What type of property is it?",
+      neverAutoAnswer: false,
+      tags: [],
     },
-    "type": TYPES.Question,
-    "edges": [
-      "n14BneoySp",
-      "ZptuQeoySp"
-    ]
+    type: TYPES.Question,
+    edges: ["n14BneoySp", "ZptuQeoySp"],
   },
-  "TtjHD8V5Z9": {
-    "data": {
-      "val": "extend",
-      "text": "Extension"
+  TtjHD8V5Z9: {
+    data: {
+      val: "extend",
+      text: "Extension",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "X1YhLhqImI": {
-    "data": {
-      "val": "new",
-      "text": "New build"
+  X1YhLhqImI: {
+    data: {
+      val: "new",
+      text: "New build",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "ZI4h6FLszP": {
-    "data": {
-      "val": "changeOfUse",
-      "text": "Change of Use"
+  ZI4h6FLszP: {
+    data: {
+      val: "changeOfUse",
+      text: "Change of Use",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "ZptuQeoySp": {
-    "data": {
-      "text": "Something else",
-      "val": "other"
+  ZptuQeoySp: {
+    data: {
+      text: "Something else",
+      val: "other",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "hWyONP37gE": {
-    "data": {
-      "val": "demolish",
-      "text": "Demolition"
+  hWyONP37gE: {
+    data: {
+      val: "demolish",
+      text: "Demolition",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "lOtvc52uBR": {
-    "data": {
-      "val": "internal",
-      "text": "Internal"
+  lOtvc52uBR: {
+    data: {
+      val: "internal",
+      text: "Internal",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "n14BneoySp": {
-    "data": {
-      "val": "residential",
-      "text": "Residential"
+  n14BneoySp: {
+    data: {
+      val: "residential",
+      text: "Residential",
     },
-    "type": TYPES.Answer,
-    "edges": [
-      "GranularPropertyQuestion"
-    ]
+    type: TYPES.Answer,
+    edges: ["GranularPropertyQuestion"],
   },
-  "r3dAheoySp": {
-    "data": {
-      "val": "residential.HMO",
-      "text": "HMO"
+  r3dAheoySp: {
+    data: {
+      val: "residential.HMO",
+      text: "HMO",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "vNV3AeoySp": {
-    "data": {
-      "val": "residential.dwelling.house",
-      "text": "House"
+  vNV3AeoySp: {
+    data: {
+      val: "residential.dwelling.house",
+      text: "House",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "DateInput": {
-    "type": TYPES.DateInput,
-    "data": {
-      "title": "When will the works begin?",
-      "fn": "proposal.startDate",
-      "min": "2024-01-01",
-      "max": "2050-01-01"
-    }
-  }
+  DateInput: {
+    type: TYPES.DateInput,
+    data: {
+      title: "When will the works begin?",
+      fn: "proposal.startDate",
+      min: "2024-01-01",
+      max: "2050-01-01",
+    },
+  },
 };
 
 const flowWithFilter: Store.Flow = {
-  "_root": {
-    "edges": [
-      "Filter"
-    ]
+  _root: {
+    edges: ["Filter"],
   },
   "96L5yOhBQJ": {
-    "data": {
-      "val": "TR-DE_MINIMIS",
-      "text": "De minimis"
+    data: {
+      val: "flag.wtt.notice",
+      text: "De minimis",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "G404TmcPne": {
-    "data": {
-      "val": "TR-MISSING_INFO",
-      "text": "Missing information"
+  G404TmcPne: {
+    data: {
+      val: "flag.wtt.missingInfo",
+      text: "Missing information",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "Filter": {
-    "data": {
-      "fn": "flag",
-      "category": "Works to trees & hedges"
+  Filter: {
+    data: {
+      fn: "flag",
+      category: "Works to trees & hedges",
     },
-    "type": TYPES.Filter,
-    "edges": [
+    type: TYPES.Filter,
+    edges: [
       "G404TmcPne",
       "UXbWvxQMPF",
       "96L5yOhBQJ",
       "W3ovRimuF3",
-      "xkiC61BIiG"
-    ]
+      "xkiC61BIiG",
+    ],
   },
-  "UXbWvxQMPF": {
-    "data": {
-      "val": "TR-REQUIRED",
-      "text": "Required"
+  UXbWvxQMPF: {
+    data: {
+      val: "flag.wtt.consentNeeded",
+      text: "Required",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "W3ovRimuF3": {
-    "data": {
-      "val": "TR-NOT_REQUIRED",
-      "text": "Not required"
+  W3ovRimuF3: {
+    data: {
+      val: "flag.wtt.notRequired",
+      text: "Not required",
     },
-    "type": TYPES.Answer
+    type: TYPES.Answer,
   },
-  "xkiC61BIiG": {
-    "data": {
-      "text": "No flag result"
+  xkiC61BIiG: {
+    data: {
+      text: "No flag result",
     },
-    "type": TYPES.Answer
-  }
+    type: TYPES.Answer,
+  },
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/collectedFlags.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/collectedFlags.test.ts
@@ -60,7 +60,12 @@ const flow: Store.Flow = {
     type: 200,
     data: {
       text: "Yes",
-      flags: ["PP-NOTICE", "EDGE_CASE", "CO_RELIEF", "PRIOR_APPROVAL"],
+      flags: [
+        "flag.pp.notice",
+        "flag.planningPolicy.edgeCase",
+        "flag.cil.relief",
+        "flag.pp.priorApproval",
+      ],
     },
   },
   NoOption: {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/collectedFlags.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/collectedFlags.test.ts
@@ -18,7 +18,7 @@ describe("Collecting flags", () => {
     expect(collectedFlags()).toEqual({
       "Community infrastructure levy": ["Relief"], // Flag value translated to display text
       "Demolition in a conservation area": [],
-      "Listed building consent": [],
+      "Works to listed buildings": [],
       "Material change of use": [],
       "Planning permission": ["Prior approval", "Notice"], // Many flags in same category are ordered highest to lowest, even if selected in opposite order
       "Planning policy": ["Edge case"],
@@ -35,7 +35,7 @@ describe("Collecting flags", () => {
     expect(collectedFlags()).toEqual({
       "Community infrastructure levy": [],
       "Demolition in a conservation area": [],
-      "Listed building consent": [],
+      "Works to listed buildings": [],
       "Material change of use": [],
       "Planning permission": [],
       "Planning policy": [],

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -428,7 +428,7 @@ const mockFlowData = {
     },
     IzT93uCmyF: {
       data: {
-        flags: ["PRIOR_APPROVAL"],
+        flags: ["flag.pp.priorApproval"],
         text: "Prior",
       },
       type: TYPES.Answer,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -394,7 +394,7 @@ const mockFlowData = {
     },
     "4FRZMfNlXf": {
       data: {
-        flags: ["PP-NOT_DEVELOPMENT"],
+        flags: ["flag.pp.notDevelopment"],
         text: "Not development",
       },
       type: TYPES.Answer,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
@@ -79,7 +79,7 @@ const mockFlowData = {
     },
     "4FRZMfNlXf": {
       data: {
-        flags: ["PP-NOT_DEVELOPMENT"],
+        flags: ["flag.pp.notDevelopment"],
         text: "Not development",
       },
       type: 200,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
@@ -113,7 +113,7 @@ const mockFlowData = {
     },
     IzT93uCmyF: {
       data: {
-        flags: ["PRIOR_APPROVAL"],
+        flags: ["flag.pp.priorApproval"],
         text: "Prior",
       },
       type: 200,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resultData.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resultData.test.ts
@@ -80,9 +80,9 @@ describe("Computing result data based on collected flags", () => {
     });
     clickContinue("TextInput", { data: { name: "Test" }, auto: false });
 
-    const category = "Listed building consent";
+    const category = "Works to listed buildings";
     const collectedLBCFlags = collectedFlags()?.[category];
-    expect(collectedLBCFlags).toEqual(["Required"]);
+    expect(collectedLBCFlags).toEqual(["Consent needed"]);
 
     // The result should be the first flag
     expect(resultData(category)?.[category]?.displayText).toEqual({
@@ -94,7 +94,7 @@ describe("Computing result data based on collected flags", () => {
       category: category,
       color: "#000000",
       text: collectedLBCFlags[0],
-      value: "LB-REQUIRED",
+      value: "flag.lbc.consentNeeded",
     });
     expect(resultData(category)?.[category]?.responses).toHaveLength(2); // TextInput is omitted
   });
@@ -111,13 +111,13 @@ describe("Computing result data based on collected flags", () => {
     });
     clickContinue("TextInput", { data: { name: "Test" }, auto: false });
 
-    const category = "Listed building consent";
+    const category = "Works to listed buildings";
     const collectedLBCFlags = collectedFlags()?.[category];
-    expect(collectedLBCFlags).toEqual(["Required"]);
+    expect(collectedLBCFlags).toEqual(["Consent needed"]);
 
     // The result should be the first flag
     const editorOverrides = {
-      "LB-REQUIRED": {
+      "flag.lbc.consentNeeded": {
         description: "This is a custom description",
       },
     };
@@ -156,7 +156,7 @@ const flow: Store.Flow = {
   },
   ListedBuildingOptionNo: {
     data: {
-      flags: ["LB-NOT_REQUIRED"],
+      flags: ["flag.lbc.notRequired"],
       text: "No",
     },
     type: 200,
@@ -186,9 +186,9 @@ const flow: Store.Flow = {
   },
   ListedBuildingConsentResult: {
     data: {
-      flagSet: "Listed building consent",
+      flagSet: "Works to listed buildings",
       overrides: {
-        "LB-REQUIRED": {
+        "flag.lbc.consentNeeded": {
           description: "This is a custom description",
         },
       },
@@ -212,7 +212,7 @@ const flow: Store.Flow = {
   },
   ListedBuildingOptionYes: {
     data: {
-      flags: ["PLANNING_PERMISSION_REQUIRED", "LB-REQUIRED"],
+      flags: ["PLANNING_PERMISSION_REQUIRED", "flag.lbc.consentNeeded"],
       text: "Yes",
     },
     type: 200,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resultData.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resultData.test.ts
@@ -61,7 +61,7 @@ describe("Computing result data based on collected flags", () => {
       category: category,
       color: "#000000",
       text: collectedPPFlags[0],
-      value: "PLANNING_PERMISSION_REQUIRED",
+      value: "flag.pp.permissionNeeded",
       description:
         "It looks like the proposed changes may require planning permission.",
     });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resultData.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/resultData.test.ts
@@ -143,7 +143,7 @@ const flow: Store.Flow = {
   },
   MaterialOptionNo: {
     data: {
-      flags: ["MCOU_FALSE", "NO_APP_REQUIRED"],
+      flags: ["flag.mcou.false", "flag.pp.permittedDevelopment"],
       text: "No",
     },
     type: 200,
@@ -205,14 +205,14 @@ const flow: Store.Flow = {
   },
   MaterialOptionYes: {
     data: {
-      flags: ["MCOU_TRUE", "PLANNING_PERMISSION_REQUIRED"],
+      flags: ["flag.mcou.true", "flag.pp.permissionNeeded"],
       text: "Yes",
     },
     type: 200,
   },
   ListedBuildingOptionYes: {
     data: {
-      flags: ["PLANNING_PERMISSION_REQUIRED", "flag.lbc.consentNeeded"],
+      flags: ["flag.pp.permissionNeeded", "flag.lbc.consentNeeded"],
       text: "Yes",
     },
     type: 200,


### PR DESCRIPTION
- Bumps planx-core to latest `main` (includes ODP Schema v0.7.2 plus flag changes)
- Updates mock test data throughout to reflect new flag values
- Fixes forward lingering `article4` spotted here: https://github.com/theopensystemslab/planx-new/pull/4151#pullrequestreview-2562119952