### PR TITLE
fix: ensure auto-answered `SetValue` nodes track allow list answers

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/mutations.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/mutations.ts
@@ -125,11 +125,15 @@ export const UPDATE_ALLOW_LIST_ANSWERS = gql`
 
 export const UPDATE_AUTO_ANSWERED_ALLOW_LIST_ANSWERS = gql`
   mutation UpdateAllowListAnswers(
+    $analytics_id: bigint!
     $allow_list_answers: jsonb
     $node_id: String!
   ) {
     update_analytics_logs(
-      where: { node_id: { _eq: $node_id } }
+      where: {
+        analytics_id: { _eq: $analytics_id }
+        node_id: { _eq: $node_id }
+      }
       _set: { allow_list_answers: $allow_list_answers }
     ) {
       returning {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/mutations.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/mutations.ts
@@ -123,6 +123,22 @@ export const UPDATE_ALLOW_LIST_ANSWERS = gql`
   }
 `;
 
+export const UPDATE_AUTO_ANSWERED_ALLOW_LIST_ANSWERS = gql`
+  mutation UpdateAllowListAnswers(
+    $allow_list_answers: jsonb
+    $node_id: String!
+  ) {
+    update_analytics_logs(
+      where: { node_id: { _eq: $node_id } }
+      _set: { allow_list_answers: $allow_list_answers }
+    ) {
+      returning {
+        id
+      }
+    }
+  }
+`;
+
 export const TRACK_INPUT_ERRORS = gql`
   mutation TrackInputErrors($id: bigint!, $error: jsonb) {
     update_analytics_logs_by_pk(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -420,10 +420,9 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
     updatedBreadcrumbKeys.forEach((breadcrumbKey) => {
       const breadcrumb = breadcrumbs[breadcrumbKey];
-
-      // track() is called from the Card component, so auto-answers are naturally omitted because they aren't rendered to a user
-      //   instead we manually insert their analytics_logs and track allow list answers as applicable here
-      if (breadcrumb?.auto) {
+      if (breadcrumb.auto) {
+        // track() is called from the Card component, so auto-answers are naturally omitted because they aren't rendered to a user
+        //   instead we manually insert their analytics_logs and track allow list answers as applicable here
         track(breadcrumbKey);
         updateAutoAnsweredNodeWithAllowListAnswers(breadcrumbKey, breadcrumb);
       } else {

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -371,7 +371,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     //   Do not track allow list answers for Questions or Checklists because these will always be equal or less granular data values than put to the user
     if (
       flow[nodeId]?.type !== TYPES.SetValue ||
-      ["removeOne", "removeAll"].includes(flow[nodeId]?.data?.operation)
+      !["append", "replace"].includes(flow[nodeId]?.data?.operation)
     )
       return;
 
@@ -383,11 +383,12 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     );
     if (!allowListAnswers) return;
 
-    // We can't rely on lastVisibleNodeAnalyticsLogId variable here because we have an auto-answered node (not visible)
+    // We can't rely on lastVisibleNodeAnalyticsLogId variable here to mutate a single record because we have an auto-answered node (not visible), so instead we update entire session using analyticsId
     //   But this shouldn't matter in the case of SetValues because very nodeId has same data value (this would not hold for Questions and Checklists with different option paths)
     await publicClient.mutate({
       mutation: UPDATE_AUTO_ANSWERED_ALLOW_LIST_ANSWERS,
       variables: {
+        analytics_id: analyticsId,
         allow_list_answers: allowListAnswers,
         node_id: nodeId,
       },

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -353,7 +353,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     await publicClient.mutate({
       mutation: UPDATE_ALLOW_LIST_ANSWERS,
       variables: {
-        id: lastVisibleNodeAnalyticsLogId,
+        id: lastVisibleNodeAnalyticsLogId, // TODO ensure this is correct id when isAutoanswered = true ! Currently lagging ~2 logs (need last log, not *visible* node) else empty mutation response
         allow_list_answers: allowListAnswers,
         node_id: nodeId,
       },
@@ -386,11 +386,15 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
 
     updatedBreadcrumbKeys.forEach((breadcrumbKey) => {
       const breadcrumb = breadcrumbs[breadcrumbKey];
-      if (breadcrumb.auto) {
+
+      // track() is called from the Card, so auto-answers are naturally omitted because they aren't rendered to a user
+      //   instead we manually insert their analytics_logs here
+      if (breadcrumb?.auto) {
         track(breadcrumbKey);
-      } else {
-        updateLastVisibleNodeLogWithAllowListAnswers(breadcrumbKey, breadcrumb);
       }
+
+      // Any node should check for and record any allow-list answers
+      updateLastVisibleNodeLogWithAllowListAnswers(breadcrumbKey, breadcrumb);
     });
   }
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -29,7 +29,10 @@ export function extractNodeTitle(node: Store.Node): string {
   const nodeTitle =
     node?.type === TYPES.Content
       ? getContentTitle(node)
-      : node?.data?.title ?? node?.data?.text ?? node?.data?.flagSet;
+      : node?.data?.title ??
+        node?.data?.text ??
+        node?.data?.flagSet ??
+        node?.data?.category;
   return nodeTitle;
 }
 


### PR DESCRIPTION
Replaces #4007; see conversation here https://opensystemslab.slack.com/archives/C5Q59R3HB/p1737538391491109

**Before:**
- `analytics_logs` tracks every node you've traveled through with metadata about whether or not it's been auto-answered
- For nodes that have been put to a user, we also record `allow_list_answers` (eg answers to non-personal white-listed data fields that we can retain forever)
  - We aslo only record the `next_log_created_at` timestamp for nodes which have been put to a user, which means these timestamps can be used to understand how long users spend on _visible_ nodes
- For nodes that have been auto-answered, we won't record `allow_list_answers` even if the auto-answered node sets an allow listed data field
  - This generally makes sense because the auto-answered node is likely to be a less granular version of the thing that's already been put to a user - for example, I go through find property and my allow list answer is `property.type = residential.house.terrace`, then I'm automated through a question like "is it residential". Why would I want to duplicate a less-granular allow list answer like `property.type = residential`, or even stranger a "blank" if the automated question was "is it commercial" ?
  - But while that makes sense for Question and Checklist type nodes, it doesn't for SetValues because they can set a data field that will never otherwise be put to a user

**Now:**
- For nodes that have been auto-answered, if they are a SetValue type that is appending or replacing a data value (_not_ removing), we'll record it's allow list answer if it has an applicable data field
  - We will still omit recording allow list answers for auto-answered Questions or Checklists to reduce noise and duplication
  
**Testing:**
- This flow mocks the RAB structure as I understand it https://4178.planx.pizza/testing/rab-mock
- We're testing to ensure that we can now record `rab.exitReason = "permittedDevelopment"` as an allow list answer when it's set via SetValue, whereas previously we would have only captured `civilProject`and other reasons put to the user via non-auto-answered nodes
![Screenshot from 2025-01-22 22-25-49](https://github.com/user-attachments/assets/dd52f52c-5014-4fda-93d9-9b9ccc4e8e5d)

**Open questions:**
- The `analytics_summary` view has zero reference to `metadata.isAutoAnswered` - is this still fine or is there a use case to expose as a new column for easy filtering? 