### PR TITLE
fix: Consistent text case in the editor

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
@@ -26,14 +26,14 @@ export default function AddressInputComponent(props: Props): FCReturn {
         });
       }
     },
-    validate: () => { },
+    validate: () => {},
   });
 
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
         <ModalSectionContent
-          title="Address Input"
+          title="Address input"
           Icon={ICONS[TYPES.AddressInput]}
         >
           <InputRow>

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -89,7 +89,7 @@ export default function ConfirmationEditor(props: Props) {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Top Banner">
+        <ModalSectionContent title="Top banner">
           <InputRow>
             <Input
               placeholder="Heading"
@@ -110,7 +110,7 @@ export default function ConfirmationEditor(props: Props) {
       </ModalSection>
 
       <ModalSection>
-        <ModalSectionContent title="Next Steps" Icon={ICONS[TYPES.TaskList]}>
+        <ModalSectionContent title="Next steps" Icon={ICONS[TYPES.TaskList]}>
           <ListManager
             values={formik.values.nextSteps}
             onChange={(steps: Step[]) => {
@@ -124,7 +124,7 @@ export default function ConfirmationEditor(props: Props) {
 
       <ModalSection>
         <ModalSectionContent
-          title="More Information"
+          title="More information"
           Icon={ICONS[TYPES.Confirmation]}
         >
           <RichTextInput
@@ -136,7 +136,7 @@ export default function ConfirmationEditor(props: Props) {
       </ModalSection>
 
       <ModalSection>
-        <ModalSectionContent title="Contact Us" Icon={ICONS[TYPES.Send]}>
+        <ModalSectionContent title="Contact us" Icon={ICONS[TYPES.Send]}>
           <RichTextInput
             value={formik.values.contactInfo}
             name="contactInfo"

--- a/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
@@ -33,7 +33,7 @@ export default function ContactInputComponent(props: Props): FCReturn {
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
         <ModalSectionContent
-          title="Contact Input"
+          title="Contact input"
           Icon={ICONS[TYPES.ContactInput]}
         >
           <InputRow>

--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
@@ -19,7 +19,7 @@ describe("DateInputComponent - Editor Modal", () => {
         <DateInputComponent id="test" />
       </DndProvider>,
     );
-    expect(screen.getByText("Date Input")).toBeInTheDocument();
+    expect(screen.getByText("Date input")).toBeInTheDocument();
   });
 
   it("throws an error for incompatible date values", async () => {

--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -40,7 +40,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
   return (
     <form onSubmit={formik.handleSubmit} id="modal" name="modal">
       <ModalSection>
-        <ModalSectionContent title="Date Input" Icon={ICONS[TYPES.DateInput]}>
+        <ModalSectionContent title="Date input" Icon={ICONS[TYPES.DateInput]}>
           <InputRow>
             <Input
               format="large"

--- a/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -34,7 +34,7 @@ function FindPropertyComponent(props: Props) {
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
         <ModalSectionContent
-          title="Find Property"
+          title="Find property"
           Icon={ICONS[TYPES.FindProperty]}
         >
           <InputRow>

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -69,7 +69,7 @@ const InternalPortalForm: React.FC<{
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">
       <ModalSection>
         <ModalSectionContent
-          title="Internal Portal"
+          title="Internal portal"
           Icon={ICONS[TYPES.InternalPortal]}
         >
           <ErrorWrapper error={formik.errors.text}>

--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -88,7 +88,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Next Steps" Icon={ICONS[TYPES.NextSteps]}>
+        <ModalSectionContent title="Next steps" Icon={ICONS[TYPES.NextSteps]}>
           <Box mb="1rem">
             <InputRow>
               <Input

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -55,7 +55,7 @@ describe("Pay component - Editor Modal", () => {
           <PayComponent id="test" />
         </DndProvider>,
       );
-      expect(getByText("GOV.UK Pay Metadata")).toBeInTheDocument();
+      expect(getByText("GOV.UK Pay metadata")).toBeInTheDocument();
     });
 
     it("lists the default values", () => {

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
@@ -73,7 +73,7 @@ export const GovPayMetadataSection: React.FC = () => {
 
   return (
     <ModalSection>
-      <ModalSectionContent title="GOV.UK Pay Metadata" Icon={DataObjectIcon}>
+      <ModalSectionContent title="GOV.UK Pay metadata" Icon={DataObjectIcon}>
         <Typography variant="subtitle2" sx={{ mb: 2 }}>
           Include metadata alongside payments, such as VAT codes, cost centers,
           or ledger codes. See{" "}

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
@@ -17,7 +17,7 @@ export const InviteToPaySection: React.FC = () => {
 
   return (
     <ModalSection>
-      <ModalSectionContent title="Invite to Pay" Icon={ICONS[TYPES.Pay]}>
+      <ModalSectionContent title="Invite to pay" Icon={ICONS[TYPES.Pay]}>
         <InputRow>
           <Switch
             checked={values.allowInviteToPay}

--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -108,7 +108,7 @@ const ResultComponent: React.FC<Props> = (props) => {
 
           <Box mt={2}>
             <Typography variant="h5" component="h6">
-              Flag Text Overrides (optional)
+              Flag text overrides (optional)
             </Typography>
             <Typography variant="body2">
               The overrides you set here will change what is displayed to the

--- a/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -72,14 +72,14 @@ const TaskListComponent: React.FC<Props> = (props) => {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Task List" Icon={ICONS[TYPES.TaskList]}>
+        <ModalSectionContent title="Task list" Icon={ICONS[TYPES.TaskList]}>
           <Box mb="1rem">
             <InputRow>
               <Input
                 name="title"
                 value={formik.values.title}
                 onChange={formik.handleChange}
-                placeholder="Main Title"
+                placeholder="Main title"
                 format="large"
               />
             </InputRow>
@@ -88,7 +88,7 @@ const TaskListComponent: React.FC<Props> = (props) => {
                 name="description"
                 value={formik.values.description}
                 onChange={formik.handleChange}
-                placeholder="Main Description"
+                placeholder="Main description"
               />
             </InputRow>
           </Box>

--- a/editor.planx.uk/src/@planx/components/TaskList/TaskList.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/TaskList/TaskList.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Basic = {
   args: {
-    title: "Your Next Steps",
+    title: "Your next steps",
     description: "To reverse climate change",
     tasks: [
       { title: "Do this first", description: "It's a very important task." },

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -29,7 +29,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
         });
       }
     },
-    validate: () => { },
+    validate: () => {},
   });
 
   const handleRadioChange = (event: React.SyntheticEvent<Element, Event>) => {
@@ -40,7 +40,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
-        <ModalSectionContent title="Text Input" Icon={ICONS[TYPES.TextInput]}>
+        <ModalSectionContent title="Text input" Icon={ICONS[TYPES.TextInput]}>
           <InputRow>
             <Input
               format="large"

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ContactForm.tsx
@@ -46,7 +46,7 @@ export default function ContactForm({ formikConfig, onSuccess }: FormProps) {
 
   return (
     <SettingsForm
-      legend="Contact Information"
+      legend="Contact information"
       formik={formik}
       description={
         <>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/SubmissionsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/SubmissionsForm.tsx
@@ -33,7 +33,7 @@ export default function SubmissionsForm({
 
   return (
     <SettingsForm
-      legend="Submission Information"
+      legend="Submission information"
       formik={formik}
       description={
         <>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowDescription/FlowDescription.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowDescription/FlowDescription.tsx
@@ -44,14 +44,14 @@ const FlowDescription = () => {
     <Box mb={2}>
       <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
-          Service Information
+          Service information
         </Typography>
         <Typography variant="body1">
           Useful information about this service.
         </Typography>
       </SettingsSection>
       <SettingsForm
-        legend="Service Description"
+        legend="Service description"
         formik={formik}
         description={
           <>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -101,9 +101,10 @@ const FlowStatus = () => {
       </SettingsSection>
       <SettingsSection background>
         <Switch
-          label={statusForm.values.status as Capitalize<string>}
+          label={statusForm.values.status as string}
           name={"service.status"}
           variant="editorPage"
+          capitalize
           checked={statusForm.values.status === "online"}
           onChange={() =>
             statusForm.setFieldValue(

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -20,7 +20,7 @@ import type { FlowSettings } from "../../../../../types";
 import { useStore } from "../../../lib/store";
 
 const TextInput: React.FC<{
-  title: Capitalize<string>;
+  title: string;
   richText?: boolean;
   description?: string;
   switchProps?: SwitchProps;
@@ -123,7 +123,7 @@ export const FooterLinksAndLegalDisclaimer = () => {
       </SettingsSection>
       <SettingsSection background>
         <TextInput
-          title="Legal Disclaimer"
+          title="Legal disclaimer"
           description="Displayed on the 'Result' pages of the service (if it contains any)"
           switchProps={{
             name: "elements.legalDisclaimer.show",
@@ -144,10 +144,10 @@ export const FooterLinksAndLegalDisclaimer = () => {
       </SettingsSection>
       <SettingsSection background>
         <InputGroup flowSpacing>
-          <InputLegend>Footer Links</InputLegend>
+          <InputLegend>Footer links</InputLegend>
           <InputRow>
             <TextInput
-              title="Help Page"
+              title="Help page"
               richText
               description="A place to communicate FAQs, useful tips, or contact information"
               switchProps={{
@@ -169,7 +169,7 @@ export const FooterLinksAndLegalDisclaimer = () => {
           </InputRow>
           <InputRow>
             <TextInput
-              title="Privacy Page"
+              title="Privacy page"
               richText
               description="Your privacy policy"
               switchProps={{

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -54,20 +54,20 @@ const NodeTypeSelect: React.FC<{
         <option value={TYPES.NextSteps}>Next steps</option>
       </optgroup>
       <optgroup label="Inputs">
-        <option value={TYPES.TextInput}>Text Input</option>
-        <option value={TYPES.FileUpload}>File Upload</option>
+        <option value={TYPES.TextInput}>Text input</option>
+        <option value={TYPES.FileUpload}>File upload</option>
         <option value={TYPES.FileUploadAndLabel}>Upload and label</option>
-        <option value={TYPES.NumberInput}>Number Input</option>
-        <option value={TYPES.DateInput}>Date Input</option>
-        <option value={TYPES.AddressInput}>Address Input</option>
-        <option value={TYPES.ContactInput}>Contact Input</option>
+        <option value={TYPES.NumberInput}>Number input</option>
+        <option value={TYPES.DateInput}>Date input</option>
+        <option value={TYPES.AddressInput}>Address input</option>
+        <option value={TYPES.ContactInput}>Contact input</option>
         <option value={TYPES.List}>List</option>
         <option value={TYPES.Page}>Page</option>
-        <option value={TYPES.MapAndLabel}>Map and Label (Testing only)</option>
+        <option value={TYPES.MapAndLabel}>Map and label (testing only)</option>
         <option value={TYPES.Feedback}>Feedback</option>
       </optgroup>
       <optgroup label="Information">
-        <option value={TYPES.TaskList}>Task List</option>
+        <option value={TYPES.TaskList}>Task list</option>
         <option value={TYPES.Notice}>Notice</option>
         <option value={TYPES.Result}>Result</option>
         <option value={TYPES.Content}>Content</option>
@@ -82,10 +82,10 @@ const NodeTypeSelect: React.FC<{
       </optgroup>
       <optgroup label="Navigation">
         <option value={TYPES.Filter}>Filter</option>
-        <option value={TYPES.InternalPortal}>Internal Portal</option>
-        <option value={TYPES.ExternalPortal}>External Portal</option>
+        <option value={TYPES.InternalPortal}>Internal portal</option>
+        <option value={TYPES.ExternalPortal}>External portal</option>
         <option value={TYPES.Section}>Section</option>
-        <option value={TYPES.SetValue}>Set Value</option>
+        <option value={TYPES.SetValue}>Set value</option>
       </optgroup>
       <optgroup label="Payment">
         <option value={TYPES.Calculate}>Calculate</option>

--- a/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -56,12 +56,12 @@ function Component() {
       <form onSubmit={formik.handleSubmit}>
         <SettingsSection>
           <Typography variant="h2" component="h3" gutterBottom>
-            Global Settings
+            Global settings
           </Typography>
         </SettingsSection>
         <SettingsSection background>
           <InputGroup flowSpacing>
-            <InputLegend>Footer Elements</InputLegend>
+            <InputLegend>Footer elements</InputLegend>
             <SettingsDescription>
               <p>Manage the content that will appear in the footer.</p>
               <p>

--- a/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel.tsx
@@ -44,7 +44,7 @@ function Component() {
     <Container maxWidth={false}>
       <SettingsSection>
         <Typography variant="h2" component="h1" gutterBottom>
-          Platform Admin Panel
+          Platform admin panel
         </Typography>
         <Typography variant="body1">
           {`This is an overview of each team's integrations and settings for the `}

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -109,7 +109,7 @@ const editorRoutes = compose(
         useStore.getState().setAdminPanelData(data.adminPanel);
 
         return {
-          title: makeTitle("Platform Admin Panel"),
+          title: makeTitle("Platform admin panel"),
           view: <AdminPanelView />,
         };
       });

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -1,5 +1,7 @@
 import Box from "@mui/material/Box";
-import FormControlLabel, { formControlLabelClasses } from "@mui/material/FormControlLabel";
+import FormControlLabel, {
+  formControlLabelClasses,
+} from "@mui/material/FormControlLabel";
 // eslint-disable-next-line no-restricted-imports
 import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
 import React from "react";
@@ -8,35 +10,46 @@ import { FONT_WEIGHT_BOLD } from "theme";
 interface Props {
   checked?: boolean;
   onChange: MuiSwitchProps["onChange"];
-  label: Capitalize<string>
+  label: string;
   name?: string;
-  variant?: "editorPage" | "editorModal"
+  variant?: "editorPage" | "editorModal";
+  capitalize?: boolean;
 }
 
-export const Switch: React.FC<Props> = ({ checked, onChange, label, name, variant = "editorModal" }) => (
+export const Switch: React.FC<Props> = ({
+  checked,
+  onChange,
+  label,
+  name,
+  variant = "editorModal",
+  capitalize = false,
+}) => (
   <Box>
     <FormControlLabel
       control={
         <MuiSwitch
           checked={checked}
           onChange={onChange}
-          sx={{ pointerEvents: "auto"}}
-          />
-        }
+          sx={{ pointerEvents: "auto" }}
+        />
+      }
       name={name}
       label={label}
-      sx={{ 
-        pointerEvents: "none", 
-        [`& .${formControlLabelClasses.label}`]: { 
-          pointerEvents: "auto", 
+      sx={{
+        pointerEvents: "none",
+        [`& .${formControlLabelClasses.label}`]: {
+          pointerEvents: "auto",
           display: "contents",
           ...(variant === "editorPage" && {
             fontWeight: FONT_WEIGHT_BOLD,
-            textTransform: "capitalize",
+            textTransform: "",
             fontSize: 19,
-          })
-        }
+          }),
+          ...(capitalize && {
+            textTransform: "capitalize",
+          }),
+        },
       }}
     />
   </Box>
-)
+);


### PR DESCRIPTION
## What does this PR do?

Currently we use a mix of `Sentence case` and `Title Case` across the editor, with broad mix of the two being used for titles, legends and labels. Our style guides for PlanX state that sentence case should be used except for referring to proper nouns. PR adjusts all visible titles, legends and labels to be sentence case.

Labels for switches were programatically capitalised into title case, I've added a prop `capitalize` which can be used where needed (online/offline switch).