### PR TITLE
fix: Option label reordering in `ListManager`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Options.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Options.tsx
@@ -38,15 +38,15 @@ export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
               formik.setFieldValue("options", newCombinedOptions);
             }}
             newValueLabel="add new option"
-            newValue={() =>
-              ({
-                data: {
-                  text: "",
-                  description: "",
-                  val: "",
-                },
-              }) as Option
-            }
+            newValue={() => ({
+              id: "",
+              data: {
+                text: "",
+                description: "",
+                val: "",
+                flags: [],
+              },
+            })}
             Editor={ChecklistOptionsEditor}
             editorExtraProps={{
               showValueField: !!formik.values.fn,

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/ExclusiveOrOptionManager.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/ExclusiveOrOptionManager.tsx
@@ -61,16 +61,18 @@ export const ExclusiveOrOptionManager = ({
             newValueLabel='add "or" option'
             maxItems={1}
             noDragAndDrop
-            newValue={() => {
-              return {
+            newValue={() =>
+              ({
+                id: "",
                 data: {
                   text: "",
                   description: "",
                   val: "",
+                  flags: [],
                   exclusive: true,
                 },
-              } as Option;
-            }}
+              }) satisfies Option
+            }
             Editor={BaseOptionsEditor}
             editorExtraProps={{
               showValueField: !!formik.values.fn,

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -74,15 +74,15 @@ export const GroupedOptions = ({ formik }: Props) => {
                     newOptions,
                   );
                 }}
-                newValue={() =>
-                  ({
-                    data: {
-                      text: "",
-                      description: "",
-                      val: "",
-                    },
-                  }) as Option
-                }
+                newValue={() => ({
+                  id: "",
+                  data: {
+                    text: "",
+                    description: "",
+                    val: "",
+                    flags: [],
+                  },
+                })}
                 newValueLabel="add new option"
                 Editor={ChecklistOptionsEditor}
                 editorExtraProps={{

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -1,5 +1,6 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { FormikErrors, FormikValues, useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef } from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
@@ -13,7 +14,6 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
 
-import { useStore } from "pages/FlowEditor/lib/store";
 import { InternalNotes } from "../../../ui/editor/InternalNotes";
 import { MoreInformation } from "../../../ui/editor/MoreInformation/MoreInformation";
 import { BaseNodeData, Option, parseBaseNodeData } from "../shared";
@@ -68,15 +68,16 @@ export const Question: React.FC<Props> = (props) => {
     validate: ({ options, ...values }) => {
       const errors: FormikErrors<FormikValues> = {};
       if (values.fn && !options.some((option) => option.data.val)) {
-        errors.fn =
-          "At least one option must also set a data field";
+        errors.fn = "At least one option must also set a data field";
       }
       return errors;
     },
   });
 
   const schema = useStore().getFlowSchema();
-  const initialOptionVals = formik.initialValues.options?.map((option) => option.data?.val);
+  const initialOptionVals = formik.initialValues.options?.map(
+    (option) => option.data?.val,
+  );
 
   const focusRef = useRef<HTMLInputElement | null>(null);
 
@@ -144,19 +145,23 @@ export const Question: React.FC<Props> = (props) => {
             onChange={(newOptions) => {
               formik.setFieldValue("options", newOptions);
             }}
-            newValue={() =>
-              ({
-                data: {
-                  text: "",
-                  description: "",
-                  val: "",
-                },
-              }) as Option
-            }
+            newValue={() => ({
+              id: "",
+              data: {
+                text: "",
+                description: "",
+                val: "",
+                flags: [],
+              },
+            })}
             Editor={QuestionOptionsEditor}
             editorExtraProps={{
               showValueField: !!formik.values.fn,
-              schema: getOptionsSchemaByFn(formik.values.fn, schema?.options, initialOptionVals),
+              schema: getOptionsSchemaByFn(
+                formik.values.fn,
+                schema?.options,
+                initialOptionVals,
+              ),
             }}
           />
         </ModalSectionContent>


### PR DESCRIPTION
## Context
This is me trying to unpick and resolve the changes made in [https://github.com/theopensystemslab/planx-new/pulls whi](https://github.com/theopensystemslab/planx-new/pull/4171) which touch and fix a few things, but is failing E2E tests in a way I've not yet identified. I'm hoping that splitting up the fixes will help me narrow this down. Next up is the same issue for the `DataFieldAutocomplete`.

This PR intentionally does not try to address any issues with the `DataFieldAutocomplete`.

## What's the problem?
When using a the `ListManger` and re-ordering options, the associated tags are not correctly re-ordered and remain in their index position. This only happens on new, unsaved, list items. See demo below on staging - 

https://github.com/user-attachments/assets/4da620de-b0df-441a-8085-693802ed91de

I believe that this is caused by inputs going from controlled to uncontrolled ([docs](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components)), as the following error can be seen in the console on dev mode - 

<img width="568" alt="image" src="https://github.com/user-attachments/assets/ec5c88c1-f2a3-4782-8ce1-77cf38856b25" />

## What's the solution?
By setting all fields to have a value (i.e. not `undefined`), no inputs should go from controlled to uncontrolled.
