### PR TITLE
fix: Force `DataFieldAutocomplete` to be controlled

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
@@ -84,7 +84,7 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
             ...props.value,
             data: {
               ...props.value.data,
-              val: targetValue ? targetValue : undefined,
+              val: targetValue ?? "",
             },
           });
         }}

--- a/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
@@ -1,12 +1,10 @@
 import {
-  AutocompleteChangeReason,
   AutocompleteProps,
   createFilterOptions,
 } from "@mui/material/Autocomplete";
 import ListItem from "@mui/material/ListItem";
-import isNull from "lodash/isNull";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useMemo } from "react";
+import React from "react";
 import AutocompleteInput from "ui/shared/AutocompleteInput";
 import InputRow from "ui/shared/InputRow";
 
@@ -39,30 +37,18 @@ const filter = createFilterOptions<string>();
 
 export const DataFieldAutocomplete: React.FC<Props> = (props) => {
   const defaultSchema = useStore().getFlowSchema()?.nodes || [];
-  const { value: initialValue, schema: options = defaultSchema } = props;
+  const { value, schema: options = defaultSchema } = props;
 
-  const value: string | undefined = useMemo(
-    () => options?.find((option) => option === initialValue),
-    [initialValue, options],
-  );
-
-  const handleChange = (
-    _event: React.SyntheticEvent,
-    value: string | null,
-    _reason: AutocompleteChangeReason,
-  ) => {
-    if (typeof value === "string") {
-      // Adding a new option
-      if (value.startsWith('Add "')) {
-        props.onChange(value.split('"')[1]);
-      } else {
-        // Selecting an option
-        props.onChange(value);
-      }
-    } else if (isNull(value)) {
-      // Clearing an option
-      props.onChange(value);
+  const handleChange = (_event: React.SyntheticEvent, value: string | null) => {
+    // Adding a new option via the "Add" button
+    if (typeof value === "string" && value.startsWith('Add "')) {
+      const optionValue = value.split('"')[1];
+      props.onChange(optionValue);
+      return;
     }
+
+    // Selecting or clearing an option
+    props.onChange(value);
   };
 
   return (


### PR DESCRIPTION
## Context
This is me trying to unpick and resolve the changes made in [https://github.com/theopensystemslab/planx-new/pulls whi](https://github.com/theopensystemslab/planx-new/pull/4171) which touch and fix a few things, but is failing E2E tests in a way I've not yet identified. I'm hoping that splitting up the fixes will help me narrow this down. 

## What's the problem?
When using a the `ListManger` and re-ordering options, the associated data fields are not correctly re-ordered and remain in their index position. This only happens on new, unsaved, list items.

I believe that this is caused by inputs going from controlled to uncontrolled ([docs](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components)), as the following error can be seen in the console on dev mode - 

<img width="568" alt="image" src="https://github.com/user-attachments/assets/ec5c88c1-f2a3-4782-8ce1-77cf38856b25" />

## What's the solution?
By setting all fields to have a value (i.e. not `undefined`), no inputs should go from controlled to uncontrolled.

Note: There's an issue when blurring from data input fields - this only works when values are selected via the "Add xxx" button, or when hitting `Enter` on the keyboard. PR #4188 addresses this.