### PR TITLE
fix: Use `autoSelect` prop to capture blur events on `DataFieldAutocomplete`

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
@@ -1,7 +1,7 @@
 import {
   AutocompleteChangeReason,
   AutocompleteProps,
-  createFilterOptions
+  createFilterOptions,
 } from "@mui/material/Autocomplete";
 import ListItem from "@mui/material/ListItem";
 import isNull from "lodash/isNull";
@@ -25,7 +25,11 @@ const renderOptions: AutocompleteProps<
   "div"
 >["renderOption"] = (props, option) => {
   return (
-    <ListItem key={option} sx={{ fontFamily: (theme) => theme.typography.data.fontFamily }} {...props}>
+    <ListItem
+      key={option}
+      sx={{ fontFamily: (theme) => theme.typography.data.fontFamily }}
+      {...props}
+    >
       {option}
     </ListItem>
   );
@@ -50,7 +54,7 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
     if (typeof value === "string") {
       // Adding a new option
       if (value.startsWith('Add "')) {
-        props.onChange(value.split(('"'))[1]);
+        props.onChange(value.split('"')[1]);
       } else {
         // Selecting an option
         props.onChange(value);
@@ -69,6 +73,7 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
         placeholder="Data field"
         required={Boolean(props.required)}
         onChange={handleChange}
+        autoSelect
         value={value}
         options={options}
         filterOptions={(options, params) => {


### PR DESCRIPTION
## Context
This is me trying to unpick and resolve the changes made in [https://github.com/theopensystemslab/planx-new/pulls whi](https://github.com/theopensystemslab/planx-new/pull/4171) which touch and fix a few things, but is failing E2E tests in a way I've not yet identified. I'm hoping that splitting up the fixes will help me narrow this down.

## What's the problem?
When using the `DataFieldAutocomplete` field, values are only captured (the `handleChange()` function being called) only happens when I select a value with the mouse or hit enter. If I type and tab (or click) away, the input will display my value but Formik will not update - this leads to a number of issues.

## What's the solution?
The `autoSelect` prop controls this, so it's just a case of setting this to `true`. 

> **`autoSelect`**
>
> If `true`, the selected option becomes the value of the input when the Autocomplete loses focus unless the user chooses a different option or changes the character string in the input.
>
> When using the `freeSolo` mode, the typed value will be the input value if the Autocomplete loses focus without highlighting an option.

Docs - https://mui.com/material-ui/api/autocomplete/#props