### PR TITLE
feat: Add 24hr expiry to JWT

### DIFF
--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -28,6 +28,7 @@ export const buildJWTForAPIRole = () =>
       },
     },
     process.env.JWT_SECRET!,
+    { expiresIn: "24h" },
   );
 
 const generateHasuraClaimsForUser = (user: User): HasuraClaims => ({

--- a/api.planx.uk/tests/mockJWT.ts
+++ b/api.planx.uk/tests/mockJWT.ts
@@ -12,7 +12,7 @@ function getJWT({ role }: { role: Role }) {
     },
   };
 
-  return jwt.sign(data, process.env.JWT_SECRET!);
+  return jwt.sign(data, process.env.JWT_SECRET!, { expiresIn: "24h" });
 }
 
 function authHeader({ role }: { role: Role }) {

--- a/e2e/tests/api-driven/src/jwt.ts
+++ b/e2e/tests/api-driven/src/jwt.ts
@@ -13,7 +13,7 @@ export const buildJWT = async (email: string): Promise<string | undefined> => {
     "https://hasura.io/jwt/claims": generateHasuraClaimsForUser(user),
   };
 
-  const jwt = JWT.sign(data, process.env.JWT_SECRET!);
+  const jwt = JWT.sign(data, process.env.JWT_SECRET!, { expiresIn: "24h" });
   return jwt;
 };
 

--- a/e2e/tests/ui-driven/src/helpers/context.ts
+++ b/e2e/tests/ui-driven/src/helpers/context.ts
@@ -117,6 +117,7 @@ export function generateAuthenticationToken(userId: string) {
       },
     },
     process.env.JWT_SECRET,
+    { expiresIn: "24h" },
   );
 }
 

--- a/e2e/tests/ui-driven/src/utils.ts
+++ b/e2e/tests/ui-driven/src/utils.ts
@@ -35,7 +35,7 @@ export const getJWT = (userId) => {
     },
   };
 
-  return jwt.sign(data, process.env.JWT_SECRET!);
+  return jwt.sign(data, process.env.JWT_SECRET!, { expiresIn: "24h" });
 };
 
 export const insertTeam = async (teamName) => {


### PR DESCRIPTION
## What's the problem?
Flagged by Jumpsec pen test - 

> The applications did not securely expire user session tokens, which provides more opportunities for adversaries to compromise valid tokens and gain access to user accounts.
>
> Ensure session tokens expire within 24 hours after creation and that any log out functionality invalidates the current session token.

## What's the solution?
This adds a 24hr expiry to the token - see docs here https://github.com/auth0/node-jsonwebtoken?tab=readme-ov-file#usage

### Also...
To test this I think we probably need to do it manually - we could change it to 30 minutes on this PR, merge to staging and test, then reopen with a 24hr timer. Sounds like a lot of hassle potentially - once this is merged to `main` we should be able to see the `exp` property of the token and see if we get logged out tomorrow. Any issues with this?

In the medium term, we might want a more sophisticated "refresh" pattern for these tokens where a new one with an additional 24hrs gets created on each successful action.