### PR TITLE
chore: Bump Metabase to v0.52.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   metabase:
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.52.6
+    image: metabase/metabase:v0.52.7
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -201,7 +201,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.52.6",
+        image: "metabase/metabase:v0.52.7",
         portMappings: [metabaseListenerHttp],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/4179 - there's a new version! (thanks @jamdelion!)