### PR TITLE
fix: Set default value for `FlagsSelect`

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
@@ -50,11 +50,11 @@ const renderTags: AutocompleteProps<
 export const FlagsSelect: React.FC<Props> = (props) => {
   const { value: initialFlagValues } = props;
 
-  const value: Flag[] | undefined = useMemo(
+  const value: Flag[] = useMemo(
     () =>
       initialFlagValues?.flatMap((initialFlagValue) =>
         flatFlags.filter((flag) => flag.value === initialFlagValue),
-      ),
+      ) || [],
     [initialFlagValues],
   );
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/collectedFlags.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/collectedFlags.test.ts
@@ -72,6 +72,7 @@ const flow: Store.Flow = {
     type: 200,
     data: {
       text: "No",
+      flags: [],
     },
   },
 };


### PR DESCRIPTION
## What's the problem?
Details outlined here - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1737640916451959 (OSL slack)

When rearranging some options, an error is thrown. This is caused by options having no value for the new `flag` property which the autocomplete is expecting. As it's currently defaulting to `undefined` (the return type of `Array.prototype.filter`) this is throwing a controlled/uncontrolled error again.

## What's the solution?
Default to an empty array instead of `undefined`. 

This will mean that options without flags, will have this set to the truthy value of `[]`. I've not yet found a place where this will be an issue - we would generally iterate over flags for answers which is safe with an empty array, for example here in `collectedFlagsByCategory()` - 

https://github.com/theopensystemslab/planx-new/blob/5678a56bc69fca95d22157d7222d6895e90cb31f/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts#L950-L954