### PR TITLE
feat: Gracefully handle expired JWTs

### DIFF
--- a/api.planx.uk/.env.test.example
+++ b/api.planx.uk/.env.test.example
@@ -28,7 +28,7 @@ FILE_API_KEY_GATESHEAD=👻
 FILE_API_KEY_DONCASTER=👻
 
 # Editor
-EDITOR_URL_EXT=example.com
+EDITOR_URL_EXT=https://www.example.com
 
 # Hasura
 HASURA_GRAPHQL_URL=http://hasura:8080/v1/graphql

--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -35,5 +35,4 @@ CMD ["npm", "start"]
 FROM base as development
 ENV NODE_ENV development
 RUN pnpm install
-
 CMD ["pnpm", "dev"]

--- a/api.planx.uk/Dockerfile
+++ b/api.planx.uk/Dockerfile
@@ -35,4 +35,5 @@ CMD ["npm", "start"]
 FROM base as development
 ENV NODE_ENV development
 RUN pnpm install
+
 CMD ["pnpm", "dev"]

--- a/api.planx.uk/client/index.test.ts
+++ b/api.planx.uk/client/index.test.ts
@@ -1,7 +1,7 @@
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { getClient } from "./index.js";
 import { userContext } from "../modules/auth/middleware.js";
-import { getJWT } from "../tests/mockJWT.js";
+import { getTestJWT } from "../tests/mockJWT.js";
 
 test("getClient() throws an error if a store is not set", () => {
   expect(() => getClient()).toThrow();
@@ -12,7 +12,7 @@ test("getClient() returns a client if store is set", () => {
   getStoreMock.mockReturnValue({
     user: {
       sub: "123",
-      jwt: getJWT({ role: "teamEditor" }),
+      jwt: getTestJWT({ role: "teamEditor" }),
     },
   });
 

--- a/api.planx.uk/errors/requestHandlers.ts
+++ b/api.planx.uk/errors/requestHandlers.ts
@@ -1,0 +1,53 @@
+import type { ErrorRequestHandler } from "express";
+import { ServerError } from "./serverError.js";
+import airbrake from "../airbrake.js";
+
+/**
+ * Check for expired JWTs, redirect to /logout if found
+ */
+export const expiredJWTHandler: ErrorRequestHandler = (
+  errorObject,
+  _res,
+  res,
+  next,
+) => {
+  const isJWTExpiryError =
+    errorObject?.name === "UnauthorizedError" &&
+    errorObject?.message === "jwt expired";
+
+  if (!isJWTExpiryError) return next(errorObject);
+
+  const logoutPage = new URL("/logout", process.env.EDITOR_URL_EXT!).toString();
+  return res.redirect(logoutPage);
+};
+
+/**
+ * Fallback error handler
+ * Must be final Express middleware
+ */
+export const errorHandler: ErrorRequestHandler = (
+  errorObject,
+  _req,
+  res,
+  _next,
+) => {
+  const { status = 500, message = "Something went wrong" } = (() => {
+    if (
+      airbrake &&
+      (errorObject instanceof Error || errorObject instanceof ServerError)
+    ) {
+      airbrake.notify(errorObject);
+      return {
+        ...errorObject,
+        message: errorObject.message.concat(", this error has been logged"),
+      };
+    } else {
+      console.log(errorObject);
+      return errorObject;
+    }
+  })();
+
+  res.status(status).send({
+    error: message,
+  });
+};

--- a/api.planx.uk/modules/auth/middleware.ts
+++ b/api.planx.uk/modules/auth/middleware.ts
@@ -209,7 +209,9 @@ type UseRoleAuth = (authRoles: Role[]) => RequestHandler;
  */
 export const useRoleAuth: UseRoleAuth =
   (authRoles) => async (req, res, next) => {
-    useJWT(req, res, () => {
+    useJWT(req, res, (err) => {
+      if (err) return next(err);
+
       if (!req?.user)
         return next({
           status: 401,
@@ -273,7 +275,9 @@ export const usePlatformAdminAuth = useRoleAuth(["platformAdmin"]);
  * Allow any logged in user to access route, without checking roles
  */
 export const useLoginAuth: RequestHandler = (req, res, next) =>
-  useJWT(req, res, () => {
+  useJWT(req, res, (err) => {
+    if (err) return next(err);
+
     if (req?.user?.sub) {
       userContext.run(
         {

--- a/api.planx.uk/modules/flows/publish/publish.test.ts
+++ b/api.planx.uk/modules/flows/publish/publish.test.ts
@@ -1,7 +1,7 @@
 import supertest from "supertest";
 
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
-import { authHeader, getJWT } from "../../../tests/mockJWT.js";
+import { authHeader, getTestJWT } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
 import { userContext } from "../../auth/middleware.js";
 import { mockFlowData } from "../../../tests/mocks/validateAndPublishMocks.js";
@@ -11,7 +11,7 @@ beforeAll(() => {
   getStoreMock.mockReturnValue({
     user: {
       sub: "123",
-      jwt: getJWT({ role: "teamEditor" }),
+      jwt: getTestJWT({ role: "teamEditor" }),
     },
   });
 });

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -1,7 +1,7 @@
 import supertest from "supertest";
 
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
-import { authHeader, getJWT } from "../../../tests/mockJWT.js";
+import { authHeader, getTestJWT } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
 import { flowWithInviteToPay } from "../../../tests/mocks/inviteToPayData.js";
 import { userContext } from "../../auth/middleware.js";
@@ -13,7 +13,7 @@ beforeAll(() => {
   getStoreMock.mockReturnValue({
     user: {
       sub: "123",
-      jwt: getJWT({ role: "teamEditor" }),
+      jwt: getTestJWT({ role: "teamEditor" }),
     },
   });
 });

--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.test.ts
@@ -40,7 +40,7 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: New offices
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -110,15 +110,15 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: New offices
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123\n\nService: Apply for a Lawful Development Certificate
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123\n\nService: Apply for a Lawful Development Certificate
       Address: 2 High Street
       Project type: New offices
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=456\n\nService: Apply for a Lawful Development Certificate
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=456\n\nService: Apply for a Lawful Development Certificate
       Address: 3 High Street
       Project type: New offices
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=789`;
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=789`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -170,7 +170,7 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: New offices
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -203,7 +203,7 @@ describe("buildContentFromSessions function", () => {
       Address: Address not submitted
       Project type: New offices
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],
@@ -237,7 +237,7 @@ describe("buildContentFromSessions function", () => {
       Address: 1 High Street
       Project type: Project type not submitted
       Expiry Date: 29 May 2026
-      Link: example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
+      Link: https://www.example.com/team/apply-for-a-lawful-development-certificate/published?sessionId=123`;
     expect(
       await buildContentFromSessions(
         sessions as LowCalSession[],

--- a/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/utils.test.ts
@@ -30,7 +30,8 @@ describe("getResumeLink util function", () => {
       propertyType: "house",
     };
     const testCase = getResumeLink(session, { slug: "team" } as Team, "flow");
-    const expectedResult = "example.com/team/flow/published?sessionId=123";
+    const expectedResult =
+      "https://www.example.com/team/flow/published?sessionId=123";
     expect(testCase).toEqual(expectedResult);
   });
 });

--- a/api.planx.uk/modules/saveAndReturn/service/validateSession.test.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/validateSession.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../tests/mocks/saveAndReturnMocks.js";
 import type { Node, Flow, Breadcrumb } from "../../../types.js";
 import { userContext } from "../../auth/middleware.js";
-import { getJWT } from "../../../tests/mockJWT.js";
+import { getTestJWT } from "../../../tests/mockJWT.js";
 
 const validateSessionPath = "/validate-session";
 const getStoreMock = vi.spyOn(userContext, "getStore");
@@ -28,7 +28,7 @@ describe("Validate Session endpoint", () => {
     getStoreMock.mockReturnValue({
       user: {
         sub: "123",
-        jwt: getJWT({ role: "teamEditor" }),
+        jwt: getTestJWT({ role: "teamEditor" }),
       },
     });
   });

--- a/api.planx.uk/modules/team/service.test.ts
+++ b/api.planx.uk/modules/team/service.test.ts
@@ -1,4 +1,4 @@
-import { getJWT } from "../../tests/mockJWT.js";
+import { getTestJWT } from "../../tests/mockJWT.js";
 import { userContext } from "../auth/middleware.js";
 
 import {
@@ -40,7 +40,7 @@ describe("TeamService", () => {
     getStoreMock.mockReturnValue({
       user: {
         sub: "123",
-        jwt: getJWT({ role: "teamEditor" }),
+        jwt: getTestJWT({ role: "teamEditor" }),
       },
     });
   });

--- a/api.planx.uk/tests/mockJWT.ts
+++ b/api.planx.uk/tests/mockJWT.ts
@@ -1,7 +1,13 @@
 import type { Role } from "@opensystemslab/planx-core/types";
 import jwt from "jsonwebtoken";
 
-function getJWT({ role }: { role: Role }) {
+function getTestJWT({
+  role,
+  isExpired = false,
+}: {
+  role: Role;
+  isExpired?: boolean;
+}) {
   const data = {
     sub: "123",
     email: "test@opensystemslab.io",
@@ -10,13 +16,23 @@ function getJWT({ role }: { role: Role }) {
       "x-hasura-default-role": role,
       "x-hasura-user-id": "123",
     },
+    // 1st Jan, 1970
+    ...(isExpired && { exp: 0 }),
   };
 
-  return jwt.sign(data, process.env.JWT_SECRET!, { expiresIn: "24h" });
+  return isExpired
+    ? // Expiry hardcoded to token
+      jwt.sign(data, process.env.JWT_SECRET!)
+    : // Generate standard 24hr expiry
+      jwt.sign(data, process.env.JWT_SECRET!, { expiresIn: "24h" });
 }
 
 function authHeader({ role }: { role: Role }) {
-  return { Authorization: `Bearer ${getJWT({ role })}` };
+  return { Authorization: `Bearer ${getTestJWT({ role })}` };
 }
 
-export { authHeader, getJWT };
+function expiredAuthHeader({ role }: { role: Role }) {
+  return { Authorization: `Bearer ${getTestJWT({ role, isExpired: true })}` };
+}
+
+export { authHeader, getTestJWT, expiredAuthHeader };

--- a/e2e/tests/ui-driven/src/utils.ts
+++ b/e2e/tests/ui-driven/src/utils.ts
@@ -25,7 +25,7 @@ export const gqlAdmin = async (query, variables = {}) => {
   return json;
 };
 
-export const getJWT = (userId) => {
+export const getTestJWT = (userId) => {
   const data = {
     sub: String(userId),
     "https://hasura.io/jwt/claims": {

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -153,7 +153,20 @@ const parseErrorTypeFromHasuraResponse = (message: string) => {
   };
 };
 
-const handleExpiredJWTErrors = () => (window.location.href = "/logout");
+export const handleExpiredJWTErrors = () => {
+  toast.error("Session expired, redirecting to login page...", {
+    toastId: "jwt_expiry_error",
+    hideProgressBar: false,
+    progress: undefined,
+    autoClose: 2_000,
+    onClose: () => (window.location.href = "/logout"),
+  });
+
+  // Fallback if case of toast not firing
+  setTimeout(() => {
+    window.location.href = "/logout"
+  }, 2_500);
+}
 
 const handleValidationErrors = (operation: Operation) => {
   const user = useStore.getState().getUser();

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -128,6 +128,7 @@ const handleHasuraGraphQLErrors = (
 
     const errors = parseErrorTypeFromHasuraResponse(message);
 
+    if (errors.expiredJWT) handleExpiredJWTErrors();
     if (errors.validation) handleValidationErrors(operation);
     if (errors.permission) handlePermissionErrors(operation);
   });
@@ -143,11 +144,16 @@ const parseErrorTypeFromHasuraResponse = (message: string) => {
 
   const validationErrors = [/Invalid HTML content/gi];
 
+  const expiredJWTError = [/Could not verify JWT: JWTExpired/gi];
+
   return {
     permission: permissionErrors.some((re) => re.test(message)),
     validation: validationErrors.some((re) => re.test(message)),
+    expiredJWT: expiredJWTError.some((re) => re.test(message)),
   };
 };
+
+const handleExpiredJWTErrors = () => (window.location.href = "/logout");
 
 const handleValidationErrors = (operation: Operation) => {
   const user = useStore.getState().getUser();

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -77,7 +77,7 @@ const getLoggedInUser = async () => {
     });
     return response.data;
   } catch (error) {
-    console.error("Failed to fetch user matching JWT cookie");
-    handleExpiredJWTErrors()
+    handleExpiredJWTErrors();
+    throw Error("Failed to fetch user matching JWT cookie");
   }
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -1,6 +1,7 @@
 import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { Role, Team, User, UserTeams } from "@opensystemslab/planx-core/types";
 import axios from "axios";
+import { handleExpiredJWTErrors } from "lib/graphql";
 import type { StateCreator } from "zustand";
 
 import { EditorStore } from "./editor";
@@ -76,6 +77,7 @@ const getLoggedInUser = async () => {
     });
     return response.data;
   } catch (error) {
-    throw Error("Failed to fetch user matching JWT cookie");
+    console.error("Failed to fetch user matching JWT cookie");
+    handleExpiredJWTErrors()
   }
 };


### PR DESCRIPTION
## What does this PR do?
- Follow on to #4191 & #4193
- Handles an expired token in the following ways - 
  - API request - redirect to "/logout" using `res.redirect()`
  - GraphQL error - catch and parse error, set `window.location.href`

There's a notable exception here with requests made to planx-core. When these requests fail we currently call a `console.error()` (generally), which can't get caught in a meaningful way by an error boundary. When I've been navigating as an Editor it's not really an issue as most pages require an Apollo request or API request, so I may get a component not loading and then a redirect a few moments later. If this feels like a real usability issue we can work our way through these, throw errors, and catch in an `ErrorBoundary`.

## To test...
If you want to try this out locally, please pull down the branch and change the following line to a short timeout, e.g. `"2m"` - 

https://github.com/theopensystemslab/planx-new/blob/main/api.planx.uk/modules/auth/service.ts#L19

## To do...
- [x] Test coverage
