### PR TITLE
fix: Sanitise zip filename

### DIFF
--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -18,6 +18,7 @@ import { $api } from "../../../client/index.js";
 import type { Passport as IPassport } from "../../../types.js";
 import { getFileFromS3 } from "../../file/service/getFile.js";
 import { isApplicationTypeSupported } from "./helpers.js";
+import sanitize from "sanitize-filename";
 
 export async function buildSubmissionExportZip({
   sessionId,
@@ -216,7 +217,8 @@ export class ExportZip {
     // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath
     const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
     const __dirname = path.dirname(__filename); // get the name of the directory
-    this.filename = path.join(__dirname, `${flowSlug}-${sessionId}.zip`);
+    const sanitisedFilename = sanitize(`${flowSlug}-${sessionId}.zip`);
+    this.filename = path.join(__dirname, sanitisedFilename);
   }
 
   addFile({ name, buffer }: { name: string; buffer: Buffer }) {

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -50,6 +50,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "pino-noir": "^2.2.1",
+    "sanitize-filename": "^1.6.3",
     "slack-notify": "^2.0.7",
     "string-to-stream": "^3.0.1",
     "swagger-jsdoc": "^6.2.8",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -131,6 +131,9 @@ dependencies:
   pino-noir:
     specifier: ^2.2.1
     version: 2.2.1
+  sanitize-filename:
+    specifier: ^1.6.3
+    version: 1.6.3
   slack-notify:
     specifier: ^2.0.7
     version: 2.0.7
@@ -6760,6 +6763,12 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  /sanitize-filename@1.6.3:
+    resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
+    dev: false
+
   /sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
     dev: false
@@ -7253,6 +7262,12 @@ packages:
     dependencies:
       punycode: 2.3.1
 
+  /truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+    dependencies:
+      utf8-byte-length: 1.0.5
+    dev: false
+
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
@@ -7377,6 +7392,10 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  /utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/code-scanning/41

Although in its current implementation the user input `sessionId` will always be a valid session ID, it seems worthwhile to follow this recommendation out of an abundance of caution. A future implementation of this class may take input from elsewhere (without going through a validation step, or a roundtrip to the db).