### PR TITLE
feat: Add `is_statutory_application_type` to Seed scripts

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -51,7 +51,7 @@ done
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url, staging_power_automate_api_key FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
 echo team_integrations downloaded
 
-psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at, has_send_component FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at, has_send_component, is_statutory_application_type FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
 echo published_flows downloaded
 
 if [[ ${RESET} == "reset_flows" ]]; then

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -6,11 +6,11 @@ CREATE TEMPORARY TABLE sync_published_flows (
   summary text,
   publisher_id int,
   created_at timestamptz,
-  has_send_component boolean  
+  has_send_component boolean,
+  is_statutory_application_type boolean,
   );
-
 /* Ensure columns here are kept in sync with container.sh */
-\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
+\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component,is_statutory_application_type) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
 
 INSERT INTO published_flows (
   id,
@@ -19,8 +19,9 @@ INSERT INTO published_flows (
   summary,
   publisher_id,
   created_at,
-  has_send_component  
-  )
+  has_send_component,
+  is_statutory_application_type, 
+)
 SELECT
   id,
   data,
@@ -28,8 +29,9 @@ SELECT
   summary,
   publisher_id,
   created_at,
-  has_send_component
-  FROM sync_published_flows
+  has_send_component,
+  is_statutory_application_type
+FROM sync_published_flows
 ON CONFLICT (id) DO UPDATE
 SET
   data = EXCLUDED.data,
@@ -37,4 +39,5 @@ SET
   summary = EXCLUDED.summary,
   publisher_id = EXCLUDED.publisher_id,
   created_at = EXCLUDED.created_at,
-  has_send_component = EXCLUDED.has_send_component;
+  has_send_component = EXCLUDED.has_send_component,
+  is_statutory_application_type = EXCLUDED.is_statutory_application_type;

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -7,7 +7,7 @@ CREATE TEMPORARY TABLE sync_published_flows (
   publisher_id int,
   created_at timestamptz,
   has_send_component boolean,
-  is_statutory_application_type boolean,
+  is_statutory_application_type boolean
   );
 /* Ensure columns here are kept in sync with container.sh */
 \copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component,is_statutory_application_type) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
@@ -20,7 +20,7 @@ INSERT INTO published_flows (
   publisher_id,
   created_at,
   has_send_component,
-  is_statutory_application_type, 
+  is_statutory_application_type
 )
 SELECT
   id,

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -10,7 +10,7 @@ CREATE TEMPORARY TABLE sync_published_flows (
   is_statutory_application_type boolean
   );
 /* Ensure columns here are kept in sync with container.sh */
-\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component,is_statutory_application_type) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
+\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component, is_statutory_application_type) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
 
 INSERT INTO published_flows (
   id,


### PR DESCRIPTION
Following a migration to add `is_statutory_application_type` to the database, I have updated the necessary scripts.

https://github.com/theopensystemslab/planx-new/pull/4169

I have tested locally with `sync-data` and have it running without error.