### PR TITLE
fix: Drop expiry from internal only JWT

### DIFF
--- a/api.planx.uk/modules/auth/service.ts
+++ b/api.planx.uk/modules/auth/service.ts
@@ -3,7 +3,9 @@ import { $api } from "../../client/index.js";
 import type { User, Role } from "@opensystemslab/planx-core/types";
 import type { HasuraClaims, JWTData } from "./types.js";
 
-export const buildJWT = async (email: string): Promise<string | undefined> => {
+export const buildUserJWT = async (
+  email: string,
+): Promise<string | undefined> => {
   const user = await $api.user.getByEmail(email);
   if (!user) return;
 
@@ -28,7 +30,6 @@ export const buildJWTForAPIRole = () =>
       },
     },
     process.env.JWT_SECRET!,
-    { expiresIn: "24h" },
   );
 
 const generateHasuraClaimsForUser = (user: User): HasuraClaims => ({

--- a/api.planx.uk/modules/auth/strategy/google.ts
+++ b/api.planx.uk/modules/auth/strategy/google.ts
@@ -1,5 +1,5 @@
 import { Strategy as GoogleStrategy } from "passport-google-oauth20";
-import { buildJWT } from "../service.js";
+import { buildUserJWT } from "../service.js";
 
 export const googleStrategy = new GoogleStrategy(
   {
@@ -11,7 +11,7 @@ export const googleStrategy = new GoogleStrategy(
     const { email } = profile._json;
     if (!email) throw Error("Unable to authenticate without email");
 
-    const jwt = await buildJWT(email);
+    const jwt = await buildUserJWT(email);
 
     if (!jwt) {
       return done({

--- a/api.planx.uk/modules/auth/strategy/microsoft-oidc.ts
+++ b/api.planx.uk/modules/auth/strategy/microsoft-oidc.ts
@@ -6,7 +6,7 @@ import type {
   StrategyVerifyCallbackReq,
 } from "openid-client";
 import { Strategy } from "openid-client";
-import { buildJWT } from "../service.js";
+import { buildUserJWT } from "../service.js";
 
 export const MICROSOFT_OPENID_CONFIG_URL =
   "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration";
@@ -70,7 +70,7 @@ const verifyCallback: StrategyVerifyCallbackReq<Express.User> = async (
     return done(new Error("Unable to authenticate without email"));
   }
 
-  const jwt = await buildJWT(email);
+  const jwt = await buildUserJWT(email);
   if (!jwt) {
     return done({
       status: 404,


### PR DESCRIPTION
## What's the problem?
Internal requests from the API to Hasura are failing due to expired JWTs. See recent failures in the `#planx-notifications-internal` Slack channel (OSL).

This is happening as the `$api` client is a singleton, generated once, along with its associated JWT. Calls made by users via the API pass along their JWTs, generated at login, along with their associated roles. The internal JWT used by the API to access Haura is used for various cron jobs, admin endpoints, and other utilities.

Some cron processes are passing as their rely on the admin secret and not the JWT.

We haven't hit this (at time of writing) on staging or production as it's not yet been 24hrs since a deploy.

## What's the solution?
Remove the expiry on internal-only JWTs. This isn't actually required and it's only needed for user instantiated requests.

We could (should?) implement a process where this token is still time-limited, but can be automatically refreshed when expired. I'm just opting for a simple and pragmatic roll-back here just now.