### PR TITLE
chore: Improve email failure logging

### DIFF
--- a/api.planx.uk/modules/sendEmail/controller.ts
+++ b/api.planx.uk/modules/sendEmail/controller.ts
@@ -27,7 +27,7 @@ export const singleApplicationEmailController: SingleApplicationEmail = async (
     });
     return res.json(response);
   } catch (error) {
-    emailErrorHandler(next, error, template);
+    emailErrorHandler(next, error, template, sessionId);
   }
 };
 
@@ -42,7 +42,12 @@ export const paymentEmailController: PaymentEmail = async (_req, res, next) => {
     });
     return res.json(response);
   } catch (error) {
-    emailErrorHandler(next, error, template);
+    emailErrorHandler(
+      next,
+      error,
+      template,
+      `(payment request) ${paymentRequestId}`,
+    );
   }
 };
 
@@ -69,7 +74,7 @@ export const confirmationEmailController: ConfirmationEmail = async (
       return res.json(response);
     }
   } catch (error) {
-    emailErrorHandler(next, error, template);
+    emailErrorHandler(next, error, template, sessionId);
   }
 };
 
@@ -77,11 +82,12 @@ const emailErrorHandler = (
   next: NextFunction,
   error: unknown,
   template: string,
+  sessionId: string,
 ) =>
   next(
     new ServerError({
       status: error instanceof ServerError ? error.status : undefined,
-      message: `Failed to send "${template}" email. ${
+      message: `Failed to send "${template}" email for session ${sessionId}. ${
         (error as Error).message
       }`,
     }),


### PR DESCRIPTION
Quick issue I spotted - it would be nice to expose this session id for debugging. It's currently possible to get this via Hasura events but it's a bit tricker that way round. 

With this id exposed we can re-trigger emails quickly and simply via the API docs.