### PR TITLE
fix: Log email and s3 submission failures to airbrake

### DIFF
--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -1,3 +1,4 @@
+import { ServerError } from "../../../errors/serverError.js";
 import { sendEmail } from "../../../lib/notify/index.js";
 import type { EmailSubmissionNotifyConfig } from "../../../types.js";
 import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils.js";
@@ -77,11 +78,12 @@ export const sendToEmail: SendIntegrationController = async (
       govuk_notify_template: "Submit",
     });
   } catch (error) {
-    return next({
-      error,
-      message: `Failed to send "Submit" email (${localAuthority}): ${
-        (error as Error).message
-      }`,
-    });
+    return next(
+      new ServerError({
+        message: `Failed to send "Submit" email (${localAuthority}): ${
+          (error as Error).message
+        }`,
+      }),
+    );
   }
 };

--- a/api.planx.uk/modules/send/s3/index.ts
+++ b/api.planx.uk/modules/send/s3/index.ts
@@ -9,6 +9,7 @@ import { markSessionAsSubmitted } from "../../saveAndReturn/service/utils.js";
 import { isApplicationTypeSupported } from "../utils/helpers.js";
 import type { SendIntegrationController } from "../types.js";
 import { convertObjectToMulterJSONFile } from "../../file/service/utils.js";
+import { ServerError } from "../../../errors/serverError.js";
 
 interface CreateS3Application {
   insertS3Application: {
@@ -127,12 +128,13 @@ const sendToS3: SendIntegrationController = async (_req, res, next) => {
       auditEntryId,
     });
   } catch (error) {
-    return next({
-      error,
-      message: `Failed to upload submission to S3 (${localAuthority}): ${
-        (error as Error).message
-      }`,
-    });
+    return next(
+      new ServerError({
+        message: `Failed to upload submission to S3 (${localAuthority}): ${
+          (error as Error).message
+        }`,
+      }),
+    );
   }
 };
 


### PR DESCRIPTION
## What's the problem?
Recent email and s3 submissions errors did not log to Airbrake, and were only caught via failed Hasura events.

Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1737837277353679 (OSL Slack) for further context.

## What's the solution?
By instantiating a `ServerError` (or a plain `Error`), we can catch this in our `ErrorRequestHandler` middleware ([here](https://github.com/theopensystemslab/planx-new/blob/a7eff12ddf2a7baef4b6c309e02e304b7f14d4d5/api.planx.uk/errors/requestHandlers.ts#L24-L53)) and log to Airbrake. This gives us better visibility on any failures.