### PR TITLE
fix: Add filetype validation to API

### DIFF
--- a/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -1,0 +1,43 @@
+import multer from "multer";
+import path from "path";
+
+/**
+ * 30mb to match limit set in frontend
+ * See editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+ */
+const FILE_SIZE_LIMIT = 30 * 1024 * 1024;
+
+/**
+ * Should match MIME type restrictions in frontend
+ * See editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+ */
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf"];
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".pdf"];
+
+const validateExtension = (filename: string): boolean => {
+  const extension = path.extname(filename).toLowerCase();
+  return ALLOWED_EXTENSIONS.includes(extension);
+};
+
+/**
+ * Filter out invalid files
+ */
+const fileFilter: multer.Options["fileFilter"] = (_req, file, callback) => {
+  const isValidMimeType = ALLOWED_MIME_TYPES.includes(file.mimetype);
+  const isValidExtension = validateExtension(file.originalname);
+
+  if (isValidMimeType && isValidExtension) {
+    callback(null, true);
+  } else {
+    callback(new Error("Unsupported file type"));
+  }
+};
+
+const multerOptions: multer.Options = {
+  limits: {
+    fileSize: FILE_SIZE_LIMIT,
+  },
+  fileFilter,
+};
+
+export const useFileUpload = multer(multerOptions).single("file");

--- a/api.planx.uk/modules/file/routes.ts
+++ b/api.planx.uk/modules/file/routes.ts
@@ -15,12 +15,13 @@ import {
   uploadFileSchema,
 } from "./controller.js";
 import { validate } from "../../shared/middleware/validate.js";
+import { useFileUpload } from "./middleware/useFileUpload.js";
 
 const router = Router();
 
 router.post(
   "/file/public/upload",
-  multer().single("file"),
+  useFileUpload,
   useTeamEditorAuth,
   validate(uploadFileSchema),
   publicUploadController,
@@ -28,7 +29,7 @@ router.post(
 
 router.post(
   "/file/private/upload",
-  multer().single("file"),
+  useFileUpload,
   validate(uploadFileSchema),
   privateUploadController,
 );


### PR DESCRIPTION
## What's the problem?
Described as follows by the pen test - 

> **Description**
> The application does not implement proper content filtering for file upload function allowing an attacker to upload a malicious file on the system.
>
> **Recommendation**
> Implement file content and extension filtering before saving the file on the server.

Currently, we only restrict this via the frontend. Files are sent to Scanii for checking, but are still written to the server first as this rightly points out.

## What's the solution?
Add restrictions, using the Multer `fileFilter` ([docs](https://github.com/expressjs/multer?tab=readme-ov-file#filefilter)) to stop the upload of files that don't meet the criteria. I've also added a file size restriction to match the frontend here - not a requirement for the pen test but seemed worthwhile to pick up at the same time.

## To test
 - Upload a HTML (or anything else) file on staging API docs - file upload is accepted
 - Upload a HTML (or anything else) file on Pizza API docs - file upload is rejected