### PR TITLE
chore: Bump jinja

### DIFF
--- a/infrastructure/performance/pyproject.toml
+++ b/infrastructure/performance/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "har2locust==0.9.3",
     "idna==3.10",
     "itsdangerous==2.2.0",
-    "jinja2==3.1.4",
+    "jinja2==3.1.5",
     "locust==2.32.1",
     "locust-plugins==4.5.3",
     "markupsafe==3.0.2",

--- a/infrastructure/performance/uv.lock
+++ b/infrastructure/performance/uv.lock
@@ -251,14 +251,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369", size = 240245 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d", size = 133271 },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ requires-dist = [
     { name = "har2locust", specifier = "==0.9.3" },
     { name = "idna", specifier = "==3.10" },
     { name = "itsdangerous", specifier = "==2.2.0" },
-    { name = "jinja2", specifier = "==3.1.4" },
+    { name = "jinja2", specifier = "==3.1.5" },
     { name = "locust", specifier = "==2.32.1" },
     { name = "locust-plugins", specifier = "==4.5.3" },
     { name = "markupsafe", specifier = "==3.0.2" },


### PR DESCRIPTION
Replaces https://github.com/theopensystemslab/planx-new/pulls?q=is%3Apr+is%3Aopen+-label%3Ademo

Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/166 & https://github.com/theopensystemslab/planx-new/security/dependabot/167

`uv` is new to me but looks fab - worked a charm 👌 (thanks @freemvmt)