### PR TITLE
fix: Use current values to populate `DataAutocomplete` options, not just static initial values

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Options.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Options.tsx
@@ -6,7 +6,7 @@ import ListManager from "ui/editor/ListManager/ListManager";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 
 import { Option } from "../../shared";
-import { useInitialOptions } from "../Public/hooks/useInitialOptions";
+import { useCurrentOptions } from "../Public/hooks/useInitialOptions";
 import { ExclusiveOrOptionManager } from "./components/ExclusiveOrOptionManager";
 import { GroupedOptions } from "./components/GroupedOptions";
 import ChecklistOptionsEditor from "./components/OptionsEditor";
@@ -19,7 +19,7 @@ export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
 
   const exclusiveOrOptionManagerShouldRender = nonExclusiveOptions.length > 0;
 
-  const { schema, initialOptionVals } = useInitialOptions(formik);
+  const { schema, currentOptionVals } = useCurrentOptions(formik);
 
   return (
     <ModalSectionContent subtitle="Options">
@@ -53,7 +53,7 @@ export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
                 schema,
-                initialOptionVals,
+                currentOptionVals,
               ),
             }}
           />

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/ExclusiveOrOptionManager.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/ExclusiveOrOptionManager.tsx
@@ -8,7 +8,7 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import { Option } from "../../../shared";
 import { Group } from "../../model";
-import { useInitialOptions } from "../../Public/hooks/useInitialOptions";
+import { useCurrentOptions } from "../../Public/hooks/useInitialOptions";
 
 interface Props {
   formik: FormikHookReturn;
@@ -25,7 +25,7 @@ export const ExclusiveOrOptionManager = ({
   groupIndex,
   grouped,
 }: Props) => {
-  const { schema, initialOptionVals } = useInitialOptions(formik);
+  const { schema, currentOptionVals } = useCurrentOptions(formik);
 
   return (
     <Box mt={2}>
@@ -81,7 +81,7 @@ export const ExclusiveOrOptionManager = ({
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
                 schema,
-                initialOptionVals,
+                currentOptionVals,
               ),
             }}
           />

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -15,7 +15,7 @@ import InputRow from "ui/shared/InputRow";
 import { Option } from "../../../shared";
 import type { Group } from "../../model";
 import { partitionGroupedOptions } from "../../Public/helpers";
-import { useInitialOptions } from "../../Public/hooks/useInitialOptions";
+import { useCurrentOptions } from "../../Public/hooks/useInitialOptions";
 import { ExclusiveOrOptionManager } from "./ExclusiveOrOptionManager";
 import ChecklistOptionsEditor from "./OptionsEditor";
 
@@ -24,7 +24,7 @@ interface Props {
 }
 
 export const GroupedOptions = ({ formik }: Props) => {
-  const { schema, initialOptionVals } = useInitialOptions(formik);
+  const { schema, currentOptionVals } = useCurrentOptions(formik);
 
   const [exclusiveOptions, nonExclusiveOptionGroups] = partitionGroupedOptions(
     formik.values.groupedOptions,
@@ -113,7 +113,7 @@ export const GroupedOptions = ({ formik }: Props) => {
                   schema: getOptionsSchemaByFn(
                     formik.values.fn,
                     schema,
-                    initialOptionVals,
+                    currentOptionVals,
                   ),
                 }}
               />

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/hooks/useInitialOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/hooks/useInitialOptions.tsx
@@ -4,16 +4,16 @@ import { FormikHookReturn } from "types";
 
 import { Option } from "../../../shared";
 
-export const useInitialOptions = (formik: FormikHookReturn) => {
+export const useCurrentOptions = (formik: FormikHookReturn) => {
   const schema = useStore().getFlowSchema()?.options;
 
-  const initialOptions: Option[] | undefined =
-    formik.initialValues.options ||
-    formik.initialValues.groupedOptions
+  const currentOptions: Option[] | undefined =
+    formik.values.options ||
+    formik.values.groupedOptions
       ?.map((group: Group<Option>) => group.children)
       ?.flat();
 
-  const initialOptionVals = initialOptions?.map((option) => option.data?.val);
+  const currentOptionVals = currentOptions?.map((option) => option.data?.val);
 
-  return { initialOptions, schema, initialOptionVals };
+  return { currentOptions, schema, currentOptionVals };
 };

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -75,7 +75,7 @@ export const Question: React.FC<Props> = (props) => {
   });
 
   const schema = useStore().getFlowSchema();
-  const initialOptionVals = formik.initialValues.options?.map(
+  const currentOptionVals = formik.values.options?.map(
     (option) => option.data?.val,
   );
 
@@ -160,7 +160,7 @@ export const Question: React.FC<Props> = (props) => {
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
                 schema?.options,
-                initialOptionVals,
+                currentOptionVals,
               ),
             }}
           />

--- a/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -65,7 +65,7 @@ export const getPreviouslySubmittedData = ({
   return data;
 };
 
-export const getOptionsSchemaByFn = (fn?: string, defaultOptionsSchema?: string[], initialOptions?: (string | undefined)[]) => {
+export const getOptionsSchemaByFn = (fn?: string, defaultOptionsSchema?: string[], currentOptions?: (string | undefined)[]) => {
     let schema = defaultOptionsSchema;
 
     // For certain data fields, suggest based on full ODP Schema enums rather than current flow schema
@@ -74,7 +74,7 @@ export const getOptionsSchemaByFn = (fn?: string, defaultOptionsSchema?: string[
     if (fn === "property.type") schema = getValidSchemaValues("PropertyType");
 
     // Ensure that any initial values outside of ODP Schema enums will still be recognised/pre-populated when modal loads
-    initialOptions?.forEach((option) => {
+    currentOptions?.forEach((option) => {
       if (option && !schema?.includes(option)) {
         schema?.push(option);
       }


### PR DESCRIPTION
## What's the problem?
The `DataAutocomplete` component is not aware of the current status of the form, just the initial status. As I enter new values across fields, I should be able to reference and select them within my component. Raised here as an issue on OSL Slack - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1737660734834029?thread_ts=1737640916.451959&cid=C5Q59R3HB

## What's the solution?
Rather than just entering the `formik.initialValues` as the schema, dynamically pass the current `formik.values`. As I enter new values across the current component, I can see this change reflected across all my `DataAutocomplete` components.

## To test..
 Please watch video in Slack thread referenced above for context
 - I can open a new node (e.g. question or checklist)
 - As I enter data values, each autocomplete maintains a full copy of the current options, not just the initial options
 - This works on new and existing nodes