### PR TITLE
fix(wip): Don't allow `DataAutocomplete` to select the first value

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
@@ -85,7 +85,6 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
         selectOnFocus
         clearOnEscape
         handleHomeEndKeys
-        autoHighlight
       />
     </InputRow>
   );


### PR DESCRIPTION
_Still a work in progress - getting inconsistent results locally and on pizza_

## What's the problem?
Currently, we're using the `autoHighlight` prop ([docs](https://mui.com/material-ui/api/autocomplete/#props)) which is automatically selecting the first value on focus. I don't believe that this is the intended behaviour, as highlighted by @augustlindemer here - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1737660734834029?thread_ts=1737640916.451959&cid=C5Q59R3HB (OSL Slack).

## What's the solution?
Removing this prop (setting to the default `false`) removes this behaviour. I can now enter a value, tab away / lost focus, and my new value is retained.

## To test...
_TODO!_