### PR TITLE
fix: Add file extension check to filename parameter in body

### DIFF
--- a/api.planx.uk/modules/file/controller.ts
+++ b/api.planx.uk/modules/file/controller.ts
@@ -5,6 +5,7 @@ import { getFileFromS3 } from "./service/getFile.js";
 import { z } from "zod";
 import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 import { ServerError } from "../../errors/index.js";
+import { validateExtension } from "./middleware/useFileUpload.js";
 
 assert(process.env.AWS_S3_BUCKET);
 assert(process.env.AWS_S3_REGION);
@@ -18,7 +19,11 @@ interface UploadFileResponse {
 
 export const uploadFileSchema = z.object({
   body: z.object({
-    filename: z.string().trim().min(1),
+    filename: z
+      .string()
+      .trim()
+      .min(1)
+      .refine(validateExtension, { message: "Unsupported file type" }),
   }),
 });
 

--- a/api.planx.uk/modules/file/file.test.ts
+++ b/api.planx.uk/modules/file/file.test.ts
@@ -128,11 +128,26 @@ describe("File upload", () => {
     it("should not upload without file", async () => {
       await supertest(app)
         .post(PRIVATE_ENDPOINT)
-        .field("filename", "some filename")
+        .field("filename", "some_filename.png")
         .expect(500)
         .then((res) => {
           expect(mockPutObject).not.toHaveBeenCalled();
           expect(res.body.error).toMatch(/Missing file/);
+        });
+    });
+
+    it("should not upload a file with an invalid extension in the filename parameter (no attachment)", async () => {
+      await supertest(app)
+        .post(PRIVATE_ENDPOINT)
+        .field("filename", "my_file.exe") // filename does not match multer.file.filename
+        .attach("file", Buffer.from("some data"), {
+          filename: "my_file.jpg",
+          contentType: "image/jpg",
+        })
+        .expect(500)
+        .then((res) => {
+          expect(mockPutObject).not.toHaveBeenCalled();
+          expect(res.body.error).toMatch(/Unsupported file type/);
         });
     });
 
@@ -222,11 +237,27 @@ describe("File upload", () => {
       await supertest(app)
         .post(PUBLIC_ENDPOINT)
         .set(auth)
-        .field("filename", "some filename")
+        .field("filename", "some_filename.jpg")
         .expect(500)
         .then((res) => {
           expect(mockPutObject).not.toHaveBeenCalled();
           expect(res.body.error).toMatch(/Missing file/);
+        });
+    });
+
+    it("should not upload a file with an invalid extension in the filename parameter (no attachment)", async () => {
+      await supertest(app)
+        .post(PUBLIC_ENDPOINT)
+        .set(auth)
+        .field("filename", "my_file.exe") // filename does not match multer.file.filename
+        .attach("file", Buffer.from("some data"), {
+          filename: "my_file.jpg",
+          contentType: "image/jpg",
+        })
+        .expect(500)
+        .then((res) => {
+          expect(mockPutObject).not.toHaveBeenCalled();
+          expect(res.body.error).toMatch(/Unsupported file type/);
         });
     });
 

--- a/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -14,7 +14,7 @@ const FILE_SIZE_LIMIT = 30 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf"];
 const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".pdf"];
 
-const validateExtension = (filename: string): boolean => {
+export const validateExtension = (filename: string): boolean => {
   const extension = path.extname(filename).toLowerCase();
   return ALLOWED_EXTENSIONS.includes(extension);
 };


### PR DESCRIPTION
## What's the problem?
From Phil at Jumpsec - 

> I've looked at the file upload issue again and have noticed that whilst the restrictions have been implemented on the initial filetype uploaded, the "filename" parameter of the upload forms can be used to change the file extension of the file. I've attached a screenshot of this to demonstrate what I mean. I'm still exploring the exploitability of this, but would you be able to implement the same checks on the "filename" parameter file extension value as well to make sure this also matches the allowed list of file types? 

## What's the solution?
By adding the same validation to our Zod schema, we can share this validation check across the values in the body of the incoming http request, as well as the attached file.

## To test
- Upload a file with a valid extension / mime type (e.g. `myImage.png`)
- Use an invalid extension for the `filename` param (e.g. `myImage.exe`)
- Get a Zod validation error ✅ 

![image](https://github.com/user-attachments/assets/8f386515-3e90-4e87-8639-c914a30bed12)
