### PR TITLE
chore: adjust row and column access permissions in Hasura

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2664,13 +2664,14 @@
       permission:
         check: {}
         columns:
-          - id
-          - first_name
-          - last_name
           - created_at
-          - updated_at
-          - is_platform_admin
           - email
+          - first_name
+          - id
+          - is_platform_admin
+          - is_staging_only
+          - last_name
+          - updated_at
   select_permissions:
     - role: api
       permission:
@@ -2687,36 +2688,49 @@
     - role: demoUser
       permission:
         columns:
-          - created_at
-          - email
-          - first_name
           - id
-          - is_platform_admin
+          - first_name
           - last_name
+          - created_at
           - updated_at
-        filter: {}
+          - is_platform_admin
+          - is_staging_only
+          - email
+        filter:
+          created_flows:
+            creator_id:
+              _eq: '"x-hasura-user-id"'
     - role: platformAdmin
       permission:
         columns:
           - id
           - first_name
           - last_name
-          - email
           - created_at
           - updated_at
           - is_platform_admin
+          - is_staging_only
+          - email
         filter: {}
     - role: teamEditor
       permission:
         columns:
-          - created_at
-          - email
-          - first_name
           - id
-          - is_platform_admin
+          - first_name
           - last_name
+          - created_at
           - updated_at
-        filter: {}
+          - is_platform_admin
+          - is_staging_only
+          - email
+        filter:
+          teams:
+            _and:
+              - user_id:
+                  _eq: '"x-hasura-user-id"'
+              - role:
+                  _eq: teamEditor
+      comment: ""
   update_permissions:
     - role: platformAdmin
       permission:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2721,7 +2721,7 @@
         filter:
           created_flows:
             creator_id:
-              _eq: '"x-hasura-user-id"'
+              _eq: x-hasura-user-id
     - role: platformAdmin
       permission:
         columns:
@@ -2749,7 +2749,7 @@
           teams:
             _and:
               - user_id:
-                  _eq: '"x-hasura-user-id"'
+                  _eq: x-hasura-user-id
               - role:
                   _eq: teamEditor
       comment: ""

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2496,11 +2496,12 @@
     - role: platformAdmin
       permission:
         columns:
-          - created_at
-          - domain
           - id
+          - metabase_id
+          - domain
           - name
           - slug
+          - created_at
           - updated_at
         filter: {}
     - role: public
@@ -2522,7 +2523,13 @@
           - name
           - slug
           - updated_at
-        filter: {}
+        filter:
+          members:
+            _and:
+              - user_id:
+                  _eq: x-hasura-user-id
+              - role:
+                  _eq: teamEditor
   update_permissions:
     - role: api
       permission:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -344,17 +344,17 @@
     - role: platformAdmin
       permission:
         columns:
-          - address
-          - created_at
-          - device
           - feedback_id
           - feedback_score
+          - device
+          - node_data
+          - address
+          - application_type
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
-          - node_data
           - node_id
           - node_text
           - node_title
@@ -366,22 +366,23 @@
           - uprn
           - user_comment
           - user_context
+          - created_at
         filter: {}
       comment: ""
     - role: teamEditor
       permission:
         columns:
-          - address
-          - created_at
-          - device
           - feedback_id
           - feedback_score
+          - device
+          - node_data
+          - address
+          - application_type
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
-          - node_data
           - node_id
           - node_text
           - node_title
@@ -393,6 +394,7 @@
           - uprn
           - user_comment
           - user_context
+          - created_at
         filter:
           team:
             members:
@@ -1784,11 +1786,22 @@
 - table:
     name: submission_services_log
     schema: public
+  object_relationships:
+    - name: team
+      using:
+        manual_configuration:
+          column_mapping:
+            team_id: id
+          insertion_order: null
+          remote_table:
+            name: teams
+            schema: public
   select_permissions:
     - role: demoUser
       permission:
         columns:
           - retry
+          - team_id
           - response
           - event_id
           - event_type
@@ -1796,12 +1809,17 @@
           - created_at
           - flow_id
           - session_id
-        filter: {}
+        filter:
+          team:
+            flows:
+              creator_id:
+                _eq: x-hasura-user-id
       comment: ""
     - role: platformAdmin
       permission:
         columns:
           - retry
+          - team_id
           - response
           - event_id
           - event_type
@@ -1815,6 +1833,7 @@
       permission:
         columns:
           - retry
+          - team_id
           - response
           - event_id
           - event_type
@@ -1822,7 +1841,14 @@
           - created_at
           - flow_id
           - session_id
-        filter: {}
+        filter:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
       comment: ""
 - table:
     name: submission_services_summary

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2190,14 +2190,8 @@
           - submission_email
           - reference_code
           - boundary_url
-        filter:
-          id:
-            _in:
-              - 1
-              - 29
-              - 30
-              - 32
-      comment: 'For the demo user, we want to ensure they can only select their own team settings [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team. The demo user cannot insert or update any settings.'
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:
@@ -2249,14 +2243,7 @@
           - reference_code
           - submission_email
           - team_id
-        filter:
-          team:
-            members:
-              _and:
-                - user_id:
-                    _eq: x-hasura-user-id
-                - role:
-                    _eq: teamEditor
+        filter: {}
       comment: ""
   update_permissions:
     - role: platformAdmin
@@ -2496,12 +2483,11 @@
     - role: platformAdmin
       permission:
         columns:
-          - id
-          - metabase_id
+          - created_at
           - domain
+          - id
           - name
           - slug
-          - created_at
           - updated_at
         filter: {}
     - role: public
@@ -2523,13 +2509,7 @@
           - name
           - slug
           - updated_at
-        filter:
-          members:
-            _and:
-              - user_id:
-                  _eq: x-hasura-user-id
-              - role:
-                  _eq: teamEditor
+        filter: {}
   update_permissions:
     - role: api
       permission:
@@ -2710,48 +2690,36 @@
     - role: demoUser
       permission:
         columns:
-          - id
-          - first_name
-          - last_name
           - created_at
-          - updated_at
-          - is_platform_admin
-          - is_staging_only
           - email
-        filter:
-          created_flows:
-            creator_id:
-              _eq: x-hasura-user-id
+          - first_name
+          - id
+          - is_platform_admin
+          - last_name
+          - updated_at
+        filter: {}
     - role: platformAdmin
       permission:
         columns:
-          - id
-          - first_name
-          - last_name
           - created_at
-          - updated_at
-          - is_platform_admin
-          - is_staging_only
           - email
+          - first_name
+          - id
+          - is_platform_admin
+          - last_name
+          - updated_at
         filter: {}
     - role: teamEditor
       permission:
         columns:
-          - id
-          - first_name
-          - last_name
           - created_at
-          - updated_at
-          - is_platform_admin
-          - is_staging_only
           - email
-        filter:
-          teams:
-            _and:
-              - user_id:
-                  _eq: x-hasura-user-id
-              - role:
-                  _eq: teamEditor
+          - first_name
+          - id
+          - is_platform_admin
+          - last_name
+          - updated_at
+        filter: {}
       comment: ""
   update_permissions:
     - role: platformAdmin

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2190,8 +2190,14 @@
           - submission_email
           - reference_code
           - boundary_url
-        filter: {}
-      comment: ""
+        filter:
+          id:
+            _in:
+              - 1
+              - 29
+              - 30
+              - 32
+      comment: 'For the demo user, we want to ensure they can only select their own team settings [id = 32], and the teams: Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team. The demo user cannot insert or update any settings.'
     - role: platformAdmin
       permission:
         columns:
@@ -2243,23 +2249,32 @@
           - reference_code
           - submission_email
           - team_id
-        filter: {}
+        filter:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
       comment: ""
   update_permissions:
     - role: platformAdmin
       permission:
         columns:
-          - boundary_bbox
-          - boundary_url
-          - email_reply_to_id
+          - id
           - external_planning_site_name
           - external_planning_site_url
+          - homepage
           - help_email
           - help_opening_hours
           - help_phone
-          - homepage
-          - reference_code
+          - email_reply_to_id
+          - team_id
+          - boundary_bbox
           - submission_email
+          - reference_code
+          - boundary_url
         filter: {}
         check: null
       comment: ""

--- a/hasura.planx.uk/migrations/1738063575726_add_team_id_submissions_log_view/down.sql
+++ b/hasura.planx.uk/migrations/1738063575726_add_team_id_submissions_log_view/down.sql
@@ -1,0 +1,75 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE (((se.webhook_conf)::text !~~ '%email/%'::text) AND (seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry
+   FROM (all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;

--- a/hasura.planx.uk/migrations/1738063575726_add_team_id_submissions_log_view/up.sql
+++ b/hasura.planx.uk/migrations/1738063575726_add_team_id_submissions_log_view/up.sql
@@ -1,0 +1,77 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE (((se.webhook_conf)::text !~~ '%email/%'::text) AND (seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id
+   FROM (all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON f.id = ls.flow_id
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;


### PR DESCRIPTION
Per audit feedback:
- [x] `GetSubmissions` 
  - This is called via editor Apollo client (not via `$api` role so unchanged)
  - Queries `submission_services_log` view which previously did not have row-level permissions configured
    - Updated query definition to join to flows to access `team_id`, established "relationship" to `teams`, added row-level permissions for both `teamEditor` & `demoUser` roles
- [x] `GetFeedbackForFlow`
  - This is called via editor Apollo client (not via `$api` role so unchanged)
  - Queries `feedback_summary` view which DID have row-level permissions configured already
    - Updated column-level permissions to toggle-all rather than omit recently added column

Following changes are rolled back per PR feedback / comments below:
- `GetUsersForTeam`
  - This is called via editor Apollo client (not via `$api` role so unchanged)
  - Queries `users` table which does not have row-level permissions configured
    - Added row-level "select" permissions for both `teamEditor` & `demoUser` roles, toggled all columns (any reason no one was allowed to "select" `staging_only` before?)
- `GetTeamBySlug`
  - This is called via API "move flow" and defined in planx-core
  - Queries `teams` with relationship to `themes` and `settings`
    - `teams` does not have row-level "select" permissions configured for the `teamEditor` role - these are now added
    - `team_themes` has full select-all access across rows and row-level "update" permissions already - I think this is correct
    - `team_settings` handled in point below
- `GetTeamSettings`
  - This is defined in planx-core and called via editor
  - Queries `team_settings` table which does not have row-level "select" permissions configured (only "update") 
    - Added row-level "select" permissions for both `teamEditor` & `demoUser` roles
- `GetFlow`
  - This is called via editor
  - Queries `flows` table which only has row-level permissions configured for `demoUser`
    - Column-level permissions are out of date here and randomly omitting a lot of recently added fields (eg `templated_from`, `description`) - do we want this or select-all ? 

**Future todo:**
- Update all applicable introspection tests to match new configs - or add more E2E coverage for these scenarios ! 