### PR TITLE
fix: Add login check on `/download-schema` route

### DIFF
--- a/api.planx.uk/modules/flows/docs.yaml
+++ b/api.planx.uk/modules/flows/docs.yaml
@@ -273,6 +273,8 @@ paths:
       summary: Download flow schema
       description: Download a CSV file representing the flow's schema
       tags: ["flows"]
+      security:
+        - bearerAuth: []
       parameters:
         - $ref: "#/components/parameters/flowId"
       responses:

--- a/api.planx.uk/modules/flows/routes.ts
+++ b/api.planx.uk/modules/flows/routes.ts
@@ -1,6 +1,10 @@
 import { Router } from "express";
 import { validate } from "../../shared/middleware/validate.js";
-import { usePlatformAdminAuth, useTeamEditorAuth } from "../auth/middleware.js";
+import {
+  useLoginAuth,
+  usePlatformAdminAuth,
+  useTeamEditorAuth,
+} from "../auth/middleware.js";
 import { copyFlowController, copyFlowSchema } from "./copyFlow/controller.js";
 import {
   copyFlowAsPortalSchema,
@@ -73,6 +77,7 @@ router.post(
 
 router.get(
   "/flows/:flowId/download-schema",
+  useLoginAuth,
   validate(downloadFlowSchema),
   downloadFlowSchemaController,
 );


### PR DESCRIPTION
## What does this PR do?
Only allows authenticated users to access the `/download-schema` route by applying the `useLoginAuth()` middleware.

## Why?
This was flagged by the pen test. Whilst there's no security issue here - the flow data should be public, there is a performance concern for exposing this endpoint. This isn't a public feature, and a potentially expensive request - it could degrade performance if this was hit over and over.