### PR TITLE
test: Update metabase tests for latest vitest version

### DIFF
--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -10,6 +10,7 @@ import { createCollection } from "./createCollection.js";
 describe("createTeamCollection", () => {
   beforeEach(() => {
     nock.cleanAll();
+    vi.resetAllMocks();
   });
 
   test("creates new collection when metabase ID doesn't exist", async () => {


### PR DESCRIPTION
## What's the problem?
API tests on `main` are failing following the merge of #4072 

## What's the cause?
We upgraded vitest from v2 to v3 ([PR here](https://github.com/theopensystemslab/planx-new/pull/4182)) in order to resolve CVE-2025-24010. Vitest v3 has some changes to how spies are handled ([release notes here](https://github.com/vitest-dev/vitest/releases/tag/v3.0.0)) which wasn't picked up in #4072 as it wasn't rebased to `main`.

We could force all PRs to be rebase to `main` before merge using GH branch protection but I think this would be a real pain to manage for little benefit. Very few issues like this make it to `main` and can be easily identified and resolves before reach `production`.