### PR TITLE
refactor: split Rich Text Input file into smaller files

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -9,7 +9,7 @@ import { PublicProps } from "@planx/components/shared/types";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
-import { emptyContent } from "ui/editor/RichTextInput/RichTextInput";
+import { emptyContent } from "ui/editor/RichTextInput/utils";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 import { HelpButton, Image } from "../shared/Preview/CardHeader/styled";

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -14,7 +14,7 @@ import { HelpClickMetadata } from "pages/FlowEditor/lib/analytics/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
-import { emptyContent } from "ui/editor/RichTextInput/RichTextInput";
+import { emptyContent } from "ui/editor/RichTextInput/utils";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -14,7 +14,7 @@ import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import { emptyContent } from "ui/editor/RichTextInput/RichTextInput";
+import { emptyContent } from "ui/editor/RichTextInput/utils";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 import { HelpButton, Image } from "../shared/Preview/CardHeader/styled";

--- a/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/CardHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/CardHeader.tsx
@@ -2,7 +2,7 @@ import HelpIcon from "@mui/icons-material/Help";
 import Typography from "@mui/material/Typography";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import React from "react";
-import { emptyContent } from "ui/editor/RichTextInput/RichTextInput";
+import { emptyContent } from "ui/editor/RichTextInput/utils";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 import { DESCRIPTION_TEXT } from "../../constants";

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.stories.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.stories.tsx
@@ -5,7 +5,8 @@ import Stack from "@mui/material/Stack";
 import { Meta } from "@storybook/react";
 import React, { useState } from "react";
 
-import RichTextInput, { fromHtml, injectVariables } from "./RichTextInput";
+import RichTextInput from "./RichTextInput";
+import { fromHtml, injectVariables } from "./utils";
 
 const meta = {
   title: "Design System/Atoms/Form Elements/RichTextInput",

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.test.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { setup } from "testUtils";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 
-import { modifyDeep } from "./RichTextInput";
+import { modifyDeep } from "./utils";
 
 test("modifyDeep helper", () => {
   /**

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -8,241 +8,37 @@ import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
 import LinkIcon from "@mui/icons-material/Link";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
-import { type Editor, type JSONContent } from "@tiptap/core";
-import Bold from "@tiptap/extension-bold";
-import BulletList from "@tiptap/extension-bullet-list";
-import Document from "@tiptap/extension-document";
-import HardBreak from "@tiptap/extension-hard-break";
-import Heading from "@tiptap/extension-heading";
+import { type Editor } from "@tiptap/core";
 import History from "@tiptap/extension-history";
-import Italic from "@tiptap/extension-italic";
-import Link from "@tiptap/extension-link";
-import ListItem from "@tiptap/extension-list-item";
 import Mention from "@tiptap/extension-mention";
-import OrderedList from "@tiptap/extension-ordered-list";
-import Paragraph from "@tiptap/extension-paragraph";
 import ExtensionPlaceholder from "@tiptap/extension-placeholder";
-import Text from "@tiptap/extension-text";
-import { generateHTML, generateJSON } from "@tiptap/html";
-import { EditorContent, ReactRenderer, useEditor } from "@tiptap/react";
-import { map } from "ramda";
+import { EditorContent, useEditor } from "@tiptap/react";
 import React, {
   ChangeEvent,
   type FC,
-  forwardRef,
   useCallback,
   useEffect,
-  useImperativeHandle,
   useRef,
   useState,
 } from "react";
-import tippy, { type Instance } from "tippy.js";
-import { create } from "zustand";
 
 import Input from "../../shared/Input/Input";
 import PublicFileUploadButton from "../../shared/PublicFileUploadButton";
-import CustomImage from "../RichTextImage";
 import { PopupError } from "./components/PopUpError";
+import { suggestion } from "./components/suggestion";
+import { RichContentContainer, StyledBubbleMenu } from "./styles";
+import { commonExtensions } from "./tiptapExtensions";
+import { Props } from "./types";
 import {
-  MentionItems,
-  MentionItemsButton,
-  MentionItemsEmpty,
-  RichContentContainer,
-  StyledBubbleMenu,
-} from "./styles";
-import { MentionListProps, Props } from "./types";
-
-const passportClassName = "passport";
-
-// Shared tiptap editor extensions
-const commonExtensions = [
-  Document,
-  Paragraph,
-  Text,
-  Bold,
-  Italic,
-  HardBreak,
-  Link.configure({
-    openOnClick: false,
-    autolink: false,
-  }),
-  Heading.configure({
-    levels: [1, 2, 3],
-  }),
-  BulletList,
-  OrderedList,
-  ListItem,
-  CustomImage,
-];
-
-// Tiptap editor extensions used to convert between HTML and Prosemirror document state (used internally by tiptap)
-const conversionExtensions = [
-  ...commonExtensions,
-  Mention.configure({
-    HTMLAttributes: {
-      class: passportClassName,
-    },
-  }),
-];
-
-interface VariablesState {
-  variables: string[];
-  addVariable: (newVariable: string) => void;
-}
-
-export const emptyContent = "<p></p>";
-
-// Specify whether a selection is unsuitable for ensuring accessible links
-const linkSelectionError = (selectionHtml: string): string | null => {
-  if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
-    const text = selectionHtml.slice(3, -4);
-    const lowercaseText = text.toLowerCase().trim().replace(/[.,]/g, "");
-    if (lowercaseText === "click here" || lowercaseText === "clicking here") {
-      return "Links must be set over text that accurately describes what the link is for. Avoid generic language such as 'click here'.";
-    }
-    if (text[0] && text[0] !== text[0].toUpperCase() && text.length < 8) {
-      return "Make sure the link text accurately describes the what the link is for.";
-    }
-  }
-  return null;
-};
-
-// Maintain a store of variables as they are created in the '@'-mention plugin, making them available in memory for next time.
-// TODO: explore instantiating from a hard-coded list, or persisting in either the backend or local storage.
-const useVariablesStore = create<VariablesState>()((set) => ({
-  variables: [],
-  addVariable: (newVariable: string) =>
-    set((state) => ({ variables: [...state.variables, newVariable] })),
-}));
-
-export const toHtml = (doc: JSONContent) => {
-  const outgoingHtml = generateHTML(doc, conversionExtensions);
-  return outgoingHtml === emptyContent ? "" : outgoingHtml;
-};
-
-export const fromHtml = (htmlString: string) => {
-  return generateJSON(
-    htmlString === "" ? emptyContent : htmlString,
-    conversionExtensions,
-  );
-};
-
-export const injectVariables = (
-  htmlString: string,
-  vars: Record<string, string>,
-) => {
-  const doc = fromHtml(htmlString);
-  return toHtml(
-    modifyDeep((node) => {
-      return node.type === "mention"
-        ? {
-            ...node,
-            type: "text",
-            text: vars[node.attrs.id] || "Unknown",
-            attrs: undefined,
-          }
-        : null;
-    })(doc),
-  );
-};
-
-/**
- * Traverse a nested object/array and apply a modification at each level. If the modifier returns `null`, it leaves the result unchanged.
- * Used to inject placeholder values into a document structure.
- */
-export const modifyDeep =
-  (fn: (field: Value) => Value) =>
-  (val: Value): Value => {
-    if (!val) {
-      return val;
-    }
-    const mod = fn(val);
-    if (mod) {
-      return mod;
-    }
-    if (Array.isArray(val)) {
-      return map(modifyDeep(fn), val);
-    }
-    if (typeof val === "object") {
-      return map(modifyDeep(fn), val);
-    }
-    return val;
-  };
-
-// Generic value that `modifyDeep` works off of. Since it can be object, array or primitive, any typing more accurate than `any` is not compiling at the moment.
-// TODO: find a better typing alternative
-type Value = any;
-
-const initialUrlValue = "https://";
-
-// Makes sure that if the user pastes a full URL into the input, the pre-populated `https://` is removed
-// e.g. https://https://something.com -> https://something.com
-// Also trim whitespace from links which flag sanitation errors
-const trimUrlValue = (url: string) => {
-  if (url.startsWith(`${initialUrlValue}${initialUrlValue}`)) {
-    return url.slice(initialUrlValue.length);
-  }
-  return url.trim();
-};
-
-const getContentHierarchyError = (doc: JSONContent): string | null => {
-  let h1Index = -1;
-  let h2Index = -1;
-
-  let error: string | null = null;
-
-  (doc.content || []).forEach((d: JSONContent, index) => {
-    if (d.type === "paragraph") {
-      return;
-    } else if (d.type === "heading") {
-      const level = d.attrs?.level === 1 ? 1 : 2;
-      if (level === 1) {
-        if (h1Index === -1 && h2Index !== -1) {
-          error = "A level 1 heading must come before a level 2 heading.";
-        } else if (h1Index !== -1) {
-          error =
-            "There cannot be more than one level 1 heading in the document.";
-        } else if (index !== 0) {
-          error = "The level 1 heading must come first in the document.";
-        }
-        h1Index = index;
-        return;
-      }
-      if (level === 2) {
-        if (h1Index === -1) {
-          error = "A level 1 heading must come before a level 2 heading.";
-        }
-        h2Index = index;
-        return;
-      }
-    }
-    return null;
-  });
-
-  return error;
-};
-
-const getLinkNewTabError = (
-  content: JSONContent | undefined = [],
-): string | undefined => {
-  let error: string | undefined;
-  if (!content) return;
-
-  content.forEach((child: JSONContent) => {
-    if (!child.content) return;
-
-    child.content.forEach(({ marks, text }) => {
-      const isLink = marks?.map(({ type }) => type).includes("link");
-      const hasOpenTabText = text?.includes("(opens in a new tab)");
-
-      if (hasOpenTabText && !isLink) {
-        error = 'Links must wrap the text "(opens in a new tab)"';
-      }
-    });
-  });
-
-  return error;
-};
+  fromHtml,
+  getContentHierarchyError,
+  getLinkNewTabError,
+  initialUrlValue,
+  linkSelectionError,
+  passportClassName,
+  toHtml,
+  trimUrlValue,
+} from "./utils";
 
 const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");
@@ -569,154 +365,5 @@ const RichTextInput: FC<Props> = (props) => {
     </RichContentContainer>
   );
 };
-
-// Implemented based on the mention plugin example code snippets: https://tiptap.dev/api/nodes/mention
-const suggestion = {
-  items: ({ query }: { query: string }) => {
-    return useVariablesStore
-      .getState()
-      .variables.filter((item) =>
-        item.toLowerCase().includes(query.toLowerCase()),
-      )
-      .slice(0, 5);
-  },
-
-  render: () => {
-    let component: undefined | ReactRenderer<any, any>;
-    let popup: Instance[] | undefined;
-
-    return {
-      onStart: (props: any) => {
-        component = new ReactRenderer(MentionList, {
-          props,
-          editor: props.editor,
-        });
-
-        if (!props.clientRect) {
-          return;
-        }
-
-        popup = tippy("body", {
-          getReferenceClientRect: props.clientRect,
-          appendTo: () => document.body,
-          content: component.element,
-          showOnCreate: true,
-          interactive: true,
-          trigger: "manual",
-          placement: "bottom-start",
-        });
-      },
-
-      onUpdate(props: any) {
-        component?.updateProps(props);
-
-        if (!props.clientRect) {
-          return;
-        }
-
-        popup?.[0]?.setProps({
-          getReferenceClientRect: props.clientRect,
-        });
-      },
-
-      onKeyDown(props: any) {
-        if (props.event.key === "Escape") {
-          popup?.[0]?.hide();
-          return true;
-        }
-
-        return component?.ref?.onKeyDown(props);
-      },
-
-      onExit() {
-        popup?.[0]?.destroy();
-        component?.destroy();
-      },
-    };
-  },
-};
-
-// Implemented based on the mention plugin example code snippets: https://tiptap.dev/api/nodes/mention
-const MentionList = forwardRef((props: MentionListProps, ref) => {
-  const variablesStore = useVariablesStore();
-  const [selectedIndex, setSelectedIndex] = useState(0);
-
-  const selectItem = (index: number) => {
-    const item = props.items[index];
-
-    if (item) {
-      props.command({ id: item });
-    }
-  };
-
-  const upHandler = () => {
-    setSelectedIndex(
-      (selectedIndex + props.items.length - 1) % props.items.length,
-    );
-  };
-
-  const downHandler = () => {
-    setSelectedIndex((selectedIndex + 1) % props.items.length);
-  };
-
-  const enterHandler = () => {
-    selectItem(selectedIndex);
-  };
-
-  useEffect(() => setSelectedIndex(0), [props.items]);
-
-  useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }: any) => {
-      if (event.key === "ArrowUp") {
-        upHandler();
-        return true;
-      }
-
-      if (event.key === "ArrowDown") {
-        downHandler();
-        return true;
-      }
-
-      if (event.key === "Enter") {
-        enterHandler();
-        return true;
-      }
-
-      return false;
-    },
-  }));
-
-  return (
-    <MentionItems>
-      {props.query.length > 0 && (
-        <MentionItemsButton
-          variant="text"
-          onClick={() => {
-            props.command({ id: props.query });
-            variablesStore.addVariable(props.query);
-          }}
-        >
-          + Add <span className={passportClassName}>@{props.query}</span>
-        </MentionItemsButton>
-      )}
-      {props.items.length > 0 ? (
-        props.items.map((item: any, index: number) => (
-          <MentionItemsButton
-            variant="text"
-            className={`mention-item ${
-              index === selectedIndex ? "mention-item-selected" : ""
-            }`}
-            key={index}
-            onClick={() => selectItem(index)}
-          >
-            <span className={passportClassName}>@{item}</span>
-          </MentionItemsButton>
-        ))
-      ) : (
-        <MentionItemsEmpty variant="body2">No results</MentionItemsEmpty>
-      )}
-    </MentionItems>
-  );
-});
 
 export default RichTextInput;

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -32,15 +32,12 @@ import { suggestion } from "./components/suggestion";
 import { RichContentContainer, StyledBubbleMenu } from "./styles";
 import { commonExtensions, passportClassName } from "./tiptapExtensions";
 import { Props } from "./types";
+import { fromHtml, initialUrlValue, toHtml, trimUrlValue } from "./utils";
 import {
-  fromHtml,
   getContentHierarchyError,
   getLinkNewTabError,
-  initialUrlValue,
   linkSelectionError,
-  toHtml,
-  trimUrlValue,
-} from "./utils";
+} from "./validationHelpers";
 
 const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -1,10 +1,6 @@
 import Check from "@mui/icons-material/Check";
 import Close from "@mui/icons-material/Close";
 import Delete from "@mui/icons-material/Delete";
-import FormatBold from "@mui/icons-material/FormatBold";
-import FormatItalic from "@mui/icons-material/FormatItalic";
-import FormatListBulleted from "@mui/icons-material/FormatListBulleted";
-import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
 import LinkIcon from "@mui/icons-material/Link";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
@@ -26,6 +22,12 @@ import Input from "../../shared/Input/Input";
 import PublicFileUploadButton from "../../shared/PublicFileUploadButton";
 import { H1Button, H2Button } from "./components/HeadingButtons";
 import { PopupError } from "./components/PopUpError";
+import {
+  BoldButton,
+  BulletListButton,
+  ItalicButton,
+  OrderedListButton,
+} from "./components/RichTextInputButtons";
 import { suggestion } from "./components/suggestion";
 import { RichContentContainer, StyledBubbleMenu } from "./styles";
 import { commonExtensions, passportClassName } from "./tiptapExtensions";
@@ -210,42 +212,10 @@ const RichTextInput: FC<Props> = (props) => {
             <>
               <H1Button editor={editor} />
               <H2Button editor={editor} />
-              <IconButton
-                size="small"
-                color={editor.isActive("bold") ? "primary" : undefined}
-                onClick={() => {
-                  editor.chain().focus().toggleBold().run();
-                }}
-              >
-                <FormatBold />
-              </IconButton>
-              <IconButton
-                size="small"
-                color={editor.isActive("italic") ? "primary" : undefined}
-                onClick={() => {
-                  editor.chain().focus().toggleItalic().run();
-                }}
-              >
-                <FormatItalic />
-              </IconButton>
-              <IconButton
-                size="small"
-                color={editor.isActive("bulletList") ? "primary" : undefined}
-                onClick={() => {
-                  editor.chain().focus().toggleBulletList().run();
-                }}
-              >
-                <FormatListBulleted />
-              </IconButton>
-              <IconButton
-                size="small"
-                color={editor.isActive("orderedList") ? "primary" : undefined}
-                onClick={() => {
-                  editor.chain().focus().toggleOrderedList().run();
-                }}
-              >
-                <FormatListNumbered />
-              </IconButton>
+              <BoldButton editor={editor} />
+              <ItalicButton editor={editor} />
+              <BulletListButton editor={editor} />
+              <OrderedListButton editor={editor} />
               <PublicFileUploadButton
                 variant="tooltip"
                 onChange={(src) =>

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -8,8 +8,6 @@ import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
 import LinkIcon from "@mui/icons-material/Link";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
-import { type InputBaseProps } from "@mui/material/InputBase";
-import { styled } from "@mui/material/styles";
 import { type Editor, type JSONContent } from "@tiptap/core";
 import Bold from "@tiptap/extension-bold";
 import BulletList from "@tiptap/extension-bullet-list";
@@ -38,7 +36,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { inputFocusStyle } from "theme";
 import tippy, { type Instance } from "tippy.js";
 import { create } from "zustand";
 
@@ -50,72 +47,10 @@ import {
   MentionItems,
   MentionItemsButton,
   MentionItemsEmpty,
+  RichContentContainer,
   StyledBubbleMenu,
 } from "./styles";
-
-interface Props extends InputBaseProps {
-  className?: string;
-  onChange?: (ev: ChangeEvent<HTMLInputElement>) => void;
-  bordered?: boolean;
-  errorMessage?: string;
-}
-
-export const RichContentContainer = styled(Box)(({ theme }) => ({
-  position: "relative",
-  "& .ProseMirror": {
-    padding: "12px 15px",
-    backgroundColor: theme.palette.common.white,
-    minHeight: "50px",
-    border: `1px solid ${theme.palette.border.main}`,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    wordBreak: "break-word",
-    "& a": {
-      color: "currentColor",
-    },
-    "& > *": {
-      margin: 0,
-    },
-    "& > * + *": {
-      marginTop: theme.spacing(1),
-    },
-    "& ol, & ul": {
-      marginBottom: theme.spacing(1),
-    },
-    "& ol li, & ul li": {
-      margin: theme.spacing(0.5, 0, 0),
-    },
-    "& ol p, & ul p": {
-      margin: 0,
-    },
-    "& h1, & h2, & h3": {
-      "& strong": {
-        fontWeight: "inherit",
-      },
-    },
-    // Styles for placeholder text, to match ui/Input.tsx
-    "& p.is-editor-empty:first-of-type::before": {
-      color: theme.palette.text.placeholder,
-      opacity: 1,
-      content: `attr(data-placeholder)`,
-      float: "left",
-      height: 0,
-      pointerEvents: "none",
-    },
-    // Focus styles
-    "&.ProseMirror-focused": {
-      ...inputFocusStyle,
-    },
-    // Styles for injected passport/mention
-    "& .passport": {
-      backgroundColor: theme.palette.secondary.main,
-      color: theme.palette.text.primary,
-      padding: theme.spacing(0.25, 0.5),
-      borderRadius: "4px",
-    },
-  },
-}));
+import { MentionListProps, Props } from "./types";
 
 const passportClassName = "passport";
 
@@ -700,18 +635,6 @@ const suggestion = {
     };
   },
 };
-
-export interface Placeholder {
-  id: string;
-  label: string;
-}
-
-interface MentionListProps {
-  items: Placeholder[];
-  query: string;
-  command: any;
-  onCreatePlaceholder: (val: string) => void;
-}
 
 // Implemented based on the mention plugin example code snippets: https://tiptap.dev/api/nodes/mention
 const MentionList = forwardRef((props: MentionListProps, ref) => {

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -24,10 +24,11 @@ import React, {
 
 import Input from "../../shared/Input/Input";
 import PublicFileUploadButton from "../../shared/PublicFileUploadButton";
+import { H1Button, H2Button } from "./components/HeadingButtons";
 import { PopupError } from "./components/PopUpError";
 import { suggestion } from "./components/suggestion";
 import { RichContentContainer, StyledBubbleMenu } from "./styles";
-import { commonExtensions } from "./tiptapExtensions";
+import { commonExtensions, passportClassName } from "./tiptapExtensions";
 import { Props } from "./types";
 import {
   fromHtml,
@@ -35,7 +36,6 @@ import {
   getLinkNewTabError,
   initialUrlValue,
   linkSelectionError,
-  passportClassName,
   toHtml,
   trimUrlValue,
 } from "./utils";
@@ -208,32 +208,8 @@ const RichTextInput: FC<Props> = (props) => {
             />
           ) : (
             <>
-              <IconButton
-                size="small"
-                color={
-                  editor.isActive("heading", { level: 1 })
-                    ? "primary"
-                    : undefined
-                }
-                onClick={() => {
-                  editor.chain().focus().toggleHeading({ level: 1 }).run();
-                }}
-              >
-                <strong>H1</strong>
-              </IconButton>
-              <IconButton
-                size="small"
-                color={
-                  editor.isActive("heading", { level: 2 })
-                    ? "primary"
-                    : undefined
-                }
-                onClick={() => {
-                  editor.chain().focus().toggleHeading({ level: 2 }).run();
-                }}
-              >
-                <strong>H2</strong>
-              </IconButton>
+              <H1Button editor={editor} />
+              <H2Button editor={editor} />
               <IconButton
                 size="small"
                 color={editor.isActive("bold") ? "primary" : undefined}

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -1,7 +1,6 @@
 import Check from "@mui/icons-material/Check";
 import Close from "@mui/icons-material/Close";
 import Delete from "@mui/icons-material/Delete";
-import Error from "@mui/icons-material/Error";
 import FormatBold from "@mui/icons-material/FormatBold";
 import FormatItalic from "@mui/icons-material/FormatItalic";
 import FormatListBulleted from "@mui/icons-material/FormatListBulleted";
@@ -10,9 +9,7 @@ import LinkIcon from "@mui/icons-material/Link";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { type InputBaseProps } from "@mui/material/InputBase";
-import Popover from "@mui/material/Popover";
 import { styled } from "@mui/material/styles";
-import Typography from "@mui/material/Typography";
 import { type Editor, type JSONContent } from "@tiptap/core";
 import Bold from "@tiptap/extension-bold";
 import BulletList from "@tiptap/extension-bullet-list";
@@ -48,6 +45,7 @@ import { create } from "zustand";
 import Input from "../../shared/Input/Input";
 import PublicFileUploadButton from "../../shared/PublicFileUploadButton";
 import CustomImage from "../RichTextImage";
+import { PopupError } from "./components/PopUpError";
 import {
   MentionItems,
   MentionItemsButton,
@@ -309,47 +307,6 @@ const getLinkNewTabError = (
   });
 
   return error;
-};
-
-const PopupError: FC<{ id: string; error: string }> = (props) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  const open = Boolean(anchorEl);
-
-  return (
-    <Box>
-      <IconButton size="small" onClick={handleOpen}>
-        <Error />
-      </IconButton>
-      <Popover
-        id="popover"
-        sx={{
-          zIndex: 100000,
-          maxWidth: "xs",
-          padding: 10,
-        }}
-        open={open}
-        onClose={handleClose}
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "right",
-        }}
-      >
-        <Typography variant="body2" sx={{ padding: 1 }}>
-          {props.error}
-        </Typography>
-      </Popover>
-    </Box>
-  );
 };
 
 const RichTextInput: FC<Props> = (props) => {

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -131,12 +131,13 @@ const RichTextInput: FC<Props> = (props) => {
       return;
     }
     const editorValue = internalValue.current || toHtml(editor.getJSON());
-    if (props.value !== editorValue) {
-      internalValue.current = stringValue;
-      const doc = fromHtml(stringValue);
-      setContentHierarchyError(getContentHierarchyError(doc));
-      editor.commands.setContent(doc);
+    if (props.value === editorValue) {
+      return;
     }
+    internalValue.current = stringValue;
+    const doc = fromHtml(stringValue);
+    setContentHierarchyError(getContentHierarchyError(doc));
+    editor.commands.setContent(doc);
   }, [stringValue]);
 
   // Returns the HTML snippet under the current selection, typically wrapped in a <p> tag, e.g. '<p>selected text</p>'
@@ -161,12 +162,13 @@ const RichTextInput: FC<Props> = (props) => {
 
   // Focus/select the URL input field value when it appears in the UI
   useEffect(() => {
-    if (isAddingLink) {
-      urlInputRef.current?.focus();
-      const href = editor?.getAttributes("link")?.href || initialUrlValue;
-      if (href !== initialUrlValue) {
-        urlInputRef.current?.select();
-      }
+    if (!isAddingLink) {
+      return;
+    }
+    urlInputRef.current?.focus();
+    const href = editor?.getAttributes("link")?.href || initialUrlValue;
+    if (href !== initialUrlValue) {
+      urlInputRef.current?.select();
     }
   }, [isAddingLink]);
 

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -8,7 +8,6 @@ import FormatListBulleted from "@mui/icons-material/FormatListBulleted";
 import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
 import LinkIcon from "@mui/icons-material/Link";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import { type InputBaseProps } from "@mui/material/InputBase";
 import Popover from "@mui/material/Popover";
@@ -30,12 +29,7 @@ import Paragraph from "@tiptap/extension-paragraph";
 import ExtensionPlaceholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
 import { generateHTML, generateJSON } from "@tiptap/html";
-import {
-  BubbleMenu,
-  EditorContent,
-  ReactRenderer,
-  useEditor,
-} from "@tiptap/react";
+import { EditorContent, ReactRenderer, useEditor } from "@tiptap/react";
 import { map } from "ramda";
 import React, {
   ChangeEvent,
@@ -54,6 +48,12 @@ import { create } from "zustand";
 import Input from "../../shared/Input/Input";
 import PublicFileUploadButton from "../../shared/PublicFileUploadButton";
 import CustomImage from "../RichTextImage";
+import {
+  MentionItems,
+  MentionItemsButton,
+  MentionItemsEmpty,
+  StyledBubbleMenu,
+} from "./styles";
 
 interface Props extends InputBaseProps {
   className?: string;
@@ -117,43 +117,6 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
       borderRadius: "4px",
     },
   },
-}));
-
-const StyledBubbleMenu = styled(BubbleMenu)(({ theme }) => ({
-  background: theme.palette.background.default,
-  boxShadow: "0 2px 6px 0 rgba(0, 0, 0, 0.2)",
-  display: "flex",
-  alignItems: "center",
-  padding: theme.spacing(0.25),
-}));
-
-const MentionItems = styled(Box)(({ theme }) => ({
-  background: theme.palette.common.white,
-  fontSize: "0.875em",
-  boxShadow: "0 2px 6px rgba(0, 0, 0, 0.3)",
-  borderRadius: "4px",
-  width: "150px",
-  overflow: "hidden",
-  padding: theme.spacing(0.25),
-}));
-
-const MentionItemsButton = styled(Button)(({ theme }) => ({
-  border: 0,
-  background: "none",
-  boxShadow: "none",
-  padding: theme.spacing(0.25),
-  display: "block",
-  width: "100%",
-  textAlign: "left",
-  "&.mention-item-selected": {
-    background: `rgba(0, 0, 0, 0.03)`,
-  },
-}));
-
-const MentionItemsEmpty = styled(Typography)(({ theme }) => ({
-  padding: theme.spacing(0.25),
-  margin: 0,
-  color: theme.palette.text.secondary,
 }));
 
 const passportClassName = "passport";

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/HeadingButtons.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/HeadingButtons.tsx
@@ -1,0 +1,34 @@
+import IconButton from "@mui/material/IconButton";
+import { type Editor } from "@tiptap/core";
+import { Level } from "@tiptap/extension-heading";
+import React from "react";
+
+const HeadingButton = ({
+  editor,
+  level,
+}: {
+  editor: Editor;
+  level: number;
+}) => (
+  <IconButton
+    size="small"
+    color={editor.isActive("heading", { level }) ? "primary" : undefined}
+    onClick={() => {
+      editor
+        .chain()
+        .focus()
+        .toggleHeading({ level: level as Level })
+        .run();
+    }}
+  >
+    <strong>`H${level}</strong>
+  </IconButton>
+);
+
+export const H1Button = ({ editor }: { editor: Editor }) => {
+  return <HeadingButton editor={editor} level={1} />;
+};
+
+export const H2Button = ({ editor }: { editor: Editor }) => {
+  return <HeadingButton editor={editor} level={2} />;
+};

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/HeadingButtons.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/HeadingButtons.tsx
@@ -21,7 +21,7 @@ const HeadingButton = ({
         .run();
     }}
   >
-    <strong>`H${level}</strong>
+    <strong>H{level}</strong>
   </IconButton>
 );
 

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/MentionList.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/MentionList.tsx
@@ -1,0 +1,97 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+
+import { passportClassName, useVariablesStore } from "../utils";
+import {
+  MentionItems,
+  MentionItemsButton,
+  MentionItemsEmpty,
+} from "./../styles";
+import { MentionListProps } from "./../types";
+
+// Implemented based on the mention plugin example code snippets: https://tiptap.dev/api/nodes/mention
+export const MentionList = forwardRef((props: MentionListProps, ref) => {
+  const variablesStore = useVariablesStore();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const selectItem = (index: number) => {
+    const item = props.items[index];
+
+    if (item) {
+      props.command({ id: item });
+    }
+  };
+
+  const upHandler = () => {
+    setSelectedIndex(
+      (selectedIndex + props.items.length - 1) % props.items.length,
+    );
+  };
+
+  const downHandler = () => {
+    setSelectedIndex((selectedIndex + 1) % props.items.length);
+  };
+
+  const enterHandler = () => {
+    selectItem(selectedIndex);
+  };
+
+  useEffect(() => setSelectedIndex(0), [props.items]);
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }: any) => {
+      if (event.key === "ArrowUp") {
+        upHandler();
+        return true;
+      }
+
+      if (event.key === "ArrowDown") {
+        downHandler();
+        return true;
+      }
+
+      if (event.key === "Enter") {
+        enterHandler();
+        return true;
+      }
+
+      return false;
+    },
+  }));
+
+  return (
+    <MentionItems>
+      {props.query.length > 0 && (
+        <MentionItemsButton
+          variant="text"
+          onClick={() => {
+            props.command({ id: props.query });
+            variablesStore.addVariable(props.query);
+          }}
+        >
+          + Add <span className={passportClassName}>@{props.query}</span>
+        </MentionItemsButton>
+      )}
+      {props.items.length > 0 ? (
+        props.items.map((item: any, index: number) => (
+          <MentionItemsButton
+            variant="text"
+            className={`mention-item ${
+              index === selectedIndex ? "mention-item-selected" : ""
+            }`}
+            key={index}
+            onClick={() => selectItem(index)}
+          >
+            <span className={passportClassName}>@{item}</span>
+          </MentionItemsButton>
+        ))
+      ) : (
+        <MentionItemsEmpty variant="body2">No results</MentionItemsEmpty>
+      )}
+    </MentionItems>
+  );
+});

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/MentionList.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/MentionList.tsx
@@ -5,7 +5,8 @@ import React, {
   useState,
 } from "react";
 
-import { passportClassName, useVariablesStore } from "../utils";
+import { passportClassName } from "../tiptapExtensions";
+import { useVariablesStore } from "../utils";
 import {
   MentionItems,
   MentionItemsButton,

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/PopUpError.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/PopUpError.tsx
@@ -1,0 +1,47 @@
+import Error from "@mui/icons-material/Error";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Popover from "@mui/material/Popover";
+import Typography from "@mui/material/Typography";
+import React, { type FC, useState } from "react";
+
+export const PopupError: FC<{ id: string; error: string }> = (props) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+
+  return (
+    <Box>
+      <IconButton size="small" onClick={handleOpen}>
+        <Error />
+      </IconButton>
+      <Popover
+        id="popover"
+        sx={{
+          zIndex: 100_000,
+          maxWidth: "xs",
+          padding: 10,
+        }}
+        open={open}
+        onClose={handleClose}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+      >
+        <Typography variant="body2" sx={{ padding: 1 }}>
+          {props.error}
+        </Typography>
+      </Popover>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/RichTextInputButtons.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/RichTextInputButtons.tsx
@@ -1,0 +1,73 @@
+import FormatBold from "@mui/icons-material/FormatBold";
+import FormatItalic from "@mui/icons-material/FormatItalic";
+import FormatListBulleted from "@mui/icons-material/FormatListBulleted";
+import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
+import IconButton from "@mui/material/IconButton";
+import { type Editor } from "@tiptap/core";
+import React, { ReactElement } from "react";
+
+const RichTextInputButton = ({
+  editor,
+  type,
+  onClick,
+  icon,
+}: {
+  editor: Editor;
+  type: string;
+  onClick: () => void;
+  icon: ReactElement;
+}) => {
+  return (
+    <IconButton
+      size="small"
+      color={editor.isActive(type) ? "primary" : undefined}
+      onClick={onClick}
+    >
+      {icon}
+    </IconButton>
+  );
+};
+
+export const BoldButton = ({ editor }: { editor: Editor }) => (
+  <RichTextInputButton
+    editor={editor}
+    type="bold"
+    icon={<FormatBold />}
+    onClick={() => {
+      editor.chain().focus().toggleBold().run();
+    }}
+  />
+);
+
+export const ItalicButton = ({ editor }: { editor: Editor }) => (
+  <RichTextInputButton
+    editor={editor}
+    type="italic"
+    icon={<FormatItalic />}
+    onClick={() => {
+      editor.chain().focus().toggleItalic().run();
+    }}
+  />
+);
+
+export const BulletListButton = ({ editor }: { editor: Editor }) => (
+  <RichTextInputButton
+    editor={editor}
+    type="bulletList"
+    icon={<FormatListBulleted />}
+    onClick={() => {
+      editor.chain().focus().toggleBulletList().run();
+    }}
+  />
+);
+
+export const OrderedListButton = ({ editor }: { editor: Editor }) => (
+  <RichTextInputButton
+    editor={editor}
+    type="orderedList"
+    icon={<FormatListNumbered />}
+    onClick={() => {
+      editor.chain().focus().toggleOrderedList().run();
+    }}
+  />
+);

--- a/editor.planx.uk/src/ui/editor/RichTextInput/components/suggestion.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/components/suggestion.tsx
@@ -1,0 +1,71 @@
+import { ReactRenderer } from "@tiptap/react";
+import tippy, { type Instance } from "tippy.js";
+
+import { useVariablesStore } from "./../utils";
+import { MentionList } from "./MentionList";
+
+// Implemented based on the mention plugin example code snippets: https://tiptap.dev/api/nodes/mention
+export const suggestion = {
+  items: ({ query }: { query: string }) => {
+    return useVariablesStore
+      .getState()
+      .variables.filter((item) =>
+        item.toLowerCase().includes(query.toLowerCase()),
+      )
+      .slice(0, 5);
+  },
+
+  render: () => {
+    let component: undefined | ReactRenderer<any, any>;
+    let popup: Instance[] | undefined;
+
+    return {
+      onStart: (props: any) => {
+        component = new ReactRenderer(MentionList, {
+          props,
+          editor: props.editor,
+        });
+
+        if (!props.clientRect) {
+          return;
+        }
+
+        popup = tippy("body", {
+          getReferenceClientRect: props.clientRect,
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: "manual",
+          placement: "bottom-start",
+        });
+      },
+
+      onUpdate(props: any) {
+        component?.updateProps(props);
+
+        if (!props.clientRect) {
+          return;
+        }
+
+        popup?.[0]?.setProps({
+          getReferenceClientRect: props.clientRect,
+        });
+      },
+
+      onKeyDown(props: any) {
+        if (props.event.key === "Escape") {
+          popup?.[0]?.hide();
+          return true;
+        }
+
+        return component?.ref?.onKeyDown(props);
+      },
+
+      onExit() {
+        popup?.[0]?.destroy();
+        component?.destroy();
+      },
+    };
+  },
+};

--- a/editor.planx.uk/src/ui/editor/RichTextInput/styles.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/styles.ts
@@ -3,6 +3,64 @@ import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { BubbleMenu } from "@tiptap/react";
+import { inputFocusStyle } from "theme";
+
+export const RichContentContainer = styled(Box)(({ theme }) => ({
+  position: "relative",
+  "& .ProseMirror": {
+    padding: "12px 15px",
+    backgroundColor: theme.palette.common.white,
+    minHeight: "50px",
+    border: `1px solid ${theme.palette.border.main}`,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    wordBreak: "break-word",
+    "& a": {
+      color: "currentColor",
+    },
+    "& > *": {
+      margin: 0,
+    },
+    "& > * + *": {
+      marginTop: theme.spacing(1),
+    },
+    "& ol, & ul": {
+      marginBottom: theme.spacing(1),
+    },
+    "& ol li, & ul li": {
+      margin: theme.spacing(0.5, 0, 0),
+    },
+    "& ol p, & ul p": {
+      margin: 0,
+    },
+    "& h1, & h2, & h3": {
+      "& strong": {
+        fontWeight: "inherit",
+      },
+    },
+    // Styles for placeholder text, to match ui/Input.tsx
+    "& p.is-editor-empty:first-of-type::before": {
+      color: theme.palette.text.placeholder,
+      opacity: 1,
+      content: `attr(data-placeholder)`,
+      float: "left",
+      height: 0,
+      pointerEvents: "none",
+    },
+    // Focus styles
+    "&.ProseMirror-focused": {
+      ...inputFocusStyle,
+    },
+    // Styles for injected passport/mention
+    "& .passport": {
+      backgroundColor: theme.palette.secondary.main,
+      color: theme.palette.text.primary,
+      padding: theme.spacing(0.25, 0.5),
+      borderRadius: "4px",
+    },
+  },
+}));
 
 export const StyledBubbleMenu = styled(BubbleMenu)(({ theme }) => ({
   background: theme.palette.background.default,

--- a/editor.planx.uk/src/ui/editor/RichTextInput/styles.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/styles.ts
@@ -1,0 +1,42 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { BubbleMenu } from "@tiptap/react";
+
+export const StyledBubbleMenu = styled(BubbleMenu)(({ theme }) => ({
+  background: theme.palette.background.default,
+  boxShadow: "0 2px 6px 0 rgba(0, 0, 0, 0.2)",
+  display: "flex",
+  alignItems: "center",
+  padding: theme.spacing(0.25),
+}));
+
+export const MentionItems = styled(Box)(({ theme }) => ({
+  background: theme.palette.common.white,
+  fontSize: "0.875em",
+  boxShadow: "0 2px 6px rgba(0, 0, 0, 0.3)",
+  borderRadius: "4px",
+  width: "150px",
+  overflow: "hidden",
+  padding: theme.spacing(0.25),
+}));
+
+export const MentionItemsButton = styled(Button)(({ theme }) => ({
+  border: 0,
+  background: "none",
+  boxShadow: "none",
+  padding: theme.spacing(0.25),
+  display: "block",
+  width: "100%",
+  textAlign: "left",
+  "&.mention-item-selected": {
+    background: `rgba(0, 0, 0, 0.03)`,
+  },
+}));
+
+export const MentionItemsEmpty = styled(Typography)(({ theme }) => ({
+  padding: theme.spacing(0.25),
+  margin: 0,
+  color: theme.palette.text.secondary,
+}));

--- a/editor.planx.uk/src/ui/editor/RichTextInput/tiptapExtensions.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/tiptapExtensions.ts
@@ -1,0 +1,46 @@
+import Bold from "@tiptap/extension-bold";
+import BulletList from "@tiptap/extension-bullet-list";
+import Document from "@tiptap/extension-document";
+import HardBreak from "@tiptap/extension-hard-break";
+import Heading from "@tiptap/extension-heading";
+import Italic from "@tiptap/extension-italic";
+import Link from "@tiptap/extension-link";
+import ListItem from "@tiptap/extension-list-item";
+import Mention from "@tiptap/extension-mention";
+import OrderedList from "@tiptap/extension-ordered-list";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+
+import CustomImage from "../RichTextImage";
+import { passportClassName } from "./utils";
+
+// Shared tiptap editor extensions
+export const commonExtensions = [
+  Document,
+  Paragraph,
+  Text,
+  Bold,
+  Italic,
+  HardBreak,
+  Link.configure({
+    openOnClick: false,
+    autolink: false,
+  }),
+  Heading.configure({
+    levels: [1, 2, 3],
+  }),
+  BulletList,
+  OrderedList,
+  ListItem,
+  CustomImage,
+];
+
+// Tiptap editor extensions used to convert between HTML and Prosemirror document state (used internally by tiptap)
+export const conversionExtensions = [
+  ...commonExtensions,
+  Mention.configure({
+    HTMLAttributes: {
+      class: passportClassName,
+    },
+  }),
+];

--- a/editor.planx.uk/src/ui/editor/RichTextInput/tiptapExtensions.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/tiptapExtensions.ts
@@ -12,7 +12,8 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Text from "@tiptap/extension-text";
 
 import CustomImage from "../RichTextImage";
-import { passportClassName } from "./utils";
+
+export const passportClassName = "passport";
 
 // Shared tiptap editor extensions
 export const commonExtensions = [

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -18,3 +18,7 @@ export interface Props extends InputBaseProps {
   bordered?: boolean;
   errorMessage?: string;
 }
+export interface VariablesState {
+  variables: string[];
+  addVariable: (newVariable: string) => void;
+}

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line no-restricted-imports
+import type { InputBaseProps } from "@mui/material";
+import { ChangeEvent } from "react";
+
+export interface MentionListProps {
+  items: Placeholder[];
+  query: string;
+  command: any;
+  onCreatePlaceholder: (val: string) => void;
+}
+export interface Placeholder {
+  id: string;
+  label: string;
+}
+export interface Props extends InputBaseProps {
+  className?: string;
+  onChange?: (ev: ChangeEvent<HTMLInputElement>) => void;
+  bordered?: boolean;
+  errorMessage?: string;
+}

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import type { InputBaseProps } from "@mui/material";
+import type { InputBaseProps } from "@mui/material/InputBase";
 import { ChangeEvent } from "react";
 
 export interface MentionListProps {

--- a/editor.planx.uk/src/ui/editor/RichTextInput/utils.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/utils.ts
@@ -1,0 +1,163 @@
+import { type JSONContent } from "@tiptap/core";
+import { generateHTML, generateJSON } from "@tiptap/html";
+import { map } from "ramda";
+import { create } from "zustand";
+
+import { conversionExtensions } from "./tiptapExtensions";
+import { VariablesState } from "./types";
+
+/**
+ * Traverse a nested object/array and apply a modification at each level. If the modifier returns `null`, it leaves the result unchanged.
+ * Used to inject placeholder values into a document structure.
+ */
+export const modifyDeep =
+  (fn: (field: Value) => Value) =>
+  (val: Value): Value => {
+    if (!val) {
+      return val;
+    }
+    const mod = fn(val);
+    if (mod) {
+      return mod;
+    }
+    if (Array.isArray(val)) {
+      return map(modifyDeep(fn), val);
+    }
+    if (typeof val === "object") {
+      return map(modifyDeep(fn), val);
+    }
+    return val;
+  };
+
+// Generic value that `modifyDeep` works off of. Since it can be object, array or primitive, any typing more accurate than `any` is not compiling at the moment.
+// TODO: find a better typing alternative
+type Value = any;
+
+export const initialUrlValue = "https://";
+
+// Makes sure that if the user pastes a full URL into the input, the pre-populated `https://` is removed
+// e.g. https://https://something.com -> https://something.com
+// Also trim whitespace from links which flag sanitation errors
+export const trimUrlValue = (url: string) => {
+  if (url.startsWith(`${initialUrlValue}${initialUrlValue}`)) {
+    return url.slice(initialUrlValue.length);
+  }
+  return url.trim();
+};
+
+export const getContentHierarchyError = (doc: JSONContent): string | null => {
+  let h1Index = -1;
+  let h2Index = -1;
+
+  let error: string | null = null;
+
+  (doc.content || []).forEach((d: JSONContent, index) => {
+    if (d.type === "paragraph") {
+      return;
+    } else if (d.type === "heading") {
+      const level = d.attrs?.level === 1 ? 1 : 2;
+      if (level === 1) {
+        if (h1Index === -1 && h2Index !== -1) {
+          error = "A level 1 heading must come before a level 2 heading.";
+        } else if (h1Index !== -1) {
+          error =
+            "There cannot be more than one level 1 heading in the document.";
+        } else if (index !== 0) {
+          error = "The level 1 heading must come first in the document.";
+        }
+        h1Index = index;
+        return;
+      }
+      if (level === 2) {
+        if (h1Index === -1) {
+          error = "A level 1 heading must come before a level 2 heading.";
+        }
+        h2Index = index;
+        return;
+      }
+    }
+    return null;
+  });
+
+  return error;
+};
+
+// Maintain a store of variables as they are created in the '@'-mention plugin, making them available in memory for next time.
+// TODO: explore instantiating from a hard-coded list, or persisting in either the backend or local storage.
+export const useVariablesStore = create<VariablesState>()((set) => ({
+  variables: [],
+  addVariable: (newVariable: string) =>
+    set((state) => ({ variables: [...state.variables, newVariable] })),
+}));
+
+export const passportClassName = "passport";
+
+export const emptyContent = "<p></p>";
+
+// Specify whether a selection is unsuitable for ensuring accessible links
+export const linkSelectionError = (selectionHtml: string): string | null => {
+  if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
+    const text = selectionHtml.slice(3, -4);
+    const lowercaseText = text.toLowerCase().trim().replace(/[.,]/g, "");
+    if (lowercaseText === "click here" || lowercaseText === "clicking here") {
+      return "Links must be set over text that accurately describes what the link is for. Avoid generic language such as 'click here'.";
+    }
+    if (text[0] && text[0] !== text[0].toUpperCase() && text.length < 8) {
+      return "Make sure the link text accurately describes the what the link is for.";
+    }
+  }
+  return null;
+};
+
+export const toHtml = (doc: JSONContent) => {
+  const outgoingHtml = generateHTML(doc, conversionExtensions);
+  return outgoingHtml === emptyContent ? "" : outgoingHtml;
+};
+
+export const fromHtml = (htmlString: string) => {
+  return generateJSON(
+    htmlString === "" ? emptyContent : htmlString,
+    conversionExtensions,
+  );
+};
+
+export const injectVariables = (
+  htmlString: string,
+  vars: Record<string, string>,
+) => {
+  const doc = fromHtml(htmlString);
+  return toHtml(
+    modifyDeep((node) => {
+      return node.type === "mention"
+        ? {
+            ...node,
+            type: "text",
+            text: vars[node.attrs.id] || "Unknown",
+            attrs: undefined,
+          }
+        : null;
+    })(doc),
+  );
+};
+
+export const getLinkNewTabError = (
+  content: JSONContent | undefined = [],
+): string | undefined => {
+  let error: string | undefined;
+  if (!content) return;
+
+  content.forEach((child: JSONContent) => {
+    if (!child.content) return;
+
+    child.content.forEach(({ marks, text }) => {
+      const isLink = marks?.map(({ type }) => type).includes("link");
+      const hasOpenTabText = text?.includes("(opens in a new tab)");
+
+      if (hasOpenTabText && !isLink) {
+        error = 'Links must wrap the text "(opens in a new tab)"';
+      }
+    });
+  });
+
+  return error;
+};

--- a/editor.planx.uk/src/ui/editor/RichTextInput/utils.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/utils.ts
@@ -45,43 +45,6 @@ export const trimUrlValue = (url: string) => {
   return url.trim();
 };
 
-export const getContentHierarchyError = (doc: JSONContent): string | null => {
-  let h1Index = -1;
-  let h2Index = -1;
-
-  let error: string | null = null;
-
-  (doc.content || []).forEach((d: JSONContent, index) => {
-    if (d.type === "paragraph") {
-      return;
-    } else if (d.type === "heading") {
-      const level = d.attrs?.level === 1 ? 1 : 2;
-      if (level === 1) {
-        if (h1Index === -1 && h2Index !== -1) {
-          error = "A level 1 heading must come before a level 2 heading.";
-        } else if (h1Index !== -1) {
-          error =
-            "There cannot be more than one level 1 heading in the document.";
-        } else if (index !== 0) {
-          error = "The level 1 heading must come first in the document.";
-        }
-        h1Index = index;
-        return;
-      }
-      if (level === 2) {
-        if (h1Index === -1) {
-          error = "A level 1 heading must come before a level 2 heading.";
-        }
-        h2Index = index;
-        return;
-      }
-    }
-    return null;
-  });
-
-  return error;
-};
-
 // Maintain a store of variables as they are created in the '@'-mention plugin, making them available in memory for next time.
 // TODO: explore instantiating from a hard-coded list, or persisting in either the backend or local storage.
 export const useVariablesStore = create<VariablesState>()((set) => ({
@@ -91,21 +54,6 @@ export const useVariablesStore = create<VariablesState>()((set) => ({
 }));
 
 export const emptyContent = "<p></p>";
-
-// Specify whether a selection is unsuitable for ensuring accessible links
-export const linkSelectionError = (selectionHtml: string): string | null => {
-  if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
-    const text = selectionHtml.slice(3, -4);
-    const lowercaseText = text.toLowerCase().trim().replace(/[.,]/g, "");
-    if (lowercaseText === "click here" || lowercaseText === "clicking here") {
-      return "Links must be set over text that accurately describes what the link is for. Avoid generic language such as 'click here'.";
-    }
-    if (text[0] && text[0] !== text[0].toUpperCase() && text.length < 8) {
-      return "Make sure the link text accurately describes the what the link is for.";
-    }
-  }
-  return null;
-};
 
 export const toHtml = (doc: JSONContent) => {
   const outgoingHtml = generateHTML(doc, conversionExtensions);
@@ -136,26 +84,4 @@ export const injectVariables = (
         : null;
     })(doc),
   );
-};
-
-export const getLinkNewTabError = (
-  content: JSONContent | undefined = [],
-): string | undefined => {
-  let error: string | undefined;
-  if (!content) return;
-
-  content.forEach((child: JSONContent) => {
-    if (!child.content) return;
-
-    child.content.forEach(({ marks, text }) => {
-      const isLink = marks?.map(({ type }) => type).includes("link");
-      const hasOpenTabText = text?.includes("(opens in a new tab)");
-
-      if (hasOpenTabText && !isLink) {
-        error = 'Links must wrap the text "(opens in a new tab)"';
-      }
-    });
-  });
-
-  return error;
 };

--- a/editor.planx.uk/src/ui/editor/RichTextInput/utils.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/utils.ts
@@ -90,8 +90,6 @@ export const useVariablesStore = create<VariablesState>()((set) => ({
     set((state) => ({ variables: [...state.variables, newVariable] })),
 }));
 
-export const passportClassName = "passport";
-
 export const emptyContent = "<p></p>";
 
 // Specify whether a selection is unsuitable for ensuring accessible links

--- a/editor.planx.uk/src/ui/editor/RichTextInput/validationHelpers.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/validationHelpers.ts
@@ -1,0 +1,75 @@
+import type { JSONContent } from "@tiptap/core";
+
+export const getLinkNewTabError = (
+  content: JSONContent | undefined = [],
+): string | undefined => {
+  let error: string | undefined;
+  if (!content) return;
+
+  content.forEach((child: JSONContent) => {
+    if (!child.content) return;
+
+    child.content.forEach(({ marks, text }) => {
+      const isLink = marks?.map(({ type }) => type).includes("link");
+      const hasOpenTabText = text?.includes("(opens in a new tab)");
+
+      if (hasOpenTabText && !isLink) {
+        error = 'Links must wrap the text "(opens in a new tab)"';
+      }
+    });
+  });
+
+  return error;
+};
+
+// Specify whether a selection is unsuitable for ensuring accessible links
+export const linkSelectionError = (selectionHtml: string): string | null => {
+  if (selectionHtml.startsWith("<p>") && selectionHtml.endsWith("</p>")) {
+    const text = selectionHtml.slice(3, -4);
+    const lowercaseText = text.toLowerCase().trim().replace(/[.,]/g, "");
+    if (lowercaseText === "click here" || lowercaseText === "clicking here") {
+      return "Links must be set over text that accurately describes what the link is for. Avoid generic language such as 'click here'.";
+    }
+    if (text[0] && text[0] !== text[0].toUpperCase() && text.length < 8) {
+      return "Make sure the link text accurately describes the what the link is for.";
+    }
+  }
+  return null;
+};
+
+export const getContentHierarchyError = (doc: JSONContent): string | null => {
+  let h1Index = -1;
+  let h2Index = -1;
+
+  let error: string | null = null;
+
+  (doc.content || []).forEach((d: JSONContent, index) => {
+    if (d.type === "paragraph") {
+      return;
+    } else if (d.type === "heading") {
+      const level = d.attrs?.level === 1 ? 1 : 2;
+      if (level === 1) {
+        if (h1Index === -1 && h2Index !== -1) {
+          error = "A level 1 heading must come before a level 2 heading.";
+        } else if (h1Index !== -1) {
+          error =
+            "There cannot be more than one level 1 heading in the document.";
+        } else if (index !== 0) {
+          error = "The level 1 heading must come first in the document.";
+        }
+        h1Index = index;
+        return;
+      }
+      if (level === 2) {
+        if (h1Index === -1) {
+          error = "A level 1 heading must come before a level 2 heading.";
+        }
+        h2Index = index;
+        return;
+      }
+    }
+    return null;
+  });
+
+  return error;
+};


### PR DESCRIPTION
🔥 Blazing in to completely split this file up as it was my most hated file to look at (so far...). 

Using the excuse of the next ticket on my radar (https://trello.com/c/Sv8IfEVi/3206-add-validation-to-editor-modals-to-prevent-made-policy-reference-links-from-being-added-to-help-text) to do this now!

**Summary:**
- `RichTextInput.tsx` now mostly just contains the main input component and editor.
- `/components` sub-folder contains all other defined components that were in the main folder, along with newly extracted `RichTextInputButtons` (such as `H1Button`)
- Styled components extracted to `styles.ts`
- Type definitions extracted to `types.ts`
- Most of the helper functions extracted to `utils.ts`

Now much easier to read in my opinion! 🤭 