### PR TITLE
feat(templates): Add fk relationship between `flows.templated_from` and `flows.id`

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -445,6 +445,15 @@
     - name: team
       using:
         foreign_key_constraint_on: team_id
+    - name: template
+      using:
+        manual_configuration:
+          column_mapping:
+            templated_from: id
+          insertion_order: null
+          remote_table:
+            name: flows
+            schema: public
   array_relationships:
     - name: document_templates
       using:


### PR DESCRIPTION
## What?
Add foreign key relationship between the `flows.templated_from` column and `flows.id`

## Why?
Required for templates, in order to join onto queries and the upcoming `flow_customisations` table.