### PR TITLE
feat: Do not allow template flows to be deleted / archived

### DIFF
--- a/e2e/tests/api-driven/src/demo-workspace/helper.ts
+++ b/e2e/tests/api-driven/src/demo-workspace/helper.ts
@@ -277,10 +277,13 @@ export async function updateFlow(client, flowId: UUID): Promise<UUID> {
 }
 
 export async function deleteFlow(client, flowId: UUID): Promise<UUID> {
-  const { delete_flows_by_pk: response } = await client.request(
+  const { update_flows_by_pk: response } = await client.request(
     gql`
-      mutation deleteFlow($flowId: uuid!) {
-        delete_flows_by_pk(id: $flowId) {
+      mutation softDeleteFlow($flowId: uuid!) {
+        update_flows_by_pk(
+          pk_columns: { id: $flowId }
+          _set: { deleted_at: "now()" }
+        ) {
           id
         }
       }

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -169,8 +169,8 @@ export interface EditorStore extends Store.Store {
   ) => Promise<string>;
   createFlowFromTemplate: (
     templateId: string,
-    teamId: string,
-  ) => Promise<object>;
+    teamId: number,
+  ) => Promise<AxiosResponse>;
   validateAndDiffFlow: (flowId: string) => Promise<any>;
   getFlows: (teamId: number) => Promise<FlowSummary[]>;
   isClone: (id: NodeId) => boolean;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -1,12 +1,12 @@
 import { gql } from "@apollo/client";
 import { getPathForNode, sortFlow } from "@opensystemslab/planx-core";
 import {
+  ComponentType as TYPES,
   flatFlags,
   FlowGraph,
   FlowStatus,
   NodeId,
   OrderedFlow,
-  ComponentType as TYPES,
 } from "@opensystemslab/planx-core/types";
 import {
   add,
@@ -31,9 +31,9 @@ import { type } from "ot-json0";
 import type { StateCreator } from "zustand";
 import { persist } from "zustand/middleware";
 
-import { type Store } from ".";
 import { FlowLayout } from "../../components/Flow";
 import { connectToDB, getConnection } from "./../sharedb";
+import { type Store } from ".";
 import type { SharedStore } from "./shared";
 import { UserStore } from "./user";
 
@@ -169,9 +169,8 @@ export interface EditorStore extends Store.Store {
   ) => Promise<string>;
   createFlowFromTemplate: (
     templateId: string,
-    teamId: number,
-  ) => Promise<AxiosResponse>;
-  deleteFlow: (teamId: number, flowSlug: string) => Promise<object>;
+    teamId: string,
+  ) => Promise<object>;
   validateAndDiffFlow: (flowId: string) => Promise<any>;
   getFlows: (teamId: number) => Promise<FlowSummary[]>;
   isClone: (id: NodeId) => boolean;
@@ -341,25 +340,6 @@ export const editorStore: StateCreator<
       },
     );
 
-    return response;
-  },
-
-  deleteFlow: async (teamId, flowSlug) => {
-    const response = await client.mutate({
-      mutation: gql`
-        mutation DeleteFlow($team_id: Int, $flow_slug: String) {
-          delete_flows(
-            where: { team_id: { _eq: $team_id }, slug: { _eq: $flow_slug } }
-          ) {
-            affected_rows
-          }
-        }
-      `,
-      variables: {
-        flow_slug: flowSlug,
-        team_id: teamId,
-      },
-    });
     return response;
   },
 

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -123,16 +123,6 @@ const FlowItem: React.FC<FlowItemProps> = ({
   teamSlug,
   refreshFlows,
 }) => {
-  const [deleting, setDeleting] = useState(false);
-  const handleDelete = () => {
-    useStore
-      .getState()
-      .deleteFlow(teamId, flow.slug)
-      .then(() => {
-        setDeleting(false);
-        refreshFlows();
-      });
-  };
   const handleCopy = () => {
     useStore
       .getState()
@@ -152,18 +142,6 @@ const FlowItem: React.FC<FlowItemProps> = ({
 
   return (
     <>
-      {deleting && (
-        <Confirm
-          title="Confirm Delete"
-          open={deleting}
-          content="Deleting a service cannot be reversed."
-          onClose={() => {
-            setDeleting(false);
-          }}
-          onConfirm={handleDelete}
-          submitLabel="Delete Service"
-        />
-      )}
       <DashboardListItem>
         <DashboardLink href={`./${flow.slug}`} prefetch={false}>
           <Typography variant="h4" component="h2">
@@ -240,13 +218,6 @@ const FlowItem: React.FC<FlowItemProps> = ({
                     }
                   }
                 },
-              },
-              {
-                label: "Delete",
-                onClick: () => {
-                  setDeleting(true);
-                },
-                error: true,
               },
             ]}
           />

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -811,6 +811,7 @@
           - created_at
           - creator_id
           - data
+          - deleted_at
           - description
           - id
           - limitations
@@ -842,6 +843,7 @@
       permission:
         columns:
           - data
+          - deleted_at
           - description
           - is_template
           - limitations
@@ -866,6 +868,7 @@
       permission:
         columns:
           - data
+          - deleted_at
           - description
           - limitations
           - name

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -670,7 +670,9 @@
           - version
         computed_fields:
           - data_merged
-        filter: {}
+        filter:
+          deleted_at:
+            _is_null: true
         allow_aggregations: true
     - role: demoUser
       permission:
@@ -694,19 +696,22 @@
         computed_fields:
           - data_merged
         filter:
-          _or:
-            - _and:
-                - creator_id:
-                    _eq: x-hasura-user-id
+          _and:
+            - _or:
+                - _and:
+                    - creator_id:
+                        _eq: x-hasura-user-id
+                    - team:
+                        id:
+                          _eq: 32
                 - team:
                     id:
-                      _eq: 32
-            - team:
-                id:
-                  _in:
-                    - 1
-                    - 29
-                    - 30
+                      _in:
+                        - 1
+                        - 29
+                        - 30
+            - deleted_at:
+                _is_null: true
       comment: 'For the demo user, we want to ensure they can only see their own flows, and flows from the Open Digital Planning [id = 30], Open Systems Lab [id = 1], and Templates [id = 29]  team '
     - role: platformAdmin
       permission:
@@ -729,7 +734,9 @@
           - version
         computed_fields:
           - data_merged
-        filter: {}
+        filter:
+          deleted_at:
+            _is_null: true
         allow_aggregations: true
     - role: public
       permission:
@@ -748,7 +755,9 @@
           - version
         computed_fields:
           - data_merged
-        filter: {}
+        filter:
+          deleted_at:
+            _is_null: true
         allow_aggregations: true
       comment: ""
     - role: teamEditor
@@ -772,7 +781,9 @@
           - version
         computed_fields:
           - data_merged
-        filter: {}
+        filter:
+          deleted_at:
+            _is_null: true
         allow_aggregations: true
   update_permissions:
     - role: api
@@ -793,8 +804,15 @@
           - team_id
           - updated_at
           - version
-        filter: {}
-        check: {}
+        filter:
+          deleted_at:
+            _is_null: true
+        check:
+          _and:
+            - deleted_at:
+                _is_null: false
+            - templated_from:
+                _is_null: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -824,11 +842,19 @@
           - version
         filter:
           _and:
-            - team_id:
-                _eq: 32
-            - creator_id:
-                _eq: x-hasura-user-id
-        check: null
+            - _and:
+                - team_id:
+                    _eq: 32
+                - creator_id:
+                    _eq: x-hasura-user-id
+            - deleted_at:
+                _is_null: true
+        check:
+          _and:
+            - deleted_at:
+                _is_null: false
+            - templated_from:
+                _is_null: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -853,8 +879,15 @@
           - status
           - summary
           - team_id
-        filter: {}
-        check: null
+        filter:
+          deleted_at:
+            _is_null: true
+        check:
+          _and:
+            - deleted_at:
+                _is_null: false
+            - templated_from:
+                _is_null: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -878,14 +911,22 @@
           - summary
           - team_id
         filter:
-          team:
-            members:
-              _and:
-                - user_id:
-                    _eq: x-hasura-user-id
-                - role:
-                    _eq: teamEditor
-        check: null
+          _and:
+            - team:
+                members:
+                  _and:
+                    - user_id:
+                        _eq: x-hasura-user-id
+                    - role:
+                        _eq: teamEditor
+            - deleted_at:
+                _is_null: true
+        check:
+          _and:
+            - deleted_at:
+                _is_null: false
+            - templated_from:
+                _is_null: true
         validate_input:
           definition:
             forward_client_headers: false

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -805,14 +805,12 @@
           - updated_at
           - version
         filter:
-          deleted_at:
-            _is_null: true
-        check:
           _and:
+            - is_template:
+                _eq: false
             - deleted_at:
-                _is_null: false
-            - templated_from:
                 _is_null: true
+        check: {}
         validate_input:
           definition:
             forward_client_headers: false
@@ -842,19 +840,15 @@
           - version
         filter:
           _and:
-            - _and:
-                - team_id:
-                    _eq: 32
-                - creator_id:
-                    _eq: x-hasura-user-id
+            - team_id:
+                _eq: 32
+            - creator_id:
+                _eq: x-hasura-user-id
             - deleted_at:
                 _is_null: true
-        check:
-          _and:
-            - deleted_at:
-                _is_null: false
-            - templated_from:
-                _is_null: true
+            - is_template:
+                _eq: false
+        check: {}
         validate_input:
           definition:
             forward_client_headers: false
@@ -882,12 +876,7 @@
         filter:
           deleted_at:
             _is_null: true
-        check:
-          _and:
-            - deleted_at:
-                _is_null: false
-            - templated_from:
-                _is_null: true
+        check: {}
         validate_input:
           definition:
             forward_client_headers: false
@@ -921,12 +910,9 @@
                         _eq: teamEditor
             - deleted_at:
                 _is_null: true
-        check:
-          _and:
-            - deleted_at:
-                _is_null: false
-            - templated_from:
-                _is_null: true
+            - is_template:
+                _eq: false
+        check: {}
         validate_input:
           definition:
             forward_client_headers: false

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -892,29 +892,6 @@
             timeout: 10
             url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
           type: http
-  delete_permissions:
-    - role: demoUser
-      permission:
-        filter:
-          _and:
-            - team_id:
-                _eq: 32
-            - creator_id:
-                _eq: x-hasura-user-id
-      comment: ""
-    - role: platformAdmin
-      permission:
-        filter: {}
-    - role: teamEditor
-      permission:
-        filter:
-          team:
-            members:
-              _and:
-                - user_id:
-                    _eq: x-hasura-user-id
-                - role:
-                    _eq: teamEditor
 - table:
     name: global_settings
     schema: public

--- a/hasura.planx.uk/migrations/1738318254560_alter_table_public_flows_add_column_deleted_at/down.sql
+++ b/hasura.planx.uk/migrations/1738318254560_alter_table_public_flows_add_column_deleted_at/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."flows" DROP COLUMN "deleted_at";

--- a/hasura.planx.uk/migrations/1738318254560_alter_table_public_flows_add_column_deleted_at/up.sql
+++ b/hasura.planx.uk/migrations/1738318254560_alter_table_public_flows_add_column_deleted_at/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."flows" add column "deleted_at" timestamptz
+ null;

--- a/hasura.planx.uk/tests/flows.test.js
+++ b/hasura.planx.uk/tests/flows.test.js
@@ -37,6 +37,7 @@ describe("flows and operations", () => {
       expect(i.mutations).toContain("delete_operations");
     });
   });
+
   describe("platformAdmin", () => {
     let i;
     beforeAll(async () => {
@@ -67,9 +68,9 @@ describe("flows and operations", () => {
       expect(i.mutations).not.toContain("delete_operations");
     });
 
-    test("can delete flows", () => {
-      expect(i.mutations).toContain("delete_flows_by_pk");
-      expect(i.mutations).toContain("delete_flows");
+    test("cannot delete flows", () => {
+      expect(i.mutations).not.toContain("delete_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_flows");
     });
 
     test("can query published flows", () => {
@@ -114,9 +115,9 @@ describe("flows and operations", () => {
       expect(i.mutations).toContain("insert_operations");
     });
 
-    test("can delete flows", () => {
-      expect(i.mutations).toContain("delete_flows_by_pk");
-      expect(i.mutations).toContain("delete_flows");
+    test("cannot delete flows", () => {
+      expect(i.mutations).not.toContain("delete_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_flows");
     });
 
     test("cannot delete operations", () => {
@@ -166,9 +167,9 @@ describe("flows and operations", () => {
       expect(i.mutations).toContain("insert_operations");
     });
 
-    test("can delete flows", () => {
-      expect(i.mutations).toContain("delete_flows_by_pk");
-      expect(i.mutations).toContain("delete_flows");
+    test("cannot delete flows", () => {
+      expect(i.mutations).not.toContain("delete_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_flows");
     });
 
     test("cannot delete operations", () => {


### PR DESCRIPTION
## What does this PR do?
 - Removes "delete" button from the frontend UI - to be replaced by "Archive" [in this ticket](https://trello.com/c/fhoa1wCa/3166-add-ability-to-archive-flows-instead-of-deleting-them?filter=archive)
 - Adds `flows.deleted_at` column in order to allow a soft delete pattern

### Permissions
 - Removes "delete" permissions from all roles for the `flows` table
 - Allows all roles to set the `flows.deleted_at` column (within the parameters of their current permission levels)
 - Does not allow any roles to soft delete (set `flows.deleted_at`) for template flows

Some of this is pretty tricky to understand via the `tables.yaml` and took a bit of trial and error to figure out. Some e2e test coverage is needed here to explain this and act as a guard rail for future changes. I'm planning on introducing this in a future PR so that I'm not holding up the "archive flows" ticket @RODO94 will be shortly working on. 

### To manually test - 
 - Log into PlanX to get a JWT
 - Use this in the Hasura console, test out mutations and queries based on the permission level of your JWT
 - E2E tests incoming here on another PR 🚀 