### PR TITLE
feat: Set up relationship between a template flow and children derived from it

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -485,7 +485,7 @@
           table:
             name: published_flows
             schema: public
-    - name: template_children
+    - name: templated_flows
       using:
         manual_configuration:
           column_mapping:

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -485,6 +485,15 @@
           table:
             name: published_flows
             schema: public
+    - name: template_children
+      using:
+        manual_configuration:
+          column_mapping:
+            id: templated_from
+          insertion_order: null
+          remote_table:
+            name: flows
+            schema: public
   computed_fields:
     - name: data_merged
       definition:


### PR DESCRIPTION
Quick follow up to #4232 

Something I missed here is that I need a relationship established between a parent template flow, and all of its children (flows derived from it).

This is what we'll use to cascade changes from parent → child, and to block template flows which have "children" to be deleted/archived.