### PR TITLE
fix: Sync new `flows.summary` and `flows.limitation` columns

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -14,7 +14,9 @@ CREATE TEMPORARY TABLE sync_flows (
   status text,
   name text,
   templated_from uuid,
-  description text
+  description text,
+  summary varchar(120),
+  limitations text
   );
 \copy sync_flows FROM '/tmp/flows.csv' WITH (FORMAT csv, DELIMITER ';');
 
@@ -31,7 +33,9 @@ INSERT INTO flows (
   status,
   name,
   templated_from,
-  description
+  description,
+  summary,
+  limitations
 )
 SELECT
   id,
@@ -46,7 +50,9 @@ SELECT
   status,
   name,
   templated_from,
-  description
+  description,
+  summary,
+  limitations
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -61,7 +67,9 @@ SET
   status = EXCLUDED.status,
   name = EXCLUDED.name,
   templated_from = EXCLUDED.templated_from,
-  description = EXCLUDED.description;
+  description = EXCLUDED.description,
+  summary = EXCLUDED.summary,
+  limitations = EXCLUDED.limitations;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;


### PR DESCRIPTION
## What's the problem?
Identified by @RODO94 here - https://github.com/theopensystemslab/planx-new/pull/4235#issuecomment-2627439158

The sync script is currently failing on `main`.

## What's solution?
Two new columns were added here but missed from the sync script - https://github.com/theopensystemslab/planx-new/pull/4145/files#diff-e120d8d8f11dfabb1f6e3d57d577b2f9ac0d0c1ef1a4695d4ab9c265d7cd4eb0

This PR updates the sync script to included these new columns.