### PR TITLE
fix: switch order of column select in `seed-database` flows scripts

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -13,8 +13,8 @@ CREATE TEMPORARY TABLE sync_flows (
   analytics_link text,
   status text,
   name text,
-  templated_from uuid,
   description text,
+  templated_from uuid,
   summary varchar(120),
   limitations text
   );
@@ -32,8 +32,8 @@ INSERT INTO flows (
   analytics_link,
   status,
   name,
-  templated_from,
   description,
+  templated_from,
   summary,
   limitations
 )
@@ -49,8 +49,8 @@ SELECT
   NULL,
   status,
   name,
-  templated_from,
   description,
+  templated_from,
   summary,
   limitations
 FROM sync_flows
@@ -66,8 +66,8 @@ SET
   analytics_link = NULL,
   status = EXCLUDED.status,
   name = EXCLUDED.name,
-  templated_from = EXCLUDED.templated_from,
   description = EXCLUDED.description,
+  templated_from = EXCLUDED.templated_from,
   summary = EXCLUDED.summary,
   limitations = EXCLUDED.limitations;
 


### PR DESCRIPTION
Seed scripts were failing and showing the error with the input mistake as it was trying to add `<p>...</p>` to the `templated_from` column which expected a `uuid` type. Seems like this is a simple ordering issue of seed script changes happening close together and in fact, `<p>...</p>` should be trying to update the `description` column.

I have switched these round locally, and it is working as expected

#### For testing

Here's the problem `flow_id` : `9d70b18e-be0d-4f21-944c-a129da271ebd`