### PR TITLE
chore: Improve logging for `fileType` errors

### DIFF
--- a/api.planx.uk/modules/file/controller.ts
+++ b/api.planx.uk/modules/file/controller.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
 import { ServerError } from "../../errors/index.js";
 import { validateExtension } from "./middleware/useFileUpload.js";
+import path from "path";
 
 assert(process.env.AWS_S3_BUCKET);
 assert(process.env.AWS_S3_REGION);
@@ -23,7 +24,9 @@ export const uploadFileSchema = z.object({
       .string()
       .trim()
       .min(1)
-      .refine(validateExtension, { message: "Unsupported file type" }),
+      .refine(validateExtension, (input) => ({
+        message: `Unsupported file type: ${path.extname(input).toLowerCase()}`,
+      })),
   }),
 });
 

--- a/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -29,7 +29,11 @@ const fileFilter: multer.Options["fileFilter"] = (_req, file, callback) => {
   if (isValidMimeType && isValidExtension) {
     callback(null, true);
   } else {
-    callback(new Error("Unsupported file type"));
+    callback(
+      new Error(
+        `Unsupported file type. Mimetype: ${file.mimetype}. Extension: ${path.extname(file.originalname).toLowerCase()}`,
+      ),
+    );
   }
 };
 


### PR DESCRIPTION
Noticed a fair number of file type errors since the last deploy - https://planx.airbrake.io/projects/329753/groups/3994017674295351163?tab=notice-list

Additional logging here should check we're not being overly restrictive on the API, or too open on the frontend.