### PR TITLE
feat: additional error messages for duplicate flow name and moving a flow

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -180,7 +180,7 @@ export interface EditorStore extends Store.Store {
   makeUnique: (id: NodeId, parent?: NodeId) => void;
   moveFlow: (
     flowId: string,
-    teamName: string,
+    teamSlug: string,
     flowName: string,
   ) => Promise<any>;
   moveNode: (
@@ -490,8 +490,7 @@ export const editorStore: StateCreator<
     send(ops);
   },
 
-  moveFlow(flowId: string, teamName: string, flowName: string) {
-    const teamSlug = slugify(teamName);
+  moveFlow(flowId: string, teamSlug: string, flowName: string) {
     const valid = get().canUserEditTeam(teamSlug);
     if (!valid) {
       alert(
@@ -517,7 +516,7 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `Failed to move this flow. ${teamName} already has a flow with name '${flowName}'. Rename the flow and try again`,
+            `Failed to move this flow. ${teamSlug} already has a flow with name '${flowName}'. Rename the flow and try again`,
           );
         } else {
           alert(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -492,11 +492,10 @@ export const editorStore: StateCreator<
 
   moveFlow(flowId: string, teamName: string, flowName: string) {
     const teamSlug = slugify(teamName);
-    console.log(teamSlug);
     const valid = get().canUserEditTeam(teamSlug);
     if (!valid) {
       alert(
-        `You do not have permission to move this service into ${teamSlug}, try again`,
+        `You do not have permission to move this flow into ${teamSlug}, try again`,
       );
       return Promise.resolve();
     }
@@ -518,11 +517,11 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `${teamName} already has a service with name '${flowName}'. Rename the service and try again`,
+            `Failed to move this flow. ${teamName} already has a flow with name '${flowName}'. Rename the flow and try again`,
           );
         } else {
           alert(
-            "Failed to move this service. Make sure you're entering a valid team name and try again",
+            "Failed to move this flow. Make sure you're entering a valid team name and try again",
           );
         }
       });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -515,7 +515,7 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `${teamSlug} already have a service with name: '${flowName}'. Enter a different name and try again `,
+            `${teamSlug} already have a service with name: '${flowName}'. Rename the service and try again `,
           );
         } else {
           alert(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -492,10 +492,11 @@ export const editorStore: StateCreator<
 
   moveFlow(flowId: string, teamName: string, flowName: string) {
     const teamSlug = slugify(teamName);
+    console.log(teamSlug);
     const valid = get().canUserEditTeam(teamSlug);
     if (!valid) {
       alert(
-        `You do not have permission to move this flow into ${teamSlug}, try again`,
+        `You do not have permission to move this service into ${teamSlug}, try again`,
       );
       return Promise.resolve();
     }
@@ -517,11 +518,11 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `The ${teamName} team already has a service with name '${flowName}'. Rename the service and try again `,
+            `${teamName} already has a service with name '${flowName}'. Rename the service and try again`,
           );
         } else {
           alert(
-            "Failed to move this flow. Make sure you're entering a valid team name and try again",
+            "Failed to move this service. Make sure you're entering a valid team name and try again",
           );
         }
       });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -517,7 +517,7 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `The ${teamName} team already has a service with name: '${flowName}'. Rename the service and try again `,
+            `The ${teamName} team already has a service with name '${flowName}'. Rename the service and try again `,
           );
         } else {
           alert(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -177,7 +177,11 @@ export interface EditorStore extends Store.Store {
   setLastPublishedDate: (date: string) => void;
   isFlowPublished: boolean;
   makeUnique: (id: NodeId, parent?: NodeId) => void;
-  moveFlow: (flowId: string, teamSlug: string) => Promise<any>;
+  moveFlow: (
+    flowId: string,
+    teamSlug: string,
+    flowName: string,
+  ) => Promise<any>;
   moveNode: (
     id: NodeId,
     parent?: NodeId,
@@ -485,7 +489,7 @@ export const editorStore: StateCreator<
     send(ops);
   },
 
-  moveFlow(flowId: string, teamSlug: string) {
+  moveFlow(flowId: string, teamSlug: string, flowName: string) {
     const valid = get().canUserEditTeam(teamSlug);
     if (!valid) {
       alert(
@@ -507,11 +511,18 @@ export const editorStore: StateCreator<
         },
       )
       .then((res) => alert(res?.data?.message))
-      .catch(() =>
-        alert(
-          "Failed to move this flow. Make sure you're entering a valid team name and try again",
-        ),
-      );
+      .catch(({ response }) => {
+        const { data } = response;
+        if (data.error.toLowerCase().includes("uniqueness violation")) {
+          alert(
+            `${teamSlug} already have a service with name: '${flowName}'. Enter a different name and try again `,
+          );
+        } else {
+          alert(
+            "Failed to move this flow. Make sure you're entering a valid team name and try again",
+          );
+        }
+      });
   },
 
   moveNode(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -28,6 +28,7 @@ import omitBy from "lodash/omitBy";
 import { customAlphabet } from "nanoid-good";
 import en from "nanoid-good/locale/en";
 import { type } from "ot-json0";
+import { slugify } from "utils";
 import type { StateCreator } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -179,7 +180,7 @@ export interface EditorStore extends Store.Store {
   makeUnique: (id: NodeId, parent?: NodeId) => void;
   moveFlow: (
     flowId: string,
-    teamSlug: string,
+    teamName: string,
     flowName: string,
   ) => Promise<any>;
   moveNode: (
@@ -489,7 +490,8 @@ export const editorStore: StateCreator<
     send(ops);
   },
 
-  moveFlow(flowId: string, teamSlug: string, flowName: string) {
+  moveFlow(flowId: string, teamName: string, flowName: string) {
+    const teamSlug = slugify(teamName);
     const valid = get().canUserEditTeam(teamSlug);
     if (!valid) {
       alert(
@@ -515,7 +517,7 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `The ${teamSlug} team already has a service with name: '${flowName}'. Rename the service and try again `,
+            `The ${teamName} team already has a service with name: '${flowName}'. Rename the service and try again `,
           );
         } else {
           alert(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -515,7 +515,7 @@ export const editorStore: StateCreator<
         const { data } = response;
         if (data.error.toLowerCase().includes("uniqueness violation")) {
           alert(
-            `${teamSlug} already have a service with name: '${flowName}'. Rename the service and try again `,
+            `The ${teamSlug} team already has a service with name: '${flowName}'. Rename the service and try again `,
           );
         } else {
           alert(

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -182,8 +182,8 @@ const FlowItem: React.FC<FlowItemProps> = ({
                 onClick: async () => {
                   const newName = prompt("New name", flow.name);
                   if (newName && newName !== flow.name) {
-                    const verifiedNameAndSlug = getUniqueFlow(newName, flows);
-                    if (verifiedNameAndSlug) {
+                    const uniqueFlow = getUniqueFlow(newName, flows);
+                    if (uniqueFlow) {
                       await client.mutate({
                         mutation: gql`
                           mutation UpdateFlowSlug(
@@ -206,8 +206,8 @@ const FlowItem: React.FC<FlowItemProps> = ({
                         variables: {
                           teamId: teamId,
                           slug: flow.slug,
-                          newSlug: verifiedNameAndSlug.slug,
-                          newName: verifiedNameAndSlug.name,
+                          newSlug: uniqueFlow.slug,
+                          newName: uniqueFlow.name,
                         },
                       });
 
@@ -230,7 +230,7 @@ const FlowItem: React.FC<FlowItemProps> = ({
                   if (newTeam) {
                     if (slugify(newTeam) === teamSlug) {
                       alert(
-                        `This service already belongs to ${teamSlug}, skipping move`,
+                        `This flow already belongs to ${teamSlug}, skipping move`,
                       );
                     } else {
                       handleMove(newTeam, flow.name);

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -226,14 +226,16 @@ const FlowItem: React.FC<FlowItemProps> = ({
               {
                 label: "Move",
                 onClick: () => {
-                  const newTeam = prompt("New team");
+                  const newTeam = prompt(
+                    "Add the new team's slug. A slug is a way to represent a team name, for example 'Barking & Dagenham' would be 'barking-and-dagenham'. ",
+                  );
                   if (newTeam) {
                     if (slugify(newTeam) === teamSlug) {
                       alert(
                         `This flow already belongs to ${teamSlug}, skipping move`,
                       );
                     } else {
-                      handleMove(newTeam, flow.name);
+                      handleMove(slugify(newTeam), flow.name);
                     }
                   }
                 },

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -236,7 +236,7 @@ const FlowItem: React.FC<FlowItemProps> = ({
                         `This flow already belongs to ${teamSlug}, skipping move`,
                       );
                     } else {
-                      handleMove(slugify(newTeam), flow.name);
+                      handleMove(newTeam, flow.name);
                     }
                   }
                 },

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -227,7 +227,7 @@ const FlowItem: React.FC<FlowItemProps> = ({
                 label: "Move",
                 onClick: () => {
                   const newTeam = prompt(
-                    "Add the new team's slug. A slug is a way to represent a team name, for example 'Barking & Dagenham' would be 'barking-and-dagenham'. ",
+                    "Enter the destination team's slug. A slug is the URL name of a team, for example 'Barking & Dagenham' would be 'barking-and-dagenham'. ",
                   );
                   if (newTeam) {
                     if (slugify(newTeam) === teamSlug) {


### PR DESCRIPTION
## Where does this PR come from?

This PR is linked to this Trello ticket: https://trello.com/c/Lsjy4ZgQ/3195-add-descriptive-error-message-for-duplicate-slug-when-copying-a-service-and-moving-it-to-a-new-team

It comes from a situation where a flow was copied and the user tried to move it to another team, but the other team already had a flow with the same name. No useful error was shown to point the user towards how to resolve it. This is what I have added here.

## What has been added?

To guide users towards resolving errors themselves, I have added two new pathways / error messages.

1. For duplicate names within a team, I have added a new prompt pre-populated with the first attempted name

This should help users tweak their initial trial to push it through.

2. I have added a conditional alert for the `uniqueness violation` error messages which points towards a slug duplication within a team.

The struggle I had here was how to efficiently compare the slug name with that of the new team. This approach seemed the lightest without adding a new `getFlows()` with the new team ID, which could maybe be added at the api level or in the frontend, but this seemed to grow the boundaries of this task. I was also thinking of a future where we use the Dialog components we have created for user lists for services, changing the way users interact with these actions. 

