### PR TITLE
feat: Setup Slack notification for failed Fargate deployment

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -73,6 +73,8 @@ config:
     secure: AAABAE+wD6ahxO45tq/JWp6odrHX9jOhdjlMsCqS6kFqBgJ+3T56fOSgpZ26nEftv9IwWZQh/v93tRtTDEb+uw==
   application:session-secret:
     secure: AAABACeZpncVIdwarlb/J9qtaPqUob0YwbaOVDNEgfhSJ71aq0pkZml1EP+JqMKvyhkG483LcIiGzEh/ZDJehMu2
+  application:slack-internal-errors-webhook:
+    secure: AAABAPmtMxpmHMrR6WYt9ymGMW8LhvB6oyRLUWf7nnKbE/8JIpMSaWVAaL8YJUsbQsqTHey/KnsGv3W0kSrQ862/WOLpWFoTQeDhUlpWS6zkaxAztEdA+LstkYJovV0TXNKU52TU/t05
   application:slack-webhook-url:
     secure: AAABANpjl5NnZcSFTUB3iHS4qsQuSgHGkki0yYn/LEB9Oq6kqg/RFSvwl6toXoLjgKRwhcguba8Qyp/gA+nCSMyFu7i36QVFiTRjPFsoQ9esTEo/zGqyNf2tCL/AFd+oE2/WLo1TSq7/Qt7hVm49
   application:ssl-barking-and-dagenham-cert:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -74,6 +74,8 @@ config:
     secure: AAABAKhzYRhAmGmoBY1fPF75JWSWMOTORRCUAPKqvFUJMA60U5IFDUvPZ1Y+FuLtQ6Y1sQ8Q3laXGbp0f9j3Lw==
   application:session-secret:
     secure: AAABALL3iIm9+wB88/0ig7H+Y8Rmhb9OqaIz6sSTHmb5jf8+vBvXzY79z4pG6mJq9YPCxg==
+  application:slack-internal-errors-webhook:
+    secure: AAABABwTdMsmBinkBYWM+0LjLw+VTtw+XtB71qZ7/Mqpo9MPO0IMctz5nAho7jyoSrcDCJRrRVlqJngTHgXt9Iyr2qsrg/jwtH+e1/n1nZ7hQYV0UWClw5pEPDQkInsX3qHinSknun3k
   application:slack-webhook-url:
     secure: AAABALzK5KLP5po8giGePS/+ZpcWQHf8LfvCcdlY/oSv6NvC3y6D44CeIAiUdDXTB7VeUX5JFeaceDyZ9C1N5CAWFOLPCCKvuLjuDtk7QZe/rczqd2QnMDLh+Q9wPlQSb4PIoK8jWNEmvQC3QMgq
   application:uniform-client-aylesbury-vale:

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -7,7 +7,10 @@ import * as pulumi from "@pulumi/pulumi";
 import * as tldjs from "tldjs";
 
 import { CreateService } from './../types';
-import { addRedirectToCloudFlareListenerRule } from "../utils/addListenerRule";
+import {
+  addRedirectToCloudFlareListenerRule,
+  setupFailureNotificationForDeployments,
+} from "../utils";
 
 export const createHasuraService = async ({
   vpc,
@@ -218,4 +221,6 @@ export const createHasuraService = async ({
     ttl: 1,
     proxied: true,
   });
+
+  setupFailureNotificationForDeployments("hasura", cluster, hasuraService);
 }

--- a/infrastructure/application/utils/failureNotification.ts
+++ b/infrastructure/application/utils/failureNotification.ts
@@ -35,7 +35,7 @@ export const setupFailureNotificationForDeployments = (
       alarmActions: [topic.arn],
       comparisonOperator: "GreaterThanThreshold",
       evaluationPeriods: 1,
-      metricName: "ECSServiceFailedTaskCount",
+      metricName: "UnhealthyTaskCount",
       namespace: "AWS/ECS",
       period: 300,
       statistic: "Sum",

--- a/infrastructure/application/utils/failureNotification.ts
+++ b/infrastructure/application/utils/failureNotification.ts
@@ -1,0 +1,50 @@
+"use strict";
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+/**
+ * Send a Slack notification when a Fargate service rolls back it's deployment
+ * Any initial Pulumi errors already handle this via notifications from GHA
+ * This will catch instances where the container has successfully deployed, but may be unhealthy and is caught by a circuit breaker
+ */
+export const setupFailureNotificationForDeployments = (
+  serviceName: string,
+  cluster: awsx.ecs.Cluster,
+  service: awsx.ecs.FargateService
+) => {
+  const config = new pulumi.Config();
+
+  const topic = new aws.sns.Topic(`${serviceName}-deployment-alerts`, {
+    name: `${serviceName}-deployment-alerts`,
+  });
+
+  new aws.sns.TopicSubscription(
+    `${serviceName}-slack-alert`,
+    {
+      topic: topic.arn,
+      protocol: "https",
+      endpoint: config.requireSecret("slack-internal-errors-webhook"),
+    }
+  );
+
+  new aws.cloudwatch.MetricAlarm(
+    `${serviceName}-deployment-alarm-notification`,
+    {
+      alarmActions: [topic.arn],
+      comparisonOperator: "GreaterThanThreshold",
+      evaluationPeriods: 1,
+      metricName: "ECSServiceFailedTaskCount",
+      namespace: "AWS/ECS",
+      period: 300,
+      statistic: "Sum",
+      threshold: 0,
+      alarmDescription: `Alarm for ${serviceName} Fargate service deployment failures`,
+      dimensions: {
+        ClusterName: cluster.cluster.name,
+        ServiceName: service.service.name,
+      },
+    }
+  );
+};

--- a/infrastructure/application/utils/index.ts
+++ b/infrastructure/application/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./addListenerRule";
 export * from "./generateCORSAllowList";
 export * from "./generateTeamSecrets";
+export * from "./failureNotification";


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/4096

When a deployment fails on AWS, this will trigger a Slack webhook to ping the `#planx-notifications-internal` channel which is where notifications are currently set up for failed CI deployments.

I believe that this only applies to Hasura currently which has circuit breakers and rollbacks in place - other failures should fail a health check and trigger notifications via CI/Pulumi or UptimeRobot. However I've aimed to write the code in an agnostic way so that we could apply it to other services in future if needed to.

Currently there's just a single webhook for both staging and production - if we find we need to / want to differentiate here I can set up one per-environment if required. Once I've been able to test this I should be able to see if the notification natively includes this information or if I actually need two webhooks.

Helpful guide this is essentially based on - https://www.youtube.com/watch?v=CszzQcPAqNM