### PR TITLE
fix: Set correct webhook URL as secret

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -74,7 +74,7 @@ config:
   application:session-secret:
     secure: AAABACeZpncVIdwarlb/J9qtaPqUob0YwbaOVDNEgfhSJ71aq0pkZml1EP+JqMKvyhkG483LcIiGzEh/ZDJehMu2
   application:slack-internal-errors-webhook:
-    secure: AAABAPmtMxpmHMrR6WYt9ymGMW8LhvB6oyRLUWf7nnKbE/8JIpMSaWVAaL8YJUsbQsqTHey/KnsGv3W0kSrQ862/WOLpWFoTQeDhUlpWS6zkaxAztEdA+LstkYJovV0TXNKU52TU/t05
+    secure: AAABAD03UlWhbs3DiYA1+dWxlmNKA1kvgNT1Z4NsKFUpfUUtgsB8nEV5xbVHE7ZfPaJHF/G/BknTO7FqTZdxP0FIWJeKBxAL587+Bo47hBJQO0ETy0VMy02D5YovAlJ+wd33ctyQRB/t5J2v30smkoV25slDfMwQ5A==
   application:slack-webhook-url:
     secure: AAABANpjl5NnZcSFTUB3iHS4qsQuSgHGkki0yYn/LEB9Oq6kqg/RFSvwl6toXoLjgKRwhcguba8Qyp/gA+nCSMyFu7i36QVFiTRjPFsoQ9esTEo/zGqyNf2tCL/AFd+oE2/WLo1TSq7/Qt7hVm49
   application:ssl-barking-and-dagenham-cert:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -75,7 +75,7 @@ config:
   application:session-secret:
     secure: AAABALL3iIm9+wB88/0ig7H+Y8Rmhb9OqaIz6sSTHmb5jf8+vBvXzY79z4pG6mJq9YPCxg==
   application:slack-internal-errors-webhook:
-    secure: AAABABwTdMsmBinkBYWM+0LjLw+VTtw+XtB71qZ7/Mqpo9MPO0IMctz5nAho7jyoSrcDCJRrRVlqJngTHgXt9Iyr2qsrg/jwtH+e1/n1nZ7hQYV0UWClw5pEPDQkInsX3qHinSknun3k
+    secure: AAABAPkO1mBzTkXVWjpzAeP9ZbkifOiBwxj+rL5OONBu6DY87Pw1FualS6jSmQ5yeoGovZowNy3iMsArq4lxSX2BnBAur4O4a90Qou5zGUFACSTfLkZOgsyImvbdwRRnFPBBskfQ+bqwX9OZjO5AAXkEa9bqu3ViFQ==
   application:slack-webhook-url:
     secure: AAABALzK5KLP5po8giGePS/+ZpcWQHf8LfvCcdlY/oSv6NvC3y6D44CeIAiUdDXTB7VeUX5JFeaceDyZ9C1N5CAWFOLPCCKvuLjuDtk7QZe/rczqd2QnMDLh+Q9wPlQSb4PIoK8jWNEmvQC3QMgq
   application:uniform-client-aylesbury-vale:


### PR DESCRIPTION
Fix for #4245. Turns out I used the incorrect URL for the variable!

I provided the workflow URL (formatted `https://slack.com/shortcuts/XXX`) when I intended to use the webhook URL (formatted `https://hooks.slack.com/triggers/XXX`).