### PR TITLE
fix: account for undefined `node` to prevent corrupted internal portals

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -24,7 +24,7 @@ const Node: React.FC<any> = (props) => {
   const allProps = {
     ...props,
     wasVisited,
-    tags: node.data?.tags,
+    tags: node?.data?.tags,
   };
 
   const type = props.type as TYPES;


### PR DESCRIPTION
See thread https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1738656913551289

When re-created locally, this throws a simple TypeError `Cannot read 'data' of undefined at Node.tsx:27`.

Suspect this is trying to be called before the `flow` has been fully loaded/set in the store. This clears up immediate "corrupted" bug locally for me, but we'll eventually want to get to the bottom of this - I think the common editor Preview sidepanel error `id "nodeId" not found` is a similar race condition.