### PR TITLE
fix: Visited clone styling

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -122,7 +122,7 @@ $fontMonospace: "Source Code Pro", monospace;
   &.isClone > div {
     margin-top: 3px;
     position: relative;
-    ::before {
+    a::before {
       content: "";
       position: absolute;
       left: -4px;
@@ -133,6 +133,12 @@ $fontMonospace: "Source Code Pro", monospace;
       border: $nodeBorderWidth dashed $nodeBorder;
       z-index: -1;
     }
+  }
+
+  // Increase offset of clone styling when visit styling is also applied
+  &.isClone.wasVisited a::before {
+    left: -8px;
+    top: -8px;
   }
 
   &.hasFailed {


### PR DESCRIPTION
## What does this PR do?

Quick one: fixes clone styling so that visited clones are still given visible border treatment.

Before (left) vs after (right):

![image](https://github.com/user-attachments/assets/bc8c0f72-5c1f-4d93-ba7c-b00c939d6bfb)

**Test:**
https://4251.planx.pizza/testing/clone-styling