### PR TITLE
feat[api]: create flows from templates

### DIFF
--- a/api.planx.uk/modules/flows/createFlow/controller.ts
+++ b/api.planx.uk/modules/flows/createFlow/controller.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import { ServerError } from "../../../errors/index.js";
+import { createFlow } from "../../../helpers.js";
+import type { Flow } from "../../../types.js";
+
+interface CreateFlowResponse {
+  message: string;
+  id: Flow["id"];
+  slug: Flow["slug"];
+}
+
+export const createFlowSchema = z.object({
+  body: z.object({
+    teamId: z.number(),
+    slug: z.string(),
+    name: z.string(),
+    data: z.any(), // FlowGraph
+  }),
+});
+
+export type CreateFlowController = ValidatedRequestHandler<
+  typeof createFlowSchema,
+  CreateFlowResponse
+>;
+
+export const createFlowController: CreateFlowController = async (
+  _req,
+  res,
+  next,
+) => {
+  try {
+    const { teamId, slug, name, data } = res.locals.parsedReq.body;
+
+    // createFlow automatically handles the associated operation and initial publish
+    const { id } = await createFlow(teamId, slug, name, data);
+
+    res.status(200).send({
+      message: `Successfully created flow ${slug}`,
+      id,
+      slug,
+    });
+  } catch (error) {
+    return next(
+      new ServerError({ message: `Failed to create flow. Error: ${error}` }),
+    );
+  }
+};

--- a/api.planx.uk/modules/flows/createFlow/controller.ts
+++ b/api.planx.uk/modules/flows/createFlow/controller.ts
@@ -1,7 +1,8 @@
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { z } from "zod";
-import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { ServerError } from "../../../errors/index.js";
 import { createFlow } from "../../../helpers.js";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import type { Flow } from "../../../types.js";
 
 interface CreateFlowResponse {
@@ -15,7 +16,6 @@ export const createFlowSchema = z.object({
     teamId: z.number(),
     slug: z.string(),
     name: z.string(),
-    data: z.any(), // FlowGraph
   }),
 });
 
@@ -30,10 +30,11 @@ export const createFlowController: CreateFlowController = async (
   next,
 ) => {
   try {
-    const { teamId, slug, name, data } = res.locals.parsedReq.body;
+    const { teamId, slug, name } = res.locals.parsedReq.body;
+    const initialFlowData: FlowGraph = { _root: { edges: [] } };
 
     // createFlow automatically handles the associated operation and initial publish
-    const { id } = await createFlow(teamId, slug, name, data);
+    const { id } = await createFlow(teamId, slug, name, initialFlowData);
 
     res.status(200).send({
       message: `Successfully created flow ${slug}`,

--- a/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
+++ b/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
@@ -15,12 +15,10 @@ const validBody = {
   teamId: 1,
   slug: "my-new-flow",
   name: "My new flow",
-  data: mockNewFlowData,
 };
 
 const invalidBody = {
   slug: "my-new-flow",
-  data: mockNewFlowData,
 };
 
 beforeEach(() => {

--- a/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
+++ b/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
@@ -1,0 +1,157 @@
+import supertest from "supertest";
+
+import { queryMock } from "../../../tests/graphqlQueryMock.js";
+import { authHeader } from "../../../tests/mockJWT.js";
+import app from "../../../server.js";
+import type { Flow } from "../../../types.js";
+
+const mockNewFlowData: Flow["data"] = {
+  _root: {
+    edges: [],
+  },
+};
+
+const validBody = {
+  teamId: 1,
+  slug: "my-new-flow",
+  name: "My new flow",
+  data: mockNewFlowData,
+};
+
+const invalidBody = {
+  slug: "my-new-flow",
+  data: mockNewFlowData,
+};
+
+beforeEach(() => {
+  queryMock.mockQuery({
+    name: "GetFlowData",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        data: mockNewFlowData,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertFlow",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        id: "2",
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertOperation",
+    matchOnVariables: false,
+    data: {
+      operation: {
+        id: 1,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "PublishFlow",
+    matchOnVariables: false,
+    data: {
+      publishedFlow: {
+        data: mockNewFlowData,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "GetMostRecentPublishedFlow",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        publishedFlows: [
+          {
+            data: mockNewFlowData,
+          },
+        ],
+      },
+    },
+  });
+});
+
+const auth = authHeader({ role: "teamEditor" });
+
+it("returns an error if authorization headers are not set", async () => {
+  await supertest(app)
+    .post("/flows/create")
+    .send(validBody)
+    .expect(401)
+    .then((res) => {
+      expect(res.body).toEqual({
+        error: "No authorization token was found",
+      });
+    });
+});
+
+it("returns an error if the user does not have the correct role", async () => {
+  await supertest(app)
+    .post("/flows/create")
+    .send(validBody)
+    .set(authHeader({ role: "teamViewer" }))
+    .expect(403);
+});
+
+it("returns an error if required properties are missing in the request body", async () => {
+  await supertest(app)
+    .post("/flows/create")
+    .send(invalidBody)
+    .set(auth)
+    .expect(400)
+    .then((res) => {
+      expect(res.body).toHaveProperty("issues");
+      expect(res.body).toHaveProperty("name", "ZodError");
+    });
+});
+
+it("returns an error when the service errors", async () => {
+  queryMock.reset();
+  queryMock.mockQuery({
+    name: "InsertFlow",
+    variables: {
+      team_id: 1,
+      slug: "my-new-flow",
+      name: "My new flow",
+      data: mockNewFlowData,
+    },
+    data: {},
+    graphqlErrors: [
+      {
+        message: "Something went wrong",
+      },
+    ],
+  });
+
+  await supertest(app)
+    .post("/flows/create")
+    .send(validBody)
+    .set(auth)
+    .expect(500)
+    .then((res) => {
+      expect(res.body.error).toMatch(/Failed to create flow/);
+    });
+});
+
+it("successfully creates a new flow", async () => {
+  await supertest(app)
+    .post("/flows/create")
+    .send(validBody)
+    .set(auth)
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual({
+        message: `Successfully created flow ${validBody.slug}`,
+        id: "2",
+        slug: validBody.slug,
+      });
+    });
+});

--- a/api.planx.uk/modules/flows/createFlowFromTemplate/controller.ts
+++ b/api.planx.uk/modules/flows/createFlowFromTemplate/controller.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
+import { ServerError } from "../../../errors/index.js";
+import type { Flow } from "../../../types.js";
+import { createFlowFromTemplate } from "./service.js";
+
+interface CreateFlowFromTemplateResponse {
+  message: string;
+  id: Flow["id"];
+  slug: Flow["slug"];
+}
+
+export const createFlowFromTemplateSchema = z.object({
+  params: z.object({
+    templateId: z.string(),
+  }),
+  body: z.object({
+    teamId: z.number(),
+  }),
+});
+
+export type CreateFlowFromTemplateController = ValidatedRequestHandler<
+  typeof createFlowFromTemplateSchema,
+  CreateFlowFromTemplateResponse
+>;
+
+export const createFlowFromTemplateController: CreateFlowFromTemplateController =
+  async (_req, res, next) => {
+    try {
+      const { templateId } = res.locals.parsedReq.params;
+      const { teamId } = res.locals.parsedReq.body;
+
+      const { id, slug } = await createFlowFromTemplate(templateId, teamId);
+
+      res.status(200).send({
+        message: `Successfully created flow from template ${slug}`,
+        id,
+        slug,
+      });
+    } catch (error) {
+      return next(
+        new ServerError({
+          message: `Failed to create flow from template. Error: ${error}`,
+        }),
+      );
+    }
+  };

--- a/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
+++ b/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
@@ -1,0 +1,158 @@
+import supertest from "supertest";
+
+import { queryMock } from "../../../tests/graphqlQueryMock.js";
+import { authHeader } from "../../../tests/mockJWT.js";
+import app from "../../../server.js";
+import type { Flow } from "../../../types.js";
+
+const mockSourceTemplateFlowData: Flow["data"] = {
+  _root: {
+    edges: ["Content"],
+  },
+  Content: {
+    type: 250,
+    data: {
+      text: "This a fake template",
+    },
+  },
+};
+
+const validBody = {
+  teamId: 1,
+};
+
+const invalidBody = {};
+
+beforeEach(() => {
+  queryMock.mockQuery({
+    name: "GetFlowData",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        data: mockSourceTemplateFlowData,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertFlow",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        id: "2",
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertOperation",
+    matchOnVariables: false,
+    data: {
+      operation: {
+        id: 1,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "PublishFlow",
+    matchOnVariables: false,
+    data: {
+      publishedFlow: {
+        data: mockSourceTemplateFlowData,
+      },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "GetMostRecentPublishedFlow",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        publishedFlows: [
+          {
+            data: mockSourceTemplateFlowData,
+          },
+        ],
+      },
+    },
+  });
+});
+
+const auth = authHeader({ role: "teamEditor" });
+
+it("returns an error if authorization headers are not set", async () => {
+  await supertest(app)
+    .post("/flows/create-from-template/1")
+    .send(validBody)
+    .expect(401)
+    .then((res) => {
+      expect(res.body).toEqual({
+        error: "No authorization token was found",
+      });
+    });
+});
+
+it("returns an error if the user does not have the correct role", async () => {
+  await supertest(app)
+    .post("/flows/create-from-template/1")
+    .send(validBody)
+    .set(authHeader({ role: "teamViewer" }))
+    .expect(403);
+});
+
+it("returns an error if required properties are missing in the request body", async () => {
+  await supertest(app)
+    .post("/flows/create-from-template/1")
+    .send(invalidBody)
+    .set(auth)
+    .expect(400)
+    .then((res) => {
+      expect(res.body).toHaveProperty("issues");
+      expect(res.body).toHaveProperty("name", "ZodError");
+    });
+});
+
+it("returns an error when the service errors", async () => {
+  queryMock.reset();
+  queryMock.mockQuery({
+    name: "InsertFlow",
+    variables: {
+      team_id: 1,
+      slug: "my-new-flow-template",
+      name: "My new flow (template)",
+      data: mockSourceTemplateFlowData,
+      templated_from: "1",
+    },
+    data: {},
+    graphqlErrors: [
+      {
+        message: "Something went wrong",
+      },
+    ],
+  });
+
+  await supertest(app)
+    .post("/flows/create-from-template/1")
+    .send(validBody)
+    .set(auth)
+    .expect(500)
+    .then((res) => {
+      expect(res.body.error).toMatch(/Failed to create flow/);
+    });
+});
+
+it("successfully creates a new flow from a template", async () => {
+  await supertest(app)
+    .post("/flows/create-from-template/1")
+    .send(validBody)
+    .set(auth)
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual({
+        message: "Successfully created flow from template undefined-template",
+        id: "2",
+        slug: "undefined-template",
+      });
+    });
+});

--- a/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
+++ b/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
@@ -1,0 +1,26 @@
+import { createFlow, getFlowData } from "../../../helpers.js";
+
+const createFlowFromTemplate = async (
+  templateId: string,
+  teamId: number,
+): Promise<{ id: string; slug: string }> => {
+  // Fetch the source template data
+  const sourceTemplate = await getFlowData(templateId);
+
+  const newSlug = sourceTemplate.name + "-template";
+  const newName = sourceTemplate.name + " (template)";
+
+  // Create the new templated flow, including an associated operation and initial publish, and templated_from reference to the source templateId
+  const { id } = await createFlow(
+    teamId,
+    newSlug,
+    newName,
+    sourceTemplate.data,
+    undefined,
+    templateId,
+  );
+
+  return { id: id, slug: newSlug };
+};
+
+export { createFlowFromTemplate };

--- a/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
+++ b/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
@@ -16,7 +16,7 @@ const createFlowFromTemplate = async (
     newSlug,
     newName,
     sourceTemplate.data,
-    undefined,
+    undefined, // flows.copied_from
     templateId,
   );
 

--- a/api.planx.uk/modules/flows/docs.yaml
+++ b/api.planx.uk/modules/flows/docs.yaml
@@ -22,6 +22,11 @@ components:
       name: portalNodeId
       type: string
       required: true
+    templateId:
+      in: path
+      name: templateId
+      type: string
+      required: true
   schemas:
     Node:
       type: object
@@ -45,6 +50,32 @@ components:
         insert:
           type: boolean
           description: Operator to indicate if the copied flow should be inserted to the database, or simple returned in the response body
+    CreateFlow:
+      type: object
+      properties:
+        teamId:
+          type: number
+          example: 1
+          required: true
+        slug:
+          type: string
+          example: my-new-flow
+          required: true
+        name:
+          type: string
+          example: My new flow
+          required: true
+        data:
+          type: object
+          example: { _root: { edges: [] } }
+          required: true
+    CreateFlowFromTemplate:
+      type: object
+      properties:
+        teamId:
+          type: number
+          example: 1
+          required: true
     FlowData:
       type: object
       additionalProperties: true
@@ -76,6 +107,34 @@ components:
           example: Your flow has valid file types
       required: true
   responses:
+    CreateFlow:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Successfully created flow my-new-flow"
+              id:
+                type: string
+                description: The UUID of the new flow
+              slug:
+                type: string
+    CreateFlowFromTemplate:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Successfully created flow from template my-new-flow-template"
+              id:
+                type: string
+                description: The UUID of the new templated flow
+              slug:
+                type: string
     CopyFlow:
       content:
         application/json:
@@ -165,6 +224,42 @@ components:
             properties:
               $ref: "#/components/schemas/FlowData"
 paths:
+  /flows/create:
+    post:
+      summary: Create a new flow
+      tags: ["flows"]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFlow"
+      responses:
+        "200":
+          $ref: "#/components/responses/CreateFlow"
+        "500":
+          $ref: "#/components/responses/ErrorMessage"
+  /flows/create-from-template/{templateId}:
+    post:
+      summary: Create a new flow from a template
+      tags: ["flows"]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/templateId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFlowFromTemplate"
+      responses:
+        "200":
+          $ref: "#/components/responses/CreateFlowFromTemplate"
+        "500":
+          $ref: "#/components/responses/ErrorMessage"
   /flows/{flowId}/copy:
     post:
       summary: Copy a flow

--- a/api.planx.uk/modules/flows/docs.yaml
+++ b/api.planx.uk/modules/flows/docs.yaml
@@ -65,10 +65,6 @@ components:
           type: string
           example: My new flow
           required: true
-        data:
-          type: object
-          example: { _root: { edges: [] } }
-          required: true
     CreateFlowFromTemplate:
       type: object
       properties:

--- a/api.planx.uk/modules/flows/routes.ts
+++ b/api.planx.uk/modules/flows/routes.ts
@@ -31,7 +31,30 @@ import {
   validateAndDiffFlowController,
   validateAndDiffSchema,
 } from "./validate/controller.js";
+import {
+  createFlowController,
+  createFlowSchema,
+} from "./createFlow/controller.js";
+import {
+  createFlowFromTemplateController,
+  createFlowFromTemplateSchema,
+} from "./createFlowFromTemplate/controller.js";
+
 const router = Router();
+
+router.post(
+  "/flows/create",
+  useTeamEditorAuth,
+  validate(createFlowSchema),
+  createFlowController,
+);
+
+router.post(
+  "/flows/create-from-template/:templateId",
+  useTeamEditorAuth,
+  validate(createFlowFromTemplateSchema),
+  createFlowFromTemplateController,
+);
 
 router.post(
   "/flows/:flowId/copy",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -309,7 +309,6 @@ export const editorStore: StateCreator<
         teamId: teamId,
         slug: newSlug,
         name: newName,
-        data: { [ROOT_NODE_KEY]: { edges: [] } },
       },
       {
         headers: {
@@ -325,7 +324,9 @@ export const editorStore: StateCreator<
     const token = get().jwt;
 
     const response = await axios.post(
-      `${import.meta.env.VITE_APP_API_URL}/flows/create-from-template/${templateId}`,
+      `${
+        import.meta.env.VITE_APP_API_URL
+      }/flows/create-from-template/${templateId}`,
       {
         teamId: teamId,
       },

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -520,6 +520,7 @@
           - slug
           - summary
           - team_id
+          - templated_from
           - updated_at
           - version
         validate_input:
@@ -551,6 +552,7 @@
           - slug
           - summary
           - team_id
+          - templated_from
           - updated_at
           - version
         validate_input:
@@ -581,6 +583,7 @@
           - slug
           - summary
           - team_id
+          - templated_from
           - updated_at
           - version
         validate_input:
@@ -617,6 +620,7 @@
           - slug
           - summary
           - team_id
+          - templated_from
           - updated_at
           - version
         validate_input:


### PR DESCRIPTION
**Changes:**
- Removes redundant `createFlow` GraphQL mutations from the frontend store and instead calls a new API route `flows/create` to access existing API-side mutations already used by copy, move, etc.
- Adds another new API route `/flows/create-from-template/:templateId` which creates a new flow in the target team with a populated `templated_from` reference and data matching the source template (nodes _are not_ renamed like on copy)
  - This route _cannot_ be called from the frontend until we have a way of identifying & selecting "source templates" from the skeleton modal - but it's possible to call it direct from Swagger docs in the meantime by passing any valid `flowId` as the `templateId`