### PR TITLE
chore: rename "placeholder" tag to "customisation", bump planx-core

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#db49201",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#db49201
-    version: github.com/theopensystemslab/planx-core/db49201(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
+    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7723,9 +7723,9 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/db49201(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/db49201}
-    id: github.com/theopensystemslab/planx-core/db49201
+  github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
+    id: github.com/theopensystemslab/planx-core/2fe8707
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#db49201",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#db49201
-    version: github.com/theopensystemslab/planx-core/db49201(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
+    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7)
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2989,9 +2989,9 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/db49201(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/db49201}
-    id: github.com/theopensystemslab/planx-core/db49201
+  github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
+    id: github.com/theopensystemslab/planx-core/2fe8707
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#db49201",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#db49201
-    version: github.com/theopensystemslab/planx-core/db49201(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
+    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7)
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2543,9 +2543,9 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/db49201(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/db49201}
-    id: github.com/theopensystemslab/planx-core/db49201
+  github.com/theopensystemslab/planx-core/2fe8707(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
+    id: github.com/theopensystemslab/planx-core/2fe8707
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^5.15.10",
     "@mui/utils": "^5.15.11",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#db49201",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2fe8707",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#db49201
-    version: github.com/theopensystemslab/planx-core/db49201(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2fe8707
+    version: github.com/theopensystemslab/planx-core/2fe8707(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14652,9 +14652,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/db49201(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/db49201}
-    id: github.com/theopensystemslab/planx-core/db49201
+  github.com/theopensystemslab/planx-core/2fe8707(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fe8707}
+    id: github.com/theopensystemslab/planx-core/2fe8707
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -26,12 +26,15 @@ type Props = {
 } & NodeTags;
 
 const Checklist: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, copyNode, showHelpText] = useStore((state) => [
-    state.isClone,
-    state.childNodesOf(props.id),
-    state.copyNode,
-    state.showHelpText,
-  ]);
+  const [isClone, childNodes, copyNode, showHelpText, user] = useStore(
+    (state) => [
+      state.isClone,
+      state.childNodesOf(props.id),
+      state.copyNode,
+      state.showHelpText,
+      state.getUser(),
+    ],
+  );
 
   const parent = getParentId(props.parent);
 
@@ -81,6 +84,10 @@ const Checklist: React.FC<Props> = React.memo((props) => {
   const hasHelpText =
     props.data?.policyRef || props.data?.info || props.data?.howMeasured;
 
+  const tagsByRole = user?.isPlatformAdmin
+    ? props.tags
+    : props.tags?.filter((tag) => tag !== "customisation");
+
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
@@ -122,7 +129,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           {props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />
           )}
-          {props.tags?.map((tag) => <Tag tag={tag} key={tag} />)}
+          {tagsByRole?.map((tag) => <Tag tag={tag} key={tag} />)}
         </Box>
         {groupedOptions ? (
           <ol className="categories">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -86,6 +86,11 @@ const ExternalPortal: React.FC<any> = (props) => {
     editHref = `${window.location.pathname}/nodes/${parent}/nodes/${props.id}/edit`;
   }
 
+  const user = useStore.getState().getUser();
+  const tagsByRole = user?.isPlatformAdmin
+    ? props.tags
+    : props.tags?.filter((tag: NodeTag) => tag !== "customisation");
+
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
@@ -98,7 +103,7 @@ const ExternalPortal: React.FC<any> = (props) => {
             <MoreVert titleAccess="Edit Portal" />
           </Link>
         </Box>
-        {props.tags?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
+        {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
       </li>
     </>
   );
@@ -138,6 +143,11 @@ const InternalPortal: React.FC<any> = (props) => {
 
   const ref = useScrollOnPreviousURLMatch<HTMLLIElement>(props.id);
 
+  const user = useStore.getState().getUser();
+  const tagsByRole = user?.isPlatformAdmin
+    ? props.tags
+    : props.tags?.filter((tag: NodeTag) => tag !== "customisation");
+
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
@@ -156,7 +166,7 @@ const InternalPortal: React.FC<any> = (props) => {
             <MoreVert titleAccess="Edit Portal" />
           </Link>
         </Box>
-        {props.tags?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
+        {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
       </li>
     </>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -26,12 +26,15 @@ type Props = {
 } & NodeTags;
 
 const Question: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, copyNode, showHelpText] = useStore((state) => [
-    state.isClone,
-    state.childNodesOf(props.id),
-    state.copyNode,
-    state.showHelpText,
-  ]);
+  const [isClone, childNodes, copyNode, showHelpText, user] = useStore(
+    (state) => [
+      state.isClone,
+      state.childNodesOf(props.id),
+      state.copyNode,
+      state.showHelpText,
+      state.getUser(),
+    ],
+  );
 
   const parent = getParentId(props.parent);
 
@@ -64,6 +67,10 @@ const Question: React.FC<Props> = React.memo((props) => {
 
   const hasHelpText =
     props.data?.policyRef || props.data?.info || props.data?.howMeasured;
+
+  const tagsByRole = user?.isPlatformAdmin
+    ? props.tags
+    : props.tags?.filter((tag) => tag !== "customisation");
 
   return (
     <>
@@ -102,7 +109,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           {props.type !== TYPES.SetValue && props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />
           )}
-          {props.tags?.map((tag) => <Tag tag={tag} key={tag} />)}
+          {tagsByRole?.map((tag) => <Tag tag={tag} key={tag} />)}
         </Box>
         <ol className="options">
           {childNodes.map((child: any) => (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -10,9 +10,9 @@ export const TAG_DISPLAY_VALUES: Record<
   NodeTag,
   { color: keyof Palette["nodeTag"]; displayName: string; editableBy?: Role[] }
 > = {
-  placeholder: {
+  customisation: {
     color: "blocking",
-    displayName: "Placeholder",
+    displayName: "Customisation",
     editableBy: ["platformAdmin"],
   },
   toReview: {

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -53,21 +53,23 @@ describe("Checklist Component for a Platform Admin", () => {
     expect(optionTexts).toEqual(expect.arrayContaining(tagDisplayNames));
   });
 
-  it("renders all tags with Placeholder selected as a button", async () => {
+  it("renders all tags with Customisation selected as a button", async () => {
     const { queryByTestId, queryByRole } = setup(
       <DndProvider backend={HTML5Backend}>
         <ChecklistComponent
           text=""
-          node={{ data: { text: "", tags: ["placeholder"] } }}
+          node={{ data: { text: "", tags: ["customisation"] } }}
         />
       </DndProvider>,
     );
 
-    const placeholderChip = queryByTestId("placeholder-chip");
-    const placeholderButton = queryByRole("button", { name: /placeholder/i });
+    const customisationChip = queryByTestId("customisation-chip");
+    const customisationButton = queryByRole("button", {
+      name: /customisation/i,
+    });
 
-    expect(placeholderChip).toBeInTheDocument();
-    expect(placeholderButton).toBeInTheDocument();
+    expect(customisationChip).toBeInTheDocument();
+    expect(customisationButton).toBeInTheDocument();
   });
 });
 
@@ -83,7 +85,7 @@ describe("Checklist Component for a non Platform Admin", () => {
     ),
   );
 
-  it("renders all tags except Placeholder with none selected", async () => {
+  it("renders all tags except Customisation with none selected", async () => {
     const { getByRole, user } = setup(
       <DndProvider backend={HTML5Backend}>
         <ChecklistComponent text="" />
@@ -97,23 +99,25 @@ describe("Checklist Component for a non Platform Admin", () => {
     const options = within(optionsList).getAllByRole("option");
     const optionTexts = options.map((option) => option.textContent);
 
-    expect(optionTexts).not.toContain(/placeholder/i);
+    expect(optionTexts).not.toContain(/customisation/i);
   });
 
-  it("renders all tags with static Placeholder selected", async () => {
+  it("renders all tags with static Customisation selected", async () => {
     const { getByTestId, queryByRole } = setup(
       <DndProvider backend={HTML5Backend}>
         <ChecklistComponent
           text=""
-          node={{ data: { text: "", tags: ["placeholder"] } }}
+          node={{ data: { text: "", tags: ["customisation"] } }}
         />
       </DndProvider>,
     );
 
-    const placeholderChip = getByTestId("placeholder-chip");
-    const placeholderButton = queryByRole("button", { name: /placeholder/i });
+    const customisationChip = getByTestId("customisation-chip");
+    const customisationButton = queryByRole("button", {
+      name: /customisation/i,
+    });
 
-    expect(placeholderChip).toBeInTheDocument();
-    expect(placeholderButton).not.toBeInTheDocument();
+    expect(customisationChip).toBeInTheDocument();
+    expect(customisationButton).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Follows on from #https://github.com/theopensystemslab/planx-core/pull/643 (also picking up two non-related schema PRs on `main`) 

**Key changes:**
- "Placeholder" now renamed "Customisation" per templates design call
- "Customisation" tag is _only_ visible on the graph to platformAdmins, never to anyone else (we will have a new visual design to indiccate editability that will not rely on the tag band)
  - Note the tag is still visible, and disabled, when opening the modal

| As a `platformAdmin`   | As any non-admin user |
| -------- | ------- |
| ![Screenshot from 2025-02-05 16-08-30](https://github.com/user-attachments/assets/a09f1455-b6c9-4088-b59f-c8cf73341850) | ![Screenshot from 2025-02-05 16-09-32](https://github.com/user-attachments/assets/05557ddf-8256-48ca-ae74-ff9249386fe6) |
