### PR TITLE
style: Sort flows selects

### DIFF
--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -286,12 +286,38 @@ const Team: React.FC = () => {
               filterOptions={filterOptions}
             />
           )}
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 2,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-start",
+              alignItems: "center",
+              gap: 2,
+            }}
+          >
+            <Typography variant="h3" component="h2">
+              Showing X services
+            </Typography>
+          </Box>
           {hasFeatureFlag("SORT_FLOWS") && flows && (
-            <SortControl<FlowSummary>
-              records={flows}
-              setRecords={setFlows}
-              sortOptions={sortOptions}
-            />
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+              <Typography variant="body2">
+                <strong>Sort by</strong>
+              </Typography>
+              <SortControl<FlowSummary>
+                records={flows}
+                setRecords={setFlows}
+                sortOptions={sortOptions}
+              />
+            </Box>
           )}
         </Box>
         {filteredFlows && flows && (

--- a/editor.planx.uk/src/ui/editor/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import MenuItem from "@mui/material/MenuItem";
+import { styled } from "@mui/material/styles";
 import { orderBy } from "lodash";
 import React, { useEffect, useMemo, useState } from "react";
 import { useCurrentRoute, useNavigation } from "react-navi";
@@ -9,6 +10,10 @@ import { slugify } from "utils";
 import SelectInput from "./SelectInput/SelectInput";
 
 type SortDirection = "asc" | "desc";
+
+const StyledSelectInput = styled(SelectInput)(() => ({
+  minWidth: "170px",
+}));
 
 export interface SortableFields<T> {
   /** displayName is a string to use in the Select */
@@ -95,8 +100,8 @@ export const SortControl = <T extends object>({
   }, [selectedSort, sortDirection]);
 
   return (
-    <Box display={"flex"}>
-      <SelectInput
+    <Box display={"flex"} gap={1}>
+      <StyledSelectInput
         value={selectedDisplaySlug}
         onChange={(e) => {
           const targetKey = e.target.value as string;
@@ -110,8 +115,8 @@ export const SortControl = <T extends object>({
             {displayName}
           </MenuItem>
         ))}
-      </SelectInput>
-      <SelectInput
+      </StyledSelectInput>
+      <StyledSelectInput
         value={sortDirection}
         onChange={(e) => {
           const newDirection = e.target.value as SortDirection;
@@ -127,7 +132,7 @@ export const SortControl = <T extends object>({
         >
           {selectedSort.directionNames.desc}
         </MenuItem>
-      </SelectInput>
+      </StyledSelectInput>
     </Box>
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Adds styling to the "sort flows" selects
- Updates layout with placeholder "Showing X services" title

⛳️ Requires feature flag: `window.featureFlags.toggle("SORT_FLOWS")`

Before change:
![image](https://github.com/user-attachments/assets/bc102e42-bcb9-47dd-b6da-47cb5ddadaa8)

After change:
![image](https://github.com/user-attachments/assets/1f4764fd-3312-485a-9afc-2f2ff05ca641)


Preview:
https://4258.planx.pizza/doncaster