### PR TITLE
feat: Hoist feeback to team level

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -76,7 +76,7 @@ describe("teamLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(4);
+    expect(menuItems).toHaveLength(5);
     expect(within(menuItems[0]).getByText("Services")).toBeInTheDocument();
   });
 
@@ -85,7 +85,7 @@ describe("teamLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(4);
+    expect(menuItems).toHaveLength(5);
     expect(within(menuItems[0]).getByText("Services")).toBeInTheDocument();
   });
 });
@@ -112,7 +112,7 @@ describe("flowLayoutRoutes", () => {
 
     const { getAllByRole, getByLabelText } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(6);
+    expect(menuItems).toHaveLength(5);
     expect(getByLabelText("Submissions log")).toBeInTheDocument();
   });
 
@@ -121,7 +121,7 @@ describe("flowLayoutRoutes", () => {
 
     const { getAllByRole, getByLabelText } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(6);
+    expect(menuItems).toHaveLength(5);
     expect(getByLabelText("Submissions log")).toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -165,6 +165,12 @@ function EditorNavMenu() {
       route: `/${teamSlug}/members`,
       accessibleBy: ["platformAdmin", "teamEditor"],
     },
+    {
+      title: "Feedback",
+      Icon: RateReviewIcon,
+      route: `/${teamSlug}/feedback`,
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
+    },
   ];
 
   const flowLayoutRoutesMain: Route[] = [
@@ -190,12 +196,6 @@ function EditorNavMenu() {
       title: "Submissions log",
       Icon: FactCheckIcon,
       route: `/${teamSlug}/${flowSlug}/submissions-log`,
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
-    },
-    {
-      title: "Feedback",
-      Icon: RateReviewIcon,
-      route: `/${teamSlug}/${flowSlug}/feedback`,
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
   ];

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -29,14 +29,14 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
           Feedback log
         </Typography>
         <Typography variant="body1">
-          Feedback from users about this service.
+          Feedback from users about this team's services.
         </Typography>
       </SettingsSection>
       <SettingsSection>
         {feedback.length === 0 ? (
           <ErrorSummary
             format="info"
-            heading="No feedback found for this service"
+            heading="No feedback found for this team"
             message="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
           />
         ) : (
@@ -51,6 +51,9 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
                   </TableCell>
                   <TableCell sx={{ width: 100 }}>
                     <strong>Date</strong>
+                  </TableCell>
+                  <TableCell sx={{ width: 100 }}>
+                    <strong>Service</strong>
                   </TableCell>
                   <TableCell sx={{ width: 140 }}>
                     <strong>Rating</strong>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/components/CollapsibleRow.tsx
@@ -119,6 +119,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
   const labelMap: Record<string, string> = {
     userComment: item.type === "issue" ? "What went wrong?" : "User comment",
     address: "Property address",
+    flowName: "Service",
     projectType: "Project type",
     where: "Where",
     browserPlatform: "Browser / device",
@@ -154,6 +155,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
         <TableCell>
           {format(new Date(item.createdAt), "dd/MM/yy hh:mm:ss")}
         </TableCell>
+        <TableCell>{item.flowName}</TableCell>
         <TableCell>{feedbackScore}</TableCell>
         <TableCell>{commentSummary}</TableCell>
         <TableCell sx={{ textAlign: "right" }}>
@@ -167,7 +169,7 @@ export const CollapsibleRow: React.FC<CollapsibleRowProps> = (item) => {
         </TableCell>
       </TableRow>
       <TableRow sx={{ background: (theme) => theme.palette.background.paper }}>
-        <TableCell sx={{ padding: 0, border: "none" }} colSpan={5}>
+        <TableCell sx={{ padding: 0, border: "none" }} colSpan={6}>
           <Collapse
             in={open}
             timeout="auto"

--- a/editor.planx.uk/src/routes/feedback.tsx
+++ b/editor.planx.uk/src/routes/feedback.tsx
@@ -22,17 +22,17 @@ export interface Feedback {
   createdAt: string;
   address: string | null;
   feedbackScore: number;
+  flowName: string;
 }
 
 const feedbackRoutes = compose(
   withData((req) => ({
     mountpath: req.mountpath,
-    flow: req.params.flow.split(",")[0],
   })),
 
   mount({
     "/": route(async (req) => {
-      const { team: teamSlug, flow: flowSlug } = req.params;
+      const { team: teamSlug } = req.params;
 
       const isAuthorised = useStore.getState().canUserEditTeam(teamSlug);
       if (!isAuthorised)
@@ -44,31 +44,31 @@ const feedbackRoutes = compose(
         data: { feedback },
       } = await client.query<{ feedback: Feedback[] }>({
         query: gql`
-          query GetFeedbackForFlow($teamSlug: String!, $flowSlug: String!) {
+          query GetFeedbackForTeam($teamSlug: String!) {
             feedback: feedback_summary(
               order_by: { created_at: asc }
               where: {
                 team_slug: { _eq: $teamSlug }
-                service_slug: { _eq: $flowSlug }
               }
             ) {
+              address
+              createdAt: created_at
+              feedbackScore: feedback_score
+              flowName: service_name
               id: feedback_id
-              type: feedback_type
               nodeTitle: node_title
               nodeType: node_type
+              type: feedback_type
               userComment: user_comment
               userContext: user_context
-              feedbackScore: feedback_score
-              createdAt: created_at
-              address
             }
           }
         `,
-        variables: { teamSlug, flowSlug },
+        variables: { teamSlug },
       });
 
       return {
-        title: makeTitle("Flow Feedback"),
+        title: makeTitle("Team Feedback"),
         view: <FeedbackLog feedback={feedback} />,
       };
     }),

--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -86,8 +86,6 @@ const routes = compose(
       return import("./flow");
     }),
 
-    "/:flow/feedback": setFlowAndLazyLoad(() => import("./feedback")),
-
     "/:flow/about": setFlowAndLazyLoad(() => import("./readMePage")),
 
     "/:flow/service": setFlowAndLazyLoad(() => import("./serviceSettings")),
@@ -105,6 +103,7 @@ const routes = compose(
         view: DesignSettings,
       })),
     ),
+    "/feedback": lazy(() => import("./feedback")),
     "/general-settings": compose(
       route(async (req) => ({
         title: makeTitle(

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -335,6 +335,7 @@
           - uprn
           - user_comment
           - user_context
+          - service_name
         filter:
           team:
             flows:
@@ -367,6 +368,7 @@
           - user_comment
           - user_context
           - created_at
+          - service_name
         filter: {}
       comment: ""
     - role: teamEditor
@@ -395,6 +397,7 @@
           - user_comment
           - user_context
           - created_at
+          - service_name
         filter:
           team:
             members:

--- a/hasura.planx.uk/migrations/1738840144554_add_flow_name_to_feedback_summary/down.sql
+++ b/hasura.planx.uk/migrations/1738840144554_add_flow_name_to_feedback_summary/down.sql
@@ -1,0 +1,32 @@
+DROP VIEW "public"."feedback_summary";
+
+-- Previous implementation from 1733134891363_add_application_type_to_feedback_summary/up.sql
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS 
+ SELECT fb.id AS feedback_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,
+    COALESCE((fb.node_data ->> 'title'::text), (fb.node_data ->> 'text'::text), (fb.node_data ->> 'flagSet'::text)) AS node_title,
+    (fb.node_data ->> 'description'::text) AS node_text,
+    (fb.node_data ->> 'info'::text) AS help_text,
+    (fb.node_data ->> 'policyRef'::text) AS help_sources,
+    (fb.node_data ->> 'howMeasured'::text) AS help_definition,
+    COALESCE(((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'uprn'::text) AS uprn,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'proposal.projectType'::text) AS project_type,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'property.constraints.planning'::text) AS intersecting_constraints,
+    fb.feedback_score,
+    fb.user_data -> 'passport' -> 'data' -> 'application.type' ->> 0 AS application_type
+   FROM ((feedback fb
+     LEFT JOIN flows f ON ((f.id = fb.flow_id)))
+     LEFT JOIN teams t ON ((t.id = fb.team_id)));
+
+GRANT SELECT ON "public"."feedback_summary" TO metabase_read_only;

--- a/hasura.planx.uk/migrations/1738840144554_add_flow_name_to_feedback_summary/up.sql
+++ b/hasura.planx.uk/migrations/1738840144554_add_flow_name_to_feedback_summary/up.sql
@@ -1,0 +1,32 @@
+DROP VIEW "public"."feedback_summary";
+
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS 
+ SELECT fb.id AS feedback_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    f.name AS service_name,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,
+    COALESCE((fb.node_data ->> 'title'::text), (fb.node_data ->> 'text'::text), (fb.node_data ->> 'flagSet'::text)) AS node_title,
+    (fb.node_data ->> 'description'::text) AS node_text,
+    (fb.node_data ->> 'info'::text) AS help_text,
+    (fb.node_data ->> 'policyRef'::text) AS help_sources,
+    (fb.node_data ->> 'howMeasured'::text) AS help_definition,
+    COALESCE(((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'uprn'::text) AS uprn,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'proposal.projectType'::text) AS project_type,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'property.constraints.planning'::text) AS intersecting_constraints,
+    fb.feedback_score,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> 'application.type'::text) ->> 0) AS application_type
+   FROM ((feedback fb
+     LEFT JOIN flows f ON ((f.id = fb.flow_id)))
+     LEFT JOIN teams t ON ((t.id = fb.team_id)));
+
+GRANT SELECT ON public.feedback_summary TO metabase_read_only;


### PR DESCRIPTION
## What does this PR do?
 - Moves the feedback log page a step higher - from service level to team level
 - Updates query to fetch service name
 - Updates UI to display service name

Please note: this is just aiming to sort out the routing and associated data changes - no visual or functional changes apart from this (e.g. table styling, filters, link to service).

Example - https://4261.planx.pizza/doncaster/feedback