### PR TITLE
chore: Drop fee breakdown flag

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6cc4aa3",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ecb7f67",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6cc4aa3
-    version: github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#ecb7f67
+    version: github.com/theopensystemslab/planx-core/ecb7f67(@types/react@19.0.7)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7729,9 +7729,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6cc4aa3}
-    id: github.com/theopensystemslab/planx-core/6cc4aa3
+  github.com/theopensystemslab/planx-core/ecb7f67(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ecb7f67}
+    id: github.com/theopensystemslab/planx-core/ecb7f67
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6cc4aa3",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ecb7f67",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6cc4aa3
-    version: github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#ecb7f67
+    version: github.com/theopensystemslab/planx-core/ecb7f67(@types/react@19.0.7)
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2999,9 +2999,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6cc4aa3}
-    id: github.com/theopensystemslab/planx-core/6cc4aa3
+  github.com/theopensystemslab/planx-core/ecb7f67(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ecb7f67}
+    id: github.com/theopensystemslab/planx-core/ecb7f67
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6cc4aa3",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ecb7f67",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6cc4aa3
-    version: github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@19.0.7)
+    specifier: git+https://github.com/theopensystemslab/planx-core#ecb7f67
+    version: github.com/theopensystemslab/planx-core/ecb7f67(@types/react@19.0.7)
   axios:
     specifier: ^1.7.4
     version: 1.7.4
@@ -2548,9 +2548,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@19.0.7):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6cc4aa3}
-    id: github.com/theopensystemslab/planx-core/6cc4aa3
+  github.com/theopensystemslab/planx-core/ecb7f67(@types/react@19.0.7):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ecb7f67}
+    id: github.com/theopensystemslab/planx-core/ecb7f67
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
@@ -8,7 +8,7 @@ import {
   setUpTestContext,
   tearDownTestContext,
 } from "../helpers/context.js";
-import { cards, setFeatureFlag } from "../helpers/globalHelpers.js";
+import { cards } from "../helpers/globalHelpers.js";
 import { fillGovUkCardDetails } from "../helpers/userActions.js";
 import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow.js";
 import { getPaymentRequestBySessionId } from "./helpers.js";
@@ -38,10 +38,6 @@ test.describe("Nominee journey @regression", async () => {
       await tearDownTestContext();
       throw e;
     }
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await setFeatureFlag(page, "FEE_BREAKDOWN");
   });
 
   test.afterAll(async () => {

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.4",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6cc4aa3",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#ecb7f67",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.4
     version: 1.0.0-alpha.4
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6cc4aa3
-    version: github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#ecb7f67
+    version: github.com/theopensystemslab/planx-core/ecb7f67(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14764,9 +14764,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/6cc4aa3(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6cc4aa3}
-    id: github.com/theopensystemslab/planx-core/6cc4aa3
+  github.com/theopensystemslab/planx-core/ecb7f67(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/ecb7f67}
+    id: github.com/theopensystemslab/planx-core/ecb7f67
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -6,7 +6,6 @@ import Typography from "@mui/material/Typography";
 import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
 import SaveResumeButton from "@planx/components/shared/Preview/SaveResumeButton";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { ApplicationPath } from "types";
@@ -244,7 +243,7 @@ export default function Confirm(props: Props) {
               />
             </Typography>
           </FormWrapper>
-          {hasFeatureFlag("FEE_BREAKDOWN") && <FeeBreakdown />}
+          <FeeBreakdown />
         </Banner>
       )}
       <Card>

--- a/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stories.tsx
@@ -17,9 +17,6 @@ const meta = {
       }),
     },
   },
-  loaders: [
-    () => window.localStorage.setItem("FEATURE_FLAGS", '["FEE_BREAKDOWN"]'),
-  ],
 } satisfies Meta<typeof Confirm>;
 
 type Story = StoryObj<typeof meta>;

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,6 +1,5 @@
 // add/edit/remove feature flags in array below
 const AVAILABLE_FEATURE_FLAGS = [
-  "FEE_BREAKDOWN",
   "TEMPLATES",
 ] as const;
 

--- a/editor.planx.uk/src/pages/Pay/MakePayment.tsx
+++ b/editor.planx.uk/src/pages/Pay/MakePayment.tsx
@@ -11,7 +11,6 @@ import {
 import { FeeBreakdown } from "@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown";
 import axios from "axios";
 import { format } from "date-fns";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { getExpiryDateForPaymentRequest } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useState } from "react";
@@ -232,11 +231,9 @@ export default function MakePayment({
         currentState === States.ReadyToRetry) &&
         !isLoading && (
           <>
-            {hasFeatureFlag("FEE_BREAKDOWN") && (
-              <Container maxWidth="contentWrap" sx={{ mt: 6, pb: 0 }}>
-                <FeeBreakdown inviteToPayFeeBreakdown={feeBreakdown} />
-              </Container>
-            )}
+            <Container maxWidth="contentWrap" sx={{ mt: 6, pb: 0 }}>
+              <FeeBreakdown inviteToPayFeeBreakdown={feeBreakdown} />
+            </Container>
             <Confirm
               fee={toDecimal(paymentAmount)}
               onConfirm={readyAction}


### PR DESCRIPTION
This PR removes the `FEE_BREAKDOWN` feature flag.

**Resources**
 - Trello ticket - https://trello.com/c/B3XJVH3l/3067-show-a-breakdown-of-planning-fee-service-charge-to-users
 - Storybook - https://storybook.4262.planx.pizza/?path=/docs/planx-components-pay-feebreakdown--docs
 - Testing notes - https://docs.google.com/document/d/1eIg-BcH0DaNHxYYHMfWrkUsJkjyXKMJJbGWaCkYMw9s/edit?tab=t.0
 - Documentation - https://www.notion.so/opensystemslab/How-displaying-the-fee-breakdown-works-19035d469ad180e3bcd2eab977a39a56