### PR TITLE
feat: wire up search and filter on Team page

### DIFF
--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -158,6 +158,18 @@ const Team: React.FC = () => {
   const [filteredFlows, setFilteredFlows] = useState<FlowSummary[] | null>(
     null,
   );
+  const [searchedFlows, setSearchedFlows] = useState<FlowSummary[] | null>(
+    null,
+  );
+  const [matchingFlows, setMatchingflows] = useState<FlowSummary[] | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const diffFlows =
+      searchedFlows?.filter((flow) => filteredFlows?.includes(flow)) || null;
+    setMatchingflows(diffFlows);
+  }, [searchedFlows, filteredFlows]);
 
   const sortOptions: SortableFields<FlowSummary>[] = [
     {
@@ -223,6 +235,7 @@ const Team: React.FC = () => {
       );
       setFlows(sortedFlows);
       setFilteredFlows(sortedFlows);
+      setSearchedFlows(sortedFlows);
     });
   }, [teamId, setFlows, getFlows]);
 
@@ -262,7 +275,7 @@ const Team: React.FC = () => {
           {hasFeatureFlag("SORT_FLOWS") && flows && (
             <SearchBox<FlowSummary>
               records={flows}
-              setRecords={setFilteredFlows}
+              setRecords={setSearchedFlows}
               searchKey={["name", "slug"]}
             />
           )}
@@ -294,9 +307,9 @@ const Team: React.FC = () => {
             />
           )}
         </Box>
-        {filteredFlows && flows && (
+        {matchingFlows && flows && (
           <DashboardList>
-            {filteredFlows.map((flow) => (
+            {matchingFlows.map((flow) => (
               <FlowCard
                 flow={flow}
                 flows={flows}


### PR DESCRIPTION
## What does this PR do?

This PR follows on from the `SearchBox` and `Filter` component PRs. Each component would filter `flows` and up until this point, they would `setFilteredFlows`. The issue we run into now is when a user wants to **Search** and **Filter**.

To get round this and make it clear what does what. Each component will still search/filter `flows` but they will set their own array `searchedFlows || filteredFlows` - this will then be filtered in the `useEffect` and set a new state variable called `matchedFlows`

My thinking is that:

- If you search first
   - `searchedFlows` will change
   - `filteredFlows` will be equal to `flows`
   - `searchedFlows` is filtered based on whether they exist in `filteredFlows`
   - The return will be set as `matchedFlows`
- if you filter first
   - `filteredFlows` will change
   - `searchedFlows` will be equal to `flows`
   - `searchedFlows` will be based on whether it exists in `filteredFlows`
   - The return will be set as `matchedFlows`
 
 ### To Test

Use different combinations of searching and filtering, doing so in different orders.

It is best to create your own target filter and toggle it `offline` or `online` and just filtering by `status`. Filtering by multiple criteria shouldn't affect this work.