### PR TITLE
fix: read url params for search

### DIFF
--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -156,8 +156,6 @@ export const Filters = <T extends object>({
     get(values.filters, filterKey) === filterValue
       ? removeFilter(filterKey)
       : setFieldValue("filters", newObject);
-
-    handleSubmit();
   };
 
   const removeFilter = (targetFilter: FilterKey<T>) => {
@@ -196,7 +194,6 @@ export const Filters = <T extends object>({
                       (keys) => keys === value,
                     ) as FilterKey<T>;
                     removeFilter(targetKey);
-                    handleSubmit();
                   }}
                 />
               );

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -141,6 +141,12 @@ export const Filters = <T extends object>({
     }
   }, []);
 
+  useEffect(() => {
+    if (values.filters) {
+      handleSubmit();
+    }
+  }, [handleSubmit, values.filters]);
+
   const handleChange = (filterKey: FilterKey<T>, filterValue: FilterValues) => {
     const newObject = {
       ...values.filters,


### PR DESCRIPTION
## What does this PR do?

This is a leftover bug from the `Filter` component work where the searchParams were being cleared on mount. 

Found that it was due to us parsing the filters from the URL and submitting, but that `values.filters` in formik would still be undefined, so it would clear the filters and not apply them. I added a simple effect to re-run `handleSubmit` when this is done. This also has the added effect of not requiring us to re-call `handleSubmit` at other interactions, and rely upon it running when `values.filters` changes