### PR TITLE
poc: Notion iframes in AWS Cloudfront [skip pizza]

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -42,7 +42,7 @@ describe("globalLayoutRoutes", () => {
 
     const { queryAllByRole } = setup(<EditorNavMenu />);
     const menuItems = queryAllByRole("listitem");
-    expect(menuItems).toHaveLength(0);
+    expect(menuItems).toHaveLength(2);
   });
 
   it("displays for platformAdmins", () => {
@@ -50,7 +50,7 @@ describe("globalLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(3);
+    expect(menuItems).toHaveLength(4);
     expect(within(menuItems[0]).getByText("Select a team")).toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -1,11 +1,14 @@
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
 import Info from "@mui/icons-material/Info";
 import LeaderboardIcon from "@mui/icons-material/Leaderboard";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import PaletteIcon from "@mui/icons-material/Palette";
 import RateReviewIcon from "@mui/icons-material/RateReview";
+import SchoolIcon from "@mui/icons-material/School";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
@@ -138,6 +141,24 @@ function EditorNavMenu() {
       route: "admin-panel",
       accessibleBy: ["platformAdmin"],
     },
+    {
+      title: "Resources",
+      Icon: MenuBookIcon,
+      route: "resources",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    },
+    // {
+    //   title: "Onboarding",
+    //   Icon: AssignmentTurnedInIcon,
+    //   route: "onboarding",
+    //   accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    // },
+    // {
+    //   title: "Tutorials",
+    //   Icon: SchoolIcon,
+    //   route: "tutorials",
+    //   accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    // },
   ];
 
   const teamLayoutRoutes: Route[] = [

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -115,6 +115,45 @@ const editorRoutes = compose(
       });
     }),
 
+    "/resources": route(() => {
+      return {
+        title: makeTitle("Resources"),
+        view: (
+          <iframe
+            title="notion"
+            src="https://www.notioniframe.com/notion/22ankohkzhk"
+            style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+          />
+        ),
+      };
+    }),
+
+    // "/onboarding": route(() => {
+    //   return {
+    //     title: makeTitle("Onboarding"),
+    //     view: (
+    //       <iframe
+    //         title="notion"
+    //         src="https://www.notioniframe.com/notion/1fjdisq3i73"
+    //         style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+    //       />
+    //     ),
+    //   };
+    // }),
+
+    // "/tutorials": route(() => {
+    //   return {
+    //     title: makeTitle("Tutorials"),
+    //     view: (
+    //       <iframe
+    //         title="notion"
+    //         src="https://www.notioniframe.com/notion/1wf4jidsdbv"
+    //         style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+    //       />
+    //     ),
+    //   };
+    // }),
+
     "/:team": lazy(() => import("./team")),
   }),
 );


### PR DESCRIPTION
Quick proof of concept to test if the method trialled [here](https://github.com/theopensystemslab/planx-new/pull/4154/files) will work on staging and production, using the IFrame protection set up on AWS Cloudfront.

This is just a test, and once deployed to staging I'll immediately open a revert PR.

I _think_ it will work - our iframe embed headers should stop PlanX being embedded, as opposed to us embedding.