### PR TITLE
style: Filter column widths

### DIFF
--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -207,6 +207,7 @@ export const Filters = <T extends object>({
               <fieldset
                 key={option.displayName}
                 aria-describedby={`${option.displayName}-description`}
+                style={{ flexBasis: "20%" }}
               >
                 <div
                   key={`${option.displayName}-description`}

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -1,15 +1,10 @@
 import Box from "@mui/material/Box";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { capitalize, get } from "lodash";
 import React from "react";
 import ChecklistItem from "ui/shared/ChecklistItem/ChecklistItem";
 
 import Filters, { FilterKey, FilterValues } from "./Filter";
-
-const Column = styled(Box)(() => ({
-  flexBasis: "20%",
-}));
 
 interface FiltersColumnProps<T> {
   title: string;
@@ -23,7 +18,7 @@ export const FiltersColumn = <T extends object>(
   props: FiltersColumnProps<T>,
 ) => {
   return (
-    <Column>
+    <Box>
       <Typography component={"legend"} variant="h5" pb={0.5}>
         {props.title}
       </Typography>
@@ -37,6 +32,6 @@ export const FiltersColumn = <T extends object>(
           variant="compact"
         />
       ))}
-    </Column>
+    </Box>
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Adds correct width to filter columns

Before change:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/b79a823e-95ad-4dc2-8846-e09ba64e3455" />

After change:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/871729cd-2647-4cf0-ba82-0024ba51255e" />

Preview:
https://4272.planx.pizza/doncaster
