### PR TITLE
refactor: Simplify view when no services are present

### DIFF
--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -266,7 +266,7 @@ const Team: React.FC = () => {
             </Typography>
             {showAddFlowButton && <AddFlowButton flows={flows} />}
           </Box>
-          {teamHasFlows && hasFeatureFlag("SORT_FLOWS") && flows && (
+          {teamHasFlows && hasFeatureFlag("SORT_FLOWS") && (
             <SearchBox<FlowSummary>
               records={flows}
               setRecords={setSearchedFlows}

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -40,7 +40,7 @@ const DashboardList = styled("ul")(({ theme }) => ({
 }));
 
 const GetStarted: React.FC<{ flows: FlowSummary[] | null }> = ({ flows }) => (
-  <DashboardList sx={{ paddingTop: 0 }}>
+  <DashboardList sx={{ paddingTop: 2 }}>
     <Card>
       <CardContent>
         <Typography variant="h3">No services found</Typography>
@@ -266,7 +266,7 @@ const Team: React.FC = () => {
             </Typography>
             {showAddFlowButton && <AddFlowButton flows={flows} />}
           </Box>
-          {hasFeatureFlag("SORT_FLOWS") && flows && (
+          {teamHasFlows && hasFeatureFlag("SORT_FLOWS") && flows && (
             <SearchBox<FlowSummary>
               records={flows}
               setRecords={setSearchedFlows}
@@ -274,74 +274,78 @@ const Team: React.FC = () => {
             />
           )}
         </Box>
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-end",
-          }}
-        >
-          {showAddFlowButton && hasFeatureFlag("TEMPLATES") && (
-            <StartFromTemplateButton />
-          )}
-        </Box>
-        <Box>
-          {filteredFlows && flows && (
-            <Filters<FlowSummary>
-              records={flows}
-              setFilteredRecords={setFilteredFlows}
-              filterOptions={filterOptions}
-            />
-          )}
-        </Box>
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            gap: 2,
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "flex-start",
-              alignItems: "center",
-              gap: 2,
-            }}
-          >
-            <Typography variant="h3" component="h2">
-              Showing X services
-            </Typography>
-          </Box>
-          {hasFeatureFlag("SORT_FLOWS") && flows && (
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-              <Typography variant="body2">
-                <strong>Sort by</strong>
-              </Typography>
-              <SortControl<FlowSummary>
-                records={flows}
-                setRecords={setFlows}
-                sortOptions={sortOptions}
-              />
+        {teamHasFlows && (
+          <>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-end",
+              }}
+            >
+              {showAddFlowButton && hasFeatureFlag("TEMPLATES") && (
+                <StartFromTemplateButton />
+              )}
             </Box>
-          )}
-        </Box>
-        {matchingFlows && flows && (
-          <DashboardList>
-            {matchingFlows.map((flow) => (
-              <FlowCard
-                flow={flow}
-                flows={flows}
-                key={flow.slug}
-                teamId={teamId}
-                teamSlug={slug}
-                refreshFlows={() => {
-                  fetchFlows();
+            <Box>
+              {filteredFlows && flows && (
+                <Filters<FlowSummary>
+                  records={flows}
+                  setFilteredRecords={setFilteredFlows}
+                  filterOptions={filterOptions}
+                />
+              )}
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "flex-start",
+                  alignItems: "center",
+                  gap: 2,
                 }}
-              />
-            ))}
-          </DashboardList>
+              >
+                <Typography variant="h3" component="h2">
+                  Showing X services
+                </Typography>
+              </Box>
+              {hasFeatureFlag("SORT_FLOWS") && flows && (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+                  <Typography variant="body2">
+                    <strong>Sort by</strong>
+                  </Typography>
+                  <SortControl<FlowSummary>
+                    records={flows}
+                    setRecords={setFlows}
+                    sortOptions={sortOptions}
+                  />
+                </Box>
+              )}
+            </Box>
+            {matchingFlows && flows && (
+              <DashboardList>
+                {matchingFlows.map((flow) => (
+                  <FlowCard
+                    flow={flow}
+                    flows={flows}
+                    key={flow.slug}
+                    teamId={teamId}
+                    teamSlug={slug}
+                    refreshFlows={() => {
+                      fetchFlows();
+                    }}
+                  />
+                ))}
+              </DashboardList>
+            )}
+          </>
         )}
         {flows && !flows.length && <GetStarted flows={flows} />}
       </Container>

--- a/editor.planx.uk/src/pages/Team.tsx
+++ b/editor.planx.uk/src/pages/Team.tsx
@@ -237,7 +237,7 @@ const Team: React.FC = () => {
     fetchFlows();
   }, [fetchFlows]);
 
-  const teamHasFlows = !isEmpty(filteredFlows) && !isEmpty(flows);
+  const teamHasFlows = !isEmpty(flows);
   const showAddFlowButton = teamHasFlows && canUserEditTeam(slug);
 
   return (


### PR DESCRIPTION
## What does this PR do?

- Removes search, filters and sort when no services are present

Before changes:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/cc118843-33fd-4df0-87ee-ee34555647b3" />

After changes:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/b4f424bc-a396-43cd-a000-805a271ef755" />

**Preview:**
https://4273.planx.pizza/a-new-team