### PR TITLE
fix: Transparent focused checkboxes

### DIFF
--- a/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import Box, { BoxProps } from "@mui/material/Box";
+  import Box, { BoxProps } from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import React from "react";
 import { borderedFocusStyle } from "theme";
@@ -16,7 +16,10 @@ const Root = styled(Box, {
     borderColor: theme.palette.text.primary,
     border: "2px solid",
     backgroundColor: theme.palette.common.white,
-    "&:focus-within": borderedFocusStyle,
+    "&:focus-within": {
+      ...borderedFocusStyle,
+      background: "inherit",
+    },
     ...(disabled && {
       border: `2px solid ${theme.palette.grey[400]}`,
       backgroundColor: theme.palette.grey[400],


### PR DESCRIPTION
Small fix for UI issue noticed on the filters PRs that's not yet been addressed.

When a checkbox is focused on the filters, it picks up a grey background - this resolves the issue.