### PR TITLE
feat: simple `/admin/feedback/:feedbackId` endpoint to access associated user data

### DIFF
--- a/api.planx.uk/modules/admin/feedback/feedback.test.ts
+++ b/api.planx.uk/modules/admin/feedback/feedback.test.ts
@@ -1,0 +1,57 @@
+import supertest from "supertest";
+import app from "../../../server.js";
+import { queryMock } from "../../../tests/graphqlQueryMock.js";
+import { authHeader } from "../../../tests/mockJWT.js";
+
+describe("Feedback admin endpoint", () => {
+  beforeEach(() => {
+    queryMock.mockQuery({
+      name: "GetFeedback",
+      variables: {
+        feedbackId: 1,
+      },
+      data: {
+        feedback: {},
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires a user to be logged in", async () => {
+    await supertest(app)
+      .get(`/admin/feedback/1`)
+      .expect(401)
+      .then((res) =>
+        expect(res.body).toEqual({
+          error: "No authorization token was found",
+        }),
+      );
+  });
+
+  it("requires a user to have the 'platformAdmin' role", async () => {
+    await supertest(app)
+      .get(`/admin/feedback/1`)
+      .set(authHeader({ role: "teamEditor" }))
+      .expect(403);
+  });
+
+  it("returns an error if the feedback ID can't be found", async () => {
+    await supertest(app)
+      .get(`/admin/feedback/999`)
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(500);
+  });
+
+  it("returns JSON", async () => {
+    await supertest(app)
+      .get(`/admin/feedback/1`)
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(200)
+      .then((res) => {
+        expect(res.text).toBe("{}");
+      });
+  });
+});

--- a/api.planx.uk/modules/admin/feedback/feedback.ts
+++ b/api.planx.uk/modules/admin/feedback/feedback.ts
@@ -55,16 +55,16 @@ interface FeedbackResponse {
     };
     createdAt: string;
     feedbackType: string;
-    feedbackScore: string;
-    feedbackStatus: string;
+    feedbackScore: string | null;
+    feedbackStatus: string | null;
     userDevice: Record<string, string>;
-    userContext: string;
+    userContext: string | null;
     userComment: string;
-    userBreadcrumb: Breadcrumbs;
-    userPassport: Passport["data"];
-    nodeId: Node["id"];
-    nodeType: Node["type"];
-    nodeData: Node["data"];
+    userBreadcrumb: Breadcrumbs | null;
+    userPassport: Passport["data"] | null;
+    nodeId: Node["id"] | null;
+    nodeType: Node["type"] | null;
+    nodeData: Node["data"] | null;
   };
 }
 

--- a/api.planx.uk/modules/admin/feedback/feedback.ts
+++ b/api.planx.uk/modules/admin/feedback/feedback.ts
@@ -1,0 +1,108 @@
+import type { Breadcrumbs, Node, Team } from "@opensystemslab/planx-core/types";
+import type { NextFunction, Request, Response } from "express";
+import { gql } from "graphql-request";
+
+import { $api } from "../../../client/index.js";
+import type { Flow, Passport } from "../../../types.js";
+
+/**
+ * @swagger
+ * /admin/feedback/{feedbackId}:
+ *  get:
+ *    summary: Returns a feedback entry with user data
+ *    description: Returns a feedback entry plus its' associated session user data, including the passport and breadcrumbs
+ *    tags:
+ *      - admin
+ *    parameters:
+ *      - in: path
+ *        name: feedbackId
+ *        type: string
+ *        required: true
+ *    security:
+ *      - bearerAuth: []
+ */
+export const getFeedbackWithUserData = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const feedbackId = parseInt(req.params.feedbackId);
+    const feedback = await getFeedbackById(feedbackId);
+    if (feedback) {
+      res.send(feedback);
+    } else {
+      res.send({
+        message: `Cannot find feedback record ${feedbackId}; double-check your feedbackId is correct`,
+      });
+    }
+  } catch (error) {
+    return next({
+      message:
+        "Failed to fetch feedback admin data: " + (error as Error).message,
+    });
+  }
+};
+
+interface FeedbackResponse {
+  feedback: {
+    id: number;
+    flow: {
+      slug: Flow["slug"];
+    };
+    team: {
+      slug: Team["slug"];
+    };
+    createdAt: string;
+    feedbackType: string;
+    feedbackScore: string;
+    feedbackStatus: string;
+    userDevice: Record<string, string>;
+    userContext: string;
+    userComment: string;
+    userBreadcrumb: Breadcrumbs;
+    userPassport: Passport["data"];
+    nodeId: Node["id"];
+    nodeType: Node["type"];
+    nodeData: Node["data"];
+  };
+}
+
+const getFeedbackById = async (
+  feedbackId: number,
+): Promise<FeedbackResponse | null> => {
+  const { feedback } = await $api.client.request<
+    Record<"feedback", FeedbackResponse | null>
+  >(
+    gql`
+      query GetFeedback($feedbackId: Int!) {
+        feedback: feedback_by_pk(id: $feedbackId) {
+          id
+          flow {
+            slug
+          }
+          team {
+            slug
+          }
+          createdAt: created_at
+          feedbackType: feedback_type
+          feedbackScore: feedback_score
+          feedbackStatus: status
+          userDevice: device
+          userContext: user_context
+          userComment: user_comment
+          userBreadcrumbs: user_data(path: "breadcrumbs")
+          userPassport: user_data(path: "passport.data")
+          nodeId: node_id
+          nodeType: node_type
+          nodeData: node_data
+        }
+      }
+    `,
+    {
+      feedbackId,
+    },
+  );
+
+  return feedback;
+};

--- a/api.planx.uk/modules/admin/routes.ts
+++ b/api.planx.uk/modules/admin/routes.ts
@@ -1,17 +1,19 @@
 import { Router } from "express";
 import { usePlatformAdminAuth } from "../auth/middleware.js";
-import { getOneAppXML } from "./session/oneAppXML.js";
+import { getFeedbackWithUserData } from "./feedback/feedback.js";
 import { getCSVData, getRedactedCSVData } from "./session/csv.js";
-import { getHTMLExport, getRedactedHTMLExport } from "./session/html.js";
-import { generateZip } from "./session/zip.js";
-import { getSessionSummary } from "./session/summary.js";
 import { getDigitalPlanningApplicationPayload } from "./session/digitalPlanningData.js";
+import { getHTMLExport, getRedactedHTMLExport } from "./session/html.js";
+import { getOneAppXML } from "./session/oneAppXML.js";
+import { getSessionSummary } from "./session/summary.js";
+import { generateZip } from "./session/zip.js";
 
 const router = Router();
 
 router.use("/admin/", usePlatformAdminAuth);
 
 // TODO: Split the routes below into controller and service components
+router.get("/admin/feedback/:feedbackId", getFeedbackWithUserData);
 router.get("/admin/session/:sessionId/xml", getOneAppXML);
 router.get("/admin/session/:sessionId/csv", getCSVData);
 router.get("/admin/session/:sessionId/csv-redacted", getRedactedCSVData);

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -283,8 +283,20 @@
     - role: api
       permission:
         columns:
-          - created_at
+          - feedback_score
           - id
+          - team_id
+          - device
+          - user_data
+          - feedback_type
+          - node_id
+          - created_at
+          - flow_id
+          - node_data
+          - node_type
+          - status
+          - user_comment
+          - user_context
         filter: {}
       comment: ""
   delete_permissions:


### PR DESCRIPTION
See thread https://opensystemslab.slack.com/archives/C01E3AC0C03/p1738856231269679?thread_ts=1738767687.943469&cid=C01E3AC0C03

Testing notes:
- I've added a quick feedback entry via this pizza already (feedback id = 1)
- Login into the editor, then confirm you get a JSON response at [https://api.4277.planx.pizza/admin/feedback/1](https://api.4277.planx.pizza/admin/feedback/1)
  - The JSON response notably includes `userBreadcrumbs` & `userPassport` keys ! 
  - Note that when accessing `/admin` endpoints on staging or prod you'll additionally need to be connected to WARP