### PR TITLE
feat: Embed using native Notion "Share > Embed this page" option

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -42,7 +42,7 @@ describe("globalLayoutRoutes", () => {
 
     const { queryAllByRole } = setup(<EditorNavMenu />);
     const menuItems = queryAllByRole("listitem");
-    expect(menuItems).toHaveLength(0);
+    expect(menuItems).toHaveLength(2);
   });
 
   it("displays for platformAdmins", () => {
@@ -50,7 +50,7 @@ describe("globalLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(3);
+    expect(menuItems).toHaveLength(4);
     expect(within(menuItems[0]).getByText("Select a team")).toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -1,11 +1,14 @@
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
 import Info from "@mui/icons-material/Info";
 import LeaderboardIcon from "@mui/icons-material/Leaderboard";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import PaletteIcon from "@mui/icons-material/Palette";
 import RateReviewIcon from "@mui/icons-material/RateReview";
+import SchoolIcon from "@mui/icons-material/School";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
@@ -138,6 +141,24 @@ function EditorNavMenu() {
       route: "admin-panel",
       accessibleBy: ["platformAdmin"],
     },
+    {
+      title: "Resources",
+      Icon: MenuBookIcon,
+      route: "resources",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    },
+    // {
+    //   title: "Onboarding",
+    //   Icon: AssignmentTurnedInIcon,
+    //   route: "onboarding",
+    //   accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    // },
+    // {
+    //   title: "Tutorials",
+    //   Icon: SchoolIcon,
+    //   route: "tutorials",
+    //   accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    // },
   ];
 
   const teamLayoutRoutes: Route[] = [

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -115,6 +115,45 @@ const editorRoutes = compose(
       });
     }),
 
+    "/resources": route(() => {
+      return {
+        title: makeTitle("Resources"),
+        view: (
+          <iframe
+            title="notion"
+            src="https://www.notioniframe.com/notion/22ankohkzhk"
+            style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+          />
+        ),
+      };
+    }),
+
+    // "/onboarding": route(() => {
+    //   return {
+    //     title: makeTitle("Onboarding"),
+    //     view: (
+    //       <iframe
+    //         title="notion"
+    //         src="https://www.notioniframe.com/notion/1fjdisq3i73"
+    //         style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+    //       />
+    //     ),
+    //   };
+    // }),
+
+    // "/tutorials": route(() => {
+    //   return {
+    //     title: makeTitle("Tutorials"),
+    //     view: (
+    //       <iframe
+    //         title="notion"
+    //         src="https://www.notioniframe.com/notion/1wf4jidsdbv"
+    //         style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+    //       />
+    //     ),
+    //   };
+    // }),
+
     "/:team": lazy(() => import("./team")),
   }),
 );

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -10,6 +10,7 @@ import {
 } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import NotionEmbed from "ui/editor/NotionEmbed";
 
 import { client } from "../lib/graphql";
 import GlobalSettingsView from "../pages/GlobalSettings";
@@ -118,13 +119,7 @@ const editorRoutes = compose(
     "/resources": route(() => {
       return {
         title: makeTitle("Resources"),
-        view: (
-          <iframe
-            title="notion"
-            src="https://www.notioniframe.com/notion/22ankohkzhk"
-            style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
-          />
-        ),
+        view: <NotionEmbed page="resources" title="PlanX Resources" />,
       };
     }),
 

--- a/editor.planx.uk/src/ui/editor/NotionEmbed.tsx
+++ b/editor.planx.uk/src/ui/editor/NotionEmbed.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+const NOTION_PAGES = {
+  resources: "6b896f88be4c4b4c8ec8474a34c70d7c",
+} as const;
+
+const NotionEmbed: React.FC<{
+  page: keyof typeof NOTION_PAGES;
+  title: string;
+}> = ({ page, title }) => {
+  const pageId = NOTION_PAGES[page];
+  const embedUrl = `https://opensystemslab.notion.site/ebd/${pageId}`;
+
+  return (
+    <iframe
+      src={embedUrl}
+      width="100%"
+      height="600"
+      style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
+      title={title}
+    />
+  );
+};
+
+export default NotionEmbed;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/edbb86a2-0e1f-471c-b15e-0890d6ab3094)

Turns out we can do this and save the $2 monthly fee - still need to check ours Cloudfront setup allow this without changes to CSP headers.