### PR TITLE
feat(templates): Add `flows.is_template` column

### DIFF
--- a/editor.planx.uk/src/pages/Team/StartFromTemplateButton.tsx
+++ b/editor.planx.uk/src/pages/Team/StartFromTemplateButton.tsx
@@ -1,0 +1,96 @@
+import { gql, useQuery } from "@apollo/client";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import MenuItem from "@mui/material/MenuItem";
+import { useFormik } from "formik";
+import React, { useState } from "react";
+import { AddButton } from "ui/editor/AddButton";
+import SelectInput from "ui/editor/SelectInput/SelectInput";
+import InputLabel from "ui/public/InputLabel";
+
+export interface TemplateOverview {
+  name: string;
+  slug: string;
+  id: string;
+}
+
+export const StartFromTemplateButton: React.FC<{
+  templates: TemplateOverview[];
+}> = ({ templates }) => {
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+
+  const formik = useFormik<{ templateId: string }>({
+    initialValues: { templateId: templates[0].id },
+    onSubmit: ({ templateId }) => {
+      console.log(
+        `POST to /flows/create-from-template/${templateId}, then redirect`,
+      );
+    },
+    validateOnBlur: false,
+    validateOnChange: false,
+  });
+
+  return (
+    <Box mt={1}>
+      <AddButton onClick={() => setDialogOpen(true)}>
+        Start from a template
+      </AddButton>
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+        maxWidth="md"
+      >
+        <DialogTitle variant="h3" component="h1">
+          {`Start from a template`}
+        </DialogTitle>
+        <DialogContent>
+          {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent dictum interdum tellus laoreet faucibus. Aliquam ultricies vitae nunc non efficitur. Mauris leo nulla, luctus sit amet ullamcorper a, porta at mauris. Integer nec elit a magna dapibus bibendum.`}
+          <Box mt={2} component="form" onSubmit={formik.handleSubmit}>
+            <InputLabel
+              label="Available templates"
+              id={`select-label-templates`}
+            >
+              <SelectInput
+                value={formik.values.templateId}
+                name="templateId"
+                bordered
+                required={true}
+                title={"Available templates"}
+                labelId={`select-label-templates`}
+                onChange={(e) =>
+                  formik.setFieldValue("templateId", e.target.value)
+                }
+              >
+                {templates.map((template) => (
+                  <MenuItem key={template.slug} value={template.id}>
+                    {template.name}
+                  </MenuItem>
+                ))}
+              </SelectInput>
+            </InputLabel>
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ paddingX: 2 }}>
+          <Button disableRipple onClick={() => setDialogOpen(false)}>
+            BACK
+          </Button>
+          <Button
+            type="submit"
+            color="primary"
+            variant="contained"
+            disableRipple
+            onClick={() => formik.handleSubmit()}
+          >
+            CREATE TEMPLATE
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -333,7 +333,7 @@ const Team: React.FC = () => {
     fetchFlows();
   }, [fetchFlows]);
 
-  const { data: templateData } = useQuery<{ flows: TemplateOverview[] }>(gql`
+  const { data: templates } = useQuery<{ flows: TemplateOverview[] }>(gql`
     query GetTemplates {
       flows(where: { is_template: { _eq: true } }) {
         id
@@ -347,8 +347,8 @@ const Team: React.FC = () => {
   const showAddFlowButton = teamHasFlows && canUserEditTeam(slug);
   const showAddTemplateButton =
     showAddFlowButton &&
-    templateData &&
-    Boolean(templateData?.flows.length) &&
+    templates &&
+    Boolean(templates?.flows.length) &&
     hasFeatureFlag("TEMPLATES");
 
   return (
@@ -383,7 +383,7 @@ const Team: React.FC = () => {
         >
           {showAddFlowButton && <AddFlowButton flows={flows} />}
           {showAddTemplateButton && (
-            <StartFromTemplateButton templates={templateData.flows} />
+            <StartFromTemplateButton templates={templates.flows} />
           )}
         </Box>
       </Box>

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,4 +1,4 @@
-import { gql } from "@apollo/client";
+import { gql, useQuery } from "@apollo/client";
 import Edit from "@mui/icons-material/Edit";
 import Visibility from "@mui/icons-material/Visibility";
 import Box from "@mui/material/Box";
@@ -9,7 +9,6 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
-import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { hasFeatureFlag } from "lib/featureFlags";
@@ -17,16 +16,18 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Link, useNavigation } from "react-navi";
 import { borderedFocusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { AddButton } from "ui/editor/AddButton";
-import SelectInput from "ui/editor/SelectInput/SelectInput";
 import { SortableFields, SortControl } from "ui/editor/SortControl";
-import InputLabel from "ui/public/InputLabel";
 import { slugify } from "utils";
 
-import { client } from "../lib/graphql";
-import SimpleMenu from "../ui/editor/SimpleMenu";
-import { useStore } from "./FlowEditor/lib/store";
-import { FlowSummary } from "./FlowEditor/lib/store/editor";
-import { formatLastEditMessage } from "./FlowEditor/utils";
+import { client } from "../../lib/graphql";
+import SimpleMenu from "../../ui/editor/SimpleMenu";
+import { useStore } from "../FlowEditor/lib/store";
+import { FlowSummary } from "../FlowEditor/lib/store/editor";
+import { formatLastEditMessage } from "../FlowEditor/utils";
+import {
+  StartFromTemplateButton,
+  TemplateOverview,
+} from "./StartFromTemplateButton";
 
 const DashboardList = styled("ul")(({ theme }) => ({
   padding: theme.spacing(0, 0, 3),
@@ -293,78 +294,6 @@ const AddFlowButton: React.FC<{ flows: FlowSummary[] }> = ({ flows }) => {
   return <AddButton onClick={addFlow}>Add a new service</AddButton>;
 };
 
-const StartFromTemplateButton: React.FC<{}> = () => {
-  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-
-  // TODO fetch flows marked as "source templates"
-  const mockTemplateOptions = [
-    {
-      id: "123-456",
-      name: "Apply for planning permission",
-      slug: "apply-for-planning-permission",
-    },
-    {
-      id: "789-123",
-      name: "Apply for a lawful development certificate",
-      slug: "apply-for-a-lawful-development-certificate",
-    },
-  ];
-
-  return (
-    <Box mt={1}>
-      <AddButton onClick={() => setDialogOpen(true)}>
-        Start from a template
-      </AddButton>
-      <Dialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-        maxWidth="md"
-      >
-        <DialogTitle variant="h3" component="h1">
-          {`Start from a template`}
-        </DialogTitle>
-        <DialogContent>
-          {`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent dictum interdum tellus laoreet faucibus. Aliquam ultricies vitae nunc non efficitur. Mauris leo nulla, luctus sit amet ullamcorper a, porta at mauris. Integer nec elit a magna dapibus bibendum.`}
-          <Box mt={2}>
-            <InputLabel
-              label="Available templates"
-              id={`select-label-templates`}
-            >
-              <SelectInput
-                bordered
-                required={true}
-                title={"Available templates"}
-                labelId={`select-label-templates`}
-                value={mockTemplateOptions[0].slug}
-                onChange={() => console.log("TODO formik?")}
-                name={"templates"}
-              >
-                {mockTemplateOptions.map((option) => (
-                  <MenuItem key={option.id} value={option.slug}>
-                    {option.name}
-                  </MenuItem>
-                ))}
-              </SelectInput>
-            </InputLabel>
-          </Box>
-        </DialogContent>
-        <DialogActions sx={{ paddingX: 2 }}>
-          <Button onClick={() => setDialogOpen(false)}>BACK</Button>
-          <Button
-            color="primary"
-            variant="contained"
-            onClick={() => console.log("TODO create template")}
-          >
-            CREATE TEMPLATE
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
-  );
-};
-
 const Team: React.FC = () => {
   const [{ id: teamId, slug }, canUserEditTeam, getFlows] = useStore(
     (state) => [state.getTeam(), state.canUserEditTeam, state.getFlows],
@@ -404,8 +333,23 @@ const Team: React.FC = () => {
     fetchFlows();
   }, [fetchFlows]);
 
+  const { data: templateData } = useQuery<{ flows: TemplateOverview[] }>(gql`
+    query GetTemplates {
+      flows(where: { is_template: { _eq: true } }) {
+        id
+        slug
+        name
+      }
+    }
+  `);
+
   const teamHasFlows = flows && Boolean(flows.length);
   const showAddFlowButton = teamHasFlows && canUserEditTeam(slug);
+  const showAddTemplateButton =
+    showAddFlowButton &&
+    templateData &&
+    Boolean(templateData?.flows.length) &&
+    hasFeatureFlag("TEMPLATES");
 
   return (
     <Container maxWidth="formWrap">
@@ -438,8 +382,8 @@ const Team: React.FC = () => {
           }}
         >
           {showAddFlowButton && <AddFlowButton flows={flows} />}
-          {showAddFlowButton && hasFeatureFlag("TEMPLATES") && (
-            <StartFromTemplateButton />
+          {showAddTemplateButton && (
+            <StartFromTemplateButton templates={templateData.flows} />
           )}
         </Box>
       </Box>

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -592,6 +592,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -657,6 +658,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -679,6 +681,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -714,6 +717,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -734,6 +738,7 @@
           - creator_id
           - data
           - id
+          - is_template
           - name
           - settings
           - slug
@@ -755,6 +760,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -837,6 +843,7 @@
         columns:
           - data
           - description
+          - is_template
           - limitations
           - name
           - settings

--- a/hasura.planx.uk/migrations/1738946199211_alter_table_public_flows_add_column_is_template/down.sql
+++ b/hasura.planx.uk/migrations/1738946199211_alter_table_public_flows_add_column_is_template/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."flows" DROP COLUMN "is_template";

--- a/hasura.planx.uk/migrations/1738946199211_alter_table_public_flows_add_column_is_template/up.sql
+++ b/hasura.planx.uk/migrations/1738946199211_alter_table_public_flows_add_column_is_template/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."flows" add column "is_template" boolean
+ not null default 'false';


### PR DESCRIPTION
## What does this PR do?
 - Create a new `flows.is_template` column
 - Readable by all, but can only be set by `platformAdmins`
 - Updates `StartFromTemplateButton` component to display actual list of templates, wires up basic formik
 - Just logs out a value, doesn't interact with the API

Having this additional column will massively simplify some of the permissions in https://github.com/theopensystemslab/planx-new/pull/4234 which are trying to check the existance of a relationship, instead of a simple value.