### PR TITLE
feat: Setup remaining Notion iframes

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu.test.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.test.tsx
@@ -37,12 +37,12 @@ describe("globalLayoutRoutes", () => {
     } as ReturnType<typeof mockNavi.useCurrentRoute>);
   });
 
-  it("does not display for teamEditors", () => {
+  it("displays for teamEditors", () => {
     mockGetUserRoleForCurrentTeam.mockReturnValue("teamEditor");
 
     const { queryAllByRole } = setup(<EditorNavMenu />);
     const menuItems = queryAllByRole("listitem");
-    expect(menuItems).toHaveLength(2);
+    expect(menuItems).toHaveLength(4);
   });
 
   it("displays for platformAdmins", () => {
@@ -50,7 +50,7 @@ describe("globalLayoutRoutes", () => {
 
     const { getAllByRole } = setup(<EditorNavMenu />);
     const menuItems = getAllByRole("listitem");
-    expect(menuItems).toHaveLength(4);
+    expect(menuItems).toHaveLength(6);
     expect(within(menuItems[0]).getByText("Select a team")).toBeInTheDocument();
   });
 });

--- a/editor.planx.uk/src/components/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu.tsx
@@ -147,18 +147,18 @@ function EditorNavMenu() {
       route: "resources",
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
     },
-    // {
-    //   title: "Onboarding",
-    //   Icon: AssignmentTurnedInIcon,
-    //   route: "onboarding",
-    //   accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
-    // },
-    // {
-    //   title: "Tutorials",
-    //   Icon: SchoolIcon,
-    //   route: "tutorials",
-    //   accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
-    // },
+    {
+      title: "Onboarding",
+      Icon: AssignmentTurnedInIcon,
+      route: "onboarding",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    },
+    {
+      title: "Tutorials",
+      Icon: SchoolIcon,
+      route: "tutorials",
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+    },
   ];
 
   const teamLayoutRoutes: Route[] = [

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/GetStarted.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/GetStarted.tsx
@@ -1,0 +1,42 @@
+import SchoolIcon from "@mui/icons-material/School";
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { Link } from "react-navi";
+
+const Root = styled(Box)(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(1),
+  width: "266px",
+  padding: theme.spacing(2),
+  background: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.border.main}`,
+  position: "relative",
+  marginTop: theme.spacing(1),
+  borderRadius: "4px",
+  "&::before": {
+    content: "''",
+    position: "absolute",
+    top: "-11px",
+    left: `calc(50% - 1px)`,
+    width: "2px",
+    height: theme.spacing(1),
+    background: "#D0D0D0",
+  },
+}));
+
+export const GetStarted: React.FC = () => (
+  <Root>
+    <SchoolIcon />
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="body1">
+        <strong>New to Plan✕?</strong>
+      </Typography>
+      <Typography variant="body2">
+        Visit the <Link href="../../tutorials">guides and tutorials</Link> to
+        get started.
+      </Typography>
+    </Box>
+  </Root>
+);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/GetStarted.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/GetStarted.tsx
@@ -8,7 +8,7 @@ import { Link } from "react-navi";
 const Root = styled(Box)(({ theme }) => ({
   display: "flex",
   gap: theme.spacing(1),
-  width: "266px",
+  width: "300px",
   padding: theme.spacing(2),
   background: theme.palette.background.paper,
   border: `1px solid ${theme.palette.border.main}`,
@@ -31,7 +31,7 @@ export const GetStarted: React.FC = () => (
     <SchoolIcon />
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <Typography variant="body1">
-        <strong>New to Plan✕?</strong>
+        <strong>Starting a new service?</strong>
       </Typography>
       <Typography variant="body2">
         Visit the <Link href="../../tutorials">guides and tutorials</Link> to

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -5,6 +5,7 @@ import { useStore } from "../../lib/store";
 import EndPoint from "./components/EndPoint";
 import Hanger from "./components/Hanger";
 import Node from "./components/Node";
+import { GetStarted } from "./GetStarted";
 
 export enum FlowLayout {
   TOP_DOWN = "top-down",
@@ -24,10 +25,13 @@ const Flow = ({ breadcrumbs = [] }: any) => {
     href: `${window.location.pathname.split(id)[0]}${id}`,
   }));
 
+  const showGetStarted = !childNodes.length;
+
   return (
     <>
       <ol id="flow" data-layout={flowLayout} className="decisions">
         <EndPoint text="start" />
+        {showGetStarted && <GetStarted />}
 
         {breadcrumbs.map((bc: any) => (
           <Node key={bc.id} {...bc} />

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -119,35 +119,23 @@ const editorRoutes = compose(
     "/resources": route(() => {
       return {
         title: makeTitle("Resources"),
-        view: <NotionEmbed page="resources" title="PlanX Resources" />,
+        view: <NotionEmbed page="resources" title="Resources" />,
       };
     }),
 
-    // "/onboarding": route(() => {
-    //   return {
-    //     title: makeTitle("Onboarding"),
-    //     view: (
-    //       <iframe
-    //         title="notion"
-    //         src="https://www.notioniframe.com/notion/1fjdisq3i73"
-    //         style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
-    //       />
-    //     ),
-    //   };
-    // }),
+    "/onboarding": route(() => {
+      return {
+        title: makeTitle("Onboarding"),
+        view: <NotionEmbed page="onboarding" title="Onboarding" />,
+      };
+    }),
 
-    // "/tutorials": route(() => {
-    //   return {
-    //     title: makeTitle("Tutorials"),
-    //     view: (
-    //       <iframe
-    //         title="notion"
-    //         src="https://www.notioniframe.com/notion/1wf4jidsdbv"
-    //         style={{ width: "100%", height: "100%", border: "0", padding: "0" }}
-    //       />
-    //     ),
-    //   };
-    // }),
+    "/tutorials": route(() => {
+      return {
+        title: makeTitle("Tutorials"),
+        view: <NotionEmbed page="tutorials" title="Tutorials" />,
+      };
+    }),
 
     "/:team": lazy(() => import("./team")),
   }),

--- a/editor.planx.uk/src/ui/editor/NotionEmbed.tsx
+++ b/editor.planx.uk/src/ui/editor/NotionEmbed.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 const NOTION_PAGES = {
   resources: "6b896f88be4c4b4c8ec8474a34c70d7c",
+  onboarding: "2e6ea7226c53440280fbd0aaaa1a0fa3",
+  tutorials: "d0918f124af9414ca765c5336c1cbc5b",
 } as const;
 
 const NotionEmbed: React.FC<{


### PR DESCRIPTION
## What does this PR do?
 - Adds "Tutorials" and "Onboarding" links to sidebar
 - Adds "GetStarted" option to empty flows
 - All based on @ianjon3s's work on https://github.com/theopensystemslab/planx-new/pull/4154/files, and the new Notion iframes from #4279 

Tested and working on staging (AWS Cloudfront) ✅ 

I've scheduled a message to Rish [in this thread](https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1738837581734279) (ODP Slack) for Monday morning asking him to test the staging environment - lets make sure it's just the Notion iframes that are blocked and not the entire site 🤞 

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/e73fecb2-bac8-4a2a-b60e-37e45fecc457" />

---

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/616ddb79-1e40-4b4c-abfd-8854a5ac426a" />
Note: Dark mode is displaying as this is my system preferences. We can configure this in Notion and hardcode to "Light" if we wish to do so.




