### PR TITLE
feat: handle Metabase API <-> PlanX API camelCase to snake_case conversion (v2)

### DIFF
--- a/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/collection.test.ts
@@ -65,19 +65,19 @@ describe("createTeamCollection", () => {
     metabaseMock
       .post("/api/collection/", {
         name: testName,
-        parentId: 100,
+        parent_id: 100,
       })
       .reply(200, {
         id: 123,
         name: testName,
-        parentId: 100,
+        parent_id: 100,
       });
 
     // Mock GET request for verifying the new collection
     metabaseMock.get("/api/collection/123").reply(200, {
       id: 123,
       name: testName,
-      parentId: 100,
+      parent_id: 100,
     });
 
     const collectionId = await createCollection({
@@ -233,6 +233,9 @@ describe("edge cases", () => {
   });
 
   test("handles missing slug", async () => {
+    vi.spyOn($api.client, "request").mockRejectedValue(
+      new Error("Invalid slug"),
+    );
     await expect(
       createTeamCollection({
         slug: "",
@@ -273,6 +276,9 @@ describe("edge cases", () => {
         message: "Slug too long",
       });
 
+    vi.spyOn($api.client, "request").mockRejectedValue(
+      new Error("Slug too long"),
+    );
     await expect(
       createTeamCollection({
         slug: longSlug,

--- a/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/createCollection.ts
@@ -1,9 +1,21 @@
-import type { MetabaseCollectionParams } from "./types.js";
+import type {
+  CreateCollectionParams,
+  MetabaseCreateCollectionParams,
+} from "./types.js";
 import { $metabase } from "../shared/client.js";
 
 export async function createCollection(
-  params: MetabaseCollectionParams,
+  params: CreateCollectionParams,
 ): Promise<number> {
-  const response = await $metabase.post(`/api/collection/`, params);
+  const metabaseCreateCollectionParams: MetabaseCreateCollectionParams = {
+    name: params.name,
+    description: params.description,
+    parent_id: params.parentId,
+  };
+
+  const response = await $metabase.post(
+    `/api/collection/`,
+    metabaseCreateCollectionParams,
+  );
   return response.data.id;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/getCollection.ts
@@ -8,5 +8,13 @@ export async function getCollection(
   id: number,
 ): Promise<GetCollectionResponse> {
   const response = await $metabase.get(`/api/collection/${id}`);
-  return response.data;
+
+  const transformedCollection = {
+    name: response.data.name,
+    id: response.data.id,
+    slug: response.data.slug,
+    parentId: response.data.parent_id,
+  };
+
+  return transformedCollection;
 }

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
 import type { ApiResponse } from "../shared/types.js";
 
-/** Interface for incoming request, in camelCase */
+/** Interface for incoming request */
 export interface NewCollectionParams {
   slug: string;
   description?: string;
@@ -10,9 +10,15 @@ export interface NewCollectionParams {
   parentId?: number;
 }
 
-/** Interface for request after transforming to snake case (Metabase takes snake while PlanX API takes camel) */
-export type MetabaseCollectionParams = Omit<NewCollectionParams, "slug"> & {
+/** We use a name and not slug here so that the eventual dashboard name is in title case */
+export type CreateCollectionParams = Omit<NewCollectionParams, "slug"> & {
   name: string;
+};
+
+export type MetabaseCreateCollectionParams = {
+  name: string;
+  description?: string;
+  parent_id?: number;
 };
 
 /** TODO: when running on production, turn below comment back into code
@@ -42,6 +48,7 @@ export interface NewCollectionResponse {
 }
 
 export interface GetCollectionResponse {
+  name: string;
   id: number;
   slug: string;
   parentId: number;

--- a/api.planx.uk/modules/analytics/metabase/dashboard/copyDashboard.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/copyDashboard.ts
@@ -1,14 +1,21 @@
-import type { CopyDashboardParams, GetDashboardResponse } from "./types.js";
+import type {
+  CopyDashboardParams,
+  GetDashboardResponse,
+  MetabaseCopyDashboardParams,
+} from "./types.js";
 import { $metabase } from "../shared/client.js";
-import { toMetabaseParams } from "./types.js";
 
 export async function copyDashboard(
   params: CopyDashboardParams,
 ): Promise<GetDashboardResponse["id"]> {
-  const metabaseParams = toMetabaseParams(params);
+  const copyDashboardParams: MetabaseCopyDashboardParams = {
+    name: params.name,
+    description: params.description,
+    collection_id: params.collectionId,
+  };
   const response = await $metabase.post(
     `/api/dashboard/${params.templateId}/copy`,
-    metabaseParams,
+    copyDashboardParams,
   );
   return response.data.id;
 }

--- a/api.planx.uk/modules/analytics/metabase/dashboard/dashboard.test.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/dashboard.test.ts
@@ -2,7 +2,6 @@ import nock from "nock";
 import { copyDashboard } from "./copyDashboard.js";
 import { getDashboard } from "./getDashboard.js";
 import { updateFilter } from "./updateFilter.js";
-import { toMetabaseParams } from "./types.js";
 import { generatePublicLink } from "./generatePublicLink.js";
 
 const BASE_URL = process.env.METABASE_URL_EXT;
@@ -38,7 +37,11 @@ describe("Dashboard Operations", () => {
   describe("copyDashboard", () => {
     test("copies dashboard template", async () => {
       const metabaseMock = nock(BASE_URL!)
-        .post("/api/dashboard/7/copy", toMetabaseParams(params))
+        .post("/api/dashboard/7/copy", {
+          name: params.name,
+          description: params.description,
+          collection_id: params.collectionId,
+        })
         .reply(200, {
           id: 42,
           name: params.name,
@@ -51,15 +54,13 @@ describe("Dashboard Operations", () => {
       expect(metabaseMock.isDone()).toBe(true);
     });
 
-    test("transforms params to snake case for Metabase API", async () => {
-      const snakeCaseParams = toMetabaseParams(params);
-      expect(snakeCaseParams).toHaveProperty("collection_id");
-      expect(snakeCaseParams.collection_id).toBe(4);
-    });
-
     test("places new dashboard into correct parent", async () => {
       const metabasePostMock = nock(BASE_URL!)
-        .post("/api/dashboard/7/copy", toMetabaseParams(params))
+        .post("/api/dashboard/7/copy", {
+          name: params.name,
+          description: params.description,
+          collection_id: params.collectionId,
+        })
         .reply(200, {
           id: 42,
           name: params.name,
@@ -78,7 +79,7 @@ describe("Dashboard Operations", () => {
       const newDashboardId = await copyDashboard(params);
       const checkDashboard = await getDashboard(newDashboardId);
 
-      expect(checkDashboard.collection_id).toBe(4);
+      expect(checkDashboard.collectionId).toBe(4);
       expect(metabasePostMock.isDone()).toBe(true);
       expect(metabaseGetMock.isDone()).toBe(true);
     });
@@ -147,10 +148,6 @@ describe("Dashboard Operations", () => {
             },
           ],
         });
-
-      // nock(BASE_URL!).put(`/api/dashboard/${dashboardId}`).reply(400, {
-      //   message: "Invalid parameter type. Expected number, got string.",
-      // });
 
       await expect(
         updateFilter({

--- a/api.planx.uk/modules/analytics/metabase/dashboard/getDashboard.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/getDashboard.ts
@@ -7,7 +7,15 @@ export async function getDashboard(
 ): Promise<GetDashboardResponse> {
   try {
     const response = await $metabase.get(`/api/dashboard/${dashboardId}`);
-    return response.data;
+
+    const transformedDashboard = {
+      id: response.data.id,
+      name: response.data.name,
+      collectionId: response.data.collection_id,
+      parameters: response.data.parameters,
+    };
+
+    return transformedDashboard;
   } catch (error) {
     throw new ServerError({
       message: `Error in getDashboard: ${error}`,

--- a/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/service.ts
@@ -28,8 +28,8 @@ export async function createNewDashboard({
 
     await updateFilter({
       dashboardId: copiedDashboardId,
-      filter: filter,
-      value: value,
+      filter,
+      value,
     });
     const publicLink = await generatePublicLink(copiedDashboardId);
     return publicLink;

--- a/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/types.ts
@@ -29,18 +29,7 @@ export type MetabaseCopyDashboardParams = {
   name: string;
   description?: string;
   collection_id?: number;
-  collection_position?: number | null;
 };
-
-export function toMetabaseParams(
-  params: CopyDashboardParams,
-): MetabaseCopyDashboardParams {
-  return {
-    name: params.name,
-    description: params.description,
-    collection_id: params.collectionId,
-  };
-}
 
 export type UpdateFilterParams = {
   dashboardId: number;
@@ -72,7 +61,8 @@ export type NewDashboardHandler = ValidatedRequestHandler<
 export interface MetabaseDashboardResponse {
   name: string;
   id: number;
-  collection_id: number;
+  collectionId: number;
+  description: string;
   parameters: FilterParam[];
 }
 
@@ -90,10 +80,8 @@ export interface FilterParam {
 
 export type GetDashboardResponse = Pick<
   MetabaseDashboardResponse,
-  "name" | "id" | "collection_id"
+  "name" | "id" | "collectionId" | "parameters"
 >;
-
-export type GetFilterResponse = Pick<MetabaseDashboardResponse, "parameters">;
 
 export interface UpdatedFilterResponse {
   parameter: FilterParam;

--- a/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/updateFilter.ts
@@ -4,8 +4,8 @@ import type {
   UpdateFilterResponse,
   FilterParam,
   UpdatedFilterResponse,
-  GetFilterResponse,
 } from "./types.js";
+import { getDashboard } from "./getDashboard.js";
 
 function populateUpdatedFilterResponse(
   param: FilterParam,
@@ -35,13 +35,11 @@ export async function updateFilter(
   params: UpdateFilterParams,
 ): Promise<UpdateFilterResponse> {
   // Get existing dashboard data
-  const response = await $metabase.get<GetFilterResponse>(
-    `/api/dashboard/${params.dashboardId}`,
-  );
+  const response = await getDashboard(params.dashboardId);
 
   // Update filter default value parameter
   let updatedFilter: string | undefined;
-  const updatedParameters = response.data.parameters.map((param) => {
+  const updatedParameters = response.parameters.map((param) => {
     const result = populateUpdatedFilterResponse(
       param,
       params.filter,
@@ -51,6 +49,7 @@ export async function updateFilter(
     if (result.updatedValue) {
       updatedFilter = result.updatedValue;
     }
+
     return result.parameter;
   });
 


### PR DESCRIPTION
Replaces #4260 because my rebase got way too messy!

# What does this PR do
Requests and responses are handled once at the point of entry / exit. Each function handles any relevant transformations, and Metabase specific types are added too.

# Why
Metabase API uses snake_case, PlanX camel. Carries on from https://github.com/theopensystemslab/planx-new/pull/4157#discussion_r1932074730 in https://github.com/theopensystemslab/planx-new/pull/4157 about how best to handle case conversions.