### PR TITLE
feat: Clear filters and search button

### DIFF
--- a/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -1,10 +1,14 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
 export const ShowingServicesHeader = ({
   matchedFlowsCount,
+  setTriggerClearFiltersAndSearch,
 }: {
   matchedFlowsCount: number;
+  setTriggerClearFiltersAndSearch: (value: boolean) => void;
 }) => {
   const showingServicesMessage =
     matchedFlowsCount !== 1
@@ -12,8 +16,23 @@ export const ShowingServicesHeader = ({
       : `Showing ${matchedFlowsCount} service`;
 
   return (
-    <Typography variant="h3" component="h2">
-      {showingServicesMessage}
-    </Typography>
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "flex-start",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      <Typography variant="h3" component="h2">
+        {showingServicesMessage}
+      </Typography>
+      <Button
+        onClick={() => setTriggerClearFiltersAndSearch(true)}
+        variant="link"
+      >
+        Clear filters
+      </Button>
+    </Box>
   );
 };

--- a/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
@@ -13,17 +12,8 @@ export const ShowingServicesHeader = ({
       : `Showing ${matchedFlowsCount} service`;
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        justifyContent: "flex-start",
-        alignItems: "center",
-        gap: 2,
-      }}
-    >
-      <Typography variant="h3" component="h2">
-        {showingServicesMessage}
-      </Typography>
-    </Box>
+    <Typography variant="h3" component="h2">
+      {showingServicesMessage}
+    </Typography>
   );
 };

--- a/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -1,14 +1,10 @@
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
 export const ShowingServicesHeader = ({
   matchedFlowsCount,
-  setTriggerClearFiltersAndSearch,
 }: {
   matchedFlowsCount: number;
-  setTriggerClearFiltersAndSearch: (value: boolean) => void;
 }) => {
   const showingServicesMessage =
     matchedFlowsCount !== 1
@@ -16,23 +12,8 @@ export const ShowingServicesHeader = ({
       : `Showing ${matchedFlowsCount} service`;
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        justifyContent: "flex-start",
-        alignItems: "center",
-        gap: 2,
-      }}
-    >
-      <Typography variant="h3" component="h2">
-        {showingServicesMessage}
-      </Typography>
-      <Button
-        onClick={() => setTriggerClearFiltersAndSearch(true)}
-        variant="link"
-      >
-        Clear filters
-      </Button>
-    </Box>
+    <Typography variant="h3" component="h2">
+      {showingServicesMessage}
+    </Typography>
   );
 };

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -85,13 +85,16 @@ const Team: React.FC = () => {
   const [matchingFlows, setMatchingflows] = useState<FlowSummary[] | null>(
     null,
   );
-  const [clearTrigger, setClearTrigger] = useState<number>(0);
+  const [shouldClearFilters, setShouldClearFilters] = useState<boolean>(false);
 
   useEffect(() => {
     const diffFlows =
       searchedFlows?.filter((flow) => filteredFlows?.includes(flow)) || null;
     setMatchingflows(diffFlows);
-  }, [searchedFlows, filteredFlows]);
+    if (shouldClearFilters) {
+      setShouldClearFilters(false);
+    }
+  }, [searchedFlows, filteredFlows, shouldClearFilters]);
 
   const sortOptions: SortableFields<FlowSummary>[] = [
     {
@@ -214,7 +217,7 @@ const Team: React.FC = () => {
               records={flows}
               setRecords={setSearchedFlows}
               searchKey={["name", "slug"]}
-              clearSearch={clearTrigger}
+              clearSearch={shouldClearFilters}
             />
           )}
         </Box>
@@ -237,7 +240,7 @@ const Team: React.FC = () => {
                   records={flows}
                   setFilteredRecords={setFilteredFlows}
                   filterOptions={filterOptions}
-                  clearFilters={clearTrigger}
+                  clearFilters={shouldClearFilters}
                 />
               )}
             </Box>
@@ -262,7 +265,7 @@ const Team: React.FC = () => {
                     matchedFlowsCount={matchingFlows?.length || 0}
                   />
                   <Button
-                    onClick={() => setClearTrigger((prevId) => prevId + 1)}
+                    onClick={() => setShouldClearFilters(true)}
                     variant="link"
                   >
                     Clear filters

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -258,24 +258,11 @@ const Team: React.FC = () => {
                 gap: 2,
               }}
             >
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "flex-start",
-                  alignItems: "center",
-                  gap: 2,
-                }}
-              >
-                <Typography variant="h3" component="h2">
-                  Showing X services
-                </Typography>
-                <Button
-                  onClick={() => setTriggerClearFiltersAndSearch(true)}
-                  variant="link"
-                >
-                  Clear filters
-                </Button>
-              </Box>
+              {teamHasFlows && (
+                <ShowingServicesHeader
+                  matchedFlowsCount={matchingFlows?.length || 0}
+                />
+              )}
               {hasFeatureFlag("SORT_FLOWS") && teamHasFlows && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
                   <Typography variant="body2">

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -85,22 +85,13 @@ const Team: React.FC = () => {
   const [matchingFlows, setMatchingflows] = useState<FlowSummary[] | null>(
     null,
   );
-  const [triggerClearFiltersAndSearch, setTriggerClearFiltersAndSearch] =
-    useState<boolean>(false);
+  const [clearTrigger, setClearTrigger] = useState<number>(0);
 
   useEffect(() => {
     const diffFlows =
       searchedFlows?.filter((flow) => filteredFlows?.includes(flow)) || null;
     setMatchingflows(diffFlows);
-    if (diffFlows?.length === flows?.length && triggerClearFiltersAndSearch) {
-      setTriggerClearFiltersAndSearch(false);
-    }
-  }, [
-    searchedFlows,
-    filteredFlows,
-    flows?.length,
-    triggerClearFiltersAndSearch,
-  ]);
+  }, [searchedFlows, filteredFlows]);
 
   const sortOptions: SortableFields<FlowSummary>[] = [
     {
@@ -223,7 +214,7 @@ const Team: React.FC = () => {
               records={flows}
               setRecords={setSearchedFlows}
               searchKey={["name", "slug"]}
-              clearSearch={triggerClearFiltersAndSearch}
+              clearSearch={clearTrigger}
             />
           )}
         </Box>
@@ -246,7 +237,7 @@ const Team: React.FC = () => {
                   records={flows}
                   setFilteredRecords={setFilteredFlows}
                   filterOptions={filterOptions}
-                  clearFilters={triggerClearFiltersAndSearch}
+                  clearFilters={clearTrigger}
                 />
               )}
             </Box>
@@ -271,7 +262,7 @@ const Team: React.FC = () => {
                     matchedFlowsCount={matchingFlows?.length || 0}
                   />
                   <Button
-                    onClick={() => setTriggerClearFiltersAndSearch(true)}
+                    onClick={() => setClearTrigger((prevId) => prevId + 1)}
                     variant="link"
                   >
                     Clear filters

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,6 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -259,24 +258,12 @@ const Team: React.FC = () => {
               }}
             >
               {teamHasFlows && (
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "flex-start",
-                    alignItems: "center",
-                    gap: 2,
-                  }}
-                >
-                  <ShowingServicesHeader
-                    matchedFlowsCount={matchingFlows?.length || 0}
-                  />
-                  <Button
-                    onClick={() => setTriggerClearFiltersAndSearch(true)}
-                    variant="link"
-                  >
-                    Clear filters
-                  </Button>
-                </Box>
+                <ShowingServicesHeader
+                  matchedFlowsCount={matchingFlows?.length || 0}
+                  setTriggerClearFiltersAndSearch={
+                    setTriggerClearFiltersAndSearch
+                  }
+                />
               )}
               {hasFeatureFlag("SORT_FLOWS") && teamHasFlows && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -180,6 +180,7 @@ const Team: React.FC = () => {
 
   const teamHasFlows = !isEmpty(flows) && flows;
   const showAddFlowButton = teamHasFlows && canUserEditTeam(slug);
+  const flowsHaveBeenFiltered = matchingFlows?.length !== flows?.length;
   const showAddTemplateButton =
     showAddFlowButton &&
     templates &&
@@ -264,12 +265,14 @@ const Team: React.FC = () => {
                   <ShowingServicesHeader
                     matchedFlowsCount={matchingFlows?.length || 0}
                   />
-                  <Button
-                    onClick={() => setShouldClearFilters(true)}
-                    variant="link"
-                  >
-                    Clear filters
-                  </Button>
+                  {flowsHaveBeenFiltered && (
+                    <Button
+                      onClick={() => setShouldClearFilters(true)}
+                      variant="link"
+                    >
+                      Clear filters
+                    </Button>
+                  )}
                 </Box>
               )}
               {hasFeatureFlag("SORT_FLOWS") && teamHasFlows && (

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,5 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -258,12 +259,24 @@ const Team: React.FC = () => {
               }}
             >
               {teamHasFlows && (
-                <ShowingServicesHeader
-                  matchedFlowsCount={matchingFlows?.length || 0}
-                  setTriggerClearFiltersAndSearch={
-                    setTriggerClearFiltersAndSearch
-                  }
-                />
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "flex-start",
+                    alignItems: "center",
+                    gap: 2,
+                  }}
+                >
+                  <ShowingServicesHeader
+                    matchedFlowsCount={matchingFlows?.length || 0}
+                  />
+                  <Button
+                    onClick={() => setTriggerClearFiltersAndSearch(true)}
+                    variant="link"
+                  >
+                    Clear filters
+                  </Button>
+                </Box>
               )}
               {hasFeatureFlag("SORT_FLOWS") && teamHasFlows && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -259,9 +259,24 @@ const Team: React.FC = () => {
               }}
             >
               {teamHasFlows && (
-                <ShowingServicesHeader
-                  matchedFlowsCount={matchingFlows?.length || 0}
-                />
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "flex-start",
+                    alignItems: "center",
+                    gap: 2,
+                  }}
+                >
+                  <ShowingServicesHeader
+                    matchedFlowsCount={matchingFlows?.length || 0}
+                  />
+                  <Button
+                    onClick={() => setTriggerClearFiltersAndSearch(true)}
+                    variant="link"
+                  >
+                    Clear filters
+                  </Button>
+                </Box>
               )}
               {hasFeatureFlag("SORT_FLOWS") && teamHasFlows && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,5 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -84,12 +85,22 @@ const Team: React.FC = () => {
   const [matchingFlows, setMatchingflows] = useState<FlowSummary[] | null>(
     null,
   );
+  const [triggerClearFiltersAndSearch, setTriggerClearFiltersAndSearch] =
+    useState<boolean>(false);
 
   useEffect(() => {
     const diffFlows =
       searchedFlows?.filter((flow) => filteredFlows?.includes(flow)) || null;
     setMatchingflows(diffFlows);
-  }, [searchedFlows, filteredFlows]);
+    if (diffFlows?.length === flows?.length && triggerClearFiltersAndSearch) {
+      setTriggerClearFiltersAndSearch(false);
+    }
+  }, [
+    searchedFlows,
+    filteredFlows,
+    flows?.length,
+    triggerClearFiltersAndSearch,
+  ]);
 
   const sortOptions: SortableFields<FlowSummary>[] = [
     {
@@ -212,6 +223,7 @@ const Team: React.FC = () => {
               records={flows}
               setRecords={setSearchedFlows}
               searchKey={["name", "slug"]}
+              clearSearch={triggerClearFiltersAndSearch}
             />
           )}
         </Box>
@@ -234,6 +246,7 @@ const Team: React.FC = () => {
                   records={flows}
                   setFilteredRecords={setFilteredFlows}
                   filterOptions={filterOptions}
+                  clearFilters={triggerClearFiltersAndSearch}
                 />
               )}
             </Box>
@@ -245,11 +258,24 @@ const Team: React.FC = () => {
                 gap: 2,
               }}
             >
-              {teamHasFlows && (
-                <ShowingServicesHeader
-                  matchedFlowsCount={matchingFlows?.length || 0}
-                />
-              )}
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "flex-start",
+                  alignItems: "center",
+                  gap: 2,
+                }}
+              >
+                <Typography variant="h3" component="h2">
+                  Showing X services
+                </Typography>
+                <Button
+                  onClick={() => setTriggerClearFiltersAndSearch(true)}
+                  variant="link"
+                >
+                  Clear filters
+                </Button>
+              </Box>
               {hasFeatureFlag("SORT_FLOWS") && teamHasFlows && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
                   <Typography variant="body2">

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -44,8 +44,7 @@ interface FiltersProps<T> {
   setFilteredRecords: React.Dispatch<React.SetStateAction<T[] | null>>;
   /** An array of objects to define how to filter the records - the FilterOptions type has more information */
   filterOptions: FilterOptions<T>[];
-  /** Optional prop for clearing filters from a parent component */
-  clearFilters?: number;
+  clearFilters?: boolean;
 }
 
 /**
@@ -62,7 +61,7 @@ export const Filters = <T extends object>({
   records,
   setFilteredRecords,
   filterOptions,
-  clearFilters,
+  clearFilters = false,
 }: FiltersProps<T>) => {
   const [expanded, setExpanded] = useState<boolean>(false);
   const [optionsToFilter] = useState(filterOptions);

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -44,6 +44,8 @@ interface FiltersProps<T> {
   setFilteredRecords: React.Dispatch<React.SetStateAction<T[] | null>>;
   /** An array of objects to define how to filter the records - the FilterOptions type has more information */
   filterOptions: FilterOptions<T>[];
+  /** Optional prop for clearing filters from a parent component */
+  clearFilters: boolean;
 }
 
 /**
@@ -60,6 +62,7 @@ export const Filters = <T extends object>({
   records,
   setFilteredRecords,
   filterOptions,
+  clearFilters = false,
 }: FiltersProps<T>) => {
   const [expanded, setExpanded] = useState<boolean>(false);
   const [optionsToFilter] = useState(filterOptions);
@@ -67,7 +70,7 @@ export const Filters = <T extends object>({
   const navigation = useNavigation();
   const route = useCurrentRoute();
 
-  const { values, setFieldValue, handleSubmit } = useFormik<{
+  const { values, setFieldValue, submitForm, resetForm } = useFormik<{
     filters: Filters<T> | null;
   }>({
     initialValues: { filters: null },
@@ -143,9 +146,16 @@ export const Filters = <T extends object>({
 
   useEffect(() => {
     if (values.filters) {
-      handleSubmit();
+      submitForm();
     }
-  }, [handleSubmit, values.filters]);
+  }, [submitForm, values.filters]);
+
+  useEffect(() => {
+    if (clearFilters) {
+      resetForm();
+      submitForm();
+    }
+  }, [clearFilters, resetForm, submitForm]);
 
   const handleChange = (filterKey: FilterKey<T>, filterValue: FilterValues) => {
     const newObject = {

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -45,7 +45,7 @@ interface FiltersProps<T> {
   /** An array of objects to define how to filter the records - the FilterOptions type has more information */
   filterOptions: FilterOptions<T>[];
   /** Optional prop for clearing filters from a parent component */
-  clearFilters: boolean;
+  clearFilters?: number;
 }
 
 /**
@@ -62,7 +62,7 @@ export const Filters = <T extends object>({
   records,
   setFilteredRecords,
   filterOptions,
-  clearFilters = false,
+  clearFilters,
 }: FiltersProps<T>) => {
   const [expanded, setExpanded] = useState<boolean>(false);
   const [optionsToFilter] = useState(filterOptions);

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -18,14 +18,14 @@ interface SearchBoxProps<T> {
   records: T[] | null;
   setRecords: React.Dispatch<React.SetStateAction<T[] | null>>;
   searchKey: FuseOptionKey<T>[];
-  clearSearch?: number;
+  clearSearch?: boolean;
 }
 
 export const SearchBox = <T extends object>({
   records,
   setRecords,
   searchKey,
-  clearSearch,
+  clearSearch = false,
 }: SearchBoxProps<T>) => {
   const [isSearching, setIsSearching] = useState(false);
   const [searchedTerm, setSearchedTerm] = useState<string>();

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -35,6 +35,7 @@ export const SearchBox = <T extends object>({
   const { submitForm, setFieldValue, values, resetForm } = useFormik({
     initialValues: { pattern: "" },
     onSubmit: ({ pattern }) => {
+      if (clearSearch) return setRecords(records);
       setIsSearching(true);
       debouncedSearch(pattern);
     },
@@ -68,10 +69,9 @@ export const SearchBox = <T extends object>({
   useEffect(() => {
     if (clearSearch) {
       resetForm();
-      setRecords(records);
       submitForm();
     }
-  }, [clearSearch, resetForm, setRecords, records, submitForm]);
+  }, [clearSearch, resetForm, submitForm]);
 
   return (
     <Box maxWidth={360}>

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -18,21 +18,26 @@ interface SearchBoxProps<T> {
   records: T[] | null;
   setRecords: React.Dispatch<React.SetStateAction<T[] | null>>;
   searchKey: FuseOptionKey<T>[];
+  clearSearch: boolean;
 }
 
 export const SearchBox = <T extends object>({
   records,
   setRecords,
   searchKey,
+  clearSearch = false,
 }: SearchBoxProps<T>) => {
   const [isSearching, setIsSearching] = useState(false);
   const [searchedTerm, setSearchedTerm] = useState<string>();
 
   const searchKeys = useMemo(() => searchKey, []);
 
-  const formik = useFormik({
+  const { submitForm, setFieldValue, values, resetForm } = useFormik({
     initialValues: { pattern: "" },
     onSubmit: ({ pattern }) => {
+      if (clearSearch === true) {
+        setRecords(records);
+      }
       setIsSearching(true);
       debouncedSearch(pattern);
     },
@@ -63,6 +68,13 @@ export const SearchBox = <T extends object>({
     }
   }, [results, setRecords, searchedTerm, records]);
 
+  useEffect(() => {
+    if (clearSearch) {
+      resetForm();
+      submitForm();
+    }
+  }, [clearSearch, resetForm, submitForm]);
+
   return (
     <Box maxWidth={360}>
       <InputRow>
@@ -77,18 +89,18 @@ export const SearchBox = <T extends object>({
               }}
               name="search"
               id="search"
-              value={formik.values.pattern}
+              value={values.pattern}
               onChange={(e) => {
-                formik.setFieldValue("pattern", e.target.value);
-                formik.submitForm();
+                setFieldValue("pattern", e.target.value);
+                submitForm();
               }}
             />
             {searchedTerm && !isSearching && (
               <IconButton
                 aria-label="clear search"
                 onClick={() => {
-                  formik.setFieldValue("pattern", "");
-                  formik.submitForm();
+                  setFieldValue("pattern", "");
+                  submitForm();
                 }}
                 size="small"
                 sx={{
@@ -107,8 +119,8 @@ export const SearchBox = <T extends object>({
               <IconButton
                 aria-label="clear search"
                 onClick={() => {
-                  formik.setFieldValue("pattern", "");
-                  formik.submitForm();
+                  setFieldValue("pattern", "");
+                  submitForm();
                 }}
                 size="small"
                 sx={{

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -18,14 +18,14 @@ interface SearchBoxProps<T> {
   records: T[] | null;
   setRecords: React.Dispatch<React.SetStateAction<T[] | null>>;
   searchKey: FuseOptionKey<T>[];
-  clearSearch: boolean;
+  clearSearch?: number;
 }
 
 export const SearchBox = <T extends object>({
   records,
   setRecords,
   searchKey,
-  clearSearch = false,
+  clearSearch,
 }: SearchBoxProps<T>) => {
   const [isSearching, setIsSearching] = useState(false);
   const [searchedTerm, setSearchedTerm] = useState<string>();
@@ -35,9 +35,6 @@ export const SearchBox = <T extends object>({
   const { submitForm, setFieldValue, values, resetForm } = useFormik({
     initialValues: { pattern: "" },
     onSubmit: ({ pattern }) => {
-      if (clearSearch === true) {
-        setRecords(records);
-      }
       setIsSearching(true);
       debouncedSearch(pattern);
     },
@@ -71,9 +68,10 @@ export const SearchBox = <T extends object>({
   useEffect(() => {
     if (clearSearch) {
       resetForm();
+      setRecords(records);
       submitForm();
     }
-  }, [clearSearch, resetForm, submitForm]);
+  }, [clearSearch, resetForm, setRecords, records, submitForm]);
 
   return (
     <Box maxWidth={360}>


### PR DESCRIPTION
The final major feature for Filters and Search for the Team page is a clear all button, which clears search term and any collected filters resetting the results back to normal.

The feature should allow a user to filter the list, add a search term and in one click, clear both to reset the list. It should also work independently (if the list is only filtered, or if it is only searched).

This meets feature parity with our demo branch: https://github.com/theopensystemslab/planx-new/pull/4120

>[!IMPORTANT] 
> To test the pizza you need to toggle the feature flag "SORT_FLOWS"