### PR TITLE
fix: get name based on user role in `applicant_research_opt_in_view`

### DIFF
--- a/hasura.planx.uk/migrations/1739222061613_update_view_applicant_research_opt_in/down.sql
+++ b/hasura.planx.uk/migrations/1739222061613_update_view_applicant_research_opt_in/down.sql
@@ -1,0 +1,21 @@
+DROP VIEW IF EXISTS "public"."applicant_research_opt_in_view";
+CREATE OR REPLACE VIEW "public"."applicant_research_opt_in_view" AS
+WITH data AS (
+    SELECT
+        ls.id,
+        ls.email,
+        ls.created_at AS application_started_at,
+        ls.submitted_at,
+        ls.data->'passport'->'data'->>'applicant.name.last' as last_name,
+        ls.data->'passport'->'data'->>'applicant.name.first' as first_name,
+        f.name AS flow_name,
+        t.name AS team_name
+    FROM lowcal_sessions ls
+    JOIN flows f ON ls.flow_id = f.id
+    JOIN teams t ON t.id = f.team_id
+    WHERE ls.data->'passport'->'data'->>'applicant.researchOptIn' = '["true"]'
+)
+SELECT *
+FROM data
+WHERE last_name IS NOT NULL
+    AND first_name IS NOT NULL;

--- a/hasura.planx.uk/migrations/1739222061613_update_view_applicant_research_opt_in/up.sql
+++ b/hasura.planx.uk/migrations/1739222061613_update_view_applicant_research_opt_in/up.sql
@@ -1,0 +1,34 @@
+DROP VIEW IF EXISTS "public"."applicant_research_opt_in_view";
+CREATE OR REPLACE VIEW "public"."applicant_research_opt_in_view" AS 
+WITH data AS (
+    SELECT 
+        ls.id as planx_reference_number, 
+        ls.email, 
+        ls.created_at AS application_started_at, 
+        ls.submitted_at,
+        COALESCE(
+            ls.data->'passport'->'data'->'_address'->>'single_line_address',
+            ls.data->'passport'->'data'->'_address'->>'title'
+        ) as site_address,
+        ls.data->'passport'->'data'->'user.role'->>0 AS user_role,
+        CASE
+            WHEN ls.data->'passport'->'data'->'user.role'->>0 IN ('agent','proxy')
+            THEN ls.data->'passport'->'data'->>'applicant.agent.name.last'
+            ELSE ls.data->'passport'->'data'->>'applicant.name.last'
+        END AS last_name,
+        CASE
+            WHEN ls.data->'passport'->'data'->'user.role'->>0 IN ('agent','proxy')
+            THEN ls.data->'passport'->'data'->>'applicant.agent.name.first' 
+            ELSE ls.data->'passport'->'data'->>'applicant.name.first'
+        END AS first_name,
+        f.name AS flow_name, 
+        t.name AS team_name 
+    FROM lowcal_sessions ls 
+    JOIN flows f ON ls.flow_id = f.id 
+    JOIN teams t ON t.id = f.team_id 
+    WHERE ls.data->'passport'->'data'->>'applicant.researchOptIn' = '["true"]'
+)
+SELECT * 
+FROM data 
+WHERE last_name IS NOT NULL 
+    AND first_name IS NOT NULL;


### PR DESCRIPTION
See request here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1739179324695849

**Key changes:**
- Renames `id` to `planx_application_reference`
- Adds `site_address`
- Adds `user_role`
- Updates `first_name` and `last_name` to reference correct variables based on `user_role`