### PR TITLE
fix: remove transparent background to Checkbox component

### DIFF
--- a/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-  import Box, { BoxProps } from "@mui/material/Box";
+import Box, { BoxProps } from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import React from "react";
 import { borderedFocusStyle } from "theme";
@@ -18,7 +18,7 @@ const Root = styled(Box, {
     backgroundColor: theme.palette.common.white,
     "&:focus-within": {
       ...borderedFocusStyle,
-      background: "inherit",
+      background: theme.palette.common.white,
     },
     ...(disabled && {
       border: `2px solid ${theme.palette.grey[400]}`,


### PR DESCRIPTION
Recurring issue in the Filters work here: https://github.com/theopensystemslab/planx-new/pull/4189


Initial fix was to set the `background:"inherit"` but it didn't seem to solve the issue, maybe due to an issue on what it was inheriting.

Found the simplest solution was to set it to the colour of it's non-focused style. I also tried `unset` and other attributes, but nothing worked as well.

