### PR TITLE
fix: Clickable width and alignment of checkboxes

### DIFF
--- a/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
@@ -9,6 +9,7 @@ const Root = styled(Box, {
 })<BoxProps & { disabled?: boolean; variant?: "default" | "compact" }>(
   ({ theme, disabled, variant }) => ({
     display: "inline-flex",
+    alignSelf: "flex-start",
     flexShrink: 0,
     position: "relative",
     width: 40,
@@ -25,6 +26,7 @@ const Root = styled(Box, {
       backgroundColor: theme.palette.grey[400],
     }),
     ...(variant === "compact" && {
+      alignSelf: "center",
       width: 24,
       height: 24,
     }),

--- a/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -6,7 +6,8 @@ import * as React from "react";
 import Checkbox from "../Checkbox/Checkbox";
 
 const Root = styled(Box)(({ theme }) => ({
-  width: "100%",
+  width: "auto",
+  justifySelf: "flex-start",
   marginTop: theme.spacing(1),
   marginBottom: theme.spacing(1),
   display: "flex",


### PR DESCRIPTION
## What does this PR do?

Fixes a global (public & editor) issue where the clickable width of checkboxes extends beyond the text label.

Also addresses vertical alignment so that the first line of text is always aligned with the centre of the checkbox (rather than the whole text block).

Making both of these changes brings us inline with the GOV.UK checkbox style:
https://design-system.service.gov.uk/components/checkboxes/

Preview:
https://4300.planx.pizza/testing/checkboxes-variable-width/published?analytics=false