### PR TITLE
style: Form max-width for fee breakdown table

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -13,7 +13,8 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { formattedPriceWithCurrencySymbol } from "../../model";
 import { useFeeBreakdown } from "./useFeeBreakdown";
 
-const StyledTable = styled(Table)(() => ({
+const StyledTable = styled(Table)(({ theme }) => ({
+  maxWidth: theme.breakpoints.values.formWrap,
   [`& .${tableCellClasses.root}`]: {
     paddingLeft: 0,
     paddingRight: 0,


### PR DESCRIPTION
## What does this PR do?

Quick one: introduces `formWrap` max-width to the fee breakdown table to improve readibility.

Before change:
<img width="994" alt="image" src="https://github.com/user-attachments/assets/8ada3b23-d7f6-4732-9211-6a4214d819ee" />

After change:
<img width="994" alt="image" src="https://github.com/user-attachments/assets/65ddaedf-31b2-43df-ad6f-a38ed6951670" />

Preview (Storybook):
https://storybook.4302.planx.pizza/?path=/docs/planx-components-pay-feebreakdown--docs