### PR TITLE
refactor: Readme page external portal switch to expand

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
 import { TextInputType } from "@planx/components/TextInput/model";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
@@ -17,7 +18,6 @@ import SettingsSection from "ui/editor/SettingsSection";
 import { CharacterCounter } from "ui/shared/CharacterCounter";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
-import { Switch } from "ui/shared/Switch";
 import { object, string } from "yup";
 
 import { ExternalPortals } from "../components/Sidebar/Search/ExternalPortalList/ExternalPortals";
@@ -237,25 +237,27 @@ export const ReadMePage: React.FC<ReadMePageProps> = ({
         </form>
       </SettingsSection>
       <Box pt={2}>
-        <Switch
-          label={"Show external portals"}
-          name={"service.status"}
-          variant="editorPage"
-          checked={showExternalPortals}
-          onChange={() => setShowExternalPortals(!showExternalPortals)}
-        />
-        {showExternalPortals &&
-          (hasExternalPortals ? (
-            <Box pt={2} data-testid="searchExternalPortalList">
-              <InputLegend>External Portals</InputLegend>
-              <Typography variant="body1" my={2}>
-                Your service contains the following external portals:
-              </Typography>
-              <ExternalPortals externalPortals={externalPortals} />
-            </Box>
-          ) : (
-            <Typography>This service has no external portals.</Typography>
-          ))}
+        <SimpleExpand
+          buttonText={{
+            open: "Show external portals",
+            closed: "Hide external portals",
+          }}
+          id="externalPortalsToggle"
+        >
+          <Box py={2}>
+            {hasExternalPortals ? (
+              <Box data-testid="searchExternalPortalList">
+                <InputLegend>External Portals</InputLegend>
+                <Typography variant="body1" my={2}>
+                  Your service contains the following external portals:
+                </Typography>
+                <ExternalPortals externalPortals={externalPortals} />
+              </Box>
+            ) : (
+              <Typography>This service has no external portals.</Typography>
+            )}
+          </Box>
+        </SimpleExpand>
       </Box>
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.tsx
@@ -7,7 +7,7 @@ import { TextInputType } from "@planx/components/TextInput/model";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
 import capitalize from "lodash/capitalize";
-import React, { useState } from "react";
+import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
 import InputGroup from "ui/editor/InputGroup";
@@ -53,8 +53,6 @@ export const ReadMePage: React.FC<ReadMePageProps> = ({
   const toast = useToast();
 
   const hasExternalPortals = Boolean(Object.keys(externalPortals).length);
-
-  const [showExternalPortals, setShowExternalPortals] = useState(false);
 
   const formik = useFormik<ReadMePageForm>({
     initialValues: {


### PR DESCRIPTION
## What does this PR?

Updates readme page show/hide external portals from using a `<Switch>` to use `<SimpleExpand>`.

Rationale:
We use the switch component as an in-form input to toggle functionality or settings, this is occasionally tied in with an interface change (for example when using expandable checklists). For interface only (show/hide) functions we use `<SimpleExpand>` or the accordion component.

Something I'm not sure about (cc @jamdelion ) — is the switch/toggle a performance consideration (only fetch portal list on "show"), which I'm overriding with this change, or is it a purely visual thing?

Preview:
https://4303.planx.pizza/barnet/apply-for-prior-approval/about