### PR TITLE
feat: Hook up flow summary to card

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -153,6 +153,7 @@ export interface FlowSummary {
   slug: string;
   status: FlowStatus;
   updatedAt: string;
+  summary: string;
   operations: FlowSummaryOperations[];
   publishedFlows: PublishedFlowSummary[];
 }
@@ -370,6 +371,7 @@ export const editorStore: StateCreator<
             name
             slug
             status
+            summary
             updatedAt: updated_at
             operations(limit: 1, order_by: { created_at: desc }) {
               createdAt: created_at

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -39,7 +39,7 @@ export const CardContent = styled(Box)(({ theme }) => ({
   height: "100%",
   textDecoration: "none",
   color: "currentColor",
-  padding: theme.spacing(2),
+  padding: theme.spacing(2, 2, 1),
   display: "flex",
   flexDirection: "column",
   alignItems: "flex-start",
@@ -219,6 +219,16 @@ const FlowCard: React.FC<FlowCardProps> = ({
                 ),
             )}
           </Box>
+          {flow.summary && (
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              sx={{ "& > a": { position: "relative", zIndex: 2 } }}
+            >
+              {`${flow.summary.split(" ").slice(0, 12).join(" ")}... `}
+              <Link href={`./${flow.slug}/about`}>read more</Link>
+            </Typography>
+          )}
           <DashboardLink
             aria-label={flow.name}
             href={`./${flow.slug}`}


### PR DESCRIPTION
## What does this PR do?

Outputs flow summary on the corresponding `flowCard`.