### PR TITLE
feat: Dedicated styles for locked editor graph and modal

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -62,7 +62,7 @@ test.describe("Flow creation, publish and preview", () => {
   });
 
   test("Create a flow", async ({ browser }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(70_000);
 
     const page = await getTeamPage({
       browser,
@@ -108,7 +108,7 @@ test.describe("Flow creation, publish and preview", () => {
   test("Publish and preview flow with geospatial components", async ({
     browser,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(70_000);
 
     const page = await createAuthenticatedSession({
       browser,

--- a/e2e/tests/ui-driven/src/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow.spec.ts
@@ -58,7 +58,7 @@ test.describe("Flow creation, publish and preview", () => {
   });
 
   test("Create a flow", async ({ browser }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(70_000);
 
     const page = await getTeamPage({
       browser,

--- a/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
@@ -43,6 +43,7 @@ export default function AddressInputComponent(props: Props): FCReturn {
               value={formik.values.title}
               placeholder="Title"
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -51,16 +52,18 @@ export default function AddressInputComponent(props: Props): FCReturn {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             required
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -125,6 +125,7 @@ export default function Component(props: Props) {
               name="title"
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
@@ -133,18 +134,20 @@ export default function Component(props: Props) {
             required
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
           <InputRow>
-            <Switch
-              checked={formik.values.formatOutputForAutomations}
-              onChange={() =>
-                formik.setFieldValue(
-                  "formatOutputForAutomations",
-                  !formik.values.formatOutputForAutomations,
-                )
-              }
-              label="Format the output to automate a future Question or Checklist only"
-            />
+          <Switch            
+            checked={formik.values.formatOutputForAutomations}
+            onChange={() =>
+              formik.setFieldValue(
+                "formatOutputForAutomations",
+                !formik.values.formatOutputForAutomations
+              )
+            }
+            label="Format the output to automate a future Question or Checklist only"
+            disabled={props.disabled}
+          />
           </InputRow>
         </ModalSectionContent>
         <ModalSectionContent title="Formula">
@@ -156,6 +159,7 @@ export default function Component(props: Props) {
               value={formik.values.formula}
               onChange={formik.handleChange}
               errorMessage={formik.errors.formula}
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
@@ -172,6 +176,7 @@ export default function Component(props: Props) {
                     onChange={formik.handleChange}
                     placeholder={"insert default value"}
                     required
+                    disabled={props.disabled}
                   />
                 </InputRow>
               </InputGroup>
@@ -191,6 +196,7 @@ export default function Component(props: Props) {
                     value={formik.values.samples[variable]}
                     onChange={formik.handleChange}
                     placeholder="empty"
+                    disabled={props.disabled}
                   />
                 </InputRow>
               ))}
@@ -205,7 +211,7 @@ export default function Component(props: Props) {
           </p>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
@@ -58,14 +58,14 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
               ...values,
               ...(groupedOptions
                 ? {
-                  categories: groupedOptions.map((group) => ({
-                    title: group.title,
-                    count: group.children.length,
-                  })),
-                }
+                    categories: groupedOptions.map((group) => ({
+                      title: group.title,
+                      count: group.children.length,
+                    })),
+                  }
                 : {
-                  categories: undefined,
-                }),
+                    categories: undefined,
+                  }),
             },
           },
           processedOptions,
@@ -88,8 +88,7 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
           'Cannot configure exclusive "or" option alongside "all required" setting';
       }
       if (values.fn && !options?.some((option) => option.data.val)) {
-        errors.fn =
-          "At least one option must also set a data field";
+        errors.fn = "At least one option must also set a data field";
       }
       if (exclusiveOptions && exclusiveOptions.length > 1) {
         errors.options =
@@ -123,12 +122,14 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
                 onChange={formik.handleChange}
                 inputRef={focusRef}
                 required
+                disabled={props.disabled}
               />
               <ImgInput
                 img={formik.values.img}
                 onChange={(newUrl) => {
                   formik.setFieldValue("img", newUrl);
                 }}
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -137,12 +138,14 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
                 value={formik.values.description}
                 placeholder="Description"
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
             <ErrorWrapper error={formik.errors.fn}>
               <DataFieldAutocomplete
                 value={formik.values.fn}
                 onChange={(value) => formik.setFieldValue("fn", value)}
+                disabled={props.disabled}
               />
             </ErrorWrapper>
             <InputRow>
@@ -158,6 +161,7 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
                   })
                 }
                 label="Expandable"
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -170,9 +174,9 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
                   )
                 }
                 label="All required"
+                disabled={props.disabled}
               />
             </InputRow>
-
             <InputRow>
               <Switch
                 checked={formik.values.neverAutoAnswer}
@@ -183,15 +187,16 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
                   )
                 }
                 label="Always put to user (forgo automation)"
+                disabled={props.disabled}
               />
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
         <ErrorWrapper error={formik.errors.options}>
-          <Options formik={formik} />
+          <Options formik={formik} disabled={props.disabled} />
         </ErrorWrapper>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Options.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Options.tsx
@@ -11,7 +11,10 @@ import { ExclusiveOrOptionManager } from "./components/ExclusiveOrOptionManager"
 import { GroupedOptions } from "./components/GroupedOptions";
 import ChecklistOptionsEditor from "./components/OptionsEditor";
 
-export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
+export const Options: React.FC<{
+  formik: FormikHookReturn;
+  disabled?: boolean;
+}> = ({ formik, disabled }) => {
   const [exclusiveOptions, nonExclusiveOptions]: Option[][] = partition(
     formik.values.options,
     (option) => option.data.exclusive,
@@ -24,7 +27,7 @@ export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
   return (
     <ModalSectionContent subtitle="Options">
       {formik.values.groupedOptions ? (
-        <GroupedOptions formik={formik} />
+        <GroupedOptions formik={formik} disabled={disabled} />
       ) : (
         <>
           <ListManager
@@ -37,6 +40,7 @@ export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
 
               formik.setFieldValue("options", newCombinedOptions);
             }}
+            disabled={disabled}
             newValueLabel="add new option"
             newValue={() => ({
               id: "",
@@ -62,6 +66,7 @@ export const Options: React.FC<{ formik: FormikHookReturn }> = ({ formik }) => {
               formik={formik}
               exclusiveOptions={exclusiveOptions}
               nonExclusiveOptions={nonExclusiveOptions}
+              disabled={disabled}
             />
           ) : (
             <></>

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/ExclusiveOrOptionManager.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/ExclusiveOrOptionManager.tsx
@@ -16,6 +16,7 @@ interface Props {
   nonExclusiveOptions: Option[] | Array<Group<Option>>;
   groupIndex?: number;
   grouped?: true;
+  disabled?: boolean;
 }
 
 export const ExclusiveOrOptionManager = ({
@@ -24,6 +25,7 @@ export const ExclusiveOrOptionManager = ({
   nonExclusiveOptions,
   groupIndex,
   grouped,
+  disabled,
 }: Props) => {
   const { schema, currentOptionVals } = useCurrentOptions(formik);
 
@@ -74,6 +76,7 @@ export const ExclusiveOrOptionManager = ({
               }) satisfies Option
             }
             Editor={BaseOptionsEditor}
+            disabled={disabled}
             editorExtraProps={{
               showValueField: !!formik.values.fn,
               groupIndex,

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -148,6 +148,7 @@ export const GroupedOptions = ({ formik, disabled }: Props) => {
           grouped
           exclusiveOptions={exclusiveOptions[0]?.children}
           nonExclusiveOptions={nonExclusiveOptionGroups}
+          disabled={disabled}
         />
       ) : (
         <></>

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -21,9 +21,10 @@ import ChecklistOptionsEditor from "./OptionsEditor";
 
 interface Props {
   formik: FormikHookReturn;
+  disabled?: boolean;
 }
 
-export const GroupedOptions = ({ formik }: Props) => {
+export const GroupedOptions = ({ formik, disabled }: Props) => {
   const { schema, currentOptionVals } = useCurrentOptions(formik);
 
   const [exclusiveOptions, nonExclusiveOptionGroups] = partitionGroupedOptions(
@@ -47,6 +48,7 @@ export const GroupedOptions = ({ formik }: Props) => {
                   value={groupedOption.title}
                   placeholder="Section Title"
                   onChange={formik.handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
               <Box flex={0}>

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -62,6 +62,7 @@ export const GroupedOptions = ({ formik, disabled }: Props) => {
                     );
                   }}
                   size="large"
+                  disabled={disabled}
                 >
                   <Delete />
                 </IconButton>

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -76,6 +76,7 @@ export const GroupedOptions = ({ formik, disabled }: Props) => {
                     newOptions,
                   );
                 }}
+                disabled={disabled}
                 newValue={() => ({
                   id: "",
                   data: {
@@ -126,6 +127,7 @@ export const GroupedOptions = ({ formik, disabled }: Props) => {
       <Box mt={1}>
         <Button
           size="large"
+          disabled={disabled}
           onClick={() => {
             formik.setFieldValue(`groupedOptions`, [
               ...nonExclusiveOptionGroups,

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/OptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/OptionsEditor.tsx
@@ -2,7 +2,6 @@ import {
   BaseOptionsEditor,
   BaseOptionsEditorProps,
 } from "@planx/components/shared/BaseOptionsEditor";
-import { props } from "ramda";
 import React from "react";
 import SimpleMenu from "ui/editor/SimpleMenu";
 

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/OptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/OptionsEditor.tsx
@@ -2,6 +2,7 @@ import {
   BaseOptionsEditor,
   BaseOptionsEditorProps,
 } from "@planx/components/shared/BaseOptionsEditor";
+import { props } from "ramda";
 import React from "react";
 import SimpleMenu from "ui/editor/SimpleMenu";
 
@@ -11,6 +12,7 @@ export type ChecklistOptionsEditorProps = BaseOptionsEditorProps & {
   groups?: Array<string>;
   onMoveToGroup?: (itemIndex: number, groupIndex: number) => void;
   showValueField?: boolean;
+  disabled?: boolean;
 };
 
 const ChecklistOptionsEditor: React.FC<ChecklistOptionsEditorProps> = ({
@@ -21,6 +23,7 @@ const ChecklistOptionsEditor: React.FC<ChecklistOptionsEditorProps> = ({
   groups,
   onMoveToGroup,
   index,
+  disabled,
 }) => {
   return (
     <BaseOptionsEditor
@@ -28,6 +31,7 @@ const ChecklistOptionsEditor: React.FC<ChecklistOptionsEditorProps> = ({
       schema={schema}
       onChange={onChange}
       showValueField={showValueField}
+      disabled={disabled}
     >
       {typeof index !== "undefined" && groups && onMoveToGroup && (
         <SimpleMenu

--- a/editor.planx.uk/src/@planx/components/Checklist/types.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/types.ts
@@ -16,6 +16,7 @@ export interface ChecklistProps extends Checklist {
       text: string;
     } & BaseNodeData;
   };
+  disabled?: boolean;
 }
 
 export type PublicChecklistProps = PublicProps<Checklist>;

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -32,6 +32,7 @@ function NextStepEditor(props: ListManagerEditorProps<Step>) {
             });
           }}
           placeholder="Title"
+          disabled={props.disabled}
         />
       </InputRow>
       <InputRow>
@@ -46,6 +47,7 @@ function NextStepEditor(props: ListManagerEditorProps<Step>) {
             });
           }}
           placeholder="Description"
+          disabled={props.disabled}
         />
       </InputRow>
     </Box>
@@ -96,6 +98,7 @@ export default function ConfirmationEditor(props: Props) {
               name="heading"
               value={formik.values.heading}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -104,6 +107,7 @@ export default function ConfirmationEditor(props: Props) {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
@@ -118,6 +122,7 @@ export default function ConfirmationEditor(props: Props) {
             }}
             Editor={NextStepEditor}
             newValue={() => ({ title: "", description: "" })}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
@@ -131,6 +136,7 @@ export default function ConfirmationEditor(props: Props) {
             value={formik.values.moreInfo}
             name="moreInfo"
             onChange={formik.handleChange}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
@@ -141,6 +147,7 @@ export default function ConfirmationEditor(props: Props) {
             value={formik.values.contactInfo}
             name="contactInfo"
             onChange={formik.handleChange}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
@@ -43,6 +43,7 @@ export default function ContactInputComponent(props: Props): FCReturn {
               value={formik.values.title}
               placeholder="Title"
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -51,16 +52,18 @@ export default function ContactInputComponent(props: Props): FCReturn {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             required
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Content/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Editor.tsx
@@ -35,6 +35,7 @@ const ContentComponent: React.FC<Props> = (props) => {
               name="content"
               value={formik.values.content}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <ColorPicker
@@ -44,10 +45,11 @@ const ContentComponent: React.FC<Props> = (props) => {
             onChange={(color) => {
               formik.setFieldValue("color", color);
             }}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -48,6 +48,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
               value={formik.values.title}
               placeholder="Title"
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -56,11 +57,13 @@ const DateInputComponent: React.FC<Props> = (props) => {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
           <Box mt={2}>
             <InputRow>
@@ -72,6 +75,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
                 onChange={(newDate: string, eventType: string) => {
                   formik.setFieldValue("min", paddedDate(newDate, eventType));
                 }}
+                disabled={props.disabled}
               />
             </InputRow>
           </Box>
@@ -85,12 +89,13 @@ const DateInputComponent: React.FC<Props> = (props) => {
                 onChange={(newDate: string, eventType: string) => {
                   formik.setFieldValue("max", paddedDate(newDate, eventType));
                 }}
+                disabled={props.disabled}
               />
             </InputRow>
           </Box>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
@@ -43,6 +43,7 @@ function DrawBoundaryComponent(props: Props) {
               name="title"
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -51,6 +52,7 @@ function DrawBoundaryComponent(props: Props) {
               placeholder="Description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputGroup label="Data field">
@@ -75,6 +77,7 @@ function DrawBoundaryComponent(props: Props) {
               name="titleForUploading"
               value={formik.values.titleForUploading}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -83,6 +86,7 @@ function DrawBoundaryComponent(props: Props) {
               placeholder="Description"
               value={formik.values.descriptionForUploading}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -95,11 +99,12 @@ function DrawBoundaryComponent(props: Props) {
                 )
               }
               label="Hide file upload and allow user to continue without data"
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -52,7 +52,8 @@ const ExternalPortalForm: React.FC<{
   handleSubmit?: (val: any) => void;
   flows?: Array<Flow>;
   tags?: NodeTag[];
-}> = ({ handleSubmit, flowId, flows = [], tags = [], notes = "" }) => {
+  disabled?: boolean;
+}> = ({ handleSubmit, flowId, flows = [], tags = [], notes = "", disabled = false }) => {
   const portalSchema = Yup.object().shape({
     flowId: Yup.string().required("Add a flow to submit"),
   });
@@ -141,11 +142,12 @@ const ExternalPortalForm: React.FC<{
               handleHomeEndKeys
               autoHighlight
               forcePopupIcon={true}
+              disabled={disabled}
             />
           </ErrorWrapper>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+      <ModalFooter formik={formik} showMoreInformation={false} disabled={disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -46,6 +46,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   name="title"
                   value={formik.values.title}
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputLabel>
             </InputRow>
@@ -56,6 +57,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   value={formik.values.description}
                   placeholder="Description"
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputLabel>
             </InputRow>
@@ -70,6 +72,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   name="ratingQuestion"
                   value={formik.values.ratingQuestion}
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputLabel>
             </InputRow>
@@ -83,6 +86,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   name="freeformQuestion"
                   value={formik.values.freeformQuestion}
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputLabel>
             </InputRow>
@@ -92,6 +96,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   name="disclaimer"
                   value={formik.values.disclaimer}
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputLabel>
             </InputRow>
@@ -105,12 +110,13 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   )
                 }
                 label="Feedback required"
+                disabled={props.disabled}
               />
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -40,14 +40,14 @@ function Component(props: any) {
         props.handleSubmit({ type: TYPES.FileUpload, data: newValues });
       }
     },
-    validate: () => { },
+    validate: () => {},
   });
 
   // Rather than default to generic `useStore().getFlowSchema()`
   //   File Upload components can specifically suggest based on ODP Schema enum options
-  let schema = getValidSchemaValues("FileType") || [];
+  const schema = getValidSchemaValues("FileType") || [];
   // // Additionally ensure that existing initial values are supported & pre-populated on load
-  if (formik.initialValues?.fn && !schema?.includes(formik.initialValues.fn)) 
+  if (formik.initialValues?.fn && !schema?.includes(formik.initialValues.fn))
     schema.push(formik.initialValues.fn);
 
   return (
@@ -62,6 +62,7 @@ function Component(props: any) {
               name="title"
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -70,6 +71,7 @@ function Component(props: any) {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
@@ -77,10 +79,11 @@ function Component(props: any) {
             schema={schema}
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -78,6 +78,7 @@ function FileUploadAndLabelComponent(props: Props) {
               placeholder={formik.values.title}
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -87,6 +88,7 @@ function FileUploadAndLabelComponent(props: Props) {
               placeholder="Description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -99,6 +101,7 @@ function FileUploadAndLabelComponent(props: Props) {
                 )
               }
               label="Hide the drop zone and show files list for information only"
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
@@ -112,10 +115,11 @@ function FileUploadAndLabelComponent(props: Props) {
             }}
             Editor={FileTypeEditor}
             newValue={newFileType}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }
@@ -142,18 +146,21 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
             props.onChange(merge(props.value, { name: e.target.value }))
           }
           placeholder="File type"
+          disabled={props.disabled}
         />
       </InputRow>
       <DataFieldAutocomplete
         required
         schema={schema}
         value={props.value.fn}
+        disabled={props.disabled}
         onChange={(value) => props.onChange(merge(props.value, { fn: value }))}
       />
       <ModalSubtitle title="Rule" />
       <InputRow>
         <SelectInput
           value={props.value.rule.condition}
+          disabled={props.disabled}
           onChange={(e) =>
             props.onChange(
               setCondition(
@@ -186,6 +193,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
               )
             }
             placeholder="Data field"
+            disabled={props.disabled}
           />
           <Operator>Equals</Operator>
           <Input
@@ -202,6 +210,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
               )
             }
             placeholder="Value"
+            disabled={props.disabled}
           />
         </InputRow>
       )}
@@ -217,6 +226,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
             );
           }}
           placeholder="Why it matters"
+          disabled={props.disabled}
         />
       </InputRow>
       <InputRow>
@@ -232,6 +242,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
             );
           }}
           placeholder="Policy source"
+          disabled={props.disabled}
         />
       </InputRow>
       <InputRow>
@@ -247,10 +258,12 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
             );
           }}
           placeholder="How is it defined?"
+          disabled={props.disabled}
         />
         <InputRowItem width={50}>
           <ImgInput
             img={props.value.moreInformation?.definitionImg}
+            disabled={props.disabled}
             onChange={(newUrl) => {
               props.onChange(
                 merge(props.value, {

--- a/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -17,6 +17,7 @@ export interface Props {
   handleSubmit?: (data: any, children?: any) => void;
   node?: any;
   autoAnswer?: Node["id"];
+  disabled?: boolean;
 }
 
 const Filter: React.FC<Props> = (props) => {
@@ -71,6 +72,7 @@ const Filter: React.FC<Props> = (props) => {
             name="category"
             value={formik.values.category}
             onChange={formik.handleChange}
+            disabled={props.disabled}
           >
             {Array.from(categories).map((category) => (
               <option key={category} value={category}>

--- a/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -44,6 +44,7 @@ function FindPropertyComponent(props: Props) {
               name="title"
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -52,6 +53,7 @@ function FindPropertyComponent(props: Props) {
               placeholder="Description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
@@ -66,6 +68,7 @@ function FindPropertyComponent(props: Props) {
                 )
               }
               label="Allow users to plot new addresses without a UPRN"
+              disabled={props.disabled}
             />
           </InputRow>
           {formik.values.allowNewAddresses ? (
@@ -77,6 +80,7 @@ function FindPropertyComponent(props: Props) {
                   name="newAddressTitle"
                   value={formik.values.newAddressTitle}
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputRow>
@@ -85,6 +89,7 @@ function FindPropertyComponent(props: Props) {
                   placeholder="Description"
                   value={formik.values.newAddressDescription}
                   onChange={formik.handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputGroup label="New address description label">
@@ -96,6 +101,7 @@ function FindPropertyComponent(props: Props) {
                       name="newAddressDescriptionLabel"
                       value={formik.values.newAddressDescriptionLabel}
                       onChange={formik.handleChange}
+                      disabled={props.disabled}
                     />
                   </InputRowItem>
                 </InputRow>
@@ -106,7 +112,7 @@ function FindPropertyComponent(props: Props) {
           )}
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -36,7 +36,7 @@ const InternalPortalForm: React.FC<{
   flows = [],
   tags = [],
   notes = "",
-  disabled = false,
+  disabled,
 }) => {
   const formik = useFormik({
     initialValues: {
@@ -113,7 +113,11 @@ const InternalPortalForm: React.FC<{
           </ModalSectionContent>
         )}
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} disabled={disabled} />
+      <ModalFooter
+        formik={formik}
+        showMoreInformation={false}
+        disabled={disabled}
+      />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -28,6 +28,7 @@ const InternalPortalForm: React.FC<{
   handleSubmit?: (val: any) => void;
   flows?: Array<Flow>;
   tags?: NodeTag[];
+  disabled?: boolean;
 }> = ({
   handleSubmit,
   text = "",
@@ -35,6 +36,7 @@ const InternalPortalForm: React.FC<{
   flows = [],
   tags = [],
   notes = "",
+  disabled = false,
 }) => {
   const formik = useFormik({
     initialValues: {
@@ -79,7 +81,7 @@ const InternalPortalForm: React.FC<{
               placeholder="Enter a portal name"
               rows={2}
               value={formik.values.text}
-              disabled={!!formik.values.flowId}
+              disabled={disabled || !!formik.values.flowId}
               id="portalFlowId"
             />
           </ErrorWrapper>
@@ -100,7 +102,7 @@ const InternalPortalForm: React.FC<{
               name="flowId"
               value={formik.values.flowId}
               onChange={formik.handleChange}
-              disabled={!!formik.values.text}
+              disabled={disabled || !!formik.values.text}
             >
               {flows.map((flow) => (
                 <MenuItem key={flow.id} value={flow.id}>
@@ -111,7 +113,7 @@ const InternalPortalForm: React.FC<{
           </ModalSectionContent>
         )}
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+      <ModalFooter formik={formik} showMoreInformation={false} disabled={disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -110,6 +110,7 @@ function ListComponent(props: Props) {
               placeholder="Title"
               onChange={formik.handleChange}
               required
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -118,12 +119,14 @@ function ListComponent(props: Props) {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             required
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
           <ErrorWrapper error={formik.errors.schema?.max}>
             <InputRow>
@@ -131,6 +134,7 @@ function ListComponent(props: Props) {
               <InputRowItem>
                 <SelectInput
                   value={formik.values.schemaName}
+                  disabled={props.disabled}
                   onChange={(e) => {
                     formik.setFieldValue("schemaName", e.target.value);
                     formik.setFieldValue(
@@ -152,7 +156,7 @@ function ListComponent(props: Props) {
           </ErrorWrapper>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -61,6 +61,7 @@ function MapAndLabelComponent(props: Props) {
                 value={formik.values.title}
                 onChange={formik.handleChange}
                 required
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -69,12 +70,14 @@ function MapAndLabelComponent(props: Props) {
                 placeholder="Description"
                 value={formik.values.description}
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
             <DataFieldAutocomplete
               required
               value={formik.values.fn}
               onChange={(value) => formik.setFieldValue("fn", value)}
+              disabled={props.disabled}
             />
           </InputGroup>
         </ModalSectionContent>
@@ -107,6 +110,7 @@ function MapAndLabelComponent(props: Props) {
                           const target = e?.target as HTMLInputElement;
                           formik.setFieldValue("basemap", target.value);
                         }}
+                        disabled={props.disabled}
                       />
                     ))}
                   </RadioGroup>
@@ -134,6 +138,7 @@ function MapAndLabelComponent(props: Props) {
                           const target = e?.target as HTMLInputElement;
                           formik.setFieldValue("drawType", target.value);
                         }}
+                        disabled={props.disabled}
                       />
                     ))}
                   </RadioGroup>
@@ -149,6 +154,7 @@ function MapAndLabelComponent(props: Props) {
                     formik.setFieldValue("drawColor", color);
                   }}
                   errorMessage={formik.errors.drawColor}
+                  disabled={props.disabled}
                 />
               </InputRowItem>
             </InputRow>
@@ -168,6 +174,7 @@ function MapAndLabelComponent(props: Props) {
                     )?.schema,
                   );
                 }}
+                disabled={props.disabled}
               >
                 {SCHEMAS.map(({ name }) => (
                   <MenuItem key={name} value={name}>
@@ -179,7 +186,7 @@ function MapAndLabelComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -41,6 +41,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
             });
           }}
           placeholder="Title"
+          disabled={props.disabled}
         />
       </InputRow>
       <InputRow>
@@ -55,6 +56,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
             });
           }}
           placeholder="Description"
+          disabled={props.disabled}
         />
       </InputRow>
       <InputRow>
@@ -69,6 +71,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
             });
           }}
           placeholder="url"
+          disabled={props.disabled}
         />
       </InputRow>
     </Box>
@@ -97,6 +100,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
                 onChange={formik.handleChange}
                 placeholder="Main Title"
                 format="large"
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -105,6 +109,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
                 value={formik.values.description}
                 onChange={formik.handleChange}
                 placeholder="Main Description"
+                disabled={props.disabled}
               />
             </InputRow>
           </Box>
@@ -115,10 +120,11 @@ const NextStepsComponent: React.FC<Props> = (props) => {
             }}
             Editor={TaskEditor}
             newValue={newStep}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -20,11 +20,13 @@ export interface Props {
   id?: string;
   handleSubmit?: (data: { type: TYPES.Notice; data: Notice }) => void;
   node?: any;
+  disabled?: boolean;
 }
 
 export interface NoticeEditorProps {
   value: Notice;
   onChange: (newValue: Notice) => void;
+  disabled?: boolean;
 }
 
 const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
@@ -43,6 +45,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
                   title: ev.target.value,
                 });
               }}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -55,6 +58,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
                   description: ev.target.value,
                 });
               }}
+              disabled={props.disabled}
             />
           </InputRow>
           <ColorPicker
@@ -67,6 +71,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
                 color,
               });
             }}
+            disabled={props.disabled}
           />
           <InputRow>
             <Switch
@@ -78,6 +83,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
                 })
               }
               label="Reset to start of service"
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
@@ -93,6 +99,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
         howMeasured={props.value.howMeasured}
         policyRef={props.value.policyRef}
         info={props.value.info}
+        disabled={props.disabled}
       />
       <InternalNotes
         name="notes"
@@ -103,6 +110,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
           });
         }}
         value={props.value.notes}
+        disabled={props.disabled}
       />
       <ComponentTagSelect
         onChange={(value) =>
@@ -112,6 +120,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = (props) => {
           })
         }
         value={props.value.tags}
+        disabled={props.disabled}
       />
     </>
   );
@@ -136,6 +145,7 @@ const NoticeComponent: React.FC<Props> = (props) => {
         onChange={(notice) => {
           formik.setFieldValue("notice", notice);
         }}
+        disabled={props.disabled}
       />
     </form>
   );

--- a/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -44,6 +44,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
               value={formik.values.title}
               placeholder="Title"
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -52,11 +53,13 @@ export default function NumberInputComponent(props: Props): FCReturn {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
           <InputRow>
             <InputRowLabel>units</InputRowLabel>
@@ -66,6 +69,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
                 value={formik.values.units}
                 placeholder="eg square metres"
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRowItem>
           </InputRow>
@@ -79,6 +83,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
                 )
               }
               label="Allow negative numbers to be input"
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -88,11 +93,12 @@ export default function NumberInputComponent(props: Props): FCReturn {
                 formik.setFieldValue("isInteger", !formik.values.isInteger)
               }
               label="Only allow whole numbers"
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -47,6 +47,7 @@ function PageComponent(props: Props) {
               placeholder="Title"
               onChange={formik.handleChange}
               required
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -55,12 +56,14 @@ function PageComponent(props: Props) {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             required
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
           <InputRow>
             <InputRowLabel>Schema</InputRowLabel>
@@ -76,6 +79,7 @@ function PageComponent(props: Props) {
                     )?.schema,
                   );
                 }}
+                disabled={props.disabled}
               >
                 {PAGE_SCHEMAS.map(({ name }) => (
                   <MenuItem key={name} value={name}>
@@ -87,7 +91,7 @@ function PageComponent(props: Props) {
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -50,6 +50,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   name="title"
                   value={values.title}
                   onChange={handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputRow>
@@ -59,6 +60,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   name="bannerTitle"
                   value={values.bannerTitle}
                   onChange={handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputRow>
@@ -67,6 +69,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   name="description"
                   value={values.description}
                   onChange={handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputRow>
@@ -81,6 +84,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   name="instructionsTitle"
                   value={values.instructionsTitle}
                   onChange={handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputRow>
@@ -89,6 +93,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   name="instructionsDescription"
                   value={values.instructionsDescription}
                   onChange={handleChange}
+                  disabled={props.disabled}
                 />
               </InputRow>
               <InputRow>
@@ -96,27 +101,31 @@ const Component: React.FC<Props> = (props: Props) => {
                   checked={values.hidePay}
                   onChange={() => setFieldValue("hidePay", !values.hidePay)}
                   label="Hide the pay buttons and show fee for information only"
+                  disabled={props.disabled}
                 />
               </InputRow>
             </ModalSectionContent>
           </ModalSection>
-          <InviteToPaySection />
-          <GovPayMetadataSection />
+          <InviteToPaySection disabled={props.disabled} />
+          <GovPayMetadataSection disabled={props.disabled} />
           <MoreInformation
             changeField={handleChange}
             definitionImg={values.definitionImg}
             howMeasured={values.howMeasured}
             policyRef={values.policyRef}
             info={values.info}
+            disabled={props.disabled}
           />
           <InternalNotes
             name="notes"
             onChange={handleChange}
             value={values.notes}
+            disabled={props.disabled}
           />
           <ComponentTagSelect
             onChange={(value) => setFieldValue("tags", value)}
             value={values.tags}
+            disabled={props.disabled}
           />
         </Form>
       )}

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
@@ -32,6 +32,7 @@ interface GovPayMetadataSectionProps {
 function GovPayMetadataEditor(
   props: ListManagerEditorProps<GovPayMetadata> & {
     isFieldDisabled: (key: string, index: number) => boolean;
+    disabled?: boolean;
   },
 ) {
   const { key: currKey, value: currVal } = props.value;
@@ -52,7 +53,9 @@ function GovPayMetadataEditor(
         <InputRow>
           <Input
             aria-labelledby="key-label"
-            disabled={props.isFieldDisabled(currKey, props.index)}
+            disabled={
+              props.disabled || props.isFieldDisabled(currKey, props.index)
+            }
             value={currKey}
             onChange={({ target: { value: newKey } }) =>
               props.onChange({ key: newKey, value: currVal })
@@ -62,7 +65,9 @@ function GovPayMetadataEditor(
           <Input
             format={currVal.toString().startsWith("@") ? "data" : undefined}
             aria-labelledby="value-label"
-            disabled={props.isFieldDisabled(currKey, props.index)}
+            disabled={
+              props.disabled || props.isFieldDisabled(currKey, props.index)
+            }
             value={currVal}
             onChange={({ target: { value: newVal } }) =>
               props.onChange({ key: currKey, value: newVal })
@@ -75,7 +80,9 @@ function GovPayMetadataEditor(
   );
 }
 
-export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({ disabled }) => {
+export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
+  disabled,
+}) => {
   const { errors, setFieldValue, setTouched, touched, values } =
     useFormikContext<Pay>();
 
@@ -141,13 +148,16 @@ export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({ di
               Editor={(editorProps) => (
                 <GovPayMetadataEditor
                   {...editorProps}
-                  isFieldDisabled={(key, index) => disabled || isFieldDisabled(key, index)}
+                  isFieldDisabled={(key, index) =>
+                    disabled || isFieldDisabled(key, index)
+                  }
                 />
               )}
               newValue={() => {
                 setTouched({});
                 return { key: "", value: "" };
               }}
+              isFieldDisabled={({ key }, index) => isFieldDisabled(key, index)}
               disabled={disabled}
             />
           </>

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
@@ -25,14 +25,18 @@ export type FormikGovPayMetadata =
   | string
   | undefined;
 
+interface GovPayMetadataSectionProps {
+  disabled?: boolean;
+}
+
 function GovPayMetadataEditor(
   props: ListManagerEditorProps<GovPayMetadata> & {
     isFieldDisabled: (key: string, index: number) => boolean;
   },
 ) {
   const { key: currKey, value: currVal } = props.value;
-  const isDisabled = props.isFieldDisabled(currKey, props.index);
   const { errors, touched } = useFormikContext<Pay>();
+
   const error = parseError(
     errors.govPayMetadata as FormikGovPayMetadata,
     props.index,
@@ -48,7 +52,7 @@ function GovPayMetadataEditor(
         <InputRow>
           <Input
             aria-labelledby="key-label"
-            disabled={isDisabled}
+            disabled={props.isFieldDisabled(currKey, props.index)}
             value={currKey}
             onChange={({ target: { value: newKey } }) =>
               props.onChange({ key: newKey, value: currVal })
@@ -58,7 +62,7 @@ function GovPayMetadataEditor(
           <Input
             format={currVal.toString().startsWith("@") ? "data" : undefined}
             aria-labelledby="value-label"
-            disabled={isDisabled}
+            disabled={props.isFieldDisabled(currKey, props.index)}
             value={currVal}
             onChange={({ target: { value: newVal } }) =>
               props.onChange({ key: currKey, value: newVal })
@@ -71,7 +75,7 @@ function GovPayMetadataEditor(
   );
 }
 
-export const GovPayMetadataSection: React.FC = () => {
+export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({ disabled }) => {
   const { errors, setFieldValue, setTouched, touched, values } =
     useFormikContext<Pay>();
 
@@ -137,13 +141,14 @@ export const GovPayMetadataSection: React.FC = () => {
               Editor={(editorProps) => (
                 <GovPayMetadataEditor
                   {...editorProps}
-                  isFieldDisabled={(key, index) => isFieldDisabled(key, index)}
+                  isFieldDisabled={(key, index) => disabled || isFieldDisabled(key, index)}
                 />
               )}
               newValue={() => {
                 setTouched({});
                 return { key: "", value: "" };
               }}
+              disabled={disabled}
             />
           </>
         </ErrorWrapper>

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
@@ -25,9 +25,13 @@ export type FormikGovPayMetadata =
   | string
   | undefined;
 
-function GovPayMetadataEditor(props: ListManagerEditorProps<GovPayMetadata>) {
+function GovPayMetadataEditor(
+  props: ListManagerEditorProps<GovPayMetadata> & {
+    isFieldDisabled: (key: string, index: number) => boolean;
+  },
+) {
   const { key: currKey, value: currVal } = props.value;
-  const isDisabled = isFieldDisabled(currKey, props.index);
+  const isDisabled = props.isFieldDisabled(currKey, props.index);
   const { errors, touched } = useFormikContext<Pay>();
   const error = parseError(
     errors.govPayMetadata as FormikGovPayMetadata,
@@ -130,12 +134,16 @@ export const GovPayMetadataSection: React.FC = () => {
               onChange={(metadata) => {
                 setFieldValue("govPayMetadata", metadata);
               }}
-              Editor={GovPayMetadataEditor}
+              Editor={(editorProps) => (
+                <GovPayMetadataEditor
+                  {...editorProps}
+                  isFieldDisabled={(key, index) => isFieldDisabled(key, index)}
+                />
+              )}
               newValue={() => {
                 setTouched({});
                 return { key: "", value: "" };
               }}
-              isFieldDisabled={({ key }, index) => isFieldDisabled(key, index)}
             />
           </>
         </ErrorWrapper>

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
@@ -6,6 +6,7 @@ import { GovPayMetadata } from "@opensystemslab/planx-core/types";
 import { Pay } from "@planx/components/Pay/model";
 import { useFormikContext } from "formik";
 import React from "react";
+import { useCallback } from "react";
 import ListManager, {
   EditorProps as ListManagerEditorProps,
 } from "ui/editor/ListManager/ListManager";
@@ -86,6 +87,19 @@ export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
   const { errors, setFieldValue, setTouched, touched, values } =
     useFormikContext<Pay>();
 
+  const EditorComponent = useCallback(
+    (editorProps: ListManagerEditorProps<GovPayMetadata>) => (
+      <GovPayMetadataEditor
+        {...editorProps}
+        isFieldDisabled={(key, index) =>
+          disabled || isFieldDisabled(key, index)
+        }
+        disabled={disabled}
+      />
+    ),
+    [disabled],
+  );
+
   return (
     <ModalSection>
       <ModalSectionContent title="GOV.UK Pay metadata" Icon={DataObjectIcon}>
@@ -145,14 +159,7 @@ export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
               onChange={(metadata) => {
                 setFieldValue("govPayMetadata", metadata);
               }}
-              Editor={(editorProps) => (
-                <GovPayMetadataEditor
-                  {...editorProps}
-                  isFieldDisabled={(key, index) =>
-                    disabled || isFieldDisabled(key, index)
-                  }
-                />
-              )}
+              Editor={EditorComponent}
               newValue={() => {
                 setTouched({});
                 return { key: "", value: "" };

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
@@ -12,7 +12,11 @@ import { Switch } from "ui/shared/Switch";
 import { ICONS } from "../../shared/icons";
 import { Pay } from "../model";
 
-export const InviteToPaySection: React.FC = () => {
+interface InviteToPaySectionProps {
+  disabled?: boolean;
+}
+
+export const InviteToPaySection: React.FC<InviteToPaySectionProps> = ({ disabled }) => {
   const { handleChange, values, setFieldValue } = useFormikContext<Pay>();
 
   return (
@@ -25,6 +29,7 @@ export const InviteToPaySection: React.FC = () => {
               setFieldValue("allowInviteToPay", !values.allowInviteToPay)
             }
             label="Allow applicants to invite someone else to pay"
+            disabled={disabled}
           />
         </InputRow>
         {values.allowInviteToPay ? (
@@ -38,6 +43,7 @@ export const InviteToPaySection: React.FC = () => {
                   placeholder="Card title"
                   value={values.secondaryPageTitle}
                   onChange={handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
             </Box>
@@ -50,6 +56,7 @@ export const InviteToPaySection: React.FC = () => {
                   placeholder="Title"
                   value={values.nomineeTitle}
                   onChange={handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
               <InputRow>
@@ -58,6 +65,7 @@ export const InviteToPaySection: React.FC = () => {
                   placeholder="Description"
                   value={values.nomineeDescription}
                   onChange={handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
             </Box>
@@ -70,6 +78,7 @@ export const InviteToPaySection: React.FC = () => {
                   placeholder="Title"
                   value={values.yourDetailsTitle}
                   onChange={handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
               <InputRow>
@@ -78,6 +87,7 @@ export const InviteToPaySection: React.FC = () => {
                   placeholder="Description"
                   value={values.yourDetailsDescription}
                   onChange={handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
               <InputRow>
@@ -87,6 +97,7 @@ export const InviteToPaySection: React.FC = () => {
                   placeholder="Label"
                   value={values.yourDetailsLabel}
                   onChange={handleChange}
+                  disabled={disabled}
                 />
               </InputRow>
             </Box>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
@@ -93,6 +93,7 @@ function PlanningConstraintsComponent(props: Props) {
                 placeholder={formik.values.title}
                 value={formik.values.title}
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -101,6 +102,7 @@ function PlanningConstraintsComponent(props: Props) {
                 placeholder="Description"
                 value={formik.values.description}
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -127,6 +129,7 @@ function PlanningConstraintsComponent(props: Props) {
                             formik.values.dataValues?.length
                           }
                           onChange={changeSelectAll(formik.values.dataValues)}
+                          disabled={props.disabled}
                         />
                       </TableCell>
                       <TableCell
@@ -150,6 +153,7 @@ function PlanningConstraintsComponent(props: Props) {
                                 ) || false
                               }
                               onChange={changeDataset(dataset.val)}
+                              disabled={props.disabled}
                             />
                           </TableCell>
                           <TableCell>
@@ -201,12 +205,17 @@ function PlanningConstraintsComponent(props: Props) {
                 placeholder="Planning conditions disclaimer"
                 value={formik.values.disclaimer}
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
           </InputGroup>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+      <ModalFooter
+        formik={formik}
+        showMoreInformation={false}
+        disabled={props.disabled}
+      />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
@@ -42,6 +42,7 @@ function PropertyInformationComponent(props: Props) {
               placeholder={formik.values.title}
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -50,6 +51,7 @@ function PropertyInformationComponent(props: Props) {
               placeholder="Description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -62,11 +64,12 @@ function PropertyInformationComponent(props: Props) {
                 )
               }
               label="Show users a 'change' link to override the property type"
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -35,6 +35,7 @@ interface Props {
   };
   options?: Option[];
   handleSubmit?: Function;
+  disabled?: boolean;
 }
 
 export const Question: React.FC<Props> = (props) => {
@@ -102,6 +103,7 @@ export const Question: React.FC<Props> = (props) => {
                 placeholder="Text"
                 onChange={formik.handleChange}
                 inputRef={focusRef}
+                disabled={props.disabled}
               />
               <ImgInput
                 img={formik.values.img}
@@ -116,6 +118,7 @@ export const Question: React.FC<Props> = (props) => {
                 value={formik.values.description}
                 placeholder="Description"
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
             <ErrorWrapper error={formik.errors.fn}>
@@ -135,6 +138,7 @@ export const Question: React.FC<Props> = (props) => {
                   )
                 }
                 label="Always put to user (forgo automation)"
+                disabled={props.disabled}
               />
             </InputRow>
           </InputGroup>
@@ -142,6 +146,7 @@ export const Question: React.FC<Props> = (props) => {
         <ModalSectionContent subtitle="Options">
           <ListManager
             values={formik.values.options}
+            disabled={props.disabled}
             onChange={(newOptions) => {
               formik.setFieldValue("options", newOptions);
             }}
@@ -172,11 +177,13 @@ export const Question: React.FC<Props> = (props) => {
         howMeasured={formik.values.howMeasured}
         policyRef={formik.values.policyRef}
         info={formik.values.info}
+        disabled={props.disabled}
       />
       <InternalNotes
         name="notes"
         onChange={formik.handleChange}
         value={formik.values.notes}
+        disabled={props.disabled}
       />
       <ComponentTagSelect
         value={formik.values.tags}

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -110,6 +110,7 @@ export const Question: React.FC<Props> = (props) => {
                 onChange={(newUrl) => {
                   formik.setFieldValue("img", newUrl);
                 }}
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -126,6 +127,7 @@ export const Question: React.FC<Props> = (props) => {
                 schema={schema?.nodes}
                 value={formik.values.fn}
                 onChange={(value) => formik.setFieldValue("fn", value)}
+                disabled={props.disabled}
               />
             </ErrorWrapper>
             <InputRow>

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -188,6 +188,7 @@ export const Question: React.FC<Props> = (props) => {
       <ComponentTagSelect
         value={formik.values.tags}
         onChange={(value) => formik.setFieldValue("tags", value)}
+        disabled={props.disabled}
       />
     </form>
   );

--- a/editor.planx.uk/src/@planx/components/Question/OptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/OptionsEditor.tsx
@@ -10,6 +10,7 @@ const QuestionOptionsEditor: React.FC<BaseOptionsEditorProps> = ({
   schema,
   onChange,
   showValueField = false,
+  disabled,
 }) => {
   return (
     <BaseOptionsEditor
@@ -18,6 +19,7 @@ const QuestionOptionsEditor: React.FC<BaseOptionsEditorProps> = ({
       onChange={onChange}
       showValueField={showValueField}
       showDescriptionField={true}
+      disabled={disabled}
     />
   );
 };

--- a/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -29,6 +29,7 @@ const FlagEditor: React.FC<{
   flag: Flag;
   existingOverrides?: FlagDisplayText;
   onChange: (newValues: any) => any;
+  disabled?: boolean;
 }> = (props) => {
   const { flag, existingOverrides } = props;
 
@@ -46,6 +47,7 @@ const FlagEditor: React.FC<{
             onChange={(ev) =>
               props.onChange({ ...existingOverrides, heading: ev.target.value })
             }
+            disabled={props.disabled}
           />
         </InputLabel>
         <InputLabel label="Description">
@@ -58,6 +60,7 @@ const FlagEditor: React.FC<{
                 description: ev.target.value,
               })
             }
+            disabled={props.disabled}
           />
         </InputLabel>
       </Box>
@@ -97,6 +100,7 @@ const ResultComponent: React.FC<Props> = (props) => {
               value={formik.values.flagSet}
               onChange={formik.handleChange}
               required
+              disabled={props.disabled}
             >
               {Object.keys(flags).map((flagSet) => (
                 <option key={flagSet} value={flagSet}>
@@ -131,6 +135,7 @@ const ResultComponent: React.FC<Props> = (props) => {
                         ...{ [flag.value]: newValues },
                       });
                     }}
+                    disabled={props.disabled}
                   />
                 );
               })}

--- a/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -36,6 +36,7 @@ function Component(props: Props) {
               placeholder={formik.values.title}
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -44,11 +45,16 @@ function Component(props: Props) {
               placeholder="Description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+      <ModalFooter
+        formik={formik}
+        showMoreInformation={false}
+        disabled={props.disabled}
+      />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -1,7 +1,6 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -1,6 +1,7 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
@@ -13,6 +14,8 @@ import { ICONS } from "../shared/icons";
 import { parseSection, Section } from "./model";
 
 type Props = EditorProps<TYPES.Section, Section>;
+
+const teamSlug = window.location.pathname.split("/")[1];
 
 export default SectionComponent;
 
@@ -39,6 +42,7 @@ function SectionComponent(props: Props) {
               placeholder="Title"
               value={formik.values.title}
               onChange={formik.handleChange}
+              disabled={!useStore.getState().canUserEditTeam(teamSlug)}
             />
           </InputRow>
           <InputRow>
@@ -47,6 +51,7 @@ function SectionComponent(props: Props) {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={!useStore.getState().canUserEditTeam(teamSlug)}
             />
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -15,8 +15,6 @@ import { parseSection, Section } from "./model";
 
 type Props = EditorProps<TYPES.Section, Section>;
 
-const teamSlug = window.location.pathname.split("/")[1];
-
 export default SectionComponent;
 
 function SectionComponent(props: Props) {
@@ -42,7 +40,7 @@ function SectionComponent(props: Props) {
               placeholder="Title"
               value={formik.values.title}
               onChange={formik.handleChange}
-              disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -51,12 +49,16 @@ function SectionComponent(props: Props) {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
-              disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+              disabled={props.disabled}
             />
           </InputRow>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+      <ModalFooter
+        formik={formik}
+        showMoreInformation={false}
+        disabled={props.disabled}
+      />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -132,6 +132,7 @@ const SendComponent: React.FC<Props> = (props) => {
               value={formik.values.title}
               placeholder="Editor title"
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <Box mt={2}>
@@ -146,6 +147,7 @@ const SendComponent: React.FC<Props> = (props) => {
                       checked={formik.values.destinations.includes(
                         option.value,
                       )}
+                      disabled={props.disabled}
                     />
                   </Grid>
                 ))}

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -101,6 +101,7 @@ function SetValueComponent(props: Props) {
             required
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
         {formik.values.operation !== "removeAll" && (
@@ -113,6 +114,7 @@ function SetValueComponent(props: Props) {
                 value={formik.values.val}
                 placeholder="value"
                 onChange={formik.handleChange}
+                disabled={props.disabled}
               />
             </InputRow>
           </ModalSectionContent>
@@ -129,13 +131,14 @@ function SetValueComponent(props: Props) {
                   variant="compact"
                   value={option.value}
                   onChange={handleRadioChange}
+                  disabled={props.disabled}
                 />
               ))}
             </RadioGroup>
           </FormControl>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
+      <ModalFooter formik={formik} showMoreInformation={false} disabled={props.disabled} />
     </form>
   );
 }

--- a/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -39,6 +39,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Task>> = (props) => {
             });
           }}
           placeholder="Title"
+          disabled={props.disabled}
         />
       </InputRow>
       <InputRow>
@@ -53,6 +54,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Task>> = (props) => {
             });
           }}
           placeholder="Description"
+          disabled={props.disabled}
         />
       </InputRow>
     </Box>
@@ -81,6 +83,7 @@ const TaskListComponent: React.FC<Props> = (props) => {
                 onChange={formik.handleChange}
                 placeholder="Main title"
                 format="large"
+                disabled={props.disabled}
               />
             </InputRow>
             <InputRow>
@@ -89,6 +92,7 @@ const TaskListComponent: React.FC<Props> = (props) => {
                 value={formik.values.description}
                 onChange={formik.handleChange}
                 placeholder="Main description"
+                disabled={props.disabled}
               />
             </InputRow>
           </Box>
@@ -99,10 +103,11 @@ const TaskListComponent: React.FC<Props> = (props) => {
             }}
             Editor={TaskEditor}
             newValue={newTask}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -48,6 +48,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
               value={formik.values.title}
               placeholder="Title"
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <InputRow>
@@ -56,11 +57,13 @@ const TextInputComponent: React.FC<Props> = (props) => {
               name="description"
               value={formik.values.description}
               onChange={formik.handleChange}
+              disabled={props.disabled}
             />
           </InputRow>
           <DataFieldAutocomplete
             value={formik.values.fn}
             onChange={(value) => formik.setFieldValue("fn", value)}
+            disabled={props.disabled}
           />
         </ModalSectionContent>
         <ModalSectionContent title="Input style">
@@ -81,13 +84,14 @@ const TextInputComponent: React.FC<Props> = (props) => {
                   variant="compact"
                   value={type.id}
                   onChange={handleRadioChange}
+                  disabled={props.disabled}
                 />
               ))}
             </RadioGroup>
           </FormControl>
         </ModalSectionContent>
       </ModalSection>
-      <ModalFooter formik={formik} />
+      <ModalFooter formik={formik} disabled={props.disabled} />
     </form>
   );
 };

--- a/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
@@ -83,6 +83,7 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
         key={`${props.value.id}-data-field-autocomplete`}
         schema={props.schema}
         value={props.value.data.val}
+        disabled={props.disabled}
         onChange={(targetValue) => {
           props.onChange({
             ...props.value,
@@ -96,6 +97,7 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
     )}
     <FlagsSelect
       value={props.value.data.flags}
+      disabled={props.disabled}
       onChange={(ev) => {
         props.onChange({
           ...props.value,

--- a/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
@@ -16,6 +16,7 @@ export interface BaseOptionsEditorProps {
   showDescriptionField?: boolean;
   onChange: (newVal: Option) => void;
   children?: ReactNode;
+  disabled?: boolean;
 }
 
 export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
@@ -30,6 +31,7 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
           format="bold"
           multiline
           value={props.value.data.text || ""}
+          disabled={props.disabled}
           onChange={(ev) => {
             props.onChange({
               ...props.value,
@@ -44,6 +46,7 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
       </InputRowItem>
       <ImgInput
         img={props.value.data.img}
+        disabled={props.disabled}
         onChange={(img) => {
           props.onChange({
             ...props.value,
@@ -62,6 +65,7 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
           value={props.value.data.description || ""}
           placeholder="Description"
           multiline
+          disabled={props.disabled}
           onChange={(ev) =>
             props.onChange({
               ...props.value,

--- a/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
@@ -13,6 +13,7 @@ interface Props {
   value?: string;
   onChange: (value: string | null) => void;
   required?: boolean;
+  disabled?: boolean;
 }
 
 const renderOptions: AutocompleteProps<
@@ -62,6 +63,7 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
         autoSelect
         value={value}
         options={options}
+        disabled={props.disabled}
         filterOptions={(options, params) => {
           const filtered = filter(options, params);
           const { inputValue } = params;

--- a/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
@@ -12,6 +12,7 @@ import { SelectMultiple } from "ui/shared/SelectMultiple";
 interface Props {
   value?: Array<Flag["value"]>;
   onChange: (values: Array<Flag["value"]>) => void;
+  disabled?: boolean;
 }
 
 const renderOptions: AutocompleteProps<
@@ -81,6 +82,7 @@ export const FlagsSelect: React.FC<Props> = (props) => {
         value={value}
         renderOption={renderOptions}
         renderTags={renderTags}
+        disabled={props.disabled}
       />
     </InputRow>
   );

--- a/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio/BasicRadio.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio/BasicRadio.tsx
@@ -11,6 +11,7 @@ export interface Props {
   onChange: FormControlLabelProps["onChange"];
   variant?: "default" | "compact";
   value?: string;
+  disabled?: boolean;
 }
 
 const BasicRadio: React.FC<Props> = ({
@@ -18,12 +19,14 @@ const BasicRadio: React.FC<Props> = ({
   onChange,
   title,
   variant = "default",
+  disabled,
 }) => (
   <FormControlLabel
     value={id}
     onChange={onChange}
     control={<Radio variant={variant} />}
     label={title}
+    disabled={disabled}
     sx={(theme) => ({
       ml: theme.spacing(-1),
       mb: variant === "default" ? 1 : 0,

--- a/editor.planx.uk/src/@planx/components/shared/types.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/types.tsx
@@ -6,6 +6,7 @@ export interface EditorProps<Type, Data> {
   id?: string;
   handleSubmit?: (data: { type: Type; data: Data }) => void;
   node?: any;
+  disabled?: boolean;
 }
 
 export type PublicProps<Data> = Data & {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/DataField.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/DataField.tsx
@@ -11,16 +11,11 @@ export const DataField: React.FC<{
 
   return (
     <Box
+      className="card-data-field"
       sx={(theme) => ({
         fontFamily: theme.typography.data.fontFamily,
         fontSize: theme.typography.data,
-        backgroundColor: "#f0f0f0",
-        borderColor:
-          variant === "parent"
-            ? theme.palette.common.black
-            : theme.palette.grey[400],
-        borderWidth:
-          variant === "parent" ? "0 1px 1px 1px" : "1px 0 0 0",
+        borderWidth: variant === "parent" ? "0 1px 1px 1px" : "1px 0 0 0",
         borderStyle: "solid",
         width: "100%",
         p: 0.5,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -43,9 +43,9 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
 
   return (
     <Box
+      className="card-tag"
       sx={(theme) => ({
         bgcolor: tagBgColor,
-        borderColor: theme.palette.common.black,
         borderWidth: "0 1px 1px 1px",
         borderStyle: "solid",
         width: "100%",

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -124,6 +124,10 @@ const containsMadeLink = (data: Record<string, unknown>): boolean => {
   });
 };
 
+const canUserEditNode = (teamSlug: string) => {
+  return useStore.getState().canUserEditTeam(teamSlug);
+};
+
 const FormModal: React.FC<{
   type: string;
   handleDelete?: () => void;
@@ -146,6 +150,7 @@ const FormModal: React.FC<{
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
+  const userCanEdit = canUserEditNode(teamSlug);
 
   const toast = useToast();
 
@@ -187,6 +192,7 @@ const FormModal: React.FC<{
             {...node?.data}
             {...extraProps}
             id={id}
+            disabled={!userCanEdit}
             handleSubmit={(
               data: any,
               children: Array<any> | undefined = undefined,
@@ -236,7 +242,7 @@ const FormModal: React.FC<{
                   handleDelete();
                   navigate(rootFlowPath(true));
                 }}
-                disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+                disabled={!userCanEdit}
               >
                 delete
               </Button>
@@ -251,7 +257,7 @@ const FormModal: React.FC<{
                   makeUnique(id, parent);
                   navigate(rootFlowPath(true));
                 }}
-                disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+                disabled={!userCanEdit}
               >
                 make unique
               </Button>
@@ -265,7 +271,7 @@ const FormModal: React.FC<{
               variant="contained"
               color="primary"
               form="modal"
-              disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+              disabled={!userCanEdit}
             >
               {handleDelete ? `Update ${type}` : `Create ${type}`}
             </Button>

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -124,10 +124,6 @@ const containsMadeLink = (data: Record<string, unknown>): boolean => {
   });
 };
 
-const canUserEditNode = (teamSlug: string) => {
-  return useStore.getState().canUserEditTeam(teamSlug);
-};
-
 const FormModal: React.FC<{
   type: string;
   handleDelete?: () => void;
@@ -148,9 +144,11 @@ const FormModal: React.FC<{
   ]);
   const handleClose = () => navigate(rootFlowPath(true));
 
-  // useStore.getState().getTeam().slug undefined here, use window instead
-  const teamSlug = window.location.pathname.split("/")[1];
-  const userCanEdit = canUserEditNode(teamSlug);
+  const teamSlug = useStore.getState().getTeam().slug;
+  const canUserEditNode = (teamSlug: string) => {
+    return useStore.getState().canUserEditTeam(teamSlug);
+  };
+  const disabled = !canUserEditNode(teamSlug);
 
   const toast = useToast();
 
@@ -192,7 +190,7 @@ const FormModal: React.FC<{
             {...node?.data}
             {...extraProps}
             id={id}
-            disabled={!userCanEdit}
+            disabled={disabled}
             handleSubmit={(
               data: any,
               children: Array<any> | undefined = undefined,
@@ -242,7 +240,7 @@ const FormModal: React.FC<{
                   handleDelete();
                   navigate(rootFlowPath(true));
                 }}
-                disabled={!userCanEdit}
+                disabled={disabled}
               >
                 delete
               </Button>
@@ -257,7 +255,7 @@ const FormModal: React.FC<{
                   makeUnique(id, parent);
                   navigate(rootFlowPath(true));
                 }}
-                disabled={!userCanEdit}
+                disabled={disabled}
               >
                 make unique
               </Button>
@@ -271,7 +269,7 @@ const FormModal: React.FC<{
               variant="contained"
               color="primary"
               form="modal"
-              disabled={!userCanEdit}
+              disabled={disabled}
             >
               {handleDelete ? `Update ${type}` : `Create ${type}`}
             </Button>

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -197,13 +197,6 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
-  // Temporarily style as "can edit"
-  &.type-DrawBoundary > div > a {
-    border-width: 2px;
-    border-color: $nodeBorder;
-    background: white;
-  }
-
   &.type-SetValue > div > a {
     background: #f0f0f0;
     font-family: $fontMonospace;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -3,6 +3,8 @@ $nodeBorder: $black;
 $optionBorder: #b1b4b6;
 $hangerBackground: #f2f2f2;
 $focus: #ffdd00;
+$lockedBackground: #eeeeee;
+$lockedBorder: #b0b0b0;
 
 $endpointWidth: 50px;
 $hangerWidth: 16px;
@@ -42,6 +44,10 @@ $fontMonospace: "Source Code Pro", monospace;
   flex: 1;
   overflow: auto;
   padding: $editorPadding;
+
+  &.flow-locked {
+    background: $lockedBackground;
+  }
 
   ol,
   li {
@@ -164,6 +170,11 @@ $fontMonospace: "Source Code Pro", monospace;
     padding: 6px 12px;
     overflow-wrap: break-word;
     word-break: break-word;
+
+    .flow-locked & {
+      background: $lockedBackground;
+      border-color: $lockedBorder;
+    }
 
     * {
       pointer-events: none;
@@ -339,6 +350,9 @@ $fontMonospace: "Source Code Pro", monospace;
     background: $black;
     color: white;
     border: none;
+    .flow-locked & {
+      background: #555;
+    }
   }
   &.breadcrumb {
     background-image: $pixel;
@@ -415,6 +429,9 @@ $fontMonospace: "Source Code Pro", monospace;
       background: #fffdb0 !important;
       position: relative;
       padding-right: 20px;
+      .flow-locked & {
+        background: #f5f4d2 !important;
+      }
     }
     // Triangle shapes to simulate paper fold on sticky note
     &:not(.isClone) a {
@@ -427,6 +444,9 @@ $fontMonospace: "Source Code Pro", monospace;
         height: 0;
         border-bottom: 12px solid #fff;
         border-left: 12px solid transparent;
+        .flow-locked & {
+          border-bottom-color: $lockedBackground;
+        }
       }
       &::after {
         content: "";

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -5,6 +5,8 @@ $hangerBackground: #f2f2f2;
 $focus: #ffdd00;
 $lockedBackground: #eeeeee;
 $lockedBorder: #b0b0b0;
+$dataBackground: #f0f0f0;
+$lockedDataBackground: #e2e2e2;
 
 $endpointWidth: 50px;
 $hangerWidth: 16px;
@@ -197,8 +199,26 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
+  & .card-data-field {
+    border-color: $nodeBorder;
+    background: $dataBackground;
+
+    .flow-locked & {
+      border-color: $lockedBorder;
+      background: $lockedDataBackground;
+    }
+  }
+
+  & .card-tag {
+    border-color: $nodeBorder;
+    .flow-locked & {
+      opacity: 0.75;
+      border-color: $lockedBorder;
+    }
+  }
+
   &.type-SetValue > div > a {
-    background: #f0f0f0;
+    background: $dataBackground;
     font-family: $fontMonospace;
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -140,6 +140,10 @@ $fontMonospace: "Source Code Pro", monospace;
       background: white;
       border: $nodeBorderWidth dashed $nodeBorder;
       z-index: -1;
+      .flow-locked & {
+        border-color: $lockedBorder;
+        background: transparent;
+      }
     }
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -197,6 +197,13 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
+  // Temporarily style as "can edit"
+  &.type-DrawBoundary > div > a {
+    border-width: 2px;
+    border-color: $nodeBorder;
+    background: white;
+  }
+
   &.type-SetValue > div > a {
     background: #f0f0f0;
     font-family: $fontMonospace;

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -51,7 +51,7 @@ const FlowEditor = () => {
     (state) => state.isTestEnvBannerVisible,
   );
 
-  const teamSlug = window.location.pathname.split("/")[1];
+  const teamSlug = useStore.getState().getTeam().slug;
   const lockedFlow = !useStore.getState().canUserEditTeam(teamSlug);
 
   return (

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -51,6 +51,9 @@ const FlowEditor = () => {
     (state) => state.isTestEnvBannerVisible,
   );
 
+  const teamSlug = window.location.pathname.split("/")[1];
+  const lockedFlow = !useStore.getState().canUserEditTeam(teamSlug);
+
   return (
     <EditorContainer
       id="editor-container"
@@ -64,7 +67,12 @@ const FlowEditor = () => {
           overflowX: "auto",
         }}
       >
-        <Box id="editor" ref={scrollContainerRef} sx={{ position: "relative" }}>
+        <Box
+          id="editor"
+          ref={scrollContainerRef}
+          className={lockedFlow ? "flow-locked" : ""}
+          sx={{ position: "relative" }}
+        >
           <Flow flow={flow} breadcrumbs={breadcrumbs} />
           <EditorVisualControls
             orientation="vertical"

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -502,7 +502,7 @@ const getThemeOptions = ({
         styleOverrides: {
           root: {
             "&.Mui-disabled": {
-              backgroundColor: palette.grey[200],
+              backgroundColor: palette.background.disabled,
             },
           },
         },
@@ -511,7 +511,7 @@ const getThemeOptions = ({
         styleOverrides: {
           root: {
             "&.Mui-disabled": {
-              backgroundColor: palette.grey[200],
+              backgroundColor: palette.background.disabled,
             },
           },
           icon: {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -22,6 +22,7 @@ import { gridClasses } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
 import { TeamTheme } from "@opensystemslab/planx-core/types";
 import { getContrastTextColor } from "styleUtils";
+import { switchClasses } from "ui/shared/Switch";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
 const DEFAULT_TONAL_OFFSET = 0.1;
@@ -536,24 +537,23 @@ const getThemeOptions = ({
             padding: "8px",
             left: "-8px",
             marginRight: "-4px",
-            "& .MuiSwitch-switchBase": {
+            [`& .${switchClasses.switchBase}`]: {
               padding: "11px",
               borderRadius: "50%",
-              color: "rgb(255, 106, 0)",
-              "&.Mui-checked": {
+              [`&.${switchClasses.checked}`]: {
                 transform: "translateX(32px)",
               },
             },
-            "& .MuiSwitch-thumb": {
+            [`& .${switchClasses.thumb}`]: {
               background: palette.common.white,
               width: "22px",
               height: "22px",
             },
-            "& .MuiSwitch-track": {
+            [`& .${switchClasses.track}`]: {
               background: palette.background.dark,
               borderRadius: "20px",
               position: "relative",
-              opacity: "1 !important",
+              opacity: 1,
               "&::before, &::after": {
                 display: "inline-block",
                 position: "absolute",
@@ -575,19 +575,21 @@ const getThemeOptions = ({
                 right: "4px",
               },
             },
-            "& .MuiSwitch-switchBase.Mui-checked": {
-              "& + .MuiSwitch-track": {
+            [`& .${switchClasses.switchBase}.${switchClasses.checked}`]: {
+              [`& + .${switchClasses.track}`]: {
                 background: palette.success.dark,
-              },
-              "& + .MuiSwitch-track::before": {
                 opacity: 1,
-              },
-              "& + .MuiSwitch-track::after": {
-                opacity: 0,
+                "&::before": {
+                  opacity: 1,
+                },
+                "&::after": {
+                  opacity: 0,
+                },
               },
             },
-            "& .MuiSwitch-switchBase.Mui-disabled": {
-              "& + .MuiSwitch-track": {
+            [`& .${switchClasses.switchBase}.${switchClasses.disabled}`]: {
+              [`& + .${switchClasses.track}`]: {
+                opacity: 1,
                 background: palette.text.disabled,
               },
             },

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -586,6 +586,11 @@ const getThemeOptions = ({
                 opacity: 0,
               },
             },
+            "& .MuiSwitch-switchBase.Mui-disabled": {
+              "& + .MuiSwitch-track": {
+                background: palette.text.disabled,
+              },
+            },
           },
         },
       },

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -650,6 +650,12 @@ const getThemeOptions = ({
               outlineOffset: "1px",
               boxShadow: `0 0 0 4px ${palette.action.focus}`,
             },
+            [`&.${radioClasses.disabled}::before`]: {
+              borderColor: palette.text.disabled,
+            },
+            [`&.${radioClasses.disabled}::after`]: {
+              color: palette.text.disabled,
+            },
           },
         },
         variants: [

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -15,6 +15,8 @@ import createPalette, {
   PaletteOptions,
 } from "@mui/material/styles/createPalette";
 import { svgIconClasses } from "@mui/material/SvgIcon";
+// eslint-disable-next-line no-restricted-imports
+import { switchClasses } from "@mui/material/Switch";
 import { tablePaginationClasses } from "@mui/material/TablePagination";
 import { tooltipClasses } from "@mui/material/Tooltip";
 import { deepmerge } from "@mui/utils";
@@ -22,7 +24,6 @@ import { gridClasses } from "@mui/x-data-grid";
 import type {} from "@mui/x-data-grid/themeAugmentation";
 import { TeamTheme } from "@opensystemslab/planx-core/types";
 import { getContrastTextColor } from "styleUtils";
-import { switchClasses } from "ui/shared/Switch";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
 const DEFAULT_TONAL_OFFSET = 0.1;

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -41,6 +41,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     default: "#FFFFFF",
     paper: "#F9F8F8",
     dark: "#2c2c2c",
+    disabled: "#EEEEEE",
   },
   secondary: {
     main: "#F3F2F1",

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -86,12 +86,14 @@ declare module "@mui/material/styles/createPalette" {
     main: string;
     paper: string;
     dark: string;
+    disabled: string;
   }
 
   interface TypeBackgroundOptions {
     main: string;
     paper: string;
     dark: string;
+    disabled: string;
   }
 }
 

--- a/editor.planx.uk/src/ui/editor/ColorPicker/ColorPicker.tsx
+++ b/editor.planx.uk/src/ui/editor/ColorPicker/ColorPicker.tsx
@@ -12,6 +12,7 @@ export interface Props {
   color?: string;
   errorMessage?: string;
   onChange?: (newColor: string) => void;
+  disabled?: boolean;
 }
 
 interface RootProps extends BoxProps {
@@ -61,7 +62,7 @@ const Popover = styled(Box)(() => ({
 
 const StyledButtonBase = styled(ButtonBase, {
   shouldForwardProp: (prop) => prop !== "show",
-})<ButtonBaseProps & { show: boolean }>(({ theme, show }) => ({
+})<ButtonBaseProps & { show: boolean }>(({ theme, show, disabled }) => ({
   fontFamily: "inherit",
   fontSize: 15,
   position: "relative",
@@ -70,7 +71,10 @@ const StyledButtonBase = styled(ButtonBase, {
   textAlign: "left",
   padding: theme.spacing(1),
   whiteSpace: "nowrap",
-  backgroundColor: theme.palette.common.white,
+  backgroundColor: disabled
+    ? theme.palette.background.disabled
+    : theme.palette.common.white,
+  color: disabled ? theme.palette.text.disabled : theme.palette.text.primary,
   border: `1px solid ${theme.palette.border.main}`,
   ...(show && {
     color: theme.palette.primary.dark,
@@ -110,7 +114,12 @@ export default function ColorPicker(props: Props): FCReturn {
             {props.label}
           </Typography>
         )}
-        <StyledButtonBase show={show} onClick={handleClick} disableRipple>
+        <StyledButtonBase
+          show={show}
+          onClick={handleClick}
+          disableRipple
+          disabled={props.disabled}
+        >
           <Swatch sx={{ backgroundColor: props.color }} className="swatch" />
           {props.color}
         </StyledButtonBase>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -15,6 +15,7 @@ import { SelectMultiple } from "ui/shared/SelectMultiple";
 interface Props {
   value?: NodeTag[];
   onChange: (values: NodeTag[]) => void;
+  disabled?: boolean;
 }
 
 const skipTag = (role?: Role) => {
@@ -72,7 +73,11 @@ const renderTags: AutocompleteProps<
     );
   });
 
-export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
+export const ComponentTagSelect: React.FC<Props> = ({
+  value,
+  onChange,
+  disabled,
+}) => {
   return (
     <ModalSection>
       <ModalSectionContent title="Tags" Icon={BookmarksIcon}>
@@ -85,6 +90,7 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
             value={value}
             renderOption={renderOption}
             renderTags={renderTags}
+            disabled={disabled}
           />
         </InputRow>
       </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -22,6 +22,8 @@ const skipTag = (role?: Role) => {
   return role === userRole ? false : true;
 };
 
+const teamSlug = window.location.pathname.split("/")[1];
+
 const renderOption: AutocompleteProps<
   NodeTag,
   true,
@@ -85,6 +87,7 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
             value={value}
             renderOption={renderOption}
             renderTags={renderTags}
+            disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           />
         </InputRow>
       </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -87,7 +87,7 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
             value={value}
             renderOption={renderOption}
             renderTags={renderTags}
-            disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+            // disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           />
         </InputRow>
       </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -22,8 +22,6 @@ const skipTag = (role?: Role) => {
   return role === userRole ? false : true;
 };
 
-const teamSlug = window.location.pathname.split("/")[1];
-
 const renderOption: AutocompleteProps<
   NodeTag,
   true,
@@ -87,7 +85,6 @@ export const ComponentTagSelect: React.FC<Props> = ({ value, onChange }) => {
             value={value}
             renderOption={renderOption}
             renderTags={renderTags}
-            // disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           />
         </InputRow>
       </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
@@ -5,7 +5,6 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useMemo, useState } from "react";
 
 import PublicFileUploadButton, {
@@ -41,11 +40,13 @@ export default function ImgInput({
   onChange,
   acceptedFileTypes,
   backgroundColor,
+  disabled = false,
 }: {
   img?: string;
   onChange?: (newUrl?: string) => void;
   acceptedFileTypes?: AcceptedFileTypes;
   backgroundColor?: string;
+  disabled?: boolean;
 }): FCReturn {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
@@ -53,9 +54,6 @@ export default function ImgInput({
   const menuId = useMemo(() => {
     return `menu-${Math.floor(Math.random() * 1000000)}`;
   }, []);
-
-  // useStore.getState().getTeam().slug undefined here, use window instead
-  const teamSlug = window.location.pathname.split("/")[1];
 
   const handleRemove = () => {
     onChange && onChange(undefined);
@@ -87,10 +85,7 @@ export default function ImgInput({
         <MenuItem component="a" href={img} target="_blank">
           View
         </MenuItem>
-        <MenuItem
-          onClick={handleRemove}
-          disabled={!useStore.getState().canUserEditTeam(teamSlug)}
-        >
+        <MenuItem onClick={handleRemove} disabled={disabled}>
           Remove
         </MenuItem>
       </Menu>
@@ -105,14 +100,14 @@ export default function ImgInput({
       </ImageWrapper>
     </ImageUploadContainer>
   ) : (
-    <Tooltip title="Drop file here">
+    <Tooltip title="Drop file here" disableHoverListener={disabled}>
       <ImageUploadContainer>
         <PublicFileUploadButton
           onChange={(newUrl) => {
             setAnchorEl(null);
             onChange && onChange(newUrl);
           }}
-          disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+          disabled={disabled}
           acceptedFileTypes={acceptedFileTypes}
         />
       </ImageUploadContainer>

--- a/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
+++ b/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
@@ -40,7 +40,7 @@ export default function ImgInput({
   onChange,
   acceptedFileTypes,
   backgroundColor,
-  disabled = false,
+  disabled,
 }: {
   img?: string;
   onChange?: (newUrl?: string) => void;

--- a/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -1,5 +1,4 @@
 import BorderColorIcon from "@mui/icons-material/BorderColor";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -10,14 +9,14 @@ export interface InternalNotesProps {
   name?: string;
   value?: string;
   onChange: (ev: ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
 }
-
-const teamSlug = window.location.pathname.split("/")[1];
 
 export const InternalNotes: React.FC<InternalNotesProps> = ({
   name,
   value,
   onChange,
+  disabled,
 }) => {
   return (
     <ModalSection>
@@ -31,7 +30,7 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
             multiline
             placeholder="Internal notes"
             rows={3}
-            disabled={!useStore.getState().canUserEditTeam(teamSlug)}
+            disabled={disabled}
           />
         </InputRow>
       </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -1,4 +1,5 @@
 import BorderColorIcon from "@mui/icons-material/BorderColor";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -10,6 +11,8 @@ export interface InternalNotesProps {
   value?: string;
   onChange: (ev: ChangeEvent<HTMLInputElement>) => void;
 }
+
+const teamSlug = window.location.pathname.split("/")[1];
 
 export const InternalNotes: React.FC<InternalNotesProps> = ({
   name,
@@ -28,6 +31,7 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
             multiline
             placeholder="Internal notes"
             rows={3}
+            disabled={!useStore.getState().canUserEditTeam(teamSlug)}
           />
         </InputRow>
       </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -124,6 +124,7 @@ export default function ListManager<T, EditorExtraProps>(
                     props.onChange(setAt(index, newItem, props.values));
                   }}
                   {...(props.editorExtraProps || {})}
+                  disabled={disabled}
                 />
                 <Box sx={{ display: "flex", alignItems: "flex-start" }}>
                   <IconButton
@@ -133,9 +134,7 @@ export default function ListManager<T, EditorExtraProps>(
                     }}
                     aria-label="Delete"
                     size="large"
-                    disabled={
-                      disabled || props?.isFieldDisabled?.(item, index)
-                    }
+                    disabled={disabled || props?.isFieldDisabled?.(item, index)}
                   >
                     <Delete />
                   </IconButton>
@@ -237,6 +236,7 @@ export default function ListManager<T, EditorExtraProps>(
                               );
                             }}
                             {...(props.editorExtraProps || {})}
+                            disabled={disabled}
                           />
                           <Box>
                             <IconButton

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -10,7 +10,6 @@ import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { arrayMoveImmutable } from "array-move";
 import { nanoid } from "nanoid";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useRef, useState } from "react";
 import {
   DragDropContext,
@@ -28,6 +27,7 @@ export interface EditorProps<T> {
   index: number;
   value: T;
   onChange: (newValue: T) => void;
+  disabled?: boolean;
 }
 
 export interface Props<T, EditorExtraProps = {}> {
@@ -40,6 +40,7 @@ export interface Props<T, EditorExtraProps = {}> {
   noDragAndDrop?: boolean;
   isFieldDisabled?: (item: T, index: number) => boolean;
   maxItems?: number;
+  disabled?: boolean;
 }
 
 const Item = styled(Box)(() => ({
@@ -96,7 +97,7 @@ const InsertButton: React.FC<{
 export default function ListManager<T, EditorExtraProps>(
   props: Props<T, EditorExtraProps>,
 ) {
-  const { Editor, maxItems = Infinity } = props;
+  const { Editor, maxItems = Infinity, disabled } = props;
   // Initialize a random ID when the component mounts
   const randomId = useRef(nanoid());
 
@@ -106,9 +107,6 @@ export default function ListManager<T, EditorExtraProps>(
     props.values.map(() => nanoid()),
   );
 
-  // useStore.getState().getTeam().slug undefined here, use window instead
-  const teamSlug = window.location.pathname.split("/")[1];
-  const isViewOnly = !useStore.getState().canUserEditTeam(teamSlug);
   const isMaxLength = props.values.length >= maxItems;
   const [isDragging, setIsDragging] = useState(false);
 
@@ -136,7 +134,7 @@ export default function ListManager<T, EditorExtraProps>(
                     aria-label="Delete"
                     size="large"
                     disabled={
-                      isViewOnly || props?.isFieldDisabled?.(item, index)
+                      disabled || props?.isFieldDisabled?.(item, index)
                     }
                   >
                     <Delete />
@@ -154,7 +152,7 @@ export default function ListManager<T, EditorExtraProps>(
           props.onChange([...props.values, props.newValue()]);
           setItemKeys((prev) => [...prev, nanoid()]);
         }}
-        disabled={isViewOnly || isMaxLength}
+        disabled={disabled || isMaxLength}
       >
         {props.newValueLabel || "add new"}
       </Button>
@@ -193,7 +191,7 @@ export default function ListManager<T, EditorExtraProps>(
                   <Box>
                     {Boolean(index) && (
                       <InsertButton
-                        disabled={isViewOnly || isMaxLength}
+                        disabled={disabled || isMaxLength}
                         handleClick={() => {
                           props.onChange(
                             insertAt(index, props.newValue(), props.values),
@@ -221,11 +219,11 @@ export default function ListManager<T, EditorExtraProps>(
                             <IconButton
                               disableRipple
                               {...(props.noDragAndDrop
-                                ? { disabled: true || isViewOnly }
+                                ? { disabled: true || disabled }
                                 : provided.dragHandleProps)}
                               aria-label="Drag"
                               size="large"
-                              disabled={isViewOnly}
+                              disabled={disabled}
                             >
                               <DragHandle />
                             </IconButton>
@@ -251,7 +249,7 @@ export default function ListManager<T, EditorExtraProps>(
                               aria-label="Delete"
                               size="large"
                               disabled={
-                                isViewOnly ||
+                                disabled ||
                                 props?.isFieldDisabled?.(item, index)
                               }
                             >
@@ -276,7 +274,7 @@ export default function ListManager<T, EditorExtraProps>(
           props.onChange([...props.values, props.newValue()]);
           setItemKeys((prev) => [...prev, nanoid()]);
         }}
-        disabled={isViewOnly || isMaxLength}
+        disabled={disabled || isMaxLength}
       >
         {props.newValueLabel || "add new"}
       </Button>

--- a/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -11,6 +11,7 @@ interface Props<T extends BaseNodeData> {
   showMoreInformation?: boolean;
   showInternalNotes?: boolean;
   showTags?: boolean;
+  disabled?: boolean;
 }
 
 export const ModalFooter = <T extends BaseNodeData>({
@@ -18,6 +19,7 @@ export const ModalFooter = <T extends BaseNodeData>({
   showMoreInformation = true,
   showInternalNotes = true,
   showTags = true,
+  disabled = false,
 }: Props<T>) => (
   <>
     {showMoreInformation && (
@@ -27,6 +29,7 @@ export const ModalFooter = <T extends BaseNodeData>({
         howMeasured={formik.values.howMeasured}
         policyRef={formik.values.policyRef}
         info={formik.values.info}
+        disabled={disabled}
       />
     )}
     {showInternalNotes && (
@@ -34,6 +37,7 @@ export const ModalFooter = <T extends BaseNodeData>({
         name="notes"
         onChange={formik.handleChange}
         value={formik.values.notes}
+        disabled={disabled}
       />
     )}
     {showTags && (

--- a/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -19,7 +19,7 @@ export const ModalFooter = <T extends BaseNodeData>({
   showMoreInformation = true,
   showInternalNotes = true,
   showTags = true,
-  disabled = false,
+  disabled,
 }: Props<T>) => (
   <>
     {showMoreInformation && (

--- a/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -44,6 +44,7 @@ export const ModalFooter = <T extends BaseNodeData>({
       <ComponentTagSelect
         value={formik.values.tags}
         onChange={(value) => formik.setFieldValue("tags", value)}
+        disabled={disabled}
       />
     )}
   </>

--- a/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
+++ b/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
@@ -14,6 +14,7 @@ export const MoreInformation = ({
   howMeasured,
   policyRef,
   info,
+  disabled = false,
 }: MoreInformationProps) => {
   return (
     <ModalSection>
@@ -25,6 +26,7 @@ export const MoreInformation = ({
               name="info"
               value={info}
               onChange={changeField}
+              disabled={disabled}
             />
           </InputLabel>
           <InputLabel label="Policy source">
@@ -33,6 +35,7 @@ export const MoreInformation = ({
               name="policyRef"
               value={policyRef}
               onChange={changeField}
+              disabled={disabled}
             />
           </InputLabel>
           <InputLabel label="How it is defined?" htmlFor="howMeasured">
@@ -42,6 +45,7 @@ export const MoreInformation = ({
                 name="howMeasured"
                 value={howMeasured}
                 onChange={changeField}
+                disabled={disabled}
               />
               <ImgInput
                 img={definitionImg}
@@ -50,6 +54,7 @@ export const MoreInformation = ({
                     target: { name: "definitionImg", value: newUrl },
                   });
                 }}
+                disabled={disabled}
               />
             </InputRow>
           </InputLabel>

--- a/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
+++ b/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
@@ -14,7 +14,7 @@ export const MoreInformation = ({
   howMeasured,
   policyRef,
   info,
-  disabled = false,
+  disabled,
 }: MoreInformationProps) => {
   return (
     <ModalSection>

--- a/editor.planx.uk/src/ui/editor/MoreInformation/types.ts
+++ b/editor.planx.uk/src/ui/editor/MoreInformation/types.ts
@@ -4,4 +4,5 @@ interface MoreInformationProps {
   policyRef?: string;
   info?: string;
   definitionImg?: string;
+  disabled?: boolean;
 }

--- a/editor.planx.uk/src/ui/editor/RichTextImage.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextImage.tsx
@@ -53,6 +53,7 @@ const ImageNode: React.FC<NodeViewWrapperProps> = ({
   selected,
   node,
   updateAttributes,
+  editor,
 }) => {
   const { src, alt } = node.attrs;
 
@@ -78,6 +79,7 @@ const ImageNode: React.FC<NodeViewWrapperProps> = ({
           }}
           type="button"
           onClick={onEditAlt}
+          disabled={!editor.options.editable}
         >
           Edit
         </Link>

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -40,7 +40,7 @@ import {
   linkSelectionError,
 } from "./validationHelpers";
 
-const RichTextInput: FC<Props & { disabled?: boolean }> = (props) => {
+const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");
 
   const editor = useEditor({

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -40,7 +40,7 @@ import {
   linkSelectionError,
 } from "./validationHelpers";
 
-const RichTextInput: FC<Props> = (props) => {
+const RichTextInput: FC<Props & { disabled?: boolean }> = (props) => {
   const stringValue = String(props.value || "");
 
   const editor = useEditor({
@@ -59,7 +59,7 @@ const RichTextInput: FC<Props> = (props) => {
       }),
     ],
     content: fromHtml(stringValue),
-    editable: Boolean(props.onChange),
+    editable: !props.disabled,
   });
 
   const [addingLink, setAddingLink] = useState<{

--- a/editor.planx.uk/src/ui/editor/RichTextInput/styles.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/styles.ts
@@ -59,6 +59,11 @@ export const RichContentContainer = styled(Box)(({ theme }) => ({
       padding: theme.spacing(0.25, 0.5),
       borderRadius: "4px",
     },
+    // Styles for disabled input
+    '&[contenteditable="false"]': {
+      backgroundColor: theme.palette.background.disabled,
+      color: theme.palette.text.disabled,
+    },
   },
 }));
 

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -16,6 +16,7 @@ export interface Props extends InputBaseProps {
   onChange?: (ev: ChangeEvent<HTMLInputElement>) => void;
   bordered?: boolean;
   errorMessage?: string;
+  disabled?: boolean;
 }
 export interface VariablesState {
   variables: string[];

--- a/editor.planx.uk/src/ui/shared/Autocomplete/styles.ts
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/styles.ts
@@ -36,7 +36,6 @@ export const StyledTextField = styled(TextField)(({ theme }) => ({
   [`& .${outlinedInputClasses.root}, input`]: {
     cursor: "pointer",
     // TODO extract as `format="data"` prop more like `Input` ?
-    backgroundColor: theme.palette.background.default,
   },
   "& .MuiInputBase-root.Mui-disabled input": {
     background: "transparent",

--- a/editor.planx.uk/src/ui/shared/Autocomplete/styles.ts
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/styles.ts
@@ -33,11 +33,14 @@ export const StyledTextField = styled(TextField)(({ theme }) => ({
   "& fieldset": {
     borderColor: theme.palette.border.main,
   },
-  backgroundColor: theme.palette.background.main,
   [`& .${outlinedInputClasses.root}, input`]: {
     cursor: "pointer",
     // TODO extract as `format="data"` prop more like `Input` ?
     backgroundColor: theme.palette.background.default,
+  },
+  "& .MuiInputBase-root.Mui-disabled input": {
+    background: "transparent",
+    cursor: "default",
   },
   [`& .${inputLabelClasses.root}`]: {
     textDecoration: "underline",

--- a/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
@@ -22,8 +22,9 @@ const Root = styled(Box, {
       background: theme.palette.common.white,
     },
     ...(disabled && {
-      border: `2px solid ${theme.palette.grey[400]}`,
-      backgroundColor: theme.palette.grey[400],
+      border: `2px solid ${theme.palette.text.disabled}`,
+      backgroundColor: theme.palette.background.disabled,
+      pointerEvents: "none",
     }),
     ...(variant === "compact" && {
       alignSelf: "center",
@@ -67,6 +68,7 @@ const Icon = styled("span", {
   top: "42%",
   transform: "translate(-50%, -50%) rotate(45deg)",
   cursor: "pointer",
+  pointerEvents: "none",
   ...(variant === "compact" && {
     height: 12,
     width: 7,
@@ -75,13 +77,7 @@ const Icon = styled("span", {
     top: "44%",
   }),
   ...(disabled && {
-    borderBottom: "5px solid",
-    borderRight: "5px solid",
-    borderColor: theme.palette.common.white,
-    ...(variant === "compact" && {
-      borderBottom: "3px solid",
-      borderRight: "3px solid",
-    }),
+    borderColor: theme.palette.text.disabled,
   }),
 }));
 
@@ -91,6 +87,7 @@ export interface Props {
   onChange?: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   variant?: "default" | "compact";
+  disabled?: boolean;
 }
 
 export default function Checkbox({
@@ -99,6 +96,7 @@ export default function Checkbox({
   onChange,
   inputProps,
   variant = "default",
+  disabled,
 }: Props): FCReturn {
   const handleChange = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     e.preventDefault();
@@ -106,11 +104,7 @@ export default function Checkbox({
   };
 
   return (
-    <Root
-      onClick={handleChange}
-      disabled={inputProps?.disabled}
-      variant={variant}
-    >
+    <Root onClick={handleChange} disabled={disabled} variant={variant}>
       <Input
         defaultChecked={checked}
         type="checkbox"
@@ -118,12 +112,9 @@ export default function Checkbox({
         data-testid={id}
         {...inputProps}
         variant={variant}
+        disabled={disabled}
       />
-      <Icon
-        checked={checked}
-        disabled={inputProps?.disabled}
-        variant={variant}
-      />
+      <Icon checked={checked} disabled={disabled} variant={variant} />
     </Root>
   );
 }

--- a/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -29,6 +29,7 @@ interface Props {
   onChange: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   variant?: "default" | "compact";
+  disabled?: boolean;
 }
 
 export default function ChecklistItem({
@@ -38,6 +39,7 @@ export default function ChecklistItem({
   id,
   inputProps,
   variant,
+  disabled
 }: Props): FCReturn {
   return (
     <Root>
@@ -47,6 +49,7 @@ export default function ChecklistItem({
         onChange={onChange}
         inputProps={inputProps}
         variant={variant}
+        disabled={disabled}
       />
       <Label variant="body1" className="label" component={"label"} htmlFor={id}>
         {label}

--- a/editor.planx.uk/src/ui/shared/DateInput/DateInput.tsx
+++ b/editor.planx.uk/src/ui/shared/DateInput/DateInput.tsx
@@ -14,6 +14,7 @@ export interface Props {
   id?: string;
   onChange: (newDate: string, eventType: string) => void;
   required?: boolean;
+  disabled?: boolean;
 }
 
 const INPUT_DATE_WIDTH = "65px";
@@ -73,6 +74,7 @@ export default function DateInput(props: Props): FCReturn {
               );
             }}
             required={props.required}
+            disabled={props.disabled}
           />
         </Box>
         <Box sx={{ width: INPUT_DATE_WIDTH }}>
@@ -101,6 +103,7 @@ export default function DateInput(props: Props): FCReturn {
               );
             }}
             required={props.required}
+            disabled={props.disabled}
           />
         </Box>
         <Box sx={{ width: INPUT_YEAR_WIDTH }}>
@@ -123,6 +126,7 @@ export default function DateInput(props: Props): FCReturn {
               );
             }}
             required={props.required}
+            disabled={props.disabled}
           />
         </Box>
       </Root>

--- a/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
+++ b/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
@@ -31,7 +31,7 @@ interface RootProps extends ButtonBaseProps {
 const Root = styled(ButtonBase, {
   shouldForwardProp: (prop) =>
     !["isDragActive", "variant"].includes(prop.toString()),
-})<RootProps>(({ theme, isDragActive, variant }) => ({
+})<RootProps>(({ theme, isDragActive, variant, disabled }) => ({
   borderRadius: 0,
   height: 50,
   width: 50,
@@ -46,6 +46,9 @@ const Root = styled(ButtonBase, {
     color: "#757575",
     height: "fitContent",
     width: "fitContent",
+  }),
+  ...(disabled && {
+    backgroundColor: theme.palette.background.disabled,
   }),
 }));
 

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -67,6 +67,7 @@ export function SelectMultiple<T>(props: Props<T>) {
         disableClearable
         disableCloseOnSelect
         multiple
+        disabled={props.disabled}
         popupIcon={PopupIcon}
         renderInput={(params) => (
           <StyledTextField
@@ -77,6 +78,7 @@ export function SelectMultiple<T>(props: Props<T>) {
             }}
             label={props.label}
             placeholder={placeholder}
+            disabled={props.disabled}
           />
         )}
         ChipProps={{

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -39,6 +39,12 @@ export const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
   [`& .${autocompleteClasses.endAdornment}`]: {
     top: "unset",
   },
+  "& button.Mui-disabled > svg": {
+    color: theme.palette.text.disabled,
+  },
+  "& input": {
+    backgroundColor: "transparent",
+  },
   "&:focus-within": {
     "& svg": {
       color: "black",

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -14,6 +14,7 @@ interface Props {
   name?: string;
   variant?: "editorPage" | "editorModal";
   capitalize?: boolean;
+  disabled?: boolean;
 }
 
 export const Switch: React.FC<Props> = ({
@@ -23,6 +24,7 @@ export const Switch: React.FC<Props> = ({
   name,
   variant = "editorModal",
   capitalize = false,
+  disabled = false,
 }) => (
   <Box>
     <FormControlLabel
@@ -31,6 +33,7 @@ export const Switch: React.FC<Props> = ({
           checked={checked}
           onChange={onChange}
           sx={{ pointerEvents: "auto" }}
+          disabled={disabled}
         />
       }
       name={name}

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -3,7 +3,10 @@ import FormControlLabel, {
   formControlLabelClasses,
 } from "@mui/material/FormControlLabel";
 // eslint-disable-next-line no-restricted-imports
-import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
+import MuiSwitch, {
+  switchClasses,
+  SwitchProps as MuiSwitchProps,
+} from "@mui/material/Switch";
 import React from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
 
@@ -16,6 +19,8 @@ interface Props {
   capitalize?: boolean;
   disabled?: boolean;
 }
+
+export { switchClasses };
 
 export const Switch: React.FC<Props> = ({
   checked,

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -3,10 +3,7 @@ import FormControlLabel, {
   formControlLabelClasses,
 } from "@mui/material/FormControlLabel";
 // eslint-disable-next-line no-restricted-imports
-import MuiSwitch, {
-  switchClasses,
-  SwitchProps as MuiSwitchProps,
-} from "@mui/material/Switch";
+import MuiSwitch, { SwitchProps as MuiSwitchProps } from "@mui/material/Switch";
 import React from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
 
@@ -19,8 +16,6 @@ interface Props {
   capitalize?: boolean;
   disabled?: boolean;
 }
-
-export { switchClasses };
 
 export const Switch: React.FC<Props> = ({
   checked,

--- a/editor.planx.uk/src/ui/shared/Switch.tsx
+++ b/editor.planx.uk/src/ui/shared/Switch.tsx
@@ -24,7 +24,7 @@ export const Switch: React.FC<Props> = ({
   name,
   variant = "editorModal",
   capitalize = false,
-  disabled = false,
+  disabled,
 }) => (
   <Box>
     <FormControlLabel


### PR DESCRIPTION
## What does this PR do?

- Sets styles for non-editable graph + components (to be shared with templates)
- Configures editor modal to have `disabled` inputs when non-editable (only "Section" component done so far)

Preview:
https://4312.planx.pizza/barnet/apply-for-prior-approval