### PR TITLE
fix: query params not updating when filters update

### DIFF
--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -67,27 +67,30 @@ export const SortControl = <T extends object>({
     );
   }, [sortOptions]);
 
-  const updateSortParam = (sortOption: string) => {
-    const searchParams = new URLSearchParams();
-    searchParams.set("sort", sortOption);
-    searchParams.set("sortDirection", sortDirection);
-    navigation.navigate(
-      {
-        pathname: window.location.pathname,
-        search: `?${searchParams.toString()}`,
-      },
-      {
-        replace: true,
-      },
-    );
-  };
+  useEffect(() => {
+    const updateSortParam = (sortOption: string) => {
+      const searchParams = new URLSearchParams(route.url.search);
+      searchParams.set("sort", sortOption);
+      searchParams.set("sortDirection", sortDirection);
+      navigation.navigate(
+        {
+          pathname: window.location.pathname,
+          search: `?${searchParams.toString()}`,
+        },
+        {
+          replace: true,
+        },
+      );
+    };
+
+    updateSortParam(selectedDisplaySlug);
+  }, [navigation, route.url.search, selectedDisplaySlug, sortDirection]);
 
   useEffect(() => {
     const { fieldName } = selectedSort;
     const sortNewFlows = orderBy(records, fieldName, sortDirection);
     setRecords(sortNewFlows);
-    updateSortParam(selectedDisplaySlug);
-  }, [selectedSort, sortDirection, records]);
+  }, [selectedSort, sortDirection, records, setRecords]);
 
   return (
     <Box display={"flex"} gap={1}>


### PR DESCRIPTION
Found a bug in testing where query params were not updating when you selected a filter because `SortControl` was running at the same time when `matchingRecords` updated, but it would be before the state change of the URL changes. This meant the chosen filter would flicker in the URL and disappear. 

It made more sense to move this particular function inside it's own Effect so it can update when the URL or sort direction was to update