### PR TITLE
fix: Checkbox background style

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
@@ -25,6 +25,9 @@ const renderOptions: AutocompleteProps<
     listProps={props}
     displayName={flag.text}
     state={state}
+    checkboxProps={{
+      sx: { backgroundColor: flag.bgColor },
+    }}
   />
 );
 

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -30,6 +30,7 @@ const renderOption: AutocompleteProps<
   "div"
 >["renderOption"] = (props, tag, state) => {
   if (TAG_DISPLAY_VALUES[tag].editableBy?.some(skipTag)) return null;
+
   return (
     <RenderOptionCheckbox
       listProps={props}

--- a/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx
@@ -1,6 +1,6 @@
 import { AutocompleteRenderOptionState } from "@mui/material/Autocomplete";
 import ListItem from "@mui/material/ListItem";
-import React, { HTMLAttributes } from "react";
+import React, { ComponentProps, HTMLAttributes } from "react";
 
 import { CustomCheckbox } from "../styles";
 
@@ -8,18 +8,21 @@ interface RenderCheckboxProps {
   listProps: HTMLAttributes<HTMLLIElement>;
   displayName: string;
   state: AutocompleteRenderOptionState;
+  checkboxProps?: ComponentProps<typeof CustomCheckbox>;
 }
 
 export const RenderOptionCheckbox = ({
   listProps,
   displayName,
   state,
+  checkboxProps,
 }: RenderCheckboxProps) => {
   return (
     <ListItem {...listProps}>
       <CustomCheckbox
         aria-hidden="true"
         className={state.selected ? "selected" : ""}
+        {...checkboxProps}
       />
       {displayName}
     </ListItem>


### PR DESCRIPTION
## What does this PR do?
- Fixes [a visual regression introduced here](https://github.com/theopensystemslab/planx-new/pull/3998/files#diff-b2b6873296b0da41040b9766358555ab5d2d701a68f23b7348e5465dc7cdb613L28) in #3998
- Allows style overrides to be passed down through the shared `RenderOptionCheckbox`

This solution ensures that the background colour is correct for the filters, flag select, and general checkboxes.

| Before | After |
|--------|--------|
|![Screenshot 2025-02-13 at 16 26 04](https://github.com/user-attachments/assets/0c1e82a5-4adb-4963-915b-3dd63a28f5e5)|![Screenshot 2025-02-13 at 16 25 31](https://github.com/user-attachments/assets/bd44a070-65d8-41c8-b55b-9cf84241b74c)|
|![Screenshot 2025-02-13 at 16 20 23](https://github.com/user-attachments/assets/74118cd6-15b5-4210-a569-8228f5f439d7)|![Screenshot 2025-02-13 at 16 20 23](https://github.com/user-attachments/assets/74118cd6-15b5-4210-a569-8228f5f439d7)|
|![Screenshot 2025-02-13 at 16 28 10](https://github.com/user-attachments/assets/37cfd209-1ce0-4643-b29b-17a7b7eea37a)|![Screenshot 2025-02-13 at 16 28 10](https://github.com/user-attachments/assets/37cfd209-1ce0-4643-b29b-17a7b7eea37a)|