### PR TITLE
infra: upgrade to postgres 16.1 (then 16.7)

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -12,9 +12,9 @@ const networking = new pulumi.StackReference(`planx/networking/${env}`);
 
 const db = new aws.rds.Instance("app", {
   engine: "postgres",
-  // Available versions:
-  // $ aws rds describe-db-engine-versions --default-only --engine postgres
-  engineVersion: "17.3",
+  // AWS restricts the maximum upgrade leap, see available versions:
+  // $ aws rds describe-db-engine-versions --engine postgres  --engine-version your-version --query "DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}" --output text
+  engineVersion: "12.22",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
   instanceClass: env === "production" ? "db.t3.medium" : "db.t3.small",
   allocatedStorage: env === "production" ? 100 : 20,
@@ -27,7 +27,7 @@ const db = new aws.rds.Instance("app", {
   skipFinalSnapshot: true,
   publiclyAccessible: true,
   storageEncrypted: true,
-  backupRetentionPeriod: env === "production" ? 35 : 0,
+  backupRetentionPeriod: env === "production" ? 35 : 1,
   applyImmediately: true,
 });
 export const dbRootUrl = pulumi.interpolate`postgres://${DB_ROOT_USERNAME}:${config.require(

--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -14,7 +14,7 @@ const db = new aws.rds.Instance("app", {
   engine: "postgres",
   // Available versions:
   // $ aws rds describe-db-engine-versions --default-only --engine postgres
-  engineVersion: "12.17",
+  engineVersion: "17.3",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
   instanceClass: env === "production" ? "db.t3.medium" : "db.t3.small",
   allocatedStorage: env === "production" ? 100 : 20,

--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -14,7 +14,7 @@ const db = new aws.rds.Instance("app", {
   engine: "postgres",
   // AWS restricts the maximum upgrade leap, see available versions:
   // $ aws rds describe-db-engine-versions --engine postgres  --engine-version your-version --query "DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}" --output text
-  engineVersion: "12.22",
+  engineVersion: "16.1",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
   instanceClass: env === "production" ? "db.t3.medium" : "db.t3.small",
   allocatedStorage: env === "production" ? 100 : 20,


### PR DESCRIPTION
**Two key changes here [per Trello comments](https://trello.com/c/qda9058V/3186-update-aws-rds-postgresql-engine-version):** 
- Changes staging `backupRetention` from 0 to 1
- Bumps `engineVersion` to 16.1 which is latest major version we're able to upgrade to, once this succeeds we can aim to get to latest minor version of 16.7


AWS restricts major version leaps - see versions available to us by running 
```shell
$ aws rds describe-db-engine-versions --engine postgres  --engine-version 12.17 --query "DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}" --output text

12.18
12.19
12.20
12.21
12.22
13.13
13.14
13.15
13.16
13.17
13.18
14.10
15.5
16.1
```

This PR bumps our Pulumi data layer which will need to be manually deployed, see Docker equivalent here for local & pizza databases #4322 