### PR TITLE
fix: switch sort default to "desc"

### DIFF
--- a/editor.planx.uk/src/ui/editor/SortControl/utils.ts
+++ b/editor.planx.uk/src/ui/editor/SortControl/utils.ts
@@ -26,5 +26,5 @@ export const getSortParams = <T extends object>(
       return { sortObject, sortDirection: validSortUrl.data.sortDirection };
   }
 
-  return { sortObject: sortOptions[0], sortDirection: "asc" };
+  return { sortObject: sortOptions[0], sortDirection: "desc" };
 };


### PR DESCRIPTION
Found that we were defaulting to the oldest updated first as default, decided to switch this so the last updated service is shown at the top