### PR TITLE
infra: bump postgres to 16.3

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -14,7 +14,7 @@ const db = new aws.rds.Instance("app", {
   engine: "postgres",
   // AWS restricts the maximum upgrade leap, see available versions:
   // $ aws rds describe-db-engine-versions --engine postgres  --engine-version your-version --query "DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}" --output text
-  engineVersion: "16.1",
+  engineVersion: "16.3",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
   instanceClass: env === "production" ? "db.t3.medium" : "db.t3.small",
   allocatedStorage: env === "production" ? 100 : 20,


### PR DESCRIPTION
Our RDS instance is actually on 12.19, not 12.17 as Pulumi config had, therefore our valid jump is 16.3, not 16.1.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.MajorVersion.html