### PR TITLE
feat(sharedb): Toggle Postgres SSL for AWS environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
     environment:
       JWT_SECRET: ${JWT_SECRET}
       PG_URL: postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE}
+      APP_ENVIRONMENT: ${APP_ENVIRONMENT}
 
   # used as an S3 service mock
   minio:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -563,6 +563,7 @@ export = async () => {
             name: "PG_URL",
             value: config.requireSecret("db-url"),
           },
+          { name: "APP_ENVIRONMENT", value: env },
         ],
       },
     },

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -11,10 +11,13 @@ const { PORT = 8000, JWT_SECRET, PG_URL } = process.env;
 assert(JWT_SECRET);
 assert(PG_URL);
 
+const isLiveEnv = 
+  ["production", "staging"].includes(process.env.APP_ENVIRONMENT || "");
+
 const sharedb = new ShareDB({
   db: new PostgresDB({
     connectionString: PG_URL,
-    ssl: false,
+    ssl: isLiveEnv
   }),
 });
 


### PR DESCRIPTION
## What does this PR do?
- Toggles the `ssl` property on ShareDB

## Why do we need to do this?
Postgres 16 (on AWS RDS) sets `force_ssl` to `true` by default. This means that ShareDB is unable to connect to the postgres database while `ssl` is disabled.

One method would be to disable `ssl` on staging and production, but this seems unnecessary from both a risk and complexity option (we need to configure a new parameter group).

I spent a good bit of time trying to get `ssl: true` to work in docker environments and got pretty close. We need self-signed certificates to be generated when the postgis docker container spins up and I hit the following issues - 
- Our Alpine linux distro doesn't come with self-signed certificates (if it did, it would be simple config change)
- The distro doesn't have `openssl` installed
- Installing `openssl` and generating certs on spin up was possible, but I was then struggling to configure them due to how the data volume is mounted.
- I timeboxed this exercise and at a certain point decided to pivot back to this simpler solution.

## To test...
We need to make sure we an access flows via sharedb locally and on pizzas, and once deployed to `main` we can change out staging postgres parameter group back to the default one with `force_ssl` enabled. 

If this works, then we'll need to ensure that this change goes to production alongside the deploy of the production data layer.