### PR TITLE
feat: setup event trigger for new PlanX team -> new Metabase collection

### DIFF
--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -15,12 +15,17 @@ components:
     NewCollection:
       type: object
       properties:
+        slug:
+          type: string
+          description: PlanX team slug
         description:
           type: string
           description: Optional description for the collection
         parentId:
           type: integer
           description: Optional ID of the parent collection
+      required:
+        - slug
 
     NewDashboard:
       type: object
@@ -70,19 +75,12 @@ paths:
         "204":
           $ref: "#/components/responses/AnalyticsResponse"
 
-  /metabase/collection/{slug}:
+  /metabase/collection:
     post:
       summary: Create new Metabase collection
       description: Creates a new collection in Metabase if it doesn't already exist
       tags:
         - metabase
-      parameters:
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
-          description: PlanX team slug
       requestBody:
         required: true
         content:

--- a/api.planx.uk/modules/analytics/metabase/collection/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/controller.ts
@@ -5,7 +5,6 @@ export const metabaseCollectionsController: NewCollectionRequestHandler =
   async (_req, res) => {
     try {
       const params = {
-        ...res.locals.parsedReq.params,
         ...res.locals.parsedReq.body,
       };
       const collection = await createTeamCollection(params);

--- a/api.planx.uk/modules/analytics/metabase/collection/controller.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/controller.ts
@@ -4,9 +4,7 @@ import type { NewCollectionRequestHandler } from "./types.js";
 export const metabaseCollectionsController: NewCollectionRequestHandler =
   async (_req, res) => {
     try {
-      const params = {
-        ...res.locals.parsedReq.body,
-      };
+      const params = res.locals.parsedReq.body;
       const collection = await createTeamCollection(params);
       res.status(201).json({ data: collection });
     } catch (error) {

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -25,15 +25,13 @@ export type MetabaseCreateCollectionParams = {
  * the Metabase collection ID is for the "Council" collection
  * see https://github.com/theopensystemslab/planx-new/pull/4072#discussion_r1892631692
  **/
-// const COUNCILS_COLLECTION_ID = 58;
+const COUNCILS_COLLECTION_ID = 58;
 
 export const createTeamCollectionSchema = z.object({
-  params: z.object({
-    slug: z.string().min(1),
-  }),
   body: z.object({
+    slug: z.string().min(1),
     description: z.string().optional(),
-    parentId: z.number().optional(), //.default(COUNCILS_COLLECTION_ID),
+    parentId: z.number().optional().default(COUNCILS_COLLECTION_ID),
   }),
 });
 

--- a/api.planx.uk/modules/analytics/metabase/collection/types.ts
+++ b/api.planx.uk/modules/analytics/metabase/collection/types.ts
@@ -25,7 +25,7 @@ export type MetabaseCreateCollectionParams = {
  * the Metabase collection ID is for the "Council" collection
  * see https://github.com/theopensystemslab/planx-new/pull/4072#discussion_r1892631692
  **/
-const COUNCILS_COLLECTION_ID = 58;
+const COUNCILS_COLLECTION_ID = 78;
 
 export const createTeamCollectionSchema = z.object({
   body: z.object({

--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -23,7 +23,7 @@ router.post(
   logUserResumeController,
 );
 router.post(
-  "/metabase/collection/:slug",
+  "/metabase/collection",
   validate(createTeamCollectionSchema),
   metabaseCollectionsController,
 );

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2619,6 +2619,26 @@
           - slug
         filter: {}
         check: null
+  event_triggers:
+    - name: setup_metabase_collection
+      definition:
+        enable_manual: false
+        insert:
+          columns: '*'
+      retry_conf:
+        interval_sec: 10
+        num_retries: 0
+        timeout_sec: 60
+      webhook: '{{HASURA_PLANX_API_URL}}/metabase/collection/'
+      headers:
+        - name: authorization
+          value_from_env: HASURA_PLANX_API_KEY
+      request_transform:
+        body:
+          action: transform
+          template: "{\r\n  \"slug\": {{$body.event.data.new.slug}},\r\n  \"description\": \"Collection for {{$body.event.data.new.name}}\",\r\n  \"parentId\": 58\r\n}"
+        template_engine: Kriti
+        version: 2
 - table:
     name: teams_summary
     schema: public


### PR DESCRIPTION
# What does this PR do?
- Creates a new event trigger that listens for new rows added to `teams` table
- Changes the route (slug is now in the request body, not a URL parameter)

# Why?
- Most of the code has been written to automate the creation of collections (Metabase speak for 'folder'), we just need the plumbing in place / to know when to access the `/metabase/collection/` endpoint and what params to pass to it

# Questions
1. Will there be any instances of teams that shouldn't have a Metabase collection?
2. What should we do for all existing teams that don't have Metabase collections yet? Should they be created and updated manually? 
3. Do we need to set up retries in Hasura? 

I've tested this locally (adding new teams in `teams`) and new collections were successfully created in Metabase staging