### PR TITLE
fix: Add temporary guard to convert placeholder tags

### DIFF
--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -118,6 +118,12 @@ const editNode = validateNodeRoute(
       [key: string]: any;
     };
 
+    // Temp guard to handle non-migrated tags
+    // TODO: Migrate "placeholder" tags to "customisation"
+    node.data.tags = node.data.tags?.map((tag: string) =>
+      tag === "placeholder" ? "customisation" : tag,
+    );
+
     const extraProps = {} as any;
 
     if (node.type === TYPES.ExternalPortal)


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C01E3AC0C03/p1739802552794749 for context (OSL Slack).

**What's the problem?**
When https://github.com/theopensystemslab/planx-new/pull/4256 was merged, we didn't consider that nodes may already have the "placeholder" tag applied. Currently, any nodes with this tag will fail to render in the Editor.

**What's the solution?**
The right solution is to migrate any flows which contain the legacy "placeholder" tag to use the new "customisation" tag. I've added a blue trello card for this here - https://trello.com/c/Cvwe9t9N/3241-migrate-placeholder-tags-to-customisation

In the meantime, a quick guard to convert manually will unblock any Editors.