### PR TITLE
feat: sort null to bottom in SortControl component

### DIFF
--- a/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
+++ b/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
@@ -4,7 +4,7 @@ import { SortableFields } from "ui/editor/SortControl/SortControl";
 
 export const sortOptions: SortableFields<FlowSummary>[] = [
   {
-    displayName: "Last updated",
+    displayName: "Last edited",
     fieldName: "updatedAt",
     directionNames: { asc: "Oldest first", desc: "Newest first" },
   },

--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
-import { orderBy } from "lodash";
+import { get, orderBy } from "lodash";
 import React, { useEffect, useMemo, useState } from "react";
 import { useCurrentRoute, useNavigation } from "react-navi";
 import { Paths } from "type-fest";
@@ -88,7 +88,7 @@ export const SortControl = <T extends object>({
 
   useEffect(() => {
     const { fieldName } = selectedSort;
-    const sortNewFlows = orderBy(records,fieldName, sortDirection).sort((a:T,b:T) => sortNullToBottom(a,b, fieldName))
+    const sortNewFlows = orderBy(records,[(flow) => get(flow, fieldName) || ""], sortDirection)
     setRecords(sortNewFlows);
   }, [selectedSort, sortDirection, records, setRecords]);
 

--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -89,8 +89,8 @@ export const SortControl = <T extends object>({
 
   useEffect(() => {
     const { fieldName } = selectedSort;
-    const sortNewFlows = orderBy(records,[(flow) => get(flow, fieldName) || ""], sortDirection)
-    setRecords(sortNewFlows);
+    const sortedFlowsNullsLast = orderBy(records,[(flow) => get(flow, fieldName) || ""], sortDirection)
+    setRecords(sortedFlowsNullsLast);
   }, [selectedSort, sortDirection, records, setRecords]);
 
   return (

--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -8,7 +8,7 @@ import { Paths } from "type-fest";
 import { slugify } from "utils";
 
 import SelectInput from "../SelectInput/SelectInput";
-import { getSortParams } from "./utils";
+import { getSortParams, sortNullToBottom } from "./utils";
 
 type SortDirection = "asc" | "desc";
 
@@ -88,7 +88,7 @@ export const SortControl = <T extends object>({
 
   useEffect(() => {
     const { fieldName } = selectedSort;
-    const sortNewFlows = orderBy(records, fieldName, sortDirection);
+    const sortNewFlows = orderBy(records,fieldName, sortDirection).sort((a:T,b:T) => sortNullToBottom(a,b, fieldName))
     setRecords(sortNewFlows);
   }, [selectedSort, sortDirection, records, setRecords]);
 

--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -1,14 +1,15 @@
 import Box from "@mui/material/Box";
 import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
-import { get, orderBy } from "lodash";
+import get from "lodash/get";
+import orderBy from "lodash/orderBy";
 import React, { useEffect, useMemo, useState } from "react";
 import { useCurrentRoute, useNavigation } from "react-navi";
 import { Paths } from "type-fest";
 import { slugify } from "utils";
 
 import SelectInput from "../SelectInput/SelectInput";
-import { getSortParams, sortNullToBottom } from "./utils";
+import { getSortParams } from "./utils";
 
 type SortDirection = "asc" | "desc";
 

--- a/editor.planx.uk/src/ui/editor/SortControl/utils.ts
+++ b/editor.planx.uk/src/ui/editor/SortControl/utils.ts
@@ -3,8 +3,6 @@ import { slugify } from "utils";
 import { z } from "zod";
 
 import { SortableFields } from "./SortControl";
-import { get } from "lodash";
-import { Paths } from "type-fest";
 
 const routeQuerySchema = z.object({
   sort: z.string(),
@@ -30,16 +28,3 @@ export const getSortParams = <T extends object>(
 
   return { sortObject: sortOptions[0], sortDirection: "desc" };
 };
-
-
-export const sortNullToBottom =<T extends object> (a: T,b: T, fieldName:Paths<T>)=>{
-  const aValue = get(a, fieldName);
-  const bValue = get(b, fieldName);
-  
-  if (!aValue && !bValue) return 0;
-  if (!aValue) return 1;
-  if (!bValue) return -1;
-  
-  // For non-null values, maintain their relative order
-  return 0;
-}

--- a/editor.planx.uk/src/ui/editor/SortControl/utils.ts
+++ b/editor.planx.uk/src/ui/editor/SortControl/utils.ts
@@ -3,6 +3,8 @@ import { slugify } from "utils";
 import { z } from "zod";
 
 import { SortableFields } from "./SortControl";
+import { get } from "lodash";
+import { Paths } from "type-fest";
 
 const routeQuerySchema = z.object({
   sort: z.string(),
@@ -28,3 +30,16 @@ export const getSortParams = <T extends object>(
 
   return { sortObject: sortOptions[0], sortDirection: "desc" };
 };
+
+
+export const sortNullToBottom =<T extends object> (a: T,b: T, fieldName:Paths<T>)=>{
+  const aValue = get(a, fieldName);
+  const bValue = get(b, fieldName);
+  
+  if (!aValue && !bValue) return 0;
+  if (!aValue) return 1;
+  if (!bValue) return -1;
+  
+  // For non-null values, maintain their relative order
+  return 0;
+}


### PR DESCRIPTION
## What does this PR do?

This PR responds to feedback here: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1739788849390769

I have added a function to the `orderBy` iteratee section which mutates the original sort array by sorting all null values to the bottom. Currently, for date formats especially, these were being formatted to the 'newest' sort. 

The sort option `last updated` has now been changed to `last edited` as well.