### PR TITLE
feat: Add `revoked_tokens` table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1921,6 +1921,32 @@
       permission:
         filter: {}
 - table:
+    name: revoked_tokens
+    schema: public
+  insert_permissions:
+    - role: api
+      permission:
+        check: {}
+        columns:
+          - expires_at
+          - revoked_at
+          - token_digest
+      comment: ""
+  select_permissions:
+    - role: api
+      permission:
+        columns:
+          - expires_at
+          - revoked_at
+          - token_digest
+        filter: {}
+      comment: ""
+  delete_permissions:
+    - role: api
+      permission:
+        filter: {}
+      comment: ""
+- table:
     name: s3_applications
     schema: public
   insert_permissions:

--- a/hasura.planx.uk/migrations/1739878905926_create_table_public_revoked_tokens/down.sql
+++ b/hasura.planx.uk/migrations/1739878905926_create_table_public_revoked_tokens/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."revoked_tokens";

--- a/hasura.planx.uk/migrations/1739878905926_create_table_public_revoked_tokens/up.sql
+++ b/hasura.planx.uk/migrations/1739878905926_create_table_public_revoked_tokens/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "public"."revoked_tokens" (
+  "token_digest" text NOT NULL,
+  "revoked_at" timestamptz NOT NULL DEFAULT now(),
+  "expires_at" timestamptz NOT NULL,
+  PRIMARY KEY ("token_digest")
+);
+
+COMMENT ON TABLE "public"."revoked_tokens" IS E'Holds a digest of revoked JWTs. This table is checked as part of the auth process. Token are revoked as part of the logout process to ensure that a user\'s token cannot be re-used.';
+
+COMMENT ON COLUMN "public"."revoked_tokens"."token_digest" IS E'SHA-256 encoded digest of a user\'s JWT';

--- a/hasura.planx.uk/tests/revoked_tokens.test.js
+++ b/hasura.planx.uk/tests/revoked_tokens.test.js
@@ -1,0 +1,105 @@
+const { introspectAs } = require("./utils");
+
+describe("revoked_tokens", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query revoked_tokens", () => {
+      expect(i.queries).not.toContain("revoked_tokens");
+    });
+
+    test("cannot create, update, or delete revoked_tokens", () => {
+      expect(i).toHaveNoMutationsFor("revoked_tokens");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("can query revoked_tokens", () => {
+      expect(i.queries).toContain("revoked_tokens");
+    });
+
+    test("can create, update, or delete revoked_tokens", () => {
+      expect(i.mutations).toContain("insert_revoked_tokens");
+      expect(i.mutations).toContain("insert_revoked_tokens_one");
+      expect(i.mutations).toContain("update_revoked_tokens_by_pk");
+      expect(i.mutations).toContain("delete_revoked_tokens_by_pk");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query revoked_tokens", () => {
+      expect(i.queries).not.toContain("revoked_tokens");
+    });
+
+    test("cannot create, update, or delete revoked_tokens", () => {
+      expect(i).toHaveNoMutationsFor("revoked_tokens");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query revoked_tokens", () => {
+      expect(i.queries).not.toContain("revoked_tokens");
+    });
+
+    test("cannot create, update, or delete revoked_tokens", () => {
+      expect(i).toHaveNoMutationsFor("revoked_tokens");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query revoked_tokens", () => {
+      expect(i.queries).not.toContain("revoked_tokens");
+    });
+
+    test("cannot create, update, or delete revoked_tokens", () => {
+      expect(i).toHaveNoMutationsFor("revoked_tokens");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query revoked_tokens", () => {
+      expect(i.queries).toContain("revoked_tokens");
+    });
+
+    test("cannot update revoked_tokens", () => {
+      expect(i.mutations).not.toContain("update_revoked_tokens");
+    });
+
+    test("can delete revoked_tokens", () => {
+      expect(i.mutations).toContain("delete_revoked_tokens");
+    });
+
+    test("can insert reconciliation requests", () => {
+      expect(i.mutations).toContain("insert_revoked_tokens");
+      expect(i.mutations).toContain("insert_revoked_tokens_one");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?
- Creates the `revoked_tokens` table
- Introspection tests

## Documentation
Work in progress documentation here - https://www.notion.so/opensystemslab/How-does-authentication-work-19e35d469ad180b2bc17ce5bc29f6477

Technical checklist on Trello - https://trello.com/c/GZIRbSNO/3217-invalidate-jwt-on-logout