### PR TITLE
fix: correct Doncaster article 4 names and remove deprecated links

### DIFF
--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/doncaster.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/doncaster.ts
@@ -14,8 +14,8 @@ const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   articleFour: {
     // Planx granular values link to Digital Land entity.reference
     records: {
-      "articleFour.doncaster.hmo": "Article 4 (HMO) Boundary", // https://www.planning.data.gov.uk/entity/6100030/
-      "articleFour.doncaster.demolition": "Article 4 (DSA) Boundary", // https://www.planning.data.gov.uk/entity/6100031/
+      "articleFour.doncaster.hmo": "Article 4 (HMO) Boundary - Came into force 14 October 2019",
+      "articleFour.doncaster.demolition": "Article 4 (DSA) Boundary - Came into force 25 July 2024",
     },
   },
 };

--- a/api.planx.uk/modules/gis/service/local_authorities/metadata/doncaster.ts
+++ b/api.planx.uk/modules/gis/service/local_authorities/metadata/doncaster.ts
@@ -14,8 +14,8 @@ const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
   articleFour: {
     // Planx granular values link to Digital Land entity.reference
     records: {
-      "articleFour.doncaster.hmo": "Article 4 (HMO) Boundary - Came into force 14 October 2019",
-      "articleFour.doncaster.demolition": "Article 4 (DSA) Boundary - Came into force 25 July 2024",
+      "articleFour.doncaster.hmo": "AR4HMO",
+      "articleFour.doncaster.demolition": "AR4DSA",
     },
   },
 };


### PR DESCRIPTION
Fixes mismatched Planning Data Article 4 name entries for Doncaster.