### PR TITLE
fix: file upload error message if upload in progress

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -26,7 +26,7 @@ export const slotsSchema = array()
   .required()
   .test({
     name: "nonUploading",
-    message: "Upload at least one file",
+    message: "Please wait for upload to complete",
     test: (slots?: Array<FileUploadSlot>) => {
       return Boolean(
         slots &&

--- a/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -25,6 +25,14 @@ export interface FileUploadSlot {
 export const slotsSchema = array()
   .required()
   .test({
+    name: "minFileUploaded",
+    message: "Upload at least one file",
+    test: (slots?: Array<FileUploadSlot>) => {
+      const isAtLeastOneFileUploaded = slots && slots.length > 0;
+      return Boolean(isAtLeastOneFileUploaded);
+    },
+  })
+  .test({
     name: "nonUploading",
     message: "Please wait for upload to complete",
     test: (slots?: Array<FileUploadSlot>) => {


### PR DESCRIPTION
### How to test:

Make a file upload component and upload an image of at least 1MB in size (perhaps use example from error reported on ODP slack). An error flashes up if you press continue straight away. This PR simply changes the wording of that error message to be more clear.

**More context:**
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1739879595245729?thread_ts=1739449301.836729&cid=C088K9ZL8EA

### Before

https://github.com/user-attachments/assets/bc18a3ab-ce2f-477b-8aad-256d615f07b1

