### PR TITLE
fix: Shorten submissions log menu item

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -115,7 +115,7 @@ function EditorNavMenu() {
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
     {
-      title: "Submissions log",
+      title: "Submissions",
       Icon: FactCheckIcon,
       route: `/${teamSlug}/submissions-log`,
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],


### PR DESCRIPTION
## What does this PR do?

Quick one: shortens "Submissions log" menu item to "Submissions" to keep text on one line.

**Before change:**
<img width="270" alt="image" src="https://github.com/user-attachments/assets/bb9b3086-3d1f-42a1-b3dc-ccc02d901bf3" />

**After change:**
<img width="270" alt="image" src="https://github.com/user-attachments/assets/4b64e8f8-aaa0-4208-ad4a-6643e068c7f9" />
