### PR TITLE
feat: remove statutory application type from tags and filters

### DIFF
--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -9,6 +9,7 @@ import { inputFocusStyle } from "theme";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
 import { slugify } from "utils";
+
 import { client } from "../../../lib/graphql";
 import SimpleMenu from "../../../ui/editor/SimpleMenu";
 import { useStore } from "../../FlowEditor/lib/store";
@@ -120,8 +121,6 @@ const FlowCard: React.FC<FlowCardProps> = ({
   };
 
   const isSubmissionService = flow.publishedFlows?.[0]?.hasSendComponent;
-  const isStatutoryApplicationType =
-    flow.publishedFlows?.[0]?.isStatutoryApplicationType;
 
   const statusVariant =
     flow.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
@@ -136,11 +135,6 @@ const FlowCard: React.FC<FlowCardProps> = ({
       type: FlowTagType.ServiceType,
       displayName: "Submission",
       shouldAddTag: isSubmissionService,
-    },
-    {
-      type: FlowTagType.ApplicationType,
-      displayName: "Statutory",
-      shouldAddTag: isStatutoryApplicationType,
     },
   ];
 

--- a/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
+++ b/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
@@ -30,11 +30,6 @@ const checkFlowServiceType: FilterOptions<FlowSummary>["validationFn"] = (
   _value,
 ) => flow.publishedFlows[0]?.hasSendComponent;
 
-const checkFlowApplicationType: FilterOptions<FlowSummary>["validationFn"] = (
-  flow,
-  _value,
-) => flow.publishedFlows[0]?.isStatutoryApplicationType;
-
 export const filterOptions: FilterOptions<FlowSummary>[] = [
   {
     displayName: "Online status",
@@ -47,11 +42,5 @@ export const filterOptions: FilterOptions<FlowSummary>[] = [
     optionKey: `publishedFlows.0.hasSendComponent`,
     optionValue: ["submission"],
     validationFn: checkFlowServiceType,
-  },
-  {
-    displayName: "Application type",
-    optionKey: `name`,
-    optionValue: ["statutory"],
-    validationFn: checkFlowApplicationType,
   },
 ];


### PR DESCRIPTION
Until we get feedback on how to define what a statutory application is, we should remove this from the work.

Current issues with this have been captured in this Slack thread: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1739800315291939?thread_ts=1739788849.390769&cid=C5Q59R3HB

In short, we are incorrectly labelling some flows which are Discretionary services, but within their external portals are still assigning `application.type` to an ODP Schema approved value, which incorrectly triggers the `statutory` tag.