### PR TITLE
chore: revert "placeholder" tags workaround

### DIFF
--- a/editor.planx.uk/src/routes/flow.tsx
+++ b/editor.planx.uk/src/routes/flow.tsx
@@ -118,14 +118,6 @@ const editNode = validateNodeRoute(
       [key: string]: any;
     };
 
-    // Temp guard to handle non-migrated tags
-    // TODO: Migrate "placeholder" tags to "customisation"
-    if (node.data.tags) {
-      node.data.tags = node.data.tags?.map((tag: string) =>
-        tag === "placeholder" ? "customisation" : tag,
-      );
-    }
-
     const extraProps = {} as any;
 
     if (node.type === TYPES.ExternalPortal)


### PR DESCRIPTION
Ready to merge after production data migration completes; please note this pizza was built _before_ prod migration completed - so will be most accurate to test on staging ! 

Reverts #4335 & #4342