### PR TITLE
feat: Create '*' role to denote all users can access route

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -49,7 +49,7 @@ function EditorNavMenu() {
       title: "Select a team",
       Icon: FormatListBulletedIcon,
       route: "/",
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
     {
       title: "Global settings",
@@ -67,19 +67,19 @@ function EditorNavMenu() {
       title: "Resources",
       Icon: MenuBookIcon,
       route: "resources",
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
     {
       title: "Onboarding",
       Icon: AssignmentTurnedInIcon,
       route: "onboarding",
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
     {
       title: "Tutorials",
       Icon: SchoolIcon,
       route: "tutorials",
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
   ];
 
@@ -88,7 +88,7 @@ function EditorNavMenu() {
       title: "Services",
       Icon: FormatListBulletedIcon,
       route: `/${teamSlug}`,
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
     {
       title: "Settings",
@@ -127,13 +127,13 @@ function EditorNavMenu() {
       title: "Editor",
       Icon: EditorIcon,
       route: `/${teamSlug}/${flowSlug}`,
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
     {
       title: "About this service",
       Icon: Info,
       route: `/${teamSlug}/${flowSlug}/about`,
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "teamViewer"],
+      accessibleBy: "*",
     },
     {
       title: "Service settings",
@@ -200,9 +200,15 @@ function EditorNavMenu() {
 
   const { routes, compact } = getRoutesForUrl(url.href);
 
-  const visibleRoutes = routes.filter(
-    ({ accessibleBy }) => role && accessibleBy.includes(role),
-  );
+  const isRouteAccessible = ({ accessibleBy }: Route) => {
+    const accessibleByAll = accessibleBy === "*";
+    if (accessibleByAll) return true;
+
+    const accessibleByCurrentUserRole = role && accessibleBy.includes(role);
+    return accessibleByCurrentUserRole;
+  };
+
+  const visibleRoutes = routes.filter(isRouteAccessible);
 
   // Hide menu if the user does not have a selection of items
   if (visibleRoutes.length < 2) return null;

--- a/editor.planx.uk/src/components/EditorNavMenu/types.ts
+++ b/editor.planx.uk/src/components/EditorNavMenu/types.ts
@@ -1,11 +1,13 @@
 import { Role } from "@opensystemslab/planx-core/types";
 import React from "react";
 
+type AllUsers = "*";
+
 export interface Route {
   title: string;
   Icon: React.ElementType;
   route: string;
-  accessibleBy: Role[];
+  accessibleBy: Role[] | AllUsers;
   disabled?: boolean;
 }
 export interface RoutesForURL {


### PR DESCRIPTION
## What does this PR do?
- Creates a new value for `Route.accessibleBy` - `*`
- Replaces the full list of roles with `*` - this will mean we don't have to maintain a full list each time we add a role
- Updates logic for `visibleRoutes` to handle `*`

![image](https://github.com/user-attachments/assets/403273cf-a13f-4a79-894e-5b2ac54669bb)
