### PR TITLE
chore(iac): Standardise RDS maintenance window, minor PostgreSQL bump

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -28,7 +28,7 @@ const db = new aws.rds.Instance("app", {
   engine: "postgres",
   // AWS restricts the maximum upgrade leap, see available versions:
   // $ aws rds describe-db-engine-versions --engine postgres  --engine-version your-version --query "DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}" --output text
-  engineVersion: "16.3",
+  engineVersion: "16.7",
   // Available instance types: https://aws.amazon.com/rds/instance-types/
   instanceClass: env === "production" ? "db.t3.medium" : "db.t3.small",
   allocatedStorage: env === "production" ? 100 : 20,

--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -44,6 +44,7 @@ const db = new aws.rds.Instance("app", {
   backupRetentionPeriod: env === "production" ? 35 : 1,
   applyImmediately: true,
   parameterGroupName: parameterGroup.name,
+  maintenanceWindow: "Mon:00:00-Mon:03:00",
 });
 export const dbRootUrl = pulumi.interpolate`postgres://${DB_ROOT_USERNAME}:${config.require(
   "db-password"


### PR DESCRIPTION
## What does this PR do? 
 - Sets the AWS RDS maintenance window to `"Mon:00:00-Mon:03:00"`
 - Bumps the Postgres version to 16.7

Docs: https://www.pulumi.com/registry/packages/aws/api-docs/rds/instance/#maintenancewindow_nodejs

This will also require a manual deploy of the data layers on staging and production, happy to sort this out once approved and merged.