### PR TITLE
fix: Filter submission by flowId

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -24,11 +24,12 @@ function EditorNavMenu() {
   const { navigate } = useNavigation();
   const { url } = useCurrentRoute();
   const isRouteLoading = useLoadingRoute();
-  const [teamSlug, flowSlug, flowAnalyticsLink, role] = useStore((state) => [
+  const [teamSlug, flowSlug, flowAnalyticsLink, role, flowId] = useStore((state) => [
     state.teamSlug,
     state.flowSlug,
     state.flowAnalyticsLink,
     state.getUserRoleForCurrentTeam(),
+    state.id,
   ]);
 
   const isActive = (route: string) => url.href.endsWith(route);
@@ -144,7 +145,7 @@ function EditorNavMenu() {
     {
       title: "Submissions log",
       Icon: FactCheckIcon,
-      route: `/${teamSlug}/submissions-log?flow=${flowSlug}`,
+      route: `/${teamSlug}/submissions-log?flow=${flowId}`,
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
   ];

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -8,7 +8,7 @@ import { useStore } from "../../../lib/store";
 import EventsLog from "./EventsLog";
 import { Submission, SubmissionsProps } from "./types";
 
-const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
+const Submissions: React.FC<SubmissionsProps> = ({ flowId }) => {
   const [teamId] = useStore((state) => [state.teamId]);
 
   // submission_services_log view is already filtered for events >= Jan 1 2024
@@ -19,6 +19,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
           where: { team_id: { _eq: $team_id } }
           order_by: { created_at: asc }
         ) {
+          flowId: flow_id
           sessionId: session_id
           eventId: event_id
           eventType: event_type
@@ -38,17 +39,9 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
 
   const submissions = useMemo(() => data?.submissions || [], [data]);
 
-  const getFlowNameFromSlug = (slug: string) => {
-    return slug.replace(/-/g, " ");
-  };
-
-  const flowName = flowSlug && getFlowNameFromSlug(flowSlug);
-
-  // filter by flow if flowSlug prop is passed from route params
+  // filter by flow if flowId prop is passed from route params
   const filteredSubmissions = submissions.filter(
-    (submission) =>
-      !flowSlug ||
-      submission.flowName.toLowerCase() === flowName?.toLowerCase(),
+    (submission) => submission.flowId === flowId
   );
 
   return (
@@ -59,7 +52,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
         </Typography>
         <Typography variant="body1">
           {`Feed of payment and submission events for ${
-            flowSlug ? "this service" : "services in this team"
+            flowId ? "this service" : "services in this team"
           }.
           Successful submission events from within the last 28 days are
           available to be downloaded by team editors.`}
@@ -70,7 +63,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
           submissions={filteredSubmissions}
           loading={loading}
           error={error}
-          filterByFlow={Boolean(flowSlug)}
+          filterByFlow={Boolean(flowId)}
         />
       </SettingsSection>
     </Container>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/types.ts
@@ -1,4 +1,5 @@
 export interface Submission {
+  flowId: string;
   sessionId: string;
   eventId: string;
   eventType:
@@ -34,5 +35,5 @@ export interface EventsLogProps {
   filterByFlow?: boolean;
 }
 export interface SubmissionsProps {
-  flowSlug?: string;
+  flowId?: string;
 }

--- a/editor.planx.uk/src/routes/submissionsLog.tsx
+++ b/editor.planx.uk/src/routes/submissionsLog.tsx
@@ -7,17 +7,16 @@ import { makeTitle } from "./utils";
 const submissionsLogRoutes = compose(
   withData((req) => ({
     mountpath: req.mountpath,
-    flow: req.params.flow?.split(",")[0],
   })),
 
   mount({
     "/": compose(
       route(async (req) => {
-        const { team: teamSlug, flow: flowSlug } = req.params;
+        const { team: teamSlug, flow: flowId } = req.params;
 
         return {
-          title: makeTitle([teamSlug, "submissions-log", flowSlug].join("/")),
-          view: <Submissions flowSlug={flowSlug} />,
+          title: makeTitle([teamSlug, "submissions-log"].join("/")),
+          view: <Submissions flowId={flowId} />,
         };
       }),
     ),


### PR DESCRIPTION
## What's the problem?
Certain flows fail to display submissions, e.g. https://editor.planx.dev/camden/submissions-log?flow=camden-apply-for-a-lawful-development-certificate

Others work fine, e.g. https://editor.planx.dev/tewkesbury/submissions-log?flow=report-a-breach

## What's the cause?
We're currently passing through the flow slug and trying to generate a flow name from this in order to filter. This isn't possible as `slugify()` is a destructive, one-way, process.

For example -
 - `"CAMDEN - Apply for a lawful development certificate"` would become `"camden-apply-for-a-lawful-development-certificate"`
 - `"special CharaCTERS1@@£!!"` becomes `"special-characters1"`

There's no way to reconstruct a flow name from a flow slug, so we need to compare two static values in order to filter.

## What's the solution?
 - Filters the `/${teamSlug}/submissions-log` route by flowId instead of flowSlug