### PR TITLE
fix: Remove SORT_FLOWS from feature flag list [skip pizza]

### DIFF
--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,7 +1,6 @@
 // add/edit/remove feature flags in array below
 const AVAILABLE_FEATURE_FLAGS = [
   "FEE_BREAKDOWN",
-  "SORT_FLOWS",
   "TEMPLATES",
 ] as const;
 


### PR DESCRIPTION
## What does this PR do?

Quick one: removes `SORT_FLOWS` from the list of available feature flags.