### PR TITLE
feat: Add env guard middleware

### DIFF
--- a/api.planx.uk/modules/analytics/routes.ts
+++ b/api.planx.uk/modules/analytics/routes.ts
@@ -9,6 +9,7 @@ import { metabaseCollectionsController } from "./metabase/collection/controller.
 import { metabaseDashboardsController } from "./metabase/dashboard/controller.js";
 import { createTeamCollectionSchema } from "./metabase/collection/types.js";
 import { createNewDashboardSchema } from "./metabase/dashboard/types.js";
+import { useEnvGuard } from "../../shared/middleware/useEnvGuard.js";
 
 const router = Router();
 
@@ -22,6 +23,9 @@ router.post(
   validate(logAnalyticsSchema),
   logUserResumeController,
 );
+
+router.use("/metabase", useEnvGuard(["test", "staging", "production"]));
+
 router.post(
   "/metabase/collection/:slug",
   validate(createTeamCollectionSchema),

--- a/api.planx.uk/shared/middleware/useEnvGuard.ts
+++ b/api.planx.uk/shared/middleware/useEnvGuard.ts
@@ -1,0 +1,16 @@
+import type { RequestHandler } from "express";
+
+type Environment = "development" | "test" | "pizza" | "staging" | "production";
+
+type UseEnvGuard = (envs: Environment[]) => RequestHandler;
+
+/**
+ * Only allow access to the listed environments
+ */
+export const useEnvGuard: UseEnvGuard = (envs) => async (_req, res, next) => {
+  const currentEnv = process.env.NODE_ENV as Environment;
+  const isBlocked = !envs.includes(currentEnv);
+  if (isBlocked) return res.status(403).send();
+
+  return next();
+};


### PR DESCRIPTION
## What's the problem?
 - Metbase doesn't exist locally, or on Pizzas
 - It's going to get called via Hasura events (see #4334)
 - This will lead to a bunch of errors which we could avoid

## What are the alternatives?
- Running Metabase on pizzas (bad - more CI time for little gain)
- Running Metabase locally, syncing data (also not great - nice to optionally do it, but making it a requirement isn't ideal)
- Ignoring this, letting it fail (maybe!)

## What's the solution?
Very open to ideas here - the current implementation will stop Metabase routes from being accessible locally and on Pizzas.