### PR TITLE
fix: show submissions for all flows if no flowId

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/index.tsx
@@ -41,7 +41,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowId }) => {
 
   // filter by flow if flowId prop is passed from route params
   const filteredSubmissions = submissions.filter(
-    (submission) => submission.flowId === flowId
+    (submission) => !flowId || submission.flowId === flowId,
   );
 
   return (


### PR DESCRIPTION
A condition was missed off in the submissions filter that meant no submissions were showing if no `flowId` rather than all.

This probably would have been caught if we had test coverage in this area - I'll try to rectify that in the upcoming 'filterable submissions table' PRs.  