### PR TITLE
feat: unit tests for Filters

### DIFF
--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -12,8 +12,7 @@ import {
 import React from "react";
 import { screen } from "@testing-library/react";
 import { axe } from "vitest-axe";
-import { openFilterAccordion, selectCheckbox } from "./helpers";
-import { capitalize, filter } from "lodash";
+import { openFilterAccordion } from "./helpers";
 
 vi.mock("react-navi", () => ({
   useNavigation: () => ({
@@ -60,7 +59,7 @@ describe("the use and return of the Filter component", () => {
     expect(filterStatusOption).not.toBeVisible();
     expect(filterNameOption).not.toBeVisible();
 
-    await openFilterAccordion(screen, user)
+    await openFilterAccordion(screen, user);
 
     filterStatusOption = screen.getByText("Online status");
     filterNameOption = screen.getByText("Name");
@@ -68,7 +67,7 @@ describe("the use and return of the Filter component", () => {
     expect(filterStatusOption).toBeVisible();
     expect(filterNameOption).toBeVisible();
   });
-  
+
   it("should not have any accessibility violations on initial render", async () => {
     const { container } = setupFilterEnvironment();
     const results = await axe(container);
@@ -76,18 +75,18 @@ describe("the use and return of the Filter component", () => {
   });
 
   it("adds or removes a chip when a filter is clicked", async () => {
-    const {user} = setupFilterEnvironment()
+    const { user } = setupFilterEnvironment();
 
-    await openFilterAccordion(screen, user)
+    await openFilterAccordion(screen, user);
 
-    const selectedCheckbox = screen.getByRole('checkbox', { name: "Online" })
-    await user.click(selectedCheckbox)
+    const selectedCheckbox = screen.getByRole("checkbox", { name: "Online" });
+    await user.click(selectedCheckbox);
 
-    const filterOnlineChip = screen.getByRole('button', { name: "Online" })
-    expect(filterOnlineChip).toBeVisible()
+    const filterOnlineChip = screen.getByRole("button", { name: "Online" });
+    expect(filterOnlineChip).toBeVisible();
 
-    await user.click(selectedCheckbox)
-    expect(filterOnlineChip).not.toBeVisible()
+    await user.click(selectedCheckbox);
+    expect(filterOnlineChip).not.toBeVisible();
   });
 
   test.todo("filters the records by the options which are checked");

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -46,9 +46,11 @@ const setupFilterEnvironment = () => {
 describe("the use and return of the Filter component", () => {
   it("renders a filter accordion", async () => {
     const { user } = setupFilterEnvironment();
-    const filtersHeader = screen.getByText("Show filters");
-    expect(filtersHeader).toBeVisible();
-    await user.click(filtersHeader);
+
+    const showFiltersHeader = screen.getByText("Show filters");
+    expect(showFiltersHeader).toBeVisible();
+
+    await user.click(showFiltersHeader);
     const hideFiltersHeader = screen.getByText("Hide filters");
 
     expect(hideFiltersHeader).toBeVisible();
@@ -83,14 +85,21 @@ describe("the use and return of the Filter component", () => {
 
     await openFilterAccordion(screen, user);
 
-    const selectedCheckbox = screen.getByRole("checkbox", { name: "Online" });
-    await user.click(selectedCheckbox);
-
+    await user.click(screen.getByRole("checkbox", { name: "Online" }));
     const filterOnlineChip = screen.getByRole("button", { name: "Online" });
+
+    // when you select a filter, a clickable chip should appear for the option
     expect(filterOnlineChip).toBeVisible();
 
-    await user.click(selectedCheckbox);
+    await user.click(screen.getByRole("checkbox", { name: "Offline" }));
+    const filterOfflineChip = screen.getByRole("button", { name: "Offline" });
+
+    // when we change the filter value, the chip changes
+    expect(filterOfflineChip).toBeVisible();
     expect(filterOnlineChip).not.toBeVisible();
+
+    await user.click(screen.getByRole("checkbox", { name: "Offline" }));
+    expect(filterOfflineChip).not.toBeVisible();
   });
 
   it("filters the records by a single option", async () => {
@@ -134,6 +143,9 @@ describe("the use and return of the Filter component", () => {
         status: "offline",
       },
     ]);
+
+    // when we delect our filter, it should return to the array
+    // we passed into the prop 'records'
 
     await deselectCheckbox(screen, user, "Offline");
     expect(mockSetFilteredRecords).toHaveBeenCalledWith(mockRecords);

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -12,7 +12,11 @@ import {
 import React from "react";
 import { screen } from "@testing-library/react";
 import { axe } from "vitest-axe";
-import { openFilterAccordion, selectCheckbox } from "./helpers";
+import {
+  deselectCheckbox,
+  openFilterAccordion,
+  selectCheckbox,
+} from "./helpers";
 
 vi.mock("react-navi", () => ({
   useNavigation: () => ({
@@ -95,10 +99,12 @@ describe("the use and return of the Filter component", () => {
     await openFilterAccordion(screen, user);
     await selectCheckbox(screen, user, "Offline");
 
-    expect(mockSetFilteredRecords).toHaveBeenCalledWith([  {
+    expect(mockSetFilteredRecords).toHaveBeenCalledWith([
+      {
         name: "offline-mock",
         status: "offline",
-      }, ]);
+      },
+    ]);
   });
 
   it("filters the records multiple options", async () => {
@@ -108,20 +114,28 @@ describe("the use and return of the Filter component", () => {
     await selectCheckbox(screen, user, "Online");
     await selectCheckbox(screen, user, "Online-1");
 
-    expect(mockSetFilteredRecords).not.toHaveBeenCalledWith([
-      {
-        name: "online-mock",
-        status: "online",
-      },
-    ]);
-
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
         name: "online-1",
         status: "online",
       },
     ]);
+  });
 
-    screen.logTestingPlaygroundURL();
+  it("returns to mockRecords when all filters unchecked", async () => {
+    const { user } = setupFilterEnvironment();
+
+    await openFilterAccordion(screen, user);
+    await selectCheckbox(screen, user, "Offline");
+
+    expect(mockSetFilteredRecords).toHaveBeenCalledWith([
+      {
+        name: "offline-mock",
+        status: "offline",
+      },
+    ]);
+
+    await deselectCheckbox(screen, user, "Offline");
+    expect(mockSetFilteredRecords).toHaveBeenCalledWith(mockRecords);
   });
 });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -1,0 +1,96 @@
+import { describe, vi } from "vitest";
+import Filters from "../Filter";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { setup } from "testUtils";
+import {
+  mockFilterOptions,
+  mockRecords,
+  MockRecordType,
+  mockSetFilteredRecords,
+} from "./mocks";
+import React from "react";
+import { screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+import { openFilterAccordion, selectCheckbox } from "./helpers";
+import { capitalize, filter } from "lodash";
+
+vi.mock("react-navi", () => ({
+  useNavigation: () => ({
+    navigate: vi.fn(),
+  }),
+  useCurrentRoute: () => ({
+    url: {
+      search: "",
+    },
+  }),
+}));
+
+const setupFilterEnvironment = () => {
+  const filterEnvironment = setup(
+    <DndProvider backend={HTML5Backend}>
+      <Filters<MockRecordType>
+        records={mockRecords}
+        setFilteredRecords={mockSetFilteredRecords}
+        filterOptions={mockFilterOptions}
+      />
+    </DndProvider>,
+  );
+
+  return filterEnvironment;
+};
+
+describe("the use and return of the Filter component", () => {
+  it("renders a filter accordion", async () => {
+    const { user } = setupFilterEnvironment();
+    const filtersHeader = screen.getByText("Show filters");
+    expect(filtersHeader).toBeVisible();
+    await user.click(filtersHeader);
+    const hideFiltersHeader = screen.getByText("Hide filters");
+
+    expect(hideFiltersHeader).toBeVisible();
+  });
+
+  it("renders filter options", async () => {
+    const { user } = setupFilterEnvironment();
+
+    let filterStatusOption = screen.getByText("Online status");
+    let filterNameOption = screen.getByText("Name");
+
+    expect(filterStatusOption).not.toBeVisible();
+    expect(filterNameOption).not.toBeVisible();
+
+    await openFilterAccordion(screen, user)
+
+    filterStatusOption = screen.getByText("Online status");
+    filterNameOption = screen.getByText("Name");
+
+    expect(filterStatusOption).toBeVisible();
+    expect(filterNameOption).toBeVisible();
+  });
+  
+  it("should not have any accessibility violations on initial render", async () => {
+    const { container } = setupFilterEnvironment();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("adds or removes a chip when a filter is clicked", async () => {
+    const {user} = setupFilterEnvironment()
+
+    await openFilterAccordion(screen, user)
+
+    const selectedCheckbox = screen.getByRole('checkbox', { name: "Online" })
+    await user.click(selectedCheckbox)
+
+    const filterOnlineChip = screen.getByRole('button', { name: "Online" })
+    expect(filterOnlineChip).toBeVisible()
+
+    await user.click(selectedCheckbox)
+    expect(filterOnlineChip).not.toBeVisible()
+  });
+
+  test.todo("filters the records by the options which are checked");
+
+  test.todo("sets the new records using the results of the filter");
+});

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -12,11 +12,7 @@ import {
 import React from "react";
 import { screen } from "@testing-library/react";
 import { axe } from "vitest-axe";
-import {
-  addFilter,
-  expandFilterAccordion,
-  removeFilter,
-} from "./helpers";
+import { addFilter, expandFilterAccordion, removeFilter } from "./helpers";
 
 vi.mock("react-navi", () => ({
   useNavigation: () => ({
@@ -74,9 +70,9 @@ describe("the UI interactions of the Filter component", () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
-})
+});
 
-  describe("Filter functionality", () => {
+describe("Filter functionality", () => {
   it("manages filter chips correctly when selecting filters", async () => {
     const { user } = setupTestEnvironment();
 
@@ -94,15 +90,19 @@ describe("the UI interactions of the Filter component", () => {
     // check it has been selected
     const offlineChip = screen.getByRole("button", { name: "Offline" });
     expect(offlineChip).toBeVisible();
-    
+
     // check previous filter has been deselected
-    expect(screen.queryByRole("button", { name: "Online" })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Online" }),
+    ).not.toBeInTheDocument();
 
     // click selected filter
     await user.click(screen.getByRole("checkbox", { name: "Offline" }));
 
     // check filter is deselected
-    expect(screen.queryByRole("button", { name: "Offline" })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Offline" }),
+    ).not.toBeInTheDocument();
   });
 
   it("filters the records using a single option", async () => {
@@ -124,11 +124,11 @@ describe("the UI interactions of the Filter component", () => {
 
     await expandFilterAccordion(screen, user);
     await addFilter(screen, user, "Online");
-    await addFilter(screen, user, "Online-1");
+    await addFilter(screen, user, "Online-mock-2");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
-        name: "online-1",
+        name: "online-mock-2",
         status: "online",
       },
     ]);

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -12,7 +12,7 @@ import {
 import React from "react";
 import { screen } from "@testing-library/react";
 import { axe } from "vitest-axe";
-import { openFilterAccordion } from "./helpers";
+import { openFilterAccordion, selectCheckbox } from "./helpers";
 
 vi.mock("react-navi", () => ({
   useNavigation: () => ({
@@ -89,7 +89,17 @@ describe("the use and return of the Filter component", () => {
     expect(filterOnlineChip).not.toBeVisible();
   });
 
-  test.todo("filters the records by the options which are checked");
+  it("filters the records by the options which are checked", async () => {
+    const { user } = setupFilterEnvironment();
 
-  test.todo("sets the new records using the results of the filter");
+    await openFilterAccordion(screen, user);
+    await selectCheckbox(screen, user, "Online")
+
+    expect(mockSetFilteredRecords).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ status: "online" }),
+        ])
+      );
+  });
+
 });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -89,17 +89,39 @@ describe("the use and return of the Filter component", () => {
     expect(filterOnlineChip).not.toBeVisible();
   });
 
-  it("filters the records by the options which are checked", async () => {
+  it("filters the records by a single option", async () => {
     const { user } = setupFilterEnvironment();
 
     await openFilterAccordion(screen, user);
-    await selectCheckbox(screen, user, "Online")
+    await selectCheckbox(screen, user, "Offline");
 
-    expect(mockSetFilteredRecords).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ status: "online" }),
-        ])
-      );
+    expect(mockSetFilteredRecords).toHaveBeenCalledWith([  {
+        name: "offline-mock",
+        status: "offline",
+      }, ]);
   });
 
+  it("filters the records multiple options", async () => {
+    const { user } = setupFilterEnvironment();
+
+    await openFilterAccordion(screen, user);
+    await selectCheckbox(screen, user, "Online");
+    await selectCheckbox(screen, user, "Online-1");
+
+    expect(mockSetFilteredRecords).not.toHaveBeenCalledWith([
+      {
+        name: "online-mock",
+        status: "online",
+      },
+    ]);
+
+    expect(mockSetFilteredRecords).toHaveBeenCalledWith([
+      {
+        name: "online-1",
+        status: "online",
+      },
+    ]);
+
+    screen.logTestingPlaygroundURL();
+  });
 });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -1,18 +1,19 @@
-import { describe, vi } from "vitest";
-import Filters from "../Filter";
+import { screen } from "@testing-library/react";
+import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { setup } from "testUtils";
+import { describe, vi } from "vitest";
+import { axe } from "vitest-axe";
+
+import Filters from "../Filter";
+import { addFilter, expandFilterAccordion, removeFilter } from "./helpers";
 import {
   mockFilterOptions,
   mockRecords,
   MockRecordType,
   mockSetFilteredRecords,
 } from "./mocks";
-import React from "react";
-import { screen } from "@testing-library/react";
-import { axe } from "vitest-axe";
-import { addFilter, expandFilterAccordion, removeFilter } from "./helpers";
 
 vi.mock("react-navi", () => ({
   useNavigation: () => ({
@@ -59,7 +60,7 @@ describe("the UI interactions of the Filter component", () => {
     expect(filterStatusOption).not.toBeVisible();
     expect(filterNameOption).not.toBeVisible();
 
-    await expandFilterAccordion(screen, user);
+    await expandFilterAccordion(user);
 
     expect(filterStatusOption).toBeVisible();
     expect(filterNameOption).toBeVisible();
@@ -76,12 +77,16 @@ describe("Filter functionality", () => {
   it("manages filter chips correctly when selecting filters", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(screen, user);
+    await expandFilterAccordion(user);
+
+    expect(
+      screen.queryByRole("button", { name: "Online" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("checkbox", { name: "Online" }));
-    const onlineChip = screen.getByRole("button", { name: "Online" });
 
     // when you select a filter, a clickable chip should appear for the option
+    const onlineChip = screen.getByRole("button", { name: "Online" });
     expect(onlineChip).toBeVisible();
 
     // change filter to it's other optionValue
@@ -108,8 +113,8 @@ describe("Filter functionality", () => {
   it("filters the records using a single option", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(screen, user);
-    await addFilter(screen, user, "Offline");
+    await expandFilterAccordion(user);
+    await addFilter(user, "Offline");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -122,9 +127,9 @@ describe("Filter functionality", () => {
   it("filters the records using multiple options", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(screen, user);
-    await addFilter(screen, user, "Online");
-    await addFilter(screen, user, "Online-mock-2");
+    await expandFilterAccordion(user);
+    await addFilter(user, "Online");
+    await addFilter(user, "Online-mock-2");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -137,8 +142,8 @@ describe("Filter functionality", () => {
   it("returns to mockRecords when all filters unchecked", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(screen, user);
-    await addFilter(screen, user, "Offline");
+    await expandFilterAccordion(user);
+    await addFilter(user, "Offline");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -148,7 +153,7 @@ describe("Filter functionality", () => {
     ]);
 
     // when we remove our filter, it should return to the array we passed into the prop 'records'
-    await removeFilter(screen, user, "Offline");
+    await removeFilter(user, "Offline");
     expect(mockSetFilteredRecords).toHaveBeenCalledWith(mockRecords);
   });
 });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -24,5 +24,6 @@ export const selectCheckbox = async (
 ) => {
   const checkbox = screen.getByRole("checkbox", { name: name });
   await user.click(checkbox);
-  expect(checkbox).toHaveAttribute("selected", true);
+    const filterChip = screen.getByRole("button", { name: name });
+    expect(filterChip).toBeVisible();
 };

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -24,6 +24,6 @@ export const selectCheckbox = async (
 ) => {
   const checkbox = screen.getByRole("checkbox", { name: name });
   await user.click(checkbox);
-    const filterChip = screen.getByRole("button", { name: name });
-    expect(filterChip).toBeVisible();
+  const filterChip = screen.getByRole("button", { name: name });
+  expect(filterChip).toBeVisible();
 };

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -1,0 +1,23 @@
+import { Screen } from "@testing-library/react";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import { expect } from "vitest";
+
+export const openFilterAccordion = async (screen: Screen, user:UserEvent) => {
+    const showAccordionTitle = screen.getByText("Show filters")
+    await user.click(showAccordionTitle);
+
+    const hideAccordionTitle = screen.getByText("Hide filters")
+    expect(hideAccordionTitle).toBeVisible()
+}
+export const closeFilterAccordion = async (screen: Screen, user:UserEvent) => {
+    const hideAccordionTitle = screen.getByText("Hide filters")
+    await user.click(hideAccordionTitle);
+
+    const showAccordionTitle = screen.getByText("Show filters")
+    expect(showAccordionTitle).toBeVisible()}
+
+    export const selectCheckbox = async (screen: Screen, user: UserEvent, name:string) => {
+        const checkbox = screen.getByRole('checkbox', { name: name })
+        await user.click(checkbox)
+        expect(checkbox).toHaveAttribute("selected", true)
+    }

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -2,22 +2,27 @@ import { Screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
-export const openFilterAccordion = async (screen: Screen, user:UserEvent) => {
-    const showAccordionTitle = screen.getByText("Show filters")
-    await user.click(showAccordionTitle);
+export const openFilterAccordion = async (screen: Screen, user: UserEvent) => {
+  const showAccordionTitle = screen.getByText("Show filters");
+  await user.click(showAccordionTitle);
 
-    const hideAccordionTitle = screen.getByText("Hide filters")
-    expect(hideAccordionTitle).toBeVisible()
-}
-export const closeFilterAccordion = async (screen: Screen, user:UserEvent) => {
-    const hideAccordionTitle = screen.getByText("Hide filters")
-    await user.click(hideAccordionTitle);
+  const hideAccordionTitle = screen.getByText("Hide filters");
+  expect(hideAccordionTitle).toBeVisible();
+};
+export const closeFilterAccordion = async (screen: Screen, user: UserEvent) => {
+  const hideAccordionTitle = screen.getByText("Hide filters");
+  await user.click(hideAccordionTitle);
 
-    const showAccordionTitle = screen.getByText("Show filters")
-    expect(showAccordionTitle).toBeVisible()}
+  const showAccordionTitle = screen.getByText("Show filters");
+  expect(showAccordionTitle).toBeVisible();
+};
 
-    export const selectCheckbox = async (screen: Screen, user: UserEvent, name:string) => {
-        const checkbox = screen.getByRole('checkbox', { name: name })
-        await user.click(checkbox)
-        expect(checkbox).toHaveAttribute("selected", true)
-    }
+export const selectCheckbox = async (
+  screen: Screen,
+  user: UserEvent,
+  name: string,
+) => {
+  const checkbox = screen.getByRole("checkbox", { name: name });
+  await user.click(checkbox);
+  expect(checkbox).toHaveAttribute("selected", true);
+};

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -27,3 +27,14 @@ export const selectCheckbox = async (
   const filterChip = screen.getByRole("button", { name: name });
   expect(filterChip).toBeVisible();
 };
+
+export const deselectCheckbox = async (
+  screen: Screen,
+  user: UserEvent,
+  name: string,
+) => {
+  const checkbox = screen.getByRole("checkbox", { name: name });
+  await user.click(checkbox);
+  const filterChip = screen.queryByRole("button", { name: name });
+  expect(filterChip).toBeNull();
+};

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -2,7 +2,10 @@ import { Screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
-export const expandFilterAccordion = async (screen: Screen, user: UserEvent) => {
+export const expandFilterAccordion = async (
+  screen: Screen,
+  user: UserEvent,
+) => {
   const showAccordionTitle = screen.getByText("Show filters");
   await user.click(showAccordionTitle);
 

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -1,11 +1,8 @@
-import { Screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
-export const expandFilterAccordion = async (
-  screen: Screen,
-  user: UserEvent,
-) => {
+export const expandFilterAccordion = async (user: UserEvent) => {
   const showAccordionTitle = screen.getByText("Show filters");
   await user.click(showAccordionTitle);
 
@@ -13,22 +10,14 @@ export const expandFilterAccordion = async (
   expect(hideAccordionTitle).toBeVisible();
 };
 
-export const addFilter = async (
-  screen: Screen,
-  user: UserEvent,
-  name: string,
-) => {
+export const addFilter = async (user: UserEvent, name: string) => {
   const checkbox = screen.getByRole("checkbox", { name: name });
   await user.click(checkbox);
   const filterChip = screen.getByRole("button", { name: name });
   expect(filterChip).toBeVisible();
 };
 
-export const removeFilter = async (
-  screen: Screen,
-  user: UserEvent,
-  name: string,
-) => {
+export const removeFilter = async (user: UserEvent, name: string) => {
   const checkbox = screen.getByRole("checkbox", { name: name });
   await user.click(checkbox);
   const filterChip = screen.queryByRole("button", { name: name });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -2,22 +2,15 @@ import { Screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
-export const openFilterAccordion = async (screen: Screen, user: UserEvent) => {
+export const expandFilterAccordion = async (screen: Screen, user: UserEvent) => {
   const showAccordionTitle = screen.getByText("Show filters");
   await user.click(showAccordionTitle);
 
   const hideAccordionTitle = screen.getByText("Hide filters");
   expect(hideAccordionTitle).toBeVisible();
 };
-export const closeFilterAccordion = async (screen: Screen, user: UserEvent) => {
-  const hideAccordionTitle = screen.getByText("Hide filters");
-  await user.click(hideAccordionTitle);
 
-  const showAccordionTitle = screen.getByText("Show filters");
-  expect(showAccordionTitle).toBeVisible();
-};
-
-export const selectCheckbox = async (
+export const addFilter = async (
   screen: Screen,
   user: UserEvent,
   name: string,
@@ -28,7 +21,7 @@ export const selectCheckbox = async (
   expect(filterChip).toBeVisible();
 };
 
-export const deselectCheckbox = async (
+export const removeFilter = async (
   screen: Screen,
   user: UserEvent,
   name: string,
@@ -36,5 +29,5 @@ export const deselectCheckbox = async (
   const checkbox = screen.getByRole("checkbox", { name: name });
   await user.click(checkbox);
   const filterChip = screen.queryByRole("button", { name: name });
-  expect(filterChip).toBeNull();
+  expect(filterChip).not.toBeInTheDocument();
 };

--- a/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
@@ -8,28 +8,16 @@ export type MockRecordType = {
 
 export const mockRecords: MockRecordType[] = [
   {
-    name: "offline-1",
+    name: "offline-mock",
     status: "offline",
+  },
+  {
+    name: "online-mock",
+    status: "online",
   },
   {
     name: "online-1",
     status: "online",
-  },
-  {
-    name: "oneline-2",
-    status: "online",
-  },
-  {
-    name: "offline-2",
-    status: "offline",
-  },
-  {
-    name: "online-3",
-    status: "online",
-  },
-  {
-    name: "offline-3",
-    status: "offline",
   },
 ];
 

--- a/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
@@ -1,0 +1,55 @@
+import { vi } from "vitest";
+import { FilterOptions, FilterValues } from "../Filter";
+
+export type MockRecordType = {
+  name: string;
+  status: "online" | "offline";
+};
+
+export const mockRecords: MockRecordType[] = [
+  {
+    name: "offline-1",
+    status: "offline",
+  },
+  {
+    name: "online-1",
+    status: "online",
+  },
+  {
+    name: "oneline-2",
+    status: "online",
+  },
+  {
+    name: "offline-2",
+    status: "offline",
+  },
+  {
+    name: "online-3",
+    status: "online",
+  },
+  {
+    name: "offline-3",
+    status: "offline",
+  },
+];
+
+export const mockSetFilteredRecords = vi.fn() as React.Dispatch<
+  React.SetStateAction<MockRecordType[] | null>
+>;
+
+export const mockFilterOptions: FilterOptions<MockRecordType>[] = [
+  {
+    displayName: "Online status",
+    optionKey: "status",
+    optionValue: ["online", "offline"],
+    validationFn: (option: MockRecordType, value: string | undefined) =>
+      option.status === value,
+  },
+  {
+    displayName: "Name",
+    optionKey: "name",
+    optionValue: ["online-1", "offline-1"],
+    validationFn: (option: MockRecordType, value: string | undefined) =>
+      option.name === value,
+  },
+];

--- a/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { FilterOptions, FilterValues } from "../Filter";
+import { FilterOptions } from "../Filter";
 
 export type MockRecordType = {
   name: string;

--- a/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/mocks.ts
@@ -16,7 +16,11 @@ export const mockRecords: MockRecordType[] = [
     status: "online",
   },
   {
-    name: "online-1",
+    name: "online-mock-2",
+    status: "online",
+  },
+  {
+    name: "offline-mock-2",
     status: "online",
   },
 ];
@@ -36,7 +40,7 @@ export const mockFilterOptions: FilterOptions<MockRecordType>[] = [
   {
     displayName: "Name",
     optionKey: "name",
-    optionValue: ["online-1", "offline-1"],
+    optionValue: ["online-mock-2", "offline-mock-2"],
     validationFn: (option: MockRecordType, value: string | undefined) =>
       option.name === value,
   },


### PR DESCRIPTION
## What does this PR do?

This PR adds unit test coverage for the new `Filters` component as defined here: https://trello.com/c/YU56MRW8/3230-add-unit-tests-for-filter-component

Purpose is to ensure the component can receive an array called `records`, filter the records using `filterOptions` and set a new array with `setRecords`.

It does not delve into testing the inputs at their component level, for instance checking that checkboxes can be checked. I focused on ensuring Filters specific logic works as expected. 

With this in mind, a test in the Technical Plan made on the Trello ticket that I have not added related to displaying an array of records, but as I was structuring the tests I found this to sit outside the role of `Filters` and would be something the parent component would be responsible for. `Filters` should only receive the array and set a new filtered array when prompted.

> [!IMPORTANT]
> This is a clean copy of an approved PR: https://github.com/theopensystemslab/planx-new/pull/4375
> It was easier to create a new branch than rebase the original