### PR TITLE
fix: Create fixed-height view for data table

### DIFF
--- a/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
@@ -1,8 +1,8 @@
-import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { AdminPanelData } from "types";
+import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContainer";
 import SettingsSection from "ui/editor/SettingsSection";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnType } from "ui/shared/DataTable/types";
@@ -113,7 +113,7 @@ export const PlatformAdminPanel = () => {
   ];
 
   return (
-    <Container maxWidth={false}>
+    <FixedHeightDashboardContainer>
       <SettingsSection>
         <Typography variant="h2" component="h1" gutterBottom>
           Platform admin panel
@@ -124,9 +124,7 @@ export const PlatformAdminPanel = () => {
           {` environment.`}
         </Typography>
       </SettingsSection>
-      <SettingsSection>
-        <DataTable rows={filteredPanelData} columns={columns} />
-      </SettingsSection>
-    </Container>
+      <DataTable rows={filteredPanelData} columns={columns} />
+    </FixedHeightDashboardContainer>
   );
 };

--- a/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
@@ -1,0 +1,42 @@
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import { HEADER_HEIGHT_EDITOR } from "components/Header/Header";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { ReactNode } from "react";
+
+interface FixedHeightDashboardContainerProps {
+  children: ReactNode;
+}
+
+const FixedHeightDashboardContainer: React.FC<
+  FixedHeightDashboardContainerProps
+> = ({ children, ...props }) => {
+  const isTestEnvBannerVisible = useStore(
+    (state) => state.isTestEnvBannerVisible,
+  ); // Retrieve from the store
+
+  const containerHeight = isTestEnvBannerVisible
+    ? `calc(100vh - ${HEADER_HEIGHT_EDITOR * 2}px)`
+    : `calc(100vh - ${HEADER_HEIGHT_EDITOR}px)`;
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        height: containerHeight,
+        display: "flex",
+        flexDirection: "column",
+      }}
+      {...props}
+    >
+      <Container
+        sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+        maxWidth={false}
+      >
+        {children}
+      </Container>
+    </Box>
+  );
+};
+
+export default FixedHeightDashboardContainer;

--- a/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
@@ -13,7 +13,7 @@ const FixedHeightDashboardContainer: React.FC<
 > = ({ children, ...props }) => {
   const isTestEnvBannerVisible = useStore(
     (state) => state.isTestEnvBannerVisible,
-  ); // Retrieve from the store
+  );
 
   const containerHeight = isTestEnvBannerVisible
     ? `calc(100vh - ${HEADER_HEIGHT_EDITOR * 2}px)`

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -92,7 +92,7 @@ export const DataTable = <T,>({ rows, columns }: DataGridProps<T>) => {
   };
 
   return (
-    <Box sx={{ height: "100vh", flex: 1, position: "relative" }}>
+    <Box sx={{ mt: 2, height: "100%", position: "relative" }}>
       <Box sx={{ inset: 0, position: "absolute" }}>
         <DataGrid
           rows={rows}


### PR DESCRIPTION
## What does this PR do?

- Ensures data table fills available screen height to prevent dual scrolling and keep footer visible at all times
- Creates a reusable custom container to achieve this, can be used in place of `<Container>` for any admin/dashboard views that need to be restrained to full-screen-height with overflow scroll
- Adjusts height based on presence of test environment banner

**Preview:**
https://4376.planx.pizza/admin-panel