### PR TITLE
feat: add `SearchBox` to Teams page

### DIFF
--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -14,7 +14,6 @@ import { slugify } from "utils";
 
 import { useStore } from "./FlowEditor/lib/store";
 
-
 interface TeamTheme {
   slug: string;
   primaryColour: string;
@@ -56,13 +55,11 @@ const Teams: React.FC<Props> = ({ teams }) => {
     state.createTeam,
   ]);
 
-  const editableTeams: Team[] = [];
-  const viewOnlyTeams: Team[] = [];
-
-  teams.forEach((team) =>
-    canUserEditTeam(team.slug)
-      ? editableTeams.push(team)
-      : viewOnlyTeams.push(team),
+  const editableTeams: Team[] = teams.filter((team) =>
+    canUserEditTeam(team.slug),
+  );
+  const viewOnlyTeams: Team[] = teams.filter(
+    (team) => !canUserEditTeam(team.slug),
   );
 
   const renderTeams = (teamsToRender: Array<Team>) =>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Container from "@mui/material/Container";
@@ -6,7 +7,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
 import navigation from "lib/navigation";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-navi";
 import { borderedFocusStyle } from "theme";
 import { AddButton } from "ui/editor/AddButton";
@@ -58,6 +59,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
   ]);
 
   const [searchedTeams, setSearchedTeams] = useState<Team[] | null>(null);
+  const [clearSearch, setClearSearch] = useState<boolean>(false);
 
   const viewOnlyTeams = useMemo(
     () => teams.filter((team) => !canUserEditTeam(team.slug)),
@@ -67,6 +69,12 @@ const Teams: React.FC<Props> = ({ teams }) => {
   const editableTeams: Team[] = teams.filter((team) =>
     canUserEditTeam(team.slug),
   );
+
+  useEffect(() => {
+    if (searchedTeams === viewOnlyTeams && clearSearch) {
+      setClearSearch(false);
+    }
+  }, [clearSearch, searchedTeams, viewOnlyTeams]);
 
   const renderTeams = (teamsToRender: Array<Team>) =>
     teamsToRender.map((team) => {
@@ -86,7 +94,10 @@ const Teams: React.FC<Props> = ({ teams }) => {
     <Card>
       <CardContent>
         <Typography variant="h3">No results</Typography>
-        <Typography>Check your search term and try again </Typography>
+        <Typography pt={1}>Check your search term and try again</Typography>
+        <Button variant="link" onClick={() => setClearSearch(true)}>
+          Clear search
+        </Button>
       </CardContent>
     </Card>
   );
@@ -169,6 +180,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
               records={viewOnlyTeams}
               setRecords={setSearchedTeams}
               searchKey={["slug"]}
+              clearSearch={clearSearch}
             />
           </Box>
 

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -164,7 +164,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
               flexDirection: { xs: "column", contentWrap: "row" },
               justifyContent: "space-between",
               alignItems: { xs: "center", contentWrap: "center" },
-              gap: 6,
+              gap: 2,
             }}
           >
             <Typography
@@ -181,6 +181,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
               setRecords={setSearchedTeams}
               searchKey={["slug"]}
               clearSearch={clearSearch}
+              hideLabel={true}
             />
           </Box>
 

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -96,11 +96,6 @@ const Teams: React.FC<Props> = ({ teams }) => {
         <Typography variant="h2" component="h1">
           Select a team
         </Typography>
-        <SearchBox
-          records={viewOnlyTeams}
-          setRecords={setSearchedTeams}
-          searchKey={["slug"]}
-        />
         <Permission.IsPlatformAdmin>
           <AddButton
             onClick={async () => {
@@ -140,9 +135,26 @@ const Teams: React.FC<Props> = ({ teams }) => {
 
       {viewOnlyTeams.length > 0 && (
         <>
-          <Typography variant="h3" component="h2" mt={4} mb={2}>
-            Other teams (view only)
-          </Typography>
+          <Box
+            pb={1}
+            mt={4}
+            sx={{
+              display: "flex",
+              flexDirection: { xs: "column", contentWrap: "row" },
+              justifyContent: "space-between",
+              alignItems: { xs: "center", contentWrap: "center" },
+              gap: 2,
+            }}
+          >
+            <Typography variant="h3" component="h2" mt={2} mb={2}>
+              Other teams (view only)
+            </Typography>
+            <SearchBox
+              records={viewOnlyTeams}
+              setRecords={setSearchedTeams}
+              searchKey={["slug"]}
+            />
+          </Box>
           {searchedTeams
             ? renderTeams(searchedTeams)
             : renderTeams(viewOnlyTeams)}

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -179,7 +179,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
             <SearchBox
               records={viewOnlyTeams}
               setRecords={setSearchedTeams}
-              searchKey={["slug"]}
+              searchKey={["slug", "name"]}
               clearSearch={clearSearch}
               hideLabel={true}
             />

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -5,11 +5,12 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
 import navigation from "lib/navigation";
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { Link } from "react-navi";
 import { borderedFocusStyle } from "theme";
 import { AddButton } from "ui/editor/AddButton";
 import Permission from "ui/editor/Permission";
+import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 import { slugify } from "utils";
 
 import { useStore } from "./FlowEditor/lib/store";
@@ -55,11 +56,15 @@ const Teams: React.FC<Props> = ({ teams }) => {
     state.createTeam,
   ]);
 
+  const [searchedTeams, setSearchedTeams] = useState<Team[] | null>(null);
+
+  const viewOnlyTeams = useMemo(
+    () => teams.filter((team) => !canUserEditTeam(team.slug)),
+    [canUserEditTeam, teams],
+  );
+
   const editableTeams: Team[] = teams.filter((team) =>
     canUserEditTeam(team.slug),
-  );
-  const viewOnlyTeams: Team[] = teams.filter(
-    (team) => !canUserEditTeam(team.slug),
   );
 
   const renderTeams = (teamsToRender: Array<Team>) =>
@@ -75,6 +80,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
         </StyledLink>
       );
     });
+
   return (
     <Container maxWidth="formWrap">
       <Box
@@ -90,6 +96,11 @@ const Teams: React.FC<Props> = ({ teams }) => {
         <Typography variant="h2" component="h1">
           Select a team
         </Typography>
+        <SearchBox
+          records={viewOnlyTeams}
+          setRecords={setSearchedTeams}
+          searchKey={["slug"]}
+        />
         <Permission.IsPlatformAdmin>
           <AddButton
             onClick={async () => {
@@ -132,7 +143,9 @@ const Teams: React.FC<Props> = ({ teams }) => {
           <Typography variant="h3" component="h2" mt={4} mb={2}>
             Other teams (view only)
           </Typography>
-          {renderTeams(viewOnlyTeams)}
+          {searchedTeams
+            ? renderTeams(searchedTeams)
+            : renderTeams(viewOnlyTeams)}
         </>
       )}
     </Container>

--- a/editor.planx.uk/src/pages/Teams.tsx
+++ b/editor.planx.uk/src/pages/Teams.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -81,6 +82,15 @@ const Teams: React.FC<Props> = ({ teams }) => {
       );
     });
 
+  const noResultsCard = (
+    <Card>
+      <CardContent>
+        <Typography variant="h3">No results</Typography>
+        <Typography>Check your search term and try again </Typography>
+      </CardContent>
+    </Card>
+  );
+
   return (
     <Container maxWidth="formWrap">
       <Box
@@ -143,10 +153,16 @@ const Teams: React.FC<Props> = ({ teams }) => {
               flexDirection: { xs: "column", contentWrap: "row" },
               justifyContent: "space-between",
               alignItems: { xs: "center", contentWrap: "center" },
-              gap: 2,
+              gap: 6,
             }}
           >
-            <Typography variant="h3" component="h2" mt={2} mb={2}>
+            <Typography
+              variant="h3"
+              component="h2"
+              mt={2}
+              mb={2}
+              sx={{ textWrap: "nowrap" }}
+            >
               Other teams (view only)
             </Typography>
             <SearchBox
@@ -155,9 +171,8 @@ const Teams: React.FC<Props> = ({ teams }) => {
               searchKey={["slug"]}
             />
           </Box>
-          {searchedTeams
-            ? renderTeams(searchedTeams)
-            : renderTeams(viewOnlyTeams)}
+
+          {searchedTeams?.length ? renderTeams(searchedTeams) : noResultsCard}
         </>
       )}
     </Container>

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -87,7 +87,7 @@ export const SearchBox = <T extends object>({
             hidden: hideLabel,
           }}
         >
-          <strong aria-hidden>Search</strong>
+          <strong>Search</strong>
         </InputRowLabel>
         <InputRowItem>
           <Box sx={{ position: "relative" }}>

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -80,8 +80,14 @@ export const SearchBox = <T extends object>({
   return (
     <Box maxWidth={360}>
       <InputRow>
-        <InputRowLabel inputProps={{ htmlFor: "search", hidden: hideLabel }}>
-          <strong>Search</strong>
+        <InputRowLabel
+          inputProps={{
+            id: "search-label",
+            htmlFor: "search",
+            hidden: hideLabel,
+          }}
+        >
+          <strong aria-hidden>Search</strong>
         </InputRowLabel>
         <InputRowItem>
           <Box sx={{ position: "relative" }}>
@@ -91,6 +97,7 @@ export const SearchBox = <T extends object>({
               }}
               name="search"
               id="search"
+              aria-describedby="search-label"
               value={values.pattern}
               onChange={(e) => {
                 setFieldValue("pattern", e.target.value);

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -20,6 +20,7 @@ interface SearchBoxProps<T> {
   setRecords: React.Dispatch<React.SetStateAction<T[] | null>>;
   searchKey: FuseOptionKey<T>[];
   clearSearch?: boolean;
+  hideLabel?: boolean;
 }
 
 export const SearchBox = <T extends object>({
@@ -27,6 +28,7 @@ export const SearchBox = <T extends object>({
   setRecords,
   searchKey,
   clearSearch = false,
+  hideLabel = false,
 }: SearchBoxProps<T>) => {
   const [isSearching, setIsSearching] = useState(false);
   const [searchedTerm, setSearchedTerm] = useState<string>();
@@ -78,7 +80,7 @@ export const SearchBox = <T extends object>({
   return (
     <Box maxWidth={360}>
       <InputRow>
-        <InputRowLabel inputProps={{ htmlFor: "search" }}>
+        <InputRowLabel inputProps={{ htmlFor: "search", hidden: hideLabel }}>
           <strong>Search</strong>
         </InputRowLabel>
         <InputRowItem>

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -1,4 +1,5 @@
 import ClearIcon from "@mui/icons-material/Clear";
+import Search from "@mui/icons-material/Search";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
@@ -93,6 +94,7 @@ export const SearchBox = <T extends object>({
                 setFieldValue("pattern", e.target.value);
                 submitForm();
               }}
+              startAdornment={<Search sx={{ ml: -0.5, mr: 0.5 }} />}
             />
             {searchedTerm && !isSearching && (
               <IconButton


### PR DESCRIPTION
## What does this PR do?

This PR is for the ticket: https://trello.com/c/XOqpIQic/3013-search-teams

It introduces the `SearchBox` component to the `Teams` table which lists out all of the Team a user can edit and view. The search box only applies to teams a user can **view** not teams that they can **edit**.

To fit with the compact UI of the title, I have added a new prop to `SearchBox` so we can hide the label if it doesn't make contextual sense. To help communicate the use of the text box, I have thus added a `Search` icon from material ui. This also sits in the Service list `Team` page.