### PR TITLE
style: MUI data grid

### DIFF
--- a/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
@@ -113,7 +113,7 @@ export const PlatformAdminPanel = () => {
   ];
 
   return (
-    <FixedHeightDashboardContainer>
+    <FixedHeightDashboardContainer bgColor="background.paper">
       <SettingsSection>
         <Typography variant="h2" component="h1" gutterBottom>
           Platform admin panel

--- a/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
@@ -24,14 +24,15 @@ const DashboardContainer = styled(Box)(({ theme }) => ({
   flexDirection: "row",
   width: "100%",
   overflow: "hidden",
-  [`& > .${containerClasses.root}, & > div > .${containerClasses.root}`]: {
-    paddingTop: theme.spacing(3),
-    paddingBottom: theme.spacing(3),
-    [theme.breakpoints.up("lg")]: {
-      paddingTop: theme.spacing(5),
-      paddingBottom: theme.spacing(5),
+  [`& > .${containerClasses.root}, & > div:not(.fixed-height-container) > .${containerClasses.root}`]:
+    {
+      paddingTop: theme.spacing(3),
+      paddingBottom: theme.spacing(3),
+      [theme.breakpoints.up("lg")]: {
+        paddingTop: theme.spacing(5),
+        paddingBottom: theme.spacing(5),
+      },
     },
-  },
 }));
 
 const Layout: React.FC<PropsWithChildren> = ({ children }) => {

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -696,7 +696,8 @@ const getThemeOptions = ({
               display: "flex",
               alignItems: "flex-start",
               "&:focus": {
-                outline: "none",
+                ...inputFocusStyle,
+                boxShadow: "none",
               },
               alignItems: "center",
             },
@@ -709,6 +710,9 @@ const getThemeOptions = ({
               paddingBottom: "5px",
               [`& .${buttonClasses.root}`]: {
                 background: palette.background.default,
+                "&:focus-visible": {
+                  ...focusStyle
+                },
                 // Ensure SVG icons are equal size
                 "& svg": {
                   width: "18px",
@@ -718,6 +722,12 @@ const getThemeOptions = ({
             },
             [`& .${gridClasses.columnHeader}.${gridClasses.withBorderColor}`]: {
               borderColor: palette.border.main,
+            },
+            [`& .${gridClasses.columnHeader}`]: {
+              "&:focus": {
+                ...inputFocusStyle,
+                boxShadow: "none",
+              },
             },
             [`& .${gridClasses.columnHeaderTitle}`]: {
               fontWeight: FONT_WEIGHT_SEMI_BOLD,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -699,7 +699,6 @@ const getThemeOptions = ({
                 ...inputFocusStyle,
                 boxShadow: "none",
               },
-              alignItems: "center",
             },
             ".MuiDataGrid-columnSeparator": {
               visibility: "hidden",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -1,5 +1,6 @@
 import "themeOverrides.d.ts";
 
+import { buttonClasses } from "@mui/material/Button";
 import { radioClasses } from "@mui/material/Radio";
 import {
   alpha,
@@ -688,10 +689,8 @@ const getThemeOptions = ({
         styleOverrides: {
           root: {
             margin: 1,
-            border: "none",
-            ".MuiDataGrid-row--borderBottom .MuiDataGrid-columnHeader": {
-              borderColor: "black",
-            },
+            backgroundColor: palette.background.default,
+            borderColor: palette.border.main,
             [`& .${gridClasses.cell}`]: {
               padding: "10px",
               display: "flex",
@@ -702,6 +701,22 @@ const getThemeOptions = ({
             },
             ".MuiDataGrid-columnSeparator": {
               visibility: "hidden",
+            },
+            [`& .${gridClasses.toolbarContainer}`]: {
+              borderBottom: `1px solid ${palette.border.main}`,
+              background: palette.background.midGray,
+              paddingBottom: "5px",
+              [`& .${buttonClasses.root}`]: {
+                background: palette.background.default,
+                // Ensure SVG icons are equal size
+                "& svg": {
+                  width: "18px",
+                  height: "18px",
+                },
+              },
+            },
+            [`& .${gridClasses.columnHeader}.${gridClasses.withBorderColor}`]: {
+              borderColor: palette.border.main,
             },
             [`& .${gridClasses.columnHeaderTitle}`]: {
               fontWeight: FONT_WEIGHT_SEMI_BOLD,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -700,9 +700,6 @@ const getThemeOptions = ({
                 boxShadow: "none",
               },
             },
-            ".MuiDataGrid-columnSeparator": {
-              visibility: "hidden",
-            },
             [`& .${gridClasses.toolbarContainer}`]: {
               borderBottom: `1px solid ${palette.border.main}`,
               background: palette.background.midGray,
@@ -736,9 +733,14 @@ const getThemeOptions = ({
             },
             [`& .${gridClasses.row}.odd`]: {
               backgroundColor: lighten(palette.background.paper, 0.2),
-              "&.Mui-selected": {
-                backgroundColor: alpha(palette.primary.main, 0.05),
+            },
+            [`& .${gridClasses.row}`]: {
+              "&.Mui-selected, &.Mui-selected:hover": {
+                backgroundColor: palette.info.light,
               },
+            },
+            [`& .${gridClasses.footerContainer}`]: {
+              borderColor: palette.border.main,
             },
             [`& .${tablePaginationClasses.root}`]: {
               maxHeight: "none",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -694,6 +694,7 @@ const getThemeOptions = ({
             [`& .${gridClasses.cell}`]: {
               padding: "10px",
               display: "flex",
+              alignItems: "flex-start",
               "&:focus": {
                 outline: "none",
               },
@@ -725,7 +726,7 @@ const getThemeOptions = ({
               backgroundColor: "transparent",
             },
             [`& .${gridClasses.row}.odd`]: {
-              backgroundColor: palette.background.paper,
+              backgroundColor: lighten(palette.background.paper, 0.2),
               "&.Mui-selected": {
                 backgroundColor: alpha(palette.primary.main, 0.05),
               },

--- a/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
@@ -22,17 +22,20 @@ const FixedHeightDashboardContainer: React.FC<
 
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         width: "100%",
         height: containerHeight,
         display: "flex",
         flexDirection: "column",
         backgroundColor: bgColor,
-      }}
+        paddingTop: theme.spacing(3),
+        paddingBottom: theme.spacing(3),
+      })}
+      className="fixed-height-container"
       {...props}
     >
       <Container
-        sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+        sx={{ height: "100%", display: "flex", flexDirection: "column", py: 5 }}
         maxWidth={false}
       >
         {children}

--- a/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/FixedHeightDashboardContainer.tsx
@@ -6,11 +6,12 @@ import React, { ReactNode } from "react";
 
 interface FixedHeightDashboardContainerProps {
   children: ReactNode;
+  bgColor?: string;
 }
 
 const FixedHeightDashboardContainer: React.FC<
   FixedHeightDashboardContainerProps
-> = ({ children, ...props }) => {
+> = ({ children, bgColor, ...props }) => {
   const isTestEnvBannerVisible = useStore(
     (state) => state.isTestEnvBannerVisible,
   );
@@ -26,6 +27,7 @@ const FixedHeightDashboardContainer: React.FC<
         height: containerHeight,
         display: "flex",
         flexDirection: "column",
+        backgroundColor: bgColor,
       }}
       {...props}
     >

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -92,7 +92,7 @@ export const DataTable = <T,>({ rows, columns }: DataGridProps<T>) => {
   };
 
   return (
-    <Box sx={{ mt: 2, height: "100%", position: "relative" }}>
+    <Box sx={{ mt: 1, height: "100%", position: "relative" }}>
       <Box sx={{ inset: 0, position: "absolute" }}>
         <DataGrid
           rows={rows}

--- a/editor.planx.uk/src/ui/shared/DataTable/components/cellIcons.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/components/cellIcons.tsx
@@ -2,6 +2,6 @@ import Close from "@mui/icons-material/Close";
 import Done from "@mui/icons-material/Done";
 import React from "react";
 
-export const True: React.FC = () => <Done color="success" fontSize="small" />;
+export const True: React.FC = () => <Done color="success" fontSize="medium" />;
 
-export const False: React.FC = () => <Close color="error" fontSize="small" />;
+export const False: React.FC = () => <Close color="error" fontSize="medium" />;


### PR DESCRIPTION
## What does this PR do?

Adds styles to MUI data grid:
- Updates border styles to fit with wider editor styles
- Filter toolbar uses `midGray` background, consistent with flow filters
- Extends our bordered focus styles to focused cells
- Extends our button focus styles to buttons
- Unifies icon sizes across buttons
- Aligns boolean cell content (tick/cross) to top, maintaining horizontal line with service title and other text content
- Bumps size of tick/cross icons to increase visibility
- Unifies selected cell highlight colour
- Adjusts padding of container element to maximise canvas area for table

**Before changes:**
<img width="1567" alt="image" src="https://github.com/user-attachments/assets/c804ccd2-5839-42f3-8f10-b01d7371ae8d" />

**After changes:**
<img width="1567" alt="image" src="https://github.com/user-attachments/assets/fa1136ce-3baf-4b03-828f-2f9f722c2f2f" />