### PR TITLE
fix: matchingFlows resolving to null during flow actions

### DIFF
--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -97,7 +97,12 @@ const Team: React.FC = () => {
 
   useEffect(() => {
     const diffFlows =
-      searchedFlows?.filter((flow) => filteredFlows?.includes(flow)) || null;
+      searchedFlows?.filter(
+        (searchedFlow) =>
+          filteredFlows?.some(
+            (filteredFlow) => filteredFlow.id === searchedFlow.id,
+          ),
+      ) || null;
 
     // Sort the array at the start using the query params
     if (matchingFlows === null) {

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -145,10 +145,10 @@ export const Filters = <T extends object>({
   }, []);
 
   useEffect(() => {
-    if (values.filters) {
+    if (values.filters && records) {
       submitForm();
     }
-  }, [submitForm, values.filters]);
+  }, [submitForm, values.filters, records]);
 
   useEffect(() => {
     if (clearFilters) {

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -145,7 +145,7 @@ export const Filters = <T extends object>({
   }, []);
 
   useEffect(() => {
-    if (values.filters && records) {
+    if (values.filters || records) {
       submitForm();
     }
   }, [submitForm, values.filters, records]);


### PR DESCRIPTION
## What was the problem?

When performing an action on a `FlowCard` like `copyFlow` - `moveFlow` - `archiveFlow` - the flow list was returning `null`. This was due to the `useEffect` we have which finds the intersection of `searchedFlows` and `filteredFlows`. It kept returning `null` when the `fetchFlows()` ran which updated `searchedFlows` but not `filteredFlows`.

More details in this Slack thread: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1740561802501189

## What was the fix?

This was due to how each component was handling `flows` in it. `searchedFlows` had a useEffect with `records` as a dependency, `flows` is passed down to each component via the prop `records`. 

Still, this shouldn't be returning `null` on the filter method we have to update `matchingFlows`. 

So, what I found was that the current method of using `.filter((flow) => filteredFlows.includes(flow) || null` was insufficient and wasn't returning the right equality. I have now switched this to match on the `id` property of each flow. 

To ensure the list updates properly, I also added `records` as a dependency in the `Filters` component. 

## Things to follow up on

- I found it quite frustrating when I archived a copied flow, that I couldn't then copy the main one again. We could add a suffix to an archived flow to ensure it can be copied again in the future or remove archived flows from the duplicate name check
- The Team page is quite feature heavy now with the actions on a FlowCard and the ability to Filter, Search, and Sort. We should add test coverage to maintain the connections between the features
