### PR TITLE
fix: Make data grid cells respond to density

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -692,13 +692,22 @@ const getThemeOptions = ({
             backgroundColor: palette.background.default,
             borderColor: palette.border.main,
             [`& .${gridClasses.cell}`]: {
-              padding: "10px",
               display: "flex",
               alignItems: "flex-start",
               "&:focus": {
                 ...inputFocusStyle,
                 boxShadow: "none",
               },
+            },
+            // Set cell padding based on density setting
+            [`&.${gridClasses.root}--densityCompact .${gridClasses.cell}`]: {
+              padding: "5px 10px",
+            },
+            [`&.${gridClasses.root}--densityStandard .${gridClasses.cell}`]: {
+              padding: "10px 10px",
+            },
+            [`&.${gridClasses.root}--densityComfortable .${gridClasses.cell}`]: {
+              padding: "20px 10px",
             },
             [`& .${gridClasses.toolbarContainer}`]: {
               borderBottom: `1px solid ${palette.border.main}`,


### PR DESCRIPTION
## What does this PR do?

Currently the cells of the data grid have a fixed padding, and do not respond to the "density" setting, this PR targets the density classes to set ascending levels of padding.

Density = compact:

Density = standard:

Density = comfortable:
