### PR TITLE
[infrastructure] add snapshot reference to test restoring RDS db

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -39,6 +39,7 @@ const db = new aws.rds.Instance("app", {
   username: DB_ROOT_USERNAME,
   password: config.require("db-password"),
   skipFinalSnapshot: true,
+  snapshotIdentifier: "after-postgres-update-167",
   publiclyAccessible: true,
   storageEncrypted: true,
   backupRetentionPeriod: env === "production" ? 35 : 1,


### PR DESCRIPTION
This PR contains a very small change to the `infrastructure/data` layer, which will not be applied on merge, but only via manually running `pulumi up`.

The intention here is to test the restoration of the staging RDS postgres database from a manual snapshot (in this case `after-postgres-update-167`, a snapshot I took on 21st Feb after applying bump to postgres version `16.7` from `16.3` - see #4361). 

![image](https://github.com/user-attachments/assets/83f99e4e-3608-4bce-bbba-021fbe0a77f3)

To ensure this works, once this PR is merged, I will:
- run `pulumi up` on staging from my console
- ensure `editor.planx.dev` accessible and running as expected
- use Hasura to check whether published flow `5015` from 20th Feb exists (it should)
- check whether published flow `5024` from 26th Feb exists (it should not)
- check that we can then run [nightly prod -> staging db sync](https://github.com/theopensystemslab/planx-new/actions/workflows/sync-staging-db.yml) action to success
- check that flow `5024` is now in the db

If this all works as expected, I'd like to further test manually upgrading `before-postgres-upgrade-16` (from 14th Feb, _before_ postgres major version upgrade) in the AWS console (which is a cool feature, if it works). I'd then conduct a similar set of checks as above for that snapshot.

Finally, I'll test restoring to the the latest automatic snapshot (staging is now set up to keep snapshots from previous day), since this is likely what we'd want to do in the (unlikely!) event that the prod db falls over.

All of this would be via Pulumi, but there's also the option of [manual restoration via the AWS console](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Tutorials.RestoringFromSnapshot.html) - we should investigate how this works as a backup route, but probably not intend for it to be our main method (imho there are way more opportunities for that to go wrong).

Relates to [this Trello ticket](https://trello.com/c/f8cDu6Ty). Results will be documented in the runbook I'm developing in #4391.

## Risks & recovery

I'll take a further snapshot before I try any of the above, so that we have a most-recent restore point, even though the staging db has no sovereign data (prod db is the source of truth - and I certainly won't be touching prod!).

The only risk I envisage is if the Pulumi managed snapshot restoration process doesn't work, and also doesn't rollback gracefully.

In this case we'll have to run `pulumi up` with the `snapshotIdentifier` field removed, but we've done this successfully multiple times in the last few weeks, so it's a well rehearsed procedure. And in any case that should be our final move after all above tests are complete.