### PR TITLE
[application] rotate db-url

### DIFF
--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -10,7 +10,7 @@ config:
   application:db-password:
     secure: AAABAKd+etETq8AV5V3Xrl5X2H+rYtSw91GDBSwFyjT/HLJT9sOLNR296GTxrHkNQ8BxSOq4rxrlMHIt0lL/DQ==
   application:db-url:
-    secure: AAABAHaVuHg4NkZjMQv7N8hpKRJL13IW721pPo/ou6+itPn2PLYr8s8YjTbaxDGZg9LiB5QAgbihA1fSnIolokoZ/wJ7VzkHOI59Icci0CEoOgQrUfzDFevpgt3HaTmyrxIzemMbOPl/dGcJCTW0K9NkRADWE4z2OERcFwQBRUZuRSwIbV7teXpbY15IAW24FLNM+g==
+    secure: AAABABpoGwEP8SR9ONSboakkrdFhU4FIC4DlMScGUZhf6SSgurJG4mgqrZ7HMDNuZgvRMsSQkfpLhb/cNm8PSDZsTblSPqCuSaKHgB3R34qaOZwsCklRwLm6Ggo8x7IgvilMBk5hMXcbq6uZFCM0GwUf1o8zyOEF/ivQijis1XM78UQWd9pHJIETVAfq2Zoylo6vTg==
   application:encryption-key:
     secure: AAABAFTW2eRwQnXJq/IboPWtStOWXiF9WcsUKEiuosmp7TLZt52uKE3L+NrEGgsThOl3NkvFW2HhFa2XL6aB5w==
   application:file-api-key:

--- a/infrastructure/data/Pulumi.staging.yaml
+++ b/infrastructure/data/Pulumi.staging.yaml
@@ -2,3 +2,5 @@ config:
   aws:profile: planx-staging-pulumi
   data:db-password:
     secure: AAABAC1IL67K+rI8eqDLfUG/eTuaQlcEOOBUmXWjY8pyrS32fUCm2WQGHCo7uwb1UYREMyYOSiYHolwpcscRLQ==
+  data:db-url:
+    secure: AAABAKv6rYAchAqPSJFwp110s17+iQkEnV2NSA12T4u99xP/VIABF1uAIzUjGw4y6X6Nrb2Ro0GqhBzy7QbhGf710i0vmuijN4GjMfaCCoMwbdoNIhd+DxoXwMC4/KBwe6qaaPpu+Pzug8LLEY5Co7sbSp/chQZSAiT3Oj5LPZbDoIUtsV/Bhdd9ekJs5qAQhapRoQ==


### PR DESCRIPTION
Testing db restoration as per #4392 results in a new db instance name and hence a changed `dbRootUrl` output from the data layer. We need to rotate `db-url` in the application layer so that it points at the new db.