### PR TITLE
feat: Set up filter options for feedback type

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -11,6 +11,7 @@ import { dateFormatter } from "ui/shared/DataTable/utils";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
+import { feedbackTypeOptions } from "./feedbackFilterOptions";
 import { FeedbackLogProps } from "./types";
 import {
   EmojiRating,
@@ -32,19 +33,14 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       field: "type",
       headerName: "Type",
       width: 200,
-      type: ColumnFilterType.CUSTOM,
+      type: ColumnFilterType.ARRAY,
       columnOptions: {
-        filterable: false, // TODO: make filterable
-        sortable: false,
-        valueFormatter: (value) => {
-          const { title } = feedbackTypeText(value);
-          return title;
-        },
+        valueOptions: feedbackTypeOptions.map((option) => ({
+          value: option.value,
+          label: option.label,
+        })),
       },
-      customComponent: (params) => {
-        const { title } = feedbackTypeText(params.value);
-        return <>{title}</>;
-      },
+      customComponent: (params) => <>{feedbackTypeText(params.value)}</>,
     },
     {
       field: "createdAt",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -35,10 +35,8 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 200,
       type: ColumnFilterType.ARRAY,
       columnOptions: {
-        valueOptions: feedbackTypeOptions.map((option) => ({
-          value: option.value,
-          label: option.label,
-        })),
+        valueOptions: feedbackTypeOptions,
+        filterable: true,
       },
       customComponent: (params) => <>{feedbackTypeText(params.value)}</>,
     },
@@ -48,7 +46,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 125,
       type: ColumnFilterType.DATE,
       columnOptions: {
-        valueFormatter: dateFormatter
+        valueFormatter: dateFormatter,
       },
     },
     {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/feedbackFilterOptions.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/feedbackFilterOptions.tsx
@@ -20,5 +20,3 @@ export const feedbackTypeOptions: FeedbackTypeOption[] = (
   value: type,
   label: feedbackTypeText(type),
 }));
-
-console.log("Feedback type options: ", feedbackTypeOptions);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/feedbackFilterOptions.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/feedbackFilterOptions.tsx
@@ -1,0 +1,24 @@
+import { FeedbackType } from "./types";
+import { feedbackTypeText } from "./utils";
+
+export type FeedbackTypeOption = {
+  value: FeedbackType;
+  label: string;
+};
+
+export const feedbackTypeOptions: FeedbackTypeOption[] = (
+  [
+    "issue",
+    "idea",
+    "comment",
+    "helpful",
+    "unhelpful",
+    "component",
+    "inaccuracy",
+  ] as FeedbackType[]
+).map((type) => ({
+  value: type,
+  label: feedbackTypeText(type),
+}));
+
+console.log("Feedback type options: ", feedbackTypeOptions);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/types.ts
@@ -9,10 +9,6 @@ export type FeedbackType =
   | "unhelpful"
   | "component";
 
-export interface FeedbackTypeIcon {
-  icon: React.ReactElement;
-  title: Capitalize<string>;
-}
 export interface CollapsibleRowProps extends Feedback {
   displayFeedbackItems: string[];
 }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/utils.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/utils.tsx
@@ -23,19 +23,19 @@ export const EmojiRating: Record<number, string> = {
 export const feedbackTypeText = (type: FeedbackType) => {
   switch (type) {
     case "issue":
-      return { title: "Issue" };
+      return "Issue";
     case "idea":
-      return { title: "Idea" };
+      return "Idea";
     case "comment":
-      return { title: "Comment" };
+      return "Comment";
     case "helpful":
-      return { title: "Helpful (help text)" };
+      return "Helpful (help text)";
     case "unhelpful":
-      return { title: "Unhelpful (help text)" };
+      return "Unhelpful (help text)";
     case "component":
-      return { title: "User satisfaction" };
+      return "User satisfaction";
     default:
-      return { title: "Inaccuracy" };
+      return "Inaccuracy";
   }
 };
 

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -20,7 +20,6 @@ import {
 } from "./types";
 import {
   columnCellComponentRegistry,
-  createFilterOperator,
   getColumnFilterType,
   getValueOptions,
 } from "./utils";
@@ -83,10 +82,6 @@ export const DataTable = <T,>({
       ? {
           ...baseColDef,
           valueOptions: columnValueOptions,
-          filterOperators:
-            columnValueOptions &&
-            columnValueOptions.length > 0 &&
-            createFilterOperator(columnValueOptions),
           ...column.columnOptions,
         }
       : {

--- a/editor.planx.uk/src/ui/shared/DataTable/types.ts
+++ b/editor.planx.uk/src/ui/shared/DataTable/types.ts
@@ -7,7 +7,7 @@ import {
 
 export const ColumnFilterType = {
   BOOLEAN: "boolean",
-  ARRAY: "array", // when the column can be filtered from a range of known values
+  ARRAY: "singleSelect", // when the column can be filtered from a range of known values
   DATE: "date",
   CUSTOM: "custom",
 } as const;
@@ -34,6 +34,7 @@ export type ColumnConfig<T> = {
   columnOptions?: Omit<GridColDef, "headerName" | "field" | "type"> &
     Omit<GridSingleSelectColDef, "editable" | "type" | "field">;
 };
+
 export interface DataGridProps<T> {
   rows: readonly T[] | undefined;
   columns: Array<ColumnConfig<T>>;


### PR DESCRIPTION
## What does this PR do?

Sets up a `feedbackFilterOptions` file in order to filter by feedback type in the feedback log.