### PR TITLE
[data] keep final snapshots in case of db deletion

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -38,8 +38,9 @@ const db = new aws.rds.Instance("app", {
   name: "app",
   username: DB_ROOT_USERNAME,
   password: config.require("db-password"),
-  skipFinalSnapshot: true,
-  snapshotIdentifier: "after-postgres-update-167",
+  // we should keep a snapshot in case of (potentially mistaken) deletion
+  skipFinalSnapshot: false,
+  finalSnapshotIdentifier: "final-before-deletion",
   publiclyAccessible: true,
   storageEncrypted: true,
   backupRetentionPeriod: env === "production" ? 35 : 1,


### PR DESCRIPTION
Intended to guard against the situation where Pulumi deletes a db while instantiating a new one from a snapshot, and we have no way of recovering the state of the former because no final snapshot is taken before deletion!

(as happened yesterday when I was conducting the db restoration tests as per #4392)

Note that this is just us reverting to the default, which is for `skipFinalSnapshot: false` (not sure why we originally decided to switch it to `true`).

Relatedly, also removes the `snapshotIdentifier` input.

If applied via `pulumi up`, would cause the following change (i.e. does not imply any db replacement/deletion or anything like that):

![image](https://github.com/user-attachments/assets/49c815f4-3d51-4eb3-b6be-99f6f6134114)

Docs: https://www.pulumi.com/registry/packages/aws/api-docs/rds/instance/#skipfinalsnapshot_nodejs