### PR TITLE
style: Refine data table column widths based on content

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { format } from "date-fns";
 import capitalize from "lodash/capitalize";

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -21,7 +21,13 @@ import {
 
 export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
   const columns: ColumnConfig<Feedback>[] = [
-    { field: "flowName", headerName: "Service", width: 200 },
+    {
+      field: "flowName",
+      headerName: "Service",
+      width: 250,
+      type: ColumnFilterType.CUSTOM,
+      customComponent: (params) => <strong>{`${params.value}`}</strong>,
+    },
     {
       field: "type",
       headerName: "Type",
@@ -43,6 +49,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
     {
       field: "createdAt",
       headerName: "Date",
+      width: 125,
       type: ColumnFilterType.DATE,
       columnOptions: {
         valueFormatter: (params) =>
@@ -52,6 +59,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
     {
       field: "feedbackScore",
       headerName: "Rating",
+      width: 125,
       columnOptions: {
         filterable: false, // TODO: make filterable
         valueFormatter: (params) => EmojiRating[params],
@@ -105,10 +113,12 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
     {
       field: "browser",
       headerName: "Browser",
+      width: 125,
     },
     {
       field: "platform",
       headerName: "Device",
+      width: 125,
       columnOptions: {
         valueFormatter: (params) => capitalize(params),
       },

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
@@ -54,11 +54,17 @@ const EventsLog: React.FC<EventsLogProps> = ({
   );
 
   const columns: ColumnConfig<Submission>[] = [
-    { field: "flowName", headerName: "Service" },
+    {
+      field: "flowName",
+      headerName: "Service",
+      width: 250,
+      type: ColumnFilterType.CUSTOM,
+      customComponent: (params) => <strong>{`${params.value}`}</strong>,
+    },
     {
       field: "eventType",
       headerName: "Event",
-      width: 250,
+      width: 230,
       type: ColumnFilterType.ARRAY,
       customComponent: SubmissionEvent,
       columnOptions: {
@@ -68,6 +74,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
     {
       field: "status",
       headerName: "Status",
+      width: 125,
       type: ColumnFilterType.ARRAY,
       customComponent: StatusChip,
       columnOptions: {
@@ -77,17 +84,18 @@ const EventsLog: React.FC<EventsLogProps> = ({
     {
       field: "createdAt",
       headerName: "Date",
+      width: 125,
       columnOptions: {
         valueFormatter: (params) =>
           format(new Date(params), "dd/MM/yy hh:mm:ss"),
       },
       type: ColumnFilterType.DATE,
     },
-    { field: "sessionId", headerName: "Session ID", width: 350 },
+    { field: "sessionId", headerName: "Session ID", width: 200 },
     {
       field: "response",
       headerName: "Response",
-      width: 350,
+      width: 450,
       type: ColumnFilterType.CUSTOM,
       customComponent: (params) => <FormattedResponse {...params.row} />,
       columnOptions: {
@@ -117,7 +125,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
     },
     {
       field: "downloadSubmissionLink" as keyof Submission,
-      headerName: "",
+      headerName: "Download",
       width: 100,
       type: ColumnFilterType.CUSTOM,
       customComponent: DownloadSubmissionButton,


### PR DESCRIPTION
## What does this PR do?

- Makes first column "Service" text bold
- Refines column widths based on content to make space optimal (can be refined as we continue to use the logs)

**Feedback log before changes:**
<img width="1559" alt="image" src="https://github.com/user-attachments/assets/05f3c89b-f75a-4499-be62-49d8ea0654b9" />

**Feedback log after changes:**
<img width="1559" alt="image" src="https://github.com/user-attachments/assets/8dfe52f0-75fe-427f-a671-6962f8c555ff" />

**Submissions log before changes:**
<img width="1559" alt="image" src="https://github.com/user-attachments/assets/bdea469b-2e9d-4bc4-b3cf-4283cec46fce" />

**Submissions log after changes:**
<img width="1559" alt="image" src="https://github.com/user-attachments/assets/86636fd9-10f8-44f4-a7e2-3552e5066bcf" />
