### PR TITLE
fix: Add download column header to submissions log

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
@@ -117,7 +117,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
     },
     {
       field: "downloadSubmissionLink" as keyof Submission,
-      headerName: "",
+      headerName: "Download",
       width: 100,
       type: ColumnFilterType.CUSTOM,
       customComponent: DownloadSubmissionButton,


### PR DESCRIPTION
## What does this PR do?

Adds "Download" header to final column of submissions log table.