### PR TITLE
[application] simplify process for passing correct DB URLs to images

### DIFF
--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -9,8 +9,6 @@ config:
     secure: AAABAMwwPy7/bMKC+iEonzpc0HrzblNfFBXBi60LiSTcoF1KxQkd+vkEUfBfhY96Tx4Nf8/JML6EBhtesIjoGN+r4Y1EcpW+thJoJa/g3Ssv4Dc=
   application:db-password:
     secure: AAABAKd+etETq8AV5V3Xrl5X2H+rYtSw91GDBSwFyjT/HLJT9sOLNR296GTxrHkNQ8BxSOq4rxrlMHIt0lL/DQ==
-  application:db-url:
-    secure: AAABAIsgd8oJwUggSndLa/+RU+LuzCUjbAG0VCrI/ylnJpXHSB5uRGMWc6laV93IuAr8TPV25nk45avXrURCdDYtjxhr9/ElzdZpp/Yx5oJuqnDd74Ijqd17mz5YpkdRMkoB4SZPF2xxgnltSWn02i2hRqBb4mYaxrINPCbz5ehmmUFiC5QgV4O4xju3ZyrQjGfSuA==
   application:encryption-key:
     secure: AAABAFTW2eRwQnXJq/IboPWtStOWXiF9WcsUKEiuosmp7TLZt52uKE3L+NrEGgsThOl3NkvFW2HhFa2XL6aB5w==
   application:file-api-key:
@@ -60,8 +58,6 @@ config:
     secure: AAABACbmLC4176IBxX5iL64/nycSXEsCYSQ0hTb7t2OCVlWUc627Vr/EpBhcqPrw9q+0z8UOvRJG5/c/DflZxfPxyJRUVNu+
   application:mapbox-access-token:
     secure: AAABAMWf2zVq5/mKCLynpgzAidNsnbUEBpb47n7MRWp2xzRgwaf3kzOvnZax9N04ZScQqU6I5/tEKTBAbSb8MIBJ8mU2iTZbPg8FD6wYsetRyftm1K39KBsIl9aS7fXvZFOG7BsC4qMDEhlDkH8gbV2HTev3VvvRUe3lzVhjNGNHqQ==
-  application:mb-db-connection-uri:
-    secure: AAABAHA4NTOerqNcfoJVJ/erFiPHwUIMR1sZB4twe3VxeGa+OsSSC7hU3jO7sh7GKq7qL79rsRtSfZZJI9kwnKTPVjdqPYD8IR4SYKMwAB/WjHCYLHu6m7NSntd1IWnLeS96nX8FiUERnNd5Ht3PlVpY88N+07YY/aG0Y5cslMonzNzLDCF6mLSi5Q5bZQl8RZ7RaI1r
   application:metabase-api-key:
     secure: AAABAFf+hW09AWupsY6adrPAJHCkrTMeRX7/gaUHLYXi3QS77MVelPp9K0L4zyUL8u7zDanjuE9G/bfIlcVXLwiLLKAJkt5to9knKJqTXg==
   application:metabase-encryption-secret-key:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -8,9 +8,14 @@ import * as pulumi from "@pulumi/pulumi";
 import * as postgres from "@pulumi/postgresql";
 import * as mime from "mime";
 import * as tldjs from "tldjs";
-import * as url from "url";
 
-import { generateTeamSecrets, generateCORSAllowList, addRedirectToCloudFlareListenerRule } from "./utils";
+import {
+  DEFAULT_POSTGRES_PORT,
+  addRedirectToCloudFlareListenerRule,
+  generateTeamSecrets,
+  generateCORSAllowList,
+  getPostgresDbUrl
+} from "./utils";
 import { createHasuraService } from "./services/hasura";
 import { CustomDomains } from "../common/teams";
 
@@ -115,13 +120,14 @@ export = async () => {
   });
 
   const DB_ROOT_USERNAME = "dbuser";
-
+  const dbHost = String(config.requireSecret("db-host"))
+  const dbRootPassword = config.requireSecret("db-password");
   // ----------------------- Metabase
   const provider = new postgres.Provider("metabase", {
-    host: config.requireSecret("db-host"),
+    host: dbHost,
     port: 5432,
     username: DB_ROOT_USERNAME,
-    password: config.requireSecret("db-password"),
+    password: dbRootPassword,
     database: "postgres",
     superuser: false,
   });
@@ -191,6 +197,7 @@ export = async () => {
     domain: DOMAIN,
   });
   
+  const metabaseDbUrl = getPostgresDbUrl("metabase", String(metabasePgPassword), dbHost, DEFAULT_POSTGRES_PORT, "metabase");
   const metabaseService = new awsx.ecs.FargateService("metabase", {
     cluster,
     subnets: networking.requireOutput("publicSubnetIds"),
@@ -211,7 +218,7 @@ export = async () => {
           { name: "MB_DB_TYPE", value: "postgres" },
           {
             name: "MB_DB_CONNECTION_URI",
-            value: config.requireSecret("mb-db-connection-uri"),
+            value: metabaseDbUrl,
           },
           { name: "MB_JETTY_HOST", value: "0.0.0.0" },
           { name: "MB_JETTY_PORT", value: String(METABASE_PORT) },
@@ -244,10 +251,13 @@ export = async () => {
   });
 
   // ----------------------- Hasura
+  // we'll also pass this database URI to sharedb later on
+  const rootDbUrl = getPostgresDbUrl(DB_ROOT_USERNAME, String(dbRootPassword), dbHost);
   createHasuraService({
     vpc,
     cluster,
     repo,
+    dbUrl: rootDbUrl,
     CUSTOM_DOMAINS,
     stacks: {
       networking,
@@ -561,7 +571,7 @@ export = async () => {
           },
           {
             name: "PG_URL",
-            value: config.requireSecret("db-url"),
+            value: rootDbUrl,
           },
         ],
       },

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -16,7 +16,8 @@ export const createHasuraService = async ({
   vpc,
   cluster,
   repo,
-  CUSTOM_DOMAINS, 
+  dbUrl,
+  CUSTOM_DOMAINS,
   stacks: {
     networking, certificates, data,
   },
@@ -135,10 +136,7 @@ export const createHasuraService = async ({
               )}" }`,
             },
             { name: "HASURA_GRAPHQL_UNAUTHORIZED_ROLE", value: "public" },
-            {
-              name: "HASURA_GRAPHQL_DATABASE_URL",
-              value: config.requireSecret("db-url"),
-            },
+            { name: "HASURA_GRAPHQL_DATABASE_URL", value: dbUrl },
             {
               name: "HASURA_PLANX_API_URL",
               value: `https://api.${DOMAIN}`,

--- a/infrastructure/application/types.ts
+++ b/infrastructure/application/types.ts
@@ -5,10 +5,11 @@ export interface CreateService {
   vpc: awsx.ec2.Vpc,
   cluster: awsx.ecs.Cluster, 
   repo: awsx.ecr.Repository, 
+  dbUrl: string,
   stacks: {
     networking: pulumi.StackReference,
     certificates: pulumi.StackReference,
     data: pulumi.StackReference,
   },
-  CUSTOM_DOMAINS: Record<string, string>[], 
+  CUSTOM_DOMAINS: Record<string, string>[],
 };

--- a/infrastructure/application/utils/helpers.ts
+++ b/infrastructure/application/utils/helpers.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_POSTGRES_PORT = 5432
+export const DEFAULT_POSTGRES_DB = 'postgres'
+
+// PG docs: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+// the AWS DB endpoint/URI will be of the form `instance.xxx.region.rds.amazonaws.com`
+export const getPostgresDbUrl = (
+  roleName: string,
+  rolePassword: string,
+  awsDbUri: string, 
+  port: string | number = DEFAULT_POSTGRES_PORT,
+  databaseName: string = DEFAULT_POSTGRES_DB,
+): string => {
+  // the `postgres://` prefix provides a means of locating the resource, so this is a URL, not just a URI 
+  return `postgres://${roleName}:${rolePassword}@${awsDbUri}:${port}/${databaseName}`
+}

--- a/infrastructure/application/utils/index.ts
+++ b/infrastructure/application/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./addListenerRule";
+export * from "./failureNotification";
 export * from "./generateCORSAllowList";
 export * from "./generateTeamSecrets";
-export * from "./failureNotification";
+export * from "./helpers";


### PR DESCRIPTION
Postgres databases are accessed using a URL making use of the `postgres://` protocol, as per [this spec](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS) (note that [URLs are a subset of URIs](https://medium.com/tuanhdotnet/secrets-of-uris-urls-and-urns-understanding-their-differences-and-uses-b2b791af7323)).

We have one postgres server, hosted on AWS RDS. Connecting to the staging instance via pgAdmin, I can see the databases therein:

![image](https://github.com/user-attachments/assets/64b63ddd-908f-46fd-970e-0b9af2788694)

Metabase accesses the `metabase` database via a role called `metabase`, while Sharedb and Hasura access the default `postgres` database via the `dbuser` role. As such there are 2 different URLs that need to be baked into the respective images at build time.  We are currently storing these as Pulumi secrets called `db-url` and `md-db-connection-uri`.

This means that if we have to restore the db, and it's name changes as a result (as happened when I ran the test I describe in #4392), we have to change several Pulumi inputs in order to ensure that all constituent parts of the application layer are pointing at the new db.

However, these URLs are composed of predictable parts (see the new `helper.ts` file), and the only part that changes when the db name is cycled, is the AWS URI, which we store as a Pulumi secret under `db-host`.

Therefore, this PR proposes changes which will enable us to repair the application layer simply by rotating `db-host`.