### PR TITLE
feat: Close WS connections on JWT expiry

### DIFF
--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -73,6 +73,9 @@ const authWsLink = new WebSocketLink({
         },
       };
     },
+    connectionCallback: (error) => {
+      if (error) handleExpiredJWTErrors();
+    },
   },
 });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
@@ -1,11 +1,28 @@
+import { toast } from "react-toastify";
 import ReconnectingWebSocket from "reconnecting-websocket";
 import type { Doc } from "sharedb";
 import sharedb from "sharedb/lib/client";
 import type { Socket } from "sharedb/lib/sharedb";
 
+// Please see sharedb.planx.uk/server.js
+// Docs: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code#value
+const TOKEN_EXPIRY_CODE = 4001;
+
 const socket = new ReconnectingWebSocket(
   import.meta.env.VITE_APP_SHAREDB_URL || "",
 );
+
+socket.addEventListener("close", ({ code, reason }) => {
+  if (code === TOKEN_EXPIRY_CODE && reason === "Token expired") {
+    toast.error("Session expired, redirecting to login page...", {
+      toastId: "jwt_expiry_error",
+      hideProgressBar: false,
+      progress: undefined,
+      autoClose: 2_000,
+      onClose: () => (window.location.href = "/logout"),
+    });
+  }
+});
 
 const connection = new sharedb.Connection(socket as unknown as Socket);
 

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -7,6 +7,9 @@ const PostgresDB = require("./sharedb-postgresql");
 const createDOMPurify = require('dompurify');
 const { JSDOM } = require('jsdom');
 
+const ONE_MINUTE_IN_MS = 60 * 1000;
+const TOKEN_EXPIRY_CODE = 4001;
+
 const { PORT = 8000, JWT_SECRET, PG_URL } = process.env;
 assert(JWT_SECRET);
 assert(PG_URL);
@@ -103,6 +106,23 @@ const wss = new Server({
 });
 
 wss.on("connection", function (ws, req) {
+  // JWTs expire every 24hrs
+  // Check status every minute - client side will logout on expiry
+  const tokenCheckInterval = setInterval(() => {
+    try {
+      jwt.verify(req.authToken, JWT_SECRET, (err) => {
+        if (err) {
+          ws.close(TOKEN_EXPIRY_CODE, "Token expired");
+          clearInterval(tokenCheckInterval);
+        }
+      });
+    } catch (error) {
+      console.error("Token validation error:", error);
+      ws.close(TOKEN_EXPIRY_CODE, "Token validation error");
+      clearInterval(tokenCheckInterval);
+    }
+  }, ONE_MINUTE_IN_MS);
+
   const stream = new WebSocketJSONStream(ws);
   sharedb.listen(stream, req);
 });


### PR DESCRIPTION
## What's the problem?
The WebSocket connection to ShareDB only verifies the JWT on initial connection, and not on every message. This means that an expired token can write to the operations table as long as it was valid when the WS connection was opened.

This was identified here - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1740754874553229 (OSL Slack). Once a token expires, `ReconnectingWebsocket` closes, and then fails to re-open a connection silently, without any feedback for users.

## What's the solution?
Check the token every minute, catching any errors in the frontend and then logging out the user.

We could do this on each message, but this is probably overkill?

## To test
- Change JWT expiry to 1 or 2 minutes locally
- Open a flow, wait for expiry, get logged out automatically