### PR TITLE
fix: Set auth token to be checked on interval

### DIFF
--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -93,6 +93,7 @@ const wss = new Server({
             cb(false, 401, "Unauthorized");
           } else {
             console.log({ newConnection: decoded });
+            info.req.authToken = token;
             info.req.uId = decoded;
             cb(true);
           }


### PR DESCRIPTION
Follow up to #4416 - this actually sets up the token which is later checked.

Apologies - I commented this line out when testing the previous PR and missed that I hadn't committed this change.

To test - 
- You do not get automatically logged out after 1 minute