### PR TITLE
fix: Don't display `GetStarted` card in empty internal portals

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -1,5 +1,6 @@
 import { ROOT_NODE_KEY } from "@planx/graph";
 import React from "react";
+import { rootFlowPath } from "routes/utils";
 
 import { useStore } from "../../lib/store";
 import EndPoint from "./components/EndPoint";
@@ -25,7 +26,9 @@ const Flow = ({ breadcrumbs = [] }: any) => {
     href: `${window.location.pathname.split(id)[0]}${id}`,
   }));
 
-  const showGetStarted = !childNodes.length;
+  const [_rootPath, ...portals] = rootFlowPath(true).split(",");
+  const isFlowRoot = !portals.length;
+  const showGetStarted = isFlowRoot && !childNodes.length;
 
   return (
     <>


### PR DESCRIPTION
This PR enhances the `showGetStarted` check to make sure that the `GetStarted` card is only displayed once at the flow root.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/01da8c2e-f5df-4131-b19d-7e9b29e61094) | <img width="348" alt="image" src="https://github.com/user-attachments/assets/e8898fdb-7dbe-4765-904d-303ff8c96557" /> | 