### PR TITLE
fix: False positive ITP fee breakdown error

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -125,8 +125,7 @@ const Total: FeeBreakdownSection = ({ amount }) => (
 export const FeeBreakdown: React.FC<{
   inviteToPayFeeBreakdown?: IFeeBreakdown;
 }> = ({ inviteToPayFeeBreakdown }) => {
-  const passportFeeBreakdown = useFeeBreakdown();
-  const breakdown = passportFeeBreakdown || inviteToPayFeeBreakdown;
+  const breakdown = useFeeBreakdown(inviteToPayFeeBreakdown);
   if (!breakdown) return null;
 
   return (

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/useFeeBreakdown.tsx
@@ -10,11 +10,16 @@ import { useStore } from "pages/FlowEditor/lib/store";
  * If fee variables not found, or not successfully parsed, we do not show the user a fee breakdown
  * Instead an internal error will be raised allowing us to correct the flow content
  */
-export const useFeeBreakdown = (): FeeBreakdown | undefined => {
+export const useFeeBreakdown = (inviteToPayFeeBreakdown?: FeeBreakdown): FeeBreakdown | undefined => {
   const [passportData, sessionId] = useStore((state) => [
     state.computePassport().data,
     state.sessionId,
   ]);
+
+  // If a breakdown is provided, there's no passport to parse
+  if (inviteToPayFeeBreakdown) return inviteToPayFeeBreakdown;
+
+  // Type narrowing - all valid non-ITP sessions will have passport data by this point in the journey
   if (!passportData) return 
 
   try {


### PR DESCRIPTION
## What's the problem?
Airbrake is logging a fee breakdown error for each ITP session. However, as we already fallback to the `inviteToPayFeeBreakdown` passed into the component, the payee is presented with a valid and correct fee breakdown table.

Please see https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1740579357423249 (OSL Slack) for context.

## What's the solution?
As hooks cannot be called conditionally, this is currently written to check for the presence of the `inviteToPayFeeBreakdown` after the hook is called (and an Airbrake error has been called).

This PR checks the `inviteToPayFeeBreakdown` as part of the hook, meaning that the Airbrake error will not be triggered for ITP payments.

## To test
Please try to resume the following ITP payment (devops email address) - https://4423.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/pay?paymentRequestId=d8955063-1310-4ad8-9eed-7d86d27c9b5c

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/1c684158-10a4-4bf4-8cac-3da0a6816f5c" />

A fee breakdown is displayed, and an Airbrake error is not thrown.