### PR TITLE
fix: Display timestamps correctly in 24hr format

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -7,6 +7,7 @@ import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContain
 import SettingsSection from "ui/editor/SettingsSection";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
+import { dateFormatter } from "ui/shared/DataTable/utils";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
@@ -51,8 +52,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 125,
       type: ColumnFilterType.DATE,
       columnOptions: {
-        valueFormatter: (params) =>
-          format(new Date(params), "dd/MM/yy hh:mm:ss"),
+        valueFormatter: dateFormatter
       },
     },
     {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
@@ -1,11 +1,10 @@
 import { getGridStringOperators, GridFilterItem } from "@mui/x-data-grid";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
-import { format } from "date-fns";
 import React from "react";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
-import { containsItem } from "ui/shared/DataTable/utils";
+import { containsItem, dateFormatter } from "ui/shared/DataTable/utils";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import {
@@ -86,8 +85,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
       headerName: "Date",
       width: 125,
       columnOptions: {
-        valueFormatter: (params) =>
-          format(new Date(params), "dd/MM/yy hh:mm:ss"),
+        valueFormatter: dateFormatter
       },
       type: ColumnFilterType.DATE,
     },

--- a/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
@@ -5,6 +5,7 @@ import {
   GridValueOptionsParams,
   ValueOptions,
 } from "@mui/x-data-grid";
+import { format } from "date-fns";
 import capitalize from "lodash/capitalize";
 import React from "react";
 
@@ -111,3 +112,8 @@ export const getColumnFilterType = (columnType?: ColumnRenderType) => {
       return undefined;
   }
 };
+
+/**
+ * Format date times to a standard format, e.g 31/12/25 14:40:45
+ */
+export const dateFormatter = (value: string) => format(new Date(value), "dd/MM/yy HH:mm:ss");


### PR DESCRIPTION
## What does this PR do?
- Adds a helper function to standardise datetime outputs - `dateFormatter()`
- Applies this in feedback and submission tables