### PR TITLE
style: Team name in admin panel bold

### DIFF
--- a/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
@@ -38,6 +38,8 @@ export const PlatformAdminPanel = () => {
     {
       field: "name",
       headerName: "Team",
+      type: ColumnFilterType.CUSTOM,
+      customComponent: (params) => <strong>{`${params.value}`}</strong>,
     },
     {
       field: "referenceCode",


### PR DESCRIPTION
## What does this PR do?

Quick one: makes first column (council name) in admin panel bold, consistent with submission and feedback logs.