### PR TITLE
chore: Tidy up colour styles

### DIFF
--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -590,17 +590,18 @@ const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
 
 const Header: React.FC = () => {
   const headerRef = useRef<HTMLDivElement>(null);
-  const theme = useStore((state) => state.teamTheme);
+  const teamTheme = useStore((state) => state.teamTheme);
   return (
     <Root
       position="static"
       elevation={0}
       color="transparent"
       ref={headerRef}
-      sx={{
-        backgroundColor: theme?.primaryColour || "#2c2c2c",
+      sx={(theme) => ({
+        backgroundColor:
+          teamTheme?.primaryColour || theme.palette.background.dark,
         "@media print": { backgroundColor: "white", color: "black" },
-      }}
+      })}
     >
       <Toolbar headerRef={headerRef} />
     </Root>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -41,10 +41,10 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     default: "#FFFFFF",
     paper: "#F9F8F8",
     dark: "#2c2c2c",
-    midGray: "#e3e3e3",
   },
   secondary: {
     main: "#F3F2F1",
+    dark: "#e3e3e3",
   },
   text: {
     primary: "#0B0C0C",
@@ -91,7 +91,6 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   flowTag: {
     online: "#D6FFD7",
     offline: "#EAEAEA",
-    lightOff: "#a1a1a1",
     applicationType: "#D6EFFF",
     serviceType: "#FFEABE",
   },
@@ -674,10 +673,10 @@ const getThemeOptions = ({
         },
         styleOverrides: {
           arrow: {
-            color: "#2c2c2c",
+            color: palette.secondary.dark,
           },
           tooltip: {
-            backgroundColor: "#2c2c2c",
+            backgroundColor: palette.secondary.dark,
             left: "-5px",
             fontSize: "0.8em",
             borderRadius: 0,
@@ -706,17 +705,18 @@ const getThemeOptions = ({
             [`&.${gridClasses.root}--densityStandard .${gridClasses.cell}`]: {
               padding: "10px 10px",
             },
-            [`&.${gridClasses.root}--densityComfortable .${gridClasses.cell}`]: {
-              padding: "20px 10px",
-            },
+            [`&.${gridClasses.root}--densityComfortable .${gridClasses.cell}`]:
+              {
+                padding: "20px 10px",
+              },
             [`& .${gridClasses.toolbarContainer}`]: {
               borderBottom: `1px solid ${palette.border.main}`,
-              background: palette.background.midGray,
+              background: palette.secondary.dark,
               paddingBottom: "5px",
               [`& .${buttonClasses.root}`]: {
                 background: palette.background.default,
                 "&:focus-visible": {
-                  ...focusStyle
+                  ...focusStyle,
                 },
                 // Ensure SVG icons are equal size
                 "& svg": {

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -40,7 +40,6 @@ declare module "@mui/material/styles/createPalette" {
     flowTag: {
       online: string;
       offline: string;
-      lightOff: string;
       applicationType: string;
       serviceType: string;
     };
@@ -64,7 +63,6 @@ declare module "@mui/material/styles/createPalette" {
     flowTag?: {
       online: string;
       offline: string;
-      lightOff: string;
       applicationType: string;
       serviceType: string;
     };
@@ -88,14 +86,12 @@ declare module "@mui/material/styles/createPalette" {
     main: string;
     paper: string;
     dark: string;
-    midGray: string;
   }
 
   interface TypeBackgroundOptions {
     main: string;
     paper: string;
     dark: string;
-    midGray: string;
   }
 }
 

--- a/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
@@ -27,9 +27,9 @@ export const FiltersHeader = styled(AccordionSummary)(({ theme }) => ({
   justifyContent: "space-between",
   padding: theme.spacing(1.75, 2),
   gap: theme.spacing(3),
-  background: theme.palette.background.midGray,
+  background: theme.palette.secondary.dark,
   "&:hover": {
-    background: theme.palette.background.midGray,
+    background: theme.palette.secondary.dark,
   },
   "& .MuiAccordionSummary-expandIconWrapper": {
     display: "none",
@@ -60,7 +60,7 @@ export const StyledChip = styled(Chip)(({ theme }) => ({
 }));
 
 export const FiltersBody = styled(AccordionDetails)(({ theme }) => ({
-  background: theme.palette.background.midGray,
+  background: theme.palette.secondary.dark,
   padding: 0,
 }));
 

--- a/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
+++ b/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
@@ -29,7 +29,7 @@ export const Root = styled(Box, {
       background:
         statusVariant === StatusVariant.Online
           ? theme.palette.success.main
-          : theme.palette.flowTag.lightOff,
+          : theme.palette.action.disabled,
     },
   }),
   ...(tagType === FlowTagType.ApplicationType && {


### PR DESCRIPTION
## What does this PR do?

Tides up and simplifies colour styles.
- Removes unneeded `midGray` background colour
- Removes unneeded `lightOff` colour for `flowTag`
- Update theme to use styles from palette
- Header uses theme background style