### PR TITLE
style: Rounded flow tags

### DIFF
--- a/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
+++ b/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
@@ -9,11 +9,11 @@ export const Root = styled(Box, {
 })<FlowTagProps>(({ theme, tagType, statusVariant }) => ({
   fontSize: theme.typography.body2.fontSize,
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  padding: "2px 6px",
+  padding: "2px 8px",
   display: "flex",
   alignItems: "center",
   gap: theme.spacing(0.5),
-  borderRadius: "4px",
+  borderRadius: "50px",
   textTransform: "capitalize",
   border: "1px solid rgba(0, 0, 0, 0.2)",
   ...(tagType === FlowTagType.Status && {


### PR DESCRIPTION
## What does this PR do?

Across the PlanX editor we use fully rounded (lozenge/chip) styles for tags, flow/service tags should be consistent with this style.

**Before change:**
<img width="411" alt="image" src="https://github.com/user-attachments/assets/aebf358a-213f-4f86-ae11-1badbf450cf1" />

**After change:**
<img width="411" alt="image" src="https://github.com/user-attachments/assets/6a5e95e2-c91c-4bf7-9f22-0e2d460d2108" />