### PR TITLE
fix: ensure `SetValue` "removeOne" operation preserves array types

### DIFF
--- a/editor.planx.uk/src/@planx/components/SetValue/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.test.ts
@@ -84,6 +84,7 @@ describe("calculateNewValues() helper function", () => {
         expected: ["bear", "dog", "monkey"],
       },
       { previous: ["bear", "dog", "lion"], expected: ["bear", "dog"] },
+      { previous: ["bear"], expected: ["bear"]},
     ])(
       "input of $previous sets passport value to be $expected",
       ({ previous, expected }) => {

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.ts
@@ -33,6 +33,7 @@ export const handleSetValue: HandleSetValue = ({
   const newValues = calculateNewValues({
     nodeData,
     previous,
+    rawPrevious: previousValues,
   });
 
   if (newValues) {
@@ -48,20 +49,27 @@ export const handleSetValue: HandleSetValue = ({
 type CalculateNewValues = (params: {
   nodeData: SetValue;
   previous: string[];
+  rawPrevious: PreviousValues;
 }) => string | string[] | undefined;
 
 const calculateNewValues: CalculateNewValues = ({
   nodeData: { operation, val: current },
   previous,
+  rawPrevious,
 }) => {
   switch (operation) {
     case "replace":
       return [current];
 
     case "removeOne": {
-      // Do not convert output from string to string[] if operation not possible
-      if (previous.length === 1 && previous[0] !== current) {
+      // Strings should be preserved as strings
+      if (typeof rawPrevious === "string" && rawPrevious !== current && previous.length === 1) {
         return previous[0];
+      }
+      
+      // Single item arrays should be preserved as arrays
+      if (previous.length === 1 && previous[0] !== current) {
+        return previous;
       }
 
       const removeCurrent = (val: string) => val !== current;

--- a/editor.planx.uk/src/@planx/components/SetValue/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/utils.ts
@@ -63,7 +63,7 @@ const calculateNewValues: CalculateNewValues = ({
 
     case "removeOne": {
       // Strings should be preserved as strings
-      if (typeof rawPrevious === "string" && rawPrevious !== current && previous.length === 1) {
+      if (typeof rawPrevious === "string" && previous[0] !== current) {
         return previous[0];
       }
       

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/setValue.test.ts
@@ -267,8 +267,8 @@ describe("SetValue component", () => {
       // End of flow reached
       expect(getCurrentCard()?.id).toEqual("endOfService");
 
-      // Passport correctly populated - passport variable not removed as values do not match
-      expect(computePassport()?.data?.myKey).toEqual("mySecondValue");
+      // Passport correctly populated - passport variable not removed and array type preserved as values do not match
+      expect(computePassport()?.data?.myKey).toEqual(["mySecondValue"]);
     });
   });
 


### PR DESCRIPTION
See `property.type` bugs reported via Jonny https://opensystemslab.slack.com/archives/C01E3AC0C03/p1741172093172059 & https://opensystemslab.slack.com/archives/C01E3AC0C03/p1741171167791389

**What was happening:**
- SetValue appended a value => passport `{ "property.type": ["residential.house.detached"] }`
- SetValue removed one value (not an applicable value) => passport `{ "property.type": "residential.house.detached" }` 
  - !! Changed type from array to string !!
  - This type change both breaks future automations _and_ causes single letter, rather than first item, to be displayed in "About the property" summary table
- Question/Checklist could not be auto-answered because passport is now string, not array type

Simple fix & test cases cover all possible scenarios now!

This flow is isolated before & after example: https://editor.planx.uk/testing/set-value-subsequent-automations