### PR TITLE
fix: Await sharedb connection

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -162,7 +162,7 @@ export interface EditorStore extends Store.Store {
   addNode: (node: any, relationships?: any) => void;
   archiveFlow: (flowId: string) => Promise<{ id: string; name: string } | void>;
   connect: (src: NodeId, tgt: NodeId, object?: any) => void;
-  connectTo: (id: NodeId) => void;
+  connectTo: (id: NodeId) => Promise<void>;
   copyFlow: (flowId: string) => Promise<any>;
   copyNode: (id: NodeId) => void;
   createFlow: (

--- a/editor.planx.uk/src/routes/team.tsx
+++ b/editor.planx.uk/src/routes/team.tsx
@@ -80,7 +80,7 @@ const routes = compose(
 
         useStore.getState().setFlowName(flow.name);
         useStore.getState().setFlowSlug(slug);
-        useStore.getState().connectTo(flow.id);
+        await useStore.getState().connectTo(flow.id);
       }
 
       return import("./flow");


### PR DESCRIPTION
## What's the problem?
 - Linking to a node via URL does not work on large flows, however it does work for small / simple flows
 - The depth of the link has no impact, even the edit modal of a node at root level is impacted
 - There's a missing `await` for the asynchronous connection to ShareDB - this is likely impacted by both flow size, and additional JWT checks

## What's the solution?
- Correctly `await` for the ShareDB connection to be established. This is no faster of course, but it works!

## To test 
- [This PD link](https://editor.planx.dev/opensystemslab/permitteddevelopment,kSlbnLVTOD,XLZMHhJJNm/nodes/F82BSAQEpZ/nodes/AF6YqJdtF0/edit) fails on staging, redirects back to the root of the PD flow
- https://4434.editor.planx.pizza/opensystemslab/permitteddevelopment,x9Z6LjJVgf/nodes/CSrghRRCGY/nodes/aLRur4QI1O/edit works on the Pizza, shows a spinner