### PR TITLE
fix: Output full user comment in feedback table

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -12,12 +12,7 @@ import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
 import { FeedbackLogProps } from "./types";
-import {
-  EmojiRating,
-  feedbackTypeText,
-  generateCommentSummary,
-  stripHTMLTags,
-} from "./utils";
+import { EmojiRating, feedbackTypeText, stripHTMLTags } from "./utils";
 
 export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
   const columns: ColumnConfig<Feedback>[] = [
@@ -52,7 +47,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 125,
       type: ColumnFilterType.DATE,
       columnOptions: {
-        valueFormatter: dateFormatter
+        valueFormatter: dateFormatter,
       },
     },
     {
@@ -68,9 +63,6 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       field: "userComment",
       headerName: "Comment",
       width: 340,
-      columnOptions: {
-        valueFormatter: (params) => generateCommentSummary(params),
-      },
     },
     {
       field: "address",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/utils.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/utils.tsx
@@ -2,16 +2,6 @@ import { Feedback } from "routes/feedback";
 
 import { FeedbackType } from "./types";
 
-export const generateCommentSummary = (userComment: string | null) => {
-  const COMMENT_LENGTH = 100;
-  if (!userComment) return "No comment";
-
-  const shouldBeSummarised = userComment.length > COMMENT_LENGTH;
-  if (shouldBeSummarised) return `${userComment.slice(0, COMMENT_LENGTH)}...`;
-
-  return userComment;
-};
-
 export const EmojiRating: Record<number, string> = {
   1: "Terrible",
   2: "Poor",


### PR DESCRIPTION
## What does this PR do?

Currently the feedback table outputs a summary of the user comment, this was used in the previous implementation where the full comment was revealed as part of an expanding panel.

As we are not showing the comment anywhere else the full comment should be output here.

**Before change:**
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/4cbefd4f-749f-45e0-bfbc-49c59bfa3178" />

**After change:**
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/18838ccb-b51c-44d8-b750-546f2e9a734b" />
