### PR TITLE
fix: Prevent checklists wrapping in constraint overrides

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -192,15 +192,17 @@ export const OverrideEntitiesModal = ({
                   <legend style={visuallyHidden}>{title}</legend>
                   {Boolean(entities?.length) &&
                     entities?.map((e) => (
-                      <ChecklistItem
-                        key={`${e.entity}`}
-                        id={`entity-checkbox-${e.entity}`}
-                        label={formatEntityName(e, metadata)}
-                        checked={
-                          checkedOptions?.includes(`${e.entity}`) || false
-                        }
-                        onChange={changeCheckbox(`${e.entity}`)}
-                      />
+                      <Grid item xs={12}>
+                        <ChecklistItem
+                          key={`${e.entity}`}
+                          id={`entity-checkbox-${e.entity}`}
+                          label={formatEntityName(e, metadata)}
+                          checked={
+                            checkedOptions?.includes(`${e.entity}`) || false
+                          }
+                          onChange={changeCheckbox(`${e.entity}`)}
+                        />
+                      </Grid>
                     ))}
                 </Grid>
               </ErrorWrapper>


### PR DESCRIPTION
## What does this PR do?

(Reported by August in Slack)
In the modal for contesting constraints the checklist rows do not sit at 100% width this is due to them being placed inside a wrapping `<Grid>` but not being assigned as being `<Grid item>`s, introducing this fixes the issue.

**Before change:**
<img width="761" alt="image" src="https://github.com/user-attachments/assets/ccd17961-4cc9-49d5-8fb7-264c9692ac0d" />

**After change:**
<img width="761" alt="image" src="https://github.com/user-attachments/assets/5dbf07f7-8fb3-4c3a-ae35-a3952b93fe8a" />

