### PR TITLE
fix: regenerate E2E lock files

### DIFF
--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -2544,7 +2544,7 @@ packages:
     dev: false
 
   github.com/theopensystemslab/planx-core/38aec24(@types/react@19.0.7):
-    resolution: {commit: 38aec24, repo: git+ssh://git@github.com/theopensystemslab/planx-core.git, type: git}
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/38aec24}
     id: github.com/theopensystemslab/planx-core/38aec24
     name: '@opensystemslab/planx-core'
     version: 1.0.0


### PR DESCRIPTION
Removed both `ui-driven` & `api-driven` lockfiles and ran `pnpm i` fresh - only this one changed. 

Seeing if this might clear up our CI issue described here :crossed_fingers: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1741337036758429