### PR TITLE
[application] construct DB urls from Pulumi outputs in approved fashion

### DIFF
--- a/infrastructure/application/types.ts
+++ b/infrastructure/application/types.ts
@@ -5,7 +5,7 @@ export interface CreateService {
   vpc: awsx.ec2.Vpc,
   cluster: awsx.ecs.Cluster, 
   repo: awsx.ecr.Repository, 
-  dbUrl: string,
+  dbUrl: pulumi.Output<string>,
   stacks: {
     networking: pulumi.StackReference,
     certificates: pulumi.StackReference,


### PR DESCRIPTION
#4411 could not build because Pulumi outputs cannot be coerced into strings by using `String(...)`, because Pulumi cannot guarantee that they are known at this point. Instead we have to use the `apply` method on a given output, or the `pulumi.all` method, which allows us to access method outputs at once.

Docs: https://www.pulumi.com/docs/iac/concepts/inputs-outputs/

An alternative to our approach here would be to use `pulumi.interpolate` (as we do elsewhere in the code), which is [a kind of wrapper](https://www.pulumi.com/docs/iac/concepts/inputs-outputs/) around the aforementioned methods.

This PR should deploy properly and repair staging.