### PR TITLE
feat: Auth proxy for Hasura

### DIFF
--- a/api.planx.uk/client/index.ts
+++ b/api.planx.uk/client/index.ts
@@ -24,6 +24,15 @@ export const $public = new CoreDomainClient({
 });
 
 /**
+ * Connects to Hasura using the "admin" role
+ * Should only be used to verify token status (which bypasses proxy back to auth/validate-jwt endpoint
+ */
+export const $admin = new CoreDomainClient({
+  targetURL: process.env.HASURA_GRAPHQL_URL!,
+  auth: { adminSecret: process.env.HASURA_GRAPHQL_ADMIN_SECRET! },
+});
+
+/**
  * Get a planx-core client with permissions scoped to the current user.
  * This client instance ensures that all operations are restricted
  * to the permissions of the user who initiated the request.

--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -1,7 +1,11 @@
 import type { CookieOptions, RequestHandler, Response } from "express";
 import type { Request } from "express-jwt";
-import { revokeToken } from "./service/logout/revokeToken.js";
-import { userContext } from "./middleware.js";
+import {
+  createTokenDigest,
+  isTokenRevoked,
+  revokeToken,
+} from "./service/logout/revokeToken.js";
+import { getToken, userContext } from "./middleware.js";
 import { ServerError } from "../../errors/serverError.js";
 
 export const failedLogin: RequestHandler = (_req, _res, next) =>
@@ -99,4 +103,12 @@ export const logout: RequestHandler = async (_req, res, next) => {
       }),
     );
   }
+};
+
+export const isJWTRevoked: RequestHandler = async (req, res) => {
+  const jwt = getToken(req);
+  const tokenDigest = createTokenDigest(jwt);
+  const isRevoked = await isTokenRevoked(tokenDigest);
+
+  return isRevoked ? res.status(401).send() : res.status(200).send();
 };

--- a/api.planx.uk/modules/auth/docs.yaml
+++ b/api.planx.uk/modules/auth/docs.yaml
@@ -30,6 +30,19 @@ paths:
           description: OK
         "500":
           $ref: "#/components/responses/ErrorMessage"
+  /auth/validate-jwt:
+    get:
+      summary: Validate JSON web token (JWT)
+      description:
+        Check the status of a user's JWT. Resolves if not-revoked, rejects if JWT is revoked.
+        Used by Hasura proxy in order to check JWT status.
+        Full JWT validation and permission checks still carried out by Hasura.
+      tags: ["auth"]
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorised
   /auth/google:
     get:
       summary: Authenticate via Google SSO

--- a/api.planx.uk/modules/auth/routes.ts
+++ b/api.planx.uk/modules/auth/routes.ts
@@ -27,9 +27,7 @@ export default (passport: Authenticator): Router => {
     Controller.handleSuccess,
   );
 
-  // Dummy route with no logic
-  // TODO: Call isRevoked()
-  router.get("/auth/validate-jwt", (_req, res) => res.status(200).send());
+  router.get("/auth/validate-jwt", Controller.isJWTRevoked);
 
   return router;
 };

--- a/api.planx.uk/modules/auth/routes.ts
+++ b/api.planx.uk/modules/auth/routes.ts
@@ -27,7 +27,11 @@ export default (passport: Authenticator): Router => {
     Controller.handleSuccess,
   );
 
-  router.get("/auth/validate-jwt", Controller.isJWTRevoked);
+  router.get(
+    "/auth/validate-jwt",
+    Middleware.useNoCache,
+    Controller.isJWTRevoked,
+  );
 
   return router;
 };

--- a/api.planx.uk/modules/auth/routes.ts
+++ b/api.planx.uk/modules/auth/routes.ts
@@ -27,5 +27,9 @@ export default (passport: Authenticator): Router => {
     Controller.handleSuccess,
   );
 
+  // Dummy route with no logic
+  // TODO: Call isRevoked()
+  router.get("/auth/validate-jwt", (_req, res) => res.status(200).send());
+
   return router;
 };

--- a/api.planx.uk/modules/auth/service/logout/revokeToken.ts
+++ b/api.planx.uk/modules/auth/service/logout/revokeToken.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { $api } from "../../../../client/index.js";
+import { $admin, $api } from "../../../../client/index.js";
 import { gql } from "graphql-request";
 import { getJWTExpiration } from "../jwt.js";
 import { ServerError } from "../../../../errors/serverError.js";
@@ -27,7 +27,7 @@ export const createTokenDigest = (jwt: string) => {
 
 export const isTokenRevoked = async (tokenDigest: string): Promise<boolean> => {
   try {
-    const { revokedToken } = await $api.client.request<IsRevokedQuery>(
+    const { revokedToken } = await $admin.client.request<IsRevokedQuery>(
       gql`
         query IsTokenRevoked($token_digest: String!) {
           revokedToken: revoked_tokens_by_pk(token_digest: $token_digest) {

--- a/api.planx.uk/modules/auth/validateJWT.test.ts
+++ b/api.planx.uk/modules/auth/validateJWT.test.ts
@@ -1,0 +1,94 @@
+import supertest from "supertest";
+import app from "../../server.js";
+import { authHeader, getTestJWT } from "../../tests/mockJWT.js";
+import { queryMock } from "../../tests/graphqlQueryMock.js";
+
+const mockRevokedToken = () => {
+  queryMock.mockQuery({
+    name: "IsTokenRevoked",
+    matchOnVariables: false,
+    data: {
+      revokedToken: {
+        revokedAt: Date.now(),
+      },
+    },
+  });
+};
+
+describe("JWT in auth header", async () => {
+  test("valid JWT", async () => {
+    const authHeaderJWT = authHeader({ role: "platformAdmin" });
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set(authHeaderJWT)
+      .expect(200);
+  });
+
+  test("revoked JWT", async () => {
+    const authHeaderJWT = authHeader({ role: "platformAdmin" });
+
+    mockRevokedToken();
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set(authHeaderJWT)
+      .expect(401);
+  });
+
+  test("invalid JWT", async () => {
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set({ authorization: "Bearer NOT_A_JWT" })
+      .expect(200);
+  });
+});
+
+describe("JWT in cookie", () => {
+  test("valid JWT", async () => {
+    const jwt = getTestJWT({ role: "teamEditor" });
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set("Cookie", `jwt=${jwt}`)
+      .expect(200);
+  });
+
+  test("revoked JWT", async () => {
+    const jwt = getTestJWT({ role: "teamEditor" });
+
+    mockRevokedToken();
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set("Cookie", `jwt=${jwt}`)
+      .expect(401);
+  });
+
+  test("invalid JWT", async () => {
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set("Cookie", `jwt=NOT_A_JWT`)
+      .expect(200);
+  });
+});
+
+describe("JWT in query params", () => {
+  test("valid JWT", async () => {
+    const jwt = getTestJWT({ role: "teamEditor" });
+
+    await supertest(app).get(`/auth/validate-jwt?token=${jwt}`).expect(200);
+  });
+
+  test("revoked JWT", async () => {
+    const jwt = getTestJWT({ role: "teamEditor" });
+
+    mockRevokedToken();
+
+    await supertest(app).get(`/auth/validate-jwt?token=${jwt}`).expect(401);
+  });
+
+  test("invalid JWT", async () => {
+    await supertest(app).get(`/auth/validate-jwt?token=NOT_A_JWT`).expect(200);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
     environment:
       HASURA_PROXY_PORT: ${HASURA_PROXY_PORT}
       HASURA_NETWORK_LOCATION: "hasura"
+      API_NETWORK_LOCATION: http://api:${API_PORT}
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "localhost:$HASURA_PROXY_PORT/healthz"]
       interval: 15s

--- a/hasura.planx.uk/proxy/Caddyfile
+++ b/hasura.planx.uk/proxy/Caddyfile
@@ -1,6 +1,6 @@
 # HASURA_PROXY_PORT - The publicly exposed port through which this service can be accessed
 # HASURA_NETWORK_LOCATION - Either "hasura" in Docker environments, or "localhost" on Fargate
-
+# API_NETWORK_LOCATION - Either "http://api:${API_PORT}" in Docker environments, or external API URL on Fargate
 
 # General options
 {
@@ -10,9 +10,7 @@
 
 # Reverse proxy for Hasura GraphQL Engine
 :{$HASURA_PROXY_PORT} {
-	reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
-
-	# Update response headers
+	# Mandated security headers
 	header {
 		# Enable HSTS
 		Strict-Transport-Security "max-age=15552000; includeSubDomains"
@@ -26,4 +24,41 @@
 		# Do not leak server information
 		-Server
 	}
+
+	@hasToken {
+		# Match requests with JWT in cookie
+		header_regexp Cookie jwt=([^;]+)
+
+		# Match requests with Bearer token in Authorization header
+		header_regexp Authorization "^Bearer (\S+)$"
+
+		# Match requests with token in query parameter
+		query token=*
+	}
+
+	handle @hasToken {
+		rewrite * /auth/validate-jwt
+
+		# Forward to validation service
+		reverse_proxy {$API_NETWORK_LOCATION} {
+			method GET
+
+			@success status 2xx
+
+			# Restore original path, then proxy original request to Hasura
+			handle_response @success {
+				rewrite * {http.request.orig_uri.path}
+				reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
+			}
+
+			handle_response {
+				respond 401 {
+					body "Unauthorized - expired or invalid token"
+				}
+			}
+		}
+	}
+
+	# Default route for requests without auth header
+	reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
 }

--- a/hasura.planx.uk/proxy/Caddyfile
+++ b/hasura.planx.uk/proxy/Caddyfile
@@ -8,9 +8,7 @@
 	auto_https off
 }
 
-# Reverse proxy for Hasura GraphQL Engine
-:{$HASURA_PROXY_PORT} {
-	# Mandated security headers
+(security_headers) {
 	header {
 		# Enable HSTS
 		Strict-Transport-Security "max-age=15552000; includeSubDomains"
@@ -24,41 +22,75 @@
 		# Do not leak server information
 		-Server
 	}
+}
 
-	@hasToken {
-		# Match requests with JWT in cookie
-		header_regexp Cookie jwt=([^;]+)
+# Forward requests which require authorisation along to our REST API's JWT validation endpoint
+# This checks if the incoming JWT is revoked
+# Further validation and permissions checks still actioned by Hasura in JWT auth mode
+(validate_jwt) {
+	rewrite * /auth/validate-jwt
 
-		# Match requests with Bearer token in Authorization header
-		header_regexp Authorization "^Bearer (\S+)$"
+	# Forward to validation service
+	reverse_proxy {$API_NETWORK_LOCATION} {
+		method GET
+		header_up X-Original-URI {http.request.orig_uri.path}
 
-		# Match requests with token in query parameter
-		query token=*
-	}
+		@success status 2xx
 
-	handle @hasToken {
-		rewrite * /auth/validate-jwt
+		# Restore original path, then proxy original request to Hasura
+		handle_response @success {
+			import security_headers
+			header X-Auth-Validated true
 
-		# Forward to validation service
-		reverse_proxy {$API_NETWORK_LOCATION} {
-			method GET
+			rewrite * {http.request.orig_uri.path}
+			reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
+		}
 
-			@success status 2xx
+		handle_response {
+			import security_headers
+			header X-Auth-Validated false
 
-			# Restore original path, then proxy original request to Hasura
-			handle_response @success {
-				rewrite * {http.request.orig_uri.path}
-				reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
-			}
-
-			handle_response {
-				respond 401 {
-					body "Unauthorized - expired or invalid token"
-				}
+			respond 401 {
+				body "Unauthorized - expired or invalid token"
 			}
 		}
 	}
+}
 
-	# Default route for requests without auth header
-	reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
+# Reverse proxy for Hasura GraphQL Engine
+:{$HASURA_PROXY_PORT} {
+
+	# Validation conditions match getToken() in REST API
+	# Please see api.planx.uk/modules/auth/middleware.ts
+	@hasTokenAuth {
+		header_regexp Authorization "^Bearer (\S+)$"
+	}
+
+	@hasTokenCookie {
+		header_regexp Cookie jwt=([^;]+)
+	}
+
+	@hasTokenQuery {
+		query token=*
+	}
+
+	handle @hasTokenAuth {
+		import validate_jwt
+	}
+
+	handle @hasTokenCookie {
+		import validate_jwt
+	}
+
+	handle @hasTokenQuery {
+		import validate_jwt
+	}
+
+	# Default route for public requests
+	handle {
+		import security_headers
+		header X-Auth-Validated skip
+
+		reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
+	}
 }

--- a/hasura.planx.uk/proxy/Caddyfile
+++ b/hasura.planx.uk/proxy/Caddyfile
@@ -57,8 +57,38 @@
 	}
 }
 
+# Direct proxy to Hasura without additional JWT validation
+# Used for public GraphQL API requests and Hasura console
+(direct_to_hasura) {
+	import security_headers
+	header X-Auth-Validated skip
+
+	reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
+}
+
 # Reverse proxy for Hasura GraphQL Engine
 :{$HASURA_PROXY_PORT} {
+	@isAccessingHasuraConsole {
+		path /console /console/*
+	}
+
+	# Handle Hasura console routes - bypass JWT validation
+	handle @isAccessingHasuraConsole {
+		import direct_to_hasura
+	}
+
+	# Handle requests using the Hasura admin secret
+	# Strip JWT cookie so requests don't get proxied by REST API
+	# Hasura still handles validation and permissions in these instances
+	@isUsingAdminSecret {
+		header x-hasura-admin-secret *
+	}
+
+	handle @isUsingAdminSecret {
+		request_header -Cookie cookie_name=jwt
+
+		import direct_to_hasura
+	}
 
 	# Validation conditions match getToken() in REST API
 	# Please see api.planx.uk/modules/auth/middleware.ts
@@ -88,9 +118,6 @@
 
 	# Default route for public requests
 	handle {
-		import security_headers
-		header X-Auth-Validated skip
-
-		reverse_proxy {$HASURA_NETWORK_LOCATION}:8080
+		import direct_to_hasura
 	}
 }

--- a/hasura.planx.uk/proxy/Dockerfile
+++ b/hasura.planx.uk/proxy/Dockerfile
@@ -1,2 +1,2 @@
-FROM caddy:2.6.4-alpine
+FROM caddy:2.9.1-alpine
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -93,6 +93,7 @@ export const createHasuraService = async ({
           environment: [
             { name: "HASURA_PROXY_PORT", value: String(HASURA_PROXY_PORT) },
             { name: "HASURA_NETWORK_LOCATION", value: "localhost" },
+            { name: "API_NETWORK_LOCATION", value: `https://api.${DOMAIN}` },
           ],
         },
         hasura: {


### PR DESCRIPTION
## What does this PR do?
- Updates Caddy to v2.9.1
- Adds check for auth, if present, redirects to REST API (see logic below)
- Adds a header to show validation status

### To test
It might be nice to add a little script / small test suite to cover this in future.

For the following commands, I get a 200 with the `x-auth-validated: true` header on the response -

```sh
curl -v -H "Authorization: Bearer ${VALID_TOKEN_HERE}" https://hasura.4445.planx.pizza
```
```sh
curl -v -b "jwt=${VALID_TOKEN_HERE}" https://hasura.4445.planx.pizza
```
```sh
curl -v "https://hasura.4445.planx.pizza?token=${VALID_TOKEN_HERE}"
```

For the following commands, I get a 401 with the `x-auth-validated: false` header on the response -

```sh
curl -v -H "Authorization: Bearer ${REVOKED_TOKEN_HERE}" https://hasura.4445.planx.pizza
```
```sh
curl -v -b "jwt=${REVOKED_TOKEN_HERE}" https://hasura.4445.planx.pizza
```
```sh
curl -v "https://hasura.4445.planx.pizza?token=${REVOKED_TOKEN_HERE}"
```

(In order to revoke a token, please log in and take a copy, then logout)

For the following commands, I get a 200 with the `x-auth-validated: skip` header on the response -

```sh
curl -v https://hasura.4445.planx.pizza
```
```sh
curl -v -b "notJWT=randomCookie" https://hasura.4445.planx.pizza
```
```sh
curl -v "https://hasura.4445.planx.pizza?notToken=randomQueryString"
```

```mermaid
flowchart TD
    A[Add security headers to response] --> B{Does request need auth?};
    B -- Yes --> C[Hit REST API validation endpoint];
    C -- 2xx --> D[Forward to Hasura];
    C -- 4xx, 5xx --> E[401 Unauthorized - expired or invalid token];
    B -- No --> D;
```

## To Do...
- [x] Tests for new endpoint - https://github.com/theopensystemslab/planx-new/pull/4469
- [x] Docs for new endpoint - https://github.com/theopensystemslab/planx-new/pull/4468