### PR TITLE
fix: Constraints override checklist structure

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -178,38 +178,39 @@ export const OverrideEntitiesModal = ({
           </Typography>
           <Divider sx={{ marginY: 2 }} />
           <Box marginBottom={2}>
-            <InputLabel
-              label={title}
-              id={`checklist-label-inaccurate-entities`}
+            <ErrorWrapper
+              error={
+                showChecklistError ? ERROR_MESSAGES["checklist"] : undefined
+              }
+              id={`checklist-error-inaccurate-entities`}
             >
-              <ErrorWrapper
-                error={
-                  showChecklistError ? ERROR_MESSAGES["checklist"] : undefined
-                }
-                id={`checklist-error-inaccurate-entities`}
-              >
-                <Grid container component="fieldset">
-                  <legend style={visuallyHidden}>{title}</legend>
-                  {Boolean(entities?.length) &&
-                    entities?.map((e) => (
-                      <Grid item xs={12}>
-                        <ChecklistItem
-                          key={`${e.entity}`}
-                          id={`entity-checkbox-${e.entity}`}
-                          label={formatEntityName(e, metadata)}
-                          checked={
-                            checkedOptions?.includes(`${e.entity}`) || false
-                          }
-                          onChange={changeCheckbox(`${e.entity}`)}
-                        />
-                      </Grid>
-                    ))}
-                </Grid>
-              </ErrorWrapper>
-            </InputLabel>
+              <Grid container component="fieldset" sx={{ margin: 0 }}>
+                <Typography
+                  component="legend"
+                  gutterBottom
+                  id={`checklist-label-inaccurate-entities`}
+                >
+                  {title}
+                </Typography>
+                {Boolean(entities?.length) &&
+                  entities?.map((e) => (
+                    <Grid item xs={12} sx={{ pointerEvents: "auto" }}>
+                      <ChecklistItem
+                        key={`${e.entity}`}
+                        id={`entity-checkbox-${e.entity}`}
+                        label={formatEntityName(e, metadata)}
+                        checked={
+                          checkedOptions?.includes(`${e.entity}`) || false
+                        }
+                        onChange={changeCheckbox(`${e.entity}`)}
+                      />
+                    </Grid>
+                  ))}
+              </Grid>
+            </ErrorWrapper>
           </Box>
           <Box>
-            <InputLabel label="Tell us why" htmlFor="reason">
+            <InputLabel label="Tell us why" htmlFor="input-reason">
               <ErrorWrapper
                 error={showInputError ? ERROR_MESSAGES["input"] : undefined}
                 id={`input-error-inaccurate-entities`}
@@ -220,6 +221,7 @@ export const OverrideEntitiesModal = ({
                   multiline
                   rows={2}
                   name="reason"
+                  id="input-reason"
                   type="text"
                   value={textInput}
                   onChange={(e) => changeInput(e)}


### PR DESCRIPTION
## What does this PR do?

Reported by August here: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1741597807847749?thread_ts=1741255799.707409&cid=C01E3AC0C03

Currently the constraints override checklist is incorrectly wrapped in a `<label>` which is automatically associated with the first `<input>`, meaning the first input (checkbox) is actioned when clicking anywhere in the element (except other checklist items. Removing the wrapping label and unhiding the repeated `<legend>` rectifies this.

The `<textarea>` "Tell us why" was also not associated with its `<label>` (incorrectly associating with `name` rather than `id` as a ref), I've also fixed this by adding an `id` property.

**Testing:**
https://4447.planx.pizza/lambeth/constraints-test/published?analytics=false
Multiple TPO intersections at SE1 6HZ (Imperial War Museum)