### PR TITLE
style: Empty log notification

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -121,11 +121,13 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
         </Typography>
       </SettingsSection>
       {feedback.length === 0 ? (
-        <ErrorSummary
-          format="info"
-          heading="No feedback found for this team"
-          message="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
-        />
+        <SettingsSection>
+          <ErrorSummary
+            format="info"
+            heading="No feedback found for this team"
+            message="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
+          />
+        </SettingsSection>
       ) : (
         <DataTable
           rows={feedback}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
@@ -3,6 +3,7 @@ import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedL
 import ErrorFallback from "components/Error/ErrorFallback";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import SettingsSection from "ui/editor/SettingsSection";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
 import { containsItem, dateFormatter } from "ui/shared/DataTable/utils";
@@ -34,13 +35,15 @@ const EventsLog: React.FC<EventsLogProps> = ({
   if (error) return <ErrorFallback error={error} />;
   if (submissions.length === 0)
     return (
-      <ErrorSummary
-        format="info"
-        heading={`No payments or submissions found for this ${
-          filterByFlow ? "service" : "team"
-        }`}
-        message="If you're looking for events before 1st January 2024, please contact a PlanX developer."
-      />
+      <SettingsSection>
+        <ErrorSummary
+          format="info"
+          heading={`No payments or submissions found for this ${
+            filterByFlow ? "service" : "team"
+          }`}
+          message="If you're looking for events before 1st January 2024, please contact a PlanX developer."
+        />
+      </SettingsSection>
     );
 
   const rowData = submissions.map((submission, index) => ({

--- a/editor.planx.uk/src/ui/shared/ErrorSummary/ErrorSummary.tsx
+++ b/editor.planx.uk/src/ui/shared/ErrorSummary/ErrorSummary.tsx
@@ -19,6 +19,7 @@ const Root = styled(Box, {
   }),
   ...(format === "info" && {
     borderColor: theme.palette.border.light,
+    background: theme.palette.background.default,
   }),
 }));
 


### PR DESCRIPTION
## What does this PR do?

Quick one (nit): styles `ErrorSummary` wrapper for a bit more contrast when tables/logs are empty.

**Before change:**
<img width="1563" alt="image" src="https://github.com/user-attachments/assets/691350c2-065d-4795-bfc7-585e3dfc60cc" />

**After change:**
<img width="1563" alt="image" src="https://github.com/user-attachments/assets/18ebdd13-8349-4ae9-bb09-ce4341ee02ad" />
