### PR TITLE
fix: Table array filtering

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -30,7 +30,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 200,
       type: ColumnFilterType.ARRAY,
       columnOptions: {
-        valueOptions: feedbackTypeOptions,
+        valueOptions: feedbackTypeOptions.map((option) => option.label),
         filterable: true,
       },
       customComponent: (params) => <>{feedbackTypeText(params.value)}</>,

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -1,13 +1,19 @@
 import Typography from "@mui/material/Typography";
+import { GridFilterItem } from "@mui/x-data-grid";
 import { format } from "date-fns";
 import capitalize from "lodash/capitalize";
 import React from "react";
 import { Feedback } from "routes/feedback";
 import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContainer";
 import SettingsSection from "ui/editor/SettingsSection";
+import { MultipleOptionSelectFilter } from "ui/shared/DataTable/components/MultipleOptionSelectFilter";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
-import { dateFormatter } from "ui/shared/DataTable/utils";
+import {
+  containsItem,
+  dateFormatter,
+  isValidFilterInput,
+} from "ui/shared/DataTable/utils";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
@@ -31,7 +37,30 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       type: ColumnFilterType.ARRAY,
       columnOptions: {
         valueOptions: feedbackTypeOptions.map((option) => option.label),
-        filterable: true,
+        filterOperators: [
+          {
+            value: "is",
+            getApplyFilterFn: (filterItem: GridFilterItem) => {
+              if (!isValidFilterInput(filterItem)) {
+                return null;
+              }
+              // return a function that is applied to all the rows in turn
+              return (currentRowValue: any): boolean => {
+                return filterItem.value.some(
+                  (filterValue: Pick<GridFilterItem, "value">) =>
+                    containsItem(
+                      feedbackTypeText(currentRowValue),
+                      filterValue,
+                    ),
+                );
+              };
+            },
+            InputComponent: MultipleOptionSelectFilter,
+            InputComponentProps: {
+              options: feedbackTypeOptions.map((option) => option.label),
+            },
+          },
+        ],
       },
       customComponent: (params) => <>{feedbackTypeText(params.value)}</>,
     },

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/Submissions/components/EventsLog.tsx
@@ -1,11 +1,15 @@
-import { getGridStringOperators, GridFilterItem } from "@mui/x-data-grid";
+import { GridFilterItem } from "@mui/x-data-grid";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
-import { containsItem, dateFormatter } from "ui/shared/DataTable/utils";
+import {
+  containsItem,
+  dateFormatter,
+  defaultStringFilterOperator,
+} from "ui/shared/DataTable/utils";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import {
@@ -48,10 +52,6 @@ const EventsLog: React.FC<EventsLogProps> = ({
     id: `${submission.eventId}-${index}`,
     downloadSubmissionLink: undefined,
   }));
-
-  const defaultStringFilterOperator = getGridStringOperators().find(
-    (op) => op.value === "contains",
-  );
 
   const columns: ColumnConfig<Submission>[] = [
     {

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -20,6 +20,7 @@ import {
 } from "./types";
 import {
   columnCellComponentRegistry,
+  createFilterOperator,
   getColumnFilterType,
   getValueOptions,
 } from "./utils";
@@ -82,6 +83,10 @@ export const DataTable = <T,>({
       ? {
           ...baseColDef,
           valueOptions: columnValueOptions,
+          filterOperators:
+            columnValueOptions &&
+            columnValueOptions.length > 0 &&
+            createFilterOperator(columnValueOptions),
           ...column.columnOptions,
         }
       : {

--- a/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
@@ -33,7 +33,7 @@ export const containsItem = (
 
 export const createFilterOperator = (columnValueOptions: ValueOptions[]) => [
   {
-    value: "contains",
+    value: "is",
     getApplyFilterFn: (filterItem: GridFilterItem) => {
       if (!isValidFilterInput(filterItem)) {
         return null;
@@ -116,4 +116,5 @@ export const getColumnFilterType = (columnType?: ColumnRenderType) => {
 /**
  * Format date times to a standard format, e.g 31/12/25 14:40:45
  */
-export const dateFormatter = (value: string) => format(new Date(value), "dd/MM/yy HH:mm:ss");
+export const dateFormatter = (value: string) =>
+  format(new Date(value), "dd/MM/yy HH:mm:ss");

--- a/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import {
+  getGridStringOperators,
   GridFilterItem,
   GridValueOptionsParams,
   ValueOptions,
@@ -13,7 +14,7 @@ import { False, True } from "./components/cellIcons";
 import { MultipleOptionSelectFilter } from "./components/MultipleOptionSelectFilter";
 import { ColumnFilterType, ColumnRenderType } from "./types";
 
-const isValidFilterInput = (filterItem: GridFilterItem): boolean => {
+export const isValidFilterInput = (filterItem: GridFilterItem): boolean => {
   return (
     Array.isArray(filterItem.value) &&
     filterItem.value.length > 0 &&
@@ -64,6 +65,10 @@ export const createFilterOperator = (columnValueOptions: ValueOptions[]) => [
     },
   },
 ];
+
+export const defaultStringFilterOperator = getGridStringOperators().find(
+  (op) => op.value === "contains",
+);
 
 export const getValueOptions = (
   options:


### PR DESCRIPTION
## What does this PR do?

- Reintroduces custom filtering (multiselect) for `ARRAY` option in data table (removed here: https://github.com/theopensystemslab/planx-new/pull/4402)
- Makes "type" filter in the feedback log function correctly


### To test

Please check filters across the platform admin panel, submissions log and feedback log! This PR should fix the 'live services' filter that was broken by a previous iteration.