### PR TITLE
refactor: Reorder settings page

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -112,7 +112,7 @@ export const FooterLinksAndLegalDisclaimer = () => {
     validate: () => {},
   });
   return (
-    <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
+    <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2} pt={2}>
       <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Elements

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FooterLinksAndLegalDisclaimer.tsx
@@ -112,7 +112,7 @@ export const FooterLinksAndLegalDisclaimer = () => {
     validate: () => {},
   });
   return (
-    <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2} pt={2}>
+    <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
       <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
           Elements

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
@@ -5,7 +5,10 @@ import FlowStatus from "./FlowStatus";
 import { FooterLinksAndLegalDisclaimer } from "./FooterLinksAndLegalDisclaimer";
 
 const ServiceSettings: React.FC = () => (
-  <Container maxWidth="formWrap">
+  <Container
+    maxWidth="formWrap"
+    sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+  >
     <FlowStatus />
     <FooterLinksAndLegalDisclaimer />
   </Container>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/index.tsx
@@ -6,8 +6,8 @@ import { FooterLinksAndLegalDisclaimer } from "./FooterLinksAndLegalDisclaimer";
 
 const ServiceSettings: React.FC = () => (
   <Container maxWidth="formWrap">
-    <FooterLinksAndLegalDisclaimer />
     <FlowStatus />
+    <FooterLinksAndLegalDisclaimer />
   </Container>
 );
 


### PR DESCRIPTION
## What does this PR do?

- Reorders service settings page so that online/offline status is first

**Example:**
https://4456.planx.pizza/barnet/apply-for-service-declarations/service