### PR TITLE
fix: add has_article4_schema to seed-database scripts

### DIFF
--- a/scripts/seed-database/write/team_settings.sql
+++ b/scripts/seed-database/write/team_settings.sql
@@ -12,7 +12,8 @@ CREATE TEMPORARY TABLE sync_team_settings (
   external_planning_site_name text,
   boundary_url text,
   boundary_bbox jsonb,
-  submission_email text
+  submission_email text,
+  has_article4_schema boolean
 );
 
 \copy sync_team_settings FROM '/tmp/team_settings.csv' WITH (FORMAT csv, DELIMITER ';');
@@ -30,7 +31,8 @@ INSERT INTO
     external_planning_site_url,
     external_planning_site_name,
     boundary_url,
-    boundary_bbox
+    boundary_bbox,
+    has_article4_schema
   )
 SELECT
     id,
@@ -44,7 +46,8 @@ SELECT
     external_planning_site_url,
     external_planning_site_name,
     boundary_url,
-    boundary_bbox
+    boundary_bbox,
+    has_article4_schema
 FROM
   sync_team_settings ON CONFLICT (id) DO
 UPDATE
@@ -59,7 +62,8 @@ SET
     external_planning_site_url = EXCLUDED.external_planning_site_url,
     external_planning_site_name = EXCLUDED.external_planning_site_name,
     boundary_url = EXCLUDED.boundary_url,
-    boundary_bbox = EXCLUDED.boundary_bbox;
+    boundary_bbox = EXCLUDED.boundary_bbox,
+    has_article4_schema = EXCLUDED.has_article4_schema;
 SELECT
   setval('team_settings_id_seq', max(id))
 FROM


### PR DESCRIPTION
Seen my `pnpm sync-data` wasn't working and think this is the culprit. Made the change locally and all is fine. 

Hasura migration was recently merged to production, so makes sense. 