### PR TITLE
chore: Add input validation to `templated_flow_edits` table

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2910,6 +2910,15 @@
           - updated_at
           - flow_id
           - id
+        validate_input:
+          definition:
+            forward_client_headers: false
+            headers:
+              - name: authorization
+                value: '{{HASURA_PLANX_API_KEY}}'
+            timeout: 10
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+          type: http
       comment: Demo users can only insert records for flows from the demo team (teamId = 32)
     - role: platformAdmin
       permission:
@@ -2921,6 +2930,15 @@
           - updated_at
           - flow_id
           - id
+        validate_input:
+          definition:
+            forward_client_headers: false
+            headers:
+              - name: authorization
+                value: '{{HASURA_PLANX_API_KEY}}'
+            timeout: 10
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+          type: http
       comment: ""
     - role: teamEditor
       permission:
@@ -2940,6 +2958,15 @@
           - updated_at
           - flow_id
           - id
+        validate_input:
+          definition:
+            forward_client_headers: false
+            headers:
+              - name: authorization
+                value: '{{HASURA_PLANX_API_KEY}}'
+            timeout: 10
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+          type: http
       comment: teamEditors can only insert nodes for templated flows which they can edit
   select_permissions:
     - role: demoUser
@@ -2993,6 +3020,15 @@
             creator_id:
               _eq: x-hasura-user-id
         check: null
+        validate_input:
+          definition:
+            forward_client_headers: false
+            headers:
+              - name: authorization
+                value: '{{HASURA_PLANX_API_KEY}}'
+            timeout: 10
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+          type: http
       comment: Demo users can only update records associated with flows they have created
     - role: platformAdmin
       permission:
@@ -3005,6 +3041,15 @@
           - id
         filter: {}
         check: {}
+        validate_input:
+          definition:
+            forward_client_headers: false
+            headers:
+              - name: authorization
+                value: '{{HASURA_PLANX_API_KEY}}'
+            timeout: 10
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+          type: http
       comment: ""
     - role: teamEditor
       permission:
@@ -3025,6 +3070,15 @@
                   - role:
                       _eq: teamEditor
         check: null
+        validate_input:
+          definition:
+            forward_client_headers: false
+            headers:
+              - name: authorization
+                value: '{{HASURA_PLANX_API_KEY}}'
+            timeout: 10
+            url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
+          type: http
       comment: teamEditors can only update customisations for flows which they can edit
   delete_permissions:
     - role: platformAdmin


### PR DESCRIPTION
## What does this PR do?
 - Adds input validation for `INSERT` and `UPDATE` operations into the `templated_flow_edits` table
 - The `node_data` (JSONB) column could contain HTML which needs to be sanitised
 - This uses the existing `/webhooks/hasura/validate-input/jsonb/clean-html` endpoint
 
 Spotted whilst doing pre-pen test checks of newly added tables / columns / permissions!