### PR TITLE
chore: Don't sync `team_integrations.power_automate_webhook_url`

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -48,7 +48,7 @@ done
 
 # Copy subset of team_integrations columns
 # Do not copy production values
-psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url, staging_power_automate_api_key FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, staging_power_automate_api_key FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
 echo team_integrations downloaded
 
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at, has_send_component, is_statutory_application_type FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"

--- a/scripts/seed-database/write/team_integrations.sql
+++ b/scripts/seed-database/write/team_integrations.sql
@@ -14,7 +14,7 @@ CREATE TEMPORARY TABLE sync_team_integrations (
 \COPY sync_team_integrations FROM '/tmp/team_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
-  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, power_automate_webhook_url, staging_power_automate_api_key)
+  team_integrations (id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, staging_power_automate_api_key)
 SELECT
   id,
   team_id,
@@ -23,7 +23,6 @@ SELECT
   has_planning_data,
   staging_govpay_secret,
   staging_file_api_key,
-  power_automate_webhook_url,
   staging_power_automate_api_key
 FROM
   sync_team_integrations ON CONFLICT (id) DO
@@ -35,7 +34,6 @@ SET
   has_planning_data = EXCLUDED.has_planning_data,
   staging_govpay_secret = EXCLUDED.staging_govpay_secret,
   staging_file_api_key = EXCLUDED.staging_file_api_key,
-  power_automate_webhook_url = EXCLUDED.power_automate_webhook_url,
   staging_power_automate_api_key = EXCLUDED.staging_power_automate_api_key;
 SELECT
   setval('team_integrations_id_seq', max(id))


### PR DESCRIPTION
## What?
Removes `power_automate_webhook_url` from data sync scripts

## Why?
In some specific testing cases, council may have a staging power automate URL. This has happened recently with Doncaster. If this becomes a recurring pattern we can address with with `_staging` and `_production` column as other data values are handled.