### PR TITLE
fix: Setup internal DNS for Fargate (take 2)

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -335,6 +335,18 @@ export = async () => {
     domain: DOMAIN,
   });
 
+  const apiDiscoveryService = new aws.servicediscovery.Service("api-discovery", {
+    name: "api",
+    dnsConfig: {
+      namespaceId: networking.requireOutput("privateDnsNamespaceId"),
+      dnsRecords: [{
+        ttl: 15,
+        type: "A",
+      }],
+      routingPolicy: "INSTANCE",
+    },
+  });
+
   const apiService = new awsx.ecs.FargateService("api", {
     cluster,
     subnets: networking.requireOutput("publicSubnetIds"),
@@ -515,7 +527,7 @@ export = async () => {
       },
     },
     serviceRegistries: {
-      registryArn: networking.requireOutput("privateDnsNamespaceArn"),
+      registryArn: apiDiscoveryService.arn,
       port: config.requireNumber("api-port"),
       containerName: "api", 
       containerPort: config.requireNumber("api-port"),

--- a/infrastructure/networking/index.ts
+++ b/infrastructure/networking/index.ts
@@ -31,4 +31,4 @@ export const vpcId = vpc.id;
 export const clusterName = cluster.cluster.name;
 export const privateSubnetIds = vpc.privateSubnetIds;
 export const publicSubnetIds = vpc.publicSubnetIds;
-export const privateDnsNamespaceArn = privateDnsNamespace.arn;
+export const privateDnsNamespaceId = privateDnsNamespace.id


### PR DESCRIPTION
Follow up to #4473 

This now more correctly mimics the details required via the console. This should allow Hasura to connect directly to the API Fargate service without exiting the VPC and getting blocked by Cloudflare.

Changes to network layer already manually run for staging stack via Pulumi CLI.

![image](https://github.com/user-attachments/assets/aab8db78-5554-412c-bdfd-50a467bc2f66)