### PR TITLE
fix: Service registry port config

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -527,7 +527,6 @@ export = async () => {
     },
     serviceRegistries: {
       registryArn: apiDiscoveryService.arn,
-      port: config.requireNumber("api-port"),
       containerName: "api", 
       containerPort: config.requireNumber("api-port"),
     },


### PR DESCRIPTION
Fixes Pulumi error - 

```
Specify a value for either 'port' or the 'containerName' and 'containerPort' combination, but not both. Remove one and retry.
```

CI failure - https://app.pulumi.com/planx/application/staging/updates/3597