### PR TITLE
fix: Drop containerPort [skip pizza]

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -528,7 +528,6 @@ export = async () => {
     serviceRegistries: {
       registryArn: apiDiscoveryService.arn,
       containerName: "api", 
-      containerPort: config.requireNumber("api-port"),
     },
     desiredCount: 1,
   });


### PR DESCRIPTION
Fixes latest error - 

```
 awsx:x:ecs:FargateService$aws:ecs/service:Service (api)
    error: 1 error occurred:
	* updating urn:pulumi:staging::application::awsx:x:ecs:FargateService$aws:ecs/service:Service::api: 1 error occurred:
	* updating ECS Service: InvalidParameterException: The values specified for serviceRegistries do not require a value for 'containerPort'. Remove the value and retry.
```