### PR TITLE
fix(api): Handle missing JWT

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -107,6 +107,8 @@ export const logout: RequestHandler = async (_req, res, next) => {
 
 export const isJWTRevoked: RequestHandler = async (req, res) => {
   const jwt = getToken(req);
+  if (!jwt) return res.status(401).send();
+
   const tokenDigest = createTokenDigest(jwt);
   const isRevoked = await isTokenRevoked(tokenDigest);
 

--- a/api.planx.uk/modules/auth/validateJWT.test.ts
+++ b/api.planx.uk/modules/auth/validateJWT.test.ts
@@ -92,3 +92,7 @@ describe("JWT in query params", () => {
     await supertest(app).get(`/auth/validate-jwt?token=NOT_A_JWT`).expect(200);
   });
 });
+
+test("no JWT", async () => {
+  await supertest(app).get("/auth/validate-jwt").expect(401);
+});


### PR DESCRIPTION
Currently a request to `/auth/validate-jwt` is bringing down the API.

![image](https://github.com/user-attachments/assets/376e2685-083a-4bb2-bda7-f9eda4d16245)

