### PR TITLE
fix: Team page loading in Safari

### DIFF
--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -117,7 +117,7 @@ export const Filters = <T extends object>({
   useEffect(() => {
     const parseStateFromURL = () => {
       const searchParams = new URLSearchParams(route.url.search);
-      const searchParamToMap = searchParams.entries().toArray() as [
+      const searchParamToMap = Array.from(searchParams.entries()) as [
         FilterKey<T>,
         FilterValues,
       ][];


### PR DESCRIPTION
## What does this PR do?

Loading a team/council page in Safari is failing due to the following error:

`TypeError: searchParams.entries().toArray is not a function. (In 'searchParams.entries().toArray()', 'searchParams.entries().toArray' is undefined)`

Converting to an array using `Array.from()` fixes the issue.