### PR TITLE
fix: ensure admin panel correctly formats service names and accounts for 0 live services

### DIFF
--- a/editor.planx.uk/src/pages/PlatformAdminPanel/getFlowNamesForFilter.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel/getFlowNamesForFilter.tsx
@@ -6,8 +6,7 @@ export const getFlowNamesForFilter = (data: AdminPanelData[]) => {
   // Sort strings alphabetically, transform to title case and remove trailing spaces
   const processedData = flattenedData
     .sort()
-    .filter((str) => !str.endsWith(" "))
-    .map((str) => capitalize(str.toLowerCase()));
+    .map((str) => capitalize(str?.toLowerCase()?.trim()));
 
   // remove duplicates
   return [...new Set(processedData)];

--- a/editor.planx.uk/src/pages/PlatformAdminPanel/getFlowNamesForFilter.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel/getFlowNamesForFilter.tsx
@@ -2,12 +2,12 @@ import { capitalize } from "lodash";
 import { AdminPanelData } from "types";
 
 export const getFlowNamesForFilter = (data: AdminPanelData[]) => {
-  const flattenedData = data.flatMap((teamData) => teamData.liveFlows);
+  const flattenedFlowNames = data.flatMap((teamData) => teamData.liveFlows);
   // Sort strings alphabetically, transform to title case and remove trailing spaces
-  const processedData = flattenedData
-    .sort()
-    .map((str) => capitalize(str?.toLowerCase()?.trim()));
+  const formattedFlowNames = flattenedFlowNames
+    .map((name) => capitalize(name?.toLowerCase()?.trim()))
+    .sort();
 
-  // remove duplicates
-  return [...new Set(processedData)];
+  // Remove duplicates
+  return [...new Set(formattedFlowNames)];
 };


### PR DESCRIPTION
See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1742297258994419 && this console error on production admin panel:
![Screenshot from 2025-03-18 12-41-26](https://github.com/user-attachments/assets/f7495474-b021-454f-af02-23f772eff967)

**Changes:**
- Councils may have 0 live services now since Silvia's "online"/"offline" message (eg see B&D); these should render an empty cell rather than error
- The `endsWith` within the `filter` here would have actually _removed_ any names with a trailing space, whereas we actually just want to ensure they're included but properly "trimmed" per the comment. We also want to sort _after_ trimming :+1: 

Admin panel loads correctly on this pizza: https://4482.planx.pizza/admin-panel 

Bigger picture question - this was a still a white page error and not more gracefully picked up by our `ErrorBoundary` component, let's keep an eye on that going forward !