### PR TITLE
chore: Add Hasura to API `CORS_ALLOWLIST`

### DIFF
--- a/infrastructure/application/utils/generateCORSAllowList.ts
+++ b/infrastructure/application/utils/generateCORSAllowList.ts
@@ -6,11 +6,13 @@ export const generateCORSAllowList = (customDomains: CustomDomains, domain: stri
   const customDomainURLs = customDomains.map(team => `https://${team.domain}`);
   const editorURL = `https://${domain}`;
   const apiURL = `https://api.${domain}`; // Required for requests from API docs
+  const hasuraURL = `https://hasura.${domain}`; // Required for proxied auth requests
   const microsoftLoginURLs = ["https://login.live.com, https://login.microsoftonline.com"];
   const corsAllowList = [
     ...customDomainURLs,
     editorURL,
     apiURL,
+    hasuraURL,
     ...microsoftLoginURLs,
   ];
 


### PR DESCRIPTION
## What does this PR do?
- Adds Hasura to the API's CORS allowlist which means requests can be handled
- This is a genuine difference between Pizzas and production, which may be responsible for the 403's we're seeing
