### PR TITLE
feat: Hasura auth proxy using Cloudflare snippets

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -1,3 +1,4 @@
+import jwt from "jsonwebtoken";
 import type { CookieOptions, RequestHandler, Response } from "express";
 import type { Request } from "express-jwt";
 import {
@@ -106,10 +107,16 @@ export const logout: RequestHandler = async (_req, res, next) => {
 };
 
 export const isJWTRevoked: RequestHandler = async (req, res) => {
-  const jwt = getToken(req);
-  if (!jwt) return res.status(401).send();
+  const token = getToken(req);
+  if (!token) return res.status(401).send();
 
-  const tokenDigest = createTokenDigest(jwt);
+  try {
+    jwt.verify(token, process.env.JWT_SECRET!);
+  } catch (error) {
+    return res.status(401).send();
+  }
+
+  const tokenDigest = createTokenDigest(token);
   const isRevoked = await isTokenRevoked(tokenDigest);
 
   return isRevoked ? res.status(401).send() : res.status(200).send();

--- a/api.planx.uk/modules/auth/validateJWT.test.ts
+++ b/api.planx.uk/modules/auth/validateJWT.test.ts
@@ -40,7 +40,7 @@ describe("JWT in auth header", async () => {
     await supertest(app)
       .get("/auth/validate-jwt")
       .set({ authorization: "Bearer NOT_A_JWT" })
-      .expect(200);
+      .expect(401);
   });
 });
 
@@ -69,7 +69,7 @@ describe("JWT in cookie", () => {
     await supertest(app)
       .get("/auth/validate-jwt")
       .set("Cookie", `jwt=NOT_A_JWT`)
-      .expect(200);
+      .expect(401);
   });
 });
 
@@ -89,7 +89,7 @@ describe("JWT in query params", () => {
   });
 
   test("invalid JWT", async () => {
-    await supertest(app).get(`/auth/validate-jwt?token=NOT_A_JWT`).expect(200);
+    await supertest(app).get(`/auth/validate-jwt?token=NOT_A_JWT`).expect(401);
   });
 });
 

--- a/infrastructure/application/cloudflare/snippets/README.md
+++ b/infrastructure/application/cloudflare/snippets/README.md
@@ -1,0 +1,66 @@
+# Hasura Auth Proxy for PlanX Editor
+
+A [Cloudflare Snippet](https://developers.cloudflare.com/rules/snippets/) that acts as an authentication proxy for GraphQL requests to Hasura, validating JSON web tokens (JWTs) before forwarding requests to the Hasura API.
+
+## Overview
+
+This snippet intercepts all GraphQL requests to `hasura.editor.planx.{DOMAIN}/v1/graphql` and:
+
+1. Extracts JWT tokens from either the Authorization header or cookies
+2. Validates tokens against the PlanX API authentication service (`/auth/validate-jwt` endpoint)
+3. Forwards valid requests to Hasura or returns appropriate error responses
+
+
+### Request with valid JWT
+```mermaid
+sequenceDiagram
+    participant Client
+    participant CF as Cloudflare Snippet
+    participant API as PlanX API
+    participant Hasura
+
+    Client->>CF: GraphQL request
+    Note over CF: Extract JWT
+    
+    CF->>API: Validate JWT
+    API->>CF: Token status
+
+    CF->>Hasura: Forward request
+    Hasura->>CF: Response
+    
+    CF->>Client: Return response
+```
+
+### Request with invalid JWT
+```mermaid
+sequenceDiagram
+    participant Client
+    participant CF as Cloudflare Snippet
+    participant API as PlanX API
+    participant Hasura
+
+    Client->>CF: GraphQL request
+    Note over CF: Extract JWT
+
+    CF->>API: Validate JWT
+    API->>CF: Token status
+
+    CF->>Client: 401 Unauthorized
+```
+
+## Deployment
+
+This is currently deployed manually through the Cloudflare Snippets console (Cloudflare > Select domain > Rules > Snippets). 
+
+Please copy/paste the contents of `validate_jwt.js` to a snippet named `validate_jwt` and configure the snippet rule to - 
+
+`(http.request.full_uri wildcard "https://hasura.editor.planx.{DOMAIN}/v1/graphql")`
+
+Be sure to correctly set the environment (`.dev` | `.uk`) based on the Cloudflare domain. This applies to the snippet rule, CF domain, and the `API_URL_EXT` const.
+
+### Future improvements
+
+- [ ] Implement automated deployment via Pulumi ([docs](https://www.pulumi.com/registry/packages/cloudflare/api-docs/snippet/))
+- [ ] Write and maintain in TypeScript, generate `.js` file
+- [ ] Handle staging / production environments
+- [ ] Implement tests

--- a/infrastructure/application/cloudflare/snippets/validate_jwt.js
+++ b/infrastructure/application/cloudflare/snippets/validate_jwt.js
@@ -8,7 +8,7 @@ export default {
       if (authHeaderJWT) return authHeaderJWT;
 
       const cookies = request.headers.get("cookie");
-      const cookieJWT = cookies?.match(/(?:^|;\s*)jwt=([^;]*)(?:;|$)/)?.[1];
+      const cookieJWT = cookies?.match(/(?:^|;\s*)jwt=([^;]+)(?:;|$)/)?.[1];
       if (cookieJWT) return cookieJWT;
     };
 

--- a/infrastructure/application/cloudflare/snippets/validate_jwt.js
+++ b/infrastructure/application/cloudflare/snippets/validate_jwt.js
@@ -1,0 +1,41 @@
+export default {
+  async fetch(request) {
+    const API_URL_EXT = "https://api.editor.planx.dev";
+
+    const getJWT = (request) => {
+      const authHeader = request.headers.get("authorization");
+      const authHeaderJWT = authHeader?.match(/^Bearer (\S+)$/)?.[1];
+      if (authHeaderJWT) return authHeaderJWT;
+
+      const cookies = request.headers.get("cookie");
+      const cookieJWT = cookies?.match(/(?:^|;\s*)jwt=([^;]*)(?:;|$)/)?.[1];
+      if (cookieJWT) return cookieJWT;
+    };
+
+    const validateJWT = async (request) => {
+      const response = await fetch(`${API_URL_EXT}/auth/validate-jwt`, {
+        method: "GET",
+        headers: request.headers
+      });
+
+      return response.ok
+    };
+
+    try {
+      const jwt = getJWT(request);
+
+      // Forward request directly to Hasura
+      // Non-JWT requests (admin and public) are validated internally
+      if (!jwt) return fetch(request);
+
+      // Requests with a JWT need additional validation via our REST API
+      // We check if the token is valid (signed by PlanX) or revoked (user has logged out)
+      const isValidToken = await validateJWT(request)
+      if (isValidToken) return fetch(request);
+
+      return new Response(`Invalid or revoked token`, { status: 401 });
+    } catch (error) {
+      return new Response("Error validating token: " + error.message, { status: 500 })
+    }
+  }
+};


### PR DESCRIPTION
## What does this PR do?
 - Documents our Cloudflare snippet setup which handles additional Hasura auth (checking for block-listed token)
 - This replaces the approach originally implemented in #4445 
 - Updates the JWT endpoint to also verify JWTs (required for upcoming ShareDB PR, makes more sense to check all in one place)
 
 For more details, please see included README.md

## To do
- Handle Hasura console
  - Requests made via the console will fail if you're logged out of PlanX
  - Checking for origin or referer headers is insecure as these headers can be spoofed (thus bypassing the revoked token check)
  - Is it an issue that we need to be logged into PlanX for this to work?
 - Add back the logic for `x-auth-validated` header as a breadcrumb


## Testing
The same applies here as did in #4445 (currently minus the headers). It breaks down to -
 - I can log in / log out of staging without issue
 - Once logged in, I can make requests to Hasura (e.g. via `curl`)
 - Once logged out, requests to Hasura will fail with a `401` as they're intercepted by the CF snippet
 - Public requests to Hasura work (e.g. published, public-facing, routes)