### PR TITLE
feat(sharedb): Hand auth responsibility over to `/auth/validate-jwt` endpoint

### DIFF
--- a/api.planx.uk/modules/auth/controller.ts
+++ b/api.planx.uk/modules/auth/controller.ts
@@ -111,13 +111,12 @@ export const isJWTRevoked: RequestHandler = async (req, res) => {
   if (!token) return res.status(401).send();
 
   try {
-    jwt.verify(token, process.env.JWT_SECRET!);
+    const decoded = jwt.verify(token, process.env.JWT_SECRET!);
+    const tokenDigest = createTokenDigest(token);
+    const isRevoked = await isTokenRevoked(tokenDigest);
+
+    return isRevoked ? res.status(401).send() : res.status(200).json(decoded);
   } catch (error) {
     return res.status(401).send();
   }
-
-  const tokenDigest = createTokenDigest(token);
-  const isRevoked = await isTokenRevoked(tokenDigest);
-
-  return isRevoked ? res.status(401).send() : res.status(200).send();
 };

--- a/api.planx.uk/modules/auth/validateJWT.test.ts
+++ b/api.planx.uk/modules/auth/validateJWT.test.ts
@@ -22,7 +22,12 @@ describe("JWT in auth header", async () => {
     await supertest(app)
       .get("/auth/validate-jwt")
       .set(authHeaderJWT)
-      .expect(200);
+      .expect(200)
+      .then((res) => {
+        // Decoded JWT returned
+        expect(res.body).toHaveProperty("sub", "123");
+        expect(res.body).toHaveProperty("email", "test@opensystemslab.io");
+      });
   });
 
   test("revoked JWT", async () => {
@@ -51,7 +56,12 @@ describe("JWT in cookie", () => {
     await supertest(app)
       .get("/auth/validate-jwt")
       .set("Cookie", `jwt=${jwt}`)
-      .expect(200);
+      .expect(200)
+      .then((res) => {
+        // Decoded JWT returned
+        expect(res.body).toHaveProperty("sub", "123");
+        expect(res.body).toHaveProperty("email", "test@opensystemslab.io");
+      });
   });
 
   test("revoked JWT", async () => {
@@ -77,7 +87,14 @@ describe("JWT in query params", () => {
   test("valid JWT", async () => {
     const jwt = getTestJWT({ role: "teamEditor" });
 
-    await supertest(app).get(`/auth/validate-jwt?token=${jwt}`).expect(200);
+    await supertest(app)
+      .get(`/auth/validate-jwt?token=${jwt}`)
+      .expect(200)
+      .then((res) => {
+        // Decoded JWT returned
+        expect(res.body).toHaveProperty("sub", "123");
+        expect(res.body).toHaveProperty("email", "test@opensystemslab.io");
+      });
   });
 
   test("revoked JWT", async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
     environment:
       JWT_SECRET: ${JWT_SECRET}
       PG_URL: postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE}
-      API_URL_EXT: ${API_URL_EXT}
+      API_URL_EXT: http://api:${API_PORT}
 
   # used as an S3 service mock
   minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
     environment:
       JWT_SECRET: ${JWT_SECRET}
       PG_URL: postgres://${PG_USERNAME}:${PG_PASSWORD}@postgres/${PG_DATABASE}
+      API_URL_EXT: ${API_URL_EXT}
 
   # used as an S3 service mock
   minio:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -569,10 +569,7 @@ export = async () => {
         portMappings: [sharedbListenerHttp],
         environment: [
           { name: "PORT", value: String(SHAREDB_PORT) },
-          {
-            name: "JWT_SECRET",
-            value: config.requireSecret("jwt-secret"),
-          },
+          { name: "API_URL_EXT", value: `https://api.${DOMAIN}` },
           {
             name: "PG_URL",
             value: rootDbUrl,

--- a/sharedb.planx.uk/package.json
+++ b/sharedb.planx.uk/package.json
@@ -6,7 +6,6 @@
     "@teamwork/websocket-json-stream": "^2.0.0",
     "dompurify": "^3.2.4",
     "jsdom": "^26.0.0",
-    "jsonwebtoken": "^8.5.1",
     "pg": "^8.12.0",
     "sharedb": "^4.1.1",
     "ws": "^8.17.1"
@@ -21,8 +20,6 @@
   },
   "pnpm": {
     "overrides": {
-      "jsonwebtoken@<=8.5.1": ">=9.0.0",
-      "jsonwebtoken@<9.0.0": ">=9.0.0",
       "semver@<7.5.2": ">=7.5.2"
     }
   }

--- a/sharedb.planx.uk/pnpm-lock.yaml
+++ b/sharedb.planx.uk/pnpm-lock.yaml
@@ -5,8 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  jsonwebtoken@<=8.5.1: '>=9.0.0'
-  jsonwebtoken@<9.0.0: '>=9.0.0'
   semver@<7.5.2: '>=7.5.2'
 
 dependencies:
@@ -19,9 +17,6 @@ dependencies:
   jsdom:
     specifier: ^26.0.0
     version: 26.0.0
-  jsonwebtoken:
-    specifier: '>=9.0.0'
-    version: 9.0.1
   pg:
     specifier: ^8.12.0
     version: 8.12.0
@@ -119,10 +114,6 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: false
 
-  /buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-    dev: false
-
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -186,12 +177,6 @@ packages:
     dependencies:
       xtend: 4.0.2
     dev: true
-
-  /ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
 
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -338,35 +323,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /jsonwebtoken@9.0.1:
-    resolution: {integrity: sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==}
-    engines: {node: '>=12', npm: '>=6'}
-    dependencies:
-      jws: 3.2.2
-      lodash: 4.17.21
-      ms: 2.1.3
-      semver: 7.5.3
-    dev: false
-
-  /jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-    dev: false
-
-  /jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
-    dependencies:
-      jwa: 1.4.1
-      safe-buffer: 5.2.1
-    dev: false
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
-
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
     dev: false
@@ -376,6 +332,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -543,10 +500,6 @@ packages:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
     dev: false
 
-  /safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
-
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: false
@@ -564,6 +517,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /sharedb@4.1.1:
     resolution: {integrity: sha512-BeRQkAFQ65pRgo9k9rFsUL2CecOdSpSUBaAIU/8qT4TnMjJLz/t1RcbrgoeVvCgWqYoPdW3b1rB33WLGgzlGaQ==}
@@ -704,3 +658,4 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -88,7 +88,10 @@ async function validateJWT(authToken) {
     }
   });
 
-  if (response.ok) return;
+  if (response.ok) {
+    const decodedToken = await response.json();
+    return decodedToken;
+  }
 
   throw Error(`Invalid JWT. Please log in again. Error: ${response.body}`)
 };
@@ -100,7 +103,7 @@ const wss = new Server({
       // checks if JWT is included in cookies, does not allow connection if invalid
       const [, token] = info.req.headers.cookie?.match(/jwt\=([^;]+)/) || [];
       if (!token) return cb(false, 401, "Unauthorized");
-      await validateJWT(token);
+      const decoded = await validateJWT(token);
 
       console.log({ newConnection: decoded });
       info.req.uId = decoded;

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -1,6 +1,5 @@
 const assert = require("assert");
 const { Server } = require("ws");
-const jwt = require("jsonwebtoken");
 const ShareDB = require("sharedb");
 const WebSocketJSONStream = require("@teamwork/websocket-json-stream");
 const PostgresDB = require("./sharedb-postgresql");
@@ -10,8 +9,8 @@ const { JSDOM } = require('jsdom');
 const ONE_MINUTE_IN_MS = 60 * 1000;
 const TOKEN_EXPIRY_CODE = 4001;
 
-const { PORT = 8000, JWT_SECRET, PG_URL } = process.env;
-assert(JWT_SECRET);
+const { PORT = 8000, API_URL_EXT, PG_URL } = process.env;
+assert(API_URL_EXT);
 assert(PG_URL);
 
 const sharedb = new ShareDB({
@@ -78,30 +77,37 @@ function sanitise(input) {
   }
 }
 
+/**
+ * Checks via REST API if token is invalid (not signed by PlanX) or revoked (logged out user)
+ */
+async function validateJWT(authToken) {
+  const response = await fetch(`${API_URL_EXT}/auth/validate-jwt`, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${authToken}`
+    }
+  });
+
+  if (response.ok) return;
+
+  throw Error(`Invalid JWT. Please log in again. Error: ${response.body}`)
+};
+
 const wss = new Server({
   port: PORT,
-  verifyClient: (info, cb) => {
+  verifyClient: async (info, cb) => {
     try {
       // checks if JWT is included in cookies, does not allow connection if invalid
       const [, token] = info.req.headers.cookie?.match(/jwt\=([^;]+)/) || [];
+      if (!token) return cb(false, 401, "Unauthorized");
+      await validateJWT(token);
 
-      if (!token) {
-        cb(false, 401, "Unauthorized");
-      } else {
-        jwt.verify(token, JWT_SECRET, (err, decoded) => {
-          if (err) {
-            cb(false, 401, "Unauthorized");
-          } else {
-            console.log({ newConnection: decoded });
-            info.req.authToken = token;
-            info.req.uId = decoded;
-            cb(true);
-          }
-        });
-      }
+      console.log({ newConnection: decoded });
+      info.req.uId = decoded;
+      cb(true);
     } catch (err) {
       console.error({ err });
-      cb(false, 500, err.message);
+      cb(false, 401, `Unauthorized. Error: ${err.message}`);
     }
   },
 });
@@ -109,14 +115,9 @@ const wss = new Server({
 wss.on("connection", function (ws, req) {
   // JWTs expire every 24hrs
   // Check status every minute - client side will logout on expiry
-  const tokenCheckInterval = setInterval(() => {
+  const tokenCheckInterval = setInterval(async () => {
     try {
-      jwt.verify(req.authToken, JWT_SECRET, (err) => {
-        if (err) {
-          ws.close(TOKEN_EXPIRY_CODE, "Token expired");
-          clearInterval(tokenCheckInterval);
-        }
-      });
+      await validateJWT(req.authToken)
     } catch (error) {
       console.error("Token validation error:", error);
       ws.close(TOKEN_EXPIRY_CODE, "Token validation error");


### PR DESCRIPTION
## What does this PR do?
 - Removes responsibility on ShareDB to verify JWT, and hands this over to the REST API
 - This endpoint both validates the JWT and checks for block-listed tokens
 - It also now returns the decoded JWT as ShareDB needs the user ID to write operations to Postgres
 - Replaces https://github.com/theopensystemslab/planx-new/pull/4467

We could simplify things here further and rely entirely on the same CF snippet used for Hasura auth here, but that would mean that ShareDB would be unsecured locally and on Pizzas. Not really a risk, but maybe just a bad practice and it would make the gap between Pizzas and staging/prod a little too large? I think that keeping visibility of this auth step, as in this PR, seems the pragmatic approach.
