### PR TITLE
feat: Editable comments column in feedback table

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/FeedbackLog/FeedbackLog.tsx
@@ -22,6 +22,11 @@ import { FeedbackLogProps } from "./types";
 import { EmojiRating, feedbackTypeText, stripHTMLTags } from "./utils";
 
 export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
+  const handleProcessRowUpdate = (updatedRow: Feedback) => {
+    console.log("Added/updated editor notes:", updatedRow.editorNotes);
+    return updatedRow;
+  };
+
   const columns: ColumnConfig<Feedback>[] = [
     {
       field: "flowName",
@@ -29,6 +34,15 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 250,
       type: ColumnFilterType.CUSTOM,
       customComponent: (params) => <strong>{`${params.value}`}</strong>,
+    },
+    {
+      field: "editorNotes",
+      headerName: "Editor notes",
+      width: 250,
+      columnOptions: {
+        editable: true,
+        sortable: false,
+      },
     },
     {
       field: "type",
@@ -162,6 +176,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
           rows={feedback}
           columns={columns}
           csvExportFileName={`${format(Date.now(), "yyyy-MM-dd")}-feedback`}
+          onProcessRowUpdate={handleProcessRowUpdate}
         />
       )}
     </FixedHeightDashboardContainer>

--- a/editor.planx.uk/src/routes/feedback.tsx
+++ b/editor.planx.uk/src/routes/feedback.tsx
@@ -34,6 +34,7 @@ export interface Feedback {
   nodeId: string | null;
   nodeText: string | null;
   projectType: string | null;
+  editorNotes: string | null;
 }
 
 const feedbackRoutes = compose(

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -29,6 +29,7 @@ export const DataTable = <T,>({
   rows,
   columns,
   csvExportFileName,
+  onProcessRowUpdate,
 }: DataGridProps<T>) => {
   const renderCellComponentByType = (
     params: RenderCellParams,
@@ -128,6 +129,8 @@ export const DataTable = <T,>({
           slots={{
             toolbar: CustomToolbar,
           }}
+          getRowId={(row) => row.id}
+          processRowUpdate={onProcessRowUpdate}
         />
       </Box>
     </Box>

--- a/editor.planx.uk/src/ui/shared/DataTable/types.ts
+++ b/editor.planx.uk/src/ui/shared/DataTable/types.ts
@@ -39,4 +39,5 @@ export interface DataGridProps<T> {
   rows: readonly T[] | undefined;
   columns: Array<ColumnConfig<T>>;
   csvExportFileName?: string;
+  onProcessRowUpdate?: (updatedRow: T) => void;
 }


### PR DESCRIPTION
## What does this PR do?

Sets up front-end of feedback data table to include an editable column for notes.

There is already a column for user comments, so I've title the editable column "Editor notes" to make a clear distinction.

Column position TBC, I'm imagining this is most useful as an always visible column so I've placed it near the start.

For testing:
https://4489.planx.pizza/testing/feedback-test/feedback