### PR TITLE
feat: Add `feedback.editor_notes` column

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -302,12 +302,14 @@
     - role: platformAdmin
       permission:
         columns:
+          - editor_notes
           - id
         filter: {}
       comment: ""
     - role: teamEditor
       permission:
         columns:
+          - editor_notes
           - id
         filter:
           team:
@@ -322,6 +324,7 @@
     - role: platformAdmin
       permission:
         columns:
+          - editor_notes
           - status
         filter: {}
         check: null
@@ -329,6 +332,7 @@
     - role: teamEditor
       permission:
         columns:
+          - editor_notes
           - status
         filter:
           team:

--- a/hasura.planx.uk/migrations/1742407557667_alter_table_public_feedback_add_column_editor_comment/down.sql
+++ b/hasura.planx.uk/migrations/1742407557667_alter_table_public_feedback_add_column_editor_comment/down.sql
@@ -1,0 +1,35 @@
+-- Previous iteration from hasura.planx.uk/migrations/1738840144554_add_flow_name_to_feedback_summary/up.sql
+DROP VIEW "public"."feedback_summary";
+
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS 
+ SELECT fb.id AS feedback_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    f.name AS service_name,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,
+    COALESCE((fb.node_data ->> 'title'::text), (fb.node_data ->> 'text'::text), (fb.node_data ->> 'flagSet'::text)) AS node_title,
+    (fb.node_data ->> 'description'::text) AS node_text,
+    (fb.node_data ->> 'info'::text) AS help_text,
+    (fb.node_data ->> 'policyRef'::text) AS help_sources,
+    (fb.node_data ->> 'howMeasured'::text) AS help_definition,
+    COALESCE(((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'uprn'::text) AS uprn,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'proposal.projectType'::text) AS project_type,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'property.constraints.planning'::text) AS intersecting_constraints,
+    fb.feedback_score,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> 'application.type'::text) ->> 0) AS application_type
+   FROM ((feedback fb
+     LEFT JOIN flows f ON ((f.id = fb.flow_id)))
+     LEFT JOIN teams t ON ((t.id = fb.team_id)));
+
+GRANT SELECT ON public.feedback_summary TO metabase_read_only;
+
+ALTER TABLE "public.feedback" DROP COLUMN editor_notes;

--- a/hasura.planx.uk/migrations/1742407557667_alter_table_public_feedback_add_column_editor_comment/up.sql
+++ b/hasura.planx.uk/migrations/1742407557667_alter_table_public_feedback_add_column_editor_comment/up.sql
@@ -1,0 +1,36 @@
+alter table "public"."feedback" add column "editor_notes" text
+ null;
+
+DROP VIEW "public"."feedback_summary";
+
+CREATE OR REPLACE VIEW "public"."feedback_summary" AS 
+ SELECT fb.id AS feedback_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    f.name AS service_name,
+    fb.created_at,
+    fb.node_id,
+    fb.device,
+    fb.user_context,
+    fb.user_comment,
+    fb.feedback_type,
+    fb.status,
+    fb.node_type,
+    fb.node_data,    
+    fb.editor_notes,
+    COALESCE((fb.node_data ->> 'title'::text), (fb.node_data ->> 'text'::text), (fb.node_data ->> 'flagSet'::text)) AS node_title,
+    (fb.node_data ->> 'description'::text) AS node_text,
+    (fb.node_data ->> 'info'::text) AS help_text,
+    (fb.node_data ->> 'policyRef'::text) AS help_sources,
+    (fb.node_data ->> 'howMeasured'::text) AS help_definition,
+    COALESCE(((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'uprn'::text) AS uprn,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'proposal.projectType'::text) AS project_type,
+    (((fb.user_data -> 'passport'::text) -> 'data'::text) ->> 'property.constraints.planning'::text) AS intersecting_constraints,
+    fb.feedback_score,
+    ((((fb.user_data -> 'passport'::text) -> 'data'::text) -> 'application.type'::text) ->> 0) AS application_type
+   FROM ((feedback fb
+     LEFT JOIN flows f ON ((f.id = fb.flow_id)))
+     LEFT JOIN teams t ON ((t.id = fb.team_id)));
+
+GRANT SELECT ON public.feedback_summary TO metabase_read_only;


### PR DESCRIPTION
## What does this PR do?
 - Adds `feedback.editor_notes` column
 - Exposes via `feedback_summary` view
 - Configures permissions
 - To be wired up to UI in https://github.com/theopensystemslab/planx-new/pull/4489

## Questions
I'm working off the Figma here and unfortunately missed the last design call where this was discussed.

My initial instinct here would have been to have a new `feedback_editor_notes` table, with `user_id`, timestamps etc and a many-to-one relationship to `feedback`. Going off the designs it actually seems that for now a single `notes` column, without this associated metadata, is going to meet our requirements at least in the medium term. Is this a fair summary of the decisions we've made here?