### PR TITLE
feat(editor): Persist editor notes in feedback log

### DIFF
--- a/editor.planx.uk/src/lib/feedback.ts
+++ b/editor.planx.uk/src/lib/feedback.ts
@@ -122,5 +122,6 @@ export const FEEDBACK_SUMMARY_FIELDS = gql`
     nodeId: node_id
     nodeText: node_text
     projectType: project_type
+    editorNotes: editor_notes
   }
 `;

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.stories.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.stories.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { FeedbackLog } from "../../FeedbackLog/FeedbackLog";
+import { FeedbackLog } from "./FeedbackLog";
 import { mockFeedback } from "./mocks/mockFeedback";
 
 const meta = {

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -23,6 +23,11 @@ import { FeedbackLogProps } from "./types";
 import { EmojiRating, feedbackTypeText, stripHTMLTags } from "./utils";
 
 export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
+  const handleProcessRowUpdate = (updatedRow: Feedback) => {
+    console.log("Added/updated editor notes:", updatedRow.editorNotes);
+    return updatedRow;
+  };
+
   const columns: ColumnConfig<Feedback>[] = [
     {
       field: "status",
@@ -40,6 +45,15 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       width: 250,
       type: ColumnFilterType.CUSTOM,
       customComponent: (params) => <strong>{`${params.value}`}</strong>,
+    },
+    {
+      field: "editorNotes",
+      headerName: "Editor notes",
+      width: 250,
+      columnOptions: {
+        editable: true,
+        sortable: false,
+      },
     },
     {
       field: "type",
@@ -173,6 +187,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
           rows={feedback}
           columns={columns}
           csvExportFileName={`${format(Date.now(), "yyyy-MM-dd")}-feedback`}
+          onProcessRowUpdate={handleProcessRowUpdate}
         />
       )}
     </FixedHeightDashboardContainer>

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -1,8 +1,6 @@
 import Typography from "@mui/material/Typography";
 import { GridFilterItem } from "@mui/x-data-grid";
 import { format } from "date-fns";
-import gql from "graphql-tag";
-import { client } from "lib/graphql";
 import capitalize from "lodash/capitalize";
 import React from "react";
 import { Feedback } from "routes/feedback";
@@ -21,28 +19,13 @@ import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
 import { StatusChip } from "./components/StatusChip";
 import { feedbackTypeOptions, statusOptions } from "./feedbackFilterOptions";
+import { updateEditorNotes } from "./queries/updateEditorNotes";
 import { FeedbackLogProps } from "./types";
 import { EmojiRating, feedbackTypeText, stripHTMLTags } from "./utils";
 
 export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
   const handleProcessRowUpdate = async (updatedRow: Feedback) => {
-    await client.mutate({
-      mutation: gql`
-        mutation UpdateEditorNotes($id: Int!, $editor_notes: String) {
-          update_feedback_by_pk(
-            pk_columns: { id: $id }
-            _set: { editor_notes: $editor_notes }
-          ) {
-            id
-          }
-        }
-      `,
-      variables: {
-        id: updatedRow.id,
-        editor_notes: updatedRow.editorNotes,
-      },
-    });
-
+    await updateEditorNotes(updatedRow);
     return updatedRow;
   };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -1,6 +1,8 @@
 import Typography from "@mui/material/Typography";
 import { GridFilterItem } from "@mui/x-data-grid";
 import { format } from "date-fns";
+import gql from "graphql-tag";
+import { client } from "lib/graphql";
 import capitalize from "lodash/capitalize";
 import React from "react";
 import { Feedback } from "routes/feedback";
@@ -23,8 +25,24 @@ import { FeedbackLogProps } from "./types";
 import { EmojiRating, feedbackTypeText, stripHTMLTags } from "./utils";
 
 export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
-  const handleProcessRowUpdate = (updatedRow: Feedback) => {
-    console.log("Added/updated editor notes:", updatedRow.editorNotes);
+  const handleProcessRowUpdate = async (updatedRow: Feedback) => {
+    await client.mutate({
+      mutation: gql`
+        mutation UpdateEditorNotes($id: Int!, $editor_notes: String) {
+          update_feedback_by_pk(
+            pk_columns: { id: $id }
+            _set: { editor_notes: $editor_notes }
+          ) {
+            id
+          }
+        }
+      `,
+      variables: {
+        id: updatedRow.id,
+        editor_notes: updatedRow.editorNotes,
+      },
+    });
+
     return updatedRow;
   };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
@@ -63,6 +63,7 @@ export const mockFeedback: Feedback[] = [
     projectType: null,
     status: "read",
     editorNotes: "No action needed",
+    editorNotes: "Let's try to sort this out",
   },
   {
     address: null,

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
@@ -63,7 +63,6 @@ export const mockFeedback: Feedback[] = [
     projectType: null,
     status: "read",
     editorNotes: "No action needed",
-    editorNotes: "Let's try to sort this out",
   },
   {
     address: null,

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.tsx
@@ -1,4 +1,4 @@
-import { Feedback } from "../../../../../../routes/feedback";
+import { Feedback } from "../../../../../routes/feedback";
 
 export const mockFeedback: Feedback[] = [
   {
@@ -34,6 +34,7 @@ export const mockFeedback: Feedback[] = [
       'This service is a work in progress, any feedback you share about your experience will help us to improve it.\n<br>\n<br>\nDon\'t share any personal or financial information in your feedback. If you do we will act according to our <a href="">privacy policy</a>',
     projectType: null,
     status: "unread",
+    editorNotes: "This is important!",
   },
   {
     address: null,
@@ -61,6 +62,7 @@ export const mockFeedback: Feedback[] = [
     nodeText: null,
     projectType: null,
     status: "read",
+    editorNotes: "No action needed",
   },
   {
     address: null,
@@ -88,6 +90,7 @@ export const mockFeedback: Feedback[] = [
     nodeText: null,
     projectType: null,
     status: "urgent",
+    editorNotes: "Let's do something about this",
   },
   {
     address: null,
@@ -115,6 +118,7 @@ export const mockFeedback: Feedback[] = [
     nodeText: null,
     projectType: null,
     status: "to_follow_up",
+    editorNotes: "No action needed",
   },
   {
     address: null,
@@ -142,6 +146,7 @@ export const mockFeedback: Feedback[] = [
     nodeText: null,
     projectType: null,
     status: "unread",
+    editorNotes: null,
   },
   {
     address: null,
@@ -169,6 +174,7 @@ export const mockFeedback: Feedback[] = [
     nodeText: null,
     projectType: null,
     status: "read",
+    editorNotes: "Let's take some action here - BB",
   },
   {
     address: null,
@@ -196,5 +202,6 @@ export const mockFeedback: Feedback[] = [
     nodeText: null,
     projectType: null,
     status: "urgent",
+    editorNotes: null,
   },
 ];

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/queries/updateEditorNotes.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/queries/updateEditorNotes.ts
@@ -1,0 +1,27 @@
+import gql from "graphql-tag";
+import { client } from "lib/graphql";
+import { Feedback } from "routes/feedback";
+
+export const updateEditorNotes = async (updatedRow: Feedback) => {
+  await client.mutate({
+    mutation: gql`
+      mutation UpdateEditorNotes($id: Int!, $editor_notes: String) {
+        update_feedback_by_pk(
+          pk_columns: { id: $id }
+          _set: { editor_notes: $editor_notes }
+        ) {
+          id
+        }
+      }
+    `,
+    variables: {
+      id: updatedRow.id,
+      editor_notes: updatedRow.editorNotes,
+    },
+    update: (cache) => {
+      // As we're reading from feedback_summary but pushing an update to feedback, we need to manually invalidate Apollo's cache
+      cache.evict({ fieldName: "feedback_summary" });
+      cache.gc();
+    },
+  });
+};

--- a/editor.planx.uk/src/routes/feedback.tsx
+++ b/editor.planx.uk/src/routes/feedback.tsx
@@ -38,6 +38,7 @@ export interface Feedback {
   nodeText: string | null;
   projectType: string | null;
   status: FeedbackStatus;
+  editorNotes: string | null;
 }
 
 const feedbackRoutes = compose(

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -29,6 +29,7 @@ export const DataTable = <T,>({
   rows,
   columns,
   csvExportFileName,
+  onProcessRowUpdate,
 }: DataGridProps<T>) => {
   const renderCellComponentByType = (
     params: RenderCellParams,
@@ -128,6 +129,8 @@ export const DataTable = <T,>({
           slots={{
             toolbar: CustomToolbar,
           }}
+          getRowId={(row) => row.id}
+          processRowUpdate={onProcessRowUpdate}
         />
       </Box>
     </Box>

--- a/editor.planx.uk/src/ui/shared/DataTable/types.ts
+++ b/editor.planx.uk/src/ui/shared/DataTable/types.ts
@@ -39,4 +39,5 @@ export interface DataGridProps<T> {
   rows: readonly T[] | undefined;
   columns: Array<ColumnConfig<T>>;
   csvExportFileName?: string;
+  onProcessRowUpdate?: (updatedRow: T) => void;
 }

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -371,8 +371,10 @@
       permission:
         columns:
           - address
+          - application_type
           - created_at
           - device
+          - editor_notes
           - feedback_id
           - feedback_score
           - feedback_type
@@ -386,13 +388,13 @@
           - node_title
           - node_type
           - project_type
+          - service_name
           - service_slug
           - status
           - team_slug
           - uprn
           - user_comment
           - user_context
-          - service_name
         filter:
           team:
             flows:
@@ -402,59 +404,61 @@
     - role: platformAdmin
       permission:
         columns:
-          - feedback_id
-          - feedback_score
-          - device
-          - node_data
           - address
           - application_type
+          - created_at
+          - device
+          - editor_notes
+          - feedback_id
+          - feedback_score
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
+          - node_data
           - node_id
           - node_text
           - node_title
           - node_type
           - project_type
+          - service_name
           - service_slug
           - status
           - team_slug
           - uprn
           - user_comment
           - user_context
-          - created_at
-          - service_name
         filter: {}
       comment: ""
     - role: teamEditor
       permission:
         columns:
-          - feedback_id
-          - feedback_score
-          - device
-          - node_data
           - address
           - application_type
+          - created_at
+          - device
+          - editor_notes
+          - feedback_id
+          - feedback_score
           - feedback_type
           - help_definition
           - help_sources
           - help_text
           - intersecting_constraints
+          - node_data
           - node_id
           - node_text
           - node_title
           - node_type
           - project_type
+          - service_name
           - service_slug
           - status
           - team_slug
           - uprn
           - user_comment
           - user_context
-          - created_at
-          - service_name
         filter:
           team:
             members:


### PR DESCRIPTION
## What does this PR do?
 - Build on @ianjon3s's UI work in https://github.com/theopensystemslab/planx-new/pull/4489
 - Adds `feedback.editor_notes` column
 - Updates UI to write to this column

### To test
Feedback added to B&D already - https://4495.planx.pizza/barking-and-dagenham

The "Editor notes" column can be edited, and the data will persist.

https://github.com/user-attachments/assets/21efc871-47dc-41eb-a4bd-a406401b7e1f

