### PR TITLE
fix: Filterable single selects in data grid

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -1,19 +1,13 @@
 import Typography from "@mui/material/Typography";
-import { GridFilterItem } from "@mui/x-data-grid";
 import { format } from "date-fns";
 import capitalize from "lodash/capitalize";
 import React from "react";
 import { Feedback } from "routes/feedback";
 import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContainer";
 import SettingsSection from "ui/editor/SettingsSection";
-import { MultipleOptionSelectFilter } from "ui/shared/DataTable/components/MultipleOptionSelectFilter";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
-import {
-  containsItem,
-  dateFormatter,
-  isValidFilterInput,
-} from "ui/shared/DataTable/utils";
+import { dateFormatter } from "ui/shared/DataTable/utils";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
@@ -60,33 +54,9 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       field: "type",
       headerName: "Type",
       width: 200,
-      type: ColumnFilterType.ARRAY,
+      type: ColumnFilterType.SINGLE_SELECT,
       columnOptions: {
-        valueOptions: feedbackTypeOptions.map((option) => option.label),
-        filterOperators: [
-          {
-            value: "is",
-            getApplyFilterFn: (filterItem: GridFilterItem) => {
-              if (!isValidFilterInput(filterItem)) {
-                return null;
-              }
-              // return a function that is applied to all the rows in turn
-              return (currentRowValue: any): boolean => {
-                return filterItem.value.some(
-                  (filterValue: Pick<GridFilterItem, "value">) =>
-                    containsItem(
-                      feedbackTypeText(currentRowValue),
-                      filterValue,
-                    ),
-                );
-              };
-            },
-            InputComponent: MultipleOptionSelectFilter,
-            InputComponentProps: {
-              options: feedbackTypeOptions.map((option) => option.label),
-            },
-          },
-        ],
+        valueOptions: feedbackTypeOptions,
       },
       customComponent: (params) => <>{feedbackTypeText(params.value)}</>,
     },

--- a/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
@@ -68,7 +68,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
       field: "eventType",
       headerName: "Event",
       width: 230,
-      type: ColumnFilterType.ARRAY,
+      type: ColumnFilterType.SINGLE_SELECT,
       customComponent: SubmissionEvent,
       columnOptions: {
         valueOptions: submissionEventTypes,
@@ -78,7 +78,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
       field: "status",
       headerName: "Status",
       width: 125,
-      type: ColumnFilterType.ARRAY,
+      type: ColumnFilterType.SINGLE_SELECT,
       customComponent: StatusChip,
       columnOptions: {
         valueOptions: submissionStatusOptions,

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.stories.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.stories.tsx
@@ -36,6 +36,8 @@ export const Basic = {
         type: ColumnFilterType.ARRAY,
         columnOptions: {
           valueOptions: liveFlowValueOptions,
+          sortable: false,
+          filterOperators: arrayFilterOperators(liveFlowValueOptions),
         },
       },
       {

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -20,7 +20,7 @@ import {
 } from "./types";
 import {
   columnCellComponentRegistry,
-  createFilterOperator,
+  createArrayFilterOperator,
   getColumnFilterType,
   getValueOptions,
 } from "./utils";
@@ -80,21 +80,18 @@ export const DataTable = <T,>({
         : undefined,
     };
 
-    return column.type === ColumnFilterType.ARRAY
-      ? {
-          ...baseColDef,
-          valueOptions: columnValueOptions,
-          filterOperators:
-            columnValueOptions &&
-            columnValueOptions.length > 0 &&
-            createFilterOperator(columnValueOptions),
-          ...column.columnOptions,
-        }
-      : {
-          ...baseColDef,
-          valueOptions: undefined,
-          ...column.columnOptions,
-        };
+    const gridColDef = {
+      ...baseColDef,
+      valueOptions: columnValueOptions,
+      ...column.columnOptions,
+    };
+
+    if (column.type === ColumnFilterType.ARRAY && columnValueOptions?.length) {
+      gridColDef.filterOperators =
+        createArrayFilterOperator(columnValueOptions);
+    }
+
+    return gridColDef;
   }) as GridColDef[];
 
   const handleFilterChange = (model: GridFilterModel) => {

--- a/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
@@ -58,7 +58,6 @@ export function MultipleOptionSelectFilter<T>(props: Props<T>) {
           setChipData(value);
           return applyValue({ ...item, value });
         }}
-        value={item.value}
       />
     </FormControl>
   );

--- a/editor.planx.uk/src/ui/shared/DataTable/types.ts
+++ b/editor.planx.uk/src/ui/shared/DataTable/types.ts
@@ -7,7 +7,17 @@ import {
 
 export const ColumnFilterType = {
   BOOLEAN: "boolean",
-  ARRAY: "singleSelect", // when the column can be filtered from a range of known values
+  /**
+   * Custom data type for columns containing an array of strings
+   * Filters are customised to match single select behaviour - values within the array are treated as a discrete list
+   */
+  ARRAY: "array",
+  /**
+   * Column contains an discrete set of values
+   * Filters default to "is", "is not" vs "contains", "does not contain"
+   * Docs: https://mui.com/x/react-data-grid/column-definition/#special-properties
+   */
+  SINGLE_SELECT: "singleSelect",
   DATE: "date",
   CUSTOM: "custom",
 } as const;

--- a/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/utils.tsx
@@ -32,7 +32,9 @@ export const containsItem = (
   return false;
 };
 
-export const createFilterOperator = (columnValueOptions: ValueOptions[]) => [
+export const createArrayFilterOperator = (
+  columnValueOptions: ValueOptions[],
+) => [
   {
     value: "is",
     getApplyFilterFn: (filterItem: GridFilterItem) => {
@@ -40,23 +42,14 @@ export const createFilterOperator = (columnValueOptions: ValueOptions[]) => [
         return null;
       }
 
-      // return a function that is applied to all the rows in turn
       return (currentRowValue: string[]): boolean => {
-        if (!currentRowValue?.length) {
-          return false;
-        }
+        if (!currentRowValue?.length) return false;
 
-        return Array.isArray(currentRowValue)
-          ? currentRowValue.some((arrayItem) =>
-              filterItem.value.some(
-                (filterValue: Pick<GridFilterItem, "value">) =>
-                  containsItem(arrayItem, filterValue),
-              ),
-            )
-          : filterItem.value.some(
-              (filterValue: Pick<GridFilterItem, "value">) =>
-                containsItem(currentRowValue, filterValue),
-            );
+        return currentRowValue.some((arrayItem) =>
+          filterItem.value.some((filterValue: Pick<GridFilterItem, "value">) =>
+            containsItem(arrayItem, filterValue),
+          ),
+        );
       };
     },
     InputComponent: MultipleOptionSelectFilter,
@@ -86,6 +79,7 @@ export const columnCellComponentRegistry = {
     value ? <True /> : <False />,
   [ColumnFilterType.DATE]: () => undefined, // use default MUI data grid behaviour
   [ColumnFilterType.CUSTOM]: () => undefined,
+  [ColumnFilterType.SINGLE_SELECT]: () => undefined,
   [ColumnFilterType.ARRAY]: (value: string[], filterValues?: string[]) => {
     return (
       <Box component="ol" padding={0} margin={0} sx={{ listStyleType: "none" }}>
@@ -109,9 +103,10 @@ export const getColumnFilterType = (columnType?: ColumnRenderType) => {
       return "boolean";
     case ColumnFilterType.DATE:
       return "date";
-    case ColumnFilterType.ARRAY:
+    case ColumnFilterType.SINGLE_SELECT:
       return "singleSelect";
     case ColumnFilterType.CUSTOM:
+    case ColumnFilterType.ARRAY:
       return undefined;
     default:
       return undefined;


### PR DESCRIPTION
## What's the problem?
Whilst working on #4492 I realised that the `singleSelect` behaviour wasn't working as expected. This is due to changes made in https://github.com/theopensystemslab/planx-new/pull/4453. This is currently using a "contains" instead of an equals match which lead to filter options with "read" being a substring of "unread".

> [!IMPORTANT]
> If there's context from the week I was away or #4453 that I'm missing (i.e. another example of broken filtering?) please let me know!

Here's my understanding of the data model, and how I've managed this in this PR - 

**Single select**
This is a native MUI datagrid column type. It's used for enums (strings) and changes filters to is/is not/is any of.

![image](https://github.com/user-attachments/assets/48fb6f81-24cc-4a2b-820d-919a5e34c0bb)

By setting a column to have a type of `singleSelect`, we get this behaviour out of the box.

**Array**
This is a custom data type which is PlanX specific. It's used for the list of live services in the admin panel as this is an list of services, contained within a single "parent" (the team). We want to treat this column as an enum (filter by discrete name, not using string matching - e.g. "contains", "does not contain" etc).

As it's a custom type, we need custom filters to manage the behaviour.

## What's the solution?
- Create custom filter for our custom `ARRAY` column type
- Revert actual enum columns to `SINGLE_SELECT`

The main benefits here are that all single selects will be easily filterable using standard MUI functionality, and will not need any custom filter options - this was the issue I hit in #4492. Out custom `ARRAY` column does require custom filter operators.

## To test
 - I can filter Admin Panel > Services as expected (same behaviour as staging) ([link](https://4496.planx.pizza/))
 - I can filter Submissions Log > Status as expected (same behaviour as staging) ([link](https://storybook.4496.planx.pizza/?path=/docs/editor-components-submissions-events-log--docs))
   - Additionally, "is not" and "is one of" are added back as options 

