### PR TITLE
feat: Add online status chip to header

### DIFF
--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -1,12 +1,11 @@
-import Edit from "@mui/icons-material/Edit";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import OpenInNewOffIcon from "@mui/icons-material/OpenInNewOff";
 import Person from "@mui/icons-material/Person";
-import Visibility from "@mui/icons-material/Visibility";
 import AppBar from "@mui/material/AppBar";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import { grey } from "@mui/material/colors";
 import Container from "@mui/material/Container";
@@ -40,6 +39,8 @@ import {
   LINE_HEIGHT_BASE,
 } from "theme";
 import { ApplicationPath } from "types";
+import FlowTag from "ui/editor/FlowTag/FlowTag";
+import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
 import Reset from "ui/icons/Reset";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
@@ -55,7 +56,7 @@ const Root = styled(AppBar)(({ theme }) => ({
   color: theme.palette.common.white,
 }));
 
-const BreadcrumbsRoot = styled(Box)(() => ({
+const BreadcrumbsRoot = styled(Box)(({ theme }) => ({
   cursor: "pointer",
   fontSize: 20,
   display: "flex",
@@ -90,12 +91,13 @@ const InnerContainer = styled(Box)(() => ({
   justifyContent: "space-between",
 }));
 
-const LeftBox = styled(Box)(() => ({
+const LeftBox = styled(Box)(({ theme }) => ({
   display: "flex",
   flexGrow: 1,
   flexShrink: 0,
   flexBasis: "140px",
   justifyContent: "start",
+  gap: theme.spacing(1.5),
 }));
 
 const RightBox = styled(Box)(() => ({
@@ -232,57 +234,69 @@ const Breadcrumbs: React.FC = () => {
   ]);
 
   return (
-    <BreadcrumbsRoot>
-      <BreadcrumbsLink
-        component={ReactNaviLink}
-        href={"/"}
-        prefetch={false}
-        {...(isStandalone && { target: "_blank" })}
-        variant="body1"
-      >
-        Plan✕
-      </BreadcrumbsLink>
-      {team.slug && (
-        <>
-          {" / "}
-          <BreadcrumbsLink
-            component={ReactNaviLink}
-            href={`/${team.slug}`}
-            prefetch={false}
-            {...(isStandalone && { target: "_blank" })}
-            variant="body1"
-          >
-            {team.slug}
-          </BreadcrumbsLink>
-        </>
-      )}
+    <>
+      <BreadcrumbsRoot>
+        <BreadcrumbsLink
+          component={ReactNaviLink}
+          href={"/"}
+          prefetch={false}
+          {...(isStandalone && { target: "_blank" })}
+          variant="body1"
+        >
+          Plan✕
+        </BreadcrumbsLink>
+        {team.slug && (
+          <>
+            {" / "}
+            <BreadcrumbsLink
+              component={ReactNaviLink}
+              href={`/${team.slug}`}
+              prefetch={false}
+              {...(isStandalone && { target: "_blank" })}
+              variant="body1"
+            >
+              {team.slug}
+            </BreadcrumbsLink>
+          </>
+        )}
+        {route.data.flow && (
+          <>
+            {" / "}
+            <Link
+              style={{
+                color: "#fff",
+                textDecoration: "none",
+              }}
+              component={ReactNaviLink}
+              href={rootFlowPath(false)}
+              prefetch={false}
+              variant="body1"
+            >
+              {route.data.flow}
+            </Link>
+          </>
+        )}
+      </BreadcrumbsRoot>
       {route.data.flow && (
         <>
-          {" / "}
-          <Link
-            style={{
-              color: "#fff",
+          <Button
+            variant="link"
+            href="/service"
+            sx={(theme) => ({
+              color: theme.palette.text.primary,
               textDecoration: "none",
-            }}
-            component={ReactNaviLink}
-            href={rootFlowPath(false)}
-            prefetch={false}
-            variant="body1"
+            })}
           >
-            {route.data.flow}
-          </Link>
+            <FlowTag
+              tagType={FlowTagType.Status}
+              statusVariant={StatusVariant.Online}
+            >
+              Online
+            </FlowTag>
+          </Button>
         </>
       )}
-      {route.data.flow && (
-        <>
-          {useStore.getState().canUserEditTeam(team.slug) ? (
-            <Edit fontSize="small" />
-          ) : (
-            <Visibility fontSize="small" />
-          )}
-        </>
-      )}
-    </BreadcrumbsRoot>
+    </>
   );
 };
 

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -21,6 +21,7 @@ import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { FlowStatus } from "@opensystemslab/planx-core/types";
 import axios from "axios";
 import { clearLocalFlow } from "lib/local";
 import { capitalize } from "lodash";
@@ -57,7 +58,7 @@ const Root = styled(AppBar)(({ theme }) => ({
   color: theme.palette.common.white,
 }));
 
-const BreadcrumbsRoot = styled(Box)(({ theme }) => ({
+const BreadcrumbsRoot = styled(Box)(() => ({
   cursor: "pointer",
   fontSize: 20,
   display: "flex",
@@ -234,6 +235,10 @@ const Breadcrumbs: React.FC = () => {
     state.previewEnvironment === "standalone",
   ]);
 
+  const flowStatus = useStore.getState().status as StatusVariant | undefined;
+
+  console.log(flowStatus);
+
   return (
     <>
       <BreadcrumbsRoot>
@@ -278,6 +283,20 @@ const Breadcrumbs: React.FC = () => {
           </>
         )}
       </BreadcrumbsRoot>
+      {route.data.flow && (
+        <Button
+          variant="link"
+          href={`/${team.slug}/${route.data.flow}/service`}
+          sx={(theme) => ({
+            color: theme.palette.text.primary,
+            textDecoration: "none",
+          })}
+        >
+          <FlowTag tagType={FlowTagType.Status} statusVariant={flowStatus}>
+            {flowStatus}
+          </FlowTag>
+        </Button>
+      )}
     </>
   );
 };
@@ -453,21 +472,13 @@ const ServiceTitle: React.FC = () => {
   );
 };
 
-interface EditorToolbarProps {
+const EditorToolbar: React.FC<{
   headerRef: React.RefObject<HTMLElement>;
   route: Route;
-  flow: FlowSummary;
-}
-
-const EditorToolbar: React.FC<EditorToolbarProps> = ({ headerRef, flow }) => {
+}> = ({ headerRef }) => {
   const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
   const [user, token] = useStore((state) => [state.getUser(), state.jwt]);
-
-  const statusVariant =
-    flow?.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
-
-  console.log(statusVariant);
 
   const handleClose = () => {
     setOpen(false);
@@ -492,23 +503,6 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({ headerRef, flow }) => {
           <InnerContainer>
             <LeftBox>
               <Breadcrumbs />
-              {flow && (
-                <Button
-                  variant="link"
-                  href="/testing/online-offline-test/service"
-                  sx={(theme) => ({
-                    color: theme.palette.text.primary,
-                    textDecoration: "none",
-                  })}
-                >
-                  <FlowTag
-                    tagType={FlowTagType.Status}
-                    statusVariant={statusVariant}
-                  >
-                    {statusVariant}
-                  </FlowTag>
-                </Button>
-              )}
             </LeftBox>
             <RightBox>
               {user && (
@@ -578,10 +572,9 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({ headerRef, flow }) => {
 
 interface ToolbarProps {
   headerRef: RefObject<HTMLDivElement>;
-  flow: FlowSummary;
 }
 
-const Toolbar: React.FC<ToolbarProps> = ({ headerRef, flow }) => {
+const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
   const route = useCurrentRoute();
   const path = route.url.pathname.split("/").slice(-1)[0] || undefined;
   const [flowSlug, previewEnvironment] = useStore((state) => [
@@ -595,13 +588,7 @@ const Toolbar: React.FC<ToolbarProps> = ({ headerRef, flow }) => {
     path !== "draft" &&
     path !== "preview"
   ) {
-    return (
-      <EditorToolbar
-        headerRef={headerRef}
-        route={route}
-        flow={flow}
-      ></EditorToolbar>
-    );
+    return <EditorToolbar headerRef={headerRef} route={route}></EditorToolbar>;
   }
 
   switch (path) {

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -282,19 +282,24 @@ const Breadcrumbs: React.FC = () => {
         )}
       </BreadcrumbsRoot>
       {route.data.flow && (
-        <Button
-          variant="link"
-          href={`/${team.slug}/${route.data.flow}/service`}
-          title="Update service status"
-          sx={(theme) => ({
-            color: theme.palette.text.primary,
-            textDecoration: "none",
-          })}
-        >
-          <FlowTag tagType={FlowTagType.Status} statusVariant={flowStatus}>
-            {flowStatus}
-          </FlowTag>
-        </Button>
+        <Box sx={(theme) => ({ color: theme.palette.text.primary })}>
+          {useStore.getState().canUserEditTeam(team.slug) ? (
+            <Button
+              variant="link"
+              href={`/${team.slug}/${route.data.flow}/service`}
+              title="Update service status"
+              sx={{ textDecoration: "none" }}
+            >
+              <FlowTag tagType={FlowTagType.Status} statusVariant={flowStatus}>
+                {flowStatus}
+              </FlowTag>
+            </Button>
+          ) : (
+            <FlowTag tagType={FlowTagType.Status} statusVariant={flowStatus}>
+              {flowStatus}
+            </FlowTag>
+          )}
+        </Box>
       )}
     </>
   );

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -21,13 +21,11 @@ import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { FlowStatus } from "@opensystemslab/planx-core/types";
 import axios from "axios";
 import { clearLocalFlow } from "lib/local";
 import { capitalize } from "lodash";
 import { Route } from "navi";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { RefObject, useRef, useState } from "react";
 import {
   Link as ReactNaviLink,
@@ -235,7 +233,9 @@ const Breadcrumbs: React.FC = () => {
     state.previewEnvironment === "standalone",
   ]);
 
-  const flowStatus = useStore((state) => state.status);
+  const flowStatus = useStore((state) => state.status) as
+    | StatusVariant
+    | undefined;
 
   return (
     <>

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -40,7 +40,7 @@ import {
 } from "theme";
 import { ApplicationPath } from "types";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
-import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
+import { FlowTagType } from "ui/editor/FlowTag/types";
 import Reset from "ui/icons/Reset";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
@@ -233,9 +233,7 @@ const Breadcrumbs: React.FC = () => {
     state.previewEnvironment === "standalone",
   ]);
 
-  const flowStatus = useStore((state) => state.status) as
-    | StatusVariant
-    | undefined;
+  const flowStatus = useStore((state) => state.flowStatus);
 
   return (
     <>

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -235,9 +235,7 @@ const Breadcrumbs: React.FC = () => {
     state.previewEnvironment === "standalone",
   ]);
 
-  const flowStatus = useStore.getState().status as StatusVariant | undefined;
-
-  console.log(flowStatus);
+  const flowStatus = useStore((state) => state.status);
 
   return (
     <>

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -26,6 +26,7 @@ import { clearLocalFlow } from "lib/local";
 import { capitalize } from "lodash";
 import { Route } from "navi";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { RefObject, useRef, useState } from "react";
 import {
   Link as ReactNaviLink,
@@ -277,25 +278,6 @@ const Breadcrumbs: React.FC = () => {
           </>
         )}
       </BreadcrumbsRoot>
-      {route.data.flow && (
-        <>
-          <Button
-            variant="link"
-            href="/testing/online-offline-test/service"
-            sx={(theme) => ({
-              color: theme.palette.text.primary,
-              textDecoration: "none",
-            })}
-          >
-            <FlowTag
-              tagType={FlowTagType.Status}
-              statusVariant={StatusVariant.Online}
-            >
-              Online
-            </FlowTag>
-          </Button>
-        </>
-      )}
     </>
   );
 };
@@ -471,13 +453,21 @@ const ServiceTitle: React.FC = () => {
   );
 };
 
-const EditorToolbar: React.FC<{
+interface EditorToolbarProps {
   headerRef: React.RefObject<HTMLElement>;
   route: Route;
-}> = ({ headerRef }) => {
+  flow: FlowSummary;
+}
+
+const EditorToolbar: React.FC<EditorToolbarProps> = ({ headerRef, flow }) => {
   const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
   const [user, token] = useStore((state) => [state.getUser(), state.jwt]);
+
+  const statusVariant =
+    flow?.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
+
+  console.log(statusVariant);
 
   const handleClose = () => {
     setOpen(false);
@@ -502,6 +492,23 @@ const EditorToolbar: React.FC<{
           <InnerContainer>
             <LeftBox>
               <Breadcrumbs />
+              {flow && (
+                <Button
+                  variant="link"
+                  href="/testing/online-offline-test/service"
+                  sx={(theme) => ({
+                    color: theme.palette.text.primary,
+                    textDecoration: "none",
+                  })}
+                >
+                  <FlowTag
+                    tagType={FlowTagType.Status}
+                    statusVariant={statusVariant}
+                  >
+                    {statusVariant}
+                  </FlowTag>
+                </Button>
+              )}
             </LeftBox>
             <RightBox>
               {user && (
@@ -571,9 +578,10 @@ const EditorToolbar: React.FC<{
 
 interface ToolbarProps {
   headerRef: RefObject<HTMLDivElement>;
+  flow: FlowSummary;
 }
 
-const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
+const Toolbar: React.FC<ToolbarProps> = ({ headerRef, flow }) => {
   const route = useCurrentRoute();
   const path = route.url.pathname.split("/").slice(-1)[0] || undefined;
   const [flowSlug, previewEnvironment] = useStore((state) => [
@@ -587,7 +595,13 @@ const Toolbar: React.FC<ToolbarProps> = ({ headerRef }) => {
     path !== "draft" &&
     path !== "preview"
   ) {
-    return <EditorToolbar headerRef={headerRef} route={route}></EditorToolbar>;
+    return (
+      <EditorToolbar
+        headerRef={headerRef}
+        route={route}
+        flow={flow}
+      ></EditorToolbar>
+    );
   }
 
   switch (path) {

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -281,7 +281,7 @@ const Breadcrumbs: React.FC = () => {
         <>
           <Button
             variant="link"
-            href="/service"
+            href="/testing/online-offline-test/service"
             sx={(theme) => ({
               color: theme.palette.text.primary,
               textDecoration: "none",

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -287,6 +287,7 @@ const Breadcrumbs: React.FC = () => {
         <Button
           variant="link"
           href={`/${team.slug}/${route.data.flow}/service`}
+          title="Update service status"
           sx={(theme) => ({
             color: theme.palette.text.primary,
             textDecoration: "none",

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -10,7 +10,7 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 
 interface FlowEditorData {
   id: string;
-  status: FlowStatus;
+  flowStatus: FlowStatus;
   flowAnalyticsLink: string;
   templatedFrom: string;
   isTemplate: boolean;
@@ -69,7 +69,7 @@ export const getFlowEditorData = async (
 
   const flowEditorData: FlowEditorData = {
     id: flow.id,
-    status: flow.status,
+    flowStatus: flow.status,
     flowAnalyticsLink: flow.flowAnalyticsLink,
     templatedFrom: flow.templatedFrom,
     isTemplate: flow.isTemplate,
@@ -86,7 +86,7 @@ export const flowEditorView = async (req: NaviRequest) => {
   const [flow] = req.params.flow.split(",");
   const {
     id,
-    status,
+    flowStatus,
     flowAnalyticsLink,
     isFlowPublished,
     isTemplate,
@@ -95,7 +95,7 @@ export const flowEditorView = async (req: NaviRequest) => {
 
   useStore.setState({
     id,
-    status,
+    flowStatus,
     flowAnalyticsLink,
     isFlowPublished,
     isTemplate,

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import { FlowStatus } from "@opensystemslab/planx-core/types";
 import { NaviRequest, NotFoundError } from "navi";
 import FlowEditorLayout from "pages/layout/FlowEditorLayout";
 import React from "react";
@@ -9,7 +10,7 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 
 interface FlowEditorData {
   id: string;
-  status: string;
+  status: FlowStatus;
   flowAnalyticsLink: string;
   templatedFrom: string;
   isTemplate: boolean;
@@ -19,7 +20,7 @@ interface FlowEditorData {
 interface GetFlowEditorData {
   flows: {
     id: string;
-    status: string;
+    status: FlowStatus;
     flowAnalyticsLink: string;
     templatedFrom: string;
     isTemplate: boolean;

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -9,6 +9,7 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 
 interface FlowEditorData {
   id: string;
+  status: string;
   flowAnalyticsLink: string;
   templatedFrom: string;
   isTemplate: boolean;
@@ -18,6 +19,7 @@ interface FlowEditorData {
 interface GetFlowEditorData {
   flows: {
     id: string;
+    status: string;
     flowAnalyticsLink: string;
     templatedFrom: string;
     isTemplate: boolean;
@@ -43,6 +45,7 @@ export const getFlowEditorData = async (
           where: { slug: { _eq: $slug }, team: { slug: { _eq: $team_slug } } }
         ) {
           id
+          status
           flowAnalyticsLink: analytics_link
           templatedFrom: templated_from
           isTemplate: is_template
@@ -65,6 +68,7 @@ export const getFlowEditorData = async (
 
   const flowEditorData: FlowEditorData = {
     id: flow.id,
+    status: flow.status,
     flowAnalyticsLink: flow.flowAnalyticsLink,
     templatedFrom: flow.templatedFrom,
     isTemplate: flow.isTemplate,
@@ -79,11 +83,18 @@ export const getFlowEditorData = async (
  */
 export const flowEditorView = async (req: NaviRequest) => {
   const [flow] = req.params.flow.split(",");
-  const { id, flowAnalyticsLink, isFlowPublished, isTemplate, templatedFrom } =
-    await getFlowEditorData(flow, req.params.team);
+  const {
+    id,
+    status,
+    flowAnalyticsLink,
+    isFlowPublished,
+    isTemplate,
+    templatedFrom,
+  } = await getFlowEditorData(flow, req.params.team);
 
   useStore.setState({
     id,
+    status,
     flowAnalyticsLink,
     isFlowPublished,
     isTemplate,


### PR DESCRIPTION
## What does this PR do?

Trello ticket:
https://trello.com/c/Nm29gakJ/3152-clarify-and-simplify-publishing-and-turning-a-service-online-offline

Appends an online/offline chip to the breadcrumbs of a flow when in the flow view (including settings pages):

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/36d80c9d-c0c9-47a2-b0be-378eee827a26" />


The chip can be clicked to reach the settings page, where the status can be updated.

**Testing:**
https://4497.planx.pizza/barnet/apply-for-prior-approval