### PR TITLE
feat: Filter `FeedbackLog` by rating, node type/title, and help text

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -110,9 +110,8 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       headerName: "Help text (more information)",
       width: 280,
       type: ColumnFilterType.CUSTOM,
-      customComponent: ExpandableHelpText,
+      customComponent: (params) => <ExpandableHelpText {...params} />,
       columnOptions: {
-        filterable: false, // TODO: make filterable
         valueFormatter: (params) => stripHTMLTags(params),
       },
     },

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -96,13 +96,9 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       field: "nodeType",
       headerName: "Where",
       width: 280,
-      type: ColumnFilterType.CUSTOM,
       customComponent: (params) => (
         <>{`${params.value} - ${params.row.nodeTitle}`}</>
       ),
-      columnOptions: {
-        filterable: false, // TODO: make filterable
-      },
     },
     {
       field: "userContext",

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -73,9 +73,9 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
       field: "feedbackScore",
       headerName: "Rating",
       width: 125,
+      type: ColumnFilterType.SINGLE_SELECT,
       columnOptions: {
-        filterable: false, // TODO: make filterable
-        valueFormatter: (params) => EmojiRating[params],
+        valueOptions: EmojiRating,
       },
     },
     {

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.tsx
@@ -2,13 +2,13 @@ import { Feedback, FeedbackStatus } from "routes/feedback";
 
 import { FeedbackType } from "./types";
 
-export const EmojiRating: Record<number, string> = {
-  1: "Terrible",
-  2: "Poor",
-  3: "Neutral",
-  4: "Good",
-  5: "Excellent",
-};
+export const EmojiRating = [
+  { value: 1, label: "Terrible" },
+  { value: 2, label: "Poor" },
+  { value: 3, label: "Neutral" },
+  { value: 4, label: "Good" },
+  { value: 5, label: "Excellent" },
+];
 
 export const feedbackTypeText = (type: FeedbackType) => {
   switch (type) {


### PR DESCRIPTION
## What does this PR do?
 - Addresses outstanding "TODO" comments on `FeedbackLog`
 - Allows filtering by rating, node type, and help text (see code for more details on some caveats here)
 - Relies on https://github.com/theopensystemslab/planx-new/pull/4496