### PR TITLE
chore: Update values for `feedback_status_enum`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/StatusChip.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/StatusChip.tsx
@@ -8,8 +8,8 @@ import { feedbackStatusText } from "../utils";
 const FEEDBACK_COLOURS: Record<FeedbackStatus, ChipProps["color"]> = {
   unread: "info",
   urgent: "error",
-  to_follow_up: "warning",
-  read: "success",
+  in_progress: "warning",
+  actioned: "success",
 };
 
 export const StatusChip = (

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/feedbackFilterOptions.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/feedbackFilterOptions.tsx
@@ -29,7 +29,7 @@ export type StatusOption = {
 };
 
 export const statusOptions: StatusOption[] = (
-  ["unread", "read", "to_follow_up", "urgent"] as const
+  ["unread", "actioned", "in_progress", "urgent"] as const
 ).map((type) => ({
   value: type,
   label: feedbackStatusText[type],

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
@@ -61,7 +61,7 @@ export const mockFeedback: Feedback[] = [
     nodeId: "5SuQhstVL5",
     nodeText: null,
     projectType: null,
-    status: "read",
+    status: "actioned",
     editorNotes: "No action needed",
   },
   {
@@ -117,7 +117,7 @@ export const mockFeedback: Feedback[] = [
     nodeId: "5SuQhstVL5",
     nodeText: null,
     projectType: null,
-    status: "to_follow_up",
+    status: "in_progress",
     editorNotes: "No action needed",
   },
   {
@@ -173,7 +173,7 @@ export const mockFeedback: Feedback[] = [
     nodeId: "5SuQhstVL5",
     nodeText: null,
     projectType: null,
-    status: "read",
+    status: "actioned",
     editorNotes: "Let's take some action here - BB",
   },
   {

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.tsx
@@ -32,8 +32,8 @@ export const feedbackTypeText = (type: FeedbackType) => {
 export const feedbackStatusText: Record<FeedbackStatus, string> = {
   unread: "Unread",
   urgent: "Urgent",
-  to_follow_up: "To follow up",
-  read: "Read",
+  actioned: "Actioned",
+  in_progress: "In progress",
 };
 
 export const getCombinedHelpText = (feedback: Feedback) => {

--- a/editor.planx.uk/src/routes/feedback.tsx
+++ b/editor.planx.uk/src/routes/feedback.tsx
@@ -15,7 +15,7 @@ import { makeTitle } from "./utils";
 type FeedbackType = Sentiment | FeedbackCategory;
 
 /** Matches feedback_status_enum table */
-export type FeedbackStatus = "unread" | "read" | "to_follow_up" | "urgent";
+export type FeedbackStatus = "unread" | "in_progress" | "urgent" | "actioned";
 
 export interface Feedback {
   id: number;

--- a/hasura.planx.uk/migrations/1742568175451_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1742568175451_run_sql_migration/down.sql
@@ -1,0 +1,7 @@
+DELETE FROM "public"."feedback_status_enum" WHERE value = 'in_progress';
+DELETE FROM "public"."feedback_status_enum" WHERE value = 'actioned';
+
+INSERT INTO "public"."feedback_status_enum"("value", "comment") 
+VALUES 
+  (E'read', E'Feedback has been actioned'),
+  (E'to_follow_up', E'Further action required');

--- a/hasura.planx.uk/migrations/1742568175451_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1742568175451_run_sql_migration/up.sql
@@ -1,0 +1,7 @@
+DELETE FROM "public"."feedback_status_enum" WHERE value = 'to_follow_up';
+DELETE FROM "public"."feedback_status_enum" WHERE value = 'read';
+
+INSERT INTO "public"."feedback_status_enum"("value", "comment") 
+VALUES 
+  (E'in_progress', E'Feedback is currently being investigated'),
+  (E'actioned', E'Feedback has been actioned');


### PR DESCRIPTION
## What does this PR do?
- Updates values for `feedback.status`
  - "read" → "actioned"
  - "to_follow_up" → "in_progress"
- Please see here for full context (OSL Slack) - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1742552488002169

Once these PRs have merged to production, I'll manually run the SQL to set the status of all existing feedback to "actioned".