### PR TITLE
feat: add Planning Data links to team menus

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -4,6 +4,7 @@ import FactCheckIcon from "@mui/icons-material/FactCheck";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
 import Info from "@mui/icons-material/Info";
+import LayersIcon from "@mui/icons-material/Layers";
 import LeaderboardIcon from "@mui/icons-material/Leaderboard";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
 import PaletteIcon from "@mui/icons-material/Palette";
@@ -24,15 +25,16 @@ function EditorNavMenu() {
   const { navigate } = useNavigation();
   const { url } = useCurrentRoute();
   const isRouteLoading = useLoadingRoute();
-  const [teamSlug, flowSlug, flowAnalyticsLink, role, flowId] = useStore(
+  const [teamSlug, flowSlug, flowAnalyticsLink, role, team] = useStore(
     (state) => [
       state.teamSlug,
       state.flowSlug,
       state.flowAnalyticsLink,
       state.getUserRoleForCurrentTeam(),
-      state.id,
+      state.getTeam(),
     ],
   );
+  const referenceCode = team?.settings?.referenceCode;
 
   const isActive = (route: string) => url.href.endsWith(route);
 
@@ -123,9 +125,16 @@ function EditorNavMenu() {
       route: `/${teamSlug}/submissions`,
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
+    {
+      title: referenceCode ? `Planning Data (external link)` : `Planning Data unavailable`,
+      Icon: LayersIcon,
+      route: referenceCode ? `https://submit.planning.data.gov.uk/organisations/local-authority:${referenceCode}` : `#`,
+      accessibleBy: "*",
+      disabled: !referenceCode,
+    },
   ];
 
-  const flowLayoutRoutesMain: Route[] = [
+  const flowLayoutRoutes: Route[] = [
     {
       title: "Editor",
       Icon: EditorIcon,
@@ -156,30 +165,13 @@ function EditorNavMenu() {
       route: `/${teamSlug}/${flowSlug}/submissions`,
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
-  ];
-
-  const flowAnalyticsRoute: Route[] = flowAnalyticsLink
-    ? [
-        {
-          title: "Analytics (external link)",
-          Icon: LeaderboardIcon,
-          route: flowAnalyticsLink,
-          accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
-        },
-      ]
-    : [
-        {
-          title: "Analytics page unavailable",
-          Icon: LeaderboardIcon,
-          route: "#",
-          accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
-          disabled: true,
-        },
-      ];
-
-  const flowLayoutRoutes: Route[] = [
-    ...flowLayoutRoutesMain,
-    ...flowAnalyticsRoute,
+    {
+      title: flowAnalyticsLink ? `Analytics (external link)` : `Analytics page unavailable`,
+      Icon: LeaderboardIcon,
+      route: flowAnalyticsLink ? flowAnalyticsLink : `#`,
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
+      disabled: !flowAnalyticsLink,
+    }
   ];
 
   const defaultRoutes: RoutesForURL = {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ReferenceCodeForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/ReferenceCodeForm.tsx
@@ -16,8 +16,8 @@ export default function ReferenceCodeForm({
 }: FormProps) {
   const formSchema = Yup.object().shape({
     referenceCode: Yup.string()
-      .min(3, "Code must be 3 characters long")
-      .max(3, "Code must be 3 characters long")
+      .min(3, "Code must be at least 3 characters long")
+      .max(5, "Code cannot exceed 5 characters long")
       .required("Enter a reference code"),
   });
 
@@ -45,11 +45,11 @@ export default function ReferenceCodeForm({
       description={
         <>
           <Typography variant="body2">
-            Your local authority reference code is required for submissions.
-            This is a unique three-letter code per local authority.
+            Your local authority reference code is required for submissions and GIS integrations.
+            This is a unique three to five-letter code per local authority.
           </Typography>
           <Typography variant="body2">
-            The reference code can be found from Planning Data at:{" "}
+            Find your reference code on Planning Data at:{" "}
             <Link
               href="https://www.planning.data.gov.uk/entity/?dataset=local-authority"
               target="_blank"


### PR DESCRIPTION
A small follow-on from recent Planning Data chats https://opensystemslab.slack.com/archives/C5Q59R3HB/p1742576902272549?thread_ts=1738141256.409859&cid=C5Q59R3HB

For "council" teams, we can link directly to the Planning Data ["organisation page"](https://submit.planning.data.gov.uk/organisations) about their data health
![Screenshot from 2025-03-22 12-13-51](https://github.com/user-attachments/assets/afb7acbf-109d-4b45-8c47-909bf48b36dc)
![Screenshot from 2025-03-22 12-14-13](https://github.com/user-attachments/assets/d1dac4d7-6ed2-4a6d-9cbb-295b582b7a51)
In the future, if we get programmatic access to PD's statuses like "needs fixing" or "errors", we can imagine further adding status badges to these menu links to inform councils they have data issues which may impact their PlanX services :crystal_ball: 

