### PR TITLE
fix(permissions): Use post-update check for `flow.team_id` column

### DIFF
--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1070,7 +1070,12 @@
                 _is_null: true
             - is_template:
                 _eq: false
-        check: {}
+        check:
+          _and:
+            - team_id:
+                _eq: 32
+            - creator_id:
+                _eq: x-hasura-user-id
         validate_input:
           definition:
             forward_client_headers: false
@@ -1134,7 +1139,15 @@
                 _is_null: true
             - is_template:
                 _eq: false
-        check: {}
+        check:
+          _and:
+            - team:
+                members:
+                  _and:
+                    - user_id:
+                        _eq: x-hasura-user-id
+                    - role:
+                        _eq: teamEditor
         validate_input:
           definition:
             forward_client_headers: false


### PR DESCRIPTION
## Context
I encountered a logical error in our permission setup for the "move flow" operation when working on the feature to restrict who can copy flow ([Trello ticket](https://trello.com/c/91QhXdFy/3156-permissions-editors-can-decide-which-flows-are-copiable-by-others-and-which-ones-are-not)).

Full details of the issue I hit on this ticket here - https://trello.com/c/91QhXdFy#comment-67e14c99dd37b0322afe8a50

## What's the problem?
This made me realise that we're checking a user's access to the _current_ team when running the "move flow" operation - not the destination team they're copying into.

It's currently possible on `main` to take the following set of actions via the API - 
 - Have a user that is only teamEditor for "Team A"
 - Move a copy to "Team B" (which the user does not have access to)
 - Move is successful ❌ 
 
 You can test this via the frontend by commenting out the following frontend guard code -
 
 https://github.com/theopensystemslab/planx-new/blob/1a26b88c0d5d26ec4abd3b6b7e908452752804f7/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts#L507-L513
 
 ## What's the solution?
Add an additional post-update check to ensure that the modified flow is still within a team which the user has `teamEditor` permission for.
 
This works as we're now checking permissions for the _destination_ team - this applies when modifying the `team_id` value (the "move flow" operation) or any other column - only operations where the user has permissions on the post-update team will succeed.

I can't think of other situations where we need to change to a post-update check to stop a similar action - it really only applies when we're modifying the `team_id` of a model (which I think would just be flows).