### PR TITLE
style: List manager add row style update

### DIFF
--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -1,4 +1,4 @@
-import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import AddIcon from "@mui/icons-material/Add";
 import Delete from "@mui/icons-material/Delete";
 import DragHandle from "@mui/icons-material/DragHandle";
 import Box from "@mui/material/Box";
@@ -9,7 +9,7 @@ import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { arrayMoveImmutable } from "array-move";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import {
   DragDropContext,
   Draggable,
@@ -51,16 +51,16 @@ const InsertButtonRoot = styled(ButtonBase)(({ theme }) => ({
   paddingLeft: theme.spacing(3),
   paddingRight: theme.spacing(2),
   width: "100%",
-  height: theme.spacing(2.5),
-  "& svg": {
-    color: theme.palette.text.secondary,
-    transition: "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
-  },
-  "&:hover svg": {
-    color: theme.palette.primary.main,
-  },
-  "&:hover hr": {
+  height: theme.spacing(3),
+  color: theme.palette.grey[600],
+  transition:
+    "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), color 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
+  "&:hover": {
     opacity: 1,
+    color: theme.palette.primary.main,
+    "& hr": {
+      opacity: 1,
+    },
   },
 }));
 
@@ -68,23 +68,30 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
   border: `1px dashed ${theme.palette.primary.main}`,
   width: "91%",
   opacity: 0,
-  transition: "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
+  transition: "inherit",
 }));
 
 const InsertButton: React.FC<{
   handleClick: () => void;
   disabled: boolean;
-}> = ({ handleClick, disabled }) => (
-  <InsertButtonRoot
-    onClick={handleClick}
-    disabled={disabled}
-    disableRipple
-    tabIndex={-1}
-  >
-    <StyledDivider variant="middle" />
-    <AddCircleOutlineIcon sx={{ transform: `translateX(-6px)` }} />
-  </InsertButtonRoot>
-);
+  isDragging: boolean;
+}> = ({ handleClick, disabled, isDragging }) => {
+  return (
+    <InsertButtonRoot
+      onClick={handleClick}
+      disabled={disabled}
+      disableRipple
+      tabIndex={-1}
+      sx={{
+        opacity: isDragging ? 0 : 1,
+        visibility: isDragging ? "hidden" : "visible",
+      }}
+    >
+      <StyledDivider variant="middle" />
+      <AddIcon sx={{ transform: `translateX(-6px)` }} />
+    </InsertButtonRoot>
+  );
+};
 
 export default function ListManager<T, EditorExtraProps>(
   props: Props<T, EditorExtraProps>,
@@ -97,6 +104,7 @@ export default function ListManager<T, EditorExtraProps>(
   const teamSlug = window.location.pathname.split("/")[1];
   const isViewOnly = !useStore.getState().canUserEditTeam(teamSlug);
   const isMaxLength = props.values.length >= maxItems;
+  const [isDragging, setIsDragging] = useState(false);
 
   return props.noDragAndDrop ? (
     <>
@@ -141,7 +149,9 @@ export default function ListManager<T, EditorExtraProps>(
     </>
   ) : (
     <DragDropContext
+      onDragStart={() => setIsDragging(true)}
       onDragEnd={(dropResult: DropResult) => {
+        setIsDragging(false);
         if (!dropResult.source || !dropResult.destination) {
           return;
         }
@@ -168,6 +178,7 @@ export default function ListManager<T, EditorExtraProps>(
                           insertAt(index, props.newValue(), props.values),
                         );
                       }}
+                      isDragging={isDragging}
                     />
                   )}
                   <Draggable

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -48,20 +48,27 @@ const Item = styled(Box)(({ theme }) => ({
 
 const InsertButtonRoot = styled(ButtonBase)(({ theme }) => ({
   justifyContent: "space-between",
-  paddingLeft: theme.spacing(1.5),
-  paddingRight: theme.spacing(3),
+  paddingLeft: theme.spacing(3),
+  paddingRight: theme.spacing(2),
   width: "100%",
-  height: theme.spacing(2),
-  opacity: 0,
-  transition: "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
-  "&:hover": {
+  height: theme.spacing(2.5),
+  "& svg": {
+    color: theme.palette.text.secondary,
+    transition: "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
+  },
+  "&:hover svg": {
+    color: theme.palette.primary.main,
+  },
+  "&:hover hr": {
     opacity: 1,
   },
 }));
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
-  border: `1px solid ${theme.palette.primary.main}`,
-  width: "90%",
+  border: `1px dashed ${theme.palette.primary.main}`,
+  width: "91%",
+  opacity: 0,
+  transition: "opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
 }));
 
 const InsertButton: React.FC<{
@@ -74,8 +81,8 @@ const InsertButton: React.FC<{
     disableRipple
     tabIndex={-1}
   >
-    <AddCircleOutlineIcon color="primary" fontSize="small" sx={{ mr: -0.5 }} />
     <StyledDivider variant="middle" />
+    <AddCircleOutlineIcon sx={{ transform: `translateX(-6px)` }} />
   </InsertButtonRoot>
 );
 


### PR DESCRIPTION
## What does this PR do?

Updates styling of the list manager "insert" function:

- Keep the "add" symbol visible but simplify to a plus symbol to reduce visual noise
- Instinctively it feels like the left-side drag column should be kept free of any other interactions as it interacts in a vertical sense, so move the add icon to the right-side, so it sits with remove

Testing:
https://4512.planx.pizza/testing/long-checklist