### PR TITLE
style: Menu icon alignment

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -126,9 +126,13 @@ function EditorNavMenu() {
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
     {
-      title: referenceCode ? `Planning Data (external link)` : `Planning Data unavailable`,
+      title: referenceCode
+        ? `Planning Data (external link)`
+        : `Planning Data unavailable`,
       Icon: LayersIcon,
-      route: referenceCode ? `https://submit.planning.data.gov.uk/organisations/local-authority:${referenceCode}` : `#`,
+      route: referenceCode
+        ? `https://submit.planning.data.gov.uk/organisations/local-authority:${referenceCode}`
+        : `#`,
       accessibleBy: "*",
       disabled: !referenceCode,
     },
@@ -166,12 +170,14 @@ function EditorNavMenu() {
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
     },
     {
-      title: flowAnalyticsLink ? `Analytics (external link)` : `Analytics page unavailable`,
+      title: flowAnalyticsLink
+        ? `Analytics (external link)`
+        : `Analytics page unavailable`,
       Icon: LeaderboardIcon,
       route: flowAnalyticsLink ? flowAnalyticsLink : `#`,
       accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
       disabled: !flowAnalyticsLink,
-    }
+    },
   ];
 
   const defaultRoutes: RoutesForURL = {
@@ -241,7 +247,9 @@ function EditorNavMenu() {
                 onClick={() => handleClick(route, disabled)}
               >
                 <Icon fontSize="small" />
-                <MenuTitle variant="body3">{title}</MenuTitle>
+                <MenuTitle variant="body3" pt={0.15}>
+                  {title}
+                </MenuTitle>
               </MenuButton>
             )}
           </MenuItem>

--- a/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
@@ -1,26 +1,8 @@
-import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
-import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
-import FactCheckIcon from "@mui/icons-material/FactCheck";
-import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
-import GroupIcon from "@mui/icons-material/Group";
-import Info from "@mui/icons-material/Info";
-import LeaderboardIcon from "@mui/icons-material/Leaderboard";
-import MenuBookIcon from "@mui/icons-material/MenuBook";
-import PaletteIcon from "@mui/icons-material/Palette";
-import RateReviewIcon from "@mui/icons-material/RateReview";
-import SchoolIcon from "@mui/icons-material/School";
-import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
-import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { Role } from "@opensystemslab/planx-core/types";
-import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useRef } from "react";
-import { useCurrentRoute, useLoadingRoute, useNavigation } from "react-navi";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
-import EditorIcon from "ui/icons/Editor";
 
 const MENU_WIDTH_COMPACT = "51px";
 const MENU_WIDTH_FULL = "164px";
@@ -50,6 +32,7 @@ export const MenuItem = styled("li")(({ theme }) => ({
 export const MenuTitle = styled(Typography)(({ theme }) => ({
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
   paddingLeft: theme.spacing(0.5),
+  paddingTop: theme.spacing(0.1),
   textAlign: "left",
 })) as typeof Typography;
 
@@ -60,6 +43,7 @@ export const MenuButton = styled(IconButton, {
   width: "100%",
   border: "1px solid transparent",
   justifyContent: "flex-start",
+  alignItems: "flex-start",
   borderRadius: "3px",
   "&:hover": {
     background: theme.palette.common.white,


### PR DESCRIPTION
## What does this PR do?

Quick one:

- Updates editor menu icon/text alignment to accommodate multiple lines of text
- Removes redundant imports

Before (left) vs after (right):
![image](https://github.com/user-attachments/assets/d7e7791d-e293-4dca-a5bc-808552758bcf)
