### PR TITLE
feat: Transitions for `ListManager` items

### DIFF
--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -43,6 +43,7 @@
     "@turf/bbox-polygon": "^7.0.0",
     "@turf/buffer": "^7.0.0",
     "@turf/helpers": "^7.0.0",
+    "@types/react-transition-group": "^4.4.12",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "array-move": "^4.0.0",
     "axios": "^1.8.3",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -81,6 +81,7 @@
     "react-navi": "^0.15.0",
     "react-navi-helmet-async": "^0.15.0",
     "react-toastify": "^9.1.3",
+    "react-transition-group": "^4.4.5",
     "react-use": "^17.5.0",
     "react-virtuoso": "^4.10.4",
     "reconnecting-websocket": "^4.4.0",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -245,6 +245,9 @@ dependencies:
   react-toastify:
     specifier: ^9.1.3
     version: 9.1.3(react-dom@18.2.0)(react@18.2.0)
+  react-transition-group:
+    specifier: ^4.4.5
+    version: 4.4.5(react-dom@18.2.0)(react@18.2.0)
   react-use:
     specifier: ^17.5.0
     version: 17.5.0(react-dom@18.2.0)(react@18.2.0)
@@ -4382,7 +4385,7 @@ packages:
       '@storybook/csf': 0.1.13
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@types/lodash': 4.14.202
+      '@types/lodash': 4.17.16
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
@@ -5593,7 +5596,6 @@ packages:
 
   /@types/lodash@4.17.16:
     resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
-    dev: false
 
   /@types/markdown-it@14.1.2:
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -131,6 +131,9 @@ dependencies:
   '@turf/helpers':
     specifier: ^7.0.0
     version: 7.0.0
+  '@types/react-transition-group':
+    specifier: ^4.4.12
+    version: 4.4.12(@types/react@18.2.45)
   '@vitejs/plugin-react-swc':
     specifier: ^3.7.0
     version: 3.7.0(vite@5.4.6)

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -171,7 +171,9 @@ describe("Pay component - Editor Modal", () => {
       expect(finalDeleteButton).toBeDefined();
 
       await user.click(finalDeleteButton);
-      expect(getAllByLabelText("Delete")).toHaveLength(3);
+      await waitFor(() => {
+        expect(getAllByLabelText("Delete")).toHaveLength(3);
+      });
 
       // Required to trigger submission outside the context of FormModal component
       fireEvent.submit(getByRole("form"));

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -4,10 +4,12 @@ import DragHandle from "@mui/icons-material/DragHandle";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonBase from "@mui/material/ButtonBase";
+import Collapse from "@mui/material/Collapse";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { arrayMoveImmutable } from "array-move";
+import { nanoid } from "nanoid";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useRef, useState } from "react";
 import {
@@ -18,6 +20,7 @@ import {
   DroppableProvided,
   DropResult,
 } from "react-beautiful-dnd";
+import { TransitionGroup } from "react-transition-group";
 
 import { insertAt, removeAt, setAt } from "../../../utils";
 
@@ -98,7 +101,13 @@ export default function ListManager<T, EditorExtraProps>(
 ) {
   const { Editor, maxItems = Infinity } = props;
   // Initialize a random ID when the component mounts
-  const randomId = useRef(String(Math.random()));
+  const randomId = useRef(nanoid());
+
+  // Unique keys are required for transition group
+  // Index is an unstable key because new items can be inserted into the list
+  const [itemKeys, setItemKeys] = useState<string[]>(
+    props.values.map(() => nanoid()),
+  );
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
@@ -109,38 +118,44 @@ export default function ListManager<T, EditorExtraProps>(
   return props.noDragAndDrop ? (
     <>
       <Box>
-        {props.values.map((item, index) => {
-          return (
-            <Item key={index}>
-              <Editor
-                index={index}
-                value={item}
-                onChange={(newItem) => {
-                  props.onChange(setAt(index, newItem, props.values));
-                }}
-                {...(props.editorExtraProps || {})}
-              />
-              <Box sx={{ display: "flex", alignItems: "flex-start" }}>
-                <IconButton
-                  onClick={() => {
-                    props.onChange(removeAt(index, props.values));
+        <TransitionGroup>
+          {props.values.map((item, index) => (
+            <Collapse key={itemKeys[index]}>
+              <Item>
+                <Editor
+                  index={index}
+                  value={item}
+                  onChange={(newItem) => {
+                    props.onChange(setAt(index, newItem, props.values));
                   }}
-                  aria-label="Delete"
-                  size="large"
-                  disabled={isViewOnly || props?.isFieldDisabled?.(item, index)}
-                >
-                  <Delete />
-                </IconButton>
-              </Box>
-            </Item>
-          );
-        })}
+                  {...(props.editorExtraProps || {})}
+                />
+                <Box sx={{ display: "flex", alignItems: "flex-start" }}>
+                  <IconButton
+                    onClick={() => {
+                      props.onChange(removeAt(index, props.values));
+                      setItemKeys((prev) => prev.filter((_, i) => i !== index));
+                    }}
+                    aria-label="Delete"
+                    size="large"
+                    disabled={
+                      isViewOnly || props?.isFieldDisabled?.(item, index)
+                    }
+                  >
+                    <Delete />
+                  </IconButton>
+                </Box>
+              </Item>
+            </Collapse>
+          ))}
+        </TransitionGroup>
       </Box>
       <Button
         sx={{ mt: 2 }}
         size="large"
         onClick={() => {
           props.onChange([...props.values, props.newValue()]);
+          setItemKeys((prev) => [...prev, nanoid()]);
         }}
         disabled={isViewOnly || isMaxLength}
       >
@@ -162,78 +177,98 @@ export default function ListManager<T, EditorExtraProps>(
             dropResult.destination.index,
           ),
         );
+
+        // Adjust keys when dragging
+        setItemKeys((prev) => {
+          const newKeys = [...prev];
+          const [movedKey] = newKeys.splice(dropResult.source.index, 1);
+          newKeys.splice(dropResult!.destination!.index!, 0, movedKey);
+          return newKeys;
+        });
       }}
     >
       <Droppable droppableId={randomId.current}>
         {(provided: DroppableProvided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
-            {props.values.map((item, index) => {
-              return (
-                <React.Fragment key={index}>
-                  {Boolean(index) && (
-                    <InsertButton
-                      disabled={isViewOnly || isMaxLength}
-                      handleClick={() => {
-                        props.onChange(
-                          insertAt(index, props.newValue(), props.values),
-                        );
-                      }}
-                      isDragging={isDragging}
-                    />
-                  )}
-                  <Draggable
-                    draggableId={String(index)}
-                    index={index}
-                    key={index}
-                  >
-                    {(provided: DraggableProvided) => (
-                      <Item
-                        {...provided.draggableProps}
-                        ref={provided.innerRef}
-                      >
-                        <Box>
-                          <IconButton
-                            disableRipple
-                            {...(props.noDragAndDrop
-                              ? { disabled: true || isViewOnly }
-                              : provided.dragHandleProps)}
-                            aria-label="Drag"
-                            size="large"
-                            disabled={isViewOnly}
-                          >
-                            <DragHandle />
-                          </IconButton>
-                        </Box>
-                        <Editor
-                          index={index}
-                          value={item}
-                          onChange={(newItem) => {
-                            props.onChange(setAt(index, newItem, props.values));
-                          }}
-                          {...(props.editorExtraProps || {})}
-                        />
-                        <Box>
-                          <IconButton
-                            onClick={() => {
-                              props.onChange(removeAt(index, props.values));
-                            }}
-                            aria-label="Delete"
-                            size="large"
-                            disabled={
-                              isViewOnly ||
-                              props?.isFieldDisabled?.(item, index)
-                            }
-                          >
-                            <Delete />
-                          </IconButton>
-                        </Box>
-                      </Item>
+            <TransitionGroup>
+              {props.values.map((item, index) => (
+                <Collapse key={itemKeys[index]}>
+                  <Box>
+                    {Boolean(index) && (
+                      <InsertButton
+                        disabled={isViewOnly || isMaxLength}
+                        handleClick={() => {
+                          props.onChange(
+                            insertAt(index, props.newValue(), props.values),
+                          );
+                          setItemKeys((prev) => {
+                            const newKeys = [...prev];
+                            newKeys.splice(index, 0, nanoid());
+                            return newKeys;
+                          });
+                        }}
+                        isDragging={isDragging}
+                      />
                     )}
-                  </Draggable>
-                </React.Fragment>
-              );
-            })}
-            {provided.placeholder}
+                    <Draggable
+                      draggableId={String(index)}
+                      index={index}
+                      key={index}
+                    >
+                      {(provided: DraggableProvided) => (
+                        <Item
+                          {...provided.draggableProps}
+                          ref={provided.innerRef}
+                        >
+                          <Box>
+                            <IconButton
+                              disableRipple
+                              {...(props.noDragAndDrop
+                                ? { disabled: true || isViewOnly }
+                                : provided.dragHandleProps)}
+                              aria-label="Drag"
+                              size="large"
+                              disabled={isViewOnly}
+                            >
+                              <DragHandle />
+                            </IconButton>
+                          </Box>
+                          <Editor
+                            index={index}
+                            value={item}
+                            onChange={(newItem) => {
+                              props.onChange(
+                                setAt(index, newItem, props.values),
+                              );
+                            }}
+                            {...(props.editorExtraProps || {})}
+                          />
+                          <Box>
+                            <IconButton
+                              onClick={() => {
+                                props.onChange(removeAt(index, props.values));
+                                setItemKeys((prev) =>
+                                  prev.filter((_, i) => i !== index),
+                                );
+                              }}
+                              aria-label="Delete"
+                              size="large"
+                              disabled={
+                                isViewOnly ||
+                                props?.isFieldDisabled?.(item, index)
+                              }
+                            >
+                              <Delete />
+                            </IconButton>
+                          </Box>
+                        </Item>
+                      )}
+                    </Draggable>
+                  </Box>
+                </Collapse>
+              ))}
+              {provided.placeholder}
+            </TransitionGroup>
           </Box>
         )}
       </Droppable>
@@ -241,6 +276,7 @@ export default function ListManager<T, EditorExtraProps>(
         size="medium"
         onClick={() => {
           props.onChange([...props.values, props.newValue()]);
+          setItemKeys((prev) => [...prev, nanoid()]);
         }}
         disabled={isViewOnly || isMaxLength}
       >

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -42,11 +42,8 @@ export interface Props<T, EditorExtraProps = {}> {
   maxItems?: number;
 }
 
-const Item = styled(Box)(({ theme }) => ({
+const Item = styled(Box)(() => ({
   display: "flex",
-  "&:last-child": {
-    marginBottom: theme.spacing(2),
-  },
 }));
 
 const InsertButtonRoot = styled(ButtonBase)(({ theme }) => ({
@@ -274,6 +271,7 @@ export default function ListManager<T, EditorExtraProps>(
       </Droppable>
       <Button
         size="medium"
+        sx={{ mt: 2 }}
         onClick={() => {
           props.onChange([...props.values, props.newValue()]);
           setItemKeys((prev) => [...prev, nanoid()]);


### PR DESCRIPTION
## What does this PR do?
- Wraps ListManager items in a `TransitionGroup` ([docs](https://mui.com/material-ui/transitions/?srsltid=AfmBOop3o4bTsmlAoTgIOOUVIe6M1j3v_MQCXpB1eE9J301tFhhmMvOO#transitiongroup))
- Adds unique keys to each item, and a `Collapse` transition (other ideas welcome!)

https://github.com/user-attachments/assets/9197ea70-089f-4849-8d22-afea78708c84
