### PR TITLE
fix: Remove `FileUploadAndLabel` divider

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -1,6 +1,5 @@
 import RuleIcon from "@mui/icons-material/Rule";
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -126,13 +125,13 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
 
   // Rather than default to generic `useStore().getFlowSchema()`
   //   File Upload components can specifically suggest based on ODP Schema enum options
-  let schema = getValidSchemaValues("FileType") || [];
+  const schema = getValidSchemaValues("FileType") || [];
   // Additionally ensure that existing initial values are supported & pre-populated on load
   if (props.value.fn && !schema?.includes(props.value.fn))
     schema.push(props.value.fn);
 
   return (
-    <Box sx={{ flex: 1 }} data-testid="rule-list-manager">
+    <Box sx={{ flex: 1, mb: 2 }} data-testid="rule-list-manager">
       <ModalSubtitle title="File" />
       <InputRow>
         <Input
@@ -149,9 +148,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
         required
         schema={schema}
         value={props.value.fn}
-        onChange={(value) => 
-          props.onChange(merge(props.value, { fn: value }))
-        }
+        onChange={(value) => props.onChange(merge(props.value, { fn: value }))}
       />
       <ModalSubtitle title="Rule" />
       <InputRow>
@@ -264,7 +261,6 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
           />
         </InputRowItem>
       </InputRow>
-      <Divider sx={{ mb: 2, mt: 4 }} />
     </Box>
   );
 }


### PR DESCRIPTION
## What does this PR do?
Removes the `Divider` element between `FileUploadAndLabel` items, in favour of whitespace. This is now updated as we have the "hover" interaction to insert new items.

There's maybe an argument that this could be managed by something like a `density` prop into the `ListManager` to make this more generic. Something to think about if we need to do this again!


| State | Before | After |
|--------|--------|--------|
| No hover |![image](https://github.com/user-attachments/assets/d9b6e83e-9449-4aee-b040-9e1c28b5c022)|![image](https://github.com/user-attachments/assets/2b37d4f8-ffa8-42e7-bacf-2280959a8e11)|
| Hover |![image](https://github.com/user-attachments/assets/2a509dc9-5141-43e7-8ab7-a3633557ec60)|![image](https://github.com/user-attachments/assets/1ef41141-c509-43cf-9424-c8fc2f0f0fe1)| 