### PR TITLE
feat: Create flow from new, copy, or template

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -72,8 +72,7 @@ test.describe("Flow creation, publish and preview", () => {
 
     const editor = new PlaywrightEditor(page);
 
-    page.on("dialog", (dialog) => dialog.accept(serviceProps.name));
-    await editor.addNewService();
+    await editor.addNewService({ name: serviceProps.name });
 
     await editor.createFindProperty();
     await expect(editor.nodeList).toContainText(["Find property"]);

--- a/e2e/tests/ui-driven/src/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow.spec.ts
@@ -68,8 +68,7 @@ test.describe("Flow creation, publish and preview", () => {
 
     const editor = new PlaywrightEditor(page);
 
-    page.on("dialog", (dialog) => dialog.accept(serviceProps.name));
-    await editor.addNewService();
+    await editor.addNewService({ name: serviceProps.name });
 
     // update context to allow flow to be torn down
     context.flow = { ...serviceProps };
@@ -165,10 +164,7 @@ test.describe("Flow creation, publish and preview", () => {
 
     const editor = new PlaywrightEditor(page);
 
-    page.on("dialog", (dialog) =>
-      dialog.accept(externalPortalServiceProps.name),
-    );
-    await editor.addNewService();
+    await editor.addNewService({ name: externalPortalServiceProps.name });
 
     // update context to allow new flow to be torn down
     context.externalPortalFlow = { ...externalPortalServiceProps };

--- a/e2e/tests/ui-driven/src/pages/Editor.ts
+++ b/e2e/tests/ui-driven/src/pages/Editor.ts
@@ -34,7 +34,6 @@ import { selectedFlag } from "../helpers/globalHelpers.js";
 
 export class PlaywrightEditor {
   readonly page: Page;
-  readonly addNewServiceButton: Locator;
   readonly firstNode: Locator;
   readonly yesBranch: Locator;
   readonly noBranch: Locator;
@@ -47,9 +46,6 @@ export class PlaywrightEditor {
 
   constructor(page: Page) {
     this.page = page;
-    this.addNewServiceButton = page.locator("button", {
-      hasText: "Add a new service",
-    });
     this.firstNode = page.locator("li.hanger > a").first();
     this.yesBranch = page.locator("#flow .card .options .option").nth(0);
     this.noBranch = page.locator("#flow .card .options .option").nth(1);
@@ -62,8 +58,24 @@ export class PlaywrightEditor {
     };
   }
 
-  async addNewService() {
-    await this.addNewServiceButton.click();
+  async addNewService({
+    name,
+    mode = "new",
+  }: {
+    name: string;
+    mode?: "new" | "copy" | "template";
+  }) {
+    const openModalButton = this.page.locator("button", {
+      hasText: "Add a new service",
+    });
+    await openModalButton.click();
+
+    if (mode !== "new") {
+      throw Error("Unsupported mode for create flow");
+    }
+
+    this.page.getByLabel("Service name").fill(name);
+    this.page.getByRole("button", { name: "Add service " }).click();
   }
 
   async createQuestion() {

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -1,5 +1,6 @@
 import InputAdornment from "@mui/material/InputAdornment";
 import MenuItem from "@mui/material/MenuItem";
+import { typographyClasses } from "@mui/material/Typography";
 import { useFormikContext } from "formik";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput/SelectInput";
@@ -8,6 +9,25 @@ import Input from "ui/shared/Input/Input";
 import { slugify } from "utils";
 
 import { CREATE_FLOW_MODES, CreateFlow } from "./types";
+
+const URLPrefix: React.FC = () => {
+  const { origin, pathname } = window.location;
+  const urlPrefix = `${origin}${pathname}/`;
+
+  return (
+    <InputAdornment
+      position="start"
+      sx={(theme) => ({
+        mr: 0,
+        [`& .${typographyClasses.root}`]: {
+          color: theme.palette.text.disabled,
+        },
+      })}
+    >
+      {urlPrefix}
+    </InputAdornment>
+  );
+};
 
 export const BaseFormSection: React.FC = () => {
   const { values, setFieldValue, getFieldProps, errors } =
@@ -62,14 +82,7 @@ export const BaseFormSection: React.FC = () => {
           disabled
           id="flow.slug"
           type="text"
-          // TODO: Custom subdomains?
-          // TODO: Font colours
-          // TODO: Correctly format
-          startAdornment={
-            <InputAdornment position="start" sx={{ mr: 0 }}>
-              https://test.com/team/
-            </InputAdornment>
-          }
+          startAdornment={<URLPrefix />}
         />
       </InputLabel>
     </>

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -1,0 +1,78 @@
+import InputAdornment from "@mui/material/InputAdornment";
+import MenuItem from "@mui/material/MenuItem";
+import { useFormikContext } from "formik";
+import React from "react";
+import SelectInput from "ui/editor/SelectInput/SelectInput";
+import InputLabel from "ui/public/InputLabel";
+import Input from "ui/shared/Input/Input";
+import { slugify } from "utils";
+
+import { CREATE_FLOW_MODES, CreateFlow } from "./types";
+
+export const BaseFormSection: React.FC = () => {
+  const { values, setFieldValue, getFieldProps, errors } =
+    useFormikContext<CreateFlow>();
+
+  return (
+    <>
+      <InputLabel
+        label="How do you want to create a new service?"
+        id="create-flow-mode"
+      >
+        <SelectInput
+          value={values.mode}
+          name="mode"
+          bordered
+          required={true}
+          title={"How do you want to create a new service?"}
+          labelId="create-flow-mode"
+          onChange={(e) => {
+            setFieldValue("mode", e.target.value);
+            setFieldValue("flow.source.id", undefined);
+          }}
+        >
+          {CREATE_FLOW_MODES.map(({ mode, title }) => (
+            <MenuItem
+              key={mode}
+              value={mode}
+              // TODO: Enable "copy" and "template" modes
+              disabled={mode !== "new"}
+            >
+              {title}
+            </MenuItem>
+          ))}
+        </SelectInput>
+      </InputLabel>
+      <InputLabel label="Service name" htmlFor="flow.name">
+        <Input
+          {...getFieldProps("flow.name")}
+          id="flow.name"
+          type="text"
+          onChange={(e) => {
+            setFieldValue("flow.name", e.target.value);
+            setFieldValue("flow.slug", slugify(e.target.value));
+          }}
+          errorMessage={errors.flow?.name}
+          value={values.flow?.name}
+        />
+      </InputLabel>
+      <InputLabel label="Service URL" htmlFor="flow.slug">
+        <Input
+          {...getFieldProps("flow.slug")}
+          disabled
+          id="flow.slug"
+          type="text"
+          // TODO: Custom subdomains?
+          // TODO: Font colours
+          // TODO: Correctly format
+          startAdornment={
+            <InputAdornment position="start" sx={{ mr: 0 }}>
+              https://test.com/team/
+            </InputAdornment>
+          }
+          errorMessage={errors.flow?.slug}
+        />
+      </InputLabel>
+    </>
+  );
+};

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -70,7 +70,6 @@ export const BaseFormSection: React.FC = () => {
               https://test.com/team/
             </InputAdornment>
           }
-          errorMessage={errors.flow?.slug}
         />
       </InputLabel>
     </>

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromCopyFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromCopyFormSection.tsx
@@ -1,0 +1,37 @@
+import MenuItem from "@mui/material/MenuItem";
+import { useFormikContext } from "formik";
+import React from "react";
+import SelectInput from "ui/editor/SelectInput/SelectInput";
+import InputLabel from "ui/public/InputLabel";
+
+import { CreateFlow } from "./types";
+
+export const CreateFromCopyFormSection: React.FC = () => {
+  const { values, setFieldValue } = useFormikContext<CreateFlow>();
+
+  if (values.mode !== "copy") return null;
+
+  // TODO: Fetch data
+  const copiableFlows: { id: string; flowName: string; teamName: string }[] =
+    [];
+
+  return (
+    <InputLabel label="Available flows" id="available-flow-select">
+      <SelectInput
+        value={values.flow.sourceId}
+        name="mode"
+        bordered
+        required={true}
+        title={"Available flows"}
+        labelId="available-flow-select"
+        onChange={(e) => setFieldValue("flow.source.id", e.target.value)}
+      >
+        {copiableFlows.map(({ id, flowName, teamName }) => (
+          <MenuItem key={id} value={id}>
+            {`${teamName} - ${flowName}`}
+          </MenuItem>
+        ))}
+      </SelectInput>
+    </InputLabel>
+  );
+};

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
@@ -1,0 +1,37 @@
+import MenuItem from "@mui/material/MenuItem";
+import { useFormikContext } from "formik";
+import React from "react";
+import SelectInput from "ui/editor/SelectInput/SelectInput";
+import InputLabel from "ui/public/InputLabel";
+
+import { CreateFlow } from "./types";
+
+export const CreateFromTemplateFormSection: React.FC = () => {
+  const { values, setFieldValue } = useFormikContext<CreateFlow>();
+
+  if (values.mode !== "template") return null;
+
+  // TODO: Fetch data
+  const templateForms: { id: string; flowName: string; teamName: string }[] =
+    [];
+
+  return (
+    <InputLabel label="Available templates" id="available-templates-select">
+      <SelectInput
+        value={values.flow.sourceId}
+        name="mode"
+        bordered
+        required={true}
+        title={"Available templates"}
+        labelId="available-templates-select"
+        onChange={(e) => setFieldValue("flow.source.id", e.target.value)}
+      >
+        {templateForms.map(({ id, flowName, teamName }) => (
+          <MenuItem key={id} value={id}>
+            {`${teamName} - ${flowName}`}
+          </MenuItem>
+        ))}
+      </SelectInput>
+    </InputLabel>
+  );
+};

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -1,0 +1,99 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog, { dialogClasses } from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { Form, Formik, FormikConfig } from "formik";
+import React, { useState } from "react";
+import { AddButton } from "ui/editor/AddButton";
+
+import { BaseFormSection } from "./BaseFormSection";
+import { CreateFromCopyFormSection } from "./CreateFromCopyFormSection";
+import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
+import { CreateFlow } from "./types";
+
+// TODO: Standardise or share this
+export const StyledDialog = styled(Dialog)(({ theme }) => ({
+  [`& .${dialogClasses.paper}`]: {
+    width: "100%",
+    maxWidth: theme.breakpoints.values.md,
+    borderRadius: 0,
+    borderTop: `20px solid ${theme.palette.primary.main}`,
+    background: theme.palette.background.paper,
+    margin: theme.spacing(2),
+  },
+}));
+
+export const AddFlow: React.FC = () => {
+  const initialValues: CreateFlow = {
+    mode: "new",
+    flow: {
+      slug: "",
+      name: "",
+      sourceId: "",
+    },
+  };
+
+  // TODO: Handle flow creation across modes
+  const onSubmit: FormikConfig<CreateFlow>["onSubmit"] = (values) =>
+    console.log("Submit! Values: ", values);
+
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+
+  return (
+    <Box mt={1}>
+      <AddButton onClick={() => setDialogOpen(true)}>
+        Add a new service
+      </AddButton>
+      <Formik<CreateFlow>
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        validateOnBlur={false}
+        validateOnChange={false}
+      >
+        <Form id="modal" name="modal">
+          <StyledDialog
+            open={dialogOpen}
+            onClose={() => setDialogOpen(false)}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+            fullWidth
+          >
+            <DialogTitle variant="h3" component="h1">
+              <Box sx={{ mt: 1, mb: 4 }}>
+                <Typography variant="h3" component="h2" id="dialog-heading">
+                  Add a new service
+                </Typography>
+              </Box>
+            </DialogTitle>
+            <Box>
+              <DialogContent
+                sx={{ gap: 2, display: "flex", flexDirection: "column" }}
+              >
+                <BaseFormSection />
+                <CreateFromTemplateFormSection />
+                <CreateFromCopyFormSection />
+              </DialogContent>
+              <DialogActions sx={{ paddingX: 2 }}>
+                <Button disableRipple onClick={() => setDialogOpen(false)}>
+                  Back
+                </Button>
+                <Button
+                  type="submit"
+                  color="primary"
+                  variant="contained"
+                  disableRipple
+                >
+                  Add service
+                </Button>
+              </DialogActions>
+            </Box>
+          </StyledDialog>
+        </Form>
+      </Formik>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -6,14 +6,17 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { isAxiosError } from "axios";
 import { Form, Formik, FormikConfig } from "formik";
 import React, { useState } from "react";
+import { useNavigation } from "react-navi";
 import { AddButton } from "ui/editor/AddButton";
 
+import { useStore } from "../../../FlowEditor/lib/store";
 import { BaseFormSection } from "./BaseFormSection";
 import { CreateFromCopyFormSection } from "./CreateFromCopyFormSection";
 import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
-import { CreateFlow } from "./types";
+import { CreateFlow, validationSchema } from "./types";
 
 // TODO: Standardise or share this
 export const StyledDialog = styled(Dialog)(({ theme }) => ({
@@ -28,6 +31,9 @@ export const StyledDialog = styled(Dialog)(({ theme }) => ({
 }));
 
 export const AddFlow: React.FC = () => {
+  const { navigate } = useNavigation();
+  const { teamId, createFlow, teamSlug } = useStore();
+
   const initialValues: CreateFlow = {
     mode: "new",
     flow: {
@@ -37,9 +43,42 @@ export const AddFlow: React.FC = () => {
     },
   };
 
-  // TODO: Handle flow creation across modes
-  const onSubmit: FormikConfig<CreateFlow>["onSubmit"] = (values) =>
-    console.log("Submit! Values: ", values);
+  const onSubmit: FormikConfig<CreateFlow>["onSubmit"] = async (
+    { mode, flow },
+    { setFieldError },
+  ) => {
+    let newFlowId: string | undefined;
+
+    try {
+      switch (mode) {
+        case "new":
+          newFlowId = await createFlow(teamId, flow.slug, flow.name);
+          break;
+        case "copy":
+          // newFlowId = await createFlowFromCopy(flow);
+          break;
+        case "template":
+          // newFlowId = await createFlowFromTemplate(flow);
+          break;
+      }
+
+      if (!newFlowId) {
+        throw new Error("Flow creation failed");
+      }
+
+      navigate(`/${teamSlug}/${newFlowId}`);
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const message = error?.response?.data?.error;
+        if (message.includes("Uniqueness violation")) {
+          setFieldError("flow.name", "Flow name must be unique");
+        }
+      }
+
+      // TODO: Handle more gracefully
+      throw error;
+    }
+  };
 
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
 
@@ -53,11 +92,15 @@ export const AddFlow: React.FC = () => {
         onSubmit={onSubmit}
         validateOnBlur={false}
         validateOnChange={false}
+        validationSchema={validationSchema}
       >
-        <Form id="modal" name="modal">
+        {({ resetForm }) => (
           <StyledDialog
             open={dialogOpen}
-            onClose={() => setDialogOpen(false)}
+            onClose={() => {
+              setDialogOpen(false);
+              resetForm();
+            }}
             aria-labelledby="alert-dialog-title"
             aria-describedby="alert-dialog-description"
             fullWidth
@@ -70,29 +113,31 @@ export const AddFlow: React.FC = () => {
               </Box>
             </DialogTitle>
             <Box>
-              <DialogContent
-                sx={{ gap: 2, display: "flex", flexDirection: "column" }}
-              >
-                <BaseFormSection />
-                <CreateFromTemplateFormSection />
-                <CreateFromCopyFormSection />
-              </DialogContent>
-              <DialogActions sx={{ paddingX: 2 }}>
-                <Button disableRipple onClick={() => setDialogOpen(false)}>
-                  Back
-                </Button>
-                <Button
-                  type="submit"
-                  color="primary"
-                  variant="contained"
-                  disableRipple
+              <Form>
+                <DialogContent
+                  sx={{ gap: 2, display: "flex", flexDirection: "column" }}
                 >
-                  Add service
-                </Button>
-              </DialogActions>
+                  <BaseFormSection />
+                  <CreateFromTemplateFormSection />
+                  <CreateFromCopyFormSection />
+                </DialogContent>
+                <DialogActions sx={{ paddingX: 2 }}>
+                  <Button disableRipple onClick={() => setDialogOpen(false)}>
+                    Back
+                  </Button>
+                  <Button
+                    type="submit"
+                    color="primary"
+                    variant="contained"
+                    disableRipple
+                  >
+                    Add service
+                  </Button>
+                </DialogActions>
+              </Form>
             </Box>
           </StyledDialog>
-        </Form>
+        )}
       </Formik>
     </Box>
   );

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -75,7 +75,6 @@ export const AddFlow: React.FC = () => {
         }
       }
 
-      // TODO: Handle more gracefully
       throw error;
     }
   };

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
@@ -1,6 +1,5 @@
 import { object, string } from "yup";
 
-// TODO: Validate unique flow name
 export const validationSchema = object().shape({
   mode: string().oneOf(["new", "copy", "template"]).required(),
   flow: object({

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
@@ -1,0 +1,41 @@
+import { object, string } from "yup";
+
+// TODO: Validate unique flow name
+export const validationSchema = object().shape({
+  mode: string().oneOf(["new", "copy", "template"]).required(),
+  flow: object({
+    slug: string().required("Slug is required"),
+    name: string().required("Name is required"),
+  }).required(),
+  id: string().when("mode", {
+    is: "new",
+    then: string().notRequired(),
+    otherwise: string().required("ID is required for copy and template modes"),
+  }),
+});
+
+type NewFlow = {
+  slug: string;
+  name: string;
+  sourceId?: string;
+};
+
+export type CreateFlow = {
+  mode: "new" | "copy" | "template";
+  flow: NewFlow;
+};
+
+export const CREATE_FLOW_MODES = [
+  {
+    mode: "new",
+    title: "New flow",
+  },
+  {
+    mode: "copy",
+    title: "From copy...",
+  },
+  {
+    mode: "template",
+    title: "From template...",
+  },
+] as const;

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -7,16 +7,15 @@ import Typography from "@mui/material/Typography";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { isEmpty, orderBy } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
-import { useCurrentRoute, useNavigation } from "react-navi";
-import { AddButton } from "ui/editor/AddButton";
+import { useCurrentRoute } from "react-navi";
 import Filters from "ui/editor/Filter/Filter";
 import { SortControl } from "ui/editor/SortControl/SortControl";
 import { getSortParams } from "ui/editor/SortControl/utils";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
-import { slugify } from "utils";
 
 import { useStore } from "../FlowEditor/lib/store";
 import { FlowSummary } from "../FlowEditor/lib/store/editor";
+import { AddFlow } from "./components/AddFlow";
 import FlowCard, { Card, CardContent } from "./components/FlowCard";
 import { ShowingServicesHeader } from "./components/ShowingServicesHeader";
 import { filterOptions, sortOptions } from "./helpers/sortAndFilterOptions";
@@ -40,38 +39,17 @@ const DashboardList = styled("ul")(({ theme }) => ({
   },
 }));
 
-const GetStarted: React.FC<{ flows: FlowSummary[] | null }> = ({ flows }) => (
+const GetStarted: React.FC = () => (
   <DashboardList sx={{ paddingTop: 2 }}>
     <Card>
       <CardContent>
         <Typography variant="h3">No services found</Typography>
         <Typography>Get started by creating your first service</Typography>
-        <AddFlowButton flows={flows} />
+        <AddFlow />
       </CardContent>
     </Card>
   </DashboardList>
 );
-
-const AddFlowButton: React.FC<{ flows: FlowSummary[] | null }> = ({
-  flows,
-}) => {
-  const { navigate } = useNavigation();
-  const { teamId, createFlow, teamSlug } = useStore();
-
-  const addFlow = async () => {
-    const newFlowName = prompt("Service name");
-    if (!newFlowName) return;
-
-    const uniqueFlow = getUniqueFlow(newFlowName, flows);
-
-    if (uniqueFlow) {
-      const newId = await createFlow(teamId, uniqueFlow.slug, uniqueFlow.name);
-      navigate(`/${teamSlug}/${newId}`);
-    }
-  };
-
-  return <AddButton onClick={addFlow}>Add a new service</AddButton>;
-};
 
 const Team: React.FC = () => {
   const [{ id: teamId, slug }, canUserEditTeam, getFlows] = useStore(
@@ -175,7 +153,7 @@ const Team: React.FC = () => {
             <Typography variant="h2" component="h1" pr={1}>
               Services
             </Typography>
-            {showAddFlowButton && <AddFlowButton flows={flows} />}
+            {showAddFlowButton && <AddFlow />}
           </Box>
           {teamHasFlows && (
             <SearchBox<FlowSummary>
@@ -266,28 +244,10 @@ const Team: React.FC = () => {
             )}
           </>
         )}
-        {flows && !flows.length && <GetStarted flows={flows} />}
+        {flows && !flows.length && <GetStarted />}
       </Container>
     </Box>
   );
 };
 
 export default Team;
-
-const getUniqueFlow = (
-  name: string,
-  flows: FlowSummary[] | null,
-): { slug: string; name: string } | undefined => {
-  const newFlowSlug = slugify(name);
-  const duplicateFlowName = flows?.find((flow) => flow.slug === newFlowSlug);
-
-  if (duplicateFlowName) {
-    const updatedName = prompt(
-      `A service already exists with the name '${name}', enter another name`,
-      name,
-    );
-    if (!updatedName) return;
-    return getUniqueFlow(updatedName, flows);
-  }
-  return { slug: newFlowSlug, name: name };
-};


### PR DESCRIPTION
## What does this PR do?
- Changes "Add a new service" from a dialog to a modal
- Modal allows flow to be created from new, copy or template
  - "copy" and "template" intentionally disabled here
- Updates E2E tests 

![image](https://github.com/user-attachments/assets/bc2f8d64-e307-412d-a1cf-b2b3ec1dc289)

**Upcoming PRs**
- Integrate existing template functionality from `StartFromTemplateButton`
- Enable "create from copy..."
- Single dialog style (via MUI theme?)
  - https://github.com/theopensystemslab/planx-new/pull/4536
  - I'll rebase here once the above is merged