### PR TITLE
fix: Handle default values for existing feedback records

### DIFF
--- a/hasura.planx.uk/migrations/1742391756805_alter_table_public_feedback_alter_column_status/up.sql
+++ b/hasura.planx.uk/migrations/1742391756805_alter_table_public_feedback_alter_column_status/up.sql
@@ -11,4 +11,3 @@ VALUES
 
 -- Set default value
 alter table "public"."feedback" alter column "status" set default 'unread';
-alter table "public"."feedback" alter column "status" set not null;

--- a/hasura.planx.uk/migrations/1743425387530_squashed/down.sql
+++ b/hasura.planx.uk/migrations/1743425387530_squashed/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."feedback" alter column "status" drop not null;

--- a/hasura.planx.uk/migrations/1743425387530_squashed/up.sql
+++ b/hasura.planx.uk/migrations/1743425387530_squashed/up.sql
@@ -1,0 +1,3 @@
+UPDATE feedback SET status = 'actioned';
+
+alter table "public"."feedback" alter column "status" set not null;


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C027383TRB6/p1743418344921479 (OSL Slack) for context.

Previously these migrations only worked (locally and on staging) as there were no existing `feedback` records.

This change - 
 - Removes the initial "not null" constraint from a historic migration
   - This is failing on production, so not yet run. On staging I'll manually drop this constraint when the PR is approved
 - Populates the column, and then sets the "not null" constraint