### PR TITLE
fix: Handle additional edge cases in `teams_summary` view

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -247,7 +247,7 @@ export const editorStore: StateCreator<
         mutation updateFlow($id: uuid!) {
           flow: update_flows_by_pk(
             pk_columns: { id: $id }
-            _set: { deleted_at: "now()" }
+            _set: { deleted_at: "now()", status: "offline" }
           ) {
             id
             name

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -116,7 +116,7 @@ export interface AdminPanelData {
   primaryColour?: string;
   linkColour?: string;
   actionColour?: string;
-  liveFlows: string[];
+  liveFlows: string[] | null;
 }
 
 export interface Operation {

--- a/hasura.planx.uk/migrations/1743429247515_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1743429247515_run_sql_migration/down.sql
@@ -1,0 +1,35 @@
+-- Previous iteration from hasura.planx.uk/migrations/1742416709742_update_teams_summary_councils_only/up.sql
+CREATE OR REPLACE VIEW "public"."teams_summary" AS 
+ SELECT t.id,
+    t.name,
+    t.slug,
+    ts.reference_code,
+    ts.homepage,
+    t.domain AS subdomain,
+    ti.has_planning_data AS planning_data_enabled,
+    ts.has_article4_schema AS article_4s_enabled,
+    jsonb_build_object('helpEmail', ts.help_email, 'helpPhone', ts.help_phone, 'emailReplyToId', ts.email_reply_to_id, 'helpOpeningHours', ts.help_opening_hours) AS govnotify_personalisation,
+        CASE
+            WHEN (COALESCE(ti.production_govpay_secret, ti.staging_govpay_secret) IS NOT NULL) THEN true
+            ELSE false
+        END AS govpay_enabled,
+    ts.submission_email AS send_to_email_address,
+    COALESCE(ti.production_bops_submission_url, ti.staging_bops_submission_url) AS bops_submission_url,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour,
+        CASE
+            WHEN ((COALESCE(ti.production_file_api_key, ti.staging_file_api_key) IS NOT NULL) AND (COALESCE(ti.production_power_automate_api_key, ti.staging_power_automate_api_key) IS NOT NULL) AND (ti.power_automate_webhook_url IS NOT NULL)) THEN true
+            ELSE false
+        END AS power_automate_enabled,
+    array_agg(f.name ORDER BY f.name ASC) FILTER (WHERE (f.status = 'online'::text)) AS live_flows
+   FROM ((((teams t
+     JOIN team_integrations ti ON ((ti.team_id = t.id)))
+     JOIN team_themes tt ON ((tt.team_id = t.id)))
+     JOIN team_settings ts ON ((ts.team_id = t.id)))
+     JOIN flows f ON ((f.team_id = t.id)))
+  WHERE t.name not in ('Open Digital Planning','Open Systems Lab','PlanX','Templates','Testing','WikiHouse')
+  GROUP BY t.id, t.name, t.slug, ts.reference_code, ts.homepage, ts.help_email, ts.help_phone, ts.email_reply_to_id, ts.help_opening_hours, ts.submission_email, ts.has_article4_schema, ti.has_planning_data, ti.production_govpay_secret, ti.staging_govpay_secret, ti.production_bops_submission_url, ti.staging_bops_submission_url, ti.production_file_api_key, ti.staging_file_api_key, ti.power_automate_webhook_url, ti.production_power_automate_api_key, ti.staging_power_automate_api_key, tt.logo, tt.favicon, tt.primary_colour, tt.link_colour, tt.action_colour
+  ORDER BY t.name;

--- a/hasura.planx.uk/migrations/1743429247515_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1743429247515_run_sql_migration/up.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE VIEW "public"."teams_summary" AS 
+ SELECT t.id,
+    t.name,
+    t.slug,
+    ts.reference_code,
+    ts.homepage,
+    t.domain AS subdomain,
+    ti.has_planning_data AS planning_data_enabled,
+    ts.has_article4_schema AS article_4s_enabled,
+    jsonb_build_object('helpEmail', ts.help_email, 'helpPhone', ts.help_phone, 'emailReplyToId', ts.email_reply_to_id, 'helpOpeningHours', ts.help_opening_hours) AS govnotify_personalisation,
+        CASE
+            WHEN (COALESCE(ti.production_govpay_secret, ti.staging_govpay_secret) IS NOT NULL) THEN true
+            ELSE false
+        END AS govpay_enabled,
+    ts.submission_email AS send_to_email_address,
+    COALESCE(ti.production_bops_submission_url, ti.staging_bops_submission_url) AS bops_submission_url,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour,
+        CASE
+            WHEN ((COALESCE(ti.production_file_api_key, ti.staging_file_api_key) IS NOT NULL) AND (COALESCE(ti.production_power_automate_api_key, ti.staging_power_automate_api_key) IS NOT NULL) AND (ti.power_automate_webhook_url IS NOT NULL)) THEN true
+            ELSE false
+        END AS power_automate_enabled,
+    array_agg(f.name ORDER BY f.name) FILTER (WHERE f.status = 'online'::text AND f.deleted_at IS NULL) AS live_flows
+   FROM ((((teams t
+     JOIN team_integrations ti ON ((ti.team_id = t.id)))
+     JOIN team_themes tt ON ((tt.team_id = t.id)))
+     JOIN team_settings ts ON ((ts.team_id = t.id)))
+     LEFT JOIN flows f ON ((f.team_id = t.id)))
+  WHERE (t.name <> ALL (ARRAY['Open Digital Planning'::text, 'Open Systems Lab'::text, 'PlanX'::text, 'Templates'::text, 'Testing'::text, 'WikiHouse'::text]))
+  GROUP BY t.id, t.name, t.slug, ts.reference_code, ts.homepage, ts.help_email, ts.help_phone, ts.email_reply_to_id, ts.help_opening_hours, ts.submission_email, ts.has_article4_schema, ti.has_planning_data, ti.production_govpay_secret, ti.staging_govpay_secret, ti.production_bops_submission_url, ti.staging_bops_submission_url, ti.production_file_api_key, ti.staging_file_api_key, ti.power_automate_webhook_url, ti.production_power_automate_api_key, ti.staging_power_automate_api_key, tt.logo, tt.favicon, tt.primary_colour, tt.link_colour, tt.action_colour
+  ORDER BY t.name;


### PR DESCRIPTION
Two small fixes to the `teams_summary` view - 
 - Handle new teams, without any flows
 - Exclude deleted flows from the view
 
 Also, this sets flows to "offline" when archived.
 
 **To test (on Pizza)**
- Teams without online flows (e.g. Barking & Dagenham) are listed in admin panel
- Archived flows (e.g. Camden's “Spatial data component bundle”) is not listed in admin panel