### PR TITLE
feat: Create "analyst" role with access to admin panel

### DIFF
--- a/api.planx.uk/modules/auth/service/utils.test.ts
+++ b/api.planx.uk/modules/auth/service/utils.test.ts
@@ -9,6 +9,7 @@ const mockUser: User = {
   id: 123,
   email: "test@example.com",
   isPlatformAdmin: false,
+  isAnalyst: false,
   teams: [],
 };
 

--- a/api.planx.uk/modules/auth/service/utils.ts
+++ b/api.planx.uk/modules/auth/service/utils.ts
@@ -12,6 +12,7 @@ export const getAllowedRolesForUser = (user: User): Role[] => {
     ...teamRoles, // User specific roles
   ];
   if (user.isPlatformAdmin) allowedRoles.push("platformAdmin");
+  if (user.isAnalyst) allowedRoles.push("analyst");
 
   return [...new Set(allowedRoles)];
 };

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b33f332",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9320ee8",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b33f332
-    version: github.com/theopensystemslab/planx-core/b33f332(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#9320ee8
+    version: github.com/theopensystemslab/planx-core/9320ee8(@types/react@19.0.10)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -1906,7 +1906,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 6.4.8(@types/react@19.0.10)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 19.0.10
@@ -1946,7 +1946,7 @@ packages:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@18.3.1)
       '@mui/core-downloads-tracker': 5.16.14
       '@mui/system': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 19.0.10
@@ -2026,24 +2026,13 @@ packages:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@18.3.1)
       '@mui/private-theming': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@mui/styled-engine': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@types/react': 19.0.10
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
-    dev: false
-
-  /@mui/types@7.2.21(@types/react@19.0.10):
-    resolution: {integrity: sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 19.0.10
     dev: false
 
   /@mui/types@7.2.24(@types/react@19.0.10):
@@ -2070,7 +2059,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@types/prop-types': 15.7.14
       '@types/react': 19.0.10
       clsx: 2.1.1
@@ -7609,9 +7598,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b33f332(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b33f332}
-    id: github.com/theopensystemslab/planx-core/b33f332
+  github.com/theopensystemslab/planx-core/9320ee8(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9320ee8}
+    id: github.com/theopensystemslab/planx-core/9320ee8
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b33f332",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9320ee8",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b33f332
-    version: github.com/theopensystemslab/planx-core/b33f332(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#9320ee8
+    version: github.com/theopensystemslab/planx-core/9320ee8(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -612,7 +612,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 6.4.8(@types/react@19.0.10)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 19.0.10
@@ -648,7 +648,7 @@ packages:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@18.3.1)
       '@mui/core-downloads-tracker': 5.16.14
       '@mui/system': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 19.0.10
@@ -722,24 +722,13 @@ packages:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@18.3.1)
       '@mui/private-theming': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@mui/styled-engine': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@types/react': 19.0.10
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
-    dev: false
-
-  /@mui/types@7.2.21(@types/react@19.0.10):
-    resolution: {integrity: sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 19.0.10
     dev: false
 
   /@mui/types@7.2.24(@types/react@19.0.10):
@@ -764,7 +753,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@types/prop-types': 15.7.14
       '@types/react': 19.0.10
       clsx: 2.1.1
@@ -3168,9 +3157,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b33f332(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b33f332}
-    id: github.com/theopensystemslab/planx-core/b33f332
+  github.com/theopensystemslab/planx-core/9320ee8(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9320ee8}
+    id: github.com/theopensystemslab/planx-core/9320ee8
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/src/demo-workspace/steps/background_steps.ts
+++ b/e2e/tests/api-driven/src/demo-workspace/steps/background_steps.ts
@@ -49,6 +49,7 @@ Given(
       lastName: featureData[0].last_name,
       email: featureData[0].email,
       isPlatformAdmin: false,
+      isAnalyst: false,
     });
 
     const userTwoId = await createUser({
@@ -57,6 +58,7 @@ Given(
       lastName: featureData[1].last_name,
       email: featureData[1].email,
       isPlatformAdmin: true,
+      isAnalyst: false,
     });
 
     const userOne = await $admin.user.getById(userOneId);

--- a/e2e/tests/api-driven/src/jwt.ts
+++ b/e2e/tests/api-driven/src/jwt.ts
@@ -34,6 +34,7 @@ const getAllowedRolesForUser = (user: User): Role[] => {
     ...teamRoles, // User specific roles
   ];
   if (user.isPlatformAdmin) allowedRoles.push("platformAdmin");
+  if (user.isAnalyst) allowedRoles.push("analyst");
 
   return [...new Set(allowedRoles)];
 };

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b33f332",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9320ee8",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b33f332
-    version: github.com/theopensystemslab/planx-core/b33f332(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#9320ee8
+    version: github.com/theopensystemslab/planx-core/9320ee8(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -462,7 +462,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 6.4.8(@types/react@19.0.10)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 19.0.10
@@ -498,7 +498,7 @@ packages:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@18.3.1)
       '@mui/core-downloads-tracker': 5.16.14
       '@mui/system': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react': 19.0.10
@@ -572,24 +572,13 @@ packages:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@18.3.1)
       '@mui/private-theming': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@mui/styled-engine': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 5.16.14(@types/react@19.0.10)(react@18.3.1)
       '@types/react': 19.0.10
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
-    dev: false
-
-  /@mui/types@7.2.21(@types/react@19.0.10):
-    resolution: {integrity: sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 19.0.10
     dev: false
 
   /@mui/types@7.2.24(@types/react@19.0.10):
@@ -614,7 +603,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/types': 7.2.21(@types/react@19.0.10)
+      '@mui/types': 7.2.24(@types/react@19.0.10)
       '@types/prop-types': 15.7.14
       '@types/react': 19.0.10
       clsx: 2.1.1
@@ -2717,9 +2706,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/b33f332(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b33f332}
-    id: github.com/theopensystemslab/planx-core/b33f332
+  github.com/theopensystemslab/planx-core/9320ee8(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9320ee8}
+    id: github.com/theopensystemslab/planx-core/9320ee8
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b33f332",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9320ee8",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.5
     version: 1.0.0-alpha.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#b33f332
-    version: github.com/theopensystemslab/planx-core/b33f332(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#9320ee8
+    version: github.com/theopensystemslab/planx-core/9320ee8(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14772,9 +14772,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/b33f332(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b33f332}
-    id: github.com/theopensystemslab/planx-core/b33f332
+  github.com/theopensystemslab/planx-core/9320ee8(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/9320ee8}
+    id: github.com/theopensystemslab/planx-core/9320ee8
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.test.tsx
@@ -17,6 +17,7 @@ describe("Checklist editor component", () => {
       firstName: "Editor",
       lastName: "Test",
       isPlatformAdmin: true,
+      isAnalyst: true,
       email: "test@test.com",
       teams: [],
       jwt: "x.y.z",

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
@@ -17,6 +17,7 @@ describe("FileUploadAndLabel - Editor Modal", () => {
       firstName: "Editor",
       lastName: "Test",
       isPlatformAdmin: true,
+      isAnalyst: false,
       email: "test@test.com",
       teams: [],
       jwt: "x.y.z",

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -39,6 +39,7 @@ describe("Pay component - Editor Modal", () => {
       id: 123,
       email: "b.baggins@shire.com",
       isPlatformAdmin: true,
+      isAnalyst: true,
       firstName: "Bilbo",
       lastName: "Baggins",
       teams: [],

--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -66,7 +66,7 @@ function EditorNavMenu() {
       title: "Admin panel",
       Icon: AdminPanelSettingsIcon,
       route: "admin-panel",
-      accessibleBy: ["platformAdmin"],
+      accessibleBy: ["platformAdmin", "analyst"],
     },
     {
       title: "Resources",

--- a/editor.planx.uk/src/components/Header/Header.test.tsx
+++ b/editor.planx.uk/src/components/Header/Header.test.tsx
@@ -83,6 +83,7 @@ describe("Header Component - Editor Route", () => {
           firstName: "Test",
           lastName: "User",
           isPlatformAdmin: false,
+          isAnalyst: false,
           teams: [],
           id: 123,
           email: "test@example.com",

--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -46,11 +46,12 @@ const httpLink = createHttpLink({
  * Set auth header in Apollo client
  * Must be done post-authentication once we have a value for JWT
  */
-export const authMiddleware = setContext(async () => {
+export const authMiddleware = setContext(async (_operation, { headers }) => {
   const jwt = await getJWT();
 
   return {
     headers: {
+      ...headers,
       authorization: jwt ? `Bearer ${jwt}` : undefined,
     },
   };

--- a/editor.planx.uk/src/pages/FlowEditor/ReadMePage/tests/helpers.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/ReadMePage/tests/helpers.ts
@@ -1,12 +1,15 @@
+import { User } from "@opensystemslab/planx-core/types";
+
 import { ReadMePageProps } from "../types";
 
-export const platformAdminUser = {
+export const platformAdminUser: User & { jwt: string } = {
   id: 1,
   firstName: "Editor",
   lastName: "Test",
   isPlatformAdmin: true,
   email: "test@test.com",
   teams: [],
+  isAnalyst: false,
   jwt: "x.y.z",
 };
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -58,6 +58,7 @@ export const MembersTable = ({
     teamViewer: "Viewer",
     demoUser: "Demo User",
     public: "Public",
+    analyst: "Analyst",
   };
 
   const editUser = (member: TeamMember) => {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/mocks/mockUsers.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/mocks/mockUsers.tsx
@@ -20,6 +20,7 @@ export const emptyTeamMemberObj: TeamMember = {
 
 export const mockPlainUser: User = {
   isPlatformAdmin: false,
+  isAnalyst: false,
   firstName: "r",
   lastName: "r",
   email: "r",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts
@@ -3,7 +3,10 @@ import React, { SetStateAction } from "react";
 
 export type TeamMember = ActiveTeamMember | ArchivedTeamMember;
 
-type ArchivedTeamMember = Omit<User, "teams" | "isPlatformAdmin" | "email"> & {
+type ArchivedTeamMember = Omit<
+  User,
+  "teams" | "isPlatformAdmin" | "email" | "isAnalyst"
+> & {
   role: Role;
   email: string | null;
 };
@@ -11,16 +14,19 @@ type ArchivedTeamMember = Omit<User, "teams" | "isPlatformAdmin" | "email"> & {
 type ActiveTeamMember = Omit<User, "teams" | "isPlatformAdmin"> & {
   role: Role;
 };
+
 export interface MembersTableProps {
   members: TeamMember[];
   showAddMemberButton?: boolean;
   showEditMemberButton?: boolean;
   showRemoveMemberButton?: boolean;
 }
+
 export interface AddNewEditorModalProps {
   showModal: boolean;
   setShowModal: React.Dispatch<SetStateAction<boolean>>;
 }
+
 export interface AddNewEditorFormValues {
   email: string;
   firstName: string;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/user.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/user.test.ts
@@ -8,6 +8,7 @@ const { canUserEditTeam } = getState();
 const redUser: User = {
   id: 1,
   isPlatformAdmin: false,
+  isAnalyst: false,
   firstName: "Red",
   lastName: "Reddison",
   email: "red@red-team.com",
@@ -34,6 +35,7 @@ const redUser: User = {
 const blueUser: User = {
   id: 2,
   isPlatformAdmin: false,
+  isAnalyst: false,
   firstName: "Blue",
   lastName: "Bluey",
   email: "blue@blue-team.com",
@@ -52,6 +54,7 @@ const blueUser: User = {
 const readOnlyUser: User = {
   id: 3,
   isPlatformAdmin: false,
+  isAnalyst: false,
   firstName: "Read",
   lastName: "Only",
   email: "readonly@no-team.com",
@@ -61,6 +64,7 @@ const readOnlyUser: User = {
 const adminUser: User = {
   id: 4,
   isPlatformAdmin: true,
+  isAnalyst: false,
   firstName: "Platform",
   lastName: "Admin",
   email: "admin@opensystemslab.io",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -59,6 +59,7 @@ export const userStore: StateCreator<
     if (!user) return;
 
     if (user.isPlatformAdmin) return "platformAdmin";
+    if (user.isAnalyst) return "analyst";
 
     const currentUserTeam = user.teams.find(
       ({ team: { slug } }) => slug === teamSlug,

--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -75,7 +75,11 @@ const editorRoutes = compose(
     }),
 
     "/admin-panel": map(async (req) => {
-      const isAuthorised = useStore.getState().user?.isPlatformAdmin;
+      const user = useStore.getState().user;
+      if (!user) throw new NotFoundError();
+
+      const { isPlatformAdmin, isAnalyst } = user;
+      const isAuthorised = isPlatformAdmin || isAnalyst;
       if (!isAuthorised)
         throw new NotFoundError(
           `User does not have access to ${req.originalUrl}`,
@@ -108,6 +112,11 @@ const editorRoutes = compose(
               }
             }
           `,
+          context: {
+            headers: {
+              "x-hasura-role": isPlatformAdmin ? "platformAdmin" : "analyst"
+            }
+          }
         });
         useStore.getState().setAdminPanelData(data.adminPanel);
 

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -1,3 +1,4 @@
+import { User } from "@opensystemslab/planx-core/types";
 import ChecklistComponent from "@planx/components/Checklist/Editor/Editor";
 import { within } from "@testing-library/react";
 import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
@@ -11,12 +12,13 @@ import { it } from "vitest";
 
 const { setState } = useStore;
 
-const mockUser = {
+const mockUser: Omit<User, "isPlatformAdmin"> = {
   id: 200,
   firstName: "Testy",
   lastName: "McTester",
   email: "test@email.com",
   teams: [],
+  isAnalyst: false,
 };
 
 describe("Checklist Component for a Platform Admin", () => {

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -3296,6 +3296,7 @@
           - email
           - first_name
           - id
+          - is_analyst
           - is_platform_admin
           - is_staging_only
           - last_name
@@ -3308,6 +3309,7 @@
           - email
           - first_name
           - id
+          - is_analyst
           - is_platform_admin
           - last_name
           - updated_at
@@ -3319,6 +3321,7 @@
           - email
           - first_name
           - id
+          - is_analyst
           - is_platform_admin
           - last_name
           - updated_at
@@ -3330,6 +3333,7 @@
           - email
           - first_name
           - id
+          - is_analyst
           - is_platform_admin
           - last_name
           - updated_at

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2922,6 +2922,30 @@
     name: teams_summary
     schema: public
   select_permissions:
+    - role: analyst
+      permission:
+        columns:
+          - live_flows
+          - article_4s_enabled
+          - govpay_enabled
+          - planning_data_enabled
+          - power_automate_enabled
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - bops_submission_url
+          - favicon
+          - homepage
+          - link_colour
+          - logo
+          - name
+          - primary_colour
+          - reference_code
+          - send_to_email_address
+          - slug
+          - subdomain
+        filter: {}
+      comment: ""
     - role: platformAdmin
       permission:
         columns:

--- a/hasura.planx.uk/migrations/1743493111155_alter_table_public_users_add_column_is_analyst/down.sql
+++ b/hasura.planx.uk/migrations/1743493111155_alter_table_public_users_add_column_is_analyst/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."users"."is_analyst" is NULL;
+
+ALTER TABLE "public"."users" DROP COLUMN "is_analyst";

--- a/hasura.planx.uk/migrations/1743493111155_alter_table_public_users_add_column_is_analyst/up.sql
+++ b/hasura.planx.uk/migrations/1743493111155_alter_table_public_users_add_column_is_analyst/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."users" add column "is_analyst" boolean
+ not null default 'false';
+
+comment on column "public"."users"."is_analyst" is E'Analyst is a role granting read-only access to the admin panel';

--- a/hasura.planx.uk/tests/teams_summary.test.js
+++ b/hasura.planx.uk/tests/teams_summary.test.js
@@ -1,0 +1,104 @@
+const { introspectAs } = require("./utils");
+
+describe("teams_summary", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query teams_summary", () => {
+      expect(i.queries).not.toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("can query teams_summary and team members", () => {
+      expect(i.queries).toContain("teams_summary");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("can query teams_summary", () => {
+      expect(i.queries).toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query teams_summary", () => {
+      expect(i.queries).not.toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query teams_summary", () => {
+      expect(i.queries).not.toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("cannot query teams_summary", () => {
+      expect(i.queries).not.toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+
+  describe("analyst", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("analyst");
+    });
+
+    test("can query teams_summary", () => {
+      expect(i.queries).toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+});

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -94,6 +94,7 @@ const introspectAs = async (role, userId = undefined) => {
     platformAdmin: gqlWithRole("platformAdmin", userId),
     teamEditor: gqlWithRole("teamEditor", userId),
     api: gqlWithRole("api"),
+    analyst: gqlWithRole("analyst"),
   }[role];
   const INTROSPECTION_QUERY = `
     query IntrospectionQuery {
@@ -112,10 +113,10 @@ const introspectAs = async (role, userId = undefined) => {
   const { types } = response.data.__schema;
   const queries = types
     .find((x) => x.name === "query_root")
-    .fields.map((x) => x.name);
+    ?.fields.map((x) => x.name) || []
   const mutations = types
     .find((x) => x.name === "mutation_root")
-    .fields.map((x) => x.name);
+    ?.fields.map((x) => x.name) || []
 
   return {
     types,

--- a/hasura.planx.uk/tests/utils.js
+++ b/hasura.planx.uk/tests/utils.js
@@ -94,7 +94,7 @@ const introspectAs = async (role, userId = undefined) => {
     platformAdmin: gqlWithRole("platformAdmin", userId),
     teamEditor: gqlWithRole("teamEditor", userId),
     api: gqlWithRole("api"),
-    analyst: gqlWithRole("analyst"),
+    analyst: gqlWithRole("analyst", userId),
   }[role];
   const INTROSPECTION_QUERY = `
     query IntrospectionQuery {


### PR DESCRIPTION
## What does this PR do?
- Creates new `users.is_analyst` column
- Creates new `analyst` role in Hasura which can query the `teams_summary` (admin panel) view
- Updates types and test (relies on https://github.com/theopensystemslab/planx-core/pull/693)
- Updates admin panel query to set role based on user

## To do
 - [x] Update `users.sql` once PR merged to `production` to sync new column
   -  PR https://github.com/theopensystemslab/planx-new/pull/4537 queued up

## To test
 - Toggle your user on the Pizza to set `user.is_platform_admin = false` and `user.is_analyst = true`
 - Access admin panel