### PR TITLE
feat: Filter admin panel by team name

### DIFF
--- a/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
+++ b/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
@@ -24,8 +24,12 @@ export const PlatformAdminPanel = () => {
     {
       field: "name",
       headerName: "Team",
-      type: ColumnFilterType.CUSTOM,
+      type: ColumnFilterType.SINGLE_SELECT,
       customComponent: (params) => <strong>{`${params.value}`}</strong>,
+      columnOptions: {
+        // Allow filtering by unique team names
+        valueOptions: [...new Set(adminPanelData?.map(({ name }) => name))],
+      },
     },
     {
       field: "referenceCode",


### PR DESCRIPTION
Small thing I noticed whilst working on #4534

| Before | After |
|--------|--------|
|<img width="951" alt="image" src="https://github.com/user-attachments/assets/9851e93e-30bc-4366-a436-36e6f6b7d709" />|<img width="889" alt="image" src="https://github.com/user-attachments/assets/210e3dec-ff4e-4171-9695-8bdeabec8503" />| 