### PR TITLE
chore: Move dialog styling to MUI theme

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Modal.tsx
@@ -57,16 +57,6 @@ export const FileTaggingModal = ({
       data-testid="file-tagging-dialog"
       maxWidth="xl"
       aria-labelledby="dialog-heading"
-      PaperProps={{
-        sx: {
-          width: "100%",
-          maxWidth: (theme) => theme.breakpoints.values.md,
-          borderRadius: 0,
-          borderTop: (theme) => `20px solid ${theme.palette.primary.main}`,
-          background: "#FFF",
-          margin: (theme) => theme.spacing(2),
-        },
-      }}
     >
       <DialogContent>
         <Box sx={{ mt: 1, mb: 4 }}>

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -138,16 +138,6 @@ export const OverrideEntitiesModal = ({
       data-testid="override-planning-constraint-entities-dialog"
       maxWidth="xl"
       aria-labelledby="dialog-heading"
-      PaperProps={{
-        sx: {
-          width: "100%",
-          maxWidth: (theme) => theme.breakpoints.values.md,
-          borderRadius: 0,
-          borderTop: (theme) => `20px solid ${theme.palette.primary.main}`,
-          background: "#FFF",
-          margin: (theme) => theme.spacing(2),
-        },
-      }}
     >
       <DialogContent>
         <Box component="form">

--- a/editor.planx.uk/src/components/ConfirmationDialog.tsx
+++ b/editor.planx.uk/src/components/ConfirmationDialog.tsx
@@ -29,20 +29,7 @@ export const ConfirmationDialog: React.FC<
   const onConfirm = () => onClose(true);
 
   return (
-    <Dialog
-      data-testid="confirmation-dialog"
-      PaperProps={{
-        sx: {
-          width: "100%",
-          maxWidth: (theme) => theme.breakpoints.values.md,
-          borderRadius: 0,
-          background: "#FFF",
-          margin: (theme) => theme.spacing(2),
-        },
-      }}
-      maxWidth="xl"
-      open={open}
-    >
+    <Dialog data-testid="confirmation-dialog" maxWidth="xl" open={open}>
       <DialogTitle variant="h4">{title}</DialogTitle>
       <DialogContent dividers>{children}</DialogContent>
       <DialogActions>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Typography from "@mui/material/Typography";
@@ -7,7 +8,6 @@ import { useToast } from "hooks/useToast";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
-import { SettingsDialog } from "../styles";
 import { EditorModalProps } from "../types";
 import { optimisticallyUpdateExistingMember } from "./lib/optimisticallyUpdateMembersTable";
 
@@ -47,7 +47,7 @@ export const RemoveUserModal = ({
   };
 
   return (
-    <SettingsDialog
+    <Dialog
       aria-labelledby="dialog-heading"
       data-testid={`dialog-${actionType}-user`}
       open={showModal || false}
@@ -100,6 +100,6 @@ export const RemoveUserModal = ({
           </Button>
         </Box>
       </DialogActions>
-    </SettingsDialog>
+    </Dialog>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/components/UserUpsertModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/components/UserUpsertModal.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Typography from "@mui/material/Typography";
@@ -19,7 +20,6 @@ import {
 import { upsertMemberSchema } from "../formSchema";
 import { createAndAddUserToTeam } from "../queries/createAndAddUserToTeam";
 import { updateTeamMember } from "../queries/updateUser";
-import { SettingsDialog } from "../styles";
 import { AddNewEditorFormValues, EditorModalProps } from "../types";
 import {
   optimisticallyAddNewMember,
@@ -134,7 +134,7 @@ export const UserUpsertModal = ({
   });
 
   return (
-    <SettingsDialog
+    <Dialog
       aria-labelledby="dialog-heading"
       data-testid={`dialog-${actionType}-user`}
       open={showModal || false}
@@ -237,6 +237,6 @@ export const UserUpsertModal = ({
           </ErrorWrapper>
         </DialogActions>
       </form>
-    </SettingsDialog>
+    </Dialog>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Team/styles.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Team/styles.ts
@@ -1,5 +1,4 @@
 import Avatar from "@mui/material/Avatar";
-import Dialog from "@mui/material/Dialog";
 import { styled } from "@mui/material/styles";
 import TableRow from "@mui/material/TableRow";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -15,16 +14,5 @@ export const StyledAvatar = styled(Avatar)(({ theme }) => ({
 export const StyledTableRow = styled(TableRow)(({ theme }) => ({
   "&:nth-of-type(even)": {
     background: theme.palette.background.paper,
-  },
-}));
-
-export const SettingsDialog = styled(Dialog)(({ theme }) => ({
-  "& .MuiDialog-paper": {
-    width: "100%",
-    maxWidth: theme.breakpoints.values.md,
-    borderRadius: 0,
-    borderTop: `20px solid ${theme.palette.primary.main}`,
-    background: theme.palette.background.paper,
-    margin: theme.spacing(2),
   },
 }));

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -1,10 +1,9 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Dialog, { dialogClasses } from "@mui/material/Dialog";
+import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { isAxiosError } from "axios";
 import { Form, Formik, FormikConfig } from "formik";
@@ -15,20 +14,7 @@ import { AddButton } from "ui/editor/AddButton";
 import { useStore } from "../../../FlowEditor/lib/store";
 import { BaseFormSection } from "./BaseFormSection";
 import { CreateFromCopyFormSection } from "./CreateFromCopyFormSection";
-import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
 import { CreateFlow, validationSchema } from "./types";
-
-// TODO: Standardise or share this
-export const StyledDialog = styled(Dialog)(({ theme }) => ({
-  [`& .${dialogClasses.paper}`]: {
-    width: "100%",
-    maxWidth: theme.breakpoints.values.md,
-    borderRadius: 0,
-    borderTop: `20px solid ${theme.palette.primary.main}`,
-    background: theme.palette.background.paper,
-    margin: theme.spacing(2),
-  },
-}));
 
 export const AddFlow: React.FC = () => {
   const { navigate } = useNavigation();
@@ -89,7 +75,7 @@ export const AddFlow: React.FC = () => {
         validationSchema={validationSchema}
       >
         {({ resetForm }) => (
-          <StyledDialog
+          <Dialog
             open={dialogOpen}
             onClose={() => {
               setDialogOpen(false);
@@ -129,7 +115,7 @@ export const AddFlow: React.FC = () => {
                 </DialogActions>
               </Form>
             </Box>
-          </StyledDialog>
+          </Dialog>
         )}
       </Formik>
     </Box>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -435,6 +435,18 @@ const getThemeOptions = ({
           },
         },
       },
+      MuiDialog: {
+        styleOverrides: {
+          paper: ({ theme }) => ({
+            width: "100%",
+            maxWidth: theme.breakpoints.values.md,
+            borderRadius: 0,
+            borderTop: `20px solid ${palette.primary.main}`,
+            background: "#FFF",
+            margin: theme.spacing(2),
+          }),
+        },
+      },
       MuiIconButton: {
         defaultProps: {
           disableFocusRipple: true,

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -442,7 +442,7 @@ const getThemeOptions = ({
             maxWidth: theme.breakpoints.values.md,
             borderRadius: 0,
             borderTop: `20px solid ${palette.primary.main}`,
-            background: "#FFF",
+            background: theme.palette.background.paper,
             margin: theme.spacing(2),
           }),
         },


### PR DESCRIPTION
## What does this PR do?
 - Moves repeated (and inconsistent) dialog styles to the MUI theme, and from a number of custom components
 - To use this in future, we just need to import the MUI `Dialog` directly, and it will already have the PlanX theme attached

There's a few minor changes below, all pretty minor.

| Component | Before | After |
|--------|--------|--------|
| `FileUploadAndLabel` |<img width="619" alt="image" src="https://github.com/user-attachments/assets/85979636-c105-4246-b926-7cb9e86ba3da" />|<img width="655" alt="image" src="https://github.com/user-attachments/assets/8714eb2b-76b4-4fda-b60e-3441b3f7d0f7" />|
| `PlanningConstraints` |<img width="627" alt="image" src="https://github.com/user-attachments/assets/5e0b68b7-04da-44fb-8c65-e43db3986011" />|<img width="619" alt="image" src="https://github.com/user-attachments/assets/b0a4d70c-0bfc-4b7b-aec1-71e38218fbbd" />|
| `ConfirmationDialog` |<img width="626" alt="image" src="https://github.com/user-attachments/assets/387c8e93-3ae4-4f55-9aba-c6e5fba6f9ee" />|<img width="618" alt="image" src="https://github.com/user-attachments/assets/3c2cc6ba-8376-46e7-8dbc-0571557072d7" />|
| `SettingsDialog` |<img width="607" alt="image" src="https://github.com/user-attachments/assets/7f526d2d-9c7f-489e-b2a7-317c4dd8ca20" />|<img width="618" alt="image" src="https://github.com/user-attachments/assets/62fc652a-180c-47df-bf40-158067f2ebeb" />| 
| `FormModal`|<img width="612" alt="image" src="https://github.com/user-attachments/assets/3f4c1bc0-59aa-4a6f-bd67-5173ab118ffb" />|<img width="613" alt="image" src="https://github.com/user-attachments/assets/ded8d5bb-0edc-4ebc-bfe4-dc556de69e08" />|
| `PublishDialog` |![image](https://github.com/user-attachments/assets/8ad35acb-0cfd-4cdd-a2d4-94934366bd02)|![image](https://github.com/user-attachments/assets/20ed87a1-2664-4f42-84f6-f34a4c6b9572)|
