### PR TITLE
refactor: Simplify team page filters

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -36,7 +36,6 @@ export const CopyFeature: React.FC<Props> = ({
           bordered
           required
           title={"Copy from"}
-          labelId={`select-${destinationIndex}`}
           value={""}
           onChange={(e) => {
             const label = e.target.value as string;

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
@@ -350,12 +350,14 @@ describe("copy feature select", () => {
   });
 
   it("lists all other features as options (the current feature is not listed)", async () => {
-    const { getByTitle, user, queryByRole } = setup(<MapAndLabel {...props} />);
+    const { getByTitle, user, queryByRole, getByRole } = setup(
+      <MapAndLabel {...props} />,
+    );
     addMultipleFeatures([point1, point2]);
 
     const copyTitle = getByTitle("Copy from");
 
-    const copyInput = within(copyTitle).getByRole("combobox");
+    const copyInput = getByRole("combobox", copyTitle);
 
     expect(copyInput).not.toHaveAttribute("aria-disabled", "true");
 
@@ -379,9 +381,7 @@ describe("copy feature select", () => {
     await user.click(tabOne);
 
     const copyTitle = getByTitle("Copy from");
-    const copyInput = within(copyTitle).getByRole("combobox", {
-      name: "Copy from",
-    });
+    const copyInput = getByRole("combobox", copyTitle);
 
     await user.click(copyInput);
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -45,12 +45,14 @@ const send = (ops: Array<any>) => {
   }
 };
 
+export type FlowCardView = "grid" | "row";
+
 export interface EditorUIStore {
   flowLayout: FlowLayout;
   showSidebar: boolean;
   toggleSidebar: () => void;
-  showCardGrid: boolean;
-  toggleCardGrid: () => void;
+  flowCardView: FlowCardView;
+  setFlowCardView: (view: FlowCardView) => void;
   showTags: boolean;
   toggleShowTags: () => void;
   showImages: boolean;
@@ -79,10 +81,10 @@ export const editorUIStore: StateCreator<
       set({ showSidebar: !get().showSidebar });
     },
 
-    showCardGrid: true,
+    flowCardView: "grid",
 
-    toggleCardGrid: () => {
-      set({ showCardGrid: !get().showCardGrid });
+    setFlowCardView: (view: FlowCardView) => {
+      set({ flowCardView: view });
     },
 
     showTags: false,
@@ -121,7 +123,7 @@ export const editorUIStore: StateCreator<
     name: "editorUIStore",
     partialize: (state) => ({
       showSidebar: state.showSidebar,
-      showCardGrid: state.showCardGrid,
+      flowCardView: state.flowCardView,
       showTags: state.showTags,
       showImages: state.showImages,
       showDataFields: state.showDataFields,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -49,6 +49,8 @@ export interface EditorUIStore {
   flowLayout: FlowLayout;
   showSidebar: boolean;
   toggleSidebar: () => void;
+  showCardGrid: boolean;
+  toggleCardGrid: () => void;
   showTags: boolean;
   toggleShowTags: () => void;
   showImages: boolean;
@@ -75,6 +77,12 @@ export const editorUIStore: StateCreator<
 
     toggleSidebar: () => {
       set({ showSidebar: !get().showSidebar });
+    },
+
+    showCardGrid: true,
+
+    toggleCardGrid: () => {
+      set({ showCardGrid: !get().showCardGrid });
     },
 
     showTags: false,
@@ -113,6 +121,7 @@ export const editorUIStore: StateCreator<
     name: "editorUIStore",
     partialize: (state) => ({
       showSidebar: state.showSidebar,
+      showCardGrid: state.showCardGrid,
       showTags: state.showTags,
       showImages: state.showImages,
       showDataFields: state.showDataFields,

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -33,8 +33,8 @@ export const Card = styled("li")(({ theme }) => ({
   justifyContent: "stretch",
   borderRadius: "3px",
   backgroundColor: theme.palette.background.default,
-  border: `1px solid ${theme.palette.border.main}`,
-  boxShadow: "0 2px 4px 0 rgba(0, 0, 0, 0.1)",
+  border: `1px solid ${theme.palette.border.light}`,
+  boxShadow: "0 2px 6px 1px rgba(0, 0, 0, 0.1)",
 }));
 
 export const CardBanner = styled(Box)(({ theme }) => ({
@@ -51,7 +51,7 @@ export const CardContent = styled(Box)(({ theme }) => ({
   height: "100%",
   textDecoration: "none",
   color: "currentColor",
-  padding: theme.spacing(2, 2, 1),
+  padding: theme.spacing(2, 2, 1.5),
   display: "flex",
   flexDirection: "column",
   alignItems: "flex-start",
@@ -81,10 +81,11 @@ const LinkSubText = styled(Box)(({ theme }) => ({
 const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({
   display: "flex",
   marginTop: "auto",
-  borderTop: `1px solid ${theme.palette.border.main}`,
+  borderTop: `1px solid ${theme.palette.border.light}`,
   backgroundColor: theme.palette.background.paper,
   overflow: "hidden",
   borderRadius: "0px 0px 4px 4px",
+  maxHeight: "35px",
   "& > button": {
     padding: theme.spacing(0.25, 1),
     width: "100%",

--- a/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -12,7 +12,7 @@ export const ShowingServicesHeader = ({
       : `Showing ${matchedFlowsCount} service`;
 
   return (
-    <Typography variant="h3" component="h2">
+    <Typography variant="h4" component="h2">
       {showingServicesMessage}
     </Typography>
   );

--- a/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
+++ b/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
@@ -31,10 +31,14 @@ const checkFlowServiceType: FilterOptions<FlowSummary>["validationFn"] = (
   _value,
 ) => flow.publishedFlows[0]?.hasSendComponent;
 
-const checkFlowTemplatedFrom: FilterOptions<FlowSummary>["validationFn"] = (
+const checkFlowTemplateType: FilterOptions<FlowSummary>["validationFn"] = (
   flow,
-  _value,
-) => Boolean(flow.templatedFrom)
+  value,
+) => {
+  if (value === "template") return Boolean(flow.templatedFrom);
+  if (value === "source template") return Boolean(flow.isTemplate);
+  return false;
+};
 
 const baseFilterOptions: FilterOptions<FlowSummary>[] = [
   {
@@ -51,13 +55,15 @@ const baseFilterOptions: FilterOptions<FlowSummary>[] = [
   },
 ];
 
-const templateFilterOption: FilterOptions<FlowSummary> =  {
+const templateFilterOption: FilterOptions<FlowSummary> = {
   displayName: "Template",
   optionKey: "templatedFrom",
-  optionValue: ["template"],
-  validationFn: checkFlowTemplatedFrom,
+  optionValue: ["template", "source template"],
+  validationFn: checkFlowTemplateType,
 };
 
-export const filterOptions: FilterOptions<FlowSummary>[] = hasFeatureFlag("TEMPLATES")
+export const filterOptions: FilterOptions<FlowSummary>[] = hasFeatureFlag(
+  "TEMPLATES",
+)
   ? [...baseFilterOptions, templateFilterOption]
   : baseFilterOptions;

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,7 +1,12 @@
+
+import TableRowsIcon from "@mui/icons-material/TableRows";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Typography from "@mui/material/Typography";
 import { isEmpty, orderBy } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
@@ -19,37 +24,40 @@ import FlowCard, { Card, CardContent } from "./components/FlowCard";
 import { ShowingServicesHeader } from "./components/ShowingServicesHeader";
 import { filterOptions, sortOptions } from "./helpers/sortAndFilterOptions";
 
-const DashboardList = styled("ul")(({ theme }) => ({
-  padding: theme.spacing(2, 0, 3),
-  margin: 0,
-  display: "grid",
-  gridAutoRows: "1fr",
-  gridTemplateColumns: "repeat(1, 1fr)",
-  gridGap: theme.spacing(2),
-  [theme.breakpoints.up("md")]: {
-    gridTemplateColumns: "repeat(2, 1fr)",
-  },
-  [theme.breakpoints.up("lg")]: {
-    gridTemplateColumns: "repeat(3, 1fr)",
-  },
-}));
+const DashboardList = styled("ul")<{ viewType: "grid" | "row" }>(
+  ({ theme, viewType }) => ({
+    padding: theme.spacing(2, 0, 3),
+    margin: 0,
+    display: viewType === "grid" ? "grid" : "flex",
+    flexDirection: viewType === "grid" ? "row" : "column",
+    gap: theme.spacing(2),
+    gridAutoRows: "1fr",
+    gridTemplateColumns: viewType === "grid" ? "repeat(1, 1fr)" : "none",
+    [theme.breakpoints.up("md")]: {
+      gridTemplateColumns: viewType === "grid" ? "repeat(2, 1fr)" : "none",
+    },
+    [theme.breakpoints.up("lg")]: {
+      gridTemplateColumns: viewType === "grid" ? "repeat(3, 1fr)" : "none",
+    },
+  }),
+);
 
 export const FiltersContainer = styled(Box)(({ theme }) => ({
   width: "100%",
   margin: theme.spacing(1, 0, 2),
-  padding: theme.spacing(1.5, 2),
+  padding: theme.spacing(1.5, 0),
   display: "flex",
   flexDirection: "row",
   flexWrap: "wrap",
   alignItems: "center",
   justifyContent: "space-between",
   gap: theme.spacing(1),
-  border: `1px solid ${theme.palette.border.main}`,
-  background: theme.palette.secondary.dark,
+  borderTop: `1px solid ${theme.palette.border.light}`,
+  borderBottom: `1px solid ${theme.palette.border.light}`,
 }));
 
 const GetStarted: React.FC = () => (
-  <DashboardList sx={{ paddingTop: 2 }}>
+  <DashboardList viewType="grid" sx={{ paddingTop: 2 }}>
     <Card>
       <CardContent>
         <Typography variant="h3">No services found</Typography>
@@ -81,6 +89,17 @@ const Team: React.FC = () => {
   const [shouldClearFilters, setShouldClearFilters] = useState<boolean>(false);
 
   const route = useCurrentRoute();
+
+  const [viewType, setViewType] = useState<"grid" | "row">("grid");
+
+  const handleViewChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newView: "grid" | "row",
+  ) => {
+    if (newView) {
+      setViewType(newView);
+    }
+  };
 
   useEffect(() => {
     const diffFlows =
@@ -210,9 +229,22 @@ const Team: React.FC = () => {
                   </Button>
                 )}
               </Box>
+              <ToggleButtonGroup
+                value={viewType}
+                exclusive
+                onChange={handleViewChange}
+                size="small"
+              >
+                <ToggleButton value="grid" disableRipple>
+                  <ViewModuleIcon />
+                </ToggleButton>
+                <ToggleButton value="row" disableRipple>
+                  <TableRowsIcon />
+                </ToggleButton>
+              </ToggleButtonGroup>
             </Box>
             {sortedFlows && (
-              <DashboardList>
+              <DashboardList viewType={viewType as "grid" | "row"}>
                 {sortedFlows.map((flow) => (
                   <FlowCard
                     flow={flow}

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,4 +1,3 @@
-
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Box from "@mui/material/Box";
@@ -70,7 +69,12 @@ const GetStarted: React.FC = () => (
 
 const Team: React.FC = () => {
   const [{ id: teamId, slug }, canUserEditTeam, getFlows, isTrial] = useStore(
-    (state) => [state.getTeam(), state.canUserEditTeam, state.getFlows, state.teamSettings?.isTrial],
+    (state) => [
+      state.getTeam(),
+      state.canUserEditTeam,
+      state.getFlows,
+      state.teamSettings?.isTrial,
+    ],
   );
 
   const [flows, setFlows] = useState<FlowSummary[] | null>(null);
@@ -90,24 +94,31 @@ const Team: React.FC = () => {
 
   const route = useCurrentRoute();
 
-  const [viewType, setViewType] = useState<"grid" | "row">("grid");
+  const [showCardGrid, toggleCardGrid] = useStore((state) => [
+    state.showCardGrid,
+    state.toggleCardGrid,
+  ]);
+
+  const viewType = showCardGrid ? "grid" : "row";
 
   const handleViewChange = (
     _event: React.MouseEvent<HTMLElement>,
     newView: "grid" | "row",
   ) => {
-    if (newView) {
-      setViewType(newView);
+    if (!newView) return;
+
+    const isGrid = newView === "grid";
+    if (isGrid !== showCardGrid) {
+      toggleCardGrid();
     }
   };
 
   useEffect(() => {
     const diffFlows =
-      searchedFlows?.filter(
-        (searchedFlow) =>
-          filteredFlows?.some(
-            (filteredFlow) => filteredFlow.id === searchedFlow.id,
-          ),
+      searchedFlows?.filter((searchedFlow) =>
+        filteredFlows?.some(
+          (filteredFlow) => filteredFlow.id === searchedFlow.id,
+        ),
       ) || null;
 
     // Sort the array at the start using the query params
@@ -166,7 +177,7 @@ const Team: React.FC = () => {
             <Typography variant="h2" component="h1" pr={1}>
               Services
             </Typography>
-            { isTrial && <InfoChip label="Trial account" /> }
+            {isTrial && <InfoChip label="Trial account" />}
             {showAddFlowButton && <AddFlow />}
           </Box>
           {teamHasFlows && (

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -5,7 +5,9 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import ToggleButton, { toggleButtonClasses } from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ToggleButtonGroup, {
+  toggleButtonGroupClasses,
+} from "@mui/material/ToggleButtonGroup";
 import Typography from "@mui/material/Typography";
 import { isEmpty, orderBy } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
@@ -63,14 +65,20 @@ export const FiltersContainer = styled(Box)(({ theme }) => ({
 export const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   borderColor: theme.palette.border.main,
+  borderRadius: 0,
+  margin: 0,
+  [`&.${toggleButtonGroupClasses.lastButton}`]: {
+    borderColor: theme.palette.border.main,
+  },
   "&:hover": {
     backgroundColor: theme.palette.background.paper,
   },
   [`&.${toggleButtonClasses.selected}`]: {
-    backgroundColor: theme.palette.secondary.dark,
+    backgroundColor: theme.palette.background.default,
+    boxShadow: `0 -4px 0 0 ${theme.palette.info.main} inset`,
   },
   [`&.${toggleButtonClasses.selected}:hover`]: {
-    backgroundColor: theme.palette.secondary.dark,
+    backgroundColor: theme.palette.background.default,
   },
 }));
 

--- a/editor.planx.uk/src/pages/Team/index.tsx
+++ b/editor.planx.uk/src/pages/Team/index.tsx
@@ -20,7 +20,7 @@ import { ShowingServicesHeader } from "./components/ShowingServicesHeader";
 import { filterOptions, sortOptions } from "./helpers/sortAndFilterOptions";
 
 const DashboardList = styled("ul")(({ theme }) => ({
-  padding: theme.spacing(3, 0),
+  padding: theme.spacing(2, 0, 3),
   margin: 0,
   display: "grid",
   gridAutoRows: "1fr",
@@ -32,6 +32,20 @@ const DashboardList = styled("ul")(({ theme }) => ({
   [theme.breakpoints.up("lg")]: {
     gridTemplateColumns: "repeat(3, 1fr)",
   },
+}));
+
+export const FiltersContainer = styled(Box)(({ theme }) => ({
+  width: "100%",
+  margin: theme.spacing(1, 0, 2),
+  padding: theme.spacing(1.5, 2),
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "wrap",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: theme.spacing(1),
+  border: `1px solid ${theme.palette.border.main}`,
+  background: theme.palette.secondary.dark,
 }));
 
 const GetStarted: React.FC = () => (
@@ -147,14 +161,26 @@ const Team: React.FC = () => {
         </Box>
         {teamHasFlows && (
           <>
-            <Box>
+            <FiltersContainer>
               <Filters<FlowSummary>
                 records={flows}
                 setFilteredRecords={setFilteredFlows}
                 filterOptions={filterOptions}
                 clearFilters={shouldClearFilters}
               />
-            </Box>
+              {teamHasFlows && matchingFlows && (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+                  <Typography variant="body2">
+                    <strong>Sort by</strong>
+                  </Typography>
+                  <SortControl<FlowSummary>
+                    records={matchingFlows}
+                    setRecords={setSortedFlows}
+                    sortOptions={sortOptions}
+                  />
+                </Box>
+              )}
+            </FiltersContainer>
             <Box
               sx={{
                 display: "flex",
@@ -169,6 +195,7 @@ const Team: React.FC = () => {
                   justifyContent: "flex-start",
                   alignItems: "center",
                   gap: 2,
+                  minHeight: "50px",
                 }}
               >
                 <ShowingServicesHeader
@@ -183,18 +210,6 @@ const Team: React.FC = () => {
                   </Button>
                 )}
               </Box>
-              {teamHasFlows && matchingFlows && (
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-                  <Typography variant="body2">
-                    <strong>Sort by</strong>
-                  </Typography>
-                  <SortControl<FlowSummary>
-                    records={matchingFlows}
-                    setRecords={setSortedFlows}
-                    sortOptions={sortOptions}
-                  />
-                </Box>
-              )}
             </Box>
             {sortedFlows && (
               <DashboardList>

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -1,23 +1,13 @@
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
-import { capitalize, findKey, get, isEmpty, omit } from "lodash";
+import { get, isEmpty, omit } from "lodash";
 import React, { useEffect, useState } from "react";
 import { useCurrentRoute, useNavigation } from "react-navi";
 import { Paths } from "type-fest";
 import { slugify } from "utils";
 
 import { FiltersColumn } from "./FiltersColumn";
-import {
-  FiltersBody,
-  FiltersContainer,
-  FiltersContent,
-  FiltersHeader,
-  FiltersToggle,
-  StyledChip,
-} from "./FilterStyles";
+import { FiltersContent } from "./FilterStyles";
 import { addToSearchParams, clearSearchParams } from "./searchParamUtils";
 
 export type FilterKey<T> = Paths<T>;
@@ -63,7 +53,6 @@ export const Filters = <T extends object>({
   filterOptions,
   clearFilters = false,
 }: FiltersProps<T>) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
   const [optionsToFilter] = useState(filterOptions);
 
   const navigation = useNavigation();
@@ -174,74 +163,38 @@ export const Filters = <T extends object>({
   };
 
   return (
-    <FiltersContainer
-      expanded={expanded}
-      onChange={() => setExpanded(!expanded)}
-    >
-      <FiltersHeader
-        expandIcon={
-          expanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />
-        }
-      >
-        <FiltersToggle>
-          {expanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-          <Typography variant="h4">
-            {expanded ? "Hide filters" : "Show filters"}
-          </Typography>
-        </FiltersToggle>
-        <Box sx={{ display: "flex", gap: 1 }}>
-          {values.filters &&
-            Object.entries(values.filters).map(([_key, value]) => {
-              if (!value) return;
-              return (
-                <StyledChip
-                  onClick={(e) => e.stopPropagation()}
-                  label={capitalize(`${value}`)}
-                  key={`${value}`}
-                  onDelete={() => {
-                    const targetKey = findKey(
-                      values.filters,
-                      (keys) => keys === value,
-                    ) as FilterKey<T>;
-                    removeFilter(targetKey);
-                  }}
-                />
-              );
-            })}
-        </Box>
-      </FiltersHeader>
-      <FiltersBody>
-        <form name="filters" aria-label="Filter options">
-          <FiltersContent>
-            {optionsToFilter.map((option) => (
-              <fieldset
-                key={option.displayName}
-                aria-describedby={`${option.displayName}-description`}
-                style={{ flexBasis: "20%" }}
-              >
-                <div
-                  key={`${option.displayName}-description`}
-                  id={`${option.displayName}-description`}
-                  className="sr-only"
-                  hidden
-                >
-                  Select options to filter the list by {option.displayName}
-                </div>
+    <form name="filters" aria-label="Filter options">
+      <FiltersContent>
+        <Typography variant="body2">
+          <strong>Filter by</strong>
+        </Typography>
+        {optionsToFilter.map((option) => (
+          <fieldset
+            key={option.displayName}
+            aria-describedby={`${option.displayName}-description`}
+            style={{ flexBasis: "160px" }}
+          >
+            <div
+              key={`${option.displayName}-description`}
+              id={`${option.displayName}-description`}
+              className="sr-only"
+              hidden
+            >
+              Select options to filter the list by {option.displayName}
+            </div>
 
-                <FiltersColumn
-                  key={`${option.displayName}-filter-column`}
-                  title={option.displayName}
-                  optionKey={option.optionKey}
-                  optionValues={option.optionValue}
-                  filters={values.filters}
-                  handleChange={handleChange}
-                />
-              </fieldset>
-            ))}
-          </FiltersContent>
-        </form>
-      </FiltersBody>
-    </FiltersContainer>
+            <FiltersColumn
+              key={`${option.displayName}-filter-column`}
+              title={option.displayName}
+              optionKey={option.optionKey}
+              optionValues={option.optionValue}
+              filters={values.filters}
+              handleChange={handleChange}
+            />
+          </fieldset>
+        ))}
+      </FiltersContent>
+    </form>
   );
 };
 

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -163,16 +163,20 @@ export const Filters = <T extends object>({
   };
 
   return (
-    <form name="filters" aria-label="Filter options">
-      <FiltersContent>
-        <Typography variant="body2">
+    <FiltersContent>
+      <form
+        name="filters"
+        aria-label="Filter options"
+        style={{ display: "flex", alignItems: "center", gap: "10px" }}
+      >
+        <Typography variant="body2" sx={{ flexShrink: 0 }}>
           <strong>Filter by</strong>
         </Typography>
         {optionsToFilter.map((option) => (
           <fieldset
             key={option.displayName}
             aria-describedby={`${option.displayName}-description`}
-            style={{ flexBasis: "160px" }}
+            style={{ flexBasis: "160px", flexShrink: 0 }}
           >
             <div
               key={`${option.displayName}-description`}
@@ -193,8 +197,8 @@ export const Filters = <T extends object>({
             />
           </fieldset>
         ))}
-      </FiltersContent>
-    </form>
+      </form>
+    </FiltersContent>
   );
 };
 

--- a/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -181,7 +181,6 @@ export const Filters = <T extends object>({
             <div
               key={`${option.displayName}-description`}
               id={`${option.displayName}-description`}
-              className="sr-only"
               hidden
             >
               Select options to filter the list by {option.displayName}
@@ -194,6 +193,7 @@ export const Filters = <T extends object>({
               optionValues={option.optionValue}
               filters={values.filters}
               handleChange={handleChange}
+              name={option.displayName}
             />
           </fieldset>
         ))}

--- a/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
@@ -1,53 +1,14 @@
-import Accordion, { accordionClasses } from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary, {
-  accordionSummaryClasses,
-} from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
-
-export const FiltersContainer = styled(Accordion)(({ theme }) => ({
-  width: "100%",
-  display: "flex",
-  flexDirection: "column",
-  margin: theme.spacing(1, 0, 3),
-  border: `1px solid ${theme.palette.border.main}`,
-  [`&.${accordionClasses.root}.Mui-expanded`]: {
-    margin: theme.spacing(1, 0, 3),
-  },
-  [`& .${accordionSummaryClasses.root} > div`]: {
-    margin: "0",
-  },
-}));
-
-export const FiltersHeader = styled(AccordionSummary)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "space-between",
-  padding: theme.spacing(1.75, 2),
-  gap: theme.spacing(3),
-  background: theme.palette.secondary.dark,
-  "&:hover": {
-    background: theme.palette.secondary.dark,
-  },
-  "& .MuiAccordionSummary-expandIconWrapper": {
-    display: "none",
-  },
-}));
-
-export const FiltersToggle = styled(Box)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  gap: theme.spacing(0.5),
-  minWidth: "160px",
-  minHeight: "32px",
-}));
 
 export const StyledChip = styled(Chip)(({ theme }) => ({
   background: theme.palette.common.white,
   cursor: "default",
   textTransform: "capitalize",
+  display: "flex",
+  justifyContent: "space-between",
+  borderRadius: "50px",
   "& > svg": {
     fill: theme.palette.text.secondary,
   },
@@ -59,20 +20,15 @@ export const StyledChip = styled(Chip)(({ theme }) => ({
   },
 }));
 
-export const FiltersBody = styled(AccordionDetails)(({ theme }) => ({
-  background: theme.palette.secondary.dark,
-  padding: 0,
-}));
-
 export const FiltersContent = styled(Box)(({ theme }) => ({
-  borderTop: `1px solid ${theme.palette.border.main}`,
-  padding: theme.spacing(2.5, 2.5, 2, 2.5),
+  width: "100%",
+  margin: theme.spacing(1, 0, 3),
+  padding: theme.spacing(1.5, 2),
   display: "flex",
   flexDirection: "row",
   flexWrap: "wrap",
-}));
-
-export const FiltersFooter = styled(Box)(({ theme }) => ({
-  borderTop: `1px solid ${theme.palette.border.main}`,
-  padding: theme.spacing(1.5, 2),
+  alignItems: "center",
+  gap: theme.spacing(1),
+  border: `1px solid ${theme.palette.border.main}`,
+  background: theme.palette.secondary.dark,
 }));

--- a/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
@@ -1,21 +1,35 @@
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
+import { focusStyle } from "theme";
 
 export const StyledChip = styled(Chip)(({ theme }) => ({
   background: theme.palette.background.dark,
   color: theme.palette.common.white,
   cursor: "default",
   textTransform: "capitalize",
+  fontSize: theme.typography.body3.fontSize,
   display: "flex",
+  flexDirection: "row-reverse",
   justifyContent: "space-between",
   borderRadius: "50px",
   height: "36px",
   "& > svg": {
+    marginRight: "6px !important",
     fill: theme.palette.secondary.dark,
-    "&:hover": {
-      fill: theme.palette.common.white,
+  },
+  "&:focus": {
+    ...focusStyle,
+    "& > svg": {
+      fill: theme.palette.background.dark,
     },
+  },
+  "&:hover": {
+    background: theme.palette.background.dark,
+    cursor: "pointer",
+  },
+  "&:hover > svg": {
+    fill: theme.palette.common.white,
   },
 }));
 

--- a/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
@@ -3,32 +3,26 @@ import Chip from "@mui/material/Chip";
 import { styled } from "@mui/material/styles";
 
 export const StyledChip = styled(Chip)(({ theme }) => ({
-  background: theme.palette.common.white,
+  background: theme.palette.background.dark,
+  color: theme.palette.common.white,
   cursor: "default",
   textTransform: "capitalize",
   display: "flex",
   justifyContent: "space-between",
   borderRadius: "50px",
+  height: "36px",
   "& > svg": {
-    fill: theme.palette.text.secondary,
-  },
-  "&:hover": {
-    background: theme.palette.common.white,
-    "& > svg": {
-      fill: theme.palette.text.primary,
+    fill: theme.palette.secondary.dark,
+    "&:hover": {
+      fill: theme.palette.common.white,
     },
   },
 }));
 
 export const FiltersContent = styled(Box)(({ theme }) => ({
-  width: "100%",
-  margin: theme.spacing(1, 0, 3),
-  padding: theme.spacing(1.5, 2),
   display: "flex",
   flexDirection: "row",
-  flexWrap: "wrap",
   alignItems: "center",
   gap: theme.spacing(1),
-  border: `1px solid ${theme.palette.border.main}`,
-  background: theme.palette.secondary.dark,
+  flexShrink: 0,
 }));

--- a/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/FilterStyles.ts
@@ -14,6 +14,9 @@ export const StyledChip = styled(Chip)(({ theme }) => ({
   justifyContent: "space-between",
   borderRadius: "50px",
   height: "36px",
+  "& > span": {
+    paddingRight: 0,
+  },
   "& > svg": {
     marginRight: "6px !important",
     fill: theme.palette.secondary.dark,

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -54,7 +54,7 @@ export const FiltersColumn = <T extends object>(
           displayEmpty
           sx={{ height: 40, maxWidth: "200px" }}
         >
-          <MenuItem value="" disabled>
+          <MenuItem value="" disabled style={visuallyHidden}>
             {props.title}
           </MenuItem>
           {props.optionValues.map((value) => (

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -15,6 +15,7 @@ interface FiltersColumnProps<T> {
   optionValues: FilterValues[];
   filters?: Filters<T> | null;
   handleChange: (key: FilterKey<T>, value: FilterValues | "") => void;
+  name: string;
 }
 
 export const FiltersColumn = <T extends object>(
@@ -40,6 +41,7 @@ export const FiltersColumn = <T extends object>(
       ) : (
         <SelectInput
           value={selectedValue}
+          name={props.name}
           onChange={(event) =>
             props.handleChange(
               props.optionKey,

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -36,7 +36,7 @@ export const FiltersColumn = <T extends object>(
       {selectedValue ? (
         <StyledChip
           label={capitalize(`${selectedValue}`)}
-          onDelete={() => props.handleChange(props.optionKey, "")}
+          onClick={() => props.handleChange(props.optionKey, "")}
         />
       ) : (
         <SelectInput

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -1,3 +1,4 @@
+import CancelIcon from "@mui/icons-material/Cancel";
 import Box from "@mui/material/Box";
 import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
@@ -37,6 +38,7 @@ export const FiltersColumn = <T extends object>(
         <StyledChip
           label={capitalize(`${selectedValue}`)}
           onClick={() => props.handleChange(props.optionKey, "")}
+          icon={<CancelIcon fontSize="small" />}
         />
       ) : (
         <SelectInput

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -1,37 +1,74 @@
 import Box from "@mui/material/Box";
+import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
 import { capitalize, get } from "lodash";
 import React from "react";
-import ChecklistItem from "ui/shared/ChecklistItem/ChecklistItem";
 
+import SelectInput from "../SelectInput/SelectInput";
 import Filters, { FilterKey, FilterValues } from "./Filter";
+import { StyledChip } from "./FilterStyles";
 
 interface FiltersColumnProps<T> {
   title: string;
   optionKey: FilterKey<T>;
   optionValues: FilterValues[];
   filters?: Filters<T> | null;
-  handleChange: (key: FilterKey<T>, value: FilterValues) => void;
+  handleChange: (key: FilterKey<T>, value: FilterValues | "") => void;
 }
 
 export const FiltersColumn = <T extends object>(
   props: FiltersColumnProps<T>,
 ) => {
+  const selectedValue = get(props.filters, props.optionKey) || "";
+
   return (
     <Box>
-      <Typography component={"legend"} variant="h5" pb={0.5}>
+      <Typography
+        component={"legend"}
+        variant="h5"
+        pb={0.5}
+        style={visuallyHidden}
+      >
         {props.title}
       </Typography>
-      {props.optionValues.map((value) => (
-        <ChecklistItem
-          key={`${props.optionKey.toString()}-${value}-checkbox`}
-          onChange={() => props.handleChange(props.optionKey, value)}
-          label={capitalize(`${value}`)}
-          id={`${props.optionKey.toString()}-${value}-checkbox`}
-          checked={get(props.filters, props.optionKey) === value}
-          variant="compact"
+      {selectedValue ? (
+        <StyledChip
+          label={capitalize(`${selectedValue}`)}
+          onDelete={() => props.handleChange(props.optionKey, "")}
+          sx={{
+            width: "100%",
+            height: 40,
+            display: "flex",
+            alignItems: "center",
+          }}
         />
-      ))}
+      ) : (
+        <SelectInput
+          value={selectedValue}
+          onChange={(event) =>
+            props.handleChange(
+              props.optionKey,
+              event.target.value as FilterValues,
+            )
+          }
+          fullWidth
+          displayEmpty
+          sx={{ height: 40, maxWidth: "200px" }}
+        >
+          <MenuItem value="" disabled>
+            {props.title}
+          </MenuItem>
+          {props.optionValues.map((value) => (
+            <MenuItem
+              key={`${props.optionKey.toString()}-${value}`}
+              value={value}
+            >
+              {capitalize(`${value}`)}
+            </MenuItem>
+          ))}
+        </SelectInput>
+      )}
     </Box>
   );
 };

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -36,12 +36,6 @@ export const FiltersColumn = <T extends object>(
         <StyledChip
           label={capitalize(`${selectedValue}`)}
           onDelete={() => props.handleChange(props.optionKey, "")}
-          sx={{
-            width: "100%",
-            height: 40,
-            display: "flex",
-            alignItems: "center",
-          }}
         />
       ) : (
         <SelectInput

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -7,7 +7,7 @@ import { describe, vi } from "vitest";
 import { axe } from "vitest-axe";
 
 import Filters from "../Filter";
-import { addFilter, expandFilterAccordion, removeFilter } from "./helpers";
+import { addFilter, removeFilter } from "./helpers";
 import {
   mockFilterOptions,
   mockRecords,
@@ -41,43 +41,23 @@ const setupTestEnvironment = () => {
 };
 
 describe("the UI interactions of the Filter component", () => {
-  it("toggles visibility when the filter accordion is clicked", async () => {
-    const { user } = setupTestEnvironment();
-
-    const showFiltersHeader = screen.getByText("Show filters");
-    expect(showFiltersHeader).toBeVisible();
-
-    await user.click(showFiltersHeader);
-    expect(screen.getByText("Hide filters")).toBeVisible();
-  });
-
-  it("display the filter options when the accordion is open", async () => {
-    const { user } = setupTestEnvironment();
-
-    const filterStatusOption = screen.getByText("Online status");
-    const filterNameOption = screen.getByText("Name");
-
-    expect(filterStatusOption).not.toBeVisible();
-    expect(filterNameOption).not.toBeVisible();
-
-    await expandFilterAccordion(user);
-
-    expect(filterStatusOption).toBeVisible();
-    expect(filterNameOption).toBeVisible();
-  });
-
   it("should not have any accessibility violations on initial render", async () => {
     const { container } = setupTestEnvironment();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it("displays the filter options by default", () => {
+    setupTestEnvironment();
+
+    expect(screen.getByText("Online status")).toBeVisible();
+    expect(screen.getByText("Name")).toBeVisible();
   });
 });
 
 describe("Filter functionality", () => {
   it("manages filter chips correctly when selecting filters", async () => {
     const { user } = setupTestEnvironment();
-
-    await expandFilterAccordion(user);
 
     expect(
       screen.queryByRole("button", { name: "Online" }),
@@ -113,7 +93,6 @@ describe("Filter functionality", () => {
   it("filters the records using a single option", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(user);
     await addFilter(user, "Offline");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
@@ -127,7 +106,6 @@ describe("Filter functionality", () => {
   it("filters the records using multiple options", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(user);
     await addFilter(user, "Online");
     await addFilter(user, "Online-mock-2");
 
@@ -142,7 +120,6 @@ describe("Filter functionality", () => {
   it("returns to mockRecords when all filters unchecked", async () => {
     const { user } = setupTestEnvironment();
 
-    await expandFilterAccordion(user);
     await addFilter(user, "Offline");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -50,8 +50,8 @@ describe("the UI interactions of the Filter component", () => {
   it("displays the filter options by default", () => {
     setupTestEnvironment();
 
-    expect(screen.getByText("Online status")).toBeVisible();
-    expect(screen.getByText("Name")).toBeVisible();
+    expect(screen.getByLabelText("Online status")).toBeVisible();
+    expect(screen.getByLabelText("Name")).toBeVisible();
   });
 });
 
@@ -64,7 +64,7 @@ describe("Filter functionality", () => {
     ).not.toBeInTheDocument();
 
     // Open combobox and select "Online"
-    await user.click(screen.getByText("Online status"));
+    await user.click(screen.getByRole("combobox", { name: "Online status" }));
     await user.click(screen.getByRole("option", { name: "Online" }));
 
     // Expect online chip to be visible
@@ -80,7 +80,7 @@ describe("Filter functionality", () => {
     ).not.toBeInTheDocument();
 
     // Open combobox and select "Offline"
-    await user.click(screen.getByText("Online status"));
+    await user.click(screen.getByRole("combobox", { name: "Online status" }));
     await user.click(screen.getByRole("option", { name: "Offline" }));
 
     // Expect offline chip to be visible
@@ -99,7 +99,7 @@ describe("Filter functionality", () => {
   it("filters the records using a single option", async () => {
     const { user } = setupTestEnvironment();
 
-    await addFilter(user, "Online status");
+    await addFilter(user, "Online status", "Offline");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -112,8 +112,8 @@ describe("Filter functionality", () => {
   it("filters the records using multiple options", async () => {
     const { user } = setupTestEnvironment();
 
-    await addFilter(user, "Online status");
-    await addFilter(user, "Online-mock-2");
+    await addFilter(user, "Online status", "Online");
+    await addFilter(user, "Name", "Online-mock-2");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -126,7 +126,7 @@ describe("Filter functionality", () => {
   it("returns to mockRecords when all filters unchecked", async () => {
     const { user } = setupTestEnvironment();
 
-    await addFilter(user, "Online status");
+    await addFilter(user, "Online status", "Offline");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -136,7 +136,7 @@ describe("Filter functionality", () => {
     ]);
 
     // when we remove our filter, it should return to the array we passed into the prop 'records'
-    await removeFilter(user, "Online status");
+    await removeFilter(user, "Offline");
     expect(mockSetFilteredRecords).toHaveBeenCalledWith(mockRecords);
   });
 });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -56,35 +56,41 @@ describe("the UI interactions of the Filter component", () => {
 });
 
 describe("Filter functionality", () => {
-  it("manages filter chips correctly when selecting filters", async () => {
+  it("manages filter chips correctly when selecting and deselecting filters", async () => {
     const { user } = setupTestEnvironment();
 
     expect(
       screen.queryByRole("button", { name: "Online" }),
     ).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("checkbox", { name: "Online" }));
+    // Open combobox and select "Online"
+    await user.click(screen.getByText("Online status"));
+    await user.click(screen.getByRole("option", { name: "Online" }));
 
-    // when you select a filter, a clickable chip should appear for the option
+    // Expect online chip to be visible
     const onlineChip = screen.getByRole("button", { name: "Online" });
     expect(onlineChip).toBeVisible();
 
-    // change filter to it's other optionValue
-    await user.click(screen.getByRole("checkbox", { name: "Offline" }));
+    // Click the "Online" chip to remove it
+    await user.click(onlineChip);
 
-    // check it has been selected
-    const offlineChip = screen.getByRole("button", { name: "Offline" });
-    expect(offlineChip).toBeVisible();
-
-    // check previous filter has been deselected
+    // Verify "Online" chip is removed
     expect(
       screen.queryByRole("button", { name: "Online" }),
     ).not.toBeInTheDocument();
 
-    // click selected filter
-    await user.click(screen.getByRole("checkbox", { name: "Offline" }));
+    // Open combobox and select "Offline"
+    await user.click(screen.getByText("Online status"));
+    await user.click(screen.getByRole("option", { name: "Offline" }));
 
-    // check filter is deselected
+    // Expect offline chip to be visible
+    const offlineChip = screen.getByRole("button", { name: "Offline" });
+    expect(offlineChip).toBeVisible();
+
+    // Click the "Offline" chip to remove it
+    await user.click(offlineChip);
+
+    // Verify "Offline" chip is removed
     expect(
       screen.queryByRole("button", { name: "Offline" }),
     ).not.toBeInTheDocument();
@@ -93,7 +99,7 @@ describe("Filter functionality", () => {
   it("filters the records using a single option", async () => {
     const { user } = setupTestEnvironment();
 
-    await addFilter(user, "Offline");
+    await addFilter(user, "Online status");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -106,7 +112,7 @@ describe("Filter functionality", () => {
   it("filters the records using multiple options", async () => {
     const { user } = setupTestEnvironment();
 
-    await addFilter(user, "Online");
+    await addFilter(user, "Online status");
     await addFilter(user, "Online-mock-2");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
@@ -120,7 +126,7 @@ describe("Filter functionality", () => {
   it("returns to mockRecords when all filters unchecked", async () => {
     const { user } = setupTestEnvironment();
 
-    await addFilter(user, "Offline");
+    await addFilter(user, "Online status");
 
     expect(mockSetFilteredRecords).toHaveBeenCalledWith([
       {
@@ -130,7 +136,7 @@ describe("Filter functionality", () => {
     ]);
 
     // when we remove our filter, it should return to the array we passed into the prop 'records'
-    await removeFilter(user, "Offline");
+    await removeFilter(user, "Online status");
     expect(mockSetFilteredRecords).toHaveBeenCalledWith(mockRecords);
   });
 });

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -2,14 +2,6 @@ import { screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
-export const expandFilterAccordion = async (user: UserEvent) => {
-  const showAccordionTitle = screen.getByText("Show filters");
-  await user.click(showAccordionTitle);
-
-  const hideAccordionTitle = screen.getByText("Hide filters");
-  expect(hideAccordionTitle).toBeVisible();
-};
-
 export const addFilter = async (user: UserEvent, name: string) => {
   const checkbox = screen.getByRole("checkbox", { name: name });
   await user.click(checkbox);

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -3,15 +3,14 @@ import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
 export const addFilter = async (user: UserEvent, name: string) => {
-  const checkbox = screen.getByRole("checkbox", { name: name });
-  await user.click(checkbox);
-  const filterChip = screen.getByRole("button", { name: name });
+  const combobox = screen.getByRole("combobox", { name: "Online status" });
+  await user.click(combobox);
+  const filterChip = screen.getByRole("button", { name });
   expect(filterChip).toBeVisible();
 };
 
 export const removeFilter = async (user: UserEvent, name: string) => {
-  const checkbox = screen.getByRole("checkbox", { name: name });
-  await user.click(checkbox);
-  const filterChip = screen.queryByRole("button", { name: name });
+  const filterChip = screen.getByRole("button", { name });
+  await user.click(filterChip);
   expect(filterChip).not.toBeInTheDocument();
 };

--- a/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
+++ b/editor.planx.uk/src/ui/editor/Filter/tests/helpers.ts
@@ -2,15 +2,23 @@ import { screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { expect } from "vitest";
 
-export const addFilter = async (user: UserEvent, name: string) => {
-  const combobox = screen.getByRole("combobox", { name: "Online status" });
+export const addFilter = async (
+  user: UserEvent,
+  selectLabel: string,
+  optionLabel: string,
+) => {
+  const combobox = screen.getByRole("combobox", { name: selectLabel });
   await user.click(combobox);
-  const filterChip = screen.getByRole("button", { name });
+
+  const option = screen.getByRole("option", { name: optionLabel });
+  await user.click(option);
+
+  const filterChip = screen.getByRole("button", { name: optionLabel });
   expect(filterChip).toBeVisible();
 };
 
-export const removeFilter = async (user: UserEvent, name: string) => {
-  const filterChip = screen.getByRole("button", { name });
+export const removeFilter = async (user: UserEvent, optionLabel: string) => {
+  const filterChip = screen.getByRole("button", { name: optionLabel });
   await user.click(filterChip);
   expect(filterChip).not.toBeInTheDocument();
 };

--- a/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
+++ b/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
@@ -83,47 +83,40 @@ export default function SelectInput({
   ...props
 }: Props): FCReturn {
   return (
-    console.log(props),
-    console.log({ value }),
-    (
-      <>
-        <label
-          id={`${name?.replaceAll(" ", "-")}-label`}
-          style={visuallyHidden}
-        >
-          {name}
-        </label>
-        <Root
-          variant="standard"
-          value={value}
-          labelId={`${name?.replaceAll(" ", "-")}-label`}
-          classes={{
-            select: classes.rootSelect,
-            icon: classes.icon,
-          }}
-          onChange={onChange}
-          IconComponent={ArrowIcon}
-          input={<Input bordered={bordered} />}
-          inputProps={{
-            name,
-            classes: {
-              select: classes.inputSelect,
-            },
-          }}
-          MenuProps={{
-            anchorOrigin: {
-              vertical: "bottom",
-              horizontal: "center",
-            },
-            classes: {
-              paper: classes.menuPaper,
-            },
-          }}
-          {...props}
-        >
-          {children}
-        </Root>
-      </>
-    )
+    <>
+      <label id={`${name?.replaceAll(" ", "-")}-label`} style={visuallyHidden}>
+        {name}
+      </label>
+      <Root
+        variant="standard"
+        value={value}
+        labelId={`${name?.replaceAll(" ", "-")}-label`}
+        classes={{
+          select: classes.rootSelect,
+          icon: classes.icon,
+        }}
+        onChange={onChange}
+        IconComponent={ArrowIcon}
+        input={<Input bordered={bordered} />}
+        inputProps={{
+          name,
+          classes: {
+            select: classes.inputSelect,
+          },
+        }}
+        MenuProps={{
+          anchorOrigin: {
+            vertical: "bottom",
+            horizontal: "center",
+          },
+          classes: {
+            paper: classes.menuPaper,
+          },
+        }}
+        {...props}
+      >
+        {children}
+      </Root>
+    </>
   );
 }

--- a/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
+++ b/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
@@ -1,6 +1,7 @@
 import ArrowIcon from "@mui/icons-material/KeyboardArrowDown";
 import Select, { selectClasses, SelectProps } from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
+import { visuallyHidden } from "@mui/utils";
 import React, { ReactNode } from "react";
 
 import Input from "../../shared/Input/Input";
@@ -82,34 +83,47 @@ export default function SelectInput({
   ...props
 }: Props): FCReturn {
   return (
-    <Root
-      variant="standard"
-      value={value}
-      classes={{
-        select: classes.rootSelect,
-        icon: classes.icon,
-      }}
-      onChange={onChange}
-      IconComponent={ArrowIcon}
-      input={<Input bordered={bordered} />}
-      inputProps={{
-        name,
-        classes: {
-          select: classes.inputSelect,
-        },
-      }}
-      MenuProps={{
-        anchorOrigin: {
-          vertical: "bottom",
-          horizontal: "center",
-        },
-        classes: {
-          paper: classes.menuPaper,
-        },
-      }}
-      {...props}
-    >
-      {children}
-    </Root>
+    console.log(props),
+    console.log({ value }),
+    (
+      <>
+        <label
+          id={`${name?.replaceAll(" ", "-")}-label`}
+          style={visuallyHidden}
+        >
+          {name}
+        </label>
+        <Root
+          variant="standard"
+          value={value}
+          labelId={`${name?.replaceAll(" ", "-")}-label`}
+          classes={{
+            select: classes.rootSelect,
+            icon: classes.icon,
+          }}
+          onChange={onChange}
+          IconComponent={ArrowIcon}
+          input={<Input bordered={bordered} />}
+          inputProps={{
+            name,
+            classes: {
+              select: classes.inputSelect,
+            },
+          }}
+          MenuProps={{
+            anchorOrigin: {
+              vertical: "bottom",
+              horizontal: "center",
+            },
+            classes: {
+              paper: classes.menuPaper,
+            },
+          }}
+          {...props}
+        >
+          {children}
+        </Root>
+      </>
+    )
   );
 }

--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -15,6 +15,7 @@ type SortDirection = "asc" | "desc";
 
 const StyledSelectInput = styled(SelectInput)(() => ({
   minWidth: "170px",
+  height: "40px",
 }));
 
 export interface SortableFields<T> {

--- a/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -3,6 +3,7 @@ import Search from "@mui/icons-material/Search";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
+import { visuallyHidden } from "@mui/utils";
 import { useFormik } from "formik";
 import { FuseOptionKey } from "fuse.js";
 import { useSearch } from "hooks/useSearch";
@@ -87,7 +88,7 @@ export const SearchBox = <T extends object>({
             hidden: hideLabel,
           }}
         >
-          <strong>Search</strong>
+          <strong style={visuallyHidden}>Search</strong>
         </InputRowLabel>
         <InputRowItem>
           <Box sx={{ position: "relative" }}>


### PR DESCRIPTION
## What does this PR do?

- Introduces a simpler filter block with no accordion
- Simplifies styling of filter cards
- Introduces a grid/row view switch to the team page UI, which is updated in the store
- Adds a `Source Template` filter option to the template filter (run `window.featureFlags.toggle("TEMPLATES")` to see)

**Testing:**
https://4541.planx.pizza/a-new-team?sort=last-edited&sortDirection=desc