### PR TITLE
chore: Drop Canterbury FOIYNPP redirect

### DIFF
--- a/editor.planx.uk/src/routes/index.tsx
+++ b/editor.planx.uk/src/routes/index.tsx
@@ -91,12 +91,6 @@ export default isPreviewOnlyDomain
     })
   : mount({
       "/:team/:flow/published": loadPublishedRoutes(), // loads current published flow if exists, or throws Not Found if unpublished
-      "/canterbury/find-out-if-you-need-planning-permission/preview": map(
-        async (req) =>
-          redirect(
-            `/canterbury/find-out-if-you-need-planning-permission/published${req?.search}`,
-          ),
-      ), // temporary redirect while Canterbury works with internal IT to update advertised service links
       "/:team/:flow/preview": loadPreviewRoutes(), // loads current draft flow and latest published external portals, or throws Not Found if any external portal is unpublished
       "/:team/:flow/draft": loadDraftRoutes(), // loads current draft flow and draft external portals
       "/:team/:flow/pay": loadPayRoutes(),


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1743678613301409 (OSL Slack) for context.

This temporary redirect is no longer required.