### PR TITLE
feat: add automation validation for boolean formulas

### DIFF
--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -53,7 +53,7 @@ export default function Component(props: Props) {
         }
         if (typeof result === "boolean" && !values.formatOutputForAutomations) {
           errors.formula =
-            "For boolean functions, toggle on 'Format the output to automate a future Question or Checklist only'";
+            "For Boolean functions, toggle on 'Format the output to automate a future Question or Checklist only'";
         }
       } catch (error: any) {
         errors.formula = error.message;

--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -51,6 +51,10 @@ export default function Component(props: Props) {
         if (Number.isNaN(Number(result))) {
           errors.formula = "Enter a formula which outputs a number";
         }
+        if (typeof result === "boolean" && !values.formatOutputForAutomations) {
+          errors.formula =
+            "For boolean functions, please check 'Format the output to automate a future Question or Checklist only'.";
+        }
       } catch (error: any) {
         errors.formula = error.message;
       }
@@ -131,16 +135,16 @@ export default function Component(props: Props) {
             onChange={(value) => formik.setFieldValue("fn", value)}
           />
           <InputRow>
-          <Switch            
-            checked={formik.values.formatOutputForAutomations}
-            onChange={() =>
-              formik.setFieldValue(
-                "formatOutputForAutomations",
-                !formik.values.formatOutputForAutomations
-              )
-            }
-            label="Format the output to automate a future Question or Checklist only"
-          />
+            <Switch
+              checked={formik.values.formatOutputForAutomations}
+              onChange={() =>
+                formik.setFieldValue(
+                  "formatOutputForAutomations",
+                  !formik.values.formatOutputForAutomations,
+                )
+              }
+              label="Format the output to automate a future Question or Checklist only"
+            />
           </InputRow>
         </ModalSectionContent>
         <ModalSectionContent title="Formula">
@@ -196,8 +200,8 @@ export default function Component(props: Props) {
             <></>
           )}
           <p>
-            <strong>{formik.values.fn || "<output>"}</strong> would be set
-            to <strong>{sampleResult}</strong>
+            <strong>{formik.values.fn || "<output>"}</strong> would be set to{" "}
+            <strong>{sampleResult}</strong>
           </p>
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -53,7 +53,7 @@ export default function Component(props: Props) {
         }
         if (typeof result === "boolean" && !values.formatOutputForAutomations) {
           errors.formula =
-            "For boolean functions, please check 'Format the output to automate a future Question or Checklist only'.";
+            "For boolean functions, toggle on 'Format the output to automate a future Question or Checklist only'";
         }
       } catch (error: any) {
         errors.formula = error.message;


### PR DESCRIPTION
Adds a validation check to the calculate component, ensuring the component is toggled to 'automate a future question or checklist' if the formula returns a boolean value.