### PR TITLE
style: Tidy feedback table

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/ExpandableHelpText.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/ExpandableHelpText.tsx
@@ -12,7 +12,7 @@ export const ExpandableHelpText = (props: GridCellParams) => {
   const { truncated: truncatedHelpText, full: fullHelpText } =
     getCombinedHelpText(row);
   return (
-    <Box>
+    <Box sx={{ "& p": { mt: 0 } }}>
       <ReactMarkdownOrHtml source={truncatedHelpText} />
 
       {fullHelpText && (
@@ -23,7 +23,9 @@ export const ExpandableHelpText = (props: GridCellParams) => {
             closed: "Hide full text",
           }}
         >
-          <ReactMarkdownOrHtml source={fullHelpText} />
+          <Box sx={{ "& p": { marginTop: "0.5em" } }}>
+            <ReactMarkdownOrHtml source={fullHelpText} />
+          </Box>
         </SimpleExpand>
       )}
     </Box>

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -714,6 +714,9 @@ const getThemeOptions = ({
               {
                 padding: "20px 10px",
               },
+            [`& .${gridClasses.cell}.${gridClasses.cellCheckbox}`]: {
+              paddingTop: "1px",
+            },
             [`& .${gridClasses.toolbarContainer}`]: {
               borderBottom: `1px solid ${palette.border.main}`,
               background: palette.secondary.dark,

--- a/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -133,6 +133,7 @@ export const DataTable = <T,>({
           getRowId={(row) => row.id}
           processRowUpdate={onProcessRowUpdate}
           checkboxSelection={checkboxSelection}
+          disableRowSelectionOnClick
         />
       </Box>
     </Box>


### PR DESCRIPTION
## What does this PR do?

Some small tweaks to the feedback table styling:

- Align row select with content (before vs after)
![image](https://github.com/user-attachments/assets/a7102969-5a4b-4f27-8c8a-d846ed45d864)

- Disable row select on click. As we're now using checkboxes to select rows, and also editable cells (editor notes), it's unnecessary to be able to select a row on click

- Remove excess margins from help text (before vs after)
![image](https://github.com/user-attachments/assets/c102ef56-34e7-4bdc-bfdf-5084d6fe80dc)