### PR TITLE
fix: correct GraphQL type for `email_applications` table

### DIFF
--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -154,7 +154,7 @@ interface FindApplication {
 export async function checkEmailAuditTable(sessionId: string): Promise<string> {
   const application = await $api.client.request<FindApplication>(
     gql`
-      query FindApplication($session_id: String = "") {
+      query FindApplication($session_id: uuid!) {
         emailApplications: email_applications(
           where: {
             session_id: { _eq: $session_id }


### PR DESCRIPTION
Fixes https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1743778821764219

Introduced in https://github.com/theopensystemslab/planx-new/pull/4540 (`s3_applications` table legitimately has `text` type column for `session_id`, so this was only wrong in one of the two places introduced)