### PR TITLE
fix: publish validation checks for schema values should "fail" not "warn"

### DIFF
--- a/api.planx.uk/modules/flows/validate/service/fileTypes.ts
+++ b/api.planx.uk/modules/flows/validate/service/fileTypes.ts
@@ -37,7 +37,7 @@ const validateFileTypes = (flowGraph: FlowGraph): FlowValidationResponse => {
     });
     return {
       title: "File types",
-      status: "Warn",
+      status: "Fail",
       message: `Your FileUpload or UploadAndLabel are setting data fields that are not supported by the current release of the ODP Schema: ${summarisedInvalidFileFns.join(", ")}`,
     };
   }

--- a/api.planx.uk/modules/flows/validate/service/projectTypes.ts
+++ b/api.planx.uk/modules/flows/validate/service/projectTypes.ts
@@ -35,7 +35,7 @@ const validateProjectTypes = (flowGraph: FlowGraph): FlowValidationResponse => {
     });
     return {
       title: "Project types",
-      status: "Warn",
+      status: "Fail",
       message: `Your Checklists setting "proposal.projectType" include options that are not supported by the current release of the ODP Schema: ${summarisedInvalidProjectVals.join(", ")}`,
     };
   }

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -450,7 +450,7 @@ describe("invite to pay validation on diff", () => {
 });
 
 describe("ODP Schema file type validation on diff", () => {
-  it("warns if any file data fields aren't supported by the ODP Schema", async () => {
+  it("fails if any file data fields aren't supported by the ODP Schema", async () => {
     const alteredFlow = {
       ...mockFlowData,
       fileUpload: {
@@ -511,7 +511,7 @@ describe("ODP Schema file type validation on diff", () => {
         expect(res.body.validationChecks).toEqual([
           {
             title: "File types",
-            status: "Warn",
+            status: "Fail",
             message:
               "Your FileUpload or UploadAndLabel are setting data fields that are not supported by the current release of the ODP Schema: sitePlanTypo (1)",
           },


### PR DESCRIPTION
We've had two recent cases of submissions failing on unsupported `FileType` or `ProjectType` enum values. The validation checks for these are currently set to a "Warning" status rather than "Fail", which makes them very easy to ignore.

Now that passport values auto-suggest in the editor, there's less barrier to making them full failures and easier to discover/fix to use supported values.