### PR TITLE
fix: Use enum, not string, for `flow.status` value

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -247,7 +247,7 @@ export const editorStore: StateCreator<
         mutation updateFlow($id: uuid!) {
           flow: update_flows_by_pk(
             pk_columns: { id: $id }
-            _set: { deleted_at: "now()", status: "offline" }
+            _set: { deleted_at: "now()", status: offline }
           ) {
             id
             name


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3c17fff5-e6f0-4e7a-9848-3359d1c1109e)
