### PR TITLE
feat: add node heading to extractNodeTitle

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -32,7 +32,8 @@ export function extractNodeTitle(node: Store.Node): string {
       : node?.data?.title ??
         node?.data?.text ??
         node?.data?.flagSet ??
-        node?.data?.category;
+        node?.data?.category ??
+        node?.data?.heading;
   return nodeTitle;
 }
 


### PR DESCRIPTION
Tiny change so that we can track Confirmation node headings in analytics too. I tested this locally (previously `node_title` would have been `null` for Confirmation nodes but they're pulling through successfully now). 

Let me know if there's a better way to do this, or if there was a specific reason as to why this was omitted before? Or if there might be any tricky implications that I've overlooked..? See both after and before in logs screenshot!

![image](https://github.com/user-attachments/assets/9c1472d4-09a5-4784-8c1f-3475de89e297)
