### PR TITLE
fix: CSS specificty for HTML anchors

### DIFF
--- a/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
@@ -6,7 +6,7 @@ import ReactMarkdown from "react-markdown";
 import { FONT_WEIGHT_SEMI_BOLD, linkStyle } from "theme";
 
 const styles = (theme: Theme) => ({
-  "& a": linkStyle(theme.palette.link.main),
+  "&& a": linkStyle(theme.palette.link.main),
   "& h1": theme.typography.h2,
   "& h2": theme.typography.h3,
   "& h3": theme.typography.h3,


### PR DESCRIPTION
## What's the problem?
In the `Banner` component, links added via `<ReactMarkdownOrHTML/>` can have their `anchor` style incorrectly overriden.

![image](https://github.com/user-attachments/assets/999fa259-162c-43cd-85ca-291ac862d85f)

I've not quite got to the bottom of why this is happening in a seemingly non-deterministic way - some builds don't have this issue, but other do. MUI should always compile CSS via the React DOM tree model - meaning children come after parents.

## What's the solution?
By using a `&&` we can increase the specificity of the class (as it doubles up), meaning that the `ReactMarkdownOrHTML` style will be applied.

![image](https://github.com/user-attachments/assets/946346a5-e02d-44ef-a27a-3fb664a782ee)


### References
- https://dev.to/magischerzwerg/double-ampersand-trick-in-sass-with-react-4khe
- https://styled-components.com/docs/basics#pseudoelements-pseudoselectors-and-nesting