### PR TITLE
fix: Confirmation banner link colour

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -19,7 +19,6 @@ export const Basic = {
     heading: "Application sent",
     description: `A payment receipt has been emailed to you. You will also 
     receive an email to confirm when your application has been received.`,
-    color: { background: "#EFF7EE", text: "#0B0C0C" },
     sessionId: "123-t3st-456",
     applicableDetails: {
       "Planning Application Reference": "LBL–LDCP-2138261",

--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -19,7 +19,7 @@ export const Basic = {
     heading: "Application sent",
     description: `A payment receipt has been emailed to you. You will also 
     receive an email to confirm when your application has been received.`,
-    color: { background: "rgba(1, 99, 96, 0.1)", text: "#000" },
+    color: { background: "#EFF7EE", text: "#0B0C0C" },
     sessionId: "123-t3st-456",
     applicableDetails: {
       "Planning Application Reference": "LBL–LDCP-2138261",

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -56,10 +56,6 @@ export default function ConfirmationEditor(props: Props) {
   const type = TYPES.Confirmation;
   const formik = useFormik({
     initialValues: {
-      color: props.node?.color || {
-        text: "#000",
-        background: "rgba(1, 99, 96, 0.1)",
-      },
       heading: props.node?.data?.heading || "Application sent",
       description:
         props.node?.data?.description ||

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@opensystemslab/planx-core", () => {
 it("should not have any accessibility violations", async () => {
   const { container } = setup(
     <ConfirmationComponent
-      color={{ text: "#000", background: "rgba(1, 99, 96, 0.1)" }}
+      color={{ text: "#0B0C0C", background: "#EFF7EE" }}
       heading="heading"
       description="description"
       nextSteps={[
@@ -65,7 +65,7 @@ describe("Confirmation component", () => {
 
     const { user } = setup(
       <ConfirmationComponent
-        color={{ text: "#000", background: "rgba(1, 99, 96, 0.1)" }}
+        color={{ text: "#0B0C0C", background: "#EFF7EE" }}
         heading="heading"
         description="description"
         nextSteps={[
@@ -105,7 +105,7 @@ describe("Confirmation component", () => {
 
     const { user } = setup(
       <ConfirmationComponent
-        color={{ text: "#000", background: "rgba(1, 99, 96, 0.1)" }}
+        color={{ text: "#0B0C0C", background: "#EFF7EE" }}
         heading="heading"
         description="description"
         nextSteps={[

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -25,7 +25,6 @@ vi.mock("@opensystemslab/planx-core", () => {
 it("should not have any accessibility violations", async () => {
   const { container } = setup(
     <ConfirmationComponent
-      color={{ text: "#0B0C0C", background: "#EFF7EE" }}
       heading="heading"
       description="description"
       nextSteps={[
@@ -65,7 +64,6 @@ describe("Confirmation component", () => {
 
     const { user } = setup(
       <ConfirmationComponent
-        color={{ text: "#0B0C0C", background: "#EFF7EE" }}
         heading="heading"
         description="description"
         nextSteps={[
@@ -105,7 +103,6 @@ describe("Confirmation component", () => {
 
     const { user } = setup(
       <ConfirmationComponent
-        color={{ text: "#0B0C0C", background: "#EFF7EE" }}
         heading="heading"
         description="description"
         nextSteps={[

--- a/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -1,5 +1,6 @@
 import Check from "@mui/icons-material/Check";
 import Box from "@mui/material/Box";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { QuestionAndResponses } from "@opensystemslab/planx-core/types";
 import Card from "@planx/components/shared/Preview/Card";
@@ -86,11 +87,15 @@ interface PresentationalProps extends Props {
 
 export function Presentational(props: PresentationalProps) {
   const isFinalCard = useStore().isFinalCard();
+  const theme = useTheme();
   return (
     <Box width="100%">
       <Banner
         heading={props.heading || ""}
-        color={props.color}
+        color={{
+          background: theme.palette.success.light,
+          text: theme.palette.text.primary,
+        }}
         Icon={Check}
         iconTitle={"Success"}
       >

--- a/editor.planx.uk/src/@planx/components/Confirmation/model.ts
+++ b/editor.planx.uk/src/@planx/components/Confirmation/model.ts
@@ -8,6 +8,7 @@ export interface Step {
 export interface Confirmation extends BaseNodeData {
   heading?: string;
   description?: string;
+  color?: { text: string; background: string };
   nextSteps?: Step[];
   moreInfo?: string;
   contactInfo?: string;

--- a/editor.planx.uk/src/@planx/components/Confirmation/model.ts
+++ b/editor.planx.uk/src/@planx/components/Confirmation/model.ts
@@ -8,7 +8,6 @@ export interface Step {
 export interface Confirmation extends BaseNodeData {
   heading?: string;
   description?: string;
-  color?: { text: string; background: string };
   nextSteps?: Step[];
   moreInfo?: string;
   contactInfo?: string;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
@@ -105,8 +105,8 @@ export const mockFlow: FlowGraph = {
   "7eG9iF86xd": {
     data: {
       color: {
-        text: "#000",
-        background: "rgba(1, 99, 96, 0.1)",
+        text: "#0B0C0C",
+        background: "#EFF7EE",
       },
       heading: "Snake",
       moreInfo: "<p>Tarantula</p>",
@@ -562,8 +562,8 @@ export const mockConfirmationResult: SearchResult<IndexedNode> = {
     type: 725,
     data: {
       color: {
-        text: "#000",
-        background: "rgba(1, 99, 96, 0.1)",
+        text: "#0B0C0C",
+        background: "#EFF7EE",
       },
       heading: "Snake",
       moreInfo: "<p>Tarantula</p>",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -72,6 +72,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
   success: {
     main: "#49A74C",
     dark: "#265A26",
+    light: "#EFF7EE",
   },
   info: {
     main: "#2196F3",


### PR DESCRIPTION
## What does this PR do?

Issue reported by @augustlindemer in Slack (also reported by council officers):
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1744024034664429

The background colour was being passed in to the confirmation dialog as an opacity of a solid colour using the alpha value `rgba(1, 99, 96, 0.1)` , I've updated it to be a solid colour (defined unused theme variable palette.success.light). Interestingly VSCode previews this as a dark colour based on the rgb values alone, could be that this was causing `getContrastTextColor` to do the same, albeit intermittently. Either way we should use solid colours wherever possible.

Also, the colour values (bg + text) were being passed into the confirmation dialog as `initialValues`, presumably because we had intended this component to be user-customisable. As it isn't this leaves us no way to change the colour after the component is created, so I've updated to hardcoded values pulling from the theme palette.

Reported service fixed:
https://4568.planx.pizza/templates/apply-for-pre-application-advice-work-in-progress-copy

<img width="1121" alt="image" src="https://github.com/user-attachments/assets/c57d3ec3-90ee-45e0-adfe-5ef8b6c5b192" />
