### PR TITLE
fix: Fee breakdown table text contrast

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -46,7 +46,10 @@ const Header: FeeBreakdownRow = ({ amount }) => (
         Amount {amount.payableVAT ? ` (excl VAT)` : ``}
       </TableCell>
       {amount.payableVAT ? (
-        <TableCell align="right" sx={{ color: "GrayText" }}>
+        <TableCell
+          align="right"
+          sx={(theme) => ({ color: theme.palette.text.secondary })}
+        >
           VAT (20%)
         </TableCell>
       ) : (
@@ -70,7 +73,10 @@ const ApplicationFee: FeeBreakdownRow = ({ amount }) => (
       {formattedPriceWithCurrencySymbol(amount.calculated)}
     </TableCell>
     {amount.payableVAT && amount.payableVAT > 0 ? (
-      <TableCell align="right" sx={{ color: "GrayText" }}>
+      <TableCell
+        align="right"
+        sx={(theme) => ({ color: theme.palette.text.secondary })}
+      >
         {amount.calculatedVAT && amount.calculatedVAT > 0
           ? formattedPriceWithCurrencySymbol(amount.calculatedVAT)
           : undefined}
@@ -118,7 +124,12 @@ const Reductions: FeeBreakdownRow = ({ amount, reductions }) => {
       {reductions.map((reduction) => (
         <TableRow key={reduction}>
           <TableCell colSpan={amount.payableVAT ? 4 : 2}>
-            <Box sx={{ pl: 2, color: "GrayText" }}>
+            <Box
+              sx={(theme) => ({
+                pl: theme.spacing(2),
+                color: theme.palette.text.secondary,
+              })}
+            >
               {exemptionsReductionLookup[reduction]}
             </Box>
           </TableCell>
@@ -157,7 +168,12 @@ const Exemptions: FeeBreakdownRow = ({ exemptions, amount }) => {
       {exemptions.map((exemption) => (
         <TableRow key={exemption}>
           <TableCell colSpan={amount.payableVAT ? 4 : 2}>
-            <Box sx={{ pl: 2, color: "GrayText" }}>
+            <Box
+              sx={(theme) => ({
+                pl: theme.spacing(2),
+                color: theme.palette.text.secondary,
+              })}
+            >
               {exemptionsReductionLookup[exemption]}
             </Box>
           </TableCell>
@@ -182,7 +198,10 @@ const FastTrackFee: FeeBreakdownRow = ({ amount }) => {
       <TableCell align="right">
         {formattedPriceWithCurrencySymbol(amount.fastTrack)}
       </TableCell>
-      <TableCell align="right" sx={{ color: "GrayText" }}>
+      <TableCell
+        align="right"
+        sx={(theme) => ({ color: theme.palette.text.secondary })}
+      >
         {formattedPriceWithCurrencySymbol(amount.fastTrackVAT)}
       </TableCell>
       <TableCell align="right">
@@ -205,7 +224,10 @@ const ServiceCharge: FeeBreakdownRow = ({ amount }) => {
       <TableCell align="right">
         {formattedPriceWithCurrencySymbol(amount.serviceCharge)}
       </TableCell>
-      <TableCell align="right" sx={{ color: "GrayText" }}>
+      <TableCell
+        align="right"
+        sx={(theme) => ({ color: theme.palette.text.secondary })}
+      >
         {formattedPriceWithCurrencySymbol(amount.serviceChargeVAT)}
       </TableCell>
       <TableCell align="right">
@@ -228,7 +250,10 @@ const PaymentProcessingFee: FeeBreakdownRow = ({ amount }) => {
       <TableCell align="right">
         {formattedPriceWithCurrencySymbol(amount.paymentProcessing)}
       </TableCell>
-      <TableCell align="right" sx={{ color: "GrayText" }}>
+      <TableCell
+        align="right"
+        sx={(theme) => ({ color: theme.palette.text.secondary })}
+      >
         {formattedPriceWithCurrencySymbol(amount.paymentProcessingVAT)}
       </TableCell>
       <TableCell align="right">


### PR DESCRIPTION
## What does this PR do?

Quick one: spotted in Storybook, the fee breakdown table uses the system text colour `GrayText` which does not give adequate contrast for WCAG AA. I've updated to use `palette.text.secondary` which bumps the contrast to a passing level.

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/516f134a-7dff-4bfd-bf21-def25ab3c92a" />

`GrayText` (left) vs `text.secondary` (right):

![image](https://github.com/user-attachments/assets/d0c5999f-73e5-434e-9c87-2f9bcfc7393d)


There are several uses of text colour `GrayText` also in the editor that I'll pick up as a separate PR.
