### PR TITLE
style: Form styling for search tab

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/ExternalPortals.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/ExternalPortals.tsx
@@ -13,7 +13,7 @@ export const ExternalPortals: React.FC<ExternalPortalsProps> = ({
     <Root>
       {Object.values(externalPortals).map(({ name, href }) => (
         <ListItem key={`external-portal-card-${name}`} disablePadding>
-          <ListItemButton component="a" href={`../${href}`}>
+          <ListItemButton component="a" href={`../${href}`} disableRipple>
             <Typography variant="body2">
               {href.replaceAll("/", " / ")}
             </Typography>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/styles.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/styles.ts
@@ -4,6 +4,6 @@ import { styled } from "@mui/material/styles";
 export const Root = styled(List)(({ theme }) => ({
   color: theme.palette.text.primary,
   padding: theme.spacing(0.5, 0),
-  backgroundColor: theme.palette.background.paper,
+  backgroundColor: theme.palette.background.default,
   border: `1px solid ${theme.palette.border.light}`,
 }));

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.tsx
@@ -37,7 +37,7 @@ export const SearchHeader: Components<Data, Context>["Header"] = ({
       <Typography
         component={"label"}
         htmlFor="pattern"
-        variant="h3"
+        variant="h4"
         mb={1}
         display={"block"}
       >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
@@ -18,6 +18,7 @@ const SearchResultCardRoot = styled(ListItemButton, {
   shouldForwardProp: (prop) => prop !== "portalId",
 })<{ portalId?: string }>(({ theme, portalId }) => ({
   border: `1px solid ${theme.palette.common.black}`,
+  background: theme.palette.background.default,
   display: "block",
   padding: 0,
   borderWidth: portalId ? 4 : 2,
@@ -74,7 +75,11 @@ export const SearchResultCard: React.FC<{
   const headlineVariant = isDataKey ? "data" : undefined;
 
   return (
-    <SearchResultCardRoot onClick={handleClick} portalId={portalId}>
+    <SearchResultCardRoot
+      onClick={handleClick}
+      portalId={portalId}
+      disableRipple
+    >
       {portalId && <InternalPortalHeader portalId={portalId} />}
       <Box p={1}>
         <Box

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -1,5 +1,6 @@
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
+import { useTheme } from "@mui/material/styles";
 import { IndexedNode } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
 import {
@@ -90,8 +91,14 @@ const Search: React.FC = () => {
     [search],
   );
 
+  const theme = useTheme();
+  const backgroundStyle = {
+    background: theme.palette.background.paper,
+  };
+
   return (
     <Virtuoso<Data, Context>
+      style={backgroundStyle}
       totalCount={results.length}
       context={{
         results,


### PR DESCRIPTION
## What does this PR do?

- As the search tab is a form input it should have a `paper` background to be consistent with other forms in the editor
- Also disables ripple on result cards

**Before (left) vs after (right):**
![image](https://github.com/user-attachments/assets/97e3c229-d19d-4f98-90ab-d94b27ea62d6)
