### PR TITLE
chore: Error handling for archiving flows

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -240,30 +240,30 @@ export const editorStore: StateCreator<
   },
 
   archiveFlow: async (flowId) => {
-    const { data } = await client.mutate<{
-      flow: { id: string; name: string };
-    }>({
-      mutation: gql`
-        mutation updateFlow($id: uuid!) {
-          flow: update_flows_by_pk(
-            pk_columns: { id: $id }
-            _set: { deleted_at: "now()", status: offline }
-          ) {
-            id
-            name
+    try {
+      const { data } = await client.mutate<{
+        flow: { id: string; name: string };
+      }>({
+        mutation: gql`
+          mutation updateFlow($id: uuid!) {
+            flow: update_flows_by_pk(
+              pk_columns: { id: $id }
+              _set: { deleted_at: "now()", status: offline }
+            ) {
+              id
+              name
+            }
           }
-        }
-      `,
-      variables: {
-        id: flowId,
-      },
-    });
+        `,
+        variables: {
+          id: flowId,
+        },
+      });
 
-    if (!data)
-      return alert(
-        `We are unable to archive this flow, refesh and try again or contact an admin`,
-      );
-    return data?.flow;
+      return data?.flow;
+    } catch (error) {
+      throw Error("Failed to archive flow", { cause: error })
+    };
   },
 
   connect: (src, tgt, { before = undefined } = {}) => {

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -3,6 +3,7 @@ import MoreHoriz from "@mui/icons-material/MoreHoriz";
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { useToast } from "hooks/useToast";
 import React, { useState } from "react";
 import { Link, useCurrentRoute } from "react-navi";
 import { inputFocusStyle } from "theme";
@@ -110,15 +111,20 @@ const FlowCard: React.FC<FlowCardProps> = ({
   );
 
   const route = useCurrentRoute();
+  const toast = useToast();
 
   const {
     sortObject: { displayName: sortDisplayName },
   } = getSortParams<FlowSummary>(route.url.query, sortOptions);
 
-  const handleArchive = () => {
-    archiveFlow(flow.id).then(() => {
+  const handleArchive = async () => {
+    try {
+      await archiveFlow(flow.id);
       refreshFlows();
-    });
+      toast.success("Archived flow");
+    } catch (error) {
+      toast.error("We are unable to archive this flow, refesh and try again or contact an admin");
+    };
   };
 
   const handleCopy = () => {


### PR DESCRIPTION
## What does this PR do?
 - Give user feedback (via a toast message) on success or failure of the "Archive" operation
 - Recently raised as a suggestion via ODP Slack

In future, it would be nice to apply this pattern more broadly (e.g. to copy and move) and have a better structure in place for this than a few try/catch blocks.