### PR TITLE
fix: Publish dialog styles

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/AlteredExternalPortals.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/AlteredExternalPortals.tsx
@@ -7,6 +7,7 @@ import Typography from "@mui/material/Typography";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
 import React, { useState } from "react";
 import { useAsync } from "react-use";
+import { focusStyle } from "theme";
 import BlockQuote from "ui/editor/BlockQuote";
 
 import { useStore } from "../../../lib/store";
@@ -45,6 +46,12 @@ const AlteredExternalPortalListItem = (props: ExternalPortal) => {
         py: 0.7,
         margin: 0,
         mb: 1,
+        "&:focus-within": {
+          ...focusStyle,
+          "& *": {
+            color: "text.primary",
+          },
+        },
       }}
     >
       <ListItemText

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -316,10 +316,10 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
             <StepLabel
               sx={(theme) => ({
                 fontWeight: "bold",
-                [`& .${stepIconClasses.completed}`]: {
+                [`& .${stepIconClasses.completed} svg`]: {
                   color: theme.palette.success.main,
                 },
-                [`& .${stepIconClasses.active}`]: {
+                [`& .${stepIconClasses.active} svg`]: {
                   color: theme.palette.info.main,
                 },
               })}


### PR DESCRIPTION
## What does this PR do?

Fixes styles in publishing dialog:

- Steps (before vs after)
![image](https://github.com/user-attachments/assets/6d1c8ef2-2451-4ddf-852a-9bb171791dbe)

- Focus state for portals (before vs after)
![image](https://github.com/user-attachments/assets/3c8b1669-a407-44af-9357-d5763af87ade)