### PR TITLE
feat: Create team modal

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -7,6 +7,7 @@ import {
 import gql from "graphql-tag";
 import { client } from "lib/graphql";
 import { TeamMember } from "pages/FlowEditor/components/Team/types";
+import { CreateTeam } from "pages/Teams/AddTeamButton";
 import type { StateCreator } from "zustand";
 
 import { SharedStore } from "./shared";
@@ -29,7 +30,7 @@ export interface TeamStore {
   fetchCurrentTeamSettings: () => Promise<TeamSettings>;
   updateTeamTheme: (theme: Partial<TeamTheme>) => Promise<boolean>;
   updateTeamSettings: (teamSettings: Partial<TeamSettings>) => Promise<boolean>;
-  createTeam: (newTeam: { name: string; slug: string }) => Promise<number>;
+  createTeam: (newTeam: CreateTeam) => Promise<number>;
   setTeamMembers: (teamMembers: TeamMember[]) => Promise<void>;
   deleteUser: (userId: number) => Promise<boolean>;
 }
@@ -120,6 +121,7 @@ export const teamStore: StateCreator<
               externalPlanningSiteName: external_planning_site_name
               externalPlanningSiteUrl: external_planning_site_url
               submissionEmail: submission_email
+              isTrial: is_trial
             }
           }
         }

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -1,39 +1,15 @@
-import InputAdornment from "@mui/material/InputAdornment";
 import MenuItem from "@mui/material/MenuItem";
-import { typographyClasses } from "@mui/material/Typography";
 import { useFormikContext } from "formik";
 import { hasFeatureFlag } from "lib/featureFlags";
-import React, { useState } from "react";
+import React from "react";
 import SelectInput from "ui/editor/SelectInput/SelectInput";
+import { URLPrefix } from "ui/editor/URLPrefix";
 import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input/Input";
 import { slugify } from "utils";
 
 import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
 import { CREATE_FLOW_MODES, CreateFlow } from "./types";
-
-const URLPrefix: React.FC = () => {
-  // Store in component state so this does not update when user submits form
-  const [urlPrefix] = useState(() => {
-    const { origin, pathname } = window.location;
-    return `${origin}${pathname}/`;
-  });
-
-  return (
-    <InputAdornment
-      position="start"
-      sx={(theme) => ({
-        mr: 0,
-        [`& .${typographyClasses.root}`]: {
-          color: theme.palette.text.disabled,
-        },
-      })}
-    >
-      {urlPrefix}
-    </InputAdornment>
-  );
-};
-
 export const BaseFormSection: React.FC = () => {
   const { values, setFieldValue, getFieldProps, errors } =
     useFormikContext<CreateFlow>();

--- a/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -1,0 +1,157 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Typography from "@mui/material/Typography";
+import { Form, Formik, FormikConfig } from "formik";
+import navigation from "lib/navigation";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+import { AddButton } from "ui/editor/AddButton";
+import Permission from "ui/editor/Permission";
+import { URLPrefix } from "ui/editor/URLPrefix";
+import InputLabel from "ui/public/InputLabel";
+import Input from "ui/shared/Input/Input";
+import { Switch } from "ui/shared/Switch";
+import { slugify } from "utils";
+import { boolean, object, SchemaOf, string } from "yup";
+
+export interface CreateTeam {
+  name: string;
+  slug: string;
+  settings: {
+    isTrial: boolean;
+  };
+}
+
+const validationSchema: SchemaOf<CreateTeam> = object({
+  name: string().required("Name is required"),
+  slug: string().required("Slug is required"),
+  settings: object({
+    isTrial: boolean().required(),
+  }),
+});
+
+export const AddTeamButton: React.FC = () => {
+  const [createTeam] = useStore((state) => [state.createTeam]);
+
+  const initialValues: CreateTeam = {
+    name: "",
+    slug: "",
+    settings: {
+      isTrial: false,
+    },
+  };
+
+  const onSubmit: FormikConfig<CreateTeam>["onSubmit"] = async (values) => {
+    await createTeam(values);
+    navigation.navigate(`/${values.slug}`);
+  };
+
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+
+  return (
+    <Permission.IsPlatformAdmin>
+      <AddButton onClick={() => setDialogOpen(true)}>Add a new team</AddButton>
+      <Formik<CreateTeam>
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        validateOnBlur={false}
+        validateOnChange={false}
+        validationSchema={validationSchema}
+      >
+        {({
+          resetForm,
+          getFieldProps,
+          errors,
+          setFieldValue,
+          values,
+          isSubmitting,
+        }) => (
+          <Dialog
+            open={dialogOpen}
+            onClose={() => {
+              setDialogOpen(false);
+              resetForm();
+            }}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+            fullWidth
+          >
+            <DialogTitle variant="h3" component="h1">
+              <Box sx={{ mt: 1, mb: 4 }}>
+                <Typography variant="h3" component="h2" id="dialog-heading">
+                  Add a new team
+                </Typography>
+              </Box>
+            </DialogTitle>
+            <Box>
+              <Form>
+                <DialogContent
+                  sx={{ gap: 2, display: "flex", flexDirection: "column" }}
+                >
+                  <InputLabel label="Team name" htmlFor="name">
+                    <Input
+                      {...getFieldProps("name")}
+                      id="name"
+                      type="text"
+                      onChange={(e) => {
+                        setFieldValue("name", e.target.value);
+                        setFieldValue("slug", slugify(e.target.value));
+                      }}
+                      errorMessage={errors.name}
+                    />
+                  </InputLabel>
+                  <InputLabel label="Editor URL" htmlFor="slug">
+                    <Input
+                      {...getFieldProps("slug")}
+                      disabled
+                      type="text"
+                      startAdornment={<URLPrefix />}
+                    />
+                  </InputLabel>
+                  <Switch
+                    name="isTrial"
+                    checked={values.settings.isTrial}
+                    onChange={() =>
+                      setFieldValue(
+                        "settings.isTrial",
+                        !values.settings.isTrial,
+                      )
+                    }
+                    label={"Trial account"}
+                  />
+                  <Typography variant="body2" mt={-2}>
+                    A trial account has limited access to PlanX functionality
+                    (e.g. turning services online). A team can be promoted to
+                    having full access via the settings panel.
+                  </Typography>
+                </DialogContent>
+                <DialogActions sx={{ paddingX: 2 }}>
+                  <Button
+                    disableRipple
+                    disabled={isSubmitting}
+                    onClick={() => setDialogOpen(false)}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    type="submit"
+                    color="primary"
+                    variant="contained"
+                    disableRipple
+                    disabled={isSubmitting}
+                  >
+                    Add team
+                  </Button>
+                </DialogActions>
+              </Form>
+            </Box>
+          </Dialog>
+        )}
+      </Formik>
+    </Permission.IsPlatformAdmin>
+  );
+};

--- a/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -125,7 +125,7 @@ export const AddTeamButton: React.FC = () => {
                   />
                   <Typography variant="body2" mt={-2}>
                     A trial account has limited access to PlanX functionality
-                    (e.g. turning services online). A team can be promoted to
+                    (e.g. turning services online). Trail teams can be promoted to
                     having full access via the settings panel.
                   </Typography>
                 </DialogContent>

--- a/editor.planx.uk/src/pages/Teams/index.tsx
+++ b/editor.planx.uk/src/pages/Teams/index.tsx
@@ -6,16 +6,13 @@ import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { Team } from "@opensystemslab/planx-core/types";
-import navigation from "lib/navigation";
 import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-navi";
 import { borderedFocusStyle } from "theme";
-import { AddButton } from "ui/editor/AddButton";
-import Permission from "ui/editor/Permission";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
-import { slugify } from "utils";
 
-import { useStore } from "./FlowEditor/lib/store";
+import { useStore } from "../FlowEditor/lib/store";
+import { AddTeamButton } from "./AddTeamButton";
 
 interface TeamTheme {
   slug: string;
@@ -53,10 +50,7 @@ const TeamColourBand = styled(Box)(({ theme }) => ({
 }));
 
 const Teams: React.FC<Props> = ({ teams }) => {
-  const [canUserEditTeam, createTeam] = useStore((state) => [
-    state.canUserEditTeam,
-    state.createTeam,
-  ]);
+  const [canUserEditTeam] = useStore((state) => [state.canUserEditTeam]);
 
   const [searchedTeams, setSearchedTeams] = useState<Team[] | null>(null);
   const [clearSearch, setClearSearch] = useState<boolean>(false);
@@ -90,7 +84,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
       );
     });
 
-  const noResultsCard = (
+  const NoResultsCard = (
     <Card>
       <CardContent>
         <Typography variant="h3">No results</Typography>
@@ -117,33 +111,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
         <Typography variant="h2" component="h1">
           Select a team
         </Typography>
-        <Permission.IsPlatformAdmin>
-          <AddButton
-            onClick={async () => {
-              const newTeamName = prompt("Team name");
-
-              if (newTeamName) {
-                const newSlug = slugify(newTeamName);
-                const teamSlugDuplicate = teams.find(
-                  (team) => team.slug === newSlug,
-                );
-                if (teamSlugDuplicate !== undefined) {
-                  alert(
-                    `A team with the name "${teamSlugDuplicate.name}" already exists. Enter a unique team name to continue.`,
-                  );
-                } else {
-                  await createTeam({
-                    name: newTeamName,
-                    slug: newSlug,
-                  });
-                  navigation.navigate(`/${newSlug}`);
-                }
-              }
-            }}
-          >
-            Add a new team
-          </AddButton>
-        </Permission.IsPlatformAdmin>
+        <AddTeamButton />
       </Box>
       {editableTeams.length > 0 && (
         <>
@@ -185,7 +153,7 @@ const Teams: React.FC<Props> = ({ teams }) => {
             />
           </Box>
 
-          {searchedTeams?.length ? renderTeams(searchedTeams) : noResultsCard}
+          {searchedTeams?.length ? renderTeams(searchedTeams) : NoResultsCard}
         </>
       )}
     </Container>

--- a/editor.planx.uk/src/ui/editor/URLPrefix.tsx
+++ b/editor.planx.uk/src/ui/editor/URLPrefix.tsx
@@ -1,0 +1,30 @@
+import InputAdornment from "@mui/material/InputAdornment";
+import { typographyClasses } from "@mui/material/Typography";
+import React, { useState } from "react";
+
+/**
+ * InputAdornment for text inputs displaying the current URL
+ * Used to display URLs when creating teams and flows
+ */
+export const URLPrefix: React.FC = () => {
+  // Store in component state so this does not update when user submits form
+  const [urlPrefix] = useState(() => {
+    const { origin, pathname } = window.location;
+    const path = pathname !== "/" ? pathname : "";
+    return `${origin}${path}/`;
+  });
+
+  return (
+    <InputAdornment
+      position="start"
+      sx={(theme) => ({
+        mr: 0,
+        [`& .${typographyClasses.root}`]: {
+          color: theme.palette.text.disabled,
+        },
+      })}
+    >
+      {urlPrefix}
+    </InputAdornment>
+  );
+};


### PR DESCRIPTION
## What does this PR do?
- Opens a modal when creating a team
- Allows the `isTrial` property to be toggled
- All additional team settings etc can be configured in the existing team settings interface

<img width="626" alt="image" src="https://github.com/user-attachments/assets/048540cf-6ceb-4758-b413-6a1115800458" />
