### PR TITLE
feat: Toggle trial account status in team settings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
@@ -1,0 +1,81 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import Permission from "ui/editor/Permission";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import SettingsSection from "ui/editor/SettingsSection";
+import { Switch } from "ui/shared/Switch";
+import { boolean, object, SchemaOf } from "yup";
+
+import { FormProps } from ".";
+
+interface TrialAccountForm {
+  isTrial: boolean;
+}
+
+export default function TrialAccountForm({
+  formikConfig,
+  onSuccess,
+}: FormProps) {
+  const formSchema: SchemaOf<TrialAccountForm> = object({
+    isTrial: boolean().required(),
+  });
+
+  const formik = useFormik({
+    ...formikConfig,
+    validationSchema: formSchema,
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await useStore.getState().updateTeamSettings({
+        isTrial: values.isTrial,
+      });
+      if (isSuccess) {
+        onSuccess();
+        resetForm({ values });
+      }
+    },
+  });
+
+  return (
+    <Permission.IsPlatformAdmin>
+      <Box component="form" onSubmit={formik.handleSubmit} mt={2}>
+        <SettingsSection background>
+          <Switch
+            label="Trial account"
+            name="isTrial"
+            variant="editorPage"
+            capitalize
+            checked={formik.values.isTrial}
+            onChange={() =>
+              formik.setFieldValue("isTrial", !formik.values.isTrial)
+            }
+          />
+          <SettingsDescription>
+            <p>Toggle this team between "trial" access and full access</p>
+            <p>
+              A trial team had limited access to PlanX features. They are not
+              able to publish services and turn them online.
+            </p>
+          </SettingsDescription>
+
+          <Box>
+            <Button type="submit" variant="contained" disabled={!formik.dirty}>
+              Save
+            </Button>
+            <Button
+              onClick={() => formik.resetForm()}
+              type="reset"
+              variant="contained"
+              disabled={!formik.dirty}
+              color="secondary"
+              sx={{ ml: 1.5 }}
+            >
+              Reset changes
+            </Button>
+          </Box>
+        </SettingsSection>
+      </Box>
+    </Permission.IsPlatformAdmin>
+  );
+}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { useFormik } from "formik";
+import { useToast } from "hooks/useToast";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import Permission from "ui/editor/Permission";
@@ -23,16 +24,25 @@ export default function TrialAccountForm({
     isTrial: boolean().required(),
   });
 
+  const toast = useToast();
+
+
   const formik = useFormik({
     ...formikConfig,
     validationSchema: formSchema,
     onSubmit: async (values, { resetForm }) => {
-      const isSuccess = await useStore.getState().updateTeamSettings({
-        isTrial: values.isTrial,
-      });
-      if (isSuccess) {
+      try {
+        const isSuccess = await useStore.getState().updateTeamSettings({
+          isTrial: values.isTrial,
+        });
+
+        if (!isSuccess) throw Error("updateTeamSettings() failed");
+
         onSuccess();
         resetForm({ values });
+      } catch (error) {
+        console.error(error)
+        toast.error("Failed to update team's trial account status");
       }
     },
   });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
@@ -64,8 +64,8 @@ export default function TrialAccountForm({
           <SettingsDescription>
             <p>Toggle this team between "trial" access and full access</p>
             <p>
-              A trial team had limited access to PlanX features. They are not
-              able to publish services and turn them online.
+              A trial team had limited access to PlanX features - they are not
+              able to turn services online.
             </p>
           </SettingsDescription>
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/index.tsx
@@ -11,6 +11,7 @@ import BoundaryForm from "./BoundaryForm";
 import ContactForm from "./ContactForm";
 import ReferenceCodeForm from "./ReferenceCodeForm";
 import SubmissionsForm from "./SubmissionsForm";
+import TrialAccountForm from "./TrialAccountForm";
 
 export interface FormProps {
   formikConfig: FormikConfig<TeamSettings>;
@@ -68,6 +69,7 @@ const GeneralSettings: React.FC = () => {
             onSuccess={onSuccess}
           />
           <SubmissionsForm formikConfig={formikConfig} onSuccess={onSuccess} />
+          <TrialAccountForm formikConfig={formikConfig} onSuccess={onSuccess} />
         </>
       )}
     </Container>


### PR DESCRIPTION
## What does this PR do?
- Adds form section (for platformAdmins only) allowing the team's "trial" status to be toggled in team settings
- Relies on `planx-core` changes and type updates in https://github.com/theopensystemslab/planx-new/pull/4577

<img width="501" alt="image" src="https://github.com/user-attachments/assets/6678cfde-c8a6-44c4-9e4e-4dc00c7349ba" />