### PR TITLE
feat: Disable online/offline toggle for trial teams

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import type { FlowStatus } from "@opensystemslab/planx-core/types";
+import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import axios from "axios";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
@@ -104,19 +105,12 @@ const FlowStatus = () => {
       </SettingsSection>
       <SettingsSection background>
         {isTrial &&
-          <Box sx={(theme) => ({
-            border: `2px solid ${theme.palette.border.light}`,
-            marginBottom: theme.spacing(1),
-            padding: theme.spacing(1),
-            backgroundColor: theme.palette.common.white,
-            text: theme.palette.common.black,
-            display: "flex"
-          })}>
+          <WarningContainer>
             <PendingActionsIcon sx={{ mr: 1 }} />
             <Typography variant="body2">
               Teams in "trial" mode cannot turn flows online.
             </Typography>
-          </Box>
+          </WarningContainer>
         }
         <Switch
           disabled={isTrial}
@@ -140,7 +134,7 @@ const FlowStatus = () => {
           </p>
           <p>Offline services can still be edited and published as normal.</p>
         </SettingsDescription>
-        { !isTrial &&
+        {!isTrial &&
           <PublicLink
             isFlowPublished={isFlowPublished}
             status={flowStatus || "offline"}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -1,3 +1,4 @@
+import PendingActionsIcon from "@mui/icons-material/PendingActions";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
@@ -23,6 +24,7 @@ const FlowStatus = () => {
     flowSlug,
     teamDomain,
     isFlowPublished,
+    isTrial,
   ] = useStore((state) => [
     state.flowStatus,
     state.updateFlowStatus,
@@ -31,6 +33,7 @@ const FlowStatus = () => {
     state.flowSlug,
     state.teamDomain,
     state.isFlowPublished,
+    state.teamSettings.isTrial
   ]);
   const toast = useToast();
 
@@ -100,7 +103,23 @@ const FlowStatus = () => {
         </Typography>
       </SettingsSection>
       <SettingsSection background>
+        {isTrial &&
+          <Box sx={(theme) => ({
+            border: `2px solid ${theme.palette.border.light}`,
+            marginBottom: theme.spacing(1),
+            padding: theme.spacing(1),
+            backgroundColor: theme.palette.common.white,
+            text: theme.palette.common.black,
+            display: "flex"
+          })}>
+            <PendingActionsIcon sx={{ mr: 1 }} />
+            <Typography variant="body2">
+              Teams in "trial" mode cannot turn flows online.
+            </Typography>
+          </Box>
+        }
         <Switch
+          disabled={isTrial}
           label={statusForm.values.status as string}
           name={"service.status"}
           variant="editorPage"
@@ -121,13 +140,14 @@ const FlowStatus = () => {
           </p>
           <p>Offline services can still be edited and published as normal.</p>
         </SettingsDescription>
-
-        <PublicLink
-          isFlowPublished={isFlowPublished}
-          status={flowStatus || "offline"}
-          subdomain={subdomainLink}
-          publishedLink={publishedLink}
-        />
+        { !isTrial &&
+          <PublicLink
+            isFlowPublished={isFlowPublished}
+            status={flowStatus || "offline"}
+            subdomain={subdomainLink}
+            publishedLink={publishedLink}
+          />
+        }
 
         <Box>
           <Button

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -43,13 +43,13 @@ const FlowStatus = () => {
     },
     onSubmit: async (values, { resetForm }) => {
       const isSuccess = await updateFlowStatus(values.status);
-      if (isSuccess) {
-        toast.success("Service settings updated successfully");
-        // Send a Slack notification to #planx-notifications
-        sendFlowStatusSlackNotification(values.status);
-        // Reset "dirty" status to disable Save & Reset buttons
-        resetForm({ values });
-      }
+      if (!isSuccess) return toast.error("Failed to update settings");
+
+      toast.success("Service settings updated successfully");
+      // Send a Slack notification to #planx-notifications
+      sendFlowStatusSlackNotification(values.status);
+      // Reset "dirty" status to disable Save & Reset buttons
+      resetForm({ values });
     },
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -57,12 +57,19 @@ export const settingsStore: StateCreator<
 
   updateFlowStatus: async (newStatus) => {
     const { id, $client } = get();
-    const result = await $client.flow.setStatus({
-      flow: { id },
-      status: newStatus,
-    });
-    set({ flowStatus: newStatus });
-    return Boolean(result?.id);
+    try {
+      const result = await $client.flow.setStatus({
+        flow: { id },
+        status: newStatus,
+      });
+      if (!result?.id) throw Error("Failed to update flow status");
+
+      set({ flowStatus: newStatus });
+      return Boolean(result.id);
+    } catch (error) {
+      console.error(error)
+      return false
+    }
   },
 
   flowCanCreateFromCopy: undefined,

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1038,7 +1038,15 @@
                 _eq: false
             - deleted_at:
                 _is_null: true
-        check: {}
+        check:
+          _not:
+            _and:
+              - status:
+                  _eq: online
+              - team:
+                  team_settings:
+                    is_trial:
+                      _eq: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -1082,6 +1090,14 @@
                 _eq: 32
             - creator_id:
                 _eq: x-hasura-user-id
+            - _not:
+                _and:
+                  - status:
+                      _eq: online
+                  - team:
+                      team_settings:
+                        is_trial:
+                          _eq: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -1110,7 +1126,15 @@
         filter:
           deleted_at:
             _is_null: true
-        check: {}
+        check:
+          _not:
+            _and:
+              - status:
+                  _eq: online
+              - team:
+                  team_settings:
+                    is_trial:
+                      _eq: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -1156,6 +1180,14 @@
                         _eq: x-hasura-user-id
                     - role:
                         _eq: teamEditor
+            - _not:
+                _and:
+                  - status:
+                      _eq: online
+                  - team:
+                      team_settings:
+                        is_trial:
+                          _eq: true
         validate_input:
           definition:
             forward_client_headers: false
@@ -2597,6 +2629,7 @@
           - help_phone
           - homepage
           - id
+          - is_trial
           - reference_code
           - team_id
         filter: {}


### PR DESCRIPTION
## What does this PR do?
 - Disable online/offline toggle for trial team
 - Adds a basic warning / explanation
 - Configures Hasura permissions so that a flow cannot be in "online" status whilst it's parent team is in "trial" mode.

![image](https://github.com/user-attachments/assets/36af968f-827a-48a8-954b-318aeb70c623)
