### PR TITLE
fix: Update text and typos for trial account text

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
@@ -62,9 +62,9 @@ export default function TrialAccountForm({
             }
           />
           <SettingsDescription>
-            <p>Toggle this team between "trial" access and full access</p>
+            <p>Toggle this team between "trial account" and "full access"</p>
             <p>
-              A trial team had limited access to PlanX features - they are not
+              A trial account has limited access to PlanX features - they are not
               able to turn services online.
             </p>
           </SettingsDescription>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -108,7 +108,7 @@ const FlowStatus = () => {
           <WarningContainer>
             <PendingActionsIcon sx={{ mr: 1 }} />
             <Typography variant="body2">
-              Teams in "trial" mode cannot turn flows online.
+              Trial accounts cannot turn flows online.
             </Typography>
           </WarningContainer>
         }

--- a/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -125,7 +125,7 @@ export const AddTeamButton: React.FC = () => {
                   />
                   <Typography variant="body2" mt={-2}>
                     A trial account has limited access to PlanX functionality
-                    (e.g. turning services online). Trail teams can be promoted to
+                    (e.g. turning services online). Trial accounts can be promoted to
                     having full access via the settings panel.
                   </Typography>
                 </DialogContent>


### PR DESCRIPTION
- Fixes typos
- Standardises term to "trial account"
- Please see https://docs.google.com/document/d/1PUrPEmHg2Pp7vc_IfAQrIxMCq8lJ4sYskp77KHZAW1w/edit?tab=t.0 for reference