### PR TITLE
fix: Trial account caching, toggling flows offline

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#32d8b49",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#002bd48",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#32d8b49
-    version: github.com/theopensystemslab/planx-core/32d8b49(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#002bd48
+    version: github.com/theopensystemslab/planx-core/002bd48(@types/react@19.0.10)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7515,9 +7515,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/32d8b49(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/32d8b49}
-    id: github.com/theopensystemslab/planx-core/32d8b49
+  github.com/theopensystemslab/planx-core/002bd48(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/002bd48}
+    id: github.com/theopensystemslab/planx-core/002bd48
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#32d8b49",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#002bd48",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#32d8b49
-    version: github.com/theopensystemslab/planx-core/32d8b49(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#002bd48
+    version: github.com/theopensystemslab/planx-core/002bd48(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -1086,7 +1086,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /convert-source-map@1.9.0:
@@ -3085,9 +3085,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/32d8b49(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/32d8b49}
-    id: github.com/theopensystemslab/planx-core/32d8b49
+  github.com/theopensystemslab/planx-core/002bd48(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/002bd48}
+    id: github.com/theopensystemslab/planx-core/002bd48
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#32d8b49",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#002bd48",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#32d8b49
-    version: github.com/theopensystemslab/planx-core/32d8b49(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#002bd48
+    version: github.com/theopensystemslab/planx-core/002bd48(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -2634,9 +2634,9 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/32d8b49(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/32d8b49}
-    id: github.com/theopensystemslab/planx-core/32d8b49
+  github.com/theopensystemslab/planx-core/002bd48(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/002bd48}
+    id: github.com/theopensystemslab/planx-core/002bd48
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#32d8b49",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#002bd48",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.5
     version: 1.0.0-alpha.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#32d8b49
-    version: github.com/theopensystemslab/planx-core/32d8b49(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#002bd48
+    version: github.com/theopensystemslab/planx-core/002bd48(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14728,9 +14728,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/32d8b49(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/32d8b49}
-    id: github.com/theopensystemslab/planx-core/32d8b49
+  github.com/theopensystemslab/planx-core/002bd48(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/002bd48}
+    id: github.com/theopensystemslab/planx-core/002bd48
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/TrialAccountForm.tsx
@@ -62,10 +62,13 @@ export default function TrialAccountForm({
             }
           />
           <SettingsDescription>
-            <p>Toggle this team between "trial account" and "full access"</p>
+            <p>Toggle this team between "trial account" and "full access".</p>
             <p>
               A trial account has limited access to PlanX features - they are not
               able to turn services online.
+            </p>
+            <p>
+              Toggling this to a trial account will turn this team's flows offline.
             </p>
           </SettingsDescription>
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -165,9 +165,16 @@ export const teamStore: StateCreator<
     return await $client.team.updateTheme(teamId, theme);
   },
 
-  updateTeamSettings: async (teamSettings: Partial<TeamSettings>) => {
-    const { teamId, $client } = get();
-    return await $client.team.updateTeamSettings(teamId, teamSettings);
+  updateTeamSettings: async (updatedTeamSettings: Partial<TeamSettings>) => {
+    const { teamId, $client, teamSettings: currentTeamSettings } = get();
+    const isSuccess = await $client.team.updateTeamSettings(
+      teamId,
+      updatedTeamSettings,
+    );
+    if (isSuccess)
+      set({ teamSettings: { ...currentTeamSettings, ...updatedTeamSettings } });
+
+    return isSuccess;
   },
 
   setTeamMembers: async (teamMembers: TeamMember[]) => {


### PR DESCRIPTION
## What does this PR do?
- Fixes cache issue with Zustand store so `teamSettings.isTrial` is correctly persisted
- Toggle all flows offline for a team when setting `team_settings.is_trial = true`
  - Relies on https://github.com/theopensystemslab/planx-core/pull/712
