### PR TITLE
feat: Folder styling for internal portals

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -90,7 +90,7 @@ test.describe("Flow creation, publish and preview", () => {
     await expect(editor.nodeList).toContainText(["About the property"]);
     await editor.createInternalPortal();
     await editor.populateInternalPortal();
-    await page.getByRole("link", { name: "start" }).click(); // return to main flow
+    await page.getByRole("link", { name: serviceProps.name }).click(); // return to main flow
     // await editor.createUploadAndLabel();
     await editor.createDrawBoundary();
     await editor.createPlanningConstraints();

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Breadcrumb.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Breadcrumb.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Link } from "react-navi";
 
-const Breadcrumb: React.FC<any> = (props) => (
-  <li className="card portal breadcrumb">
+const Breadcrumb: React.FC<any> = ({ className = "", ...props }) => (
+  <li className={`card portal breadcrumb ${className}`}>
     <Link href={props.href} prefetch={false}>
       <span>{props.data.text}</span>
     </Link>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -29,6 +29,7 @@ const Node: React.FC<any> = (props) => {
     templatedNodeInstructions: node.data?.templatedNodeInstructions,
     areTemplatedNodeInsructionsRequired:
       node.data?.areTemplatedNodeInstructionsRequired,
+    className: props.className || "",
   };
 
   const type = props.type as TYPES;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -95,7 +95,11 @@ const ExternalPortal: React.FC<any> = (props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
-        <Box className={classNames("card", "portal", { isDragging })}>
+        <Box
+          className={classNames("card", "portal", "external-portal", {
+            isDragging,
+          })}
+        >
           <Link href={`/${href}`} prefetch={false} ref={drag}>
             <span>{href}</span>
           </Link>
@@ -152,14 +156,17 @@ const InternalPortal: React.FC<any> = (props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
-        <Box className={classNames("card", "portal", { isDragging })}>
+        <Box
+          className={classNames("card", "portal", "internal-portal", {
+            isDragging,
+          })}
+        >
           <Link
             href={href}
             prefetch={false}
             ref={drag}
             onContextMenu={handleContext}
           >
-            {Icon && <Icon />}
             <span>{props.data.text}</span>
           </Link>
           <Link href={editHref} prefetch={false} className="portalMenu">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import React from "react";
+import { Link } from "react-navi";
 import { rootFlowPath } from "routes/utils";
 
 import { useStore } from "../../lib/store";
@@ -31,6 +32,8 @@ const Flow = ({ breadcrumbs = [] }: any) => {
   const isFlowRoot = !portals.length;
   const showGetStarted = isFlowRoot && !childNodes.length;
 
+  const flowName = useStore((state) => state.flowName);
+
   return (
     <>
       <ol
@@ -38,7 +41,16 @@ const Flow = ({ breadcrumbs = [] }: any) => {
         data-layout={flowLayout}
         className={`decisions${breadcrumbs.length ? " nested-decisions" : ""}`}
       >
-        <EndPoint text="start" />
+        {!breadcrumbs.length ? (
+          <EndPoint text="start" />
+        ) : (
+          <li className="root-node-link">
+            <Link href={rootFlowPath(false)} prefetch={false}>
+              {flowName}
+            </Link>
+          </li>
+        )}
+
         {showGetStarted && <GetStarted />}
 
         {breadcrumbs.map((bc: any, index: number) => (
@@ -59,7 +71,7 @@ const Flow = ({ breadcrumbs = [] }: any) => {
           <Hanger />
         </Box>
 
-        <EndPoint text="end" />
+        {!breadcrumbs.length && <EndPoint text="end" />}
       </ol>
     </>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import React from "react";
 import { rootFlowPath } from "routes/utils";
@@ -32,19 +33,32 @@ const Flow = ({ breadcrumbs = [] }: any) => {
 
   return (
     <>
-      <ol id="flow" data-layout={flowLayout} className="decisions">
+      <ol
+        id="flow"
+        data-layout={flowLayout}
+        className={`decisions${breadcrumbs.length ? " nested-decisions" : ""}`}
+      >
         <EndPoint text="start" />
         {showGetStarted && <GetStarted />}
 
-        {breadcrumbs.map((bc: any) => (
-          <Node key={bc.id} {...bc} />
+        {breadcrumbs.map((bc: any, index: number) => (
+          <Node
+            key={bc.id}
+            {...bc}
+            className={
+              index === breadcrumbs.length - 1 ? "active-breadcrumb" : ""
+            }
+          />
         ))}
 
-        {childNodes.map((node) => (
-          <Node key={node.id} {...node} />
-        ))}
+        <Box className="flow-child-nodes">
+          {childNodes.map((node) => (
+            <Node key={node.id} {...node} />
+          ))}
 
-        <Hanger />
+          <Hanger />
+        </Box>
+
         <EndPoint text="end" />
       </ol>
     </>

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -368,6 +368,16 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
+.flow-child-nodes {
+  width: 100%;
+  .nested-decisions & {
+    background: #f9f9f9;
+    border: 2px dashed $lockedBorder;
+    margin-top: -2px;
+    padding: 0 ($padding * 2);
+  }
+}
+
 .portal {
   justify-content: center !important;
   > a {
@@ -381,11 +391,13 @@ $fontMonospace: "Source Code Pro", monospace;
   &.breadcrumb {
     background-image: $pixel;
     background-repeat: no-repeat;
+    min-width: 200px;
     [data-layout="top-down"] & {
       background-position: center top;
-      background-size: $lineWidth $padding;
+      background-size: $lineWidth ($padding * 2);
       > a {
-        margin: $padding 0 0;
+        margin: ($padding * 2) 0 0;
+        width: 100%;
       }
     }
     [data-layout="left-right"] & {
@@ -395,9 +407,24 @@ $fontMonospace: "Source Code Pro", monospace;
         margin: 0 0 0 $padding;
       }
     }
+    &.active-breadcrumb {
+      width: 100% !important;
+    }
     > a {
-      background: #666;
+      background: $black;
       text-align: center;
+      &::before {
+        content: "";
+        position: absolute;
+        top: -5px;
+        left: 0;
+        width: 40px;
+        height: 8px;
+        background-color: #666;
+        clip-path: polygon(0 0, 90% 0, 100% 100%, 0% 100%);
+        border-top-left-radius: 2px;
+        z-index: -1;
+      }
     }
   }
   .portalMenu {

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -40,6 +40,21 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
+@mixin folderStyle($width) {
+  &::before {
+    content: "";
+    position: absolute;
+    top: -5px;
+    left: 0;
+    width: $width;
+    height: 8px;
+    background-color: #666;
+    clip-path: polygon(0 0, 90% 0, 100% 100%, 0% 100%);
+    border-top-left-radius: 2px;
+    z-index: -1;
+  }
+}
+
 // ------------------------------------------------
 
 #editor {
@@ -292,6 +307,20 @@ $fontMonospace: "Source Code Pro", monospace;
   cursor: pointer;
 }
 
+.root-node-link > a {
+  display: block;
+  text-decoration: none;
+  cursor: pointer;
+  padding: $padding;
+  color: $black;
+  background: white;
+  border-radius: 3px;
+  border: 1px solid $optionBorder;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+  font-weight: 600;
+  font-size: 14px;
+}
+
 .option {
   > a {
     border-color: $optionBorder;
@@ -371,7 +400,6 @@ $fontMonospace: "Source Code Pro", monospace;
 .flow-child-nodes {
   width: 100%;
   .nested-decisions & {
-    background: #f9f9f9;
     border: 2px dashed $lockedBorder;
     margin-top: -2px;
     padding: 0 ($padding * 2);
@@ -385,7 +413,7 @@ $fontMonospace: "Source Code Pro", monospace;
     color: white;
     border: none;
     .flow-locked & {
-      background: #555;
+      background: $black;
     }
   }
   &.breadcrumb {
@@ -413,19 +441,13 @@ $fontMonospace: "Source Code Pro", monospace;
     > a {
       background: $black;
       text-align: center;
-      &::before {
-        content: "";
-        position: absolute;
-        top: -5px;
-        left: 0;
-        width: 40px;
-        height: 8px;
-        background-color: #666;
-        clip-path: polygon(0 0, 90% 0, 100% 100%, 0% 100%);
-        border-top-left-radius: 2px;
-        z-index: -1;
-      }
+      @include folderStyle(40px);
     }
+  }
+  &.internal-portal {
+    background: $black;
+    text-align: center;
+    @include folderStyle(30px);
   }
   .portalMenu {
     border-left: $nodeBorderWidth solid #aaa;


### PR DESCRIPTION
## What does this PR do?

- Updates internal portals to have a "folder" style as root components
- When inside an internal portal:
  - "start" and "end" markers are removed in favour of a clear hierarchy
  - root flow name is displayed as a link
  - any parent internal portals are added to the hierarchy as folder breadcrumbs
  - folder styling is extended to "encompass" internal portal contents (second image)
- Also updates search for internal portals to have folder style

**Testing:**
https://4595.planx.pizza/testing/nesting-testing

**Real-world example:**
https://4595.planx.pizza/opensystemslab/permitteddevelopment,GkLVVIasqD,4sdQOdsv6G,zmgKVgZFA0,7nb1Ns0Xyn,XUrPURgXtu,QGbTxfHGcx,lHPhZSPP8f

**Previews:**
![image](https://github.com/user-attachments/assets/54d2888a-e73f-405b-adc1-d70f845b65a2)

![image](https://github.com/user-attachments/assets/57423a7e-1c7a-4e3e-9e93-d988296057db)
