### PR TITLE
fix(sharedb): Improved error handling

### DIFF
--- a/editor.planx.uk/src/lib/graphql.ts
+++ b/editor.planx.uk/src/lib/graphql.ts
@@ -158,11 +158,11 @@ const parseErrorTypeFromHasuraResponse = (message: string) => {
 };
 
 export const handleExpiredJWTErrors = () => {
-  toast.error("Session expired, redirecting to login page...", {
-    toastId: "jwt_expiry_error",
+  toast.error("[GraphQL error]: Session expired, redirecting to login page...", {
+    toastId: "hasura_jwt_expiry_error",
     hideProgressBar: false,
     progress: undefined,
-    autoClose: 2_000,
+    autoClose: 4_000,
     onClose: () => (window.location.href = "/logout"),
   });
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
@@ -1,4 +1,4 @@
-import { toast } from "react-toastify";
+import { toast, ToastOptions } from "react-toastify";
 import ReconnectingWebSocket from "reconnecting-websocket";
 import type { Doc } from "sharedb";
 import sharedb from "sharedb/lib/client";
@@ -6,27 +6,53 @@ import type { Socket } from "sharedb/lib/sharedb";
 
 // Please see sharedb.planx.uk/server.js
 // Docs: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code#value
-const TOKEN_EXPIRY_CODE = 4001;
+const TOKEN_EXPIRY_CODE = 4001 as const;
 
-const socket = new ReconnectingWebSocket(
-  import.meta.env.VITE_APP_SHAREDB_URL || "",
-);
+const createWSConnection = () => {
+  const socket = new ReconnectingWebSocket(
+    import.meta.env.VITE_APP_SHAREDB_URL || ""
+  );
 
-socket.addEventListener("close", ({ code, reason }) => {
-  if (code === TOKEN_EXPIRY_CODE && reason === "Token expired") {
-    toast.error("Session expired, redirecting to login page...", {
-      toastId: "jwt_expiry_error",
-      hideProgressBar: false,
-      progress: undefined,
-      autoClose: 2_000,
-      onClose: () => (window.location.href = "/logout"),
+  const toastConfig: Partial<ToastOptions> = {
+    hideProgressBar: false,
+    progress: undefined,
+    autoClose: 4_000,
+    onClose: () => (window.location.href = "/logout"),
+  };
+
+  /** Listen for expired tokens events and force logout */
+  socket.addEventListener("close", ({ code, reason }) => {
+    if (code === TOKEN_EXPIRY_CODE && reason === "Token validation error") {
+      toast.error("[ShareDB error]: Session expired, redirecting to login page...", {
+        toastId: "sharedb_jwt_expiry",
+        ...toastConfig,
+      });
+    }
+  });
+
+  /** Fallback for unhandled ShareDB errors - log user out to prevent silent failures */
+  socket.addEventListener("error", ({ error, message }) => {
+    console.error("Unhandled ShareDB error: ", { error, message });
+
+    // Only display a single toast at a time
+    if (toast.isActive("sharedb_jwt_expiry")) return;
+
+    toast.error("[ShareDB error]: Unhandled error, redirecting to login page...", {
+      toastId: "sharedb_error",
+      ...toastConfig,
     });
-  }
-});
+  });
 
-const connection = new sharedb.Connection(socket as unknown as Socket);
+  return socket;
+};
 
-export const getConnection = (id: string) => connection.get("flows", id);
+const getShareDBConnection = (): sharedb.Connection => {
+  const socket = createWSConnection();
+  return new sharedb.Connection(socket as unknown as Socket);
+};
+
+export const getFlowConnection = (id: string) =>
+  getShareDBConnection().get("flows", id);
 
 export const createDoc = async (
   doc: Doc,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -31,7 +31,7 @@ import type { StateCreator } from "zustand";
 import { persist } from "zustand/middleware";
 
 import { FlowLayout } from "../../components/Flow";
-import { connectToDB, getConnection } from "./../sharedb";
+import { connectToDB, getFlowConnection } from "./../sharedb";
 import { type Store } from ".";
 import type { SharedStore } from "./shared";
 import { UserStore } from "./user";
@@ -274,7 +274,7 @@ export const editorStore: StateCreator<
 
     console.log("connecting to", id, get().id);
 
-    doc = getConnection(id);
+    doc = getFlowConnection(id);
     (window as any)["doc"] = doc;
 
     await connectToDB(doc);

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -93,7 +93,7 @@ async function validateJWT(authToken) {
     return decodedToken;
   }
 
-  throw Error(`Invalid JWT. Please log in again. Error: ${response.body}`)
+  throw Error("Invalid JWT. Please log in again.");
 };
 
 const wss = new Server({
@@ -107,6 +107,7 @@ const wss = new Server({
 
       console.log({ newConnection: decoded });
       info.req.uId = decoded;
+      info.req.authToken = token;
       cb(true);
     } catch (err) {
       console.error({ err });


### PR DESCRIPTION
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/61627a9d-1fbf-4789-9621-8578d681d7f0" />

## What does this PR do?
 - Addresses issues raised a few times recently where ShareDB is silently failing, notably in this thread - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1744706505311059(OSL Slack)
 - Fixes bug with ShareDB auth checking
 - Improves error messages and error handling in frontend
 - Ensure WS client is only instantiated when required. This currently this happens on all public services! (see video below)


https://github.com/user-attachments/assets/1d1046e7-af15-4524-b969-5e078d4ae17e

 
I'm not totally convinced that this resolves the issues we're facing here - if this was the issue faced by Jonny (silent ShareDB error due to invalid token) I would have still expected Apollo to recognise this and trigger a logout.

At a minimum this PR rules some issues out and should give better visibility to any remaining issues. When a session is expired, this is now handled by both Hasura / Apollo as well as ShareDB. 