### PR TITLE
chore: bump vultr-action

### DIFF
--- a/.github/workflows/pizza-teardown-manual.yml
+++ b/.github/workflows/pizza-teardown-manual.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Remove vultr resources
-        uses: theopensystemslab/vultr-action@v2.0
+        uses: theopensystemslab/vultr-action@v2.1
         with:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}

--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Remove vultr resources
-        uses: theopensystemslab/vultr-action@v2.0
+        uses: theopensystemslab/vultr-action@v2.1
         with:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -306,7 +306,7 @@ jobs:
     steps:
       - name: Create Pizza (if it doesn't exist)
         id: create
-        uses: theopensystemslab/vultr-action@v2.0
+        uses: theopensystemslab/vultr-action@v2.1
         with:
           action: create
           api_key: ${{ secrets.VULTR_API_KEY }}


### PR DESCRIPTION
Bumps `vultr-action` used in Github Actions to latest (v2.1). See PR #[3](https://github.com/theopensystemslab/vultr-action/pull/3).