### PR TITLE
feat: checklist options allow and display descriptions

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/GroupedOptions.tsx
@@ -92,6 +92,7 @@ export const GroupedOptions = ({ formik, disabled }: Props) => {
                 editorExtraProps={{
                   groupIndex,
                   showValueField: !!formik.values.fn,
+                  showDescriptionField: true,
                   onMoveToGroup: (
                     movedItemIndex: number,
                     moveToGroupIndex: number,

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/components/OptionsEditor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/components/OptionsEditor.tsx
@@ -30,6 +30,7 @@ const ChecklistOptionsEditor: React.FC<ChecklistOptionsEditorProps> = ({
       schema={schema}
       onChange={onChange}
       showValueField={showValueField}
+      showDescriptionField={true}
       disabled={disabled}
     >
       {typeof index !== "undefined" && groups && onMoveToGroup && (

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/ChecklistItems.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/ChecklistItems.tsx
@@ -31,6 +31,7 @@ export const ChecklistItems = ({
             <ChecklistItem
               onChange={changeCheckbox(option.id)}
               label={option.data.text}
+              description={option.data.description}
               id={option.id}
               checked={
                 formik.values.checked.includes(option.id) &&

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklistOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklistOptions.tsx
@@ -26,7 +26,7 @@ export const GroupedChecklistOptions = ({
 }: GroupedChecklistOptionsProps) => {
   const { expandedGroups, toggleGroup } = useExpandedGroups(
     groupedOptions,
-    previouslySubmittedData
+    previouslySubmittedData,
   );
 
   return (
@@ -56,6 +56,7 @@ export const GroupedChecklistOptions = ({
                       onChange={changeCheckbox(option.id)}
                       key={option.data.text}
                       label={option.data.text}
+                      description={option.data.description}
                       id={option.id}
                       checked={formik.values.checked.includes(option.id)}
                     />

--- a/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -25,6 +25,7 @@ const Label = styled(Typography)(({ theme }) => ({
 interface Props {
   id?: string;
   label: string;
+  description?: string;
   checked: boolean;
   onChange: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
@@ -34,6 +35,7 @@ interface Props {
 
 export default function ChecklistItem({
   label,
+  description,
   onChange,
   checked,
   id,
@@ -51,9 +53,32 @@ export default function ChecklistItem({
         variant={variant}
         disabled={disabled}
       />
-      <Label variant="body1" className="label" component={"label"} htmlFor={id}>
-        {label}
-      </Label>
+      {description ? (
+        <Box>
+          <Label
+            variant="body1"
+            color="text.primary"
+            className="label"
+            component={"label"}
+            htmlFor={id}
+            pb={0}
+          >
+            {label}
+          </Label>
+          <Typography variant="body2" color="text.secondary" px={1.5}>
+            {description}
+          </Typography>
+        </Box>
+      ) : (
+        <Label
+          variant="body1"
+          className="label"
+          component={"label"}
+          htmlFor={id}
+        >
+          {label}
+        </Label>
+      )}
     </Root>
   );
 }


### PR DESCRIPTION
[This is one from the content team's wishlist](https://opensystemslab.slack.com/lists/T03T7JTFV/F08HZNBTA7R?record_id=Rec08HZNC1RGX) and also useful for updates to the Send component 

`description` has always been in the `Option` model/types, but never displayed to editors or on the public interface. 

Now, editors can add descriptions to all non-exclusive options, grouped or not. I am still _not_ exposing the "description" input for the exclusive "or" option, does this seem correct?