### PR TITLE
feat: add customisable disclaimer to the Review component

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -49,6 +49,17 @@ function Component(props: Props) {
             />
           </InputRow>
         </ModalSectionContent>
+        <ModalSectionContent subtitle="Disclaimer">
+          <InputRow>
+            <RichTextInput
+              name="disclaimer"
+              placeholder="Disclaimer"
+              value={formik.values.disclaimer}
+              onChange={formik.handleChange}
+              disabled={props.disabled}
+            />
+          </InputRow>
+        </ModalSectionContent>
       </ModalSection>
       <ModalFooter
         formik={formik}

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -13,6 +13,7 @@ export default Component;
 interface Props {
   title: string;
   description: string;
+  disclaimer: string;
   breadcrumbs: Store.Breadcrumbs;
   flow: Store.Flow;
   passport: Store.Passport;
@@ -38,6 +39,7 @@ function Component(props: Props) {
         changeAnswer={props.changeAnswer}
         showChangeButton={props.showChangeButton}
         sectionComponent="h2"
+        disclaimer={props.disclaimer}
       />
       <PrintButton />
     </Card>

--- a/editor.planx.uk/src/@planx/components/Review/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Public.test.tsx
@@ -5,6 +5,7 @@ import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
+import { DEFAULT_REVIEW_DISCLAIMER } from "../model";
 import {
   breadcrumbsWithEmptySections,
   flowWithEmptySections,
@@ -68,7 +69,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
-        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
+        disclaimer={DEFAULT_REVIEW_DISCLAIMER}
         flow={mockedFlow}
         breadcrumbs={mockedBreadcrumbs}
         passport={mockedPassport}

--- a/editor.planx.uk/src/@planx/components/Review/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Public.test.tsx
@@ -42,6 +42,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={{}}
         breadcrumbs={{}}
         passport={{}}
@@ -67,6 +68,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={mockedFlow}
         breadcrumbs={mockedBreadcrumbs}
         passport={mockedPassport}
@@ -89,6 +91,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={mockedFlow}
         breadcrumbs={mockedBreadcrumbs}
         passport={mockedPassport}
@@ -108,6 +111,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={mockedFlow}
         breadcrumbs={mockedBreadcrumbs}
         passport={mockedPassport}
@@ -143,6 +147,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={mockedFlow}
         breadcrumbs={mockedBreadcrumbs}
         passport={mockedPassport}
@@ -178,6 +183,7 @@ describe("Simple flow", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={mockedFlow}
         breadcrumbs={mockedBreadcrumbs}
         passport={mockedPassport}
@@ -218,6 +224,7 @@ describe("File uploads", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={fileUploadFlow}
         breadcrumbs={fileUploadBreadcrumbs}
         passport={fileUploadPassport}
@@ -236,6 +243,7 @@ describe("File uploads", () => {
       <Review
         title="Review"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={drawBoundaryFlow}
         breadcrumbs={uploadedPlansBreadcrumb}
         passport={uploadedPlansPassport}
@@ -270,6 +278,7 @@ describe("Flow with sections", () => {
       <Review
         title="Review with sections"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={flowWithSections}
         breadcrumbs={breadcrumbsWithSections}
         passport={passportWithSections}
@@ -297,6 +306,7 @@ describe("Flow with sections", () => {
       <Review
         title="Review with sections"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={flowWithSections}
         breadcrumbs={breadcrumbsWithSections}
         passport={passportWithSections}
@@ -328,6 +338,7 @@ describe("Flow with empty sections", () => {
       <Review
         title="Review with empty sections"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={flowWithEmptySections}
         breadcrumbs={breadcrumbsWithEmptySections}
         passport={passportWithEmptySections}
@@ -361,6 +372,7 @@ describe("Flow with empty sections", () => {
       <Review
         title="Review with empty sections"
         description="Check your answers before submitting"
+        disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
         flow={flowWithEmptySections}
         breadcrumbs={breadcrumbsWithEmptySections}
         passport={passportWithEmptySections}

--- a/editor.planx.uk/src/@planx/components/Review/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/index.tsx
@@ -20,7 +20,8 @@ function Component(props: PublicProps<Review>) {
   return (
     <Presentational
       title={props.title}
-      description={props.description || ""}
+      description={props.description}
+      disclaimer={props.disclaimer}
       breadcrumbs={breadcrumbs}
       flow={flow}
       passport={passport}

--- a/editor.planx.uk/src/@planx/components/Review/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/index.tsx
@@ -3,6 +3,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import type { Review } from "../model";
+import { DEFAULT_REVIEW_DISCLAIMER } from "../model";
 import Presentational from "./Presentational";
 
 export default Component;
@@ -21,7 +22,7 @@ function Component(props: PublicProps<Review>) {
     <Presentational
       title={props.title}
       description={props.description}
-      disclaimer={props.disclaimer}
+      disclaimer={props.disclaimer || DEFAULT_REVIEW_DISCLAIMER}
       breadcrumbs={breadcrumbs}
       flow={flow}
       passport={passport}

--- a/editor.planx.uk/src/@planx/components/Review/Review.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Review.stories.tsx
@@ -29,6 +29,7 @@ export const Basic = () => {
     <Presentational
       title="Review"
       description="Check your answers before submitting"
+      disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
       breadcrumbs={mockedBreadcrumbs}
       flow={mockedFlow}
       passport={mockedPassport}
@@ -46,6 +47,7 @@ export const WithSections = () => {
     <Presentational
       title="Review"
       description="Check your answers before submitting"
+      disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
       breadcrumbs={breadcrumbsWithSections}
       flow={flowWithSections}
       passport={passportWithSections}

--- a/editor.planx.uk/src/@planx/components/Review/Review.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Review.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from "@storybook/react";
 import React from "react";
 
+import { DEFAULT_REVIEW_DISCLAIMER } from "./model";
 import {
   breadcrumbsWithSections,
   flowWithSections,
@@ -29,7 +30,7 @@ export const Basic = () => {
     <Presentational
       title="Review"
       description="Check your answers before submitting"
-      disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
+      disclaimer={DEFAULT_REVIEW_DISCLAIMER}
       breadcrumbs={mockedBreadcrumbs}
       flow={mockedFlow}
       passport={mockedPassport}
@@ -47,7 +48,7 @@ export const WithSections = () => {
     <Presentational
       title="Review"
       description="Check your answers before submitting"
-      disclaimer="<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
+      disclaimer={DEFAULT_REVIEW_DISCLAIMER}
       breadcrumbs={breadcrumbsWithSections}
       flow={flowWithSections}
       passport={passportWithSections}

--- a/editor.planx.uk/src/@planx/components/Review/model.ts
+++ b/editor.planx.uk/src/@planx/components/Review/model.ts
@@ -15,5 +15,5 @@ export const parseContent = (
   notes: data?.notes || "",
 });
 
-const DEFAULT_REVIEW_DISCLAIMER =
+export const DEFAULT_REVIEW_DISCLAIMER =
   "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>";

--- a/editor.planx.uk/src/@planx/components/Review/model.ts
+++ b/editor.planx.uk/src/@planx/components/Review/model.ts
@@ -3,6 +3,7 @@ import { BaseNodeData } from "../shared";
 export interface Review extends BaseNodeData {
   title: string;
   description: string;
+  disclaimer: string;
 }
 
 export const parseContent = (
@@ -10,5 +11,9 @@ export const parseContent = (
 ): Review => ({
   title: data?.title || "Check your answers before sending your application",
   description: data?.description || "",
+  disclaimer: data?.disclaimer || DEFAULT_REVIEW_DISCLAIMER,
   notes: data?.notes || "",
 });
+
+const DEFAULT_REVIEW_DISCLAIMER =
+  "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>";

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -17,6 +17,7 @@ import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 import {
   Field,
@@ -331,19 +332,13 @@ function SummaryList(props: SummaryListProps) {
         confirmText="Yes"
         cancelText="No"
       >
-        <Typography>
-          Changing this answer means you will need to confirm any other answers
-          after it. This is because:
-          <ul>
-            <li>
-              a different answer might mean the service asks new questions
-            </li>
-            <li>
-              your planning officer needs the right information to assess your
-              application
-            </li>
-          </ul>
-        </Typography>
+        <ReactMarkdownOrHtml
+          // sketchy way to find the Review node in the flow to get the disclaimer, breaks if more than one review node in flow
+          source={
+            Object.values(props.flow).find((node) => node.type === TYPES.Review)
+              ?.data?.disclaimer
+          }
+        ></ReactMarkdownOrHtml>
       </ConfirmationDialog>
     </>
   );

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -142,6 +142,7 @@ const presentationalComponents: {
 type BreadcrumbEntry = [NodeId, Store.Breadcrumbs];
 
 interface SummaryListBaseProps {
+  disclaimer: string;
   flow: Store.Flow;
   passport: Store.Passport;
   changeAnswer: (id: NodeId) => void;
@@ -240,6 +241,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
                   passport={props.passport}
                   changeAnswer={props.changeAnswer}
                   showChangeButton={props.showChangeButton}
+                  disclaimer={props.disclaimer}
                 />
               </React.Fragment>
             ),
@@ -257,6 +259,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
         passport={props.passport}
         changeAnswer={props.changeAnswer}
         showChangeButton={props.showChangeButton}
+        disclaimer={props.disclaimer}
       />
     );
   }
@@ -332,13 +335,7 @@ function SummaryList(props: SummaryListProps) {
         confirmText="Yes"
         cancelText="No"
       >
-        <ReactMarkdownOrHtml
-          // sketchy way to find the Review node in the flow to get the disclaimer, breaks if more than one review node in flow
-          source={
-            Object.values(props.flow).find((node) => node.type === TYPES.Review)
-              ?.data?.disclaimer
-          }
-        ></ReactMarkdownOrHtml>
+        <ReactMarkdownOrHtml source={props.disclaimer}></ReactMarkdownOrHtml>
       </ConfirmationDialog>
     </>
   );

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -142,7 +142,7 @@ const presentationalComponents: {
 type BreadcrumbEntry = [NodeId, Store.Breadcrumbs];
 
 interface SummaryListBaseProps {
-  disclaimer: string;
+  disclaimer?: string;
   flow: Store.Flow;
   passport: Store.Passport;
   changeAnswer: (id: NodeId) => void;


### PR DESCRIPTION
Adds a customisable disclaimer to the Review component. 

First commit adds a rich text input _Disclaimer_ section to the editor modal, with default content.

Second commit adds a somewhat sketchy approach using the standard library method 'find' to (inefficiently) search for the Review component by node type and retrieve its disclaimer. I can't see anything else using this approach, so presumably there are cleaner and more efficient ways of retrieving the data of the Review component.

Unfortunately any of my attempts to retrieve the disclaimer through props defaulted to the default content. I'd much appreciate suggestions!