### PR TITLE
chore: Bump `http-proxy-middleware`

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -35,7 +35,7 @@
     "graphql-request": "^4.3.0",
     "he": "^1.2.0",
     "helmet": "^7.1.0",
-    "http-proxy-middleware": "^2.0.7",
+    "http-proxy-middleware": "^2.0.9",
     "husky": "^8.0.3",
     "isomorphic-fetch": "^3.0.0",
     "jsdom": "^24.1.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -87,8 +87,8 @@ dependencies:
     specifier: ^7.1.0
     version: 7.1.0
   http-proxy-middleware:
-    specifier: ^2.0.7
-    version: 2.0.7(@types/express@4.17.21)
+    specifier: ^2.0.9
+    version: 2.0.9(@types/express@4.17.21)
   husky:
     specifier: ^8.0.3
     version: 8.0.3
@@ -5005,8 +5005,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-middleware@2.0.7(@types/express@4.17.21):
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  /http-proxy-middleware@2.0.9(@types/express@4.17.21):
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/208 and https://github.com/theopensystemslab/planx-new/security/dependabot/209