### PR TITLE
fix: Allow Pizza teardown GHA to write comment to PR

### DIFF
--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -1,6 +1,7 @@
 name: Pizza Teardown
 
-permissions: read-all
+permissions:
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Follow up to #4606 

The most recent action failed, as it needs to write a comment to the PR once it's associated Pizza has been torn down - https://github.com/theopensystemslab/planx-new/actions/runs/14618215456
