### PR TITLE
chore: update Submisison & Feedback page copy in editor

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -17,7 +17,10 @@ import { updateEditorNotes } from "./queries/updateEditorNotes";
 import { Feedback, FeedbackLogProps } from "./types";
 import { EmojiRating, feedbackTypeText, stripHTMLTags } from "./utils";
 
-export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
+export const FeedbackLog: React.FC<FeedbackLogProps> = ({
+  feedback,
+  isFlowLevel,
+}) => {
   const handleProcessRowUpdate = async (updatedRow: Feedback) => {
     await updateEditorNotes(updatedRow);
     return updatedRow;
@@ -138,17 +141,21 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({ feedback }) => {
     <FixedHeightDashboardContainer bgColor="background.paper">
       <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
-          Feedback log
+          Feedback
         </Typography>
         <Typography variant="body1" maxWidth="contentWrap">
-          Feedback from users about this team's services.
+          Feedback reports from users about{" "}
+          {isFlowLevel ? "this service" : "all services in this team"}. This
+          table only includes feedback received within the last six months.
         </Typography>
       </SettingsSection>
       {feedback.length === 0 ? (
         <SettingsSection>
           <ErrorSummary
             format="info"
-            heading="No feedback found for this team"
+            heading={`No feedback found for this ${
+              isFlowLevel ? "service" : "team"
+            }`}
             message="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
           />
         </SettingsSection>

--- a/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/types.ts
@@ -42,4 +42,5 @@ export interface CollapsibleRowProps extends Feedback {
 }
 export interface FeedbackLogProps {
   feedback: Feedback[];
+  isFlowLevel?: boolean;
 }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Submissions/Submissions.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Submissions/Submissions.tsx
@@ -52,13 +52,10 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
           Submissions
         </Typography>
         <Typography variant="body1" maxWidth="contentWrap">
-          {`Feed of payment and submission events for ${
-            flowSlug ? "this service" : "services in this team"
-          }.`}
-        </Typography>
-        <Typography variant="body1" maxWidth="contentWrap">
-          Successful submission events from within the last 28 days are
-          available to be downloaded by team editors.
+          Payment and send events for{" "}
+          {flowSlug ? "this service" : "all services in this team"}. Successful
+          submissions received within the last 28 days are available to
+          download. This table includes events since 1st January 2024.
         </Typography>
       </SettingsSection>
       <EventsLog

--- a/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
@@ -42,10 +42,10 @@ const EventsLog: React.FC<EventsLogProps> = ({
       <SettingsSection>
         <ErrorSummary
           format="info"
-          heading={`No payments or submissions found for this ${
+          heading={`No payment or send events found for this ${
             filterByFlow ? "service" : "team"
           }`}
-          message="If you're looking for events before 1st January 2024, please contact a PlanX developer."
+          message="If you're looking for events before 1st January 2024, please contact a PlanX developer"
         />
       </SettingsSection>
     );

--- a/editor.planx.uk/src/routes/serviceFeedback.tsx
+++ b/editor.planx.uk/src/routes/serviceFeedback.tsx
@@ -48,7 +48,7 @@ const serviceFeedbackRoutes = compose(
 
       return {
         title: makeTitle("Service feedback"),
-        view: <FeedbackLog feedback={feedback} />,
+        view: <FeedbackLog feedback={feedback} isFlowLevel={true} />,
       };
     }),
   }),


### PR DESCRIPTION
Came up today here: https://opendigitalplanning.slack.com/archives/C01AD3YPZ24/p1745405987128419

Both subheader descriptions updated to include timeline of included data and use consistent wording for service/team context.

**After (team level):**
![Screenshot from 2025-04-23 17-54-28](https://github.com/user-attachments/assets/86989faf-be86-45d0-b424-8f46ec329645)
![Screenshot from 2025-04-23 17-53-17](https://github.com/user-attachments/assets/6ef2bbef-5b5a-4d34-b7c6-d8c6a996a753)
