### PR TITLE
fix: prevent checklist item wrapping in list and page components

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
@@ -44,13 +44,15 @@ export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
         <Grid container component="fieldset">
           <legend style={visuallyHidden}>{title}</legend>
           {options.map((option) => (
-            <ChecklistItem
-              key={option.id}
-              onChange={changeCheckbox(option.id)}
-              label={option.data.text}
-              id={option.id}
-              checked={value.includes(option.id)}
-            />
+            <Grid item xs={12}>
+              <ChecklistItem
+                key={option.id}
+                onChange={changeCheckbox(option.id)}
+                label={option.data.text}
+                id={option.id}
+                checked={value.includes(option.id)}
+              />
+            </Grid>
           ))}
         </Grid>
       </ErrorWrapper>


### PR DESCRIPTION
Similar to @ianjon3s recently fix to constraint overwrite checklist items [here](https://github.com/theopensystemslab/planx-new/pull/4441), this PR fixes the wrapping thereof in list and page components.