### PR TITLE
fix: align list and page number input styling with number input component

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/NumberFieldInput.tsx
@@ -1,8 +1,8 @@
-import Box from "@mui/material/Box";
 import type { NumberField } from "@planx/components/shared/Schema/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input/Input";
+import InputRow from "ui/shared/InputRow";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../constants";
@@ -19,7 +19,7 @@ export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
       {data.description && (
         <FieldInputDescription description={data.description} />
       )}
-      <Box sx={{ display: "flex", alignItems: "baseline" }}>
+      <InputRow>
         <Input
           {...fieldProps}
           onChange={formik.handleChange}
@@ -36,7 +36,7 @@ export const NumberFieldInput: React.FC<Props<NumberField>> = (props) => {
           }}
         />
         {data.units && <InputRowLabel>{data.units}</InputRowLabel>}
-      </Box>
+      </InputRow>
     </InputLabel>
   );
 };


### PR DESCRIPTION
This PR replaces the generic Box container in the NumberFieldInput for List and Page component schemas with InputRow styling to ensure consistency with the NumberInput component (in particular, units prop margin). 

Alternatively we could add additional styling to the Box container, not sure if this is a preferable solution @DafyddLlyr?
![image](https://github.com/user-attachments/assets/95819f8f-6d57-4a35-b4fa-44f8f17ac31d)