### PR TITLE
fix: add basic application type error handling to Uniform

### DIFF
--- a/api.planx.uk/modules/send/uniform/uniform.ts
+++ b/api.planx.uk/modules/send/uniform/uniform.ts
@@ -177,7 +177,7 @@ type GetApplicationTypeResponse = {
   lowcal_sessions_by_pk: {
     data: string[];
   };
-}
+};
 
 /**
  * Query this session to retrieve application.type from the passport
@@ -186,18 +186,18 @@ async function getApplicationType(
   sessionId: string,
 ): Promise<string | undefined> {
   const applicationType: GetApplicationTypeResponse = await $api.client.request(
-      gql`
-        query GetApplicationType($id: uuid!) {
-          lowcal_sessions_by_pk(id: $id) {
-            data(path:"passport.data['application.type']")
-          }
+    gql`
+      query GetApplicationType($id: uuid!) {
+        lowcal_sessions_by_pk(id: $id) {
+          data(path: "passport.data['application.type']")
         }
-      `,
-      {
-        id: sessionId,
-      },
-    );
-  
+      }
+    `,
+    {
+      id: sessionId,
+    },
+  );
+
   return applicationType?.lowcal_sessions_by_pk?.data?.[0];
 }
 

--- a/api.planx.uk/modules/send/uniform/uniform.ts
+++ b/api.planx.uk/modules/send/uniform/uniform.ts
@@ -84,9 +84,9 @@ export const sendToUniform: SendIntegrationController = async (
   // only LDC-E & LDC-P application types are supported
   const applicationType = await getApplicationType(payload.sessionId);
   if (applicationType === "ldc.listedBuildingWorks") {
-    return res.status(200).send({
-      sessionId: payload.sessionId,
-      message: `Skipping send, Idox/Uniform connector does not support application type: ${applicationType}`,
+    return next({
+      status: 400,
+      message: `Skipping send, Idox/Uniform connector does not support application type ${applicationType} (${payload.sessionId})`,
     });
   }
 


### PR DESCRIPTION
We've received a second LDC Listed Building Works type! 

Unfortunately, these are currently failing at the "attach archive" step, _after_ successfully creating a submission, because the XML mapping fails which leads to errors in the "queue" on the LPA's side. We want to fail earlier to prevent creating an initial submission at all. This is a quick solution !