### PR TITLE
chore: Bump API rate limits

### DIFF
--- a/api.planx.uk/rateLimit.ts
+++ b/api.planx.uk/rateLimit.ts
@@ -5,7 +5,7 @@ import rateLimit from "express-rate-limit";
 const apiLimiter = rateLimit({
   message: "[API limiter]: Too many requests, please try again",
   windowMs: 10 * 60 * 1000, // 10 minutes
-  max: 250,
+  max: 2500,
   standardHeaders: true,
   legacyHeaders: false,
   skip: (req: Request, _res: Response) => {

--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -93,6 +93,10 @@ async function validateJWT(authToken) {
     return decodedToken;
   }
 
+  if (response.status === 429) {
+    throw Error("API rate limit exceeded");
+  }
+
   throw Error("Invalid JWT. Please log in again.");
 };
 


### PR DESCRIPTION
## What's the problem?
Editors are hitting the API rate limit - as confirmed by AWS logs (see thread here on OSL Slack - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1745418917141539).

This is happening because we're now hitting the `/auth/validate-jwt` endpoint far more frequently.

## Quick short term fix
 - Bump API rate limits
 - Log error to be able to confirm (via dev console and AWS logs) if this is the issue if hit again

## Better medium term fixes (TBD - added to dev call agenda)
- More nuanced rate limiting (ignore ShareDB requests?)
- Rate limit via Cloudflare for more sophisticated rate limiting controls
- Implement more sophisticated auth pattern in ShareDB