### PR TITLE
fix: dashboard automation 

### DIFF
--- a/api.planx.uk/modules/analytics/metabase/dashboard/findDashboardTemplate.ts
+++ b/api.planx.uk/modules/analytics/metabase/dashboard/findDashboardTemplate.ts
@@ -5,7 +5,7 @@ const DASHBOARD_IDS = {
     FOIYNPP: 73,
     LDC: 124,
     preApp: 120,
-    RAB: 129,
+    RAB: 150,
   },
   staging: {
     AFPP: 185,

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -870,6 +870,7 @@
     - role: api
       permission:
         columns:
+          - analytics_link
           - can_create_from_copy
           - copied_from
           - created_at


### PR DESCRIPTION
Updates `api` role permissions to include `select` on `flows.analytics_link`. (While testing #4415 on staging I realised that the last step was failing because of this.) 

The RAB template has also been changed since this was written, so the new production ID is updated. 