### PR TITLE
feat: Populate additional "submit" template fields

### DIFF
--- a/api.planx.uk/lib/notify/templates/inviteToPay/confirmation-payee.ts
+++ b/api.planx.uk/lib/notify/templates/inviteToPay/confirmation-payee.ts
@@ -1,4 +1,4 @@
-import { type NotifyConfig, type NotifyTemplate } from "../index.js";
+import { type EmailFooter, type NotifyConfig, type NotifyTemplate } from "../index.js";
 
 /**
  * GovNotify template: https://www.notifications.service.gov.uk/services/012e65af-0eb2-45d5-87bd-4248354c4c22/templates/0c8e8b26-01cd-4896-91e6-12c38ef25387
@@ -9,13 +9,9 @@ export const confirmationPayeeTemplate: NotifyTemplate<Config> = {
   config: {} as Config,
 };
 
-export type Config = NotifyConfig<{
+export type Config = NotifyConfig<EmailFooter & {
   serviceName: string;
   sessionId: string;
   address: string;
   projectType: string;
-  applicantName: string;
-  helpEmail: string;
-  helpOpeningHours: string;
-  helpPhone: string;
 }>;

--- a/api.planx.uk/lib/notify/templates/inviteToPay/confirmation-payee.ts
+++ b/api.planx.uk/lib/notify/templates/inviteToPay/confirmation-payee.ts
@@ -1,4 +1,8 @@
-import { type EmailFooter, type NotifyConfig, type NotifyTemplate } from "../index.js";
+import {
+  type EmailFooter,
+  type NotifyConfig,
+  type NotifyTemplate,
+} from "../index.js";
 
 /**
  * GovNotify template: https://www.notifications.service.gov.uk/services/012e65af-0eb2-45d5-87bd-4248354c4c22/templates/0c8e8b26-01cd-4896-91e6-12c38ef25387
@@ -9,9 +13,12 @@ export const confirmationPayeeTemplate: NotifyTemplate<Config> = {
   config: {} as Config,
 };
 
-export type Config = NotifyConfig<EmailFooter & {
-  serviceName: string;
-  sessionId: string;
-  address: string;
-  projectType: string;
-}>;
+export type Config = NotifyConfig<
+  EmailFooter & {
+    serviceName: string;
+    sessionId: string;
+    address: string;
+    projectType: string;
+    applicantName: string;
+  }
+>;

--- a/api.planx.uk/lib/notify/templates/sendToEmail/submit-application.ts
+++ b/api.planx.uk/lib/notify/templates/sendToEmail/submit-application.ts
@@ -14,4 +14,8 @@ export type Config = NotifyConfig<{
   sessionId: string;
   applicantEmail: string;
   downloadLink: string;
+  address: string;
+  fee: string;
+  projectType: string;
+  applicantName: string;
 }>;

--- a/api.planx.uk/lib/notify/templates/sendToEmail/submit-application.ts
+++ b/api.planx.uk/lib/notify/templates/sendToEmail/submit-application.ts
@@ -1,10 +1,10 @@
 import { type NotifyConfig, type NotifyTemplate } from "../index.js";
 
 /**
- * GovNotify template: https://www.notifications.service.gov.uk/services/012e65af-0eb2-45d5-87bd-4248354c4c22/templates/7e77bdae-7379-4dd8-a8cc-086a0029163c
+ * GovNotify template: https://www.notifications.service.gov.uk/services/012e65af-0eb2-45d5-87bd-4248354c4c22/templates/2c61750b-3ecc-4726-9ee2-e67fd523954f
  */
 export const submitTemplate: NotifyTemplate<Config> = {
-  id: "7e77bdae-7379-4dd8-a8cc-086a0029163c",
+  id: "2c61750b-3ecc-4726-9ee2-e67fd523954f",
   access: "private",
   config: {} as Config,
 };

--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -123,10 +123,7 @@ const getSubmitEmailConfig = async ({
       .filter(Boolean)
       .join(" ");
 
-    const payable = getFeeBreakdown(passportData).amount.payable;
-    const fee = payable
-      ? payable.toLocaleString("en-GB", { style: "currency", currency: "GBP" })
-      : "N/A";
+    const fee = getFee(passportData);
 
     const flowName = flow.name;
 
@@ -147,7 +144,7 @@ const getSubmitEmailConfig = async ({
         address: addressLine || "Address not submitted",
         projectType: projectType || "Project type not submitted",
         applicantName,
-        fee,
+        fee: fee || "N/A",
       },
       emailReplyToId: teamSettings.emailReplyToId,
     };
@@ -157,5 +154,20 @@ const getSubmitEmailConfig = async ({
     throw new Error(
       `Failed to fetch details for 'submit' email template for session ${sessionId}. Error: ${error}`,
     );
+  }
+};
+
+const getFee = (passportData: Record<string, unknown>): string | undefined => {
+  try {
+    const payable = getFeeBreakdown(passportData).amount.payable;
+    const fee = payable.toLocaleString("en-GB", {
+      style: "currency",
+      currency: "GBP",
+    });
+
+    return fee;
+  } catch (error) {
+    // Ignore (valid) error - this may not be a fee-carrying service
+    return undefined;
   }
 };

--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -1,3 +1,7 @@
+import {
+  formatRawProjectTypes,
+  getFeeBreakdown,
+} from "@opensystemslab/planx-core";
 import { ServerError } from "../../../errors/serverError.js";
 import { sendEmail } from "../../../lib/notify/index.js";
 import type { TemplateRegistry } from "../../../lib/notify/templates/index.js";
@@ -9,6 +13,10 @@ import {
   getTeamEmailSettings,
   insertAuditEntry,
 } from "./service.js";
+import type {
+  SiteAddress,
+  TeamContactSettings,
+} from "@opensystemslab/planx-core/types";
 
 export const sendToEmail: SendIntegrationController = async (
   req,
@@ -41,27 +49,11 @@ export const sendToEmail: SendIntegrationController = async (
       });
     }
 
-    // Get the applicant email and flow slug associated with the session
-    const { email, flow } = await getSessionEmailDetailsById(sessionId);
-    const flowName = flow.name;
-
-    // Make application files download magic link
-    const params = new URLSearchParams({
-      email: teamSettings.submissionEmail,
-      localAuthority: localAuthority,
+    const config = await getSubmitEmailConfig({
+      teamSettings,
+      localAuthority,
+      sessionId,
     });
-    const applicationFilesDownloadLink = `${process.env.API_URL_EXT}/download-application-files/${sessionId}?${params}`;
-
-    // Prepare email template
-    const config: TemplateRegistry["submit"]["config"] = {
-      personalisation: {
-        serviceName: flowName,
-        sessionId,
-        applicantEmail: email,
-        downloadLink: applicationFilesDownloadLink,
-      },
-      emailReplyToId: teamSettings.emailReplyToId,
-    };
 
     // Send the email
     const response = await sendEmail(
@@ -96,4 +88,65 @@ export const sendToEmail: SendIntegrationController = async (
       }),
     );
   }
+};
+
+const getSubmitEmailConfig = async ({
+  teamSettings,
+  localAuthority,
+  sessionId,
+}: {
+  teamSettings: TeamContactSettings;
+  localAuthority: string;
+  sessionId: string;
+}): Promise<TemplateRegistry["submit"]["config"]> => {
+  const { email, flow, passportData } =
+    await getSessionEmailDetailsById(sessionId);
+
+  // Type narrowing
+  if (!teamSettings.submissionEmail) throw Error("Submission email missing!");
+
+  const projectTypes = passportData["proposal.projectType"] as string[];
+  const projectType = formatRawProjectTypes(projectTypes);
+
+  const address = passportData["_address"] as SiteAddress;
+  const addressLine = address?.single_line_address || address?.title;
+
+  const applicantName = [
+    passportData["applicant.name.title"],
+    passportData["applicant.name.first"],
+    passportData["applicant.name.last"],
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const payable = getFeeBreakdown(passportData).amount.payable;
+  const fee = payable
+    ? payable.toLocaleString("en-GB", { style: "currency", currency: "GBP" })
+    : "N/A";
+
+  const flowName = flow.name;
+
+  // Make application files download magic link
+  const params = new URLSearchParams({
+    email: teamSettings.submissionEmail,
+    localAuthority,
+  });
+  const applicationFilesDownloadLink = `${process.env.API_URL_EXT}/download-application-files/${sessionId}?${params}`;
+
+  // Prepare email template
+  const config: TemplateRegistry["submit"]["config"] = {
+    personalisation: {
+      serviceName: flowName,
+      sessionId,
+      applicantEmail: email,
+      downloadLink: applicationFilesDownloadLink,
+      address: addressLine || "Address not submitted",
+      projectType: projectType || "Project type not submitted",
+      applicantName,
+      fee,
+    },
+    emailReplyToId: teamSettings.emailReplyToId,
+  };
+
+  return config;
 };

--- a/api.planx.uk/modules/send/email/index.ts
+++ b/api.planx.uk/modules/send/email/index.ts
@@ -106,8 +106,11 @@ const getSubmitEmailConfig = async ({
     // Type narrowing
     if (!teamSettings.submissionEmail) throw Error("Submission email missing!");
 
-    const projectTypes = passportData["proposal.projectType"] as string[];
-    const projectType = formatRawProjectTypes(projectTypes);
+    const projectTypes = passportData["proposal.projectType"] as
+      | string[]
+      | undefined;
+    const projectType =
+      projectTypes?.length && formatRawProjectTypes(projectTypes);
 
     const address = passportData["_address"] as SiteAddress;
     const addressLine = address?.single_line_address || address?.title;

--- a/api.planx.uk/modules/send/email/service.ts
+++ b/api.planx.uk/modules/send/email/service.ts
@@ -58,6 +58,7 @@ export async function getSessionData(sessionId: string) {
 
 interface GetSessionEmailDetailsById {
   session: {
+    passportData: Record<string, unknown>;
     email: string;
     flow: {
       slug: string;
@@ -71,6 +72,7 @@ export async function getSessionEmailDetailsById(sessionId: string) {
     gql`
       query GetSessionEmailDetails($id: uuid!) {
         session: lowcal_sessions_by_pk(id: $id) {
+          passportData: data(path: "passport.data")
           email
           flow {
             slug


### PR DESCRIPTION
## What does this PR do?
 - Fetches and formats additional data required for updated "submit" email
 - Points to new template in GovNotify ([link](https://www.notifications.service.gov.uk/services/012e65af-0eb2-45d5-87bd-4248354c4c22/templates/2c61750b-3ecc-4726-9ee2-e67fd523954f))
   - Once merged to prod, I'll delete old template and remove the `(copy)` suffix in the GovNotiy name

![image](https://github.com/user-attachments/assets/82a9347c-a506-47cc-94b6-e15ed5045c4b)

![image](https://github.com/user-attachments/assets/fdfa63ee-18e9-405c-a55d-0d09dd0fe387)
