### PR TITLE
chore: Clip map by buffered boundary, not address point

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -212,9 +212,16 @@ export default function Component(props: Props) {
   /**
    * Clip map extent to buffered boundary, with a fallback to address point if required
    */
-  const clipGeojsonData = boundary
-    ? JSON.stringify(buffer(boundary, bufferInMeters, { units: "meters" }))
-    : JSON.stringify(buffer(addressPoint, bufferInMeters, { units: "meters" }));
+  const clipGeojsonData = (() => {
+    if (boundary)
+      return JSON.stringify(
+        buffer(boundary, bufferInMeters, { units: "meters" }),
+      );
+    if (addressPoint)
+      return JSON.stringify(
+        buffer(addressPoint, bufferInMeters, { units: "meters" }),
+      );
+  })();
 
   function getBody(mapValidationError?: string, fileValidationError?: string) {
     if (page === "draw") {


### PR DESCRIPTION
## What's the problem?
Tewkesbury have reported that they're unable to use the map component with certain large sites. Please see details in https://trello.com/c/tBvJdQtf/2938-allow-users-to-zoom-out-more-to-draw-the-site-outline-for-larger-projects-that-combine-multiple-sites

It's not possible to pan and view the entire site, or adjust all vertices. 

## What's the cause?
The `Map` component sets a buffer around the site based on the address point provided by the OS. For certain large sites, the boundary clips the buffered address point, and cannot be viewed within the map frame. 

## What's the solution?
Buffer the boundary, not the address point. This is how other instances of `my-map` are already setting the `clipGeojsonData` prop.

### To test
- **Staging** - Postcode `GL20 8DF` results in a clipped site boundary ([link](https://editor.planx.dev/tewkesbury/report-a-planning-breach/preview))
- **Pizza** - Postcode `GL20 8DF` can be viewed in full, and a buffer exists around it allowing all vertices to be edited ([link](https://4621.planx.pizza/tewkesbury/report-a-planning-breach/preview))
