### PR TITLE
fix: Validation for internal portal

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -100,7 +100,9 @@ const NodeTypeSelect: React.FC<{
   );
 };
 
-const containsMadeLink = (data: Record<string, unknown>): boolean => {
+const containsMadeLink = (data?: Record<string, unknown>): boolean => {
+  if (!data) return false;
+
   return Object.values(data).some((value) => {
     if (typeof value !== "string") return false;
 
@@ -192,7 +194,7 @@ const FormModal: React.FC<{
             id={id}
             disabled={disabled}
             handleSubmit={(
-              data: any,
+              data: { data?: Record<string, unknown> },
               children: Array<any> | undefined = undefined,
             ) => {
               if (containsMadeLink(data.data)) {


### PR DESCRIPTION
## What's the problem?
It's not currently possible to clone an internal portal from within the Editor modal (selecting an existing internal portal).

## What's the cause?
The global `containsMadeLink()` validation function incorrectly assumes that all incoming data will be of type `object`. This is not correct - the `InternalPortal` node can run a "clone" operation instead of submitting data for a new node. See logic here responsible for this -

https://github.com/theopensystemslab/planx-new/blob/main/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx#L58-L67

## What's the solution?
 - Fix types, and narrow accordingly
 - Longer term, I'm very keen to spend some time tightening up these types to avoid issues like this. If each component had a clear input and output, this could be avoided.
 - Also, I think there's likely a few better ways to handle this global link checking validation function. Should we tie it in with our HTML sanitation, or just rich text link editing (with a base plain text validation check as well)? Something to think about / try out sometime maybe.