### PR TITLE
feat: Track Gloucester, Cheltenham & Tewkesbury SLP in database, display boundary in Team Settings

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -1,3 +1,6 @@
+import TravelExploreIcon from "@mui/icons-material/TravelExplore";
+import Typography from "@mui/material/Typography";
+import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { bbox } from "@turf/bbox";
 import { bboxPolygon } from "@turf/bbox-polygon";
 import axios, { isAxiosError } from "axios";
@@ -5,6 +8,7 @@ import { useFormik } from "formik";
 import type { Feature, MultiPolygon, Polygon } from "geojson";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
+import { useCurrentRoute } from "react-navi";
 import InputLabel from "ui/editor/InputLabel";
 import Input from "ui/shared/Input/Input";
 import * as Yup from "yup";
@@ -16,6 +20,37 @@ export type PlanningDataEntity = Feature<
   Polygon | MultiPolygon,
   Record<string, unknown>
 >;
+
+const BoundaryDescription: React.FC = () => (
+  <>
+    <p>
+      The boundary URL is used to retrieve the outer boundary of your council
+      area. This can then help users define whether they are within your council
+      area.
+    </p>
+    <p>
+      The boundary should be given as a link from:{" "}
+      <a
+        href="https://www.planning.data.gov.uk/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        https://www.planning.data.gov.uk/entity/1234567
+      </a>
+    </p>
+  </>
+);
+
+const SLPInfo: React.FC = () => (
+  <WarningContainer>
+    <TravelExploreIcon sx={{ mr: 1 }} />
+    <Typography variant="body2" color={(theme) => theme.palette.text.secondary}>
+      Tewkesbury, Cheltenham and Gloucestershire share a Strategic and Local
+      Plan (SLP). Planning applicantions can span across boundaries of these
+      three authorities.
+    </Typography>
+  </WarningContainer>
+);
 
 /**
  * Convert a complex local authority boundary to a simplified bounding box
@@ -65,29 +100,18 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
     },
   });
 
+  const route = useCurrentRoute();
+  const teamSlug = route.data.team;
+
+  // Cheltenham, Gloucester and Tewkesbury Strategic Local Plan
+  const slpTeams = ["cheltenham", "gloucester", "tewkesbury"];
+  const isSLPTeam = slpTeams.includes(teamSlug);
+
   return (
     <SettingsForm
       formik={formik}
       legend="Boundary"
-      description={
-        <>
-          <p>
-            The boundary URL is used to retrieve the outer boundary of your
-            council area. This can then help users define whether they are
-            within your council area.
-          </p>
-          <p>
-            The boundary should be given as a link from:{" "}
-            <a
-              href="https://www.planning.data.gov.uk/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              https://www.planning.data.gov.uk/entity/1234567
-            </a>
-          </p>
-        </>
-      }
+      description={<BoundaryDescription />}
       input={
         <InputLabel label="Boundary URL" htmlFor="boundaryUrl">
           <Input
@@ -98,9 +122,12 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
               formik.setFieldValue("boundaryUrl", ev.target.value);
             }}
             id="boundaryUrl"
+            disabled={isSLPTeam}
           />
         </InputLabel>
       }
-    />
+    >
+      {isSLPTeam && <SLPInfo />}
+    </SettingsForm>
   );
 }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -153,9 +153,9 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   const route = useCurrentRoute();
   const teamSlug = route.data.team;
 
-  // Cheltenham, Gloucester and Tewkesbury Strategic Local Plan
-  const slpTeams = ["cheltenham", "gloucester", "tewkesbury"];
-  const isSLPTeam = slpTeams.includes(teamSlug);
+  // Cheltenham, Gloucester and Tewkesbury share a Strategic Local Plan
+  // All SLP services are hosted on the Tewkesbury PlanX team
+  const isSLPTeam = teamSlug === "tewkesbury"
 
   if (isSLPTeam) return <SLPInfo geojsonData={formik.values.boundaryBBox} />;
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -58,8 +58,11 @@ const BoundaryDescription: React.FC = () => (
   <>
     <p>
       The boundary URL is used to retrieve the outer boundary of your council
-      area. This can then help users define whether they are within your council
-      area.
+      area. The bounding box of your boundary (shown below) limits the area 
+      applicants can access via the map within your services.
+    </p>
+    <p>
+      The detailed boundary is still referenced when planning constraints are checked.
     </p>
     <p>
       The boundary should be given as a link from:{" "}
@@ -159,7 +162,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
   return (
     <SettingsForm
       formik={formik}
-      legend="Boundary"
+      legend="Boundary (bounding box)"
       description={<BoundaryDescription />}
       input={
         <>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -8,13 +8,13 @@ import InputLegend from "ui/editor/InputLegend";
 import SettingsDescription from "ui/editor/SettingsDescription";
 import SettingsSection from "ui/editor/SettingsSection";
 
-type SettingsFormProps<TFormikValues> = {
+type SettingsFormProps<TFormikValues> = React.PropsWithChildren<{
   legend: string;
   description: React.ReactElement;
-  input: React.ReactElement;
+  input?: React.ReactElement;
   formik: FormikProps<TFormikValues>;
   preview?: React.ReactElement;
-};
+}>;
 
 export const SettingsForm = <TFormikValues,>({
   formik,
@@ -22,6 +22,7 @@ export const SettingsForm = <TFormikValues,>({
   description,
   input,
   preview,
+  children,
 }: SettingsFormProps<TFormikValues>) => {
   return (
     <SettingsSection background>
@@ -29,6 +30,7 @@ export const SettingsForm = <TFormikValues,>({
         <InputGroup flowSpacing>
           <InputLegend>{legend}</InputLegend>
           <SettingsDescription>{description}</SettingsDescription>
+          {children}
           {input}
         </InputGroup>
         {preview && (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -11,7 +11,7 @@ import SettingsSection from "ui/editor/SettingsSection";
 type SettingsFormProps<TFormikValues> = React.PropsWithChildren<{
   legend: string;
   description: React.ReactElement;
-  input?: React.ReactElement;
+  input: React.ReactElement;
   formik: FormikProps<TFormikValues>;
   preview?: React.ReactElement;
 }>;
@@ -30,8 +30,8 @@ export const SettingsForm = <TFormikValues,>({
         <InputGroup flowSpacing>
           <InputLegend>{legend}</InputLegend>
           <SettingsDescription>{description}</SettingsDescription>
-          {children}
           {input}
+          {children}
         </InputGroup>
         {preview && (
           <Box>

--- a/editor.planx.uk/src/ui/editor/InputGroup.tsx
+++ b/editor.planx.uk/src/ui/editor/InputGroup.tsx
@@ -7,8 +7,7 @@ import Typography from "@mui/material/Typography";
 import React, { PropsWithChildren, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 
-interface Props {
-  children: JSX.Element[] | JSX.Element;
+type Props = React.PropsWithChildren<{
   label?: string;
   grow?: boolean;
   deleteInputGroup?: () => void;
@@ -18,7 +17,7 @@ interface Props {
   id?: string;
   index?: number;
   handleMove?: (dragIndex: number, hoverIndex: number) => void;
-}
+}>;
 
 interface RootProps extends BoxProps {
   flowSpacing?: boolean;


### PR DESCRIPTION
## What does this PR do?
- Updates copy in the `BoundaryForm` component to explain (and show) the bounding box used within PlanX
- For Tewkesbury shows information about their SLP, disables and removes form

Please note: there's an existing issue with displaying OS vector tiles on Pizzas unrelated to the changes made here.

![image](https://github.com/user-attachments/assets/a23a0b47-ae26-4fe2-ac80-6913161c854a)

![image](https://github.com/user-attachments/assets/39e8958e-b47d-452a-ae68-2fdee1ae4c9a)

## Context
Originally, I went for something like this - https://github.com/theopensystemslab/planx-new/commit/b49cea73a61fcb2636832e296540bcf0996c1dbc

This fetched existing `boundary_bbox` values and merged them if within the SLP. However, this would need to be done each time - for every visitor, for every instance of the map. The boundary is effectively static and can be held within the database.

I've ran the following SQL on the Pizza, and I'd proposed to run it (manually) on staging and production.

This sets the `team_setting.boundary_bbox` value for Tewkesbury to be a bounding box covering all three areas.

```sql
UPDATE team_settings
SET boundary_bbox = '{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "bbox": [
        -2.352748,
        51.80758,
        -1.801679,
        52.050567
      ],
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              -2.352748,
              51.80758
            ],
            [
              -1.801679,
              51.80758
            ],
            [
              -1.801679,
              52.050567
            ],
            [
              -2.352748,
              52.050567
            ],
            [
              -2.352748,
              51.80758
            ]
          ]
        ]
      }
    }
  ]
}'::jsonb
FROM teams
WHERE team_settings.team_id = teams.id
  AND teams.slug = 'tewkesbury';
```

## Next steps...
- [ ] Set boundaries to bounding boxes on production by updating boundary URLs for all teams
- [ ] Run SQL snippet on production
- [ ] Sync staging (or just leave overnight!)