### PR TITLE
fix: format data values as text for `Page` components on `Review` page

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -621,9 +621,10 @@ function Page(props: ComponentProps) {
   const fields = (props.node.data as Page).schema.fields;
 
   // Omit un-answered optional fields from Review component display
-  const fieldsWithAnswers = fields.filter((field) =>
-    Boolean(answers[0][field.data.fn]),
-  );
+  const fieldsWithAnswers = fields.filter((field) => {
+    const answer = answers[0][field.data.fn];
+    return Array.isArray(answer) ? answer.length > 0 : Boolean(answer);
+  });
 
   return (
     <>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -7,9 +7,9 @@ import {
   ComponentType as TYPES,
   NodeId,
 } from "@opensystemslab/planx-core/types";
-import { formatAsSingleLineAddress } from "@planx/components/AddressInput/model";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
+import { formatSchemaDisplayValue } from "@planx/components/List/utils";
 import type { Page } from "@planx/components/Page/model";
 import { ConfirmationDialog } from "components/ConfirmationDialog";
 import format from "date-fns/format";
@@ -19,16 +19,7 @@ import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
-import {
-  Field,
-  isAddressFieldResponse,
-  isChecklistFieldResponse,
-  isMapFieldResponse,
-  isNumberFieldResponse,
-  isTextResponse,
-  ResponseValue,
-  SchemaUserResponse,
-} from "../Schema/model";
+import { SchemaUserResponse } from "../Schema/model";
 
 export default SummaryListsBySections;
 
@@ -629,21 +620,9 @@ function Page(props: ComponentProps) {
   const answers = getAnswersByNode(props) as SchemaUserResponse[];
   const fields = (props.node.data as Page).schema.fields;
 
-  const displayValue = (answer: ResponseValue<Field>) => {
-    if (isTextResponse(answer)) return answer;
-    if (isNumberFieldResponse(answer)) return answer.toString();
-    if (isChecklistFieldResponse(answer)) return answer.join(", ");
-    if (isMapFieldResponse(answer)) return `${answer.length || 0} features`;
-    if (isAddressFieldResponse(answer))
-      return formatAsSingleLineAddress(answer);
-
-    // TODO: Handle other types more gracefully
-    return answer;
-  };
-
   // Omit un-answered optional fields from Review component display
-  const fieldsWithAnswers = fields.filter(
-    (field) => displayValue(answers[0][field.data.fn]) !== "",
+  const fieldsWithAnswers = fields.filter((field) =>
+    Boolean(answers[0][field.data.fn]),
   );
 
   return (
@@ -659,7 +638,7 @@ function Page(props: ComponentProps) {
               {field.data.title}
             </Typography>
             <Typography>
-              <>{displayValue(answers[0][field.data.fn])}</>
+              {formatSchemaDisplayValue(answers[0][field.data.fn], field)}
             </Typography>
           </Box>
         ))}

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/ChecklistFieldInput.tsx
@@ -10,11 +10,8 @@ import { getFieldProps, Props } from ".";
 import { FieldInputDescription } from "./shared";
 
 export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
-  const {
-    data: { title, description, options },
-    formik,
-  } = props;
-  const { id, errorMessage, name, value } = getFieldProps(props);
+  const { data, formik } = props;
+  const { id, errorMessage, name, value, title } = getFieldProps(props);
 
   if (!Array.isArray(value))
     throw Error(
@@ -39,11 +36,13 @@ export const ChecklistFieldInput: React.FC<Props<ChecklistField>> = (props) => {
 
   return (
     <InputLabel label={title} id={`checklist-label-${id}`}>
-      {description && <FieldInputDescription description={description} />}
+      {data.description && (
+        <FieldInputDescription description={data.description} />
+      )}
       <ErrorWrapper error={errorMessage} id={id}>
         <Grid container component="fieldset">
           <legend style={visuallyHidden}>{title}</legend>
-          {options.map((option) => (
+          {data.options.map((option) => (
             <Grid item xs={12}>
               <ChecklistItem
                 key={option.id}


### PR DESCRIPTION
A nicer fix / follow-up to #4622 ! 

We already have an existing helper function `formatSchemaDisplayValue` which is used for active > inactive `List` cards

**Latest**
![Screenshot from 2025-04-30 09-14-47](https://github.com/user-attachments/assets/c3fbf0ee-3508-49cd-87e5-a91bd4096015)
