### PR TITLE
feat(wip): show `platform` in `submission_services_summary`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -2,6 +2,7 @@ import ErrorOutline from "@mui/icons-material/ErrorOutline";
 import Typography from "@mui/material/Typography";
 import { SendIntegration } from "@opensystemslab/planx-core/types";
 import axios, { AxiosResponse } from "axios";
+import Bowser from "bowser";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect } from "react";
@@ -107,7 +108,8 @@ const CreateSendEvents: React.FC<Props> = ({
       ]),
     );
 
-    props.handleSubmit && props?.handleSubmit({ data });
+    const platform = Bowser.parse(window.navigator.platform); // This is a weird workaround so that we can include platform in `allow_list_answers` in order to pull it through easily in the `submission_services_summary` table
+    props.handleSubmit && props?.handleSubmit({ data: { ...data, platform } });
   }, [loading, error, value, destinations, props]);
 
   // Throw errors so that they're caught by our error boundaries and Airbrake

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -56,6 +56,7 @@ export const ALLOW_LIST = [
   "findProperty.action",
   "_overrides",
   "planningConstraints.action",
+  "platform",
   "property.constraints.planning",
   "property.type",
   "propertyInformation.action",
@@ -168,6 +169,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     nodeId: string,
     direction?: AnalyticsLogDirection,
     analyticsSessionId?: number,
+    additionalAnswers?: Record<string, any>,
   ) {
     const nodeToTrack = flow[nodeId];
 
@@ -187,6 +189,11 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     );
     const nodeType = nodeToTrack?.type ? TYPES[nodeToTrack.type] : null;
     const nodeTitle = extractNodeTitle(nodeToTrack);
+
+    const allowListAnswers = {
+      ...getAllowListAnswers(nodeId, breadcrumbs[nodeId], flow, breadcrumbs),
+      ...additionalAnswers,
+    };
 
     const result = await insertNewAnalyticsLog(
       logDirection,
@@ -322,6 +329,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
     if (!shouldTrackAnalytics) return;
     const userAgent = Bowser.parse(window.navigator.userAgent);
     const referrer = document.referrer || null;
+    const platform = Bowser.parse(window.navigator.platform);
 
     const response = await publicClient.mutate({
       mutation: INSERT_NEW_ANALYTICS,
@@ -329,6 +337,7 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         type,
         flow_id: flowId,
         user_agent: userAgent,
+        platform: platform,
         referrer,
       },
     });

--- a/hasura.planx.uk/migrations/1746011624000_add_platform_to_submission_services_summary/down.sql
+++ b/hasura.planx.uk/migrations/1746011624000_add_platform_to_submission_services_summary/down.sql
@@ -1,0 +1,103 @@
+CREATE OR REPLACE VIEW "public"."submission_services_summary" AS
+ WITH resumes_per_session AS (
+         SELECT reconciliation_requests.session_id,
+            count(reconciliation_requests.id) AS number_times_resumed
+           FROM reconciliation_requests
+          GROUP BY reconciliation_requests.session_id
+        ), bops_agg AS (
+         SELECT bops_applications.session_id,
+            json_agg(json_build_object('id', bops_applications.bops_id, 'submittedAt', bops_applications.created_at, 'destinationUrl', bops_applications.destination_url) ORDER BY bops_applications.created_at DESC) AS bops_applications
+           FROM bops_applications
+          GROUP BY bops_applications.session_id
+        ), email_agg AS (
+         SELECT email_applications.session_id,
+            json_agg(json_build_object('id', email_applications.id, 'recipient', email_applications.recipient, 'submittedAt', email_applications.created_at) ORDER BY email_applications.created_at DESC) AS email_applications
+           FROM email_applications
+          GROUP BY email_applications.session_id
+        ), uniform_agg AS (
+         SELECT uniform_applications.submission_reference,
+            json_agg(json_build_object('id', uniform_applications.idox_submission_id, 'submittedAt', uniform_applications.created_at) ORDER BY uniform_applications.created_at DESC) AS uniform_applications
+           FROM uniform_applications
+          GROUP BY uniform_applications.submission_reference
+        ), payment_requests_agg AS (
+         SELECT payment_requests.session_id,
+            json_agg(json_build_object('id', payment_requests.id, 'createdAt', payment_requests.created_at, 'paidAt', payment_requests.paid_at, 'govpayPaymentId', payment_requests.govpay_payment_id) ORDER BY payment_requests.created_at DESC) AS payment_requests
+           FROM payment_requests
+          GROUP BY payment_requests.session_id
+        ), payment_status_agg AS (
+         SELECT payment_status.session_id,
+            json_agg(json_build_object('govpayPaymentId', payment_status.payment_id, 'createdAt', payment_status.created_at, 'status', payment_status.status) ORDER BY payment_status.created_at DESC) AS payment_status
+           FROM payment_status
+          GROUP BY payment_status.session_id
+        ), s3_agg AS (
+         SELECT s3_applications.session_id,
+            json_agg(json_build_object('id', s3_applications.id, 'submittedAt', s3_applications.created_at) ORDER BY s3_applications.created_at DESC) AS s3_applications
+           FROM s3_applications
+          GROUP BY s3_applications.session_id
+        )
+ SELECT (ls.id)::text AS session_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    ls.created_at,
+    ls.submitted_at,
+    ((ls.submitted_at)::date - (ls.created_at)::date) AS session_length_days,
+    ls.has_user_saved AS user_clicked_save,
+    rps.number_times_resumed,
+    ls.allow_list_answers,
+    ((ls.allow_list_answers -> 'proposal.projectType'::text))::text AS proposal_project_type,
+    ((ls.allow_list_answers -> 'application.declaration.connection'::text))::text AS application_declaration_connection,
+    ((ls.allow_list_answers -> 'property.type'::text))::text AS property_type,
+    ((ls.allow_list_answers -> 'drawBoundary.action'::text))::text AS draw_boundary_action,
+    ((ls.allow_list_answers -> 'user.role'::text))::text AS user_role,
+    ((ls.allow_list_answers -> 'property.constraints.planning'::text))::text AS property_constraints_planning,
+        CASE
+            WHEN (((pr.payment_requests)::jsonb IS NOT NULL) AND (jsonb_array_length((pr.payment_requests)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS user_invited_to_pay,
+    pr.payment_requests,
+    ps.payment_status,
+        CASE
+            WHEN (((ba.bops_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((ba.bops_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_bops,
+    ba.bops_applications,
+        CASE
+            WHEN (((ua.uniform_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((ua.uniform_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_uniform,
+    ua.uniform_applications,
+        CASE
+            WHEN (((ea.email_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((ea.email_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_email,
+    ea.email_applications,
+    ((ls.allow_list_answers -> 'findProperty.action'::text))::text AS find_property_action,
+        CASE
+            WHEN (((sa.s3_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((sa.s3_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_s3_power_automate,
+    sa.s3_applications,
+    ((ls.allow_list_answers -> 'usedFOIYNPP'::text))::text AS used_foiynpp,
+    ((ls.allow_list_answers -> 'propertyInformation.action'::text))::text AS property_information_action,
+    ((ls.allow_list_answers -> 'planningConstraints.action'::text))::text AS planning_constraints_action,
+    ((ls.allow_list_answers -> '_overrides'::text))::text AS overrides,
+    ((ls.allow_list_answers -> 'rab.exitReason'::text))::text AS rab_exit_reason,
+    ((ls.allow_list_answers -> 'service.type'::text))::text AS pre_app_service_type,
+    ((ls.allow_list_answers -> 'application.information.harmful'::text))::text AS pre_app_harmful_info,
+    ((ls.allow_list_answers -> 'application.information.sensitive'::text))::text AS pre_app_sensitive_info,
+    ((ls.allow_list_answers -> 'application.type'::text) ->> 0) AS application_type,
+    (((ls.allow_list_answers -> '_feedback'::text) ->> 'feedbackScore'::text))::integer AS feedback_score,
+    ((ls.allow_list_answers -> 'applicant.researchOptIn'::text) ->> 0) AS applicant_research_opt_in,
+    ((ls.allow_list_answers -> 'property.type.userProvided'::text))::text AS property_type_user_provided,
+    ((ls.allow_list_answers -> 'platform'::text))::text AS platform
+   FROM (((((((((lowcal_sessions ls
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+     LEFT JOIN teams t ON ((t.id = f.team_id)))
+     LEFT JOIN resumes_per_session rps ON ((rps.session_id = (ls.id)::text)))
+     LEFT JOIN payment_requests_agg pr ON ((pr.session_id = ls.id)))
+     LEFT JOIN payment_status_agg ps ON ((ps.session_id = ls.id)))
+     LEFT JOIN bops_agg ba ON ((ba.session_id = (ls.id)::text)))
+     LEFT JOIN uniform_agg ua ON ((ua.submission_reference = (ls.id)::text)))
+     LEFT JOIN email_agg ea ON ((ea.session_id = ls.id)))
+     LEFT JOIN s3_agg sa ON ((sa.session_id = (ls.id)::text)))
+  WHERE ((f.slug IS NOT NULL) AND (t.slug IS NOT NULL));

--- a/hasura.planx.uk/migrations/1746011624000_add_platform_to_submission_services_summary/up.sql
+++ b/hasura.planx.uk/migrations/1746011624000_add_platform_to_submission_services_summary/up.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE VIEW "public"."submission_services_summary" AS 
+ WITH resumes_per_session AS (
+         SELECT reconciliation_requests.session_id,
+            count(reconciliation_requests.id) AS number_times_resumed
+           FROM reconciliation_requests
+          GROUP BY reconciliation_requests.session_id
+        ), bops_agg AS (
+         SELECT bops_applications.session_id,
+            json_agg(json_build_object('id', bops_applications.bops_id, 'submittedAt', bops_applications.created_at, 'destinationUrl', bops_applications.destination_url) ORDER BY bops_applications.created_at DESC) AS bops_applications
+           FROM bops_applications
+          GROUP BY bops_applications.session_id
+        ), email_agg AS (
+         SELECT email_applications.session_id,
+            json_agg(json_build_object('id', email_applications.id, 'recipient', email_applications.recipient, 'submittedAt', email_applications.created_at) ORDER BY email_applications.created_at DESC) AS email_applications
+           FROM email_applications
+          GROUP BY email_applications.session_id
+        ), uniform_agg AS (
+         SELECT uniform_applications.submission_reference,
+            json_agg(json_build_object('id', uniform_applications.idox_submission_id, 'submittedAt', uniform_applications.created_at) ORDER BY uniform_applications.created_at DESC) AS uniform_applications
+           FROM uniform_applications
+          GROUP BY uniform_applications.submission_reference
+        ), payment_requests_agg AS (
+         SELECT payment_requests.session_id,
+            json_agg(json_build_object('id', payment_requests.id, 'createdAt', payment_requests.created_at, 'paidAt', payment_requests.paid_at, 'govpayPaymentId', payment_requests.govpay_payment_id) ORDER BY payment_requests.created_at DESC) AS payment_requests
+           FROM payment_requests
+          GROUP BY payment_requests.session_id
+        ), payment_status_agg AS (
+         SELECT payment_status.session_id,
+            json_agg(json_build_object('govpayPaymentId', payment_status.payment_id, 'createdAt', payment_status.created_at, 'status', payment_status.status) ORDER BY payment_status.created_at DESC) AS payment_status
+           FROM payment_status
+          GROUP BY payment_status.session_id
+        ), s3_agg AS (
+         SELECT s3_applications.session_id,
+            json_agg(json_build_object('id', s3_applications.id, 'submittedAt', s3_applications.created_at) ORDER BY s3_applications.created_at DESC) AS s3_applications
+           FROM s3_applications
+          GROUP BY s3_applications.session_id
+        )
+ SELECT (ls.id)::text AS session_id,
+    t.slug AS team_slug,
+    f.slug AS service_slug,
+    ls.created_at,
+    ls.submitted_at,
+    ((ls.submitted_at)::date - (ls.created_at)::date) AS session_length_days,
+    ls.has_user_saved AS user_clicked_save,
+    rps.number_times_resumed,
+    ls.allow_list_answers,
+    ((ls.allow_list_answers -> 'proposal.projectType'::text))::text AS proposal_project_type,
+    ((ls.allow_list_answers -> 'application.declaration.connection'::text))::text AS application_declaration_connection,
+    ((ls.allow_list_answers -> 'property.type'::text))::text AS property_type,
+    ((ls.allow_list_answers -> 'drawBoundary.action'::text))::text AS draw_boundary_action,
+    ((ls.allow_list_answers -> 'user.role'::text))::text AS user_role,
+    ((ls.allow_list_answers -> 'property.constraints.planning'::text))::text AS property_constraints_planning,
+        CASE
+            WHEN (((pr.payment_requests)::jsonb IS NOT NULL) AND (jsonb_array_length((pr.payment_requests)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS user_invited_to_pay,
+    pr.payment_requests,
+    ps.payment_status,
+        CASE
+            WHEN (((ba.bops_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((ba.bops_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_bops,
+    ba.bops_applications,
+        CASE
+            WHEN (((ua.uniform_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((ua.uniform_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_uniform,
+    ua.uniform_applications,
+        CASE
+            WHEN (((ea.email_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((ea.email_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_email,
+    ea.email_applications,
+    ((ls.allow_list_answers -> 'findProperty.action'::text))::text AS find_property_action,
+        CASE
+            WHEN (((sa.s3_applications)::jsonb IS NOT NULL) AND (jsonb_array_length((sa.s3_applications)::jsonb) > 0)) THEN true
+            ELSE false
+        END AS sent_to_s3_power_automate,
+    sa.s3_applications,
+    ((ls.allow_list_answers -> 'usedFOIYNPP'::text))::text AS used_foiynpp,
+    ((ls.allow_list_answers -> 'propertyInformation.action'::text))::text AS property_information_action,
+    ((ls.allow_list_answers -> 'planningConstraints.action'::text))::text AS planning_constraints_action,
+    ((ls.allow_list_answers -> '_overrides'::text))::text AS overrides,
+    ((ls.allow_list_answers -> 'rab.exitReason'::text))::text AS rab_exit_reason,
+    ((ls.allow_list_answers -> 'service.type'::text))::text AS pre_app_service_type,
+    ((ls.allow_list_answers -> 'application.information.harmful'::text))::text AS pre_app_harmful_info,
+    ((ls.allow_list_answers -> 'application.information.sensitive'::text))::text AS pre_app_sensitive_info,
+    ((ls.allow_list_answers -> 'application.type'::text) ->> 0) AS application_type,
+    (((ls.allow_list_answers -> '_feedback'::text) ->> 'feedbackScore'::text))::integer AS feedback_score,
+    ((ls.allow_list_answers -> 'applicant.researchOptIn'::text) ->> 0) AS applicant_research_opt_in,
+    ((ls.allow_list_answers -> 'property.type.userProvided'::text))::text AS property_type_user_provided,
+    ((ls.allow_list_answers -> 'platform'::text))::text AS platform
+   FROM (((((((((lowcal_sessions ls
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+     LEFT JOIN teams t ON ((t.id = f.team_id)))
+     LEFT JOIN resumes_per_session rps ON ((rps.session_id = (ls.id)::text)))
+     LEFT JOIN payment_requests_agg pr ON ((pr.session_id = ls.id)))
+     LEFT JOIN payment_status_agg ps ON ((ps.session_id = ls.id)))
+     LEFT JOIN bops_agg ba ON ((ba.session_id = (ls.id)::text)))
+     LEFT JOIN uniform_agg ua ON ((ua.submission_reference = (ls.id)::text)))
+     LEFT JOIN email_agg ea ON ((ea.session_id = ls.id)))
+     LEFT JOIN s3_agg sa ON ((sa.session_id = (ls.id)::text)))
+  WHERE ((f.slug IS NOT NULL) AND (t.slug IS NOT NULL));
+GRANT SELECT ON "public"."feedback_summary" TO metabase_read_only;


### PR DESCRIPTION
I have to say I'm very unsure about this! (Hence draft & wip.) 

Because we've had requests for graphs to show breakdowns by device type, I tried to add `platform` to the allow list in a little workaround to show the device used for submission in `submission_services_summary`. 

Local testing of submissions is just showing me many `NULL` values which I'm also confused by:
![image](https://github.com/user-attachments/assets/3f41a540-6562-462c-aa20-c165f16c37e1)

Am I totally on the wrong track? Tips and advice greatly appreciated!

# What does this PR do?
- Creates a new migration to show `platform` in `submission_services_summary` table
- In the Send component, saves `platform` and passes it to `handleSubmit`
- Adds `platform` to allow list
- Includes `platform` in `createAnalytics`

