### PR TITLE
chore: Temp disable of WSS connection checker

### DIFF
--- a/sharedb.planx.uk/server.js
+++ b/sharedb.planx.uk/server.js
@@ -123,15 +123,15 @@ const wss = new Server({
 wss.on("connection", function (ws, req) {
   // JWTs expire every 24hrs
   // Check status every minute - client side will logout on expiry
-  const tokenCheckInterval = setInterval(async () => {
-    try {
-      await validateJWT(req.authToken)
-    } catch (error) {
-      console.error("Token validation error:", error);
-      ws.close(TOKEN_EXPIRY_CODE, "Token validation error");
-      clearInterval(tokenCheckInterval);
-    }
-  }, ONE_MINUTE_IN_MS);
+  // const tokenCheckInterval = setInterval(async () => {
+  //   try {
+  //     await validateJWT(req.authToken)
+  //   } catch (error) {
+  //     console.error("Token validation error:", error);
+  //     ws.close(TOKEN_EXPIRY_CODE, "Token validation error");
+  //     clearInterval(tokenCheckInterval);
+  //   }
+  // }, ONE_MINUTE_IN_MS);
 
   const stream = new WebSocketJSONStream(ws);
   sharedb.listen(stream, req);


### PR DESCRIPTION
Quick/pragmatic first fix for issues described here (OSL Slack) https://opensystemslab.slack.com/archives/C01E3AC0C03/p1746006499545049

I can see from the logs that we're hitting this endpoint way too often - once it fails (due to a timeout) ShareDB logs a bunch of errors.

Toggling this off temporarily will allow us to work out if the issue is the additional auth on connection (`verifyClient()`) on on the `"connection"` event.