### PR TITLE
chore: Cache validate-jwt requests for 1 minute

### DIFF
--- a/api.planx.uk/modules/auth/routes.ts
+++ b/api.planx.uk/modules/auth/routes.ts
@@ -27,11 +27,7 @@ export default (passport: Authenticator): Router => {
     Controller.handleSuccess,
   );
 
-  router.get(
-    "/auth/validate-jwt",
-    Middleware.useNoCache,
-    Controller.isJWTRevoked,
-  );
+  router.get("/auth/validate-jwt", Controller.isJWTRevoked);
 
   return router;
 };


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/4632

This will cache responses for 1 minute, which feels like an acceptable limit whilst getting to the bottom of the issues here. Once we resolve the underlying issue, we could revert this.