### PR TITLE
feat: Add sketch plan schema to list component

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -39,6 +39,7 @@ import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained
 import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
 import { ResidentialUnitsPreviousLDCE } from "./schemas/ResidentialUnits/PreviousLDCE";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
+import { Trees } from "./schemas/Trees";
 
 type Props = EditorProps<TYPES.List, List>;
 
@@ -83,6 +84,7 @@ export const SCHEMAS = [
     name: "Ownership certificate - Owners",
     schema: OwnershipCertificateOwners,
   },
+  { name: "Sketch Plan (testing only)", schema: Trees },
 ];
 
 function ListComponent(props: Props) {

--- a/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/Trees.ts
@@ -1,0 +1,49 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const Trees: Schema = {
+  type: "Tree type",
+  fields: [
+    {
+      type: "map",
+      data: {
+        title:
+          "Click the map to mark the position of a tree. Multiple trees can be added if they are of the same species, proposed work and reason. Markers can be removed by clicking the delete icon.",
+        fn: "features",
+        mapOptions: {
+          basemap: "MapboxSatellite",
+          drawType: "Point",
+          drawColor: "#66ff00",
+          drawMany: true,
+        },
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Species",
+        fn: "species",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Proposed work",
+        fn: "work",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Reasons for the proposed work",
+        fn: "reason",
+        type: TextInputType.Short,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
## What does this PR do?

Adds the sketch plan (TPO) schema back into the list component, for the purposes of testing with DAC.

Testing:
https://4638.planx.pizza/testing/list-map-schema