### PR TITLE
fix: Hide last published data on non-published routes

### DIFF
--- a/editor.planx.uk/src/components/Footer/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer/Footer.tsx
@@ -55,11 +55,13 @@ export default function Footer(props: Props) {
   return (
     <Root>
       <Container maxWidth={false}>
-        <Box pb={2}>
-          <Typography variant="body2">
-            {formatServiceLastUpdated(lastPublishedDate)}
-          </Typography>
-        </Box>
+        {lastPublishedDate && 
+          <Box pb={2}>
+            <Typography variant="body2">
+              {formatServiceLastUpdated(lastPublishedDate)}
+            </Typography>
+          </Box>
+        }
         {items && items.length > 0 && (
           <ButtonGroup pb={2.5}>
             {items

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -171,7 +171,7 @@ export interface EditorStore extends Store.Store {
   isClone: (id: NodeId) => boolean;
   lastPublished: (flowId: string) => Promise<string>;
   lastPublisher: (flowId: string) => Promise<string>;
-  lastPublishedDate: string;
+  lastPublishedDate?: string;
   setLastPublishedDate: (date: string) => void;
   isFlowPublished: boolean;
   isTemplate: boolean;
@@ -452,7 +452,7 @@ export const editorStore: StateCreator<
     return lastPublishedDate;
   },
 
-  lastPublishedDate: "",
+  lastPublishedDate: undefined,
 
   setLastPublishedDate: (date: string) => {
     set({ lastPublishedDate: date });


### PR DESCRIPTION
Noticed this when checking out the a11y test flow - we don't fetch a `lastPublishedDate` for non published routes. The type has this as `string` and sets a default of `""` when `string | undefined` is more accurate.

![image](https://github.com/user-attachments/assets/69ee0cd4-6ab5-4bf9-85ec-c7e8ac47b175)
