### PR TITLE
fix: don't allow empty strings in required text inputs

### DIFF
--- a/editor.planx.uk/src/@planx/components/AddressInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/AddressInput/Public.test.tsx
@@ -41,6 +41,28 @@ test("submits an address", async () => {
   });
 });
 
+test("requires a non-empty string before being able to continue", async () => {
+  const handleSubmit = vi.fn();
+
+  const { user } = setup(
+    <AddressInput handleSubmit={handleSubmit} title="" fn="foo" />,
+  );
+
+  await fillInFieldsUsingLabel(user, {
+    "Address line 1": "Flat 1",
+    "Address line 2 (optional)": "221b Baker St",
+    Town: " ",
+    Postcode: "SW1A 2AA",
+  });
+
+  await user.click(screen.getByTestId("continue-button"));
+
+  expect(handleSubmit).not.toHaveBeenCalled();
+
+  const errorMessage = await screen.findByText("Enter a town");
+  expect(errorMessage).toBeVisible();
+});
+
 test("recovers previously submitted text when clicking the back button", async () => {
   const handleSubmit = vi.fn();
   const componentId = uniqueId();

--- a/editor.planx.uk/src/@planx/components/AddressInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/AddressInput/model.ts
@@ -6,11 +6,11 @@ import { BaseNodeData, parseBaseNodeData } from "../shared";
 
 export const addressValidationSchema = (): SchemaOf<Address> =>
   object({
-    line1: string().required("Enter the first line of an address"),
+    line1: string().trim().required("Enter the first line of an address"),
     line2: string(),
-    town: string().required("Enter a town"),
+    town: string().trim().required("Enter a town"),
     county: string(),
-    postcode: string().required("Enter a postcode"),
+    postcode: string().trim().required("Enter a postcode"),
     country: string(),
   });
 

--- a/editor.planx.uk/src/@planx/components/ContactInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/ContactInput/Public.test.tsx
@@ -247,3 +247,29 @@ test("does not allow the name 'Test Test' to be used", async () => {
   );
   expect(errorMessage).toBeVisible();
 });
+
+test("requires a non-empty string before being able to continue", async () => {
+  const handleSubmit = vi.fn();
+
+  const { user } = setup(
+    <ContactInput
+      handleSubmit={handleSubmit}
+      title="Enter your contact details"
+      fn="applicant"
+    />,
+  );
+
+  await fillInFieldsUsingLabel(user, {
+    "First name": "Someone",
+    "Last name": " ",
+    "Phone number": "0123456789",
+    "Email address": "test@gov.uk",
+  });
+
+  await user.click(screen.getByTestId("continue-button"));
+
+  expect(handleSubmit).not.toHaveBeenCalled();
+
+  const errorMessage = await screen.findByText("Enter a last name");
+  expect(errorMessage).toBeVisible();
+});

--- a/editor.planx.uk/src/@planx/components/ContactInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/ContactInput/model.ts
@@ -14,11 +14,12 @@ export type Contact = {
 
 export const userDataSchema: SchemaOf<Contact> = object({
   title: string(),
-  firstName: string().required("Enter a first name"),
-  lastName: string().required("Enter a last name"),
+  firstName: string().trim().required("Enter a first name"),
+  lastName: string().trim().required("Enter a last name"),
   organisation: string(),
-  phone: string().required("Enter a phone number"),
+  phone: string().trim().required("Enter a phone number"),
   email: string()
+    .trim()
     .email(
       "Enter an email address in the correct format, like name@example.com",
     )

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -26,6 +26,30 @@ test("requires a value before being able to continue", async () => {
   expect(handleSubmit).toHaveBeenCalled();
 });
 
+test("requires a non-empty string before being able to continue", async () => {
+  const handleSubmit = vi.fn();
+
+  const { user } = setup(
+    <TextInput
+      title="hello"
+      type={TextInputType.Short}
+      handleSubmit={handleSubmit}
+    />,
+  );
+
+  expect(screen.getByRole("heading")).toHaveTextContent("hello");
+
+  await user.type(screen.getByLabelText("hello"), " ");
+  await user.click(screen.getByTestId("continue-button"));
+
+  expect(handleSubmit).toHaveBeenCalledTimes(0);
+
+  const errorMessage = await screen.findByText(
+    "Enter your answer before continuing",
+  );
+  expect(errorMessage).toBeVisible();
+});
+
 test("requires a valid email before being able to continue", async () => {
   const handleSubmit = vi.fn();
 

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -32,7 +32,7 @@ export const textInputValidationSchema = ({
   string()
     .when([], {
       is: () => required,
-      then: string().required("Enter your answer before continuing"),
+      then: string().trim().required("Enter your answer before continuing"),
       otherwise: string().notRequired(),
     })
     .test({


### PR DESCRIPTION
Spotted while prepping for a11y audit