### PR TITLE
feat: Chip and filter options for template flows

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -149,6 +149,7 @@ export interface FlowSummary {
   summary: string;
   operations: FlowSummaryOperations[];
   publishedFlows: PublishedFlowSummary[];
+  templatedFrom: string | null;
 }
 
 export interface EditorStore extends Store.Store {
@@ -402,6 +403,7 @@ export const editorStore: StateCreator<
                 lastName: last_name
               }
             }
+            templatedFrom: templated_from
             publishedFlows: published_flows(
               order_by: { created_at: desc }
               limit: 1

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useToast } from "hooks/useToast";
+import { hasFeatureFlag } from "lib/featureFlags";
 import React, { useState } from "react";
 import { Link, useCurrentRoute } from "react-navi";
 import { inputFocusStyle } from "theme";
@@ -143,6 +144,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
   };
 
   const isSubmissionService = flow.publishedFlows?.[0]?.hasSendComponent;
+  const isTemplateService = Boolean(flow.templatedFrom);
 
   const statusVariant =
     flow.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
@@ -158,6 +160,11 @@ const FlowCard: React.FC<FlowCardProps> = ({
       displayName: "Submission",
       shouldAddTag: isSubmissionService,
     },
+    {
+      type: FlowTagType.Template,
+      displayName: "Template",
+      shouldAddTag: hasFeatureFlag("TEMPLATES") && isTemplateService,
+    }
   ];
 
   const publishedDate = formatLastPublishMessage(

--- a/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
+++ b/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
@@ -1,3 +1,4 @@
+import { hasFeatureFlag } from "lib/featureFlags";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import { FilterOptions } from "ui/editor/Filter/Filter";
 import { SortableFields } from "ui/editor/SortControl/SortControl";
@@ -30,7 +31,12 @@ const checkFlowServiceType: FilterOptions<FlowSummary>["validationFn"] = (
   _value,
 ) => flow.publishedFlows[0]?.hasSendComponent;
 
-export const filterOptions: FilterOptions<FlowSummary>[] = [
+const checkFlowTemplatedFrom: FilterOptions<FlowSummary>["validationFn"] = (
+  flow,
+  _value,
+) => Boolean(flow.templatedFrom)
+
+const baseFilterOptions: FilterOptions<FlowSummary>[] = [
   {
     displayName: "Online status",
     optionKey: "status",
@@ -44,3 +50,14 @@ export const filterOptions: FilterOptions<FlowSummary>[] = [
     validationFn: checkFlowServiceType,
   },
 ];
+
+const templateFilterOption: FilterOptions<FlowSummary> =  {
+  displayName: "Template",
+  optionKey: "templatedFrom",
+  optionValue: ["template"],
+  validationFn: checkFlowTemplatedFrom,
+};
+
+export const filterOptions: FilterOptions<FlowSummary>[] = hasFeatureFlag("TEMPLATES")
+  ? [...baseFilterOptions, templateFilterOption]
+  : baseFilterOptions;

--- a/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
+++ b/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
@@ -38,4 +38,8 @@ export const Root = styled(Box, {
   ...(tagType === FlowTagType.ServiceType && {
     backgroundColor: theme.palette.flowTag.serviceType,
   }),
+  // TODO: Is there a colour to communicate "template"?
+  ...(tagType === FlowTagType.Template && {
+    backgroundColor: theme.palette.flowTag.serviceType,
+  }),
 }));

--- a/editor.planx.uk/src/ui/editor/FlowTag/types.ts
+++ b/editor.planx.uk/src/ui/editor/FlowTag/types.ts
@@ -2,6 +2,7 @@ export const FlowTagType = {
   Status: "status",
   ApplicationType: "applicationType",
   ServiceType: "serviceType",
+  Template: "template",
 } as const;
 
 export const StatusVariant = {


### PR DESCRIPTION
## What does this PR do?
 - Adds a "Template" chip
 - Adds a "Template" filter option
 - Both behind the `TEMPLATES` feature flag still


https://github.com/user-attachments/assets/5fc4a9a5-9335-4df8-946a-26001df14aaa

