### PR TITLE
feat: Create source template

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -125,7 +125,7 @@ const createFlow = async ({
         copied_from: copiedFrom,
         templated_from: templatedFrom,
         is_template: isTemplate,
-      }
+      },
     );
 
     await createAssociatedOperation(id);

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -67,14 +67,23 @@ interface CreateFlowResponse {
 }
 
 // Insert a new flow into the `flows` table
-const createFlow = async (
-  teamId: number,
-  slug: string,
-  name: string,
-  flowData: Flow["data"],
-  copiedFrom?: Flow["id"],
-  templatedFrom?: Flow["id"],
-) => {
+const createFlow = async ({
+  teamId,
+  slug,
+  name,
+  isTemplate,
+  flowData,
+  copiedFrom,
+  templatedFrom,
+}: {
+  teamId: number;
+  slug: string;
+  name: string;
+  isTemplate: boolean;
+  flowData: Flow["data"];
+  copiedFrom?: Flow["id"];
+  templatedFrom?: Flow["id"];
+}) => {
   const { client: $client } = getClient();
   const userId = userContext.getStore()?.user?.sub;
 
@@ -90,6 +99,7 @@ const createFlow = async (
           $data: jsonb = {}
           $copied_from: uuid
           $templated_from: uuid
+          $is_template: Boolean
         ) {
           flow: insert_flows_one(
             object: {
@@ -100,6 +110,7 @@ const createFlow = async (
               version: 1
               copied_from: $copied_from
               templated_from: $templated_from
+              is_template: $is_template
             }
           ) {
             id
@@ -113,6 +124,7 @@ const createFlow = async (
         data: flowData,
         copied_from: copiedFrom,
         templated_from: templatedFrom,
+        is_template: isTemplate,
       },
     );
 

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -66,57 +66,6 @@ interface CreateFlowResponse {
   };
 }
 
-const createFlowMutation = gql`
-  mutation InsertFlow(
-    $team_id: Int!
-    $slug: String!
-    $name: String!
-    $data: jsonb = {}
-    $copied_from: uuid
-    $templated_from: uuid
-  ) {
-    flow: insert_flows_one(
-      object: {
-        team_id: $team_id
-        slug: $slug
-        name: $name
-        data: $data
-        version: 1
-        copied_from: $copied_from
-        templated_from: $templated_from
-      }
-    ) {
-      id
-    }
-  }
-`;
-
-const createSourceTemplateMutation = gql`
-  mutation InsertSourceTemplateFlow(
-    $team_id: Int!
-    $slug: String!
-    $name: String!
-    $data: jsonb = {}
-    $copied_from: uuid
-    $templated_from: uuid
-  ) {
-    flow: insert_flows_one(
-      object: {
-        team_id: $team_id
-        slug: $slug
-        name: $name
-        data: $data
-        version: 1
-        copied_from: $copied_from
-        templated_from: $templated_from
-        is_template: true
-      }
-    ) {
-      id
-    }
-  }
-`;
-
 // Insert a new flow into the `flows` table
 const createFlow = async ({
   teamId,
@@ -138,22 +87,46 @@ const createFlow = async ({
   const { client: $client } = getClient();
   const userId = userContext.getStore()?.user?.sub;
 
-  /** Only platformAdmins have write permissions for the is_template column */
-  const mutation = isTemplate
-    ? createSourceTemplateMutation
-    : createFlowMutation;
-
   try {
     const {
       flow: { id },
-    } = await $client.request<CreateFlowResponse>(mutation, {
-      team_id: teamId,
-      slug: slug,
-      name: name,
-      data: flowData,
-      copied_from: copiedFrom,
-      templated_from: templatedFrom,
-    });
+    } = await $client.request<CreateFlowResponse>(
+      gql`
+        mutation InsertFlow(
+          $team_id: Int!
+          $slug: String!
+          $name: String!
+          $data: jsonb = {}
+          $copied_from: uuid
+          $templated_from: uuid
+          $is_template: Boolean
+        ) {
+          flow: insert_flows_one(
+            object: {
+              team_id: $team_id
+              slug: $slug
+              name: $name
+              data: $data
+              version: 1
+              copied_from: $copied_from
+              templated_from: $templated_from
+              is_template: $is_template
+            }
+          ) {
+            id
+          }
+        }
+      `,
+      {
+        team_id: teamId,
+        slug: slug,
+        name: name,
+        data: flowData,
+        copied_from: copiedFrom,
+        templated_from: templatedFrom,
+        is_template: isTemplate,
+      }
+    );
 
     await createAssociatedOperation(id);
     await publishFlow(id, "Created flow");

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -99,7 +99,6 @@ const createSourceTemplateMutation = gql`
     $data: jsonb = {}
     $copied_from: uuid
     $templated_from: uuid
-    $is_template: Boolean
   ) {
     flow: insert_flows_one(
       object: {
@@ -110,7 +109,7 @@ const createSourceTemplateMutation = gql`
         version: 1
         copied_from: $copied_from
         templated_from: $templated_from
-        is_template: $is_template
+        is_template: true
       }
     ) {
       id
@@ -154,7 +153,6 @@ const createFlow = async ({
       data: flowData,
       copied_from: copiedFrom,
       templated_from: templatedFrom,
-      ...(isTemplate && { is_template: isTemplate }),
     });
 
     await createAssociatedOperation(id);

--- a/api.planx.uk/modules/flows/copyFlow/service.ts
+++ b/api.planx.uk/modules/flows/copyFlow/service.ts
@@ -18,7 +18,14 @@ const copyFlow = async ({
   // Check if copied flow data should be inserted into `flows` table, or just returned for reference
   if (insert) {
     // Insert the flow and an associated operation
-    await createFlow(teamId, slug, name, uniqueFlowData, flowId);
+    await createFlow({
+      teamId,
+      slug,
+      name,
+      isTemplate: false,
+      flowData: uniqueFlowData,
+      copiedFrom: flowId,
+    });
   }
 
   return { flow, uniqueFlowData };

--- a/api.planx.uk/modules/flows/createFlow/controller.ts
+++ b/api.planx.uk/modules/flows/createFlow/controller.ts
@@ -16,6 +16,7 @@ export const createFlowSchema = z.object({
     teamId: z.number(),
     slug: z.string(),
     name: z.string().trim(),
+    isTemplate: z.boolean().optional().default(false),
   }),
 });
 
@@ -30,11 +31,17 @@ export const createFlowController: CreateFlowController = async (
   next,
 ) => {
   try {
-    const { teamId, slug, name } = res.locals.parsedReq.body;
-    const initialFlowData: FlowGraph = { _root: { edges: [] } };
+    const { teamId, slug, name, isTemplate } = res.locals.parsedReq.body;
+    const flowData: FlowGraph = { _root: { edges: [] } };
 
     // createFlow automatically handles the associated operation and initial publish
-    const { id } = await createFlow(teamId, slug, name, initialFlowData);
+    const { id } = await createFlow({
+      teamId,
+      slug,
+      name,
+      isTemplate,
+      flowData,
+    });
 
     res.status(200).send({
       message: `Successfully created flow ${slug}`,

--- a/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
+++ b/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
@@ -9,14 +9,14 @@ const createFlowFromTemplate = async (
   const sourceTemplate = await getFlowData(templateId);
 
   // Create the new templated flow, including an associated operation and initial publish, and templated_from reference to the source templateId
-  const { id } = await createFlow(
+  const { id } = await createFlow({
     teamId,
     slug,
     name,
-    sourceTemplate.data,
-    undefined, // flows.copied_from
-    templateId,
-  );
+    isTemplate: false,
+    flowData: sourceTemplate.data,
+    templatedFrom: templateId,
+  });
 
   return { id, slug };
 };

--- a/api.planx.uk/modules/flows/docs.yaml
+++ b/api.planx.uk/modules/flows/docs.yaml
@@ -65,6 +65,10 @@ components:
           type: string
           example: My new flow
           required: true
+        isTemplate:
+          type: boolean
+          example: true
+          required: false
     CreateFlowFromTemplate:
       type: object
       properties:

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -150,6 +150,7 @@ export interface FlowSummary {
   operations: FlowSummaryOperations[];
   publishedFlows: PublishedFlowSummary[];
   templatedFrom: string | null;
+  isTemplate: boolean;
 }
 
 export interface EditorStore extends Store.Store {
@@ -400,6 +401,7 @@ export const editorStore: StateCreator<
               }
             }
             templatedFrom: templated_from
+            isTemplate: is_template
             publishedFlows: published_flows(
               order_by: { created_at: desc }
               limit: 1

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -303,16 +303,12 @@ export const editorStore: StateCreator<
     localStorage.setItem("clipboard", id);
   },
 
-  createFlow: async ({ teamId, name, slug }) => {
+  createFlow: async (newFlow) => {
     const token = get().jwt;
 
     const response = await axios.post<{ id: string }>(
       `${import.meta.env.VITE_APP_API_URL}/flows/create`,
-      {
-        teamId,
-        slug,
-        name,
-      },
+      newFlow,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -2,15 +2,18 @@ import MenuItem from "@mui/material/MenuItem";
 import { useFormikContext } from "formik";
 import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
+import Permission from "ui/editor/Permission";
 import SelectInput from "ui/editor/SelectInput/SelectInput";
 import { URLPrefix } from "ui/editor/URLPrefix";
 import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input/Input";
+import { Switch } from "ui/shared/Switch";
 import { slugify } from "utils";
 
 import { CreateFromCopyFormSection } from "./CreateFromCopyFormSection";
 import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
 import { CREATE_FLOW_MODES, CreateFlow } from "./types";
+
 export const BaseFormSection: React.FC = () => {
   const { values, setFieldValue, getFieldProps, errors } =
     useFormikContext<CreateFlow>();
@@ -68,6 +71,21 @@ export const BaseFormSection: React.FC = () => {
           startAdornment={<URLPrefix />}
         />
       </InputLabel>
+      {values.mode === "new" && (
+        <Permission.IsPlatformAdmin>
+          <Switch
+            name="isTemplate"
+            checked={values.flow.isTemplate}
+            onChange={() =>
+              setFieldValue(
+                "flow.isTemplate",
+                !values.flow.isTemplate,
+              )
+            }
+            label={"Source template"}
+          />
+        </Permission.IsPlatformAdmin>
+      )}
     </>
   );
 };

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -32,6 +32,7 @@ export const AddFlow: React.FC = () => {
       name: "",
       sourceId: "",
       teamId,
+      isTemplate: false,
     },
   };
 

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
@@ -1,5 +1,4 @@
-import { boolean } from "mathjs";
-import { number, object, string } from "yup";
+import { boolean, number, object, string } from "yup";
 
 export const validationSchema = object().shape({
   mode: string().oneOf(["new", "copy", "template"]).required(),

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
@@ -1,3 +1,4 @@
+import { boolean } from "mathjs";
 import { number, object, string } from "yup";
 
 export const validationSchema = object().shape({
@@ -6,6 +7,7 @@ export const validationSchema = object().shape({
     slug: string().required("Slug is required"),
     name: string().required("Name is required"),
     teamId: number().integer().required("Team ID is required"),
+    isTemplate: boolean(),
     sourceId: string().when("$mode", {
       is: "new",
       then: string().notRequired(),
@@ -19,6 +21,7 @@ export type NewFlow = {
   name: string;
   teamId: number;
   sourceId?: string;
+  isTemplate?: boolean;
 };
 
 export type CreateFlow = {

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -148,6 +148,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
 
   const isSubmissionService = flow.publishedFlows?.[0]?.hasSendComponent;
   const isTemplateService = Boolean(flow.templatedFrom);
+  const isSourceTemplateService = Boolean(flow.isTemplate);
 
   const statusVariant =
     flow.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
@@ -167,7 +168,12 @@ const FlowCard: React.FC<FlowCardProps> = ({
       type: FlowTagType.Template,
       displayName: "Template",
       shouldAddTag: hasFeatureFlag("TEMPLATES") && isTemplateService,
-    }
+    },
+    {
+      type: FlowTagType.SourceTemplate,
+      displayName: "Source Template",
+      shouldAddTag: hasFeatureFlag("TEMPLATES") && isSourceTemplateService,
+    },
   ];
 
   const publishedDate = formatLastPublishMessage(

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -148,7 +148,6 @@ const FlowCard: React.FC<FlowCardProps> = ({
 
   const isSubmissionService = flow.publishedFlows?.[0]?.hasSendComponent;
   const isTemplateService = Boolean(flow.templatedFrom);
-  const isSourceTemplateService = Boolean(flow.isTemplate);
 
   const statusVariant =
     flow.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
@@ -172,7 +171,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
     {
       type: FlowTagType.SourceTemplate,
       displayName: "Source Template",
-      shouldAddTag: hasFeatureFlag("TEMPLATES") && isSourceTemplateService,
+      shouldAddTag: hasFeatureFlag("TEMPLATES") && flow.isTemplate,
     },
   ];
 

--- a/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
+++ b/editor.planx.uk/src/ui/editor/FlowTag/styles.ts
@@ -39,7 +39,8 @@ export const Root = styled(Box, {
     backgroundColor: theme.palette.flowTag.serviceType,
   }),
   // TODO: Is there a colour to communicate "template"?
-  ...(tagType === FlowTagType.Template && {
+  ...((tagType === FlowTagType.Template ||
+    tagType === FlowTagType.SourceTemplate) && {
     backgroundColor: theme.palette.flowTag.serviceType,
   }),
 }));

--- a/editor.planx.uk/src/ui/editor/FlowTag/types.ts
+++ b/editor.planx.uk/src/ui/editor/FlowTag/types.ts
@@ -3,6 +3,7 @@ export const FlowTagType = {
   ApplicationType: "applicationType",
   ServiceType: "serviceType",
   Template: "template",
+  SourceTemplate: "sourceTemplate",
 } as const;
 
 export const StatusVariant = {

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -747,6 +747,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -779,6 +780,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings
@@ -848,6 +850,7 @@
           - data
           - description
           - id
+          - is_template
           - limitations
           - name
           - settings


### PR DESCRIPTION
## What does this PR do?
 - Adds a "source template" toggle to the create flow modal (platform admins only)
 - Updates API to accept this new argument, refactors `createFlow()` to take a single options argument
 - Adds temporary "Source Template" tag to `FlowCard`
   - This will be replaced by a styled card, but serves as a visual cue for now and sorts out the data needed for this restyle
   - Please see https://github.com/theopensystemslab/planx-new/pull/4651#discussion_r2075513134

![image](https://github.com/user-attachments/assets/391c5231-453f-49f6-9411-1a5a776f2eb6)
