### PR TITLE
fix: Use Vite env var, add eslint rule

### DIFF
--- a/editor.planx.uk/.eslintrc
+++ b/editor.planx.uk/.eslintrc
@@ -104,6 +104,13 @@
           "expect"
         ]
       }
+    ],
+    "no-restricted-syntax": [
+      "error",
+        {
+          "selector": "MemberExpression[object.name='process'][property.name='env']",
+          "message": "Use import.meta.env instead of process.env in Vite applications"
+        }
     ]
   },
   "overrides": [

--- a/editor.planx.uk/src/ui/shared/WatermarkBackground.tsx
+++ b/editor.planx.uk/src/ui/shared/WatermarkBackground.tsx
@@ -55,7 +55,7 @@ const WatermarkBackground: React.FC<WatermarkBackgroundProps> = ({
   opacity = 0.1,
 }) => {
   // Only display watermark on Staging and Pizza environments
-  const isTestEnvironment = process.env.VITE_APP_ENV !== "production";
+  const isTestEnvironment = import.meta.env.VITE_APP_ENV !== "production";
   if (!isTestEnvironment) return null;
 
   return (


### PR DESCRIPTION
## What does this PR do?
 - Uses `import.meta.env` to access env vars instead of `process.env` - this is required for Vite applications ([docs](https://vite.dev/guide/env-and-mode#env-variables-and-modes))
 - Adds eslint rule so we shouldn't make this mistake again!