### PR TITLE
feat: setup event trigger to update `templated_flow_edits`

### DIFF
--- a/api.planx.uk/modules/webhooks/controller.ts
+++ b/api.planx.uk/modules/webhooks/controller.ts
@@ -192,31 +192,32 @@ export const isCleanJSONBController: IsCleanJSONBController = async (
   }
 };
 
-export const updateTemplatedFlowEditsController: UpdateTemplatedFlowEditsController = async (
-  _req,
-  res,
-  next,
-) => {
-  const { flowId, templatedFrom, data } = res.locals.parsedReq.body.payload;
+export const updateTemplatedFlowEditsController: UpdateTemplatedFlowEditsController =
+  async (_req, res, next) => {
+    const { flowId, templatedFrom, data } = res.locals.parsedReq.body.payload;
 
-  try {
-    if (isNull(templatedFrom)) {
+    try {
+      if (isNull(templatedFrom)) {
+        return res.status(200).send({
+          message: `Not a templated flow, skipping updates (${flowId})`,
+        });
+      }
+
+      const response = await updateTemplatedFlowEdits(
+        flowId,
+        templatedFrom,
+        data,
+      );
       return res.status(200).send({
-        message: `Not a templated flow, skipping updates (${flowId})`,
+        message: `Successfully updated templated flow edits (${flowId})`,
+        data: response,
       });
+    } catch (error) {
+      return next(
+        new ServerError({
+          message: `Failed to update templated flow edits ${flowId}`,
+          cause: error,
+        }),
+      );
     }
-
-    const response = await updateTemplatedFlowEdits(flowId, templatedFrom, data);
-    return res.status(200).send({
-      message: `Successfully updated templated flow edits (${flowId})`,
-      data: response,
-    });
-  } catch (error) {
-    return next(
-      new ServerError({
-        message: `Failed to update templated flow edits ${flowId}`,
-        cause: error,
-      }),
-    );
-  }
-};
+  };

--- a/api.planx.uk/modules/webhooks/routes.ts
+++ b/api.planx.uk/modules/webhooks/routes.ts
@@ -1,21 +1,23 @@
 import { Router } from "express";
+import { validate } from "../../shared/middleware/validate.js";
 import { useHasuraAuth } from "../auth/middleware.js";
 import { createPaymentSendEvents } from "../pay/service/inviteToPay/createPaymentSendEvents.js";
-import { validate } from "../../shared/middleware/validate.js";
 import {
-  isCleanJSONBController,
+  analyzeSessionsController,
   createPaymentExpiryEventsController,
   createPaymentInvitationEventsController,
   createPaymentReminderEventsController,
   createSessionExpiryEventController,
   createSessionReminderEventController,
+  isCleanJSONBController,
   sanitiseApplicationDataController,
   sendSlackNotificationController,
-  analyzeSessionsController,
+  updateTemplatedFlowEditsController,
 } from "./controller.js";
-import { sendSlackNotificationSchema } from "./service/sendNotification/schema.js";
-import { createPaymentEventSchema } from "./service/paymentRequestEvents/schema.js";
 import { createSessionEventSchema } from "./service/lowcalSessionEvents/schema.js";
+import { createPaymentEventSchema } from "./service/paymentRequestEvents/schema.js";
+import { sendSlackNotificationSchema } from "./service/sendNotification/schema.js";
+import { updateTemplatedFlowEditsEventSchema } from "./service/updateTemplatedFlowEdits/schema.js";
 import { isCleanJSONBSchema } from "./service/validateInput/schema.js";
 
 const router = Router();
@@ -60,6 +62,12 @@ router.post(
   "/webhooks/hasura/validate-input/jsonb/clean-html",
   validate(isCleanJSONBSchema),
   isCleanJSONBController,
+);
+
+router.post(
+  "/webhooks/hasura/update-templated-flow-edits",
+  validate(updateTemplatedFlowEditsEventSchema),
+  updateTemplatedFlowEditsController,
 );
 
 // TODO: Convert to the new API module structure

--- a/api.planx.uk/modules/webhooks/service/updateTemplatedFlowEdits/index.ts
+++ b/api.planx.uk/modules/webhooks/service/updateTemplatedFlowEdits/index.ts
@@ -1,0 +1,14 @@
+export const updateTemplatedFlowEdits = async (
+  flowId: string,
+  templatedFrom: string,
+  data: any,
+) => {
+  // TODO
+  // 1. Fetch flows.data where id = templatedFrom
+  // 2. JSON diff against event `data`
+  // 3. Filter diff for nodes tagged 'customisation'
+  // 4. Transform diff to `templated_flow_edits` data shape
+  // 5. Update `templated_flow_edits`
+
+  return { flowId, templatedFrom, data };
+};

--- a/api.planx.uk/modules/webhooks/service/updateTemplatedFlowEdits/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/updateTemplatedFlowEdits/schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+
+export const updateTemplatedFlowEditsEventSchema = z.object({
+  body: z.object({
+    createdAt: z.string().pipe(z.coerce.date()),
+    payload: z.object({
+      flowId: z.string(),
+      templatedFrom: z.string().nullable(),
+      data: z.any(),
+    }),
+  }),
+});
+
+export type UpdateTemplatedFlowEditsEvent = z.infer<
+  typeof updateTemplatedFlowEditsEventSchema
+>["body"];
+
+export interface UpdateTemplatedFlowEditsEventResponse {
+  message: string;
+  data?: any;
+}
+
+export type UpdateTemplatedFlowEditsController = ValidatedRequestHandler<
+  typeof updateTemplatedFlowEditsEventSchema,
+  UpdateTemplatedFlowEditsEventResponse
+>;

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -1226,6 +1226,37 @@
             }
         template_engine: Kriti
         version: 2
+    - name: update_templated_flow_edits
+      definition:
+        enable_manual: false
+        update:
+          columns:
+            - data
+      retry_conf:
+        interval_sec: 10
+        num_retries: 0
+        timeout_sec: 60
+      webhook: '{{HASURA_PLANX_API_URL}}'
+      headers:
+        - name: authorization
+          value_from_env: HASURA_PLANX_API_KEY
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "createdAt": {{$body.created_at}},
+              "payload": {
+                "flowId": {{$body.id}},
+                "templatedFrom": {{$body.event.data.new.templated_from}},
+                "data": {{$body.event.data.new.data}}
+              }
+            }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/update-templated-flow-edits'
+        version: 2
 - table:
     name: global_settings
     schema: public


### PR DESCRIPTION
Stubs out a new database event trigger that listens for updates on `flows.data`. If that flow is templated from another, it's going to diff the updated `data` against the source template's `data`, filter out differences to nodes tagged "customisation", then format and save them to `templated_flow_edits` table. This code doesn't actually do the logical second part yet, it's just the skeletal event trigger setup and request validation.

I think there might be benefit in merging just the skeletal part here early to monitor performance? This event trigger will be far more frequent than our other uses so far. Then I'll come back and fill in the logic soon.

**To test:** 
- Update a flow that is not templated from another, check the Hasura events log to confirm an event was triggered. It should have succeeded (200) with message `"Not a templated flow, skipping updates"`. 
- Update a flow that is templated from another, check the Hasura events log to confirm an event was triggered. It should have succeeded (200) with response `{ flowId, templatedFrom, data }`.
