### PR TITLE
fix: Watermark position and editor overflow scroll

### DIFF
--- a/editor.planx.uk/src/components/AnalyticsDisabled/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabled/AnalyticsDisabledBanner.tsx
@@ -8,13 +8,15 @@ import { visuallyHidden } from "@mui/utils";
 import React, { useState } from "react";
 import AnalyticsChart from "ui/icons/AnalyticsChart";
 
-const AnalyticsWarning = styled(Box)(() => ({
+const AnalyticsWarning = styled(Box)(({ theme }) => ({
   display: "flex",
   backgroundColor: "#FFFB00",
   color: "#070707",
   justifyContent: "space-between",
   alignItems: "center",
   padding: "0.2em 0",
+  position: "relative",
+  zIndex: theme.zIndex.appBar,
 }));
 
 const AnalyticsDisabledBanner: React.FC = () => {

--- a/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
@@ -14,6 +14,7 @@ export const Root = styled(Box, {
   flexShrink: 0,
   background: theme.palette.background.paper,
   borderRight: `1px solid ${theme.palette.border.light}`,
+  zIndex: theme.zIndex.appBar,
 }));
 
 export const MenuWrap = styled("ul")(({ theme }) => ({

--- a/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
@@ -9,6 +9,8 @@ import React from "react";
 const Root = styled(Box)(({ theme }) => ({
   width: "100%",
   backgroundColor: theme.palette.background.paper,
+  position: "relative",
+  zIndex: theme.zIndex.appBar,
 }));
 
 const ReportButton = styled(Button)(({ theme }) => ({

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -3,6 +3,7 @@ import "./floweditor.scss";
 import Box from "@mui/material/Box";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import { styled } from "@mui/material/styles";
+import { HEADER_HEIGHT_EDITOR } from "components/Header/Header";
 import React, { useRef } from "react";
 import { rootFlowPath } from "routes/utils";
 
@@ -20,6 +21,7 @@ const EditorContainer = styled(Box)(() => ({
   alignItems: "stretch",
   overflow: "hidden",
   flexGrow: 1,
+  maxHeight: `calc(100vh - ${HEADER_HEIGHT_EDITOR}px)`,
 }));
 
 const EditorVisualControls = styled(ButtonGroup)(({ theme }) => ({

--- a/editor.planx.uk/src/ui/shared/WatermarkBackground.tsx
+++ b/editor.planx.uk/src/ui/shared/WatermarkBackground.tsx
@@ -11,7 +11,7 @@ type WatermarkBackgroundProps = {
 };
 
 const Root = styled(Box)(() => ({
-  position: "absolute",
+  position: "fixed",
   top: "0",
   left: "0",
   width: "100%",


### PR DESCRIPTION
## What does this PR do?

Fixes two issues:

### 1. Restores `max-height` css property to the graph editor view

The `max-height` was previously variable depending on the presence of a testing banner, it was incorrectly removed entirely as part of the watermark PR.

Before: https://editor.planx.dev/barnet/apply-for-a-lawful-development-certificate
After: https://4658.planx.pizza/barnet/apply-for-a-lawful-development-certificate

### 2. Ensure fixed position of watermark so that it covers all screens

As the watermark was positioned `absolute` with a finite size, on longer screens the watermark does not cover the entire canvas. An alternative option would be to make the watermark respond to page size, however this would mean the text is inconsistently size and would cause some unwanted layout-shift behaviour when interacting with elements that change the screen size (i.e. accordions). Keeping the watermark positioned `fixed` means a consistent view across all canvas / screen sizes.

Before: https://editor.planx.dev/testing?sort=last-edited&sortDirection=desc
After: https://4658.planx.pizza/testing?sort=last-edited&sortDirection=desc