### PR TITLE
fix(a11y): Close button and h1 for help text modal

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -4,6 +4,8 @@ import Container from "@mui/material/Container";
 import Drawer, { DrawerProps } from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
 import MoreInfoFeedbackComponent from "components/Feedback/MoreInfoFeedback/MoreInfoFeedback";
 import React from "react";
 
@@ -59,6 +61,7 @@ const CloseButton = styled(Box)(({ theme }) => ({
   top: theme.spacing(1),
   right: theme.spacing(1),
   color: theme.palette.text.primary,
+  zIndex: theme.zIndex.drawer + 1,
 }));
 
 interface IMoreInfo {
@@ -93,6 +96,9 @@ const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
       </IconButton>
     </CloseButton>
     <Container maxWidth={false} sx={{ bgcolor: "white" }}>
+      <Typography variant="h1" sx={visuallyHidden}>
+        More information
+      </Typography>
       <DrawerContent>{children}</DrawerContent>
     </Container>
     <MoreInfoFeedbackComponent />


### PR DESCRIPTION
## What does this PR do?

Addresses two issues:

### 1. Fixes missing close button on help text dialog

This was caused by adding a `z-index` css property to containers.

### 2. Adds a visually hidden `<h1>` to the help text dialog

Ensures there is a `<h1>` present with the title: "More information"

Before: https://editor.planx.dev/testing/help-text/preview
After: https://4659.planx.pizza/testing/help-text/preview
