### PR TITLE
fix: preserve calculated fee = 0 in breakdowns

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3e63240",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -22,8 +22,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
-    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@19.1.2)
+    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
+    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@19.1.2)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7527,9 +7527,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/70426e7(@types/react@19.1.2):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
-    id: github.com/theopensystemslab/planx-core/70426e7
+  github.com/theopensystemslab/planx-core/6560f18(@types/react@19.1.2):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
+    id: github.com/theopensystemslab/planx-core/6560f18
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -22,8 +22,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3e63240
-    version: github.com/theopensystemslab/planx-core/3e63240(@types/react@19.1.2)
+    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
+    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@19.1.2)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -4581,11 +4581,11 @@ packages:
       strnum: 1.1.2
     dev: false
 
-  /fast-xml-parser@5.2.1:
-    resolution: {integrity: sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==}
+  /fast-xml-parser@5.2.2:
+    resolution: {integrity: sha512-ZaCmslH75Jkfowo/x44Uq8KT5SutC5BFxHmY61nmTXPccw11PVuIXKUqC2hembMkJ3nPwTkQESXiUlsKutCbMg==}
     hasBin: true
     dependencies:
-      strnum: 2.0.5
+      strnum: 2.1.0
     dev: false
 
   /fastq@1.19.1:
@@ -5384,6 +5384,7 @@ packages:
       chalk: 3.0.0
       diff-match-patch: 1.0.5
     dev: false
+    bundledDependencies: []
 
   /jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
@@ -6825,8 +6826,8 @@ packages:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
     dev: false
 
-  /strnum@2.0.5:
-    resolution: {integrity: sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==}
+  /strnum@2.1.0:
+    resolution: {integrity: sha512-w0S//9BqZZGw0L0Y8uLSelFGnDJgTyyNQLmSlPnVz43zPAiqu3w4t8J8sDqqANOGeZIZ/9jWuPguYcEnsoHv4A==}
     dev: false
 
   /stylis@4.2.0:
@@ -7522,13 +7523,13 @@ packages:
     resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
     dev: false
 
-  /zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  /zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/3e63240(@types/react@19.1.2):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3e63240}
-    id: github.com/theopensystemslab/planx-core/3e63240
+  github.com/theopensystemslab/planx-core/70426e7(@types/react@19.1.2):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
+    id: github.com/theopensystemslab/planx-core/70426e7
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -7544,7 +7545,7 @@ packages:
       copyfiles: 2.4.1
       docx: 9.4.1
       eslint: 8.57.1
-      fast-xml-parser: 5.2.1
+      fast-xml-parser: 5.2.2
       graphql: 16.11.0
       graphql-request: 6.1.0(graphql@16.11.0)
       json-schema-to-typescript: 15.0.4
@@ -7555,7 +7556,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.40.1
       uuid: 11.1.0
-      zod: 3.24.3
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/api.planx.uk/tests/mocks/inviteToPayMocks.ts
+++ b/api.planx.uk/tests/mocks/inviteToPayMocks.ts
@@ -136,7 +136,7 @@ export const createPaymentRequestQueryMock = {
     ],
     feeBreakdown: {
       amount: {
-        calculated: 123.45,
+        calculated: 0,
         calculatedVAT: 0,
         reduction: 0,
         exemption: 0,

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3e63240",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
-    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
+    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -3080,9 +3080,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
-    id: github.com/theopensystemslab/planx-core/70426e7
+  github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
+    id: github.com/theopensystemslab/planx-core/6560f18
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3e63240
-    version: github.com/theopensystemslab/planx-core/3e63240(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
+    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -1457,11 +1457,11 @@ packages:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
     dev: false
 
-  /fast-xml-parser@5.2.1:
-    resolution: {integrity: sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==}
+  /fast-xml-parser@5.2.2:
+    resolution: {integrity: sha512-ZaCmslH75Jkfowo/x44Uq8KT5SutC5BFxHmY61nmTXPccw11PVuIXKUqC2hembMkJ3nPwTkQESXiUlsKutCbMg==}
     hasBin: true
     dependencies:
-      strnum: 2.0.5
+      strnum: 2.1.0
     dev: false
 
   /fastq@1.19.1:
@@ -2732,8 +2732,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /strnum@2.0.5:
-    resolution: {integrity: sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==}
+  /strnum@2.1.0:
+    resolution: {integrity: sha512-w0S//9BqZZGw0L0Y8uLSelFGnDJgTyyNQLmSlPnVz43zPAiqu3w4t8J8sDqqANOGeZIZ/9jWuPguYcEnsoHv4A==}
     dev: false
 
   /stylis@4.2.0:
@@ -3076,13 +3076,13 @@ packages:
       type-fest: 2.19.0
     dev: false
 
-  /zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  /zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/3e63240(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3e63240}
-    id: github.com/theopensystemslab/planx-core/3e63240
+  github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
+    id: github.com/theopensystemslab/planx-core/70426e7
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -3098,7 +3098,7 @@ packages:
       copyfiles: 2.4.1
       docx: 9.4.1
       eslint: 8.57.1
-      fast-xml-parser: 5.2.1
+      fast-xml-parser: 5.2.2
       graphql: 16.11.0
       graphql-request: 6.1.0(graphql@16.11.0)
       json-schema-to-typescript: 15.0.4
@@ -3109,7 +3109,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.40.1
       uuid: 11.1.0
-      zod: 3.24.3
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3e63240",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3e63240
-    version: github.com/theopensystemslab/planx-core/3e63240(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
+    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -1345,11 +1345,11 @@ packages:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
     dev: false
 
-  /fast-xml-parser@5.2.1:
-    resolution: {integrity: sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==}
+  /fast-xml-parser@5.2.2:
+    resolution: {integrity: sha512-ZaCmslH75Jkfowo/x44Uq8KT5SutC5BFxHmY61nmTXPccw11PVuIXKUqC2hembMkJ3nPwTkQESXiUlsKutCbMg==}
     hasBin: true
     dependencies:
-      strnum: 2.0.5
+      strnum: 2.1.0
     dev: false
 
   /fastq@1.19.1:
@@ -2407,8 +2407,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /strnum@2.0.5:
-    resolution: {integrity: sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==}
+  /strnum@2.1.0:
+    resolution: {integrity: sha512-w0S//9BqZZGw0L0Y8uLSelFGnDJgTyyNQLmSlPnVz43zPAiqu3w4t8J8sDqqANOGeZIZ/9jWuPguYcEnsoHv4A==}
     dev: false
 
   /stylis@4.2.0:
@@ -2630,13 +2630,13 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  /zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/3e63240(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3e63240}
-    id: github.com/theopensystemslab/planx-core/3e63240
+  github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
+    id: github.com/theopensystemslab/planx-core/70426e7
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -2652,7 +2652,7 @@ packages:
       copyfiles: 2.4.1
       docx: 9.4.1
       eslint: 8.57.1
-      fast-xml-parser: 5.2.1
+      fast-xml-parser: 5.2.2
       graphql: 16.11.0
       graphql-request: 6.1.0(graphql@16.11.0)
       json-schema-to-typescript: 15.0.4
@@ -2663,7 +2663,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.40.1
       uuid: 11.1.0
-      zod: 3.24.3
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
-    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
+    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -2634,9 +2634,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/70426e7(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
-    id: github.com/theopensystemslab/planx-core/70426e7
+  github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
+    id: github.com/theopensystemslab/planx-core/6560f18
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#3e63240",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#70426e7",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.5
     version: 1.0.0-alpha.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#3e63240
-    version: github.com/theopensystemslab/planx-core/3e63240(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
+    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -8392,11 +8392,11 @@ packages:
   /fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
-  /fast-xml-parser@5.2.1:
-    resolution: {integrity: sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==}
+  /fast-xml-parser@5.2.2:
+    resolution: {integrity: sha512-ZaCmslH75Jkfowo/x44Uq8KT5SutC5BFxHmY61nmTXPccw11PVuIXKUqC2hembMkJ3nPwTkQESXiUlsKutCbMg==}
     hasBin: true
     dependencies:
-      strnum: 2.0.5
+      strnum: 2.1.0
     dev: false
 
   /fastest-stable-stringify@2.0.2:
@@ -12925,8 +12925,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /strnum@2.0.5:
-    resolution: {integrity: sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==}
+  /strnum@2.1.0:
+    resolution: {integrity: sha512-w0S//9BqZZGw0L0Y8uLSelFGnDJgTyyNQLmSlPnVz43zPAiqu3w4t8J8sDqqANOGeZIZ/9jWuPguYcEnsoHv4A==}
     dev: false
 
   /style-mod@4.1.2:
@@ -14236,8 +14236,8 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  /zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  /zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
   /zstddec@0.1.0:
@@ -14265,9 +14265,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/3e63240(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/3e63240}
-    id: github.com/theopensystemslab/planx-core/3e63240
+  github.com/theopensystemslab/planx-core/70426e7(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
+    id: github.com/theopensystemslab/planx-core/70426e7
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true
@@ -14283,7 +14283,7 @@ packages:
       copyfiles: 2.4.1
       docx: 9.4.1
       eslint: 8.57.1
-      fast-xml-parser: 5.2.1
+      fast-xml-parser: 5.2.2
       graphql: 16.11.0
       graphql-request: 6.1.0(graphql@16.11.0)
       json-schema-to-typescript: 15.0.4
@@ -14294,7 +14294,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.40.1
       uuid: 11.1.0
-      zod: 3.24.3
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@types/react'
       - encoding

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.5
     version: 1.0.0-alpha.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#70426e7
-    version: github.com/theopensystemslab/planx-core/70426e7(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
+    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14265,9 +14265,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/70426e7(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/70426e7}
-    id: github.com/theopensystemslab/planx-core/70426e7
+  github.com/theopensystemslab/planx-core/6560f18(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
+    id: github.com/theopensystemslab/planx-core/6560f18
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true


### PR DESCRIPTION
Relies on https://github.com/theopensystemslab/planx-core/pull/727

See bug report https://opensystemslab.slack.com/archives/C07F7215W7P/p1746545457127259?thread_ts=1746524633.032529&cid=C07F7215W7P

**For the given passport:**
![Screenshot from 2025-05-07 13-14-51](https://github.com/user-attachments/assets/6b07de3b-dc91-45b4-b6ea-63886ecb1bd0)

**`getFeeBreakdown` before:**
Incorrectly setting calculated = payable if calculated = 0 and payable > 0
![Screenshot from 2025-05-07 13-14-33](https://github.com/user-attachments/assets/0554418f-1298-4a57-b30b-b26b790fb79e)


**`getFeeBreakdown` after:**
Preserves original calculated and "Application fee" row correctly shows 0
![Screenshot from 2025-05-07 13-23-35](https://github.com/user-attachments/assets/0569d43a-0917-4aa0-b9e4-3c1053a1489c)