### PR TITLE
fix: fee breakdown should account for non-100% exemptions

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2c3892a",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -22,8 +22,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
-    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@19.1.2)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
+    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.1.2)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7527,9 +7527,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6560f18(@types/react@19.1.2):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
-    id: github.com/theopensystemslab/planx-core/6560f18
+  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.1.2):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
+    id: github.com/theopensystemslab/planx-core/a5ad59e
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -22,8 +22,8 @@ dependencies:
     specifier: ^3.701.0
     version: 3.701.0
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
-    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.1.2)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2c3892a
+    version: github.com/theopensystemslab/planx-core/2c3892a(@types/react@19.1.2)
   '@types/isomorphic-fetch':
     specifier: ^0.0.36
     version: 0.0.36
@@ -7527,9 +7527,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.1.2):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
-    id: github.com/theopensystemslab/planx-core/a5ad59e
+  github.com/theopensystemslab/planx-core/2c3892a(@types/react@19.1.2):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2c3892a}
+    id: github.com/theopensystemslab/planx-core/2c3892a
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2c3892a",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
-    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2c3892a
+    version: github.com/theopensystemslab/planx-core/2c3892a(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -3080,9 +3080,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
-    id: github.com/theopensystemslab/planx-core/a5ad59e
+  github.com/theopensystemslab/planx-core/2c3892a(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2c3892a}
+    id: github.com/theopensystemslab/planx-core/2c3892a
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^11.1.1
     version: 11.1.1
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
-    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
+    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -3080,9 +3080,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
-    id: github.com/theopensystemslab/planx-core/6560f18
+  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
+    id: github.com/theopensystemslab/planx-core/a5ad59e
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2c3892a",
     "axios": "^1.8.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
-    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2c3892a
+    version: github.com/theopensystemslab/planx-core/2c3892a(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -2634,9 +2634,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
-    id: github.com/theopensystemslab/planx-core/a5ad59e
+  github.com/theopensystemslab/planx-core/2c3892a(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2c3892a}
+    id: github.com/theopensystemslab/planx-core/2c3892a
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
-    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
+    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10)
   axios:
     specifier: ^1.8.3
     version: 1.8.3
@@ -2634,9 +2634,9 @@ packages:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
     dev: false
 
-  github.com/theopensystemslab/planx-core/6560f18(@types/react@19.0.10):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
-    id: github.com/theopensystemslab/planx-core/6560f18
+  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@19.0.10):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
+    id: github.com/theopensystemslab/planx-core/a5ad59e
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -20,7 +20,7 @@ export const mockPaymentRequest: Partial<PaymentRequest> = {
   applicantName: "Mr Agent (Agency Ltd)",
   feeBreakdown: {
     amount: {
-      calculated: 123.45,
+      calculated: 0,
       calculatedVAT: 0,
       payable: 123.45,
       payableVAT: 0,
@@ -65,7 +65,6 @@ export const mockSessionData: Omit<SessionData, "id"> = {
       "proposal.projectType": ["alter.decks", "alter.internal"],
       "applicant.agent.email": "testAgent@opensystemslab.com",
       "application.fee.payable": 123.45,
-      "application.fee.calculated": 123.45,
       "_contact.applicant.agent": {
         "applicant.agent": {
           email: "testAgent@opensystemslab.com",

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -65,6 +65,7 @@ export const mockSessionData: Omit<SessionData, "id"> = {
       "proposal.projectType": ["alter.decks", "alter.internal"],
       "applicant.agent.email": "testAgent@opensystemslab.com",
       "application.fee.payable": 123.45,
+      "application.fee.calculated": 123.45,
       "_contact.applicant.agent": {
         "applicant.agent": {
           email: "testAgent@opensystemslab.com",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#2c3892a",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -16,7 +16,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.5",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#6560f18",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a5ad59e",
     "@tiptap/core": "^2.4.0",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-bubble-menu": "^2.1.13",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.5
     version: 1.0.0-alpha.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#6560f18
-    version: github.com/theopensystemslab/planx-core/6560f18(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
+    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14265,9 +14265,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/6560f18(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/6560f18}
-    id: github.com/theopensystemslab/planx-core/6560f18
+  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
+    id: github.com/theopensystemslab/planx-core/a5ad59e
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: 1.0.0-alpha.5
     version: 1.0.0-alpha.5
   '@opensystemslab/planx-core':
-    specifier: git+https://github.com/theopensystemslab/planx-core#a5ad59e
-    version: github.com/theopensystemslab/planx-core/a5ad59e(@types/react@18.2.45)
+    specifier: git+https://github.com/theopensystemslab/planx-core#2c3892a
+    version: github.com/theopensystemslab/planx-core/2c3892a(@types/react@18.2.45)
   '@tiptap/core':
     specifier: ^2.4.0
     version: 2.4.0(@tiptap/pm@2.0.3)
@@ -14265,9 +14265,9 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/theopensystemslab/planx-core/a5ad59e(@types/react@18.2.45):
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a5ad59e}
-    id: github.com/theopensystemslab/planx-core/a5ad59e
+  github.com/theopensystemslab/planx-core/2c3892a(@types/react@18.2.45):
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2c3892a}
+    id: github.com/theopensystemslab/planx-core/2c3892a
     name: '@opensystemslab/planx-core'
     version: 1.0.0
     prepare: true

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -98,7 +98,7 @@ const ApplicationFee: FeeBreakdownRow = ({ amount }) => (
 );
 
 const Reductions: FeeBreakdownRow = ({ amount, reductions }) => {
-  if (!amount.reduction) return null;
+  if (reductions.length === 0) return null;
 
   return (
     <>
@@ -113,7 +113,9 @@ const Reductions: FeeBreakdownRow = ({ amount, reductions }) => {
           <>
             <TableCell></TableCell>
             <TableCell align="right">
-              {formattedPriceWithCurrencySymbol(amount.reduction)}
+              <strong>
+                {formattedPriceWithCurrencySymbol(amount.reduction)}
+              </strong>
             </TableCell>
           </>
         )}
@@ -143,7 +145,7 @@ const Reductions: FeeBreakdownRow = ({ amount, reductions }) => {
 };
 
 const Exemptions: FeeBreakdownRow = ({ exemptions, amount }) => {
-  if (!amount.exemption) return null;
+  if (exemptions.length === 0) return null;
 
   return (
     <>
@@ -156,7 +158,9 @@ const Exemptions: FeeBreakdownRow = ({ exemptions, amount }) => {
           <>
             <TableCell></TableCell>
             <TableCell align="right">
-              {formattedPriceWithCurrencySymbol(amount.exemption)}
+              <strong>
+                {formattedPriceWithCurrencySymbol(amount.exemption)}
+              </strong>
             </TableCell>
           </>
         )}


### PR DESCRIPTION
Relies on https://github.com/theopensystemslab/planx-core/pull/729

See this thread https://opensystemslab.slack.com/archives/C07F7215W7P/p1746524633032529

**Testing:** 
Compare journeys outlined below between https://editor.planx.uk/testing/set-fee-demo and same flow on this pizza

1. 0 intial application fee > Sports reduction > any Fast Track
  - Breakdown should display "Application fee" = 0
  - Reduction is displayed & labeled "Modification" with amount = 578
  - Payable is correct
2. 200 initial application fee > Disabilty exemption (0 off) > any Fast Track
  - Breakdown should display "Application fee" = 200
  - Exemption is displayed with amount = 0
  - Payable is correct
  
Finally, confirm no visual regressions on existing Storybook scenarios between prod and this pizza https://storybook.planx.uk/?path=/docs/planx-components-pay-feebreakdown--docs