### PR TITLE
fix: Trim flow name before adding ' (copy)' suffix

### DIFF
--- a/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
+++ b/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
@@ -34,7 +34,7 @@ export const CopyDialog: React.FC<Props> = ({ isDialogOpen, handleClose, sourceF
     mode: "copy",
     flow: {
       slug: sourceFlow.slug + "-copy",
-      name: sourceFlow.name + " (copy)",
+      name: sourceFlow.name.trim() + " (copy)",
       sourceId: sourceFlow.id,
       teamId,
     },


### PR DESCRIPTION
Based on feedback by @augustlindemer - 

> _for any flow currently with a trailing whitespace, when the copy dialogue appends  (copy) it does so without trimming the whitespace first, so it creates a flow with two whitespaces before the (copy)._

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/43e80e11-e091-4e6c-a13e-5bb6a25af969) | ![image](https://github.com/user-attachments/assets/0afa2343-9531-4982-b578-b4a2054d7518) | 