### PR TITLE
fix: handle incoming value = 0 correctly in Calculate, don't fallback to default value

### DIFF
--- a/editor.planx.uk/src/@planx/components/Calculate/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Calculate/model.test.ts
@@ -82,6 +82,13 @@ describe("evaluate", () => {
     expect(expected).toEqual(actual);
   });
 
+  test("does not default to default values when actual value is 0 and default is > 0", () => {
+    const actual = evaluate("ceil(apples/4)", { apples: 0 }, { apples: 10 });
+
+    const expected = 0;
+    expect(expected).toEqual(actual);
+  });
+
   test("defaults work with nested variables", () => {
     const actual = evaluate("a.b.c", {}, { "a.b.c": 10 });
 

--- a/editor.planx.uk/src/@planx/components/Calculate/model.ts
+++ b/editor.planx.uk/src/@planx/components/Calculate/model.ts
@@ -81,7 +81,8 @@ export function evaluate(input: string, scope = {}, defaults = {}): number {
   function applyDefaults(object: any, defaults: any) {
     const keys = new Set([...Object.keys(object), ...Object.keys(defaults)]);
     return Object.fromEntries(
-      [...keys].map((key) => [key, object[key] || defaults[key]]),
+      // Ensure that value === 0 isn't incorrectly falling back to default
+      [...keys].map((key) => [key, object[key] === 0 ? object[key] : (object[key] || defaults[key])]),
     );
   }
 }


### PR DESCRIPTION
See thread https://opensystemslab.slack.com/archives/C07F7215W7P/p1746708641958439?thread_ts=1746524633.032529&cid=C07F7215W7P

**To test:** 
- Compare same flow on this pizza to production flow https://editor.planx.uk/testing/calculator-defaults
- If you have 0 apples, you should need 0 containers
  - Production flow will incorrectly output 3 containers in passport when Calculate has default value of 10 and receives a valid incoming value of 0 apples (default should only be triggered when incoming apples are undefined)
- From what I can tell only impacting passport & `handleSubmit`, not the "Try" section of the editor modal