### PR TITLE
fix: Race condition between routes and `initUserStore()`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -14,7 +14,7 @@ export interface UserStore {
   setUser: (user: User & { jwt: string }) => void;
   getUser: () => User | undefined;
   canUserEditTeam: (teamSlug: Team["slug"]) => boolean;
-  initUserStore: () => Promise<void>;
+  initUserStore: () => Promise<User>;
   getUserRoleForCurrentTeam: () => Role | undefined;
 }
 
@@ -48,10 +48,12 @@ export const userStore: StateCreator<
   async initUserStore() {
     const { getUser, setUser } = get();
     const currentUser = getUser();
-    if (currentUser) return;
+    if (currentUser) return currentUser;
 
     const user = await getLoggedInUser();
     setUser(user);
+    
+    return user;
   },
 
   getUserRoleForCurrentTeam: () => {

--- a/editor.planx.uk/src/routes/views/authenticated.tsx
+++ b/editor.planx.uk/src/routes/views/authenticated.tsx
@@ -1,6 +1,5 @@
 import { getCookie } from "lib/cookie";
 import { redirect } from "navi";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { View } from "react-navi";
 
@@ -13,10 +12,6 @@ import AuthenticatedLayout from "../../pages/layout/AuthenticatedLayout";
 export const authenticatedView = async () => {
   const authCookie = getCookie("auth");
   if (!authCookie) return redirect("/login");
-
-  await useStore.getState().initUserStore();
-
-  useStore.getState().setPreviewEnvironment("editor");
 
   return (
     <AuthenticatedLayout>

--- a/editor.planx.uk/src/routes/views/authenticated.tsx
+++ b/editor.planx.uk/src/routes/views/authenticated.tsx
@@ -1,5 +1,6 @@
 import { getCookie } from "lib/cookie";
 import { redirect } from "navi";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { View } from "react-navi";
 
@@ -12,6 +13,8 @@ import AuthenticatedLayout from "../../pages/layout/AuthenticatedLayout";
 export const authenticatedView = async () => {
   const authCookie = getCookie("auth");
   if (!authCookie) return redirect("/login");
+
+  useStore.getState().setPreviewEnvironment("editor");
 
   return (
     <AuthenticatedLayout>


### PR DESCRIPTION
## What's the problem?
There's a race condition between routes loading (and their associated data fetches and renders) and the `UserStore` being initialised. We need the `UserStore` to be initialised for route guards to work, and as `react-navi` sits outside it react rendering hierarchy it doesn't re-render / update when Zustand stores do.

What's happening currently - 
 - User loads page
 - (Concurrently) Fetch user, load data (e.g. for `/admin-panel`)
 - If user is not returned yet, route guard fails

This behaviour is most commonly seen of refreshes and when direct linking to a nested route - simply as the home page does not have a route guard build into `react-navi`. The user request succeeds and is saved to the store before nested, guarded, routes are loaded.

## What's the solution?
The user store was being incorrectly initialised within a `View` component, which despite being hierarchical from a DOM point of view, is not awaited by `react-navi`.

By moving the call to `initUserStore()` into react-navi's context, we can access the `user` within the route for our route guards. This is then correctly tied to the react-navi lifecycle.

### To test...
- Navigate to `/admin-panel` from home
- Refresh (try it many times, should always resolve and not throw a `NotFound` error)
- Navigate directly to `/admin-panel` without first landing on home - https://4669.planx.pizza/admin-panel

**Note:** This does not yet resolve the issue outlined in [this `#planx-bugs` thread](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1746711213940839) (OSL Slack) - this appears to be a very similar issue related to the `TeamStore`.