### PR TITLE
fix: ensure `article4.caz` variables reflect correct council name too

### DIFF
--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -292,8 +292,16 @@ async function go(
       });
     }
 
-    // rename `articleFour.caz` to reflect localAuthority if applicable
-    const localCaz = `articleFour.${localAuthority}.caz`;
+    // rename `articleFour.caz` to reflect localAuthority if applicable, ensuring `councilName` segment matches other A4 values (not always same as team-slug)
+    const customTeamSlugs: Record<string, string> = {
+      "barking-and-dagenham": "barkingAndDagenham",
+      "epsom-and-ewell": "epsomAndEwell",
+      "st-albans": "stAlbans",
+      "west-berkshire": "westBerkshire",
+    };
+    const localCaz = Object.keys(customTeamSlugs).includes(localAuthority)
+      ? `articleFour.${customTeamSlugs[localAuthority]}.caz`
+      : `articleFour.${localAuthority}.caz`;
     if (formattedResult["articleFour.caz"]) {
       formattedResult[localCaz] = formattedResult["articleFour.caz"];
       delete formattedResult["articleFour.caz"];


### PR DESCRIPTION
Fixes incorrect schema value here https://api.editor.planx.dev/admin/session/08e8421b-96e2-44aa-a22f-de8090b07315/digital-planning-application?skipValidation=true

![Screenshot from 2025-05-12 12-26-06](https://github.com/user-attachments/assets/1cc6f70e-1058-4e13-ae8f-d283fb5b4c72)
