### PR TITLE
feat: `Questions` and `Checklists` can toggle "never put to user (default blank automation)"

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.test.tsx
@@ -117,4 +117,26 @@ describe("Checklist editor component", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("shows an error if 'never put to user' is toggled on without a data field", async () => {
+    const { user } = setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistEditor text={""} />
+      </DndProvider>,
+    );
+
+    await user.click(
+      screen.getByLabelText("Never put to user (default to blank automation)"),
+    );
+
+    expect(
+      screen.getByText(
+        "Set a data field for the Checklist and all options but one when never putting to user",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it.todo(
+    "shows an error if 'never put to user' is toggled on and more than one option has a blank data field",
+  );
 });

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
@@ -27,6 +27,7 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
     initialValues: {
       allRequired: props.node?.data?.allRequired || false,
       neverAutoAnswer: props.node?.data?.neverAutoAnswer || false,
+      alwaysAutoAnswerBlank: props.node?.data?.alwaysAutoAnswerBlank || false,
       description: props.node?.data?.description || "",
       fn: props.node?.data?.fn || "",
       groupedOptions: props.groupedOptions,
@@ -93,6 +94,18 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
       if (exclusiveOptions && exclusiveOptions.length > 1) {
         errors.options =
           "There should be a maximum of one exclusive option configured";
+      }
+      if (values.alwaysAutoAnswerBlank && !values.fn) {
+        errors.alwaysAutoAnswerBlank =
+          "Set a data field for the Checklist and all options but one when never putting to user";
+      }
+      if (
+        values.alwaysAutoAnswerBlank &&
+        values.fn &&
+        options?.filter((option) => !option.data.val).length !== 1
+      ) {
+        errors.alwaysAutoAnswerBlank =
+          "Exactly one option should have a blank data field when never putting to user";
       }
       return errors;
     },
@@ -190,6 +203,21 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
                 disabled={props.disabled}
               />
             </InputRow>
+            <ErrorWrapper error={formik.errors.alwaysAutoAnswerBlank}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.alwaysAutoAnswerBlank}
+                  onChange={() =>
+                    formik.setFieldValue(
+                      "alwaysAutoAnswerBlank",
+                      !formik.values.alwaysAutoAnswerBlank,
+                    )
+                  }
+                  label="Never put to user (default to blank automation)"
+                  disabled={props.disabled}
+                />
+              </InputRow>
+            </ErrorWrapper>
           </InputGroup>
         </ModalSectionContent>
         <ErrorWrapper error={formik.errors.options}>

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -30,6 +30,7 @@ export interface Checklist extends BaseNodeData {
   allRequired?: boolean;
   categories?: Array<Category>;
   neverAutoAnswer?: boolean;
+  alwaysAutoAnswerBlank?: boolean;
   autoAnswers?: string[] | undefined;
 }
 

--- a/editor.planx.uk/src/@planx/components/Checklist/types.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/types.ts
@@ -9,6 +9,7 @@ export interface ChecklistProps extends Checklist {
     data?: {
       allRequired?: boolean;
       neverAutoAnswer?: boolean;
+      alwaysAutoAnswerBlank?: boolean;
       categories?: Array<Category>;
       description?: string;
       fn?: string;

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -31,6 +31,7 @@ interface Props {
       text: string;
       type?: string;
       neverAutoAnswer?: boolean;
+      alwaysAutoAnswerBlank?: boolean;
     } & BaseNodeData;
   };
   options?: Option[];
@@ -49,6 +50,7 @@ export const Question: React.FC<Props> = (props) => {
       options: props.options || [],
       text: props.node?.data?.text || "",
       neverAutoAnswer: props.node?.data?.neverAutoAnswer || false,
+      alwaysAutoAnswerBlank: props.node?.data?.alwaysAutoAnswerBlank || false,
       ...parseBaseNodeData(props.node?.data),
     },
     onSubmit: ({ options, ...values }) => {
@@ -70,6 +72,18 @@ export const Question: React.FC<Props> = (props) => {
       const errors: FormikErrors<FormikValues> = {};
       if (values.fn && !options.some((option) => option.data.val)) {
         errors.fn = "At least one option must also set a data field";
+      }
+      if (values.alwaysAutoAnswerBlank && !values.fn) {
+        errors.alwaysAutoAnswerBlank =
+          "Set a data field for the Question and all options but one when never putting to user";
+      }
+      if (
+        values.alwaysAutoAnswerBlank &&
+        values.fn &&
+        options.filter((option) => !option.data.val).length !== 1
+      ) {
+        errors.alwaysAutoAnswerBlank =
+          "Exactly one option should have a blank data field when never putting to user";
       }
       return errors;
     },
@@ -143,6 +157,21 @@ export const Question: React.FC<Props> = (props) => {
                 disabled={props.disabled}
               />
             </InputRow>
+            <ErrorWrapper error={formik.errors.alwaysAutoAnswerBlank}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.alwaysAutoAnswerBlank}
+                  onChange={() =>
+                    formik.setFieldValue(
+                      "alwaysAutoAnswerBlank",
+                      !formik.values.alwaysAutoAnswerBlank,
+                    )
+                  }
+                  label="Never put to user (default to blank automation)"
+                  disabled={props.disabled}
+                />
+              </InputRow>
+            </ErrorWrapper>
           </InputGroup>
         </ModalSectionContent>
         <ModalSectionContent subtitle="Options">

--- a/editor.planx.uk/src/@planx/components/Question/model.ts
+++ b/editor.planx.uk/src/@planx/components/Question/model.ts
@@ -9,6 +9,7 @@ export interface Question extends BaseNodeData {
   description?: string;
   img?: string;
   neverAutoAnswer?: boolean;
+  alwaysAutoAnswerBlank?: boolean;
   responses: {
     id?: string;
     responseKey: string | number;


### PR DESCRIPTION
See for context https://opensystemslab.slack.com/archives/C01E3AC0C03/p1746778683171619

Allows editors an option override normal auto-answering navigation for blanks by marking a Question or Checklist as "never put to user (default to blank automation)". When this is toggled on, the editor modal will enforce that the Question or Checklist sets a top-level data field and that exactly one option data value is blank.

Logic changes do not impact any existing automation rules or unit tests, this is an additive-change only. New unit tests added to exemplify.

Testing https://4676.planx.pizza/testing/automations-test-flow