### PR TITLE
feat: add new page schemas

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/schemas/GLA/OpenSpace.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/GLA/OpenSpace.ts
@@ -126,7 +126,7 @@ export const OpenSpaceGLA: Schema = {
       type: "number",
       data: {
         title: "What is the area of this open space?",
-        units: "ha",
+        units: "m²",
         fn: "area",
         allowNegatives: false,
       },

--- a/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -18,6 +18,7 @@ import { EditorProps } from "../shared/types";
 import { Page, parsePage } from "./model";
 import { ProposedAdvertisements } from "./schema/AdvertConsent";
 import { EnvironmentGLA } from "./schema/Environment";
+import { MonitoringGLA } from "./schema/Monitoring";
 import { UtilitiesGLA } from "./schema/Utilities";
 
 type Props = EditorProps<TYPES.Page, Page>;
@@ -26,6 +27,7 @@ export const PAGE_SCHEMAS = [
   { name: "Advert consent", schema: ProposedAdvertisements },
   { name: "Utilities (GLA)", schema: UtilitiesGLA },
   { name: "Environmental management (GLA)", schema: EnvironmentGLA },
+  { name: "Monitoring questions (GLA)", schema: MonitoringGLA },
 ] as const;
 
 function PageComponent(props: Props) {

--- a/editor.planx.uk/src/@planx/components/Page/schema/Monitoring.ts
+++ b/editor.planx.uk/src/@planx/components/Page/schema/Monitoring.ts
@@ -1,0 +1,159 @@
+import { TextInputType } from "@planx/components/TextInput/model";
+
+import { PageSchema } from "../model";
+
+export const MonitoringGLA: PageSchema = {
+  type: "Monitoring questions",
+  fields: [
+    {
+      type: "question",
+      data: {
+        title: "What is the current ownership status of the land?",
+        fn: "property.ownership.status",
+        options: [
+          { id: "public", data: { text: "Public ownership", val: "public" } },
+          {
+            id: "private",
+            data: { text: "Private ownership", val: "private" },
+          },
+          { id: "mixed", data: { text: "Mixed ownership", val: "mixed" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      required: false,
+      data: {
+        title: "Does the property have a lead Registered Social Landlord?",
+        fn: "property.socialLandlord",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "If known, what is the title number of the property?",
+        fn: "property.titleNumber",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title:
+          "If known, what is the certificate number from the most recent Energy Performance Certificate?",
+        fn: "property.EPC",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Is the development expected to be delivered in phases?",
+        fn: "proposal.phased",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "If the development has a name, what is it?",
+        fn: "proposal.name",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Has a lead developer been assigned to the project?",
+        fn: "application.leadDeveloper",
+        options: [
+          {
+            id: "ukCompany",
+            data: {
+              text: "Yes, a registered company in the UK",
+              val: "ukCompany",
+            },
+          },
+          {
+            id: "overseasCompany",
+            data: { text: "Yes, an overseas company", val: "overseasCompany" },
+          },
+          { id: "none", data: { text: "No", val: "none" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "How much will the project cost?",
+        fn: "proposal.cost.projected",
+        options: [
+          {
+            id: "twoMillion",
+            data: { text: "Up to £2 million", val: "twoMillion" },
+          },
+          {
+            id: "twoToHundredMillion",
+            data: {
+              text: "Between £2 million and £100 million",
+              val: "twoToHundredMillion",
+            },
+          },
+          {
+            id: "moreThanHundredMillion",
+            data: {
+              text: "More than £100 million",
+              val: "moreThanHundredMillion",
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Does this application replace or amend a previously granted planning permission?",
+        fn: "application.linked.superseding",
+        options: [
+          {
+            id: "full",
+            data: { text: "Yes, an existing planning permission", val: "full" },
+          },
+          {
+            id: "partial",
+            data: {
+              text: "Yes, part of an existing planning permission",
+              val: "partial",
+            },
+          },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Is this a fast track application for the purposes of affordable housing?",
+        fn: "application.fastTrack.affordable",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+  ],
+  min: 1,
+  max: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/Page/schema/Utilities.ts
+++ b/editor.planx.uk/src/@planx/components/Page/schema/Utilities.ts
@@ -4,26 +4,37 @@ export const UtilitiesGLA: PageSchema = {
   type: "Utilities",
   fields: [
     {
-      type: "checklist",
+      type: "question",
+      data: {
+        title: "Does the development propose any fire suppression systems?",
+        fn: "utilities.fireSuppression",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title: "Does the development propose any heat pumps?",
+        fn: "utilities.heatPump",
+        options: [
+          { id: "true", data: { text: "Yes", val: "true" } },
+          { id: "false", data: { text: "No", val: "false" } },
+        ],
+      },
+    },
+    {
+      type: "number",
       required: false,
       data: {
-        title: "Does the development provide any of the following?",
-        fn: "utilities",
-        options: [
-          {
-            id: "fireSuppression",
-            data: { text: "Fire suppression systems", val: "fireSuppression" },
-          },
-          {
-            id: "communityOwned",
-            data: {
-              text: "On-site community-owned energy generation",
-              val: "communityOwned",
-            },
-          },
-          { id: "solar", data: { text: "Solar energy", val: "solar" } },
-          { id: "heatPump", data: { text: "Heat pumps", val: "heatPump" } },
-        ],
+        title: "What is the targeted internal residential water usage?",
+        description:
+          "Enter a number that describes the litres per person per day (sometimes called l/p/d).",
+        fn: "residentialWaterUsage",
+        units: "litres",
+        allowNegatives: false,
       },
     },
     {


### PR DESCRIPTION
Add news page schemas relevant for full planning applications and associated London Data Hub requirements.