### PR TITLE
feat: Make analytics link visible to analyst role

### DIFF
--- a/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -175,7 +175,7 @@ function EditorNavMenu() {
         : `Analytics page unavailable`,
       Icon: LeaderboardIcon,
       route: flowAnalyticsLink ? flowAnalyticsLink : `#`,
-      accessibleBy: ["platformAdmin", "teamEditor", "demoUser"],
+      accessibleBy: ["platformAdmin", "teamEditor", "demoUser", "analyst"],
       disabled: !flowAnalyticsLink,
     },
   ];


### PR DESCRIPTION
External analytics links are now viewable by users with the "analyst" role.

![image](https://github.com/user-attachments/assets/df6187ba-e4ab-402b-b19b-b40bc53eca8d)
