### PR TITLE
chore: CVE-2025-47273 [skip pizza]

### DIFF
--- a/infrastructure/performance/pyproject.toml
+++ b/infrastructure/performance/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyzmq==26.2.0",
     "requests==2.32.3",
     "ruff==0.7.4",
-    "setuptools==75.3.0",
+    "setuptools==78.1.1",
     "typing-extensions==4.12.2",
     "urllib3==2.2.3",
     "werkzeug==3.1.2",

--- a/infrastructure/performance/uv.lock
+++ b/infrastructure/performance/uv.lock
@@ -408,7 +408,7 @@ requires-dist = [
     { name = "pyzmq", specifier = "==26.2.0" },
     { name = "requests", specifier = "==2.32.3" },
     { name = "ruff", specifier = "==0.7.4" },
-    { name = "setuptools", specifier = "==75.3.0" },
+    { name = "setuptools", specifier = "==78.1.1" },
     { name = "typing-extensions", specifier = "==4.12.2" },
     { name = "urllib3", specifier = "==2.2.3" },
     { name = "werkzeug", specifier = "==3.1.2" },
@@ -524,11 +524,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.3.0"
+version = "78.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/22/a438e0caa4576f8c383fa4d35f1cc01655a46c75be358960d815bfbb12bd/setuptools-75.3.0.tar.gz", hash = "sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686", size = 1351577 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9c/42314ee079a3e9c24b27515f9fbc7a3c1d29992c33451779011c74488375/setuptools-78.1.1.tar.gz", hash = "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d", size = 1368163 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/12/282ee9bce8b58130cb762fbc9beabd531549952cac11fc56add11dcb7ea0/setuptools-75.3.0-py3-none-any.whl", hash = "sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd", size = 1251070 },
+    { url = "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl", hash = "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561", size = 1256462 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/218
