### PR TITLE
chore: CVE-2025-47935

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -43,7 +43,7 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "mime": "^4.0.4",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.0",
     "nanoid": "^5.0.9",
     "notifications-node-client": "^8.2.0",
     "openid-client": "^5.6.5",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -112,8 +112,8 @@ dependencies:
     specifier: ^4.0.4
     version: 4.0.4
   multer:
-    specifier: ^1.4.5-lts.1
-    version: 1.4.5-lts.1
+    specifier: ^2.0.0
+    version: 2.0.0
   nanoid:
     specifier: ^5.0.9
     version: 5.0.9
@@ -5739,9 +5739,9 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /multer@1.4.5-lts.1:
-    resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
-    engines: {node: '>= 6.0.0'}
+  /multer@2.0.0:
+    resolution: {integrity: sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==}
+    engines: {node: '>= 10.16.0'}
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/219

Release notes: https://github.com/expressjs/multer/releases/tag/v2.0.0