### PR TITLE
fix: Handle first publish of flows with no history

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -251,9 +251,12 @@ export interface FlowHistoryEntry {
 }
 
 // Get comments and operations from a flow's "History" since last publish
-export const getHistory = async (flowId: string, lastPublishedAt?: string) => {
+export const getHistory = async (flowId: string) => {
+  const lastPublishedAt = await getMostRecentPublishedFlowDate(flowId);
+  if (!lastPublishedAt) return null;
+
   const { client: $client } = getClient();
-  const response = await $client.request<{ history: FlowHistoryEntry[] | [] }>(
+  const response = await $client.request<{ history: FlowHistoryEntry[] }>(
     gql`
       query GetHistory($flow_id: uuid!, $last_published_at: timestamptz) {
         history: flow_history(

--- a/api.planx.uk/modules/flows/validate/service/index.ts
+++ b/api.planx.uk/modules/flows/validate/service/index.ts
@@ -58,9 +58,7 @@ const validateAndDiffFlow = async (
     ...flattenedFlow[key],
   }));
 
-  const lastPublishedAt = await getMostRecentPublishedFlowDate(flowId);
-  const history = await getHistory(flowId, lastPublishedAt);
-
+  const history = await getHistory(flowId);
   const validationChecks = [];
   const sections = validateSections(flattenedFlow);
   const inviteToPay = validateInviteToPay(flattenedFlow);

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -54,7 +54,7 @@ beforeEach(() => {
     matchOnVariables: false,
     data: {
       flow: {
-        publishFlows: [
+        publishedFlows: [
           {
             createdAt: "2024-12-31",
           },
@@ -852,6 +852,56 @@ describe("flow comments since last publish", () => {
       .expect(200)
       .then((res) => {
         expect(res.body.message).toEqual("No new changes to publish");
+        expect(res.body.history).toBeNull();
+      });
+  });
+});
+
+describe("an unpublished flow", () => {
+  test("it returns no history", async () => {
+    queryMock.mockQuery({
+      name: "GetMostRecentPublishedFlowVersion",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          publishedFlows: [],
+        },
+      },
+    });
+
+    const alteredFlow = {
+      ...mockFlowData,
+      externalPortalNodeId: {
+        edges: ["newSectionNodeId"],
+        type: 310,
+      },
+      newSectionNodeId: {
+        type: 360,
+      },
+    };
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          data: alteredFlow,
+          slug: "altered-flow-name",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [{ data: alteredFlow }],
+        },
+      },
+    });
+
+    await supertest(app)
+      .post("/flows/1/diff")
+      .set(auth)
+      .expect(200)
+      .then((res) => {
+        expect(res.body.message).toEqual("Changes queued to publish");
         expect(res.body.history).toBeNull();
       });
   });


### PR DESCRIPTION
## What's the problem?
An error is thrown when an unpublished flow is first published.

![image](https://github.com/user-attachments/assets/5fba3e6b-3ce4-4c95-af50-6898ef6ce900)


## What's the cause?
The `GetHistory` query requires a `last_published_at` timestamp which does not exist on unpublished flows.

## What's the solution?
Conditionally return `null` from `getHistory()` if there's no `last_published_at` timestamp.