### PR TITLE
fix: Rich text headings bug

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -54,6 +54,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
               <InputLabel label="Description" htmlFor="description">
                 <RichTextInput
                   name="description"
+                  id="description"
                   value={formik.values.description}
                   placeholder="Description"
                   onChange={formik.handleChange}
@@ -70,6 +71,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                     "",
                   )}
                   name="ratingQuestion"
+                  id="ratingQuestion"
                   value={formik.values.ratingQuestion}
                   onChange={formik.handleChange}
                   disabled={props.disabled}
@@ -84,6 +86,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                     "",
                   )}
                   name="freeformQuestion"
+                  id="freeformQuestion"
                   value={formik.values.freeformQuestion}
                   onChange={formik.handleChange}
                   disabled={props.disabled}
@@ -94,6 +97,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
               <InputLabel label="Disclaimer text" htmlFor="disclaimer">
                 <RichTextInput
                   name="disclaimer"
+                  id="disclaimer"
                   value={formik.values.disclaimer}
                   onChange={formik.handleChange}
                   disabled={props.disabled}

--- a/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
+++ b/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
@@ -20,19 +20,21 @@ export const MoreInformation = ({
     <ModalSection>
       <ModalSectionContent title="More information" Icon={Help}>
         <InputGroup flowSpacing>
-          <InputLabel label="Why it matters">
+          <InputLabel label="Why it matters" htmlFor="info">
             <RichTextInput
               multiline
               name="info"
+              id="info"
               value={info}
               onChange={changeField}
               disabled={disabled}
             />
           </InputLabel>
-          <InputLabel label="Policy source">
+          <InputLabel label="Policy source" htmlFor="policyRef">
             <RichTextInput
               multiline
               name="policyRef"
+              id="policyRef"
               value={policyRef}
               onChange={changeField}
               disabled={disabled}
@@ -43,6 +45,7 @@ export const MoreInformation = ({
               <RichTextInput
                 multiline
                 name="howMeasured"
+                id="howMeasured"
                 value={howMeasured}
                 onChange={changeField}
                 disabled={disabled}

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -90,7 +90,9 @@ const RichTextInput: FC<Props> = (props) => {
       }
       const doc = transaction.editor.getJSON();
 
-      setContentHierarchyError(getContentHierarchyError(doc, props.rootLevelContent));
+      setContentHierarchyError(
+        getContentHierarchyError(doc, props.rootLevelContent),
+      );
       setLinkNewTabError(getLinkNewTabError(doc.content));
       setLegislationLinkError(getLegislationLinkError(doc.content));
 
@@ -139,13 +141,17 @@ const RichTextInput: FC<Props> = (props) => {
     }
     internalValue.current = stringValue;
     const doc = fromHtml(stringValue);
-    setContentHierarchyError(getContentHierarchyError(fromHtml(stringValue), props.rootLevelContent));
+    setContentHierarchyError(
+      getContentHierarchyError(fromHtml(stringValue), props.rootLevelContent),
+    );
     editor.commands.setContent(doc);
   }, [stringValue]);
 
   useEffect(() => {
     const doc = fromHtml(stringValue);
-    setContentHierarchyError(getContentHierarchyError(doc, props.rootLevelContent));
+    setContentHierarchyError(
+      getContentHierarchyError(doc, props.rootLevelContent),
+    );
     setLinkNewTabError(getLinkNewTabError(doc.content));
     setLegislationLinkError(getLegislationLinkError(doc.content));
   }, [stringValue, props.rootLevelContent]);
@@ -193,131 +199,151 @@ const RichTextInput: FC<Props> = (props) => {
         .filter(Boolean)
         .join(" ")}
     >
-    <RichContentContainer className={`rich-text-editor ${props.rootLevelContent ? 'allow-h1' : ''}`}>
-      {editor && (
-        <StyledBubbleMenu
-          editor={editor}
-          tippyOptions={{
-            duration: 100,
-            // Hack to "stop" transition of BubbleMenu
-            moveTransition: "transform 600s",
-          }}
-          className="bubble-menu"
-        >
-          {addingLink ? (
-            <Input
-              ref={urlInputRef}
-              onKeyDown={(ev) => {
-                if (ev.key === "Enter") {
-                  editor
-                    .chain()
-                    .focus()
-                    .toggleLink({
-                      href: addingLink.draft,
-                    })
-                    .run();
-                  setAddingLink(null);
-                }
-              }}
-              value={addingLink.draft}
-              onChange={(ev) => {
-                setAddingLink(
-                  (prev) =>
-                    prev && {
-                      ...prev,
-                      draft: trimUrlValue(ev.target.value),
-                    },
-                );
-              }}
-            />
-          ) : (
-            <>
-              <H1Button editor={editor} label={<strong>{props.rootLevelContent ? "H1" : "H2"}</strong>} />
-              <H2Button editor={editor} label={<strong>{props.rootLevelContent ? "H2" : "H3"}</strong>} />
-              <BoldButton editor={editor} />
-              <ItalicButton editor={editor} />
-              <BulletListButton editor={editor} />
-              <OrderedListButton editor={editor} />
-              <PublicFileUploadButton
-                variant="tooltip"
-                onChange={(src) =>
-                  editor?.chain().focus().setImage({ src }).run()
-                }
+      <RichContentContainer
+        className={`rich-text-editor ${
+          props.rootLevelContent ? "allow-h1" : ""
+        }`}
+      >
+        {editor && (
+          <StyledBubbleMenu
+            editor={editor}
+            tippyOptions={{
+              duration: 100,
+              // Hack to "stop" transition of BubbleMenu
+              moveTransition: "transform 600s",
+            }}
+            className="bubble-menu"
+          >
+            {addingLink ? (
+              <Input
+                ref={urlInputRef}
+                onKeyDown={(ev) => {
+                  if (ev.key === "Enter") {
+                    editor
+                      .chain()
+                      .focus()
+                      .toggleLink({
+                        href: addingLink.draft,
+                      })
+                      .run();
+                    setAddingLink(null);
+                  }
+                }}
+                value={addingLink.draft}
+                onChange={(ev) => {
+                  setAddingLink(
+                    (prev) =>
+                      prev && {
+                        ...prev,
+                        draft: trimUrlValue(ev.target.value),
+                      },
+                  );
+                }}
               />
-            </>
-          )}
-          {addingLink ? (
-            <>
-              {(() => {
-                const error =
-                  addingLink.selectionHtml &&
-                  linkSelectionError(addingLink.selectionHtml);
-                return error ? (
-                  <PopupError id="link-popup" error={error} />
-                ) : (
-                  <IconButton
-                    size="small"
-                    onClick={() => {
-                      editor
-                        .chain()
-                        .focus()
-                        .toggleLink({
-                          href: addingLink.draft,
-                        })
-                        .run();
-                      setAddingLink(null);
-                    }}
-                  >
-                    <Check />
-                  </IconButton>
-                );
-              })()}
+            ) : (
+              <>
+                <H1Button
+                  editor={editor}
+                  label={
+                    <strong>{props.rootLevelContent ? "H1" : "H2"}</strong>
+                  }
+                />
+                <H2Button
+                  editor={editor}
+                  label={
+                    <strong>{props.rootLevelContent ? "H2" : "H3"}</strong>
+                  }
+                />
+                <BoldButton editor={editor} />
+                <ItalicButton editor={editor} />
+                <BulletListButton editor={editor} />
+                <OrderedListButton editor={editor} />
+                <PublicFileUploadButton
+                  variant="tooltip"
+                  onChange={(src) =>
+                    editor?.chain().focus().setImage({ src }).run()
+                  }
+                />
+              </>
+            )}
+            {addingLink ? (
+              <>
+                {(() => {
+                  const error =
+                    addingLink.selectionHtml &&
+                    linkSelectionError(addingLink.selectionHtml);
+                  return error ? (
+                    <PopupError id="link-popup" error={error} />
+                  ) : (
+                    <IconButton
+                      size="small"
+                      onClick={() => {
+                        editor
+                          .chain()
+                          .focus()
+                          .toggleLink({
+                            href: addingLink.draft,
+                          })
+                          .run();
+                        setAddingLink(null);
+                      }}
+                    >
+                      <Check />
+                    </IconButton>
+                  );
+                })()}
+                <IconButton
+                  size="small"
+                  disabled={!editor.isActive("link")}
+                  onClick={() => {
+                    editor.chain().focus().unsetLink().run();
+                    setAddingLink(null);
+                  }}
+                >
+                  <Delete />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setAddingLink(null);
+                  }}
+                >
+                  <Close />
+                </IconButton>
+              </>
+            ) : (
               <IconButton
                 size="small"
-                disabled={!editor.isActive("link")}
+                color={editor.isActive("link") ? "primary" : undefined}
                 onClick={() => {
-                  editor.chain().focus().unsetLink().run();
-                  setAddingLink(null);
+                  if (editor.isActive("link")) {
+                    const href =
+                      editor.getAttributes("link")?.href || initialUrlValue;
+                    setAddingLink({
+                      selectionHtml: getSelectionHtml(),
+                      draft: href,
+                    });
+                  } else {
+                    setAddingLink({
+                      selectionHtml: getSelectionHtml(),
+                      draft: initialUrlValue,
+                    });
+                  }
                 }}
               >
-                <Delete />
+                <LinkIcon />
               </IconButton>
-              <IconButton
-                size="small"
-                onClick={() => {
-                  setAddingLink(null);
-                }}
-              >
-                <Close />
-              </IconButton>
-            </>
-          ) : (
-            <IconButton
-              size="small"
-              color={editor.isActive("link") ? "primary" : undefined}
-              onClick={() => {
-                if (editor.isActive("link")) {
-                  const href =
-                    editor.getAttributes("link")?.href || initialUrlValue;
-                  setAddingLink({
-                    selectionHtml: getSelectionHtml(),
-                    draft: href,
-                  });
-                } else {
-                  setAddingLink({
-                    selectionHtml: getSelectionHtml(),
-                    draft: initialUrlValue,
-                  });
-                }
-              }}
-            >
-              <LinkIcon />
-            </IconButton>
-          )}
-        </StyledBubbleMenu>
-      )}
-      <EditorContent editor={editor} />
-    </RichContentContainer>
+            )}
+          </StyledBubbleMenu>
+        )}
+        <input
+          type="hidden"
+          name={props.name}
+          id={props["id"]}
+          value={internalValue.current ?? stringValue}
+        />
+        <EditorContent editor={editor} />
+      </RichContentContainer>
     </ErrorWrapper>
   );
 };

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -3,7 +3,7 @@ import Close from "@mui/icons-material/Close";
 import Delete from "@mui/icons-material/Delete";
 import LinkIcon from "@mui/icons-material/Link";
 import IconButton from "@mui/material/IconButton";
-import { type Editor } from "@tiptap/core";
+import { type Editor, EditorOptions } from "@tiptap/core";
 import History from "@tiptap/extension-history";
 import Mention from "@tiptap/extension-mention";
 import ExtensionPlaceholder from "@tiptap/extension-placeholder";
@@ -43,7 +43,21 @@ import {
 const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");
 
+  // a11y: Element is treated as a HTMLInputElement but Tiptap renders a HTMLDivElement
+  // Pass in input props to ensure they're passed along to the rich text editor
+  const attributes = {
+    // User provided props
+    name: props.name,
+    id: props.id,
+    ...props.inputProps,
+    // Default props overwritted by assigning our own
+    contenteditable: "false",
+    role: "textbox",
+    translate: "no",
+  } as unknown as EditorOptions["editorProps"]["attributes"];
+
   const editor = useEditor({
+    editorProps: { attributes },
     extensions: [
       ...commonExtensions,
       History,
@@ -336,12 +350,6 @@ const RichTextInput: FC<Props> = (props) => {
             )}
           </StyledBubbleMenu>
         )}
-        <input
-          type="hidden"
-          name={props.name}
-          id={props["id"]}
-          value={internalValue.current ?? stringValue}
-        />
         <EditorContent editor={editor} />
       </RichContentContainer>
     </ErrorWrapper>


### PR DESCRIPTION
# Issue

Highlighted by @augustlindemer here: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1747672628094169

When authoring content for `MoreInformation` (AKA help text), clicking twice on text toggles `H2` formatting on/off in error, making it difficult to use the editor.

**Example:**
https://editor.planx.dev/testing/content-editing/nodes/_root/nodes/iZ2Ak5BYLv/edit

# Solution

The issue seems to arise from having the `RichTextInput` component wrapped in a `<label>`, without having any means of associating it with an `<input>`, as the `RichTextInput` did not include an input by default.

The other instance of `RichTextInput` wrapped in `<label>` is in the feedback component, where there is a `htmlFor=""` attribute, which was incorrectly being associated with a `name=""` attribute on the input.

Adding both a `htmlFor=""` input to the wrapping label, and adding a hidden `<input>` element (with corresponding `id`)  both fixes the `H2` and correctly associates the label with an input.

**Testing:**
https://4693.planx.pizza/testing/content-editing/nodes/_root/nodes/fjDVxTVewJ/edit