### PR TITLE
fix: Ensure feature flags are always initialised

### DIFF
--- a/editor.planx.uk/src/index.tsx
+++ b/editor.planx.uk/src/index.tsx
@@ -8,6 +8,7 @@ import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 import { MyMap } from "@opensystemslab/map";
 import { ToastContextProvider } from "contexts/ToastContext";
 import { getCookie, setCookie } from "lib/cookie";
+import { initFeatureFlags } from "lib/featureFlags";
 import ErrorPage from "pages/ErrorPage/ErrorPage";
 import { AnalyticsProvider } from "pages/FlowEditor/lib/analytics/provider";
 import React, { Suspense, useEffect } from "react";
@@ -39,6 +40,8 @@ window.addEventListener("vite:preloadError", (event) => {
   event.preventDefault();
   window.location.reload();
 });
+
+initFeatureFlags();
 
 const hasJWT = (): boolean | void => {
   // This cookie indicates the presence of the secure httpOnly "jwt" cookie

--- a/editor.planx.uk/src/lib/featureFlags.ts
+++ b/editor.planx.uk/src/lib/featureFlags.ts
@@ -55,22 +55,24 @@ export const toggleFeatureFlag = (
 export const hasFeatureFlag = (featureFlag: FeatureFlag) =>
   activeFeatureFlags.has(featureFlag);
 
-// add methods to window for easy access in browser console
-(window as any).featureFlags = {
-  toggle: toggleFeatureFlag,
-  active: activeFeatureFlags,
-  has: hasFeatureFlag,
-};
+export const initFeatureFlags = () => {
+  // add methods to window for easy access in browser console
+  (window as any).featureFlags = {
+    toggle: toggleFeatureFlag,
+    active: activeFeatureFlags,
+    has: hasFeatureFlag,
+  };
 
-if (import.meta.env.VITE_APP_ENV !== "test") {
-  // log current flag status on page load
-  console.debug(
-    activeFeatureFlags.size > 0
-      ? `🎏 ${activeFeatureFlags.size} feature flags enabled: ${[
-          ...activeFeatureFlags,
-        ]
-          .sort()
-          .join(", ")}`
-      : `🎏 no active feature flags`,
-  );
+  if (import.meta.env.VITE_APP_ENV !== "test") {
+    // log current flag status on page load
+    console.debug(
+      activeFeatureFlags.size > 0
+        ? `🎏 ${activeFeatureFlags.size} feature flags enabled: ${[
+            ...activeFeatureFlags,
+          ]
+            .sort()
+            .join(", ")}`
+        : `🎏 no active feature flags`,
+    );
+  }
 }


### PR DESCRIPTION
## What's the problem?
Feature flags aren't available on the `window`
![image](https://github.com/user-attachments/assets/00d6f0c0-7ed8-444a-a1f0-03e5311ab328)

## What's the solution?
Rather than relying on the import order, explicitly call an init function early in the app's call chain.

## To test...
 - Feature flags unavailable on staging, prod, or other Pizzas
 - Feature flags available on this Pizza
