### PR TITLE
feat: add custom character limits to text input

### DIFF
--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -68,14 +68,14 @@ const TextInputComponent: React.FC<Props> = (props) => {
         </ModalSectionContent>
         <ModalSectionContent title="Input style">
           <FormControl component="fieldset">
-            <RadioGroup defaultValue="default" value={formik.values.type}>
+            <RadioGroup defaultValue="short" value={formik.values.type}>
               {[
-                { id: "default", title: "Default" },
                 { id: "short", title: "Short (max 120 characters)" },
                 { id: "long", title: "Long (max 250 characters)" },
                 { id: "extraLong", title: "Extra long (max 750 characters)" },
                 { id: "email", title: "Email" },
                 { id: "phone", title: "Phone" },
+                { id: "custom", title: "Custom" },
               ].map((type) => (
                 <BasicRadio
                   key={type.id}
@@ -88,6 +88,15 @@ const TextInputComponent: React.FC<Props> = (props) => {
                 />
               ))}
             </RadioGroup>
+            {formik.values.type === "custom" && (
+              <Input
+                placeholder="Maximum characters"
+                name="customLength"
+                value={formik.values.customLength}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            )}
           </FormControl>
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -93,7 +93,14 @@ const TextInputComponent: React.FC<Props> = (props) => {
                 placeholder="Maximum characters"
                 name="customLength"
                 value={formik.values.customLength}
-                onChange={formik.handleChange}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value.startsWith("-")) {
+                    return;
+                  }
+                  formik.handleChange(e);
+                }}
+                type="number"
                 disabled={props.disabled}
               />
             )}

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -4,7 +4,7 @@ import { PublicProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
-import { CharacterCounter, getTextLimit } from "ui/shared/CharacterCounter";
+import { CharacterCounter } from "ui/shared/CharacterCounter";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import { object } from "yup";
@@ -12,7 +12,7 @@ import { object } from "yup";
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../shared/constants";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { TextInput } from "./model";
-import { TextInputType, textInputValidationSchema } from "./model";
+import { getTextLimit,textInputValidationSchema } from "./model";
 
 export type Props = PublicProps<TextInput>;
 
@@ -32,10 +32,8 @@ const TextInputComponent: React.FC<Props> = (props) => {
     }),
   });
 
-  const characterCountLimit = props.type && getTextLimit(props.type);
-  const displayCharacterCount = Boolean(
-    props.type !== TextInputType.Short && characterCountLimit,
-  );
+  const characterCountLimit = getTextLimit(props.type, props.customLength);
+  const displayCharacterCount = characterCountLimit > 120;
 
   return (
     <Card handleSubmit={formik.handleSubmit} isValid>
@@ -78,8 +76,8 @@ const TextInputComponent: React.FC<Props> = (props) => {
           />
           {displayCharacterCount && (
             <CharacterCounter
+              limit={characterCountLimit}
               count={formik.values.text.length}
-              textInputType={props.type || TextInputType.Long}
               error={Boolean(formik.errors.text)}
             />
           )}

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -12,7 +12,7 @@ import { object } from "yup";
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../shared/constants";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { TextInput } from "./model";
-import { getTextLimit,textInputValidationSchema } from "./model";
+import { getTextLimit, textInputValidationSchema } from "./model";
 
 export type Props = PublicProps<TextInput>;
 
@@ -52,11 +52,9 @@ const TextInputComponent: React.FC<Props> = (props) => {
               else if (type === "phone") return "tel";
               return "text";
             })(props.type)}
-            multiline={props.type && ["long", "extraLong"].includes(props.type)}
+            multiline={getTextLimit(props.type, props.customLength) > 120}
             rows={
-              props.type && ["long", "extraLong"].includes(props.type)
-                ? 5
-                : undefined
+              getTextLimit(props.type, props.customLength) > 120 ? 5 : undefined
             }
             name="text"
             value={formik.values.text}

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -10,12 +10,26 @@ export enum TextInputType {
   ExtraLong = "extraLong",
   Email = "email",
   Phone = "phone",
+  Custom = "custom",
 }
+
+const getTextLimit = (
+  type: TextInputType | undefined,
+  customLength?: number,
+): number => {
+  if (type === TextInputType.Custom && customLength) {
+    return customLength;
+  }
+  return type ? TEXT_LIMITS[type] : 0;
+};
 
 export const TEXT_LIMITS = {
   [TextInputType.Short]: 120,
   [TextInputType.Long]: 250,
   [TextInputType.ExtraLong]: 750,
+  [TextInputType.Custom]: 120,
+  [TextInputType.Email]: 50,
+  [TextInputType.Phone]: 16,
 } as const;
 
 export const emailRegex =
@@ -23,7 +37,7 @@ export const emailRegex =
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 export const textInputValidationSchema = ({
-  data: { type },
+  data: { type, customLength },
   required,
 }: {
   data: TextInput;
@@ -41,25 +55,31 @@ export const textInputValidationSchema = ({
         if (!type) {
           return "Enter your answer before continuing";
         }
+
+        const limit = getTextLimit(type, customLength);
+
         if (type === TextInputType.Phone) {
-          return "Enter a valid phone number.";
+          return `Enter a valid phone number (maximum ${limit} characters).`;
         }
         if (type === TextInputType.Email) {
-          return "Enter an email address in the correct format, like name@example.com";
+          return `Enter a valid email address (maximum ${limit} characters).`;
         }
-        return `Your answer must be ${TEXT_LIMITS[type]} characters or fewer.`;
+        return `Your answer must be ${limit} characters or fewer.`;
       })(),
       test: (value?: string) => {
         if (!value) return true;
         if (!type) return true;
+        if (!(value && value.length <= getTextLimit(type, customLength))) {
+          return false;
+        }
 
         if (type === TextInputType.Email) {
-          return Boolean(value && emailRegex.test(value));
+          return emailRegex.test(value);
         }
         if (type === TextInputType.Phone) {
-          return Boolean(value);
+          return value.length > 0;
         }
-        return Boolean(value && value.length <= TEXT_LIMITS[type]);
+        return true;
       },
     });
 
@@ -68,6 +88,7 @@ export interface TextInput extends BaseNodeData {
   description?: string;
   fn?: string;
   type?: TextInputType;
+  customLength?: number;
 }
 
 export const parseTextInput = (
@@ -77,5 +98,6 @@ export const parseTextInput = (
   description: data?.description,
   fn: data?.fn,
   type: data?.type,
+  customLength: data?.customLength,
   ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -13,7 +13,7 @@ export enum TextInputType {
   Custom = "custom",
 }
 
-const getTextLimit = (
+export const getTextLimit = (
   type: TextInputType | undefined,
   customLength?: number,
 ): number => {

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
@@ -1,8 +1,8 @@
 import type { TextField } from "@planx/components/shared/Schema/model";
-import { TextInputType } from "@planx/components/TextInput/model";
+import { getTextLimit, TextInputType } from "@planx/components/TextInput/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
-import { CharacterCounter, getTextLimit } from "ui/shared/CharacterCounter";
+import { CharacterCounter } from "ui/shared/CharacterCounter";
 import Input from "ui/shared/Input/Input";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../constants";
@@ -52,7 +52,7 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
       />
       {displayCharacterCount && (
         <CharacterCounter
-          textInputType={data.type || TextInputType.Long}
+          limit={characterCountLimit ?? 0}
           count={fieldProps?.value?.length}
           error={Boolean(fieldProps.errorMessage)}
         />

--- a/editor.planx.uk/src/ui/shared/CharacterCounter.tsx
+++ b/editor.planx.uk/src/ui/shared/CharacterCounter.tsx
@@ -1,32 +1,16 @@
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
-import { TEXT_LIMITS, TextInputType } from "@planx/components/TextInput/model";
 import { debounce } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export type Props = {
-  textInputType: TextInputType;
+  limit: number;
   count: number;
   error: boolean;
 };
 
-export function getTextLimit(type: TextInputType): number {
-  switch (type) {
-    case TextInputType.Short:
-    case TextInputType.Long:
-    case TextInputType.ExtraLong:
-      return TEXT_LIMITS[type];
-    default:
-      return 0;
-  }
-}
-
-export const CharacterCounter: React.FC<Props> = ({
-  textInputType,
-  count,
-  error,
-}) => {
+export const CharacterCounter: React.FC<Props> = ({ limit, count, error }) => {
   const [screenReaderCount, setScreenReaderCount] = useState<number>(0);
   const [showReaderCount, setShowReaderCount] = useState<boolean>(false);
 
@@ -38,7 +22,7 @@ export const CharacterCounter: React.FC<Props> = ({
     [],
   );
 
-  const currentCharacterCount = getTextLimit(textInputType) - count;
+  const currentCharacterCount = limit - count;
 
   const showCharacterLimitError = currentCharacterCount < 0;
 
@@ -62,7 +46,7 @@ export const CharacterCounter: React.FC<Props> = ({
   return (
     <>
       <Typography id={"character-hint"} sx={visuallyHidden} aria-hidden={true}>
-        {`You can enter up to ${getTextLimit(textInputType)} characters`}
+        {`You can enter up to ${limit} characters`} {/* Use limit directly */}
       </Typography>
       <Typography
         paddingTop={0.5}


### PR DESCRIPTION
This PR adds a custom character limit input to the text input component.

It removes the previous 'Default' option and defaults to 'Short'.

It adds a new 'Custom' option that displays a number input field in which the editor can define a maximum character count.

If 'Custom' is selected but no number is provided it defaults to 120 characters (same as default 'Short').

It refactors the previous condition for multiline inputs and character count from type match (long, extra long) to directly check the applicable text limit.

If text limit >120 (either through custom character limit or selection of long/extra long), it renders the text input as multiline with character count.

Note: I have not added new tests for the custom input.