### PR TITLE
feat: add customisable regular expressions to text input component

### DIFF
--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -68,14 +68,14 @@ const TextInputComponent: React.FC<Props> = (props) => {
         </ModalSectionContent>
         <ModalSectionContent title="Input style">
           <FormControl component="fieldset">
-            <RadioGroup defaultValue="default" value={formik.values.type}>
+            <RadioGroup defaultValue="short" value={formik.values.type}>
               {[
-                { id: "default", title: "Default" },
                 { id: "short", title: "Short (max 120 characters)" },
                 { id: "long", title: "Long (max 250 characters)" },
                 { id: "extraLong", title: "Extra long (max 750 characters)" },
                 { id: "email", title: "Email" },
                 { id: "phone", title: "Phone" },
+                { id: "custom", title: "Custom" },
               ].map((type) => (
                 <BasicRadio
                   key={type.id}
@@ -88,6 +88,15 @@ const TextInputComponent: React.FC<Props> = (props) => {
                 />
               ))}
             </RadioGroup>
+            {formik.values.type === "custom" && (
+              <Input
+                placeholder="Maximum characters"
+                name="customLength"
+                value={formik.values.customLength}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            )}
           </FormControl>
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -88,7 +88,11 @@ const TextInputComponent: React.FC<Props> = (props) => {
                 />
               ))}
             </RadioGroup>
-            {formik.values.type === "custom" && (
+          </FormControl>
+        </ModalSectionContent>
+        {formik.values.type === "custom" && (
+          <ModalSectionContent title="Custom input style">
+            <InputRow>
               <Input
                 placeholder="Maximum characters"
                 name="customLength"
@@ -103,9 +107,28 @@ const TextInputComponent: React.FC<Props> = (props) => {
                 type="number"
                 disabled={props.disabled}
               />
-            )}
-          </FormControl>
-        </ModalSectionContent>
+            </InputRow>
+            <InputRow>
+              <Input
+                placeholder="Regular expression"
+                format="data"
+                name="customRegex"
+                value={formik.values.customRegex}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            </InputRow>
+            <InputRow>
+              <Input
+                placeholder="Example"
+                name="customExample"
+                value={formik.values.customExample}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            </InputRow>
+          </ModalSectionContent>
+        )}
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -93,7 +93,14 @@ const TextInputComponent: React.FC<Props> = (props) => {
                 placeholder="Maximum characters"
                 name="customLength"
                 value={formik.values.customLength}
-                onChange={formik.handleChange}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value.startsWith("-")) {
+                    return;
+                  }
+                  formik.handleChange(e);
+                }}
+                type="number"
                 disabled={props.disabled}
               />
             )}

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -33,7 +33,8 @@ const TextInputComponent: React.FC<Props> = (props) => {
   });
 
   const characterCountLimit = getTextLimit(props.type, props.customLength);
-  const displayCharacterCount = characterCountLimit > 120;
+  const displayCharacterCount =
+    characterCountLimit > 120 && props.type !== "email";
 
   return (
     <Card handleSubmit={formik.handleSubmit} isValid>
@@ -52,9 +53,15 @@ const TextInputComponent: React.FC<Props> = (props) => {
               else if (type === "phone") return "tel";
               return "text";
             })(props.type)}
-            multiline={getTextLimit(props.type, props.customLength) > 120}
+            multiline={
+              getTextLimit(props.type, props.customLength) > 120 &&
+              props.type !== "email"
+            }
             rows={
-              getTextLimit(props.type, props.customLength) > 120 ? 5 : undefined
+              getTextLimit(props.type, props.customLength) > 120 &&
+              props.type !== "email"
+                ? 5
+                : undefined
             }
             name="text"
             value={formik.values.text}

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -4,7 +4,7 @@ import { PublicProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
-import { CharacterCounter, getTextLimit } from "ui/shared/CharacterCounter";
+import { CharacterCounter } from "ui/shared/CharacterCounter";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import { object } from "yup";
@@ -12,7 +12,7 @@ import { object } from "yup";
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../shared/constants";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { TextInput } from "./model";
-import { TextInputType, textInputValidationSchema } from "./model";
+import { getTextLimit,textInputValidationSchema } from "./model";
 
 export type Props = PublicProps<TextInput>;
 
@@ -32,10 +32,8 @@ const TextInputComponent: React.FC<Props> = (props) => {
     }),
   });
 
-  const characterCountLimit = props.type && getTextLimit(props.type);
-  const displayCharacterCount = Boolean(
-    props.type !== TextInputType.Short && characterCountLimit,
-  );
+  const characterCountLimit = getTextLimit(props.type, props.customLength);
+  const displayCharacterCount = characterCountLimit > 120;
 
   return (
     <Card handleSubmit={formik.handleSubmit} isValid>
@@ -78,8 +76,8 @@ const TextInputComponent: React.FC<Props> = (props) => {
           />
           {displayCharacterCount && (
             <CharacterCounter
+              limit={characterCountLimit}
               count={formik.values.text.length}
-              textInputType={props.type || TextInputType.Long}
               error={Boolean(formik.errors.text)}
             />
           )}

--- a/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -12,7 +12,7 @@ import { object } from "yup";
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../shared/constants";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { TextInput } from "./model";
-import { getTextLimit,textInputValidationSchema } from "./model";
+import { getTextLimit, textInputValidationSchema } from "./model";
 
 export type Props = PublicProps<TextInput>;
 
@@ -52,11 +52,9 @@ const TextInputComponent: React.FC<Props> = (props) => {
               else if (type === "phone") return "tel";
               return "text";
             })(props.type)}
-            multiline={props.type && ["long", "extraLong"].includes(props.type)}
+            multiline={getTextLimit(props.type, props.customLength) > 120}
             rows={
-              props.type && ["long", "extraLong"].includes(props.type)
-                ? 5
-                : undefined
+              getTextLimit(props.type, props.customLength) > 120 ? 5 : undefined
             }
             name="text"
             value={formik.values.text}

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -28,7 +28,7 @@ export const TEXT_LIMITS = {
   [TextInputType.Long]: 250,
   [TextInputType.ExtraLong]: 750,
   [TextInputType.Custom]: 120,
-  [TextInputType.Email]: 50,
+  [TextInputType.Email]: 320,
   [TextInputType.Phone]: 16,
 } as const;
 
@@ -62,7 +62,7 @@ export const textInputValidationSchema = ({
           return `Enter a valid phone number (maximum ${limit} characters).`;
         }
         if (type === TextInputType.Email) {
-          return `Enter a valid email address (maximum ${limit} characters).`;
+          return `Enter an email address in the correct format, like name@example.com.`;
         }
         return `Your answer must be ${limit} characters or fewer.`;
       })(),

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -10,12 +10,26 @@ export enum TextInputType {
   ExtraLong = "extraLong",
   Email = "email",
   Phone = "phone",
+  Custom = "custom",
 }
+
+const getTextLimit = (
+  type: TextInputType | undefined,
+  customLength?: number,
+): number => {
+  if (type === TextInputType.Custom && customLength) {
+    return customLength;
+  }
+  return type ? TEXT_LIMITS[type] : 0;
+};
 
 export const TEXT_LIMITS = {
   [TextInputType.Short]: 120,
   [TextInputType.Long]: 250,
   [TextInputType.ExtraLong]: 750,
+  [TextInputType.Custom]: 120,
+  [TextInputType.Email]: 50,
+  [TextInputType.Phone]: 16,
 } as const;
 
 export const emailRegex =
@@ -23,7 +37,7 @@ export const emailRegex =
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 export const textInputValidationSchema = ({
-  data: { type },
+  data: { type, customLength },
   required,
 }: {
   data: TextInput;
@@ -41,25 +55,31 @@ export const textInputValidationSchema = ({
         if (!type) {
           return "Enter your answer before continuing";
         }
+
+        const limit = getTextLimit(type, customLength);
+
         if (type === TextInputType.Phone) {
-          return "Enter a valid phone number.";
+          return `Enter a valid phone number (maximum ${limit} characters).`;
         }
         if (type === TextInputType.Email) {
-          return "Enter an email address in the correct format, like name@example.com";
+          return `Enter a valid email address (maximum ${limit} characters).`;
         }
-        return `Your answer must be ${TEXT_LIMITS[type]} characters or fewer.`;
+        return `Your answer must be ${limit} characters or fewer.`;
       })(),
       test: (value?: string) => {
         if (!value) return true;
         if (!type) return true;
+        if (!(value && value.length <= getTextLimit(type, customLength))) {
+          return false;
+        }
 
         if (type === TextInputType.Email) {
-          return Boolean(value && emailRegex.test(value));
+          return emailRegex.test(value);
         }
         if (type === TextInputType.Phone) {
-          return Boolean(value);
+          return value.length > 0;
         }
-        return Boolean(value && value.length <= TEXT_LIMITS[type]);
+        return true;
       },
     });
 
@@ -68,6 +88,7 @@ export interface TextInput extends BaseNodeData {
   description?: string;
   fn?: string;
   type?: TextInputType;
+  customLength?: number;
 }
 
 export const parseTextInput = (
@@ -77,5 +98,6 @@ export const parseTextInput = (
   description: data?.description,
   fn: data?.fn,
   type: data?.type,
+  customLength: data?.customLength,
   ...parseBaseNodeData(data),
 });

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -13,7 +13,7 @@ export enum TextInputType {
   Custom = "custom",
 }
 
-const getTextLimit = (
+export const getTextLimit = (
   type: TextInputType | undefined,
   customLength?: number,
 ): number => {

--- a/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
@@ -1,8 +1,8 @@
 import type { TextField } from "@planx/components/shared/Schema/model";
-import { TextInputType } from "@planx/components/TextInput/model";
+import { getTextLimit, TextInputType } from "@planx/components/TextInput/model";
 import React from "react";
 import InputLabel from "ui/public/InputLabel";
-import { CharacterCounter, getTextLimit } from "ui/shared/CharacterCounter";
+import { CharacterCounter } from "ui/shared/CharacterCounter";
 import Input from "ui/shared/Input/Input";
 
 import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../../constants";
@@ -52,7 +52,7 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
       />
       {displayCharacterCount && (
         <CharacterCounter
-          textInputType={data.type || TextInputType.Long}
+          limit={characterCountLimit ?? 0}
           count={fieldProps?.value?.length}
           error={Boolean(fieldProps.errorMessage)}
         />

--- a/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.tsx
@@ -3,7 +3,6 @@ import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import SimpleExpand from "@planx/components/shared/Preview/SimpleExpand";
-import { TextInputType } from "@planx/components/TextInput/model";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
 import capitalize from "lodash/capitalize";
@@ -164,7 +163,7 @@ export const ReadMePage: React.FC<ReadMePageProps> = ({
             />
             <CharacterCounter
               count={formik.values.serviceSummary.length}
-              textInputType={TextInputType.Short} // 120 characters
+              limit={120}
               error={Boolean(formik.errors.serviceSummary)}
             />
           </InputGroup>

--- a/editor.planx.uk/src/ui/shared/CharacterCounter.tsx
+++ b/editor.planx.uk/src/ui/shared/CharacterCounter.tsx
@@ -1,32 +1,16 @@
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
-import { TEXT_LIMITS, TextInputType } from "@planx/components/TextInput/model";
 import { debounce } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export type Props = {
-  textInputType: TextInputType;
+  limit: number;
   count: number;
   error: boolean;
 };
 
-export function getTextLimit(type: TextInputType): number {
-  switch (type) {
-    case TextInputType.Short:
-    case TextInputType.Long:
-    case TextInputType.ExtraLong:
-      return TEXT_LIMITS[type];
-    default:
-      return 0;
-  }
-}
-
-export const CharacterCounter: React.FC<Props> = ({
-  textInputType,
-  count,
-  error,
-}) => {
+export const CharacterCounter: React.FC<Props> = ({ limit, count, error }) => {
   const [screenReaderCount, setScreenReaderCount] = useState<number>(0);
   const [showReaderCount, setShowReaderCount] = useState<boolean>(false);
 
@@ -38,7 +22,7 @@ export const CharacterCounter: React.FC<Props> = ({
     [],
   );
 
-  const currentCharacterCount = getTextLimit(textInputType) - count;
+  const currentCharacterCount = limit - count;
 
   const showCharacterLimitError = currentCharacterCount < 0;
 
@@ -62,7 +46,7 @@ export const CharacterCounter: React.FC<Props> = ({
   return (
     <>
       <Typography id={"character-hint"} sx={visuallyHidden} aria-hidden={true}>
-        {`You can enter up to ${getTextLimit(textInputType)} characters`}
+        {`You can enter up to ${limit} characters`} {/* Use limit directly */}
       </Typography>
       <Typography
         paddingTop={0.5}


### PR DESCRIPTION
This PR expands on https://github.com/theopensystemslab/planx-new/pull/4699 by further adding customisable regular expressions and input examples (for rendering validation errors).

When custom input style is selected, the modal now shows a Custom input style section with three inputs:
1. Maximum characters
2. Regular expression
3. Example

If a regex is provided, the input is validated against it and shows a default error message of 'Enter the information in the correct format.' If an example is provided, the error message renders as 'Enter the information in the correct format, like [EXAMPLE].', following the existing email pattern.

Known issue: If both a regex pattern and a character limit is provided, it does not correctly switch to displaying a character limit error if the input exceeds the limit but matches the regex. Is this a reasonable edge case that is worth considering reordering/conditionally dealing with both validations for?

Draft pending review of https://github.com/theopensystemslab/planx-new/pull/4699