### PR TITLE
fix: Env based admin panel query

### DIFF
--- a/editor.planx.uk/src/routes/authenticated.tsx
+++ b/editor.planx.uk/src/routes/authenticated.tsx
@@ -19,7 +19,7 @@ import { client } from "../lib/graphql";
 import GlobalSettingsView from "../pages/GlobalSettings";
 import { PlatformAdminPanel } from "../pages/PlatformAdminPanel/PlatformAdminPanel";
 import Teams from "../pages/Teams";
-import { makeTitle } from "./utils";
+import { makeTitle, PRODUCTION_ADMIN_PANEL_QUERY, STAGING_ADMIN_PANEL_QUERY } from "./utils";
 import { authenticatedView } from "./views/authenticated";
 
 export type TeamSummary =
@@ -106,34 +106,13 @@ const editorRoutes = compose(
           `User does not have access to ${req.originalUrl}`,
         );
 
+      const query = import.meta.env.VITE_APP_ENV === "production"
+        ? PRODUCTION_ADMIN_PANEL_QUERY
+        : STAGING_ADMIN_PANEL_QUERY
+
       return route(async () => {
         const { data } = await client.query<{ adminPanel: AdminPanelData[] }>({
-          query: gql`
-            query {
-              adminPanel: teams_summary {
-                id
-                name
-                slug
-                referenceCode: reference_code
-                homepage
-                subdomain
-                planningDataEnabled: planning_data_enabled
-                article4sEnabled: article_4s_enabled
-                govnotifyPersonalisation: govnotify_personalisation
-                govpayEnabled: govpay_enabled
-                powerAutomateEnabled: power_automate_enabled
-                sendToEmailAddress: send_to_email_address
-                bopsSubmissionURL: bops_submission_url
-                liveFlows: live_flows
-                logo
-                favicon
-                primaryColour: primary_colour
-                linkColour: link_colour
-                actionColour: action_colour
-                isTrial: is_trial
-              }
-            }
-          `,
+          query,
           context: {
             headers: {
               "x-hasura-role": isPlatformAdmin ? "platformAdmin" : "analyst",

--- a/editor.planx.uk/src/routes/utils.ts
+++ b/editor.planx.uk/src/routes/utils.ts
@@ -107,3 +107,57 @@ export const validateTeamRoute = async (req: NaviRequest) => {
   )
     throw new NotFoundError(req.originalUrl);
 };
+
+export const STAGING_ADMIN_PANEL_QUERY = gql`
+  query {
+    adminPanel: teams_summary {
+      id
+      name
+      slug
+      referenceCode: reference_code
+      homepage
+      subdomain
+      planningDataEnabled: planning_data_enabled
+      article4sEnabled: article_4s_enabled
+      govnotifyPersonalisation: govnotify_personalisation
+      govpayEnabled: govpay_enabled_staging
+      powerAutomateEnabled: power_automate_enabled_staging
+      sendToEmailAddress: send_to_email_address
+      bopsSubmissionURL: bops_submission_url_staging
+      liveFlows: live_flows
+      logo
+      favicon
+      primaryColour: primary_colour
+      linkColour: link_colour
+      actionColour: action_colour
+      isTrial: is_trial
+    }
+  }
+`;
+
+export const PRODUCTION_ADMIN_PANEL_QUERY = gql`
+  query {
+    adminPanel: teams_summary {
+      id
+      name
+      slug
+      referenceCode: reference_code
+      homepage
+      subdomain
+      planningDataEnabled: planning_data_enabled
+      article4sEnabled: article_4s_enabled
+      govnotifyPersonalisation: govnotify_personalisation
+      govpayEnabled: govpay_enabled_production
+      powerAutomateEnabled: power_automate_enabled_production
+      sendToEmailAddress: send_to_email_address
+      bopsSubmissionURL: bops_submission_url_production
+      liveFlows: live_flows
+      logo
+      favicon
+      primaryColour: primary_colour
+      linkColour: link_colour
+      actionColour: action_colour
+      isTrial: is_trial
+    }
+  }
+`;

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -3027,21 +3027,24 @@
     - role: analyst
       permission:
         columns:
-          - action_colour
-          - article_4s_enabled
-          - bops_submission_url
-          - favicon
-          - govnotify_personalisation
-          - govpay_enabled
-          - homepage
-          - id
-          - is_trial
-          - link_colour
           - live_flows
+          - article_4s_enabled
+          - govpay_enabled_production
+          - govpay_enabled_staging
+          - is_trial
+          - planning_data_enabled
+          - power_automate_enabled_production
+          - power_automate_enabled_staging
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - bops_submission_url_production
+          - bops_submission_url_staging
+          - favicon
+          - homepage
+          - link_colour
           - logo
           - name
-          - planning_data_enabled
-          - power_automate_enabled
           - primary_colour
           - reference_code
           - send_to_email_address
@@ -3052,21 +3055,24 @@
     - role: platformAdmin
       permission:
         columns:
-          - action_colour
-          - article_4s_enabled
-          - bops_submission_url
-          - favicon
-          - govnotify_personalisation
-          - govpay_enabled
-          - homepage
-          - id
-          - is_trial
-          - link_colour
           - live_flows
+          - article_4s_enabled
+          - govpay_enabled_production
+          - govpay_enabled_staging
+          - is_trial
+          - planning_data_enabled
+          - power_automate_enabled_production
+          - power_automate_enabled_staging
+          - id
+          - govnotify_personalisation
+          - action_colour
+          - bops_submission_url_production
+          - bops_submission_url_staging
+          - favicon
+          - homepage
+          - link_colour
           - logo
           - name
-          - planning_data_enabled
-          - power_automate_enabled
           - primary_colour
           - reference_code
           - send_to_email_address

--- a/hasura.planx.uk/migrations/1747989699392_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/1747989699392_run_sql_migration/down.sql
@@ -1,0 +1,122 @@
+DROP VIEW "public"."teams_summary";
+
+CREATE
+OR REPLACE VIEW "public"."teams_summary" AS
+SELECT
+  t.id,
+  t.name,
+  t.slug,
+  ts.reference_code,
+  ts.homepage,
+  t.domain AS subdomain,
+  ti.has_planning_data AS planning_data_enabled,
+  ts.has_article4_schema AS article_4s_enabled,
+  jsonb_build_object(
+    'helpEmail',
+    ts.help_email,
+    'helpPhone',
+    ts.help_phone,
+    'emailReplyToId',
+    ts.email_reply_to_id,
+    'helpOpeningHours',
+    ts.help_opening_hours
+  ) AS govnotify_personalisation,
+  CASE
+    WHEN (
+      COALESCE(
+        ti.production_govpay_secret,
+        ti.staging_govpay_secret
+      ) IS NOT NULL
+    ) THEN true
+    ELSE false
+  END AS govpay_enabled,
+  ts.submission_email AS send_to_email_address,
+  COALESCE(
+    ti.production_bops_submission_url,
+    ti.staging_bops_submission_url
+  ) AS bops_submission_url,
+  tt.logo,
+  tt.favicon,
+  tt.primary_colour,
+  tt.link_colour,
+  tt.action_colour,
+  CASE
+    WHEN (
+      (
+        COALESCE(
+          ti.production_file_api_key,
+          ti.staging_file_api_key
+        ) IS NOT NULL
+      )
+      AND (
+        COALESCE(
+          ti.production_power_automate_api_key,
+          ti.staging_power_automate_api_key
+        ) IS NOT NULL
+      )
+      AND (ti.power_automate_webhook_url IS NOT NULL)
+    ) THEN true
+    ELSE false
+  END AS power_automate_enabled,
+  array_agg(
+    f.name
+    ORDER BY
+      f.name
+  ) FILTER (
+    WHERE
+      (
+        (f.status = 'online' :: text)
+        AND (f.deleted_at IS NULL)
+      )
+  ) AS live_flows,
+  ts.is_trial
+FROM
+  (
+    (
+      (
+        (
+          teams t
+          JOIN team_integrations ti ON ((ti.team_id = t.id))
+        )
+        JOIN team_themes tt ON ((tt.team_id = t.id))
+      )
+      JOIN team_settings ts ON ((ts.team_id = t.id))
+    )
+    LEFT JOIN flows f ON ((f.team_id = t.id))
+  )
+WHERE
+  (
+    t.name <> ALL (
+      ARRAY ['Open Digital Planning'::text, 'Open Systems Lab'::text, 'PlanX'::text, 'Templates'::text, 'Testing'::text, 'WikiHouse'::text]
+    )
+  )
+GROUP BY
+  t.id,
+  t.name,
+  t.slug,
+  ts.reference_code,
+  ts.homepage,
+  ts.help_email,
+  ts.help_phone,
+  ts.email_reply_to_id,
+  ts.help_opening_hours,
+  ts.submission_email,
+  ts.has_article4_schema,
+  ti.has_planning_data,
+  ti.production_govpay_secret,
+  ti.staging_govpay_secret,
+  ti.production_bops_submission_url,
+  ti.staging_bops_submission_url,
+  ti.production_file_api_key,
+  ti.staging_file_api_key,
+  ti.power_automate_webhook_url,
+  ti.production_power_automate_api_key,
+  ti.staging_power_automate_api_key,
+  tt.logo,
+  tt.favicon,
+  tt.primary_colour,
+  tt.link_colour,
+  tt.action_colour,
+  ts.is_trial
+ORDER BY
+  t.name;

--- a/hasura.planx.uk/migrations/1747989699392_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/1747989699392_run_sql_migration/up.sql
@@ -1,0 +1,42 @@
+DROP VIEW "public"."teams_summary";
+
+CREATE OR REPLACE VIEW "public"."teams_summary" AS 
+ SELECT t.id,
+    t.name,
+    t.slug,
+    ts.reference_code,
+    ts.homepage,
+    t.domain AS subdomain,
+    ti.has_planning_data AS planning_data_enabled,
+    ts.has_article4_schema AS article_4s_enabled,
+    jsonb_build_object('helpEmail', ts.help_email, 'helpPhone', ts.help_phone, 'emailReplyToId', ts.email_reply_to_id, 'helpOpeningHours', ts.help_opening_hours) AS govnotify_personalisation,
+    (ti.staging_govpay_secret IS NOT NULL) AS govpay_enabled_staging,
+    (ti.production_govpay_secret IS NOT NULL) AS govpay_enabled_production,
+    ts.submission_email AS send_to_email_address,
+    ti.staging_bops_submission_url AS bops_submission_url_staging,
+    ti.production_bops_submission_url AS bops_submission_url_production,
+    tt.logo,
+    tt.favicon,
+    tt.primary_colour,
+    tt.link_colour,
+    tt.action_colour,
+    (
+        (ti.staging_file_api_key IS NOT NULL) AND
+        (ti.staging_power_automate_api_key IS NOT NULL) AND
+        (ti.power_automate_webhook_url IS NOT NULL)
+    )::BOOLEAN AS power_automate_enabled_staging,
+    (
+        (ti.production_file_api_key IS NOT NULL) AND
+        (ti.production_power_automate_api_key IS NOT NULL) AND
+        (ti.power_automate_webhook_url IS NOT NULL)
+    )::BOOLEAN AS power_automate_enabled_production,
+    array_agg(f.name ORDER BY f.name) FILTER (WHERE ((f.status = 'online'::text) AND (f.deleted_at IS NULL))) AS live_flows,
+    ts.is_trial
+   FROM ((((teams t
+     JOIN team_integrations ti ON ((ti.team_id = t.id)))
+     JOIN team_themes tt ON ((tt.team_id = t.id)))
+     JOIN team_settings ts ON ((ts.team_id = t.id)))
+     LEFT JOIN flows f ON ((f.team_id = t.id)))
+  WHERE (t.name <> ALL (ARRAY['Open Digital Planning'::text, 'Open Systems Lab'::text, 'PlanX'::text, 'Templates'::text, 'Testing'::text, 'WikiHouse'::text]))
+  GROUP BY t.id, t.name, t.slug, ts.reference_code, ts.homepage, ts.help_email, ts.help_phone, ts.email_reply_to_id, ts.help_opening_hours, ts.submission_email, ts.has_article4_schema, ti.has_planning_data, ti.production_govpay_secret, ti.staging_govpay_secret, ti.production_bops_submission_url, ti.staging_bops_submission_url, ti.production_file_api_key, ti.staging_file_api_key, ti.power_automate_webhook_url, ti.production_power_automate_api_key, ti.staging_power_automate_api_key, tt.logo, tt.favicon, tt.primary_colour, tt.link_colour, tt.action_colour, ts.is_trial
+  ORDER BY t.name;

--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -15,7 +15,7 @@ echo downloading data from production
 # set-up tmp dir for remote data
 mkdir -p /tmp
 
-# Create sync.sql file for all our comnands which will be executed in a single transaction
+# Create sync.sql file for all our commands which will be executed in a single transaction
 touch '/tmp/sync.sql'
 
 tables=(


### PR DESCRIPTION
## What's the problem?
- The query for the `teams_summary` view coalesces staging and production values, when there can be a significant time gap between these values being populated
- This leads to the production admin panel showing the incorrect value, when only staging is popualted
- More detail here (OSL Slack) - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1747909379331239

## What's the solution?
 - Per-env columns in the `teams_summary` view (to match the data source of `team_integrations`)
 - Conditionally query different columns, based on environment
 - Still map these columns to single, simpler, `AdminPanelData` type within the Editor