### PR TITLE
feat: add ward to property info query on `FindProperty`

### DIFF
--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -36,6 +36,7 @@ const osAddressProps = {
   "property.type": ["residential.HMO.parent"],
   "property.localAuthorityDistrict": ["Southwark"],
   "property.region": ["London"],
+  "property.ward": ["Old Kent Road"],
   "property.boundary.area": 1232.22,
   "property.boundary.area.hectares": 0.123222,
   "property.boundary": {
@@ -85,6 +86,7 @@ const proposedAddressProps = {
   },
   "property.localAuthorityDistrict": ["Southwark"],
   "property.region": ["London"],
+  "property.ward": ["Old Kent Road"],
   "property.boundary.area": 1232.22,
   "property.boundary.area.hectares": 0.123222,
   "property.boundary": {

--- a/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/localAuthorityMock.ts
+++ b/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/localAuthorityMock.ts
@@ -1,4 +1,4 @@
-// https://www.planning.data.gov.uk/entity.geojson?entries=all&geometry=POINT%28-0.0764422+51.4842527%29&geometry_relation=intersects&limit=100&dataset=local-authority-district&dataset=region&dataset=title-boundary
+// https://www.planning.data.gov.uk/entity.geojson?entries=all&geometry=POINT%28-0.0764422+51.4842527%29&geometry_relation=intersects&limit=100&dataset=local-authority-district&dataset=region&dataset=title-boundary&dataset=ward
 export default {
   type: "FeatureCollection",
   features: [
@@ -8756,6 +8756,178 @@ export default {
         prefix: "title-boundary",
         "organisation-entity": "13",
       },
+    },
+    {
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [
+            [
+              [
+                -0.053969,
+                51.487941
+              ],
+              [
+                -0.055678,
+                51.488395
+              ],
+              [
+                -0.057804,
+                51.488501
+              ],
+              [
+                -0.058339,
+                51.488067
+              ],
+              [
+                -0.061588,
+                51.487274
+              ],
+              [
+                -0.065702,
+                51.487133
+              ],
+              [
+                -0.068426,
+                51.488116
+              ],
+              [
+                -0.074788,
+                51.489182
+              ],
+              [
+                -0.076243,
+                51.490349
+              ],
+              [
+                -0.077951,
+                51.488882
+              ],
+              [
+                -0.075463,
+                51.487564
+              ],
+              [
+                -0.07615,
+                51.48701
+              ],
+              [
+                -0.076592,
+                51.48504
+              ],
+              [
+                -0.077792,
+                51.485105
+              ],
+              [
+                -0.077942,
+                51.484341
+              ],
+              [
+                -0.075936,
+                51.484114
+              ],
+              [
+                -0.075843,
+                51.484423
+              ],
+              [
+                -0.074094,
+                51.484368
+              ],
+              [
+                -0.073948,
+                51.482622
+              ],
+              [
+                -0.072926,
+                51.482725
+              ],
+              [
+                -0.073029,
+                51.48178
+              ],
+              [
+                -0.07103,
+                51.477468
+              ],
+              [
+                -0.06884,
+                51.478151
+              ],
+              [
+                -0.063019,
+                51.479265
+              ],
+              [
+                -0.060956,
+                51.476673
+              ],
+              [
+                -0.058662,
+                51.477441
+              ],
+              [
+                -0.056112,
+                51.477375
+              ],
+              [
+                -0.055868,
+                51.477668
+              ],
+              [
+                -0.054978,
+                51.477427
+              ],
+              [
+                -0.054235,
+                51.478596
+              ],
+              [
+                -0.053099,
+                51.480927
+              ],
+              [
+                -0.052782,
+                51.482725
+              ],
+              [
+                -0.053056,
+                51.485038
+              ],
+              [
+                -0.053534,
+                51.48568
+              ],
+              [
+                -0.052925,
+                51.486004
+              ],
+              [
+                -0.052854,
+                51.486684
+              ],
+              [
+                -0.053969,
+                51.487941
+              ]
+            ]
+          ]
+        ]
+      },
+      "type": "Feature",
+      "properties": {
+        "entry-date": "2025-03-04",
+        "start-date": "",
+        "end-date": "",
+        "entity": 802360,
+        "name": "Old Kent Road",
+        "dataset": "ward",
+        "typology": "geography",
+        "reference": "E05011109",
+        "prefix": "statistical-geography",
+        "organisation-entity": "10"
+      }
     },
   ],
   links: {},


### PR DESCRIPTION
Planning Data now publishes [wards](https://www.planning.data.gov.uk/dataset/ward) which means we can use the address point to query the ward name and add it to the passport as `property.ward`. Can merge this anytime and will capture in next schema release.

![Screenshot from 2025-05-23 11-30-42](https://github.com/user-attachments/assets/d4b30715-65c8-44f9-90a5-3fffdbf27259)

https://trello.com/c/OkSHmSQh/3295-auto-collect-ward-boundary-data