### PR TITLE
fix: Autocomplete icon alignment

### DIFF
--- a/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -140,11 +140,6 @@ const ExternalPortalForm: React.FC<{
                   modifiers: [{ name: "flip", enabled: false }],
                 },
               }}
-              sx={{
-                [`& .${autocompleteClasses.endAdornment}`]: {
-                  top: "unset",
-                },
-              }}
               clearOnEscape
               handleHomeEndKeys
               autoHighlight

--- a/editor.planx.uk/src/ui/shared/Autocomplete/styles.ts
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/styles.ts
@@ -9,9 +9,6 @@ export const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
   "& > div > label": {
     paddingRight: theme.spacing(3),
   },
-  [`& .${autocompleteClasses.endAdornment}`]: {
-    top: "unset",
-  },
   "&:focus-within": {
     "& svg": {
       color: "black",

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -36,9 +36,6 @@ export const StyledAutocomplete = styled(Autocomplete)(({ theme }) => ({
   "& > div > label": {
     paddingRight: theme.spacing(3),
   },
-  [`& .${autocompleteClasses.endAdornment}`]: {
-    top: "unset",
-  },
   "& button.Mui-disabled > svg": {
     color: theme.palette.text.disabled,
   },


### PR DESCRIPTION
## What does this PR do?

Fixes autocomplete icon across all instances of autocomplete. I'm unsure what has caused this recent styling regression, but removing all instances of `top: "unset",` on the icon element fixes the issue.

**Preview (before vs after for each):**

![image](https://github.com/user-attachments/assets/8f3513f9-7585-4e60-8cdb-6b6a6b8f0a37)

![image](https://github.com/user-attachments/assets/7222a80f-2f9b-43ae-922a-20f26c8570c6)

![image](https://github.com/user-attachments/assets/06ee6854-428e-47ce-aaa3-170f1a2a3c2a)

![image](https://github.com/user-attachments/assets/01dd6db6-08bc-4769-bf91-b52a28b45200)
