### PR TITLE
feat: setup database event to update templated flows on source publish

### DIFF
--- a/api.planx.uk/modules/webhooks/controller.ts
+++ b/api.planx.uk/modules/webhooks/controller.ts
@@ -16,9 +16,14 @@ import { sanitiseApplicationData } from "./service/sanitiseApplicationData/index
 import type { SanitiseApplicationData } from "./service/sanitiseApplicationData/types.js";
 import { sendSlackNotification } from "./service/sendNotification/index.js";
 import type { SendSlackNotification } from "./service/sendNotification/types.js";
-import type { UpdateTemplatedFlowEditsController } from "./service/updateTemplatedFlowEdits/schema.js";
+import type {
+  UpdateTemplatedFlowEditsController,
+  UpdateTemplatedFlowEditsEvent,
+} from "./service/updateTemplatedFlowEdits/schema.js";
 import type { IsCleanJSONBController } from "./service/validateInput/schema.js";
 import { updateTemplatedFlowEdits } from "./service/updateTemplatedFlowEdits/index.js";
+import type { UpdateTemplatedFlowsOnSourcePublishController } from "./service/updateTemplatedFlowsOnSourcePublish/schema.js";
+import { updateTemplatedFlowsOnSourcePublish } from "./service/updateTemplatedFlowsOnSourcePublish/index.js";
 
 export const sendSlackNotificationController: SendSlackNotification = async (
   _req,
@@ -216,6 +221,23 @@ export const updateTemplatedFlowEditsController: UpdateTemplatedFlowEditsControl
       return next(
         new ServerError({
           message: `Failed to update templated flow edits ${flowId}`,
+          cause: error,
+        }),
+      );
+    }
+  };
+
+export const updateTemplatedFlowsOnSourcePublishController: UpdateTemplatedFlowsOnSourcePublishController =
+  async (_req, res, next) => {
+    const { flowId } = res.locals.parsedReq.body.payload;
+
+    try {
+      const response = await updateTemplatedFlowsOnSourcePublish(flowId);
+      res.json(response);
+    } catch (error) {
+      return next(
+        new ServerError({
+          message: `Failed to update templated flows on source publish (source ID ${flowId})`,
           cause: error,
         }),
       );

--- a/api.planx.uk/modules/webhooks/controller.ts
+++ b/api.planx.uk/modules/webhooks/controller.ts
@@ -16,14 +16,11 @@ import { sanitiseApplicationData } from "./service/sanitiseApplicationData/index
 import type { SanitiseApplicationData } from "./service/sanitiseApplicationData/types.js";
 import { sendSlackNotification } from "./service/sendNotification/index.js";
 import type { SendSlackNotification } from "./service/sendNotification/types.js";
-import type {
-  UpdateTemplatedFlowEditsController,
-  UpdateTemplatedFlowEditsEvent,
-} from "./service/updateTemplatedFlowEdits/schema.js";
-import type { IsCleanJSONBController } from "./service/validateInput/schema.js";
 import { updateTemplatedFlowEdits } from "./service/updateTemplatedFlowEdits/index.js";
-import type { UpdateTemplatedFlowsOnSourcePublishController } from "./service/updateTemplatedFlowsOnSourcePublish/schema.js";
+import type { UpdateTemplatedFlowEditsController } from "./service/updateTemplatedFlowEdits/schema.js";
 import { updateTemplatedFlowsOnSourcePublish } from "./service/updateTemplatedFlowsOnSourcePublish/index.js";
+import type { UpdateTemplatedFlowsOnSourcePublishController } from "./service/updateTemplatedFlowsOnSourcePublish/schema.js";
+import type { IsCleanJSONBController } from "./service/validateInput/schema.js";
 
 export const sendSlackNotificationController: SendSlackNotification = async (
   _req,

--- a/api.planx.uk/modules/webhooks/routes.ts
+++ b/api.planx.uk/modules/webhooks/routes.ts
@@ -13,12 +13,14 @@ import {
   sanitiseApplicationDataController,
   sendSlackNotificationController,
   updateTemplatedFlowEditsController,
+  updateTemplatedFlowsOnSourcePublishController,
 } from "./controller.js";
 import { createSessionEventSchema } from "./service/lowcalSessionEvents/schema.js";
 import { createPaymentEventSchema } from "./service/paymentRequestEvents/schema.js";
 import { sendSlackNotificationSchema } from "./service/sendNotification/schema.js";
 import { updateTemplatedFlowEditsEventSchema } from "./service/updateTemplatedFlowEdits/schema.js";
 import { isCleanJSONBSchema } from "./service/validateInput/schema.js";
+import { updateTemplatedFlowsOnSourcePublishEventSchema } from "./service/updateTemplatedFlowsOnSourcePublish/schema.js";
 
 const router = Router();
 
@@ -68,6 +70,12 @@ router.post(
   "/webhooks/hasura/update-templated-flow-edits",
   validate(updateTemplatedFlowEditsEventSchema),
   updateTemplatedFlowEditsController,
+);
+
+router.post(
+  "/webhooks/hasura/update-templated-flows-on-source-publish",
+  validate(updateTemplatedFlowsOnSourcePublishEventSchema),
+  updateTemplatedFlowsOnSourcePublishController,
 );
 
 // TODO: Convert to the new API module structure

--- a/api.planx.uk/modules/webhooks/service/updateTemplatedFlowsOnSourcePublish/index.ts
+++ b/api.planx.uk/modules/webhooks/service/updateTemplatedFlowsOnSourcePublish/index.ts
@@ -1,5 +1,60 @@
+import { gql } from "graphql-request";
+import { $api } from "../../../../client/index.js";
+
 export const updateTemplatedFlowsOnSourcePublish = async (flowId: string) => {
+  const { isTemplate, templatedFlows } =
+    await getTemplatedFlowsBySourceId(flowId);
+  if (!isTemplate || templatedFlows.length === 0)
+    return {
+      message: `Skipping update because published flow is not a template or does not have any templatedFlows`,
+    };
+
+  // TODO
+  // For each templatedFlow, update its' flows.data based on live source flow data (unflattened)
+
   return {
-    message: `Flow ID ${flowId}`,
+    message: `TODO - Update ${templatedFlows.length} templatedFlows based on just-published source template ${flowId}`,
   };
+};
+
+interface GetTemplatedFlowsBySourceIdResponse {
+  isTemplate: boolean;
+  templatedFlows:
+    | {
+        id: string;
+        slug: string;
+        team: {
+          slug: string;
+        };
+      }[]
+    | [];
+}
+
+const getTemplatedFlowsBySourceId = async (
+  sourceId: string,
+): Promise<GetTemplatedFlowsBySourceIdResponse> => {
+  const { flow } = await $api.client.request<{
+    flow: GetTemplatedFlowsBySourceIdResponse | null;
+  }>(
+    gql`
+      query GetTemplatedFlowsBySourceId($id: uuid!) {
+        flow: flows_by_pk(id: $id) {
+          isTemplate: is_template
+          templatedFlows: templated_flows {
+            id
+            slug
+            team {
+              slug
+            }
+          }
+        }
+      }
+    `,
+    {
+      id: sourceId,
+    },
+  );
+  if (!flow) throw Error(`Unable to find flow with id ${sourceId}`);
+
+  return flow;
 };

--- a/api.planx.uk/modules/webhooks/service/updateTemplatedFlowsOnSourcePublish/index.ts
+++ b/api.planx.uk/modules/webhooks/service/updateTemplatedFlowsOnSourcePublish/index.ts
@@ -1,0 +1,5 @@
+export const updateTemplatedFlowsOnSourcePublish = async (flowId: string) => {
+  return {
+    message: `Flow ID ${flowId}`,
+  };
+};

--- a/api.planx.uk/modules/webhooks/service/updateTemplatedFlowsOnSourcePublish/schema.ts
+++ b/api.planx.uk/modules/webhooks/service/updateTemplatedFlowsOnSourcePublish/schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+
+export const updateTemplatedFlowsOnSourcePublishEventSchema = z.object({
+  body: z.object({
+    createdAt: z.string().pipe(z.coerce.date()),
+    payload: z.object({
+      flowId: z.string(),
+    }),
+  }),
+});
+
+export type UpdateTemplatedFlowsOnSourcePublishEvent = z.infer<
+  typeof updateTemplatedFlowsOnSourcePublishEventSchema
+>["body"];
+
+export interface UpdateTemplatedFlowsOnSourcePublishEventResponse {
+  message: string;
+  data?: any;
+}
+
+export type UpdateTemplatedFlowsOnSourcePublishController =
+  ValidatedRequestHandler<
+    typeof updateTemplatedFlowsOnSourcePublishEventSchema,
+    UpdateTemplatedFlowsOnSourcePublishEventResponse
+  >;

--- a/api.planx.uk/tsconfig.json
+++ b/api.planx.uk/tsconfig.json
@@ -16,7 +16,7 @@
     "target": "esnext",
     "types": ["vitest/globals"],
     // ensure the code is ready for per-file transpilation by tsx (used in dev mode)
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": true
   },
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/api.planx.uk/tsconfig.json
+++ b/api.planx.uk/tsconfig.json
@@ -16,7 +16,7 @@
     "target": "esnext",
     "types": ["vitest/globals"],
     // ensure the code is ready for per-file transpilation by tsx (used in dev mode)
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
 }

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2084,7 +2084,7 @@
             {
               "createdAt": {{$body.created_at}},
               "payload": {
-                "flowId": {{$body.event.new.flow_id}}
+                "flowId": {{$body.event.data.new.flow_id}}
               }
             }
         method: POST

--- a/hasura.planx.uk/metadata/tables.yaml
+++ b/hasura.planx.uk/metadata/tables.yaml
@@ -2063,6 +2063,35 @@
           - summary
         filter: {}
         allow_aggregations: true
+  event_triggers:
+    - name: update_templated_flows_on_source_publish
+      definition:
+        enable_manual: false
+        insert:
+          columns: '*'
+      retry_conf:
+        interval_sec: 10
+        num_retries: 0
+        timeout_sec: 60
+      webhook: '{{HASURA_PLANX_API_URL}}'
+      headers:
+        - name: authorization
+          value_from_env: HASURA_PLANX_API_KEY
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "createdAt": {{$body.created_at}},
+              "payload": {
+                "flowId": {{$body.event.new.flow_id}}
+              }
+            }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        url: '{{$base_url}}/webhooks/hasura/update-templated-flows-on-source-publish'
+        version: 2
 - table:
     name: reconciliation_requests
     schema: public


### PR DESCRIPTION
Sets up a Hasura event trigger on every publish. 

The logic is:
- If the published flow is _not_ a template (`isTemplate: false`), then simply return
- If the published flow is a template, then:
  - (Here) Fetch its templated flows (here)
  - (TODO) Update each templated flow with the live data of the recently published source template (unflattened), reconciling custom `templated_flow_edits` for each templated flow
  
Similar to previous template PRs, trying to keep this iterative - so event setup here & I'll pick up logic & testing in a followup! 