### PR TITLE
feat: if a flow is a template, inform the publisher about any `templated_from` children that will be updated

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -287,15 +287,13 @@ export const getHistory = async (flowId: string) => {
 };
 
 interface GetTemplatedFlowsResponse {
-  templatedFlows:
-    | {
-        slug: string;
-        team: {
-          slug: string;
-        };
-        status: FlowStatus;
-      }[]
-    | [];
+  templatedFlows: {
+    slug: string;
+    team: {
+      slug: string;
+    };
+    status: FlowStatus;
+  }[];
 }
 
 // Get templatedFlows info to display in the publishing modal when a flow "isTemplate"
@@ -303,7 +301,7 @@ export const getTemplatedFlows = async (flowId: string) => {
   const { client: $client } = getClient();
   const response = await $client.request<{ flow: GetTemplatedFlowsResponse }>(
     gql`
-      query GetIsTemplateAndTemplatedFlows($flow_id: uuid!) {
+      query GetTemplatedFlows($flow_id: uuid!) {
         flow: flows_by_pk(id: $flow_id) {
           templatedFlows: templated_flows {
             slug

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -1,4 +1,4 @@
-import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph, FlowStatus } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
 import capitalize from "lodash/capitalize.js";
@@ -284,6 +284,43 @@ export const getHistory = async (flowId: string) => {
   );
 
   return response.history;
+};
+
+interface GetTemplatedFlowsResponse {
+  templatedFlows:
+    | {
+        slug: string;
+        team: {
+          slug: string;
+        };
+        status: FlowStatus;
+      }[]
+    | [];
+}
+
+// Get templatedFlows info to display in the publishing modal when a flow "isTemplate"
+export const getTemplatedFlows = async (flowId: string) => {
+  const { client: $client } = getClient();
+  const response = await $client.request<{ flow: GetTemplatedFlowsResponse }>(
+    gql`
+      query GetIsTemplateAndTemplatedFlows($flow_id: uuid!) {
+        flow: flows_by_pk(id: $flow_id) {
+          templatedFlows: templated_flows {
+            slug
+            team {
+              slug
+            }
+            status
+          }
+        }
+      }
+    `,
+    {
+      flow_id: flowId,
+    },
+  );
+
+  return response.flow;
 };
 
 /**

--- a/api.planx.uk/modules/flows/validate/service/index.ts
+++ b/api.planx.uk/modules/flows/validate/service/index.ts
@@ -37,15 +37,13 @@ interface FlowValidateAndDiffResponse {
   message: string;
   validationChecks?: FlowValidationResponse[];
   history: FlowHistoryEntry[] | null;
-  templatedFlows?:
-    | {
-        slug: string;
-        team: {
-          slug: string;
-        };
-        status: FlowStatus;
-      }[]
-    | [];
+  templatedFlows?: {
+    slug: string;
+    team: {
+      slug: string;
+    };
+    status: FlowStatus;
+  }[];
 }
 
 const validateAndDiffFlow = async (

--- a/api.planx.uk/modules/flows/validate/service/index.ts
+++ b/api.planx.uk/modules/flows/validate/service/index.ts
@@ -1,6 +1,7 @@
 import type {
   ComponentType,
   Edges,
+  FlowStatus,
   Node,
 } from "@opensystemslab/planx-core/types";
 import * as jsondiffpatch from "jsondiffpatch";
@@ -9,7 +10,7 @@ import {
   dataMerged,
   getHistory,
   getMostRecentPublishedFlow,
-  getMostRecentPublishedFlowDate,
+  getTemplatedFlows,
   type FlowHistoryEntry,
 } from "../../../../helpers.js";
 import { validateFileTypes } from "./fileTypes.js";
@@ -36,6 +37,15 @@ interface FlowValidateAndDiffResponse {
   message: string;
   validationChecks?: FlowValidationResponse[];
   history: FlowHistoryEntry[] | null;
+  templatedFlows?:
+    | {
+        slug: string;
+        team: {
+          slug: string;
+        };
+        status: FlowStatus;
+      }[]
+    | [];
 }
 
 const validateAndDiffFlow = async (
@@ -85,11 +95,14 @@ const validateAndDiffFlow = async (
     .concat(passingChecks)
     .concat(notApplicableChecks);
 
+  const { templatedFlows } = await getTemplatedFlows(flowId);
+
   return {
     alteredNodes,
     history,
     message: "Changes queued to publish",
     validationChecks: sortedValidationChecks,
+    templatedFlows: templatedFlows,
   };
 };
 

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -92,11 +92,10 @@ beforeEach(() => {
   });
 
   queryMock.mockQuery({
-    name: "GetIsTemplateAndTemplatedFlows",
+    name: "GetTemplatedFlows",
     matchOnVariables: false,
     data: {
       flow: {
-        isTemplate: false,
         templatedFlows: [],
       },
     },

--- a/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -90,6 +90,17 @@ beforeEach(() => {
       ],
     },
   });
+
+  queryMock.mockQuery({
+    name: "GetIsTemplateAndTemplatedFlows",
+    matchOnVariables: false,
+    data: {
+      flow: {
+        isTemplate: false,
+        templatedFlows: [],
+      },
+    },
+  });
 });
 
 const auth = authHeader({ role: "platformAdmin" });

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -20,7 +20,7 @@ export type TemplatedFlows = {
     slug: string;
   };
   status: FlowStatus;
-}[] | [];
+}[];
 
 export const CheckForChangesToPublishButton: React.FC<{
   previewURL: string;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -12,6 +12,15 @@ import { HistoryItem } from "../EditHistory";
 import { AlteredNode } from "./AlteredNodes";
 import { ChangesDialog, NoChangesDialog } from "./PublishDialog";
 import { ValidationCheck } from "./ValidationChecks";
+import { FlowStatus } from "@opensystemslab/planx-core/types";
+
+export type TemplatedFlows = {
+  slug: string;
+  team: {
+    slug: string;
+  };
+  status: FlowStatus;
+}[] | [];
 
 export const CheckForChangesToPublishButton: React.FC<{
   previewURL: string;
@@ -22,12 +31,14 @@ export const CheckForChangesToPublishButton: React.FC<{
     lastPublished,
     lastPublisher,
     validateAndDiffFlow,
+    isTemplate
   ] = useStore((state) => [
     state.id,
     state.publishFlow,
     state.lastPublished,
     state.lastPublisher,
     state.validateAndDiffFlow,
+    state.isTemplate
   ]);
 
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
@@ -38,6 +49,7 @@ export const CheckForChangesToPublishButton: React.FC<{
   );
   const [alteredNodes, setAlteredNodes] = useState<AlteredNode[]>();
   const [history, setHistory] = useState<HistoryItem[]>();
+  const [templatedFlows, setTemplatedFlows] = useState<TemplatedFlows>();
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
 
   const handleCheckForChangesToPublish = async () => {
@@ -54,6 +66,7 @@ export const CheckForChangesToPublishButton: React.FC<{
           : alteredFlow?.data.message,
       );
       setValidationChecks(alteredFlow?.data?.validationChecks);
+      setTemplatedFlows(alteredFlow?.data?.templatedFlows);
       setDialogOpen(true);
     } catch (error) {
       setLastPublishedTitle("Error checking for changes to publish");
@@ -122,6 +135,8 @@ export const CheckForChangesToPublishButton: React.FC<{
             validationChecks={validationChecks}
             previewURL={previewURL}
             handlePublish={handlePublish}
+            isTemplate={isTemplate}
+            templatedFlows={templatedFlows}
           />
         )}
         <Box mr={0}>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -23,6 +23,7 @@ import { CopyButton } from "../../Settings/ServiceSettings/FlowStatus/PublicLink
 import { HistoryItem } from "../EditHistory";
 import { AlteredNode, AlteredNodesSummaryContent } from "./AlteredNodes";
 import { ValidationCheck, ValidationChecks } from "./ValidationChecks";
+import { TemplatedFlows } from "./CheckForChangesButton";
 
 interface NoChangesDialogProps {
   dialogOpen: boolean;
@@ -75,6 +76,8 @@ interface ChangesDialogProps {
   validationChecks: ValidationCheck[];
   previewURL: string;
   handlePublish: (summary: string) => Promise<void>;
+  isTemplate: boolean;
+  templatedFlows?: TemplatedFlows;
 }
 
 export const ChangesDialog = (props: ChangesDialogProps) => {
@@ -87,6 +90,8 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
     validationChecks,
     previewURL,
     handlePublish,
+    isTemplate,
+    templatedFlows,
   } = props;
 
   const steps = ["Review", "Test", "Publish"];
@@ -267,6 +272,11 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
               />
             </ErrorWrapper>
           </InputLabel>
+          {isTemplate && (
+            <Typography variant="body2" my={2}>
+              {`This flow is a template. Publishing it will automatically update the content of ${templatedFlows?.length || 0} templated flows. Each templated flow will still need to be reviewed and published by its' owner.`}
+            </Typography>
+          )}
         </DialogContent>
         <DialogFooterActions>
           <Button onClick={handleBack}>Back</Button>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -6,6 +6,8 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
 import Step from "@mui/material/Step";
 import { stepIconClasses } from "@mui/material/StepIcon";
 import StepLabel from "@mui/material/StepLabel";
@@ -22,8 +24,8 @@ import Input from "ui/shared/Input/Input";
 import { CopyButton } from "../../Settings/ServiceSettings/FlowStatus/PublicLink";
 import { HistoryItem } from "../EditHistory";
 import { AlteredNode, AlteredNodesSummaryContent } from "./AlteredNodes";
-import { ValidationCheck, ValidationChecks } from "./ValidationChecks";
 import { TemplatedFlows } from "./CheckForChangesButton";
+import { ValidationCheck, ValidationChecks } from "./ValidationChecks";
 
 interface NoChangesDialogProps {
   dialogOpen: boolean;
@@ -273,9 +275,23 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
             </ErrorWrapper>
           </InputLabel>
           {isTemplate && (
-            <Typography variant="body2" my={2}>
-              {`This flow is a template. Publishing it will automatically update the content of ${templatedFlows?.length || 0} templated flows. Each templated flow will still need to be reviewed and published by its' owner.`}
-            </Typography>
+            <>
+              <Typography variant="h4" component="h3" mt={2}>
+                {`This flow is a template`}
+              </Typography>
+              <Typography variant="body2" my={2}>
+                {`Publishing it will automatically update the contents of ${templatedFlows?.length || 0} templated flows. Each templated flow will still need to be reviewed and published by its' owner.`}
+              </Typography>
+              {templatedFlows?.length && templatedFlows.length > 0 && (
+                <List dense disablePadding sx={{ listStyleType: 'disc', marginLeft: 2 }}>
+                  {templatedFlows.map((templatedFlow, i) => (
+                    <ListItem key={i} dense disablePadding sx={{ display: 'list-item', fontSize: (theme) => theme.typography.body2 }}>
+                      {`${templatedFlow.team.slug}/${templatedFlow.slug} (${templatedFlow.status})`}
+                    </ListItem>
+                  ))}
+                </List>
+              )}
+            </>
           )}
         </DialogContent>
         <DialogFooterActions>


### PR DESCRIPTION
Simple UI warning when publishing the "source template" ! As only `platformAdmins` can create source templates, we don't have to worry about anyone else seeing this yet - a very good candidate to revisit later to finalise language & styles.

![Screenshot from 2025-05-28 13-16-46](https://github.com/user-attachments/assets/9cc10457-9d22-4307-970f-9234d09a7d5f)