### PR TITLE
fix: breakup GIS API into modular functions

### DIFF
--- a/api.planx.uk/modules/gis/service/classifiedRoads.ts
+++ b/api.planx.uk/modules/gis/service/classifiedRoads.ts
@@ -1,7 +1,7 @@
 import {
   activePlanningConstraints,
-  type Constraint,
-  type GISResponse,
+  type PlanxGISResponse,
+  type PlanxPlanningConstraintCategory,
 } from "@opensystemslab/planx-core/types";
 import type { NextFunction, Request, Response } from "express";
 import fetch from "isomorphic-fetch";
@@ -24,7 +24,7 @@ type OSFeatures = {
   }[];
 };
 
-// this is a meaningful subset of all properties returned, see nock for full sample response object
+// This is a meaningful subset of all properties returned, see nock for full sample response object
 type OSHighwayFeature = {
   OBJECTID: number;
   Identifier: string;
@@ -33,8 +33,12 @@ type OSHighwayFeature = {
   FormsPartOf: string;
 };
 
-interface RoadConstraint extends Constraint {
+interface RoadConstraint {
+  fn: string;
+  value: boolean;
+  text: string;
   data?: OSFeatures["features"];
+  category: PlanxPlanningConstraintCategory;
 }
 
 // Passport key comes from Digital Planning Schemas googlesheet
@@ -138,7 +142,7 @@ export const classifiedRoadsSearch = async (
             category: activePlanningConstraints[PASSPORT_FN].category,
           } as RoadConstraint,
         },
-      } as GISResponse);
+      } as PlanxGISResponse);
     } else {
       return res.json({
         ...baseResponse,
@@ -150,7 +154,7 @@ export const classifiedRoadsSearch = async (
             category: activePlanningConstraints[PASSPORT_FN].category,
           } as RoadConstraint,
         },
-      } as GISResponse);
+      } as PlanxGISResponse);
     }
   } catch (error: any) {
     return next({

--- a/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -1,14 +1,23 @@
 import {
-  activePlanningConstraints,
-  type Constraint,
-  type DigitalLandConstraint,
-  type GISResponse,
-  type Metadata,
+  type PlanxConstraint,
+  type PlanxGISResponse,
 } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
-import fetch from "isomorphic-fetch";
-import { addDesignatedVariable } from "./helpers.js";
+
 import { $api } from "../../../client/index.js";
+import {
+  addArticle4s,
+  addDesignatedVariable,
+  addFloodZone,
+  addIntersections,
+  addListedBuildingGrade,
+  addNots,
+  fetchConstraintsFromPlanningData,
+  fetchMetadataFromPlanningData,
+  getActivePlanningDataConstraints,
+  renameArticle4CAZ,
+  setGranularNationalPark,
+} from "./helpers.js";
 
 import * as barkingAndDagenham from "./local_authorities/metadata/barkingAndDagenham.js";
 import * as barnet from "./local_authorities/metadata/barnet.js";
@@ -74,20 +83,15 @@ async function go(
   localAuthority: string,
   geom: string,
   extras: Record<string, string>,
-): Promise<GISResponse> {
-  // get active planning constraints sourced from "Planning Data" only
-  const activePlanningConstraintsCopy = activePlanningConstraints;
-  delete activePlanningConstraintsCopy["roads.classified"];
-  const baseSchema = activePlanningConstraintsCopy as Record<
-    string,
-    DigitalLandConstraint
-  >;
+): Promise<PlanxGISResponse> {
+  // Get active planning constraints sourced from "Planning Data" only
+  const baseSchema = getActivePlanningDataConstraints();
 
-  // generate list of digital land datasets we should query and their associated passport values
+  // Generate list of datasets we should query and their associated passport values
   const activeDatasets: string[] = [];
   let activeDataValues: string[] = [];
   if (extras?.vals) {
-    // if the editor selected constraints, prioritise their selection
+    // If the editor has selected constraints, prioritise their selection
     activeDataValues = extras.vals.split(",");
     Object.keys(baseSchema).forEach((key) => {
       if (activeDataValues.includes(key)) {
@@ -97,7 +101,7 @@ async function go(
       }
     });
   } else {
-    // else default to the internally maintained list of all "active" datasets
+    // Else default to the internally maintained list of all "active" datasets
     Object.keys(baseSchema).forEach((key) => {
       activeDataValues = Object.keys(baseSchema);
       baseSchema[key]["digital-land-datasets"]?.forEach((dataset: string) => {
@@ -106,26 +110,13 @@ async function go(
     });
   }
 
-  // set up request query params per https://www.planning.data.gov.uk/docs
-  const options = {
-    entries: "current",
-    geometry: geom,
-    geometry_relation: "intersects",
-    exclude_field: "geometry,point",
-    limit: "100", // TODO handle pagination in future for large polygons & many datasets, but should be well within this limit now
-  };
-  // 'dataset' param is not array[string] per docs, instead re-specify param name per unique dataset
-  const datasets = `&dataset=${[...new Set(activeDatasets)].join(`&dataset=`)}`;
+  // Fetch constraints from Planning Data
+  const { res, url } = await fetchConstraintsFromPlanningData(
+    geom,
+    activeDatasets,
+  );
 
-  // fetch records from digital land, will return '{ count: 0, entities: [], links: {..} }' if no intersections
-  const url = `https://www.planning.data.gov.uk/entity.json?${new URLSearchParams(
-    options,
-  )}${datasets}`;
-  const res = await fetch(url)
-    .then((response: { json: () => any }) => response.json())
-    .catch((error: any) => console.log(error));
-
-  // if analytics are "on", store an audit record of the raw response
+  // If analytics are "on", store an audit record of the raw response
   if (extras?.analytics !== "false") {
     const _auditRecord = await $api.client.request(
       gql`
@@ -154,197 +145,56 @@ async function go(
   }
 
   // --- INTERSECTIONS ---
-  // check for & add any 'positive' constraints to the formattedResult
-  let formattedResult: Record<string, Constraint> = {};
+  // Check for & add any 'positive' constraints to the formattedResult
+  let formattedResult: PlanxConstraint = {};
   if (res && res.count > 0 && res.entities) {
-    res.entities.forEach((entity: { dataset: any }) => {
-      // get the planx variable that corresponds to this entity's 'dataset', should never be null because our initial request is filtered on 'dataset'
-      const key = Object.keys(baseSchema).find((key) =>
-        baseSchema[key]["digital-land-datasets"]?.includes(entity.dataset),
-      );
-      // because there can be many digital land datasets per planx variable, check if this key is already in our result
-      if (key && Object.keys(formattedResult).includes(key)) {
-        formattedResult[key]["data"]?.push(entity);
-      } else {
-        if (key) {
-          formattedResult[key] = {
-            fn: key,
-            value: true,
-            text: baseSchema[key].pos,
-            data: [entity],
-            category: baseSchema[key].category,
-          };
-        }
-      }
-    });
+    formattedResult = addIntersections(res, baseSchema, formattedResult);
   }
 
   // --- NOTS ---
-  // add active, non-intersecting planning constraints to the formattedResult
-  // TODO followup with digital land about how to return 'nots' via API (currently assumes any "active" metadata was successfully queried)
-  const nots = Object.keys(baseSchema).filter(
-    (key) =>
-      activeDataValues.includes(key) &&
-      !Object.keys(formattedResult).includes(key),
-  );
-  nots.forEach((not) => {
-    formattedResult[not] = {
-      fn: not,
-      value: false,
-      text: baseSchema[not].neg,
-      category: baseSchema[not].category,
-    };
-  });
+  // Add active, non-intersecting planning constraints to the formattedResult
+  // TODO followup with PD about how to distinguish 'nots' via API response (eg "false negatives" issue)
+  formattedResult = addNots(activeDataValues, baseSchema, formattedResult);
 
   // --- DESIGNATED LAND ---
   // add top-level 'designated' variable based on granular query results
   formattedResult = addDesignatedVariable(formattedResult);
 
-  // set granular `designated.nationalPark.broads` based on entity id (eventually extract to helper method if other cases like this)
-  const broads = "designated.nationalPark.broads";
-  if (
-    formattedResult["designated.nationalPark"] &&
-    formattedResult["designated.nationalPark"].value
-  ) {
-    formattedResult["designated.nationalPark"]?.data?.forEach((entity: any) => {
-      if (
-        baseSchema[broads]["digital-land-entities"]?.includes(entity.entity)
-      ) {
-        formattedResult[broads] = {
-          fn: broads,
-          value: true,
-          text: baseSchema[broads].pos,
-        };
-      }
-    });
-  } else {
-    // only add the granular variable if the response already includes the parent one
-    if (formattedResult["designated.nationalPark"])
-      formattedResult[broads] = { fn: broads, value: false };
-  }
+  // Set granular `designated.nationalPark.broads` based on entity ID
+  formattedResult = setGranularNationalPark(baseSchema, formattedResult);
 
   // --- FLOODING ---
-  const zoneLookup: Record<string, string> = {
-    "flood.zone.2": "flood.zoneTwo",
-    "flood.zone.3": "flood.zoneThree",
-  };
-  if (formattedResult["flood"] && formattedResult["flood"].value) {
-    Object.keys(zoneLookup).forEach(
-      (oldZone) =>
-        (formattedResult[zoneLookup[oldZone]] = {
-          fn: zoneLookup[oldZone],
-          value: Boolean(
-            formattedResult["flood"].data?.filter(
-              (entity) =>
-                entity["flood-risk-level"] === oldZone.split(".").pop(),
-            ).length,
-          ),
-        }),
-    );
-  }
+  formattedResult = addFloodZone(formattedResult);
 
   // --- LISTED BUILDINGS ---
-  const gradeLookup: Record<string, string> = {
-    "listed.grade.I": "listed.gradeOne",
-    "listed.grade.II": "listed.gradeTwo",
-    "listed.grade.II*": "listed.gradeTwoStar",
-  };
-  if (formattedResult["listed"] && formattedResult["listed"].value) {
-    Object.keys(gradeLookup).forEach(
-      (oldGrade) =>
-        (formattedResult[gradeLookup[oldGrade]] = {
-          fn: gradeLookup[oldGrade],
-          value: Boolean(
-            formattedResult["listed"].data?.filter(
-              (entity) =>
-                entity["listed-building-grade"] === oldGrade.split(".").pop(),
-            ).length,
-          ),
-        }),
-    );
-  }
+  formattedResult = addListedBuildingGrade(formattedResult);
 
   // --- ARTICLE 4S ---
-  // only attempt to set granular a4s if we have metadata for this local authority; proceed with non-granular a4 queries under "opensystemslab" team etc
+  // Only attempt to set granular a4s if we have metadata for this local authority; proceed with non-granular a4 queries under "opensystemslab" team etc
   if (Object.keys(localAuthorityMetadata).includes(localAuthority)) {
-    // get the article 4 schema map for this local authority
+    // Get the article 4 schema map for this local authority
     const { planningConstraints } = localAuthorityMetadata[localAuthority];
     const a4s = planningConstraints["articleFour"]["records"] || undefined;
 
-    // loop through any intersecting a4 data entities and set granular planx values based on this local authority's schema
+    // Loop through any intersecting a4 data entities and set granular planx values based on this local authority's schema
     if (a4s && formattedResult["articleFour"]?.value) {
-      formattedResult["articleFour"]?.data?.forEach((entity: any) => {
-        Object.keys(a4s)?.forEach((key) => {
-          if (
-            // these are various ways we link source data to granular planx values (see local_authorities/metadata for specifics)
-            entity.name.replace(/\r?\n|\r/g, " ") === a4s[key] ||
-            entity.reference === a4s[key] ||
-            entity?.["article-4-direction"] === a4s[key] ||
-            entity?.notes === a4s[key] ||
-            entity?.description?.startsWith(a4s[key]) ||
-            formattedResult[key]?.value // if this granular var is already true, make sure it remains true
-          ) {
-            formattedResult[key] = { fn: key, value: true };
-          } else {
-            formattedResult[key] = { fn: key, value: false };
-          }
-        });
-      });
+      formattedResult = addArticle4s(a4s, formattedResult);
     }
 
-    // rename `articleFour.caz` to reflect localAuthority if applicable, ensuring `councilName` segment matches other A4 values (not always same as team-slug)
-    const customTeamSlugs: Record<string, string> = {
-      "barking-and-dagenham": "barkingAndDagenham",
-      "epsom-and-ewell": "epsomAndEwell",
-      "st-albans": "stAlbans",
-      "west-berkshire": "westBerkshire",
-    };
-    const localCaz = Object.keys(customTeamSlugs).includes(localAuthority)
-      ? `articleFour.${customTeamSlugs[localAuthority]}.caz`
-      : `articleFour.${localAuthority}.caz`;
-    if (formattedResult["articleFour.caz"]) {
-      formattedResult[localCaz] = formattedResult["articleFour.caz"];
-      delete formattedResult["articleFour.caz"];
-
-      // if caz is true, but parent a4 is false, sync a4 for accurate granularity
-      if (
-        formattedResult[localCaz]?.value &&
-        !formattedResult["articleFour"]?.value
-      ) {
-        formattedResult["articleFour"] = {
-          fn: "articleFour",
-          value: true,
-          text: baseSchema["articleFour"].pos,
-          data: formattedResult[localCaz].data,
-          category: baseSchema["articleFour"].category,
-        };
-      }
-    }
+    // Rename `articleFour.caz` to reflect localAuthority if applicable, ensuring `councilName` segment matches other A4 values (not always same as team-slug)
+    formattedResult = renameArticle4CAZ(
+      localAuthority,
+      baseSchema,
+      formattedResult,
+    );
   }
 
   // --- METADATA ---
-  // additionally fetch metadata from Digital Land's "dataset" endpoint for extra context
-  const metadata: Record<string, Metadata> = {};
-  const urls = activeDatasets.map(
-    (dataset) => `https://www.planning.data.gov.uk/dataset/${dataset}.json`,
+  // Additionally fetch metadata from Digital Land's "dataset" endpoint for extra context
+  const metadata = await fetchMetadataFromPlanningData(
+    activeDatasets,
+    baseSchema,
   );
-  await Promise.all(
-    urls.map((url) =>
-      fetch(url)
-        .then((response: { json: () => any }) => response.json())
-        .catch((error: any) => console.log(error)),
-    ),
-  )
-    .then((responses) => {
-      responses.forEach((response: any) => {
-        // get the planx variable that corresponds to this 'dataset', should never be null because we only requested known datasets
-        const key = Object.keys(baseSchema).find((key) =>
-          baseSchema[key]["digital-land-datasets"]?.includes(response.dataset),
-        );
-        if (key) metadata[key] = response;
-      });
-    })
-    .catch((error) => console.log(error));
 
   return {
     sourceRequest: url,

--- a/api.planx.uk/modules/gis/service/helpers.test.ts
+++ b/api.planx.uk/modules/gis/service/helpers.test.ts
@@ -1,0 +1,108 @@
+import { type PlanxConstraint } from "@opensystemslab/planx-core/types";
+import {
+  getActivePlanningDataConstraints,
+  renameArticle4CAZ,
+} from "./helpers.js";
+
+const baseSchema = getActivePlanningDataConstraints();
+
+describe.todo("add intersections");
+
+describe.todo("add _nots");
+
+describe.todo("add `designated` variable");
+
+describe.todo("set granular `designated.nationalPark.broads`");
+
+describe.todo("add flood zones");
+
+describe.todo("add listed building grades");
+
+describe.todo("add article 4s");
+
+describe("rename `article4.caz` based on local authority", () => {
+  test("renames correctly for a one-word local authority", () => {
+    const mockIncomingResult: PlanxConstraint = {
+      "articleFour.caz": {
+        value: false,
+      },
+    };
+    const result = renameArticle4CAZ("lambeth", baseSchema, mockIncomingResult);
+
+    expect(result).toEqual({
+      "articleFour.lambeth.caz": {
+        value: false,
+      },
+    });
+  });
+
+  test("renames correctly for a hyphenated local authority", () => {
+    const mockIncomingResult: PlanxConstraint = {
+      "articleFour.caz": {
+        value: false,
+      },
+    };
+    const result = renameArticle4CAZ(
+      "west-berkshire",
+      baseSchema,
+      mockIncomingResult,
+    );
+
+    expect(result).toEqual({
+      "articleFour.westBerkshire.caz": {
+        value: false,
+      },
+    });
+  });
+
+  test("if parent a4 is false but caz is true, syncs caz data to parent", () => {
+    const mockIncomingResult: PlanxConstraint = {
+      articleFour: {
+        value: false,
+      },
+      "articleFour.caz": {
+        value: true,
+        text: "is in the Central Activities Zone",
+        data: [
+          {
+            entity: 1,
+            dataset: "central-activities-zone",
+            name: "Downtown",
+          },
+        ],
+      },
+    };
+    const result = renameArticle4CAZ(
+      "st-albans",
+      baseSchema,
+      mockIncomingResult,
+    );
+
+    expect(result).toEqual({
+      articleFour: {
+        fn: "articleFour",
+        value: true,
+        text: "is in an Article 4 direction area",
+        data: [
+          {
+            entity: 1,
+            dataset: "central-activities-zone",
+            name: "Downtown",
+          },
+        ],
+        category: "General policy",
+      },
+      "articleFour.stAlbans.caz": {
+        value: true,
+        text: "is in the Central Activities Zone",
+        data: [
+          {
+            entity: 1,
+            dataset: "central-activities-zone",
+            name: "Downtown",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/api.planx.uk/modules/gis/service/helpers.ts
+++ b/api.planx.uk/modules/gis/service/helpers.ts
@@ -1,33 +1,315 @@
-// Adds "designated" variable to response object, so we can auto-answer less granular questions like "are you on designated land"
-const addDesignatedVariable = (responseObject: any) => {
-  const resObjWithDesignated = {
-    ...responseObject,
-    designated: { value: false },
+import {
+  activePlanningConstraints,
+  type DigitalLandConstraint,
+  type MinimumDigitalLandEntitiesResponse,
+  type PlanxConstraint,
+  type PlanxMetadata,
+} from "@opensystemslab/planx-core/types";
+import fetch from "isomorphic-fetch";
+
+const getActivePlanningDataConstraints = (): Record<
+  string,
+  DigitalLandConstraint
+> => {
+  const activePlanningConstraintsCopy = activePlanningConstraints;
+  delete activePlanningConstraintsCopy["roads.classified"];
+
+  return activePlanningConstraintsCopy as Record<string, DigitalLandConstraint>;
+};
+
+const fetchConstraintsFromPlanningData = async (
+  geom: string,
+  activeDatasets: string[],
+): Promise<{ res: MinimumDigitalLandEntitiesResponse; url: string }> => {
+  // Set up request query params per https://www.planning.data.gov.uk/docs
+  const options = {
+    entries: "current",
+    geometry: geom,
+    geometry_relation: "intersects",
+    exclude_field: "geometry,point",
+    limit: "100", // TODO handle pagination in future for large polygons & many datasets, but should be well within this limit now
+  };
+  // 'dataset' param is not array[string] per docs, instead re-specify param name per unique dataset
+  const datasets = `&dataset=${[...new Set(activeDatasets)].join(`&dataset=`)}`;
+
+  // Fetch records from digital land, will return '{ count: 0, entities: [], links: {..} }' if no intersections
+  const url = `https://www.planning.data.gov.uk/entity.json?${new URLSearchParams(
+    options,
+  )}${datasets}`;
+  const res = await fetch(url)
+    .then((response: { json: () => any }) => response.json())
+    .catch((error: any) => console.log(error));
+
+  return { res, url };
+};
+
+const fetchMetadataFromPlanningData = async (
+  activeDatasets: string[],
+  baseSchema: Record<string, DigitalLandConstraint>,
+): Promise<PlanxMetadata> => {
+  const metadata: PlanxMetadata = {};
+  const urls = activeDatasets.map(
+    (dataset) => `https://www.planning.data.gov.uk/dataset/${dataset}.json`,
+  );
+
+  await Promise.all(
+    urls.map((url) =>
+      fetch(url)
+        .then((response: { json: () => any }) => response.json())
+        .catch((error: any) => console.log(error)),
+    ),
+  )
+    .then((responses) => {
+      responses.forEach((response: any) => {
+        // Get the Planx variable that corresponds to this 'dataset', should never be null because we only requested known datasets
+        const key = Object.keys(baseSchema).find((key) =>
+          baseSchema[key]["digital-land-datasets"]?.includes(response.dataset),
+        );
+        if (key) metadata[key] = response;
+      });
+    })
+    .catch((error) => console.log(error));
+
+  return metadata;
+};
+
+const addIntersections = (
+  digitalLandRes: MinimumDigitalLandEntitiesResponse,
+  baseSchema: Record<string, DigitalLandConstraint>,
+  result: PlanxConstraint,
+): PlanxConstraint => {
+  digitalLandRes.entities.forEach((entity) => {
+    // Get the planx variable that corresponds to this entity's 'dataset', should never be null because our initial request is filtered on 'dataset'
+    const key = Object.keys(baseSchema).find((key) =>
+      baseSchema[key]["digital-land-datasets"]?.includes(entity.dataset),
+    );
+    // Because there can be many digital land datasets per planx variable, check if this key is already in our result
+    if (key && Object.keys(result).includes(key)) {
+      result[key]["data"]?.push(entity);
+    } else {
+      if (key) {
+        result[key] = {
+          fn: key,
+          value: true,
+          text: baseSchema[key].pos,
+          data: [entity],
+          category: baseSchema[key].category,
+        };
+      }
+    }
+  });
+
+  return result;
+};
+
+const addNots = (
+  activeDataValues: string[],
+  baseSchema: Record<string, DigitalLandConstraint>,
+  result: PlanxConstraint,
+): PlanxConstraint => {
+  const nots = Object.keys(baseSchema).filter(
+    (key) =>
+      activeDataValues.includes(key) && !Object.keys(result).includes(key),
+  );
+
+  nots.forEach((not) => {
+    result[not] = {
+      fn: not,
+      value: false,
+      text: baseSchema[not].neg,
+      category: baseSchema[not].category,
+    };
+  });
+
+  return result;
+};
+
+// Adds "designated" variable to result object, so we can auto-answer less granular questions like "are you on designated land"
+const addDesignatedVariable = (result: PlanxConstraint): PlanxConstraint => {
+  const resultWithDesignated: PlanxConstraint = {
+    ...result,
+    designated: {
+      value: false,
+    },
   };
 
   const subVariables = ["conservationArea", "AONB", "nationalPark", "WHS"];
 
   // If any of the subvariables are true, then set "designated" to true
   subVariables.forEach((s) => {
-    if (resObjWithDesignated[`designated.${s}`]?.value) {
-      resObjWithDesignated["designated"] = { value: true };
+    if (resultWithDesignated[`designated.${s}`]?.value) {
+      resultWithDesignated["designated"] = {
+        value: true,
+      };
     }
   });
 
-  // Ensure that our response includes all the expected subVariables before returning "designated"
+  // Ensure that our result includes all the expected subVariables before returning "designated"
   //   so we don't incorrectly auto-answer any questions for individual layer queries that may have failed
   let subVariablesFound = 0;
-  Object.keys(responseObject).forEach((key) => {
+  Object.keys(result).forEach((key) => {
     if (key.startsWith(`designated.`)) {
       subVariablesFound++;
     }
   });
 
   if (subVariablesFound < subVariables.length) {
-    return responseObject;
+    return result;
   } else {
-    return resObjWithDesignated;
+    return resultWithDesignated;
   }
 };
 
-export { addDesignatedVariable };
+const setGranularNationalPark = (
+  baseSchema: Record<string, DigitalLandConstraint>,
+  result: PlanxConstraint,
+): PlanxConstraint => {
+  const broads = "designated.nationalPark.broads";
+
+  if (
+    result["designated.nationalPark"] &&
+    result["designated.nationalPark"].value
+  ) {
+    result["designated.nationalPark"]?.data?.forEach((entity: any) => {
+      if (
+        baseSchema[broads]["digital-land-entities"]?.includes(entity.entity)
+      ) {
+        result[broads] = {
+          fn: broads,
+          value: true,
+          text: baseSchema[broads].pos,
+        };
+      }
+    });
+  } else {
+    // Only add the granular variable if the response already includes the parent one
+    if (result["designated.nationalPark"])
+      result[broads] = { fn: broads, value: false };
+  }
+
+  return result;
+};
+
+const addFloodZone = (result: PlanxConstraint): PlanxConstraint => {
+  const zoneLookup: Record<string, string> = {
+    "flood.zone.2": "flood.zoneTwo",
+    "flood.zone.3": "flood.zoneThree",
+  };
+
+  if (result["flood"] && result["flood"].value) {
+    Object.keys(zoneLookup).forEach(
+      (oldZone) =>
+        (result[zoneLookup[oldZone]] = {
+          fn: zoneLookup[oldZone],
+          value: Boolean(
+            result["flood"].data?.filter(
+              (entity) =>
+                entity["flood-risk-level"] === oldZone.split(".").pop(),
+            ).length,
+          ),
+        }),
+    );
+  }
+
+  return result;
+};
+
+const addListedBuildingGrade = (result: PlanxConstraint): PlanxConstraint => {
+  const gradeLookup: Record<string, string> = {
+    "listed.grade.I": "listed.gradeOne",
+    "listed.grade.II": "listed.gradeTwo",
+    "listed.grade.II*": "listed.gradeTwoStar",
+  };
+
+  if (result["listed"] && result["listed"].value) {
+    Object.keys(gradeLookup).forEach(
+      (oldGrade) =>
+        (result[gradeLookup[oldGrade]] = {
+          fn: gradeLookup[oldGrade],
+          value: Boolean(
+            result["listed"].data?.filter(
+              (entity) =>
+                entity["listed-building-grade"] === oldGrade.split(".").pop(),
+            ).length,
+          ),
+        }),
+    );
+  }
+
+  return result;
+};
+
+const addArticle4s = (
+  a4s: Record<string, string>,
+  result: PlanxConstraint,
+): PlanxConstraint => {
+  // Loop through any intersecting a4 data entities and set granular planx values based on this local authority's schema
+  result["articleFour"]?.data?.forEach((entity: any) => {
+    Object.keys(a4s)?.forEach((key) => {
+      if (
+        // These are various ways we link source data to granular Planx values (see local_authorities/metadata for specifics)
+        entity.name.replace(/\r?\n|\r/g, " ") === a4s[key] ||
+        entity.reference === a4s[key] ||
+        entity?.["article-4-direction"] === a4s[key] ||
+        entity?.notes === a4s[key] ||
+        entity?.description?.startsWith(a4s[key]) ||
+        result[key]?.value // If this granular var is already true, make sure it remains true
+      ) {
+        result[key] = { fn: key, value: true };
+      } else {
+        result[key] = { fn: key, value: false };
+      }
+    });
+  });
+
+  return result;
+};
+
+const renameArticle4CAZ = (
+  localAuthority: string,
+  baseSchema: Record<string, DigitalLandConstraint>,
+  result: PlanxConstraint,
+): PlanxConstraint => {
+  const customTeamSlugs: Record<string, string> = {
+    "barking-and-dagenham": "barkingAndDagenham",
+    "epsom-and-ewell": "epsomAndEwell",
+    "st-albans": "stAlbans",
+    "west-berkshire": "westBerkshire",
+  };
+
+  const localCaz = Object.keys(customTeamSlugs).includes(localAuthority)
+    ? `articleFour.${customTeamSlugs[localAuthority]}.caz`
+    : `articleFour.${localAuthority}.caz`;
+
+  if (result["articleFour.caz"]) {
+    result[localCaz] = result["articleFour.caz"];
+    delete result["articleFour.caz"];
+
+    // If caz is true, but parent a4 is false, sync parent a4 for accurate granularity
+    if (result[localCaz]?.value && !result["articleFour"]?.value) {
+      result["articleFour"] = {
+        fn: "articleFour",
+        value: true,
+        text: baseSchema["articleFour"].pos,
+        data: result[localCaz].data,
+        category: baseSchema["articleFour"].category,
+      };
+    }
+  }
+
+  return result;
+};
+
+export {
+  addArticle4s,
+  addDesignatedVariable,
+  addFloodZone,
+  addIntersections,
+  addListedBuildingGrade,
+  addNots,
+  getActivePlanningDataConstraints,
+  fetchConstraintsFromPlanningData,
+  fetchMetadataFromPlanningData,
+  renameArticle4CAZ,
+  setGranularNationalPark,
+};

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.8",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#9f8d3d6",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#58269c5",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.8.3",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^3.701.0
         version: 3.812.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#9f8d3d6
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab5053(@types/react@19.1.4)
+        specifier: git+https://github.com/theopensystemslab/planx-core#58269c5
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/58269c5(@types/react@19.1.4)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1009,8 +1009,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab5053':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab5053}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/58269c5':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/58269c5}
     version: 1.0.0
 
   '@paralleldrive/cuid2@2.2.2':
@@ -5151,7 +5151,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/0ab5053(@types/react@19.1.4)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/58269c5(@types/react@19.1.4)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.4)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.4)(react@18.3.1))(@types/react@19.1.4)(react@18.3.1)


### PR DESCRIPTION
Was debugging a recent #help-issues report today where the payload had a value `articleFour.west-berkshire.caz`, when it should be transformed to `articleFour.westBerkshire.caz` based on this recent change: https://github.com/theopensystemslab/planx-new/pull/4674

The current GIS API functions are _very_ dense & hard to debug or unit test - so long overdue refactor here to split some of the formatting logic out into modular helper functions that we can write simpler tests against

Attempting to tighten up types too - see https://github.com/theopensystemslab/planx-core/pull/741