### PR TITLE
fix: as long as `fastTrackAmount` is set, `SetFee` should always write `appplication.fee.fastTrack` and `application.fee.fastTrack.VAT` to passport (0 when not applicable)

### DIFF
--- a/editor.planx.uk/src/@planx/components/SetFee/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/SetFee/utils.test.ts
@@ -78,7 +78,7 @@ describe("handleSetFees() function", () => {
   });
 
   describe("adding Fast Track fee", () => {
-    it("does not add Fast Track if passport does not have `application.fastTrack` present", () => {
+    it("adds 0 Fast Track (for Gov Pay metadata) if passport does not have `application.fastTrack` present but Fast Track amount is greater than 0", () => {
       const incomingPassport: Store.Passport = {
         data: {
           "application.fee.calculated": 200,
@@ -97,6 +97,8 @@ describe("handleSetFees() function", () => {
         "application.fee.calculated": 200,
         "application.fee.payable": 200,
         "application.fee.payable.VAT": 0,
+        "application.fee.fastTrack": 0,
+        "application.fee.fastTrack.VAT": 0,
       });
     });
 

--- a/editor.planx.uk/src/@planx/components/SetFee/utils.ts
+++ b/editor.planx.uk/src/@planx/components/SetFee/utils.ts
@@ -56,17 +56,21 @@ export const handleSetFees: HandleSetFees = ({
     fees[payableVAT] = calculatedVAT;
   }
 
-  const addFastTrack =
-    passport.data &&
-    Object.hasOwn(passport.data, "application.fastTrack") && // Any passport value is okay/expected here, checking for presence of key only
-    fastTrackFeeAmount > 0;
+  const addFastTrack = fastTrackFeeAmount > 0;
   if (addFastTrack) {
-    const fastTrackVAT = fastTrackFeeAmount * VAT_PERCENTAGE;
+    // The fastTrackFeeAmount applies if `application.fastTrack` is present in the passport (any value is okay/expected, checking presence only)
+    if (passport.data && Object.hasOwn(passport.data, "application.fastTrack")) {
+      const fastTrackVAT = fastTrackFeeAmount * VAT_PERCENTAGE;
 
-    fees["application.fee.fastTrack"] = fastTrackFeeAmount;
-    fees["application.fee.fastTrack.VAT"] = fastTrackVAT;
-    fees[payable] = fees[payable] + fastTrackFeeAmount + fastTrackVAT;
-    fees[payableVAT] = fees[payableVAT] + fastTrackVAT;
+      fees["application.fee.fastTrack"] = fastTrackFeeAmount;
+      fees["application.fee.fastTrack.VAT"] = fastTrackVAT;
+      fees[payable] = fees[payable] + fastTrackFeeAmount + fastTrackVAT;
+      fees[payableVAT] = fees[payableVAT] + fastTrackVAT;
+    } else {
+      // If this flow set a fastTrackFeeAmount, but `application.fastTrack` does not apply, still capture 0 for Gov Pay metadata reporting
+      fees["application.fee.fastTrack"] = 0;
+      fees["application.fee.fastTrack.VAT"] = 0;
+    }
   }
 
   const addServiceCharge =


### PR DESCRIPTION
Per Doncaster testing feedback here https://opendigitalplanning.slack.com/archives/C07491E8W68/p1748447435984969

Previously, we'd only write `application.fee.fastTrack` and `application.fee.fastTrack.VAT` to the passport _if_ the `fastTrackAmount` was set _and_ Fast Track was applicable to this journey (passport has `application.fastTrack`). 

Now, we write to the passport based on the first condition only, capture the `fastTrackAmount` if applicable and 0 if not applicable. Services with a `SetFee` component that do _not_ set the `fastTrackAmount` > 0 will still never produce a passport with these variables (omitted rather than 0). 