### PR TITLE
fix(data-sync): Remove dropped `metabase_id` column from sync script

### DIFF
--- a/scripts/seed-database/write/teams.sql
+++ b/scripts/seed-database/write/teams.sql
@@ -5,8 +5,7 @@ CREATE TEMPORARY TABLE sync_teams (
   slug text,
   created_at timestamptz,
   updated_at timestamptz,
-  domain text,
-  metabase_id integer
+  domain text
 );
 
 \copy sync_teams FROM '/tmp/teams.csv' WITH (FORMAT csv, DELIMITER ';');


### PR DESCRIPTION
The `teams.metabase_id` column was dropped here - https://github.com/theopensystemslab/planx-new/pull/4648/files#diff-0734838125aee00e4d8d0447fb7a75060d2fdbf79ee8628ee2e423ece0ccc7b6

As the data-sync script is trying to access it, [the process is failing](https://github.com/theopensystemslab/planx-new/actions/runs/15336082691/job/43153507762).

```sh
psql:write/teams.sql:12: ERROR:  missing data for column "metabase_id"
Database sync failed!
Error: Process completed with exit code 1.
```

Tested locally with `pnpm test-sync` ✅ 