### PR TITLE
feat: for templated flows, show when the source was last published if your template is due to publish

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -145,7 +145,7 @@ export const CheckForChangesToPublishButton: React.FC<{
             <Typography variant="body2" mt={2} sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
               {isTemplatedFlowDueToPublish 
                 ? `Your templated flow is due for review and publish.`
-                : `Your templated flow is up to date with the source, no action needed.`
+                : `Your templated flow is up to date with the source.`
               }
             </Typography>
           </Box>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -1,18 +1,21 @@
+import StarIcon from "@mui/icons-material/Star";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
+import { FlowStatus } from "@opensystemslab/planx-core/types";
 import { logger } from "airbrake";
 import { AxiosError } from "axios";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { formatLastPublishMessage } from "pages/FlowEditor/utils";
 import React, { useState } from "react";
 import { useAsync } from "react-use";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import BlockQuote from "ui/editor/BlockQuote";
 
 import { HistoryItem } from "../EditHistory";
 import { AlteredNode } from "./AlteredNodes";
 import { ChangesDialog, NoChangesDialog } from "./PublishDialog";
 import { ValidationCheck } from "./ValidationChecks";
-import { FlowStatus } from "@opensystemslab/planx-core/types";
 
 export type TemplatedFlows = {
   slug: string;
@@ -31,19 +34,26 @@ export const CheckForChangesToPublishButton: React.FC<{
     lastPublished,
     lastPublisher,
     validateAndDiffFlow,
-    isTemplate
+    isTemplate,
+    isTemplatedFrom,
+    template
   ] = useStore((state) => [
     state.id,
     state.publishFlow,
     state.lastPublished,
     state.lastPublisher,
     state.validateAndDiffFlow,
-    state.isTemplate
+    state.isTemplate,
+    state.isTemplatedFrom,
+    state.template
   ]);
 
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
     "This flow is not published yet",
   );
+  const [templateLastPublishedTitle, setTemplateLastPublishedTitle] = useState<string>();
+  const [isTemplatedFlowDueToPublish, setIsTemplatedFlowDueToPublish] = useState<boolean>(false);
+
   const [validationChecks, setValidationChecks] = useState<ValidationCheck[]>(
     [],
   );
@@ -102,7 +112,17 @@ export const CheckForChangesToPublishButton: React.FC<{
     const date = await lastPublished(flowId);
     const user = await lastPublisher(flowId);
     setLastPublishedTitle(formatLastPublishMessage(date, user));
-  }, [flowId]);
+
+    if (template) {
+      const sourceTemplateUser = await lastPublisher(template.id);
+      const sourceTemplateDate = template.publishedFlows[0].publishedAt;
+      setTemplateLastPublishedTitle(formatLastPublishMessage(sourceTemplateDate, sourceTemplateUser));
+
+      if (date) {
+        setIsTemplatedFlowDueToPublish(sourceTemplateDate > date);
+      }
+    }
+  }, [flowId, template]);
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];
@@ -110,6 +130,26 @@ export const CheckForChangesToPublishButton: React.FC<{
   return (
     <Box width="100%" mt={2}>
       <Box display="flex" flexDirection="column" alignItems="flex-end">
+        {isTemplatedFrom && template && (
+          <Box sx={{ background: "#E6D6FF", border: theme => `1px solid ${theme.palette.border.main}`, width: "100%", padding: theme => theme.spacing(1), marginBottom: theme => theme.spacing(2) }}>
+            <Typography variant="body2" sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+              <StarIcon sx={{ color: "#380F77" }} />
+              {`Templated from ${template.team.name}`}
+            </Typography>
+            <Typography variant="body2">
+              {templateLastPublishedTitle}
+            </Typography>
+            <BlockQuote>
+              {template.publishedFlows[0]?.summary}
+            </BlockQuote>
+            <Typography variant="body2" mt={2} sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+              {isTemplatedFlowDueToPublish 
+                ? `Your templated flow is due for review and publish.`
+                : `Your templated flow is up to date with the source, no action needed.`
+              }
+            </Typography>
+          </Box>
+        )}
         <Button
           data-testid="check-for-changes-to-publish-button"
           sx={{ width: "100%" }}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -177,6 +177,16 @@ export interface EditorStore extends Store.Store {
   isFlowPublished: boolean;
   isTemplate: boolean;
   isTemplatedFrom: boolean;
+  template?: {
+    id: string;
+    team: {
+      name: string;
+    }
+    publishedFlows: {
+      publishedAt: string;
+      summary: string;
+    }[];
+  };
   makeUnique: (id: NodeId, parent?: NodeId) => void;
   moveFlow: (
     flowId: string,
@@ -491,6 +501,8 @@ export const editorStore: StateCreator<
   isTemplate: false,
 
   isTemplatedFrom: false,
+
+  template: undefined,
 
   makeUnique: (id, parent) => {
     const [, ops] = makeUnique(id, parent)(get().flow);

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -15,6 +15,16 @@ interface FlowEditorData {
   templatedFrom: string;
   isTemplate: boolean;
   isFlowPublished: boolean;
+  template?: {
+    id: string;
+    team: {
+      name: string;
+    }
+    publishedFlows: {
+      publishedAt: string;
+      summary: string;
+    }[];
+  };
 }
 
 interface GetFlowEditorData {
@@ -29,6 +39,16 @@ interface GetFlowEditorData {
         count: number;
       };
     };
+    template: {
+      id: string;
+      team: {
+        name: string;
+      }
+      publishedFlows: {
+        publishedAt: string;
+        summary: string;
+      }[];
+    } | null;
   }[];
 }
 
@@ -54,6 +74,19 @@ export const getFlowEditorData = async (
             aggregate {
               count
             }
+          },
+          template {
+            id
+            team {
+              name
+            }
+            publishedFlows: published_flows(
+              order_by: { created_at: desc }
+              limit: 1
+            ) {
+              publishedAt: created_at
+              summary
+            }
           }
         }
       }
@@ -74,6 +107,7 @@ export const getFlowEditorData = async (
     templatedFrom: flow.templatedFrom,
     isTemplate: flow.isTemplate,
     isFlowPublished: flow.publishedFlowsAggregate?.aggregate.count > 0,
+    template: flow.template ? flow.template : undefined,
   };
 
   return flowEditorData;
@@ -91,6 +125,7 @@ export const flowEditorView = async (req: NaviRequest) => {
     isFlowPublished,
     isTemplate,
     templatedFrom,
+    template,
   } = await getFlowEditorData(flow, req.params.team);
 
   useStore.setState({
@@ -100,6 +135,7 @@ export const flowEditorView = async (req: NaviRequest) => {
     isFlowPublished,
     isTemplate,
     isTemplatedFrom: Boolean(templatedFrom),
+    template,
   });
 
   return (


### PR DESCRIPTION
Like other PRs, aiming to introduce functional logic here but with still very rough styles that can be iterated on !

If the source template has been published more recently: 
![Screenshot from 2025-05-30 10-26-18](https://github.com/user-attachments/assets/91cf5994-0c78-40ec-941f-958a30e21fb7)

If your template has been published more recently:
![Screenshot from 2025-05-30 12-00-44](https://github.com/user-attachments/assets/328704c8-986f-49f8-b763-3f752d4cf179)

Open questions:
- Currently, I'm just comparing publish dates between your templated flow and its' source - how do we additionally communicate, "your templated flow is up to date with the source, _but_ you have unpublished customisations" 