### PR TITLE
chore: Grant public role access to flow description, summary, and limitations

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -313,12 +313,15 @@ select_permissions:
         - created_at
         - creator_id
         - data
+        - description
         - id
         - is_template
+        - limitations
         - name
         - settings
         - slug
         - status
+        - summary
         - team_id
         - templated_from
         - updated_at


### PR DESCRIPTION
- Grants public role access to `flows.description`, `flows.summary` and `flows.limitations`
- No warning / alert required in Editor
- Required for localplanning.services