### PR TITLE
chore: Configure CORS to allow requests from localplanning.services to Hasura (staging/prod)

### DIFF
--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -123,6 +123,7 @@ export const createHasuraService = async ({
               name: "HASURA_GRAPHQL_CORS_DOMAIN",
               value: [...CUSTOM_DOMAINS.map((x: any) => x.domain), DOMAIN]
                 .map((x) => `https://*.${x}, https://${x}`)
+                .concat("https://localplanning.services")
                 .join(", "),
             },
             {


### PR DESCRIPTION
- Updates the env var `HASURA_GRAPHQL_CORS_DOMAIN` on Hasura (staging and prod) to allow requests from https://localplanning.services
- `.env` and `.env.example` do not need to be updates as requests will be coming from a `.pizza` domain which is already configures
- Currently, we're not planning on making requests to the PlanX REST API from localplanning.services