### PR TITLE
fix: `lastPublished` and `lastPublisher` queries should use `flows_by_pk`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -438,8 +438,8 @@ export const editorStore: StateCreator<
   lastPublished: async (flowId: string) => {
     const { data } = await client.query({
       query: gql`
-        query GetLastPublishedFlow($id: uuid) {
-          flows(limit: 1, where: { id: { _eq: $id } }) {
+        query GetLastPublishedFlow($id: uuid!) {
+          flow: flows_by_pk(id: $id) {
             published_flows(order_by: { created_at: desc }, limit: 1) {
               created_at
             }
@@ -451,7 +451,7 @@ export const editorStore: StateCreator<
       },
     });
 
-    const lastPublishedDate = data.flows[0].published_flows[0].created_at;
+    const lastPublishedDate = data.flow.published_flows[0].created_at;
     set({ lastPublishedDate });
     return lastPublishedDate;
   },
@@ -465,8 +465,8 @@ export const editorStore: StateCreator<
   lastPublisher: async (flowId: string) => {
     const { data } = await client.query({
       query: gql`
-        query GetLastPublisher($id: uuid) {
-          flows(limit: 1, where: { id: { _eq: $id } }) {
+        query GetLastPublisher($id: uuid!) {
+          flow: flows_by_pk(id: $id) {
             published_flows(order_by: { created_at: desc }, limit: 1) {
               user {
                 first_name
@@ -481,7 +481,7 @@ export const editorStore: StateCreator<
       },
     });
 
-    const { first_name, last_name } = data.flows[0].published_flows[0].user;
+    const { first_name, last_name } = data.flow.published_flows[0].user;
 
     return first_name.concat(" ", last_name);
   },


### PR DESCRIPTION
Minor tidy up - `flows_by_pk` is more performant than quering all `flows` with a `where` condition!