### PR TITLE
chore(lps): Return and display flow summaries

### DIFF
--- a/localplanning.services/src/lib/lpa-api.ts
+++ b/localplanning.services/src/lib/lpa-api.ts
@@ -3,10 +3,6 @@ import { PUBLIC_PLANX_GRAPHQL_API_URL } from "astro:env/client";
 export interface Service {
   name: string;
   slug: string;
-  // TODO: Public permission!
-  // description
-  // slug
-  // summary
   description: string | null;
   summary: string | null;
 }
@@ -29,9 +25,16 @@ export async function fetchAllLPAs(): Promise<LPA[]> {
             lpas: teams(order_by: { name: asc }) {
               name
               slug
-              services: flows(where: {status: { _eq: online }}, order_by: { name: asc }) {
+              services: flows(
+                where: {
+                  status: { _eq: online }
+                }
+                order_by: { name: asc }
+              ) {
                 name
                 slug
+                summary
+                description
               }
             }
           }


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/4730

This will now display flow summaries, where provided, on flow cards.

This raises a few questions - 
 - Only Doncaster have configured these, should we enforce that this is required to take a service onto LPS?
 - If so, should we restrict the query to services (and LPAs) with this configured?
 - If we're not this strict, what do we use as fallback text (currently still lorem ispum)?
 
 None of these need immediate answers 👍 