### PR TITLE
fix: Heading level warnings for help text (nested content)

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Editor.tsx
@@ -36,7 +36,7 @@ const ContentComponent: React.FC<Props> = (props) => {
               value={formik.values.content}
               onChange={formik.handleChange}
               disabled={props.disabled}
-              rootLevelContent
+              variant="rootLevelContent"
             />
           </InputRow>
           <ColorPicker

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -70,6 +70,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   value={values.description}
                   onChange={handleChange}
                   disabled={props.disabled}
+                  variant="nestedContent"
                 />
               </InputRow>
               <InputRow>
@@ -94,6 +95,7 @@ const Component: React.FC<Props> = (props: Props) => {
                   value={values.instructionsDescription}
                   onChange={handleChange}
                   disabled={props.disabled}
+                  variant="nestedContent"
                 />
               </InputRow>
               <InputRow>

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
@@ -68,6 +68,7 @@ export const InviteToPaySection: React.FC<InviteToPaySectionProps> = ({
                   value={values.nomineeDescription}
                   onChange={handleChange}
                   disabled={disabled}
+                  variant="nestedContent"
                 />
               </InputRow>
             </Box>
@@ -90,6 +91,7 @@ export const InviteToPaySection: React.FC<InviteToPaySectionProps> = ({
                   value={values.yourDetailsDescription}
                   onChange={handleChange}
                   disabled={disabled}
+                  variant="nestedContent"
                 />
               </InputRow>
               <InputRow>

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -49,6 +49,7 @@ function SectionComponent(props: Props) {
               value={formik.values.description}
               onChange={formik.handleChange}
               disabled={props.disabled}
+              variant="paragraphContent"
             />
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
+++ b/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
@@ -28,6 +28,7 @@ export const MoreInformation = ({
               value={info}
               onChange={changeField}
               disabled={disabled}
+              variant="nestedContent"
             />
           </InputLabel>
           <InputLabel label="Policy source" htmlFor="policyRef">
@@ -38,6 +39,7 @@ export const MoreInformation = ({
               value={policyRef}
               onChange={changeField}
               disabled={disabled}
+              variant="nestedContent"
             />
           </InputLabel>
           <InputLabel label="How it is defined?" htmlFor="howMeasured">
@@ -49,6 +51,7 @@ export const MoreInformation = ({
                 value={howMeasured}
                 onChange={changeField}
                 disabled={disabled}
+                variant="nestedContent"
               />
               <ImgInput
                 img={definitionImg}

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -42,6 +42,9 @@ import {
 
 const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");
+  const variant = props.variant ?? "default";
+  const isRootLevel = variant === "rootLevelContent";
+
   // a11y: Element is treated as a HTMLInputElement but Tiptap renders a HTMLDivElement
   // Pass in input props to ensure they're passed along to the rich text editor
   const attributes = {
@@ -103,9 +106,7 @@ const RichTextInput: FC<Props> = (props) => {
       }
       const doc = transaction.editor.getJSON();
 
-      setContentHierarchyError(
-        getContentHierarchyError(doc, props.rootLevelContent),
-      );
+      setContentHierarchyError(getContentHierarchyError(doc, variant));
       setLinkNewTabError(getLinkNewTabError(doc.content));
       setLegislationLinkError(getLegislationLinkError(doc.content));
 
@@ -124,7 +125,7 @@ const RichTextInput: FC<Props> = (props) => {
       } as unknown as ChangeEvent<HTMLInputElement>;
       props.onChange(changeEvent);
     },
-    [props.onChange],
+    [props.onChange, variant],
   );
 
   const handleSelectionUpdate = useCallback(() => {
@@ -155,19 +156,17 @@ const RichTextInput: FC<Props> = (props) => {
     internalValue.current = stringValue;
     const doc = fromHtml(stringValue);
     setContentHierarchyError(
-      getContentHierarchyError(fromHtml(stringValue), props.rootLevelContent),
+      getContentHierarchyError(fromHtml(stringValue), variant),
     );
     editor.commands.setContent(doc);
-  }, [stringValue]);
+  }, [stringValue, variant]);
 
   useEffect(() => {
     const doc = fromHtml(stringValue);
-    setContentHierarchyError(
-      getContentHierarchyError(doc, props.rootLevelContent),
-    );
+    setContentHierarchyError(getContentHierarchyError(doc, variant));
     setLinkNewTabError(getLinkNewTabError(doc.content));
     setLegislationLinkError(getLegislationLinkError(doc.content));
-  }, [stringValue, props.rootLevelContent]);
+  }, [stringValue, variant]);
 
   // Returns the HTML snippet under the current selection, typically wrapped in a <p> tag, e.g. '<p>selected text</p>'
   const getSelectionHtml = () => {
@@ -213,9 +212,7 @@ const RichTextInput: FC<Props> = (props) => {
         .join(" ")}
     >
       <RichContentContainer
-        className={`rich-text-editor ${
-          props.rootLevelContent ? "allow-h1" : ""
-        }`}
+        className={`rich-text-editor ${isRootLevel ? "allow-h1" : ""}`}
       >
         {editor && (
           <StyledBubbleMenu
@@ -257,15 +254,11 @@ const RichTextInput: FC<Props> = (props) => {
               <>
                 <H1Button
                   editor={editor}
-                  label={
-                    <strong>{props.rootLevelContent ? "H1" : "H2"}</strong>
-                  }
+                  label={<strong>{isRootLevel ? "H1" : "H2"}</strong>}
                 />
                 <H2Button
                   editor={editor}
-                  label={
-                    <strong>{props.rootLevelContent ? "H2" : "H3"}</strong>
-                  }
+                  label={<strong>{isRootLevel ? "H2" : "H3"}</strong>}
                 />
                 <BoldButton editor={editor} />
                 <ItalicButton editor={editor} />

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -44,6 +44,7 @@ const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");
   const variant = props.variant ?? "default";
   const isRootLevel = variant === "rootLevelContent";
+  const isParagraph = variant === "paragraphContent";
 
   // a11y: Element is treated as a HTMLInputElement but Tiptap renders a HTMLDivElement
   // Pass in input props to ensure they're passed along to the rich text editor
@@ -252,14 +253,18 @@ const RichTextInput: FC<Props> = (props) => {
               />
             ) : (
               <>
-                <H1Button
-                  editor={editor}
-                  label={<strong>{isRootLevel ? "H1" : "H2"}</strong>}
-                />
-                <H2Button
-                  editor={editor}
-                  label={<strong>{isRootLevel ? "H2" : "H3"}</strong>}
-                />
+                {!isParagraph && (
+                  <>
+                    <H1Button
+                      editor={editor}
+                      label={<strong>{isRootLevel ? "H1" : "H2"}</strong>}
+                    />
+                    <H2Button
+                      editor={editor}
+                      label={<strong>{isRootLevel ? "H2" : "H3"}</strong>}
+                    />
+                  </>
+                )}
                 <BoldButton editor={editor} />
                 <ItalicButton editor={editor} />
                 <BulletListButton editor={editor} />

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -17,7 +17,11 @@ export interface Props extends InputBaseProps {
   bordered?: boolean;
   errorMessage?: string;
   disabled?: boolean;
-  variant?: "default" | "rootLevelContent" | "nestedContent";
+  variant?:
+    | "default"
+    | "rootLevelContent"
+    | "nestedContent"
+    | "paragraphContent";
   classname?: string;
 }
 export interface VariablesState {

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -17,7 +17,7 @@ export interface Props extends InputBaseProps {
   bordered?: boolean;
   errorMessage?: string;
   disabled?: boolean;
-  rootLevelContent?: boolean;
+  variant?: "default" | "rootLevelContent" | "nestedContent";
   classname?: string;
 }
 export interface VariablesState {

--- a/editor.planx.uk/src/ui/editor/RichTextInput/validationHelpers.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/validationHelpers.ts
@@ -102,7 +102,11 @@ export const linkSelectionError = (selectionHtml: string): string | null => {
 
 export const getContentHierarchyError = (
   doc: JSONContent,
-  variant?: "default" | "rootLevelContent" | "nestedContent",
+  variant?:
+    | "default"
+    | "rootLevelContent"
+    | "nestedContent"
+    | "paragraphContent",
 ): string[] | null => {
   const errors: string[] = [];
   const topLevelNodes = doc.content || [];

--- a/editor.planx.uk/src/ui/editor/RichTextInput/validationHelpers.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/validationHelpers.ts
@@ -102,7 +102,7 @@ export const linkSelectionError = (selectionHtml: string): string | null => {
 
 export const getContentHierarchyError = (
   doc: JSONContent,
-  rootLevelContent?: boolean,
+  variant?: "default" | "rootLevelContent" | "nestedContent",
 ): string[] | null => {
   const errors: string[] = [];
   const topLevelNodes = doc.content || [];
@@ -110,9 +110,13 @@ export const getContentHierarchyError = (
   let h1Index = -1;
   let h2Index = -1;
 
-  if (rootLevelContent) {
+  if (variant === "rootLevelContent") {
     const firstNode = topLevelNodes[0];
-    if (!firstNode || firstNode.type !== "heading" || firstNode.attrs?.level !== 1) {
+    if (
+      !firstNode ||
+      firstNode.type !== "heading" ||
+      firstNode.attrs?.level !== 1
+    ) {
       errors.push("The document must start with a level 1 heading (H1).");
     }
   }
@@ -122,27 +126,33 @@ export const getContentHierarchyError = (
 
     const level = d.attrs?.level;
 
-    if (rootLevelContent) {
+    if (variant === "rootLevelContent") {
       if (level === 1) {
         if (h1Index !== -1 && index !== 0) {
-          errors.push("There cannot be more than one level 1 heading (H1) in the document.");
+          errors.push(
+            "There cannot be more than one level 1 heading (H1) in the document.",
+          );
         }
         h1Index = index;
       }
 
       if (level === 2) {
         if (h1Index === -1) {
-          errors.push("A level 1 heading (H1) must come before a level 2 heading (H2).");
+          errors.push(
+            "A level 1 heading (H1) must come before a level 2 heading (H2).",
+          );
         }
         h2Index = index;
       }
-    } else {
+    } else if (variant === "default") {
       if (level === 2) {
         if (h2Index === -1 && h1Index === -1) {
           h2Index = index;
         }
         if (h1Index === -1) {
-          errors.push("A level 2 heading (H2) must come before a level 3 heading (H3).");
+          errors.push(
+            "A level 2 heading (H2) must come before a level 3 heading (H3).",
+          );
         }
       }
 


### PR DESCRIPTION
## Issue

Reported by @augustlindemer
When authoring content that is already nested below a `<h2>` heading (specifically in the help text modal), the warning "H2 must come before H3" should not be applied.

## Solution

Current rules make the distinction between `rootLevelContent` (boolean) to determine whether a `<h1>` is already present, or if it should be required in the rich text content. Moving this a `variant` with an option for `nestedContent` allows us to ignore the rule "H2 must come before H3" for content where both `<h1>` and `<h2>` is already present (so heading hierarchy rules should not apply).

**Testing:**
https://4749.planx.pizza/a-new-team/text-validation-testing