### PR TITLE
[WIP] use custom vultr caddy to serve wildcard SSL cert on pizzas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ AWS_SECRET_KEY=👻
 
 # Vultr API key for pizzas to handle DNS challenge
 VULTR_API_KEY=👻
+VULTR_SSH_KEY_IDS=👻
 
 # User-uploaded S3 files require token-based access (token is used internally and shared with BOPS; local and pull request environments use the staging token)
 FILE_API_KEY=👻

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ AWS_S3_BUCKET=👻
 AWS_ACCESS_KEY=👻
 AWS_SECRET_KEY=👻
 
+# Vultr API key for pizzas to handle DNS challenge
+VULTR_API_KEY=👻
+
 # User-uploaded S3 files require token-based access (token is used internally and shared with BOPS; local and pull request environments use the staging token)
 FILE_API_KEY=👻
 FILE_API_KEY_NEXUS=👻

--- a/ci/caddy/Caddyfile
+++ b/ci/caddy/Caddyfile
@@ -1,19 +1,21 @@
 # initial block determines global options
 {
 	email {$TLS_EMAIL}
+
 	# dev / debugging options (comment out for main / in version control)
 	debug
 	acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
 }
 
-# TRY: separating out the wildcard and root domain?
 # see https://caddyserver.com/docs/caddyfile/patterns
 *.{$ROOT_DOMAIN}, {$ROOT_DOMAIN} {
 	# wilcard certs require a DNS challenge
 	tls {
 		dns vultr {$VULTR_API_KEY}
-		propagation_delay 60s
-		propagation_timeout 300s
+		# i.e. wait for propagation_delay before starting poll of DNS records (after put), then keep trying for propagation_timeout
+		# TRY: set env vars direct rather than relying on Caddyfile options - could also extend VULTR_POLLING_INTERVAL (default 2s)
+		propagation_delay 300s # default 0s - VULTR_TTL in lego implementation (300s is the time Vultr gives in GUI for DNS record TTL)
+		propagation_timeout 900s # default 2mins - VULTR_PROPAGATION_TIMEOUT ibid.
 	}
 
 	@root host {$ROOT_DOMAIN} www.{$ROOT_DOMAIN}
@@ -55,4 +57,7 @@
 	handle {
 		abort
 	}
+
+	# log requests
+	log
 }

--- a/ci/caddy/Caddyfile
+++ b/ci/caddy/Caddyfile
@@ -12,9 +12,9 @@
 	# wilcard certs require a DNS challenge
 	tls {
 		dns vultr {$VULTR_API_KEY}
-		# i.e. wait for propagation_delay before starting poll of DNS records (after put), then keep trying for propagation_timeout
+		# read like: wait for propagation_delay before starting poll of DNS records (after put), then keep trying for propagation_timeout
 		propagation_delay 300s # default 0s (300s is the time Vultr gives in for DNS record TTL)
-		propagation_timeout 900s # default 2mins
+		propagation_timeout -1 # default 2mins (-1 indicates to not conduct propagation check, just handover to ACME after delay)
 	}
 
 	@root host {$ROOT_DOMAIN} www.{$ROOT_DOMAIN}

--- a/ci/caddy/Caddyfile
+++ b/ci/caddy/Caddyfile
@@ -13,9 +13,8 @@
 	tls {
 		dns vultr {$VULTR_API_KEY}
 		# i.e. wait for propagation_delay before starting poll of DNS records (after put), then keep trying for propagation_timeout
-		# TRY: set env vars direct rather than relying on Caddyfile options - could also extend VULTR_POLLING_INTERVAL (default 2s)
-		propagation_delay 300s # default 0s - VULTR_TTL in lego implementation (300s is the time Vultr gives in GUI for DNS record TTL)
-		propagation_timeout 900s # default 2mins - VULTR_PROPAGATION_TIMEOUT ibid.
+		propagation_delay 300s # default 0s (300s is the time Vultr gives in for DNS record TTL)
+		propagation_timeout 900s # default 2mins
 	}
 
 	@root host {$ROOT_DOMAIN} www.{$ROOT_DOMAIN}

--- a/ci/caddy/Caddyfile
+++ b/ci/caddy/Caddyfile
@@ -1,0 +1,58 @@
+# initial block determines global options
+{
+	email {$TLS_EMAIL}
+	# dev / debugging options (comment out for main / in version control)
+	debug
+	acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+}
+
+# TRY: separating out the wildcard and root domain?
+# see https://caddyserver.com/docs/caddyfile/patterns
+*.{$ROOT_DOMAIN}, {$ROOT_DOMAIN} {
+	# wilcard certs require a DNS challenge
+	tls {
+		dns vultr {$VULTR_API_KEY}
+		propagation_delay 60s
+		propagation_timeout 300s
+	}
+
+	@root host {$ROOT_DOMAIN} www.{$ROOT_DOMAIN}
+	handle @root {
+		reverse_proxy editor:8043
+	}
+
+	@api host api.{$ROOT_DOMAIN}
+	handle @api {
+		reverse_proxy api:{$API_PORT}
+	}
+
+	@hasura host hasura.{$ROOT_DOMAIN}
+	handle @hasura {
+		reverse_proxy hasura-proxy:{$HASURA_PROXY_PORT}
+	}
+
+	@localplanning host localplanning.{$ROOT_DOMAIN}
+	handle @localplanning {
+		reverse_proxy localplanning:8043
+	}
+
+	@postgres host postgres.{$ROOT_DOMAIN}
+	handle @postgres {
+		reverse_proxy postgres:{$PG_PORT}
+	}
+
+	@sharedb host sharedb.{$ROOT_DOMAIN}
+	handle @sharedb {
+		reverse_proxy sharedb:{$SHAREDB_PORT}
+	}
+
+	@storybook host storybook.{$ROOT_DOMAIN}
+	handle @storybook {
+		reverse_proxy storybook:8044
+	}
+
+	# abort for unhandled domains
+	handle {
+		abort
+	}
+}

--- a/ci/caddy/Dockerfile
+++ b/ci/caddy/Dockerfile
@@ -1,9 +1,9 @@
 # build Caddy with the Vultr DNS-01 challenge provider
-# XXX: we'd definitely want to publish this image somewhere, rather than build every time
-FROM caddy:2.9-builder-alpine AS builder
 # see https://caddyserver.com/docs/modules/dns.providers.vultr
-RUN xcaddy build --with github.com/caddy-dns/vultr@3561810
+FROM caddy:2.10-builder-alpine AS builder
+RUN xcaddy build --with github.com/caddy-dns/vultr
 
 # copy only the custom binary into a minimal runtime image
+# TODO: we will definitely want to publish this image somewhere (e.g. AWS ECR), rather than build every time
 FROM caddy:2.10-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/ci/caddy/Dockerfile
+++ b/ci/caddy/Dockerfile
@@ -1,0 +1,8 @@
+# build Caddy with the Vultr DNS-01 challenge provider
+FROM caddy:2.10-builder-alpine AS builder
+# see https://caddyserver.com/docs/modules/dns.providers.vultr
+RUN xcaddy build --with github.com/caddy-dns/vultr
+
+# copy only the custom binary into a minimal runtime image
+FROM caddy:2.10-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/ci/caddy/Dockerfile
+++ b/ci/caddy/Dockerfile
@@ -1,8 +1,8 @@
 # build Caddy with the Vultr DNS-01 challenge provider
 # XXX: we'd definitely want to publish this image somewhere, rather than build every time
-FROM caddy:2.10-builder-alpine AS builder
+FROM caddy:2.9-builder-alpine AS builder
 # see https://caddyserver.com/docs/modules/dns.providers.vultr
-RUN xcaddy build --with github.com/caddy-dns/vultr
+RUN xcaddy build --with github.com/caddy-dns/vultr@3561810
 
 # copy only the custom binary into a minimal runtime image
 FROM caddy:2.10-alpine

--- a/ci/caddy/Dockerfile
+++ b/ci/caddy/Dockerfile
@@ -1,4 +1,5 @@
 # build Caddy with the Vultr DNS-01 challenge provider
+# XXX: we'd definitely want to publish this image somewhere, rather than build every time
 FROM caddy:2.10-builder-alpine AS builder
 # see https://caddyserver.com/docs/modules/dns.providers.vultr
 RUN xcaddy build --with github.com/caddy-dns/vultr

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -5,21 +5,6 @@ services:
   postgres:
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    labels:
-      virtual.host: postgres.${ROOT_DOMAIN}
-      virtual.port: 5432
-      virtual.tls-email: ${TLS_EMAIL}
-
-  hasura:
-    labels:
-      virtual.port: 8080
-      virtual.tls-email: ${TLS_EMAIL}
-
-  hasura-proxy:
-    labels:
-      virtual.host: hasura.${ROOT_DOMAIN}
-      virtual.port: ${HASURA_PROXY_PORT}
-      virtual.tls-email: ${TLS_EMAIL}
 
   api:
     build:
@@ -27,58 +12,46 @@ services:
     volumes:
       - "/api/node_modules"
       - "/api/dist"
-    labels:
-      virtual.host: api.${ROOT_DOMAIN}
-      virtual.port: ${API_PORT}
-      virtual.tls-email: ${TLS_EMAIL}
     environment:
       NODE_ENV: "pizza"
-
-  sharedb:
-    labels:
-      virtual.host: sharedb.${ROOT_DOMAIN}
-      virtual.port: 8000
-      virtual.tls-email: ${TLS_EMAIL}
 
   editor:
     image: pierrezemb/gostatic
     volumes:
       - ./editor.planx.uk/build:/srv/http
     entrypoint: "/goStatic -fallback /index.html"
-    labels:
-      virtual.host: ${ROOT_DOMAIN}
-      virtual.port: 8043
-      virtual.tls-email: ${TLS_EMAIL}
 
   localplanning:
     image: pierrezemb/gostatic
     volumes:
       - ./localplanning.services/dist:/srv/http
     entrypoint: "/goStatic -fallback /index.html"
-    labels:
-      virtual.host: localplanning.${ROOT_DOMAIN}
-      virtual.port: 8043
-      virtual.tls-email: ${TLS_EMAIL}
 
   storybook:
     image: pierrezemb/gostatic
     volumes:
       - ./editor.planx.uk/build/storybook:/srv/http
     entrypoint: "/goStatic -port 8044 -fallback /index.html"
-    labels:
-      virtual.host: storybook.${ROOT_DOMAIN}
-      virtual.port: 8044
-      virtual.tls-email: ${TLS_EMAIL}
 
-  caddy-gen:
-    image: wemakeservices/caddy-gen:latest
-    restart: always
+  caddy:
+    build:
+      context: ./ci/caddy
+    restart: unless-stopped
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-      - caddy_data:/data/caddy # to back up certificates
+      - ./ci/caddy/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data  # certs + keys
+      - caddy_config:/config  # autosaved JSON config
     ports:
       - 80:80
       - 443:443
+    environment:
+      - TLS_EMAIL=${TLS_EMAIL}
+      - ROOT_DOMAIN=${ROOT_DOMAIN}
+      - VULTR_API_KEY=${VULTR_API_KEY}
+      - API_PORT=${API_PORT}
+      - HASURA_PROXY_PORT=${HASURA_PROXY_PORT}
+      - PG_PORT=${PG_PORT}
+      - SHAREDB_PORT=${SHAREDB_PORT}
 
 volumes:
   postgres_data:

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -10,6 +10,11 @@ echo "root:$SSH_PASSWORD" | chpasswd
 # https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-22-04
 swapon --show
 
+# caddy runs up against kernel buffer limits of host OS, so we increase them
+# see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+sysctl -w net.core.rmem_max=7500000
+sysctl -w net.core.wmem_max=7500000
+
 # set env for this shell
 set -o allexport
 source .env.pizza

--- a/scripts/vultr/delete-acme-txt.sh
+++ b/scripts/vultr/delete-acme-txt.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# this script will purge all _acme-challenge TXT records in Vultr DNS for given pizza
+set -euo pipefail
+
+PIZZA=$1
+DOMAIN="planx.pizza"
+TARGET="_acme-challenge.$PIZZA"
+
+# pull records as JSON (using output -o flag), which looks like...
+# { "records": [ { id, type, name, data, priority, ttl }, ... ], "meta": {...} }
+json=$(vultr-cli dns record list "$DOMAIN" -o json)
+
+# extract record IDs that match our criteria with jq
+mapfile -t ids < <(
+  echo "$json" | jq -r --arg tgt "$TARGET" '
+        .records[]           # unwrap
+        | select(.type=="TXT" and .name==$tgt)
+        | .id'
+)
+
+if [[ ${#ids[@]} -eq 0 ]]; then
+  echo "No matching TXT records found - nothing to delete."
+  exit 0
+fi
+
+# loop through IDs and delete each record
+for id in "${ids[@]}"; do
+  echo "Deleting record ID $id …"
+  vultr-cli dns record delete "$DOMAIN" "$id"
+done
+
+echo "Done - removed ${#ids[@]} TXT record(s)."

--- a/scripts/vultr/delete-acme-txt.sh
+++ b/scripts/vultr/delete-acme-txt.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # this script will purge all _acme-challenge TXT records in Vultr DNS for given pizza
+# assumes you have vultr-cli installed and VULTR_API_KEY exported (or a ~/.vultr-cli.yaml config)
 set -euo pipefail
 
 PIZZA=$1


### PR DESCRIPTION
Related [Trello ticket](https://trello.com/c/aiwKQ8lb).

PR to reduce certs requested from Lets Encrypt (we're starting to hit our 50/week cap) by using a wildcard.

That is, it swaps out `caddy-gen` for plain `caddy`, the latest version of which (`2.10`) will only requests one certificate for all subdomains referenced by a wildcard address (e.g. `*.4757.planx.pizza`) - see [changelog](https://github.com/caddyserver/caddy/releases/tag/v2.10.0) - so if we can make this work, it should save us 6 certs per pizza.

This is mostly a copycat of #[4748](https://github.com/theopensystemslab/planx-new/pull/4748). Props to @DafyddLlyr for most of the legwork on this 🚀 

Took some iterating, but in the process I discovered a nice command to keep an eye on the TXT records on the DNS server (which provide the _challenge_ from Lets Encrypt):

```
watch -n2 'dig +short TXT _acme-challenge.4757.planx.pizza'
```

Relatedly, this PR adds a script to delete superfluous TXT records after the fact. Run it like:

```
./scripts/vultr/delete-acme-txt.sh 4757
```

NB. I note that to SSH into the Vultr server (like `ssh root@4757.planx.pizza`) I was still having to use the pw from the Vultr portal. This might be just because I don't know the value of `SSH_PRIVATE_KEY` though? (which I assume is just the private key for the `GHA Key` I can see in the Vultr SSH panel)

NBB. The caddy image with Vultr dns plugin takes _ages_ to build, so we might want to upload the image somewhere (e.g. AWS ECR) and pull it down each time.

**Useful refs**:

- LetsEncrypt docs on the [DNS-01 challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)
- Caddy's docs on their [automatic cert provision](https://caddyserver.com/docs/automatic-https)
- The [Vultr DNS plugin](https://github.com/caddy-dns/vultr) we bake into custom caddy build via `xcaddy` (we're dealing with a [pkg in beta](https://github.com/caddy-dns/vultr/issues/8#issuecomment-2927256068) here)
- Note that there might be [other ways](https://github.com/bsorahan/certbot-dns-vultr) to handle the DNS challenge (certbot)
- A [useful discussion on the propagation knobs](https://caddy.community/t/timeout-waiting-for-record-to-fully-propagate/22696/3)
- Solution to [increase buffer size](https://github.com/nextcloud/all-in-one/discussions/1970#discussion-4848534) (and related [quic-go docs](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes)) - as a response to seeing the log `failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB)` early in caddy spin-up