### PR TITLE
feat: Support SVG file uploads

### DIFF
--- a/api.planx.uk/modules/file/file.test.ts
+++ b/api.planx.uk/modules/file/file.test.ts
@@ -151,7 +151,7 @@ describe("File upload", () => {
         });
     });
 
-    it("should upload file", async () => {
+    it("should upload JPG", async () => {
       vi.stubEnv("API_URL_EXT", "https://api.editor.planx.dev");
       vi.stubEnv("AWS_S3_BUCKET", "myBucketName");
 
@@ -162,6 +162,46 @@ describe("File upload", () => {
         .then((res) => {
           expect(res.body).toEqual({
             fileType: "image/jpeg",
+            // Bucket name stripped from URL
+            fileUrl:
+              "https://api.editor.planx.dev/file/private/nanoid/modified%20key",
+          });
+        });
+      expect(mockPutObject).toHaveBeenCalledTimes(1);
+      expect(getSignedUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it("should upload PDF", async () => {
+      vi.stubEnv("API_URL_EXT", "https://api.editor.planx.dev");
+      vi.stubEnv("AWS_S3_BUCKET", "myBucketName");
+
+      await supertest(app)
+        .post(PRIVATE_ENDPOINT)
+        .field("filename", "some_file.pdf")
+        .attach("file", Buffer.from("some data"), "some_file.pdf")
+        .then((res) => {
+          expect(res.body).toEqual({
+            fileType: "application/pdf",
+            // Bucket name stripped from URL
+            fileUrl:
+              "https://api.editor.planx.dev/file/private/nanoid/modified%20key",
+          });
+        });
+      expect(mockPutObject).toHaveBeenCalledTimes(1);
+      expect(getSignedUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it("should upload SVG", async () => {
+      vi.stubEnv("API_URL_EXT", "https://api.editor.planx.dev");
+      vi.stubEnv("AWS_S3_BUCKET", "myBucketName");
+
+      await supertest(app)
+        .post(PRIVATE_ENDPOINT)
+        .field("filename", "some_file.svg")
+        .attach("file", Buffer.from("some data"), "some_file.svg")
+        .then((res) => {
+          expect(res.body).toEqual({
+            fileType: "image/svg+xml",
             // Bucket name stripped from URL
             fileUrl:
               "https://api.editor.planx.dev/file/private/nanoid/modified%20key",

--- a/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -11,8 +11,13 @@ const FILE_SIZE_LIMIT = 30 * 1024 * 1024;
  * Should match MIME type restrictions in frontend
  * See editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
  */
-const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf"];
-const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".pdf"];
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "application/pdf",
+  "image/svg+xml",
+];
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".pdf", ".svg"];
 
 export const validateExtension = (filename: string): boolean => {
   const extension = path.extname(filename).toLowerCase();

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -79,6 +79,7 @@ export const Dropzone: React.FC<Props> = ({
       "image/jpeg": [".jpg", ".jpeg"],
       "image/png": [".png"],
       "application/pdf": [".pdf"],
+      "image/svg+xml": [".svg"],
     },
     maxSize: MAX_UPLOAD_SIZE_MB * 1e6,
     multiple: maxFiles !== 1,


### PR DESCRIPTION
- Adds the ability to upload SVGs via frontend and API
- More explicit test for filetypes