### PR TITLE
chore: bump vultr-action to v2.3, pass ssh_key_ids in all cases

### DIFF
--- a/.github/workflows/pizza-teardown-manual.yml
+++ b/.github/workflows/pizza-teardown-manual.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Remove vultr resources
-        uses: theopensystemslab/vultr-action@v2.2-beta-5
+        uses: theopensystemslab/vultr-action@v2.3
         with:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}
@@ -28,3 +28,4 @@ jobs:
           pull_request_id: ${{  github.event.inputs.pull_request_id  }}
           region: lhr
           tag: manual-teardown
+          ssh_key_ids: ${{ secrets.VULTR_SSH_KEY_IDS }}

--- a/.github/workflows/pizza-teardown.yml
+++ b/.github/workflows/pizza-teardown.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Remove vultr resources
-        uses: theopensystemslab/vultr-action@v2.2-beta-5
+        uses: theopensystemslab/vultr-action@v2.3
         with:
           action: destroy
           api_key: ${{ secrets.VULTR_API_KEY }}
@@ -26,6 +26,7 @@ jobs:
           pull_request_id: ${{ env.PULLREQUEST_ID }}
           region: lhr
           tag: pullrequest
+          ssh_key_ids: ${{ secrets.VULTR_SSH_KEY_IDS }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -345,7 +345,7 @@ jobs:
     steps:
       - name: Create Pizza (if it doesn't exist)
         id: create
-        uses: theopensystemslab/vultr-action@v2.2-beta-5
+        uses: theopensystemslab/vultr-action@v2.3
         with:
           action: create
           api_key: ${{ secrets.VULTR_API_KEY }}
@@ -355,7 +355,7 @@ jobs:
           pull_request_id: ${{ env.PULLREQUEST_ID }}
           region: lhr
           tag: pullrequest
-          sshKeyIds: ${{ secrets.VULTR_SSH_KEY_IDS }}
+          ssh_key_ids: ${{ secrets.VULTR_SSH_KEY_IDS }}
 
       # CREATE STEPS
 


### PR DESCRIPTION
as per title - replaces #4755

related PR for vultr-action: https://github.com/theopensystemslab/vultr-action/pull/5