### PR TITLE
style: Align icon in editor modal

### DIFF
--- a/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
@@ -30,6 +30,9 @@ const LeftGutter = styled(Grid)(({ theme }) => ({
   [theme.breakpoints.up("md")]: {
     flex: `0 0 ${theme.spacing(6)}`,
   },
+  [theme.breakpoints.up("lg")]: {
+    paddingTop: theme.spacing(0.25),
+  },
 }));
 
 const SectionContent = styled(Grid)(({ theme }) => ({


### PR DESCRIPTION
## What does this PR do?

Quick one: aligns the section icon in editor modals to the text (scratching a long-standing itchy nit)

**Before:**
<img width="237" alt="image" src="https://github.com/user-attachments/assets/f73e4a14-2710-455d-a646-6b44c68c0870" />

**After:**
<img width="237" alt="image" src="https://github.com/user-attachments/assets/6bd0ec64-c4c5-485d-96d6-fc56544f7d09" />
