### PR TITLE
fix: disable "copy" flow menu item for source templates and templated flows

### DIFF
--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -114,14 +114,11 @@ const FlowCard: React.FC<FlowCardProps> = ({
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState<boolean>(false);
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState<boolean>(false);
 
-  const [archiveFlow, moveFlow, canUserEditTeam, isTemplate, isTemplatedFrom] =
-    useStore((state) => [
-      state.archiveFlow,
-      state.moveFlow,
-      state.canUserEditTeam,
-      state.isTemplate,
-      state.isTemplatedFrom,
-    ]);
+  const [archiveFlow, moveFlow, canUserEditTeam] = useStore((state) => [
+    state.archiveFlow,
+    state.moveFlow,
+    state.canUserEditTeam,
+  ]);
 
   const route = useCurrentRoute();
   const toast = useToast();

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -114,11 +114,14 @@ const FlowCard: React.FC<FlowCardProps> = ({
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState<boolean>(false);
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState<boolean>(false);
 
-  const [archiveFlow, moveFlow, canUserEditTeam] = useStore((state) => [
-    state.archiveFlow,
-    state.moveFlow,
-    state.canUserEditTeam,
-  ]);
+  const [archiveFlow, moveFlow, canUserEditTeam, isTemplate, isTemplatedFrom] =
+    useStore((state) => [
+      state.archiveFlow,
+      state.moveFlow,
+      state.canUserEditTeam,
+      state.isTemplate,
+      state.isTemplatedFrom,
+    ]);
 
   const route = useCurrentRoute();
   const toast = useToast();
@@ -156,7 +159,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
   };
 
   const isSubmissionService = flow.publishedFlows?.[0]?.hasSendComponent;
-  const isTemplateService = Boolean(flow.templatedFrom);
+  const isTemplatedService = Boolean(flow.templatedFrom);
 
   const statusVariant =
     flow.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
@@ -175,7 +178,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
     {
       type: FlowTagType.Template,
       displayName: "Template",
-      shouldAddTag: hasFeatureFlag("TEMPLATES") && isTemplateService,
+      shouldAddTag: hasFeatureFlag("TEMPLATES") && isTemplatedService,
     },
     {
       type: FlowTagType.SourceTemplate,
@@ -249,7 +252,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
                 >
                   {flow.isTemplate
                     ? "Source template"
-                    : flow.template.team.name}
+                    : `Templated from ${flow.template.team.name}`}
                 </Typography>
               </CardBanner>
             )}
@@ -309,6 +312,7 @@ const FlowCard: React.FC<FlowCardProps> = ({
               {
                 label: "Copy",
                 onClick: () => setIsCopyDialogOpen(true),
+                disabled: flow.isTemplate || isTemplatedService,
               },
               {
                 label: "Move",


### PR DESCRIPTION
Per bug today! https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1749564694647459

We never want a flow to be both `copied_from` and `templated_from`. Plus one minor visual change to flow card banners to read "Templated from [team]" per Silvia's suggestion in design thread - agree this is much more clear!
 
![Screenshot from 2025-06-10 20-48-32](https://github.com/user-attachments/assets/0f4cc400-98ac-4df6-a3fc-a1e19684db67)
