### PR TITLE
infra: repeat certificates `domain` in application stack config

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -10,6 +10,7 @@ config:
     secure: AAABAC2O6oVQLaaTRJw+MUVASpLK1Lo5qkARYpv90mbdc7T+XDLb27Z0LIKIA0yorbwvXjT1Ud4DnaCU4my5vA==
   application:db-url:
     secure: AAABAFI7BWi1MiV42eCEbNb5pkqvXsMD/AGFr76HpI96ZISZMDoTEZqMjkIOt8LKR6/dmxkgPa1pWfRYdKDYYnHJ0PY5brtHC5EwndG6Rpc9OcPmbkqjGIITv06jk1/IDxC1CRW9oq4xXhxDF4FN/MmhqqyCncUxS7jL2BhfKrQ/LMBrZtGF/e4GrXgHEqMXMTCHJQ==
+  application:domain: editor.planx.uk
   application:encryption-key:
     secure: AAABAGbTpoRtazwoNFNmaPCW0RdeTqjhEzQuYR1kl4ft7EWNxqswAu8Dc9T+YBxkYr3uaHbu5obzyo8I4QuVgg==
   application:file-api-key:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -9,6 +9,7 @@ config:
     secure: AAABAMwwPy7/bMKC+iEonzpc0HrzblNfFBXBi60LiSTcoF1KxQkd+vkEUfBfhY96Tx4Nf8/JML6EBhtesIjoGN+r4Y1EcpW+thJoJa/g3Ssv4Dc=
   application:db-password:
     secure: AAABAAVV2tpNt1KK6I/h1PqHYZf5iDySr+GJOXy1cdMbIfO6cXNxel8Rv9EwmmAaPkPh7Z4vEZHIHSJqHrPDOA==
+  application:domain: editor.planx.dev
   application:encryption-key:
     secure: AAABAFTW2eRwQnXJq/IboPWtStOWXiF9WcsUKEiuosmp7TLZt52uKE3L+NrEGgsThOl3NkvFW2HhFa2XL6aB5w==
   application:file-api-key:

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -97,7 +97,7 @@ const CUSTOM_DOMAINS: CustomDomains =
     : [];
 
 export = async () => {
-  const DOMAIN: string = await certificates.requireOutputValue("domain");
+  const DOMAIN: string = config.require("domain");
 
   const repo = new awsx.ecr.Repository("repo", {
     lifeCyclePolicyArgs: {

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -97,7 +97,7 @@ const CUSTOM_DOMAINS: CustomDomains =
     : [];
 
 export = async () => {
-  const DOMAIN: string = config.require("domain");
+  const DOMAIN = env === "production" ? "editor.planx.uk" : "editor.planx.dev"; // config.require("domain");
 
   const repo = new awsx.ecr.Repository("repo", {
     lifeCyclePolicyArgs: {


### PR DESCRIPTION
Repeats `domain` variable set in certificates stack in application stack - we were already doing this for all certificate outputs besides `domain` so hoping this clears up our latest deploy issue - see notes in this thread: https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1749631154446079

First tried swapping `await certificates.requireOutputValue("domain")` for `config.require("domain")`, but got same error. Even getting error still with an entirely hardcoded approach in latest commit (no `require()` !). Not sure what gives yet.