### PR TITLE
feat: Use chips for node tags

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -101,44 +101,36 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           wasVisited: props.wasVisited,
         })}
       >
-        <Box>
+        <Box className="card-wrapper">
           <Link
             href={href}
             prefetch={false}
             onContextMenu={handleContext}
             ref={drag}
           >
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                maxWidth: "220px",
-              }}
-            >
-              {props.data?.img && (
-                <Thumbnail
-                  imageSource={props.data?.img}
-                  imageAltText={props.data?.text}
-                />
-              )}
-              <Box sx={{ display: "flex", flexDirection: "row" }}>
-                {Icon && <Icon sx={{ marginLeft: "-6px" }} />}
-                <span>{props.text}</span>
-                {showHelpText && hasHelpText && (
-                  <Help fontSize="small" sx={{ marginLeft: "auto" }} />
-                )}
-              </Box>
-              {showTags && tagsByRole && tagsByRole.length > 0 && (
-                <Box className="card-tag-list">
-                  {tagsByRole.map((tag) => (
-                    <Tag tag={tag} key={tag} />
-                  ))}
-                </Box>
+            {props.data?.img && (
+              <Thumbnail
+                imageSource={props.data?.img}
+                imageAltText={props.data?.text}
+              />
+            )}
+            <Box sx={{ display: "flex", flexDirection: "row", width: "100%" }}>
+              {Icon && <Icon />}
+              <span>{props.text}</span>
+              {showHelpText && hasHelpText && (
+                <Help fontSize="small" sx={{ marginLeft: "auto" }} />
               )}
             </Box>
           </Link>
           {props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />
+          )}
+          {showTags && tagsByRole && tagsByRole.length > 0 && (
+            <Box className="card-tag-list">
+              {tagsByRole.map((tag) => (
+                <Tag tag={tag} key={tag} />
+              ))}
+            </Box>
           )}
         </Box>
         {groupedOptions ? (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -28,15 +28,15 @@ type Props = {
   TemplatedNodeData;
 
 const Checklist: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, copyNode, showHelpText, user] = useStore(
-    (state) => [
+  const [isClone, childNodes, copyNode, showHelpText, showTags, user] =
+    useStore((state) => [
       state.isClone,
       state.childNodesOf(props.id),
       state.copyNode,
       state.showHelpText,
+      state.showTags,
       state.getUser(),
-    ],
-  );
+    ]);
 
   const parent = getParentId(props.parent);
 
@@ -122,16 +122,24 @@ const Checklist: React.FC<Props> = React.memo((props) => {
                 />
               )}
               <Box sx={{ display: "flex", flexDirection: "row" }}>
-                {Icon && <Icon />}
-                {showHelpText && hasHelpText && <Help fontSize="small" />}
+                {Icon && <Icon sx={{ marginLeft: "-6px" }} />}
                 <span>{props.text}</span>
+                {showHelpText && hasHelpText && (
+                  <Help fontSize="small" sx={{ marginLeft: "auto" }} />
+                )}
               </Box>
+              {showTags && tagsByRole && tagsByRole.length > 0 && (
+                <Box className="card-tag-list">
+                  {tagsByRole.map((tag) => (
+                    <Tag tag={tag} key={tag} />
+                  ))}
+                </Box>
+              )}
             </Box>
           </Link>
           {props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />
           )}
-          {tagsByRole?.map((tag) => <Tag tag={tag} key={tag} />)}
         </Box>
         {groupedOptions ? (
           <ol className="categories">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -23,6 +23,7 @@ const ExternalPortal: React.FC<any> = (props) => {
   const ref = useScrollOnPreviousURLMatch<HTMLLIElement>(href);
 
   const addExternalPortal = useStore.getState().addExternalPortal;
+  const showTags = useStore((state) => state.showTags);
 
   const { data, loading } = useQuery(
     gql`
@@ -96,14 +97,28 @@ const ExternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
-          <Link href={`/${href}`} prefetch={false} ref={drag}>
-            <span>{href}</span>
-          </Link>
-          <Link href={editHref} prefetch={false} className="portalMenu">
-            <MoreVert titleAccess="Edit Portal" />
-          </Link>
+          <Box>
+            <Link href={`/${href}`} prefetch={false} ref={drag}>
+              <span>{href}</span>
+            </Link>
+            <Link href={editHref} prefetch={false} className="portalMenu">
+              <MoreVert titleAccess="Edit Portal" />
+            </Link>
+          </Box>
+          {showTags && tagsByRole && tagsByRole.length > 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 0.5,
+                borderTop: "1px solid #ccc",
+                p: 0.5,
+              }}
+            >
+              {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
+            </Box>
+          )}
         </Box>
-        {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
       </li>
     </>
   );
@@ -115,6 +130,7 @@ const InternalPortal: React.FC<any> = (props) => {
   const parent = getParentId(props.parent);
 
   const copyNode = useStore((state) => state.copyNode);
+  const showTags = useStore((state) => state.showTags);
 
   let editHref = `${window.location.pathname}/nodes/${props.id}/edit`;
   if (parent) {
@@ -153,20 +169,34 @@ const InternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
-          <Link
-            href={href}
-            prefetch={false}
-            ref={drag}
-            onContextMenu={handleContext}
-          >
-            {Icon && <Icon />}
-            <span>{props.data.text}</span>
-          </Link>
-          <Link href={editHref} prefetch={false} className="portalMenu">
-            <MoreVert titleAccess="Edit Portal" />
-          </Link>
+          <Box>
+            <Link
+              href={href}
+              prefetch={false}
+              ref={drag}
+              onContextMenu={handleContext}
+            >
+              {Icon && <Icon />}
+              <span>{props.data.text}</span>
+            </Link>
+            <Link href={editHref} prefetch={false} className="portalMenu">
+              <MoreVert titleAccess="Edit Portal" />
+            </Link>
+          </Box>
+          {showTags && tagsByRole && tagsByRole.length > 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 0.5,
+                borderTop: "1px solid #ccc",
+                p: 0.5,
+              }}
+            >
+              {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
+            </Box>
+          )}
         </Box>
-        {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
       </li>
     </>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -97,7 +97,7 @@ const ExternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
-          <Box>
+          <Box className="card-wrapper">
             <Link href={`/${href}`} prefetch={false} ref={drag}>
               <span>{href}</span>
             </Link>
@@ -106,15 +106,7 @@ const ExternalPortal: React.FC<any> = (props) => {
             </Link>
           </Box>
           {showTags && tagsByRole && tagsByRole.length > 0 && (
-            <Box
-              sx={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 0.5,
-                borderTop: "1px solid #ccc",
-                p: 0.5,
-              }}
-            >
+            <Box className="card-tag-list">
               {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
             </Box>
           )}
@@ -169,7 +161,7 @@ const InternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
-          <Box>
+          <Box className="card-wrapper">
             <Link
               href={href}
               prefetch={false}
@@ -184,15 +176,7 @@ const InternalPortal: React.FC<any> = (props) => {
             </Link>
           </Box>
           {showTags && tagsByRole && tagsByRole.length > 0 && (
-            <Box
-              sx={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 0.5,
-                borderTop: "1px solid #ccc",
-                p: 0.5,
-              }}
-            >
+            <Box className="card-tag-list">
               {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
             </Box>
           )}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -22,8 +22,10 @@ const ExternalPortal: React.FC<any> = (props) => {
 
   const ref = useScrollOnPreviousURLMatch<HTMLLIElement>(href);
 
-  const addExternalPortal = useStore.getState().addExternalPortal;
-  const showTags = useStore((state) => state.showTags);
+  const { addExternalPortal, showTags } = useStore((state) => ({
+    addExternalPortal: state.addExternalPortal,
+    showTags: state.showTags,
+  }));
 
   const { data, loading } = useQuery(
     gql`
@@ -121,8 +123,10 @@ const InternalPortal: React.FC<any> = (props) => {
 
   const parent = getParentId(props.parent);
 
-  const copyNode = useStore((state) => state.copyNode);
-  const showTags = useStore((state) => state.showTags);
+  const { copyNode, showTags } = useStore((state) => ({
+    copyNode: state.copyNode,
+    showTags: state.showTags,
+  }));
 
   let editHref = `${window.location.pathname}/nodes/${props.id}/edit`;
   if (parent) {

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -28,15 +28,15 @@ type Props = {
   TemplatedNodeData;
 
 const Question: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, copyNode, showHelpText, user] = useStore(
-    (state) => [
+  const [isClone, childNodes, copyNode, showHelpText, showTags, user] =
+    useStore((state) => [
       state.isClone,
       state.childNodesOf(props.id),
       state.copyNode,
       state.showHelpText,
+      state.showTags,
       state.getUser(),
-    ],
-  );
+    ]);
 
   const parent = getParentId(props.parent);
 
@@ -98,20 +98,44 @@ const Question: React.FC<Props> = React.memo((props) => {
             onContextMenu={handleContext}
             ref={drag}
           >
-            {props.data?.img && (
-              <Thumbnail
-                imageSource={props.data?.img}
-                imageAltText={props.data?.text}
-              />
-            )}
-            {Icon && <Icon titleAccess={iconTitleAccess} />}
-            {showHelpText && hasHelpText && <Help fontSize="small" />}
-            <span>{props.text}</span>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                maxWidth: "220px",
+              }}
+            >
+              {props.data?.img && (
+                <Thumbnail
+                  imageSource={props.data?.img}
+                  imageAltText={props.data?.text}
+                />
+              )}
+              <Box sx={{ display: "flex", flexDirection: "row" }}>
+                {Icon && (
+                  <Icon
+                    titleAccess={iconTitleAccess}
+                    sx={{ marginLeft: "-6px" }}
+                  />
+                )}
+                <span>{props.text}</span>
+                {showHelpText && hasHelpText && (
+                  <Help fontSize="small" sx={{ marginLeft: "auto" }} />
+                )}
+              </Box>
+              {showTags && tagsByRole && tagsByRole.length > 0 && (
+                <Box className="card-tag-list">
+                  {tagsByRole.map((tag) => (
+                    <Tag tag={tag} key={tag} />
+                  ))}
+                </Box>
+              )}
+            </Box>
           </Link>
+
           {props.type !== TYPES.SetValue && props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />
           )}
-          {tagsByRole?.map((tag) => <Tag tag={tag} key={tag} />)}
         </Box>
         <ol className="options">
           {childNodes.map((child: any) => (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -91,50 +91,36 @@ const Question: React.FC<Props> = React.memo((props) => {
           },
         )}
       >
-        <Box>
+        <Box className="card-wrapper">
           <Link
             href={href}
             prefetch={false}
             onContextMenu={handleContext}
             ref={drag}
           >
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                maxWidth: "220px",
-              }}
-            >
-              {props.data?.img && (
-                <Thumbnail
-                  imageSource={props.data?.img}
-                  imageAltText={props.data?.text}
-                />
-              )}
-              <Box sx={{ display: "flex", flexDirection: "row" }}>
-                {Icon && (
-                  <Icon
-                    titleAccess={iconTitleAccess}
-                    sx={{ marginLeft: "-6px" }}
-                  />
-                )}
-                <span>{props.text}</span>
-                {showHelpText && hasHelpText && (
-                  <Help fontSize="small" sx={{ marginLeft: "auto" }} />
-                )}
-              </Box>
-              {showTags && tagsByRole && tagsByRole.length > 0 && (
-                <Box className="card-tag-list">
-                  {tagsByRole.map((tag) => (
-                    <Tag tag={tag} key={tag} />
-                  ))}
-                </Box>
+            {props.data?.img && (
+              <Thumbnail
+                imageSource={props.data?.img}
+                imageAltText={props.data?.text}
+              />
+            )}
+            <Box sx={{ display: "flex", flexDirection: "row", width: "100%" }}>
+              {Icon && <Icon titleAccess={iconTitleAccess} />}
+              <span>{props.text}</span>
+              {showHelpText && hasHelpText && (
+                <Help fontSize="small" sx={{ marginLeft: "auto" }} />
               )}
             </Box>
           </Link>
-
           {props.type !== TYPES.SetValue && props.data?.fn && (
             <DataField value={props.data.fn} variant="parent" />
+          )}
+          {showTags && tagsByRole && tagsByRole.length > 0 && (
+            <Box className="card-tag-list">
+              {tagsByRole.map((tag) => (
+                <Tag tag={tag} key={tag} />
+              ))}
+            </Box>
           )}
         </Box>
         <ol className="options">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -46,12 +46,12 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
       className="card-tag"
       sx={(theme) => ({
         bgcolor: tagBgColor,
-        borderWidth: "0 1px 1px 1px",
-        borderStyle: "solid",
-        width: "100%",
-        p: 0.5,
+        border: `1px solid rgba(0, 0, 0, 0.2)`,
+        padding: "2px 8px",
+        borderRadius: "50px",
         textAlign: "center",
         fontWeight: FONT_WEIGHT_SEMI_BOLD,
+        fontSize: "12px",
         color: getContrastTextColor(tagBgColor, "#FFF"),
       })}
     >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -50,7 +50,6 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
         padding: "2px 8px",
         borderRadius: "50px",
         textAlign: "center",
-        fontWeight: FONT_WEIGHT_SEMI_BOLD,
         fontSize: "12px",
         color: getContrastTextColor(tagBgColor, "#FFF"),
       })}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -48,7 +48,7 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
       sx={{
         bgcolor: tagBgColor,
         border: `1px solid rgba(0, 0, 0, 0.2)`,
-        padding: "2px 12px",
+        padding: "4px 12px",
         borderRadius: "50px",
         textAlign: "center",
         fontSize: "12px",

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Tag.tsx
@@ -1,3 +1,4 @@
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import Box from "@mui/material/Box";
 import { Palette, useTheme } from "@mui/material/styles";
 import { NodeTag, Role } from "@opensystemslab/planx-core/types";
@@ -28,7 +29,7 @@ export const TAG_DISPLAY_VALUES: Record<
     displayName: "Analytics",
   },
   automation: {
-    color: "information",
+    color: "automation",
     displayName: "Automation",
   },
 } as const;
@@ -43,17 +44,25 @@ export const Tag: React.FC<{ tag: NodeTag }> = ({ tag }) => {
 
   return (
     <Box
-      className="card-tag"
-      sx={(theme) => ({
+      className={`card-tag ${tag}`}
+      sx={{
         bgcolor: tagBgColor,
         border: `1px solid rgba(0, 0, 0, 0.2)`,
-        padding: "2px 8px",
+        padding: "2px 12px",
         borderRadius: "50px",
         textAlign: "center",
         fontSize: "12px",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
         color: getContrastTextColor(tagBgColor, "#FFF"),
-      })}
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "4px",
+      }}
     >
+      {tag === "automation" && (
+        <AutoFixHighIcon sx={{ fontSize: "13px", color: "inherit" }} />
+      )}
       {TAG_DISPLAY_VALUES[tag].displayName}
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -165,6 +165,7 @@ $fontMonospace: "Source Code Pro", monospace;
   & a {
     position: relative;
     display: flex;
+    flex-direction: row;
     align-items: flex-start;
     justify-content: center;
     text-decoration: none;
@@ -186,17 +187,16 @@ $fontMonospace: "Source Code Pro", monospace;
       pointer-events: none;
     }
 
-    > span {
+    span {
       min-width: 80px;
-      max-width: 200px;
+      padding: 0 5px;
+      max-width: 220px;
       overflow-wrap: break-word;
     }
 
     // Component icon
     & svg {
-      margin-left: -6px;
       margin-top: -1px;
-      margin-right: 6px;
       width: 19px;
       height: 19px;
       opacity: 0.75;
@@ -213,11 +213,17 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
+  & .card-tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    padding-top: 7px;
+    margin-left: -5px;
+  }
+
   & .card-tag {
-    border-color: $nodeBorder;
     .flow-locked & {
       opacity: 0.75;
-      border-color: $lockedBorder;
     }
   }
 
@@ -342,7 +348,7 @@ $fontMonospace: "Source Code Pro", monospace;
     text-decoration: none;
     border: $nodeBorderWidth solid $nodeBorder;
     min-width: $size;
-    max-width: 200px;
+    max-width: 220px;
     min-height: $size;
     border-radius: $size;
     color: $black;
@@ -369,11 +375,17 @@ $fontMonospace: "Source Code Pro", monospace;
 }
 
 .portal {
-  justify-content: center !important;
-  > a {
+  display: flex;
+  flex-direction: column;
+  background: $black;
+  > div {
+    display: flex;
+  }
+  > div a {
     background: $black;
     color: white;
     border: none;
+
     .flow-locked & {
       background: #555;
     }
@@ -381,11 +393,13 @@ $fontMonospace: "Source Code Pro", monospace;
   &.breadcrumb {
     background-image: $pixel;
     background-repeat: no-repeat;
+    background-color: transparent;
     [data-layout="top-down"] & {
       background-position: center top;
       background-size: $lineWidth $padding;
       > a {
         margin: $padding 0 0;
+        color: #fff;
       }
     }
     [data-layout="left-right"] & {
@@ -406,6 +420,7 @@ $fontMonospace: "Source Code Pro", monospace;
     justify-content: center;
     align-items: center;
     padding: 2px 6px;
+    margin-left: auto;
     svg {
       opacity: 1;
       margin: 0;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -248,6 +248,9 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 
   & .card-tag {
+    &.automation {
+      width: 100%;
+    }
     .flow-locked & {
       opacity: 0.75;
     }

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -12,6 +12,7 @@ $endpointWidth: 50px;
 $hangerWidth: 16px;
 $lineWidth: 2px;
 $nodeBorderWidth: 1px;
+$nodeMaxWidth: 240px;
 $padding: 10px;
 $editorPadding: 30px;
 $pixel: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADElEQVQImWO4cOECAATkAnFXdNPtAAAAAElFTkSuQmCC);
@@ -102,6 +103,26 @@ $fontMonospace: "Source Code Pro", monospace;
   position: relative;
   z-index: 1;
 
+  .card-wrapper {
+    max-width: $nodeMaxWidth;
+    & > a {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+  &.portal .card-wrapper {
+    max-width: 260px;
+    & > a {
+      flex-direction: row;
+    }
+  }
+
+  .card-title {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+  }
+
   &.isDragging {
     opacity: 0.3;
     & + .hanger {
@@ -158,8 +179,8 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 
   // Allow nodes to expand to width of data when toggled
-  &:not(.type-Section):not(.portal):not(.type-Filter) > a {
-    width: 100%;
+  &:not(.type-Section):not(.portal):not(.type-Filter) > div > a {
+    max-width: 100%;
   }
 
   & a {
@@ -174,7 +195,7 @@ $fontMonospace: "Source Code Pro", monospace;
     border: $nodeBorderWidth solid $nodeBorder;
     background: white;
     user-select: none;
-    padding: 6px 12px;
+    padding: 6px;
     overflow-wrap: break-word;
     word-break: break-word;
 
@@ -188,24 +209,26 @@ $fontMonospace: "Source Code Pro", monospace;
     }
 
     span {
-      min-width: 80px;
-      padding: 0 5px;
-      max-width: 220px;
+      min-width: 100px;
+      padding: 0 10px 0 5px;
+      max-width: $nodeMaxWidth;
       overflow-wrap: break-word;
     }
 
     // Component icon
     & svg {
-      margin-top: -1px;
-      width: 19px;
-      height: 19px;
-      opacity: 0.75;
+      margin-top: -2px;
+      width: 20px;
+      height: 20px;
+      opacity: 0.95;
     }
   }
 
   & .card-data-field {
-    border-color: $nodeBorder;
+    border-color: $optionBorder;
     background: $dataBackground;
+    overflow-wrap: break-word;
+    word-break: break-word;
 
     .flow-locked & {
       border-color: $lockedBorder;
@@ -216,9 +239,12 @@ $fontMonospace: "Source Code Pro", monospace;
   & .card-tag-list {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: 5px;
-    padding-top: 7px;
-    margin-left: -5px;
+    padding: 5px;
+    background: $dataBackground;
+    border: $nodeBorderWidth solid $optionBorder;
+    border-top: none;
   }
 
   & .card-tag {
@@ -348,7 +374,7 @@ $fontMonospace: "Source Code Pro", monospace;
     text-decoration: none;
     border: $nodeBorderWidth solid $nodeBorder;
     min-width: $size;
-    max-width: 220px;
+    max-width: $nodeMaxWidth;
     min-height: $size;
     border-radius: $size;
     color: $black;

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -91,6 +91,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     blocking: "#FAE1B7",
     nonBlocking: "#FFFDB0",
     information: "#D6EFFF",
+    automation: "#B7E8B0",
   },
   flowTag: {
     online: "#D6FFD7",

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -90,7 +90,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     error: "#FFA8A1",
     blocking: "#FAE1B7",
     nonBlocking: "#FFFDB0",
-    information: "#B7FAD7",
+    information: "#D6EFFF",
   },
   flowTag: {
     online: "#D6FFD7",

--- a/editor.planx.uk/src/themeOverrides.d.ts
+++ b/editor.planx.uk/src/themeOverrides.d.ts
@@ -36,6 +36,7 @@ declare module "@mui/material/styles/createPalette" {
       nonBlocking: string;
       blocking: string;
       information: string;
+      automation: string;
     };
     flowTag: {
       online: string;
@@ -59,6 +60,7 @@ declare module "@mui/material/styles/createPalette" {
       nonBlocking: string;
       blocking: string;
       information: string;
+      automation: string;
     };
     flowTag?: {
       online: string;


### PR DESCRIPTION
## What does this PR do?

As part of the broader templates work we've identified the need to simplify graph nodes, so that we can better signpost them as custom nodes in templates.

PR makes the following changes:
- Updates tags to display as chips rather than full width banners on nodes
- Updates help text icon to be in the top-right corner to increase visibility
- (suggested change) updates info-only colour for tags to use our info blue style, used across PlanX

**Before vs after:**
![image](https://github.com/user-attachments/assets/4b07b29f-4dab-4951-aa5f-32a1519e5d3e)

**Testing:**
https://4778.planx.pizza/testing/permitted-development-jc-restructure