### PR TITLE
fix: support larger drawing buffer by `teamSlug`

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -51,7 +51,10 @@ const slotsSchema = array()
 
 export default function Component(props: Props) {
   const isMounted = useRef(false);
-  const passport = useStore((state) => state.computePassport());
+  const [passport, teamSlug] = useStore((state) => [
+    state.computePassport(),
+    state.teamSlug,
+  ]);
 
   const previousBoundary =
     props.previouslySubmittedData?.data?.[props.fn] ||
@@ -66,7 +69,11 @@ export default function Component(props: Props) {
 
   // Buffer applied to the address point to clip this map extent
   //   and applied to the site boundary and written to the passport to later clip the map extent in overview documents
-  const bufferInMeters = area && area > 15000 ? 300 : 120;
+  let bufferInMeters: number = area && area > 15000 ? 300 : 120;
+  if (teamSlug === "tewkesbury") {
+    // Tewkesbury services uniquely support "Strategic Local Partnership" boundary which requires larger buffer
+    bufferInMeters = 600;
+  }
 
   const previousFile =
     props.previouslySubmittedData?.data?.[PASSPORT_UPLOAD_KEY];


### PR DESCRIPTION
Tewkesbury continues to report that the drawing buffer is too restricted for them to launch a "Call for sites" service across the Strategic Local Partnership (SLP) area which spans three councils.

We previously updated their team boundary to correctly use the SLP boundary, but never adjusted the drawing buffer for particularly large sites. This change grants Tewkesbury twice the buffer of a normal council - 600 metres around the address point. We still want to be fairly conservative with this in order to not expose more OS vector tiles than necessary.

Hopefully this suffices! Can keep iterating on this number if needed.

See: 
- Trello https://trello.com/c/tBvJdQtf/2938-allow-users-to-zoom-out-more-to-draw-the-site-outline-for-larger-projects-that-combine-multiple-sites
- Example sites https://experience.arcgis.com/experience/d5dec168d3f84561af45784979ddc054