### PR TITLE
feat: Set up styling for template cards in graph

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -1,5 +1,6 @@
 import Help from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import {
   ComponentType as TYPES,
   NodeTags,
@@ -11,6 +12,7 @@ import mapAccum from "ramda/src/mapAccum";
 import React, { useMemo } from "react";
 import { useDrag } from "react-dnd";
 import { Link } from "react-navi";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
@@ -24,6 +26,7 @@ type Props = {
   type: TYPES;
   [key: string]: any;
   wasVisited?: boolean;
+  isTemplatedNode?: boolean;
 } & NodeTags &
   TemplatedNodeData;
 
@@ -101,7 +104,29 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           wasVisited: props.wasVisited,
         })}
       >
-        <Box className="card-wrapper">
+        <Box
+          // TODO: update card (background colour, text) for differnt states (Requried, Optional, Done)
+          className={classNames("card-wrapper", {
+            "template-card": props.isTemplatedNode,
+          })}
+          sx={
+            props.isTemplatedNode
+              ? {
+                  backgroundColor: (theme) => theme.palette.template.dark,
+                }
+              : {}
+          }
+        >
+          {props.isTemplatedNode && (
+            <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>
+              <Typography
+                variant="body3"
+                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+              >
+                Required
+              </Typography>
+            </Box>
+          )}
           <Link
             href={href}
             prefetch={false}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@apollo/client";
 import MoreVert from "@mui/icons-material/MoreVert";
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { ComponentType, NodeTag } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/shared/icons";
 import classNames from "classnames";
@@ -10,6 +11,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { useDrag } from "react-dnd";
 import { Link } from "react-navi";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { rootFlowPath } from "../../../../../routes/utils";
 import { getParentId } from "../lib/utils";
@@ -165,25 +167,49 @@ const InternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
-          <Box className="card-wrapper">
-            <Link
-              href={href}
-              prefetch={false}
-              ref={drag}
-              onContextMenu={handleContext}
-            >
-              {Icon && <Icon />}
-              <span>{props.data.text}</span>
-            </Link>
-            <Link href={editHref} prefetch={false} className="portalMenu">
-              <MoreVert titleAccess="Edit Portal" />
-            </Link>
-          </Box>
-          {showTags && tagsByRole && tagsByRole.length > 0 && (
-            <Box className="card-tag-list">
-              {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
+          <Box
+            // TODO: update card (background colour, text) for differnt states (Requried, Optional, Done)
+            className={classNames("card-wrapper", {
+              "template-card": props.isTemplatedNode,
+            })}
+            sx={
+              props.isTemplatedNode
+                ? {
+                    backgroundColor: (theme) => theme.palette.template.dark,
+                  }
+                : {}
+            }
+          >
+            {props.isTemplatedNode && (
+              <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>
+                <Typography
+                  variant="body3"
+                  sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+                >
+                  Required
+                </Typography>
+              </Box>
+            )}
+            <Box sx={{ display: "flex", alignItems: "stretch" }}>
+              <Link
+                href={href}
+                prefetch={false}
+                ref={drag}
+                onContextMenu={handleContext}
+              >
+                {Icon && <Icon />}
+                <span>{props.data.text}</span>
+              </Link>
+              <Link href={editHref} prefetch={false} className="portalMenu">
+                <MoreVert titleAccess="Edit Portal" />
+              </Link>
             </Box>
-          )}
+            {showTags && tagsByRole && tagsByRole.length > 0 && (
+              <Box className="card-tag-list">
+                {tagsByRole?.map((tag: NodeTag) => <Tag tag={tag} key={tag} />)}
+              </Box>
+            )}
+          </Box>
         </Box>
       </li>
     </>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -1,6 +1,7 @@
 import ErrorIcon from "@mui/icons-material/Error";
 import Help from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import {
   ComponentType as TYPES,
   NodeTags,
@@ -11,6 +12,7 @@ import classNames from "classnames";
 import React from "react";
 import { useDrag } from "react-dnd";
 import { Link } from "react-navi";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
@@ -24,6 +26,7 @@ type Props = {
   type: TYPES | "Error";
   [key: string]: any;
   wasVisited?: boolean;
+  isTemplatedNode?: boolean;
 } & NodeTags &
   TemplatedNodeData;
 
@@ -91,7 +94,29 @@ const Question: React.FC<Props> = React.memo((props) => {
           },
         )}
       >
-        <Box className="card-wrapper">
+        <Box
+          // TODO: update card (background colour, text) for differnt states (Requried, Optional, Done)
+          className={classNames("card-wrapper", {
+            "template-card": props.isTemplatedNode,
+          })}
+          sx={
+            props.isTemplatedNode
+              ? {
+                  backgroundColor: (theme) => theme.palette.template.dark,
+                }
+              : {}
+          }
+        >
+          {props.isTemplatedNode && (
+            <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>
+              <Typography
+                variant="body3"
+                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+              >
+                Required
+              </Typography>
+            </Box>
+          )}
           <Link
             href={href}
             prefetch={false}

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -109,9 +109,22 @@ $fontMonospace: "Source Code Pro", monospace;
       display: flex;
       flex-direction: column;
     }
+    &.template-card {
+      padding: 4px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      & a {
+        background: #fff;
+      }
+    }
   }
+
   &.portal .card-wrapper {
     max-width: 260px;
+    &.template-card a {
+      background: $black;
+    }
     & > a {
       flex-direction: row;
     }

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -45,6 +45,7 @@ const FlowEditor = () => {
 
   const teamSlug = useStore.getState().getTeam().slug;
   const lockedFlow = !useStore.getState().canUserEditTeam(teamSlug);
+  // TODO: use lockedFlow styling when editing templated flows
 
   return (
     <EditorContainer id="editor-container">


### PR DESCRIPTION
## What does this PR do?

Sets up basic styling for template/custom cards in the graph ("Required" only):

<img width="469" alt="image" src="https://github.com/user-attachments/assets/3f868e40-e24e-4b05-b9c2-1de45eae73ce" />
