### PR TITLE
chore: when creating a service from template, only select from "online" options

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowStatus/index.tsx
@@ -32,6 +32,7 @@ const FlowStatus = () => {
     isFlowPublished,
     isTrial,
     flowSettings,
+    isTemplate,
   ] = useStore((state) => [
     state.flowStatus,
     state.updateFlowStatus,
@@ -42,6 +43,7 @@ const FlowStatus = () => {
     state.isFlowPublished,
     state.teamSettings.isTrial,
     state.flowSettings,
+    state.isTemplate,
   ]);
   const toast = useToast();
 
@@ -126,6 +128,15 @@ const FlowStatus = () => {
             <PendingActionsIcon sx={{ mr: 1 }} />
             <Typography variant="body2">
               Trial accounts cannot set flows online.
+            </Typography>
+          </WarningContainer>
+        )}
+        {isTemplate && (
+          <WarningContainer>
+            <PendingActionsIcon sx={{ mr: 1 }} />
+            <Typography variant="body2">
+              Source templates are discoverable from the "Add a new service"
+              modal when they are online.
             </Typography>
           </WarningContainer>
         )}

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
@@ -19,8 +19,10 @@ export const CreateFromTemplateFormSection: React.FC = () => {
   const { values, setFieldValue } = useFormikContext<CreateFlow>();
 
   const { data } = useQuery<{ templates: TemplateOption[] }>(gql`
-    query GetTemplates {
-      templates: flows(where: { is_template: { _eq: true } }) {
+    query GetOnlineSourceTemplates {
+      templates: flows(
+        where: { is_template: { _eq: true }, status: { _eq: online } }
+      ) {
         id
         slug
         name
@@ -40,7 +42,7 @@ export const CreateFromTemplateFormSection: React.FC = () => {
 
     // Suggest a naming convention
     if (!/(copy|template)$/.test(values.flow.name)) {
-      const newFlowName = `${selectedTemplate.name} (template)`;
+      const newFlowName = `${selectedTemplate.name} (templated)`;
       setFieldValue("flow.name", newFlowName);
       setFieldValue("flow.slug", slugify(newFlowName));
     }


### PR DESCRIPTION
Does exactly what it says - rather than immediately show all source templates in options dropdown when creating a new service "from template", only show online source templates !