### PR TITLE
feat(lps): Configure content collection for legal pages

### DIFF
--- a/localplanning.services/package.json
+++ b/localplanning.services/package.json
@@ -6,7 +6,7 @@
     "astro": "astro",
     "build": "astro check && astro build",
     "check": "astro check",
-    "dev": "astro dev --open",
+    "dev": "astro dev --mode dev --open",
     "preview": "astro preview --open"
   },
   "dependencies": {

--- a/localplanning.services/src/components/LegalContentPage.astro
+++ b/localplanning.services/src/components/LegalContentPage.astro
@@ -1,0 +1,30 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Masthead from "@components/Masthead.astro";
+import Container from "@components/Container.astro";
+import type { CollectionEntry } from "astro:content";
+import { render } from "astro:content";
+
+interface Props {
+  page: CollectionEntry<"legal">;
+}
+
+const { page } = Astro.props;
+const { Content } = await render(page);
+
+const publishDate = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+}).format(page.data.lastModified);
+---
+
+<Layout>
+  <Masthead title={page.data.title}>
+    <p>{page.data.subheading}</p>
+    <p>Published at: {publishDate}</p>
+  </Masthead>
+  <Container paddingY>
+    <Content />
+  </Container>
+</Layout>

--- a/localplanning.services/src/content/config.ts
+++ b/localplanning.services/src/content/config.ts
@@ -1,0 +1,14 @@
+import { defineCollection, z } from "astro:content";
+
+const legalCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    subheading: z.string(),
+    lastModified: z.date(),
+  }),
+});
+
+export const collections = {
+  legal: legalCollection,
+};

--- a/localplanning.services/src/content/legal/accessibility.md
+++ b/localplanning.services/src/content/legal/accessibility.md
@@ -1,0 +1,13 @@
+---
+title: Accessibility
+subheading: Lorem ipsum dolor sit amet
+lastModified: 2025-06-16
+---
+
+## Heading 2
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+
+<br/>
+
+### Heading 3
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit [anim id est laborum](https://www.lipsum.com/).

--- a/localplanning.services/src/content/legal/privacy.md
+++ b/localplanning.services/src/content/legal/privacy.md
@@ -1,0 +1,13 @@
+---
+title: Privacy
+subheading: Lorem ipsum dolor sit amet
+lastModified: 2025-06-16
+---
+
+## Heading 2
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+
+<br/>
+
+### Heading 3
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit [anim id est laborum](https://www.lipsum.com/).

--- a/localplanning.services/src/pages/[...legal].astro
+++ b/localplanning.services/src/pages/[...legal].astro
@@ -1,0 +1,14 @@
+---
+import LegalContentPage from "@components/LegalContentPage.astro";
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const legalPages = await getCollection("legal");
+  return legalPages.map((page) => ({
+    params: { legal: page.slug },
+    props: { page },
+  }));
+}
+---
+
+<LegalContentPage {...Astro.props} />


### PR DESCRIPTION
## What does this PR do?
- Creates a collection of markdown files, which will be used for the text content of our legal pages (privacy, a11y statement etc). Currently just placeholder content.
- For each file in the `content/legal/` folder, a new `LegalContentPage` will be generated, which renders this content

This PR adds the following pages - 
 - https://localplanning.4790.planx.pizza/privacy/
 - https://localplanning.4790.planx.pizza/accessibility/

![image](https://github.com/user-attachments/assets/268f90b7-61c9-49c4-a25d-1a0a10fe9347)
