### PR TITLE
feat: Background colours for template cards

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -102,10 +102,13 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           className={classNames("card-wrapper", {
             "template-card": props.data?.isTemplatedNode,
           })}
-          sx={
+         sx={
             props.data?.isTemplatedNode
               ? {
-                  backgroundColor: (theme) => theme.palette.template.dark,
+                  backgroundColor: (theme) => 
+                    props.data?.areTemplatedNodeInstructionsRequired
+                      ? theme.palette.template.dark
+                      : theme.palette.template.main,
                 }
               : {}
           }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -102,9 +102,6 @@ const Checklist: React.FC<Props> = React.memo((props) => {
             props.data?.areTemplatedNodeInstructionsRequired
           }
           showStatusHeader={true}
-          className={classNames("card-wrapper", {
-            "template-card": props.data?.isTemplatedNode,
-          })}
         >
           <Link
             href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -1,6 +1,5 @@
 import Help from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import {
   ComponentType as TYPES,
   NodeTag,
@@ -11,7 +10,7 @@ import mapAccum from "ramda/src/mapAccum";
 import React, { useMemo } from "react";
 import { useDrag } from "react-dnd";
 import { Link } from "react-navi";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
@@ -97,34 +96,16 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           wasVisited: props.wasVisited,
         })}
       >
-        <Box
-          // TODO: update card (background colour, text) for differnt states (Requried, Optional, Done)
+        <TemplatedNodeContainer
+          isTemplatedNode={props.data?.isTemplatedNode}
+          areTemplatedNodeInstructionsRequired={
+            props.data?.areTemplatedNodeInstructionsRequired
+          }
+          showStatusHeader={true}
           className={classNames("card-wrapper", {
             "template-card": props.data?.isTemplatedNode,
           })}
-         sx={
-            props.data?.isTemplatedNode
-              ? {
-                  backgroundColor: (theme) => 
-                    props.data?.areTemplatedNodeInstructionsRequired
-                      ? theme.palette.template.dark
-                      : theme.palette.template.main,
-                }
-              : {}
-          }
         >
-          {props.data?.isTemplatedNode && (
-            <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>
-              <Typography
-                variant="body3"
-                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
-              >
-                {props.data?.areTemplatedNodeInstructionsRequired
-                  ? "Required"
-                  : "Optional"}
-              </Typography>
-            </Box>
-          )}
           <Link
             href={href}
             prefetch={false}
@@ -155,7 +136,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
               ))}
             </Box>
           )}
-        </Box>
+        </TemplatedNodeContainer>
         {groupedOptions ? (
           <ol className="categories">
             {groupedOptions.map(({ title, children }, i) => (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@apollo/client";
 import MoreVert from "@mui/icons-material/MoreVert";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import { ComponentType, NodeTag } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/shared/icons";
 import classNames from "classnames";
@@ -11,7 +10,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { useDrag } from "react-dnd";
 import { Link } from "react-navi";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
 import { rootFlowPath } from "../../../../../routes/utils";
 import { getParentId } from "../lib/utils";
@@ -161,34 +160,16 @@ const InternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
-          <Box
-            // TODO: update card (background colour, text) for differnt states (Requried, Optional, Done)
+          <TemplatedNodeContainer
+            isTemplatedNode={props.data?.isTemplatedNode}
+            areTemplatedNodeInstructionsRequired={
+              props.data?.areTemplatedNodeInstructionsRequired
+            }
+            showStatusHeader={true}
             className={classNames("card-wrapper", {
               "template-card": props.data?.isTemplatedNode,
             })}
-            sx={
-              props.data?.isTemplatedNode
-                ? {
-                    backgroundColor: (theme) => 
-                      props.data?.areTemplatedNodeInstructionsRequired
-                        ? theme.palette.template.dark
-                        : theme.palette.template.main,
-                  }
-                : {}
-          }
           >
-            {props.data?.isTemplatedNode && (
-              <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>
-                <Typography
-                  variant="body3"
-                  sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
-                >
-                  {props.data?.areTemplatedNodeInstructionsRequired
-                    ? "Required"
-                    : "Optional"}
-                </Typography>
-              </Box>
-            )}
             <Box sx={{ display: "flex", alignItems: "stretch" }}>
               <Link
                 href={href}
@@ -210,7 +191,7 @@ const InternalPortal: React.FC<any> = (props) => {
                 ))}
               </Box>
             )}
-          </Box>
+          </TemplatedNodeContainer>
         </Box>
       </li>
     </>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -166,9 +166,6 @@ const InternalPortal: React.FC<any> = (props) => {
               props.data?.areTemplatedNodeInstructionsRequired
             }
             showStatusHeader={true}
-            className={classNames("card-wrapper", {
-              "template-card": props.data?.isTemplatedNode,
-            })}
           >
             <Box sx={{ display: "flex", alignItems: "stretch" }}>
               <Link

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -169,10 +169,13 @@ const InternalPortal: React.FC<any> = (props) => {
             sx={
               props.data?.isTemplatedNode
                 ? {
-                    backgroundColor: (theme) => theme.palette.template.dark,
+                    backgroundColor: (theme) => 
+                      props.data?.areTemplatedNodeInstructionsRequired
+                        ? theme.palette.template.dark
+                        : theme.palette.template.main,
                   }
                 : {}
-            }
+          }
           >
             {props.data?.isTemplatedNode && (
               <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -95,7 +95,10 @@ const Question: React.FC<Props> = React.memo((props) => {
           sx={
             props.data?.isTemplatedNode
               ? {
-                  backgroundColor: (theme) => theme.palette.template.dark,
+                  backgroundColor: (theme) => 
+                    props.data?.areTemplatedNodeInstructionsRequired
+                      ? theme.palette.template.dark
+                      : theme.palette.template.main,
                 }
               : {}
           }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -92,9 +92,6 @@ const Question: React.FC<Props> = React.memo((props) => {
             props.data?.areTemplatedNodeInstructionsRequired
           }
           showStatusHeader={true}
-          className={classNames("card-wrapper", {
-            "template-card": props.data?.isTemplatedNode,
-          })}
         >
           <Link
             href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -1,7 +1,6 @@
 import ErrorIcon from "@mui/icons-material/Error";
 import Help from "@mui/icons-material/Help";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import {
   ComponentType as TYPES,
   NodeTag,
@@ -11,7 +10,7 @@ import classNames from "classnames";
 import React from "react";
 import { useDrag } from "react-dnd";
 import { Link } from "react-navi";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
@@ -87,34 +86,16 @@ const Question: React.FC<Props> = React.memo((props) => {
           },
         )}
       >
-        <Box
-          // TODO: update card (background colour, text) for differnt states (Requried, Optional, Done)
+        <TemplatedNodeContainer
+          isTemplatedNode={props.data?.isTemplatedNode}
+          areTemplatedNodeInstructionsRequired={
+            props.data?.areTemplatedNodeInstructionsRequired
+          }
+          showStatusHeader={true}
           className={classNames("card-wrapper", {
             "template-card": props.data?.isTemplatedNode,
           })}
-          sx={
-            props.data?.isTemplatedNode
-              ? {
-                  backgroundColor: (theme) => 
-                    props.data?.areTemplatedNodeInstructionsRequired
-                      ? theme.palette.template.dark
-                      : theme.palette.template.main,
-                }
-              : {}
-          }
         >
-          {props.data?.isTemplatedNode && (
-            <Box sx={{ width: "100%", textAlign: "center", p: 0.4 }}>
-              <Typography
-                variant="body3"
-                sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
-              >
-                {props.data?.areTemplatedNodeInstructionsRequired
-                  ? "Required"
-                  : "Optional"}
-              </Typography>
-            </Box>
-          )}
           <Link
             href={href}
             prefetch={false}
@@ -145,7 +126,7 @@ const Question: React.FC<Props> = React.memo((props) => {
               ))}
             </Box>
           )}
-        </Box>
+        </TemplatedNodeContainer>
         <ol className="options">
           {childNodes.map((child: any) => (
             <Node key={child.id} {...child} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
@@ -1,4 +1,3 @@
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ListItem from "@mui/material/ListItem";
 import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -73,13 +72,6 @@ export const CustomisationCard: React.FC<Props> = ({
         }
         isComplete={isComplete}
         showStatusHeader={true}
-        sx={{
-          width: "100%",
-          padding: theme.spacing(0.25, 0.25, 0.25),
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-        }}
       >
         <NodeCard nodeId={nodeId} backgroundColor={theme.palette.common.white}>
           <Typography variant="body2">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
@@ -17,11 +17,17 @@ interface Props {
   flowEdits: FlowEdits;
 }
 
-const CardContainer = styled(Box)<{ isComplete: boolean }>(
-  ({ theme, isComplete }) => ({
-    backgroundColor: isComplete
-      ? theme.palette.common.white
-      : theme.palette.template.dark,
+const CardContainer = styled(Box)<{ 
+  isComplete: boolean; 
+  areTemplatedNodeInstructionsRequired?: boolean; 
+}>(({ theme, isComplete, areTemplatedNodeInstructionsRequired }) => {
+  const getBackgroundColor = () => {
+    if (isComplete) return theme.palette.common.white;
+    if (areTemplatedNodeInstructionsRequired) return theme.palette.template.dark;
+    return theme.palette.template.main;
+  };
+  return {
+    backgroundColor: getBackgroundColor(),
     border: "1px solid",
     borderColor: isComplete ? theme.palette.border.main : "transparent",
     width: "100%",
@@ -29,8 +35,8 @@ const CardContainer = styled(Box)<{ isComplete: boolean }>(
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
-  }),
-);
+  };
+});
 
 const StatusHeader = styled(Box)(({ theme }) => ({
   display: "flex",
@@ -100,7 +106,10 @@ export const CustomisationCard: React.FC<Props> = ({
         width: "100%",
       }}
     >
-      <CardContainer isComplete={isComplete}>
+      <CardContainer 
+        isComplete={isComplete}
+        areTemplatedNodeInstructionsRequired={node.data?.areTemplatedNodeInstructionsRequired}
+      >
         <StatusHeader>
           {isComplete && <CheckCircleIcon color="success" fontSize="small" />}
           <Typography

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
@@ -66,10 +66,10 @@ export const CustomisationCard: React.FC<Props> = ({
       }}
     >
       <TemplatedNodeContainer
-        isTemplatedNode={node.data?.isTemplatedNode}
-        areTemplatedNodeInstructionsRequired={
-          node.data?.areTemplatedNodeInstructionsRequired
-        }
+        isTemplatedNode={Boolean(node.data?.isTemplatedNode)}
+        areTemplatedNodeInstructionsRequired={Boolean(
+          node.data?.areTemplatedNodeInstructionsRequired,
+        )}
         isComplete={isComplete}
         showStatusHeader={true}
       >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
@@ -1,13 +1,12 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import Box from "@mui/material/Box";
 import ListItem from "@mui/material/ListItem";
-import { styled, useTheme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useCallback } from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { NodeCard } from "ui/editor/NodeCard";
+import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
 import { FlowEdits, NodeEdits } from "./types";
 
@@ -16,36 +15,6 @@ interface Props {
   nodeEdits?: NodeEdits;
   flowEdits: FlowEdits;
 }
-
-const CardContainer = styled(Box)<{ 
-  isComplete: boolean; 
-  areTemplatedNodeInstructionsRequired?: boolean; 
-}>(({ theme, isComplete, areTemplatedNodeInstructionsRequired }) => {
-  const getBackgroundColor = () => {
-    if (isComplete) return theme.palette.common.white;
-    if (areTemplatedNodeInstructionsRequired) return theme.palette.template.dark;
-    return theme.palette.template.main;
-  };
-  return {
-    backgroundColor: getBackgroundColor(),
-    border: "1px solid",
-    borderColor: isComplete ? theme.palette.border.main : "transparent",
-    width: "100%",
-    padding: theme.spacing(0.25, 0.25, 0.25),
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-  };
-});
-
-const StatusHeader = styled(Box)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  gap: theme.spacing(0.5),
-  width: "100%",
-  padding: theme.spacing(0.5),
-}));
 
 export const CustomisationCard: React.FC<Props> = ({
   nodeId,
@@ -84,15 +53,6 @@ export const CustomisationCard: React.FC<Props> = ({
 
   const isComplete = Boolean(hasNodeBeenUpdated());
 
-  const getTemplatedNodeStatus = (
-    isComplete: boolean,
-    areTemplatedNodeInstructionsRequired?: boolean,
-  ) => {
-    if (isComplete) return "Done";
-    if (areTemplatedNodeInstructionsRequired) return "Required";
-    return "Optional";
-  };
-
   return (
     <ListItem
       key={nodeId}
@@ -106,28 +66,27 @@ export const CustomisationCard: React.FC<Props> = ({
         width: "100%",
       }}
     >
-      <CardContainer 
+      <TemplatedNodeContainer
+        isTemplatedNode={node.data?.isTemplatedNode}
+        areTemplatedNodeInstructionsRequired={
+          node.data?.areTemplatedNodeInstructionsRequired
+        }
         isComplete={isComplete}
-        areTemplatedNodeInstructionsRequired={node.data?.areTemplatedNodeInstructionsRequired}
+        showStatusHeader={true}
+        sx={{
+          width: "100%",
+          padding: theme.spacing(0.25, 0.25, 0.25),
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
       >
-        <StatusHeader>
-          {isComplete && <CheckCircleIcon color="success" fontSize="small" />}
-          <Typography
-            variant="body3"
-            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
-          >
-            {getTemplatedNodeStatus(
-              isComplete,
-              node.data?.areTemplatedNodeInstructionsRequired,
-            )}
-          </Typography>
-        </StatusHeader>
         <NodeCard nodeId={nodeId} backgroundColor={theme.palette.common.white}>
           <Typography variant="body2">
             {node.data?.templatedNodeInstructions}
           </Typography>
         </NodeCard>
-      </CardContainer>
+      </TemplatedNodeContainer>
     </ListItem>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.tsx
@@ -59,7 +59,7 @@ const Customisations = () => {
   const flowEdits = data?.edits?.[0]?.data || {};
 
   return (
-    <Box p={2} sx={{ backgroundColor: "background.paper" }}>
+    <Box p={2} sx={{ backgroundColor: "background.paper", minHeight: "100%" }}>
       <Typography variant="h4" mb={1}>
         {`Customise`}
       </Typography>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -149,18 +149,23 @@ export const CheckForChangesToPublishButton: React.FC<{
               marginBottom: (theme) => theme.spacing(2),
               display: "flex",
               flexDirection: "row",
-              alignItems: "center",
+              alignItems: "flex-start",
             }}
           >
-            <StarIcon sx={{ color: "#380F77" }} />
-            <Typography variant="body2">
-              {`Templated from ${template.team.name} - `}
-              <strong>
-                {isTemplatedFlowDueToPublish
-                  ? "Due to review and publish"
-                  : "Up to date"}
-              </strong>
-            </Typography>
+            <StarIcon sx={{ color: "#380F77", mr: 0.5 }} fontSize="small" />
+            <Box>
+              <Typography variant="body2">
+                {`Templated from ${template.team.name}`}
+              </Typography>
+              <Typography variant="body2">
+                <strong>
+                  {isTemplatedFlowDueToPublish
+                    ? "Due to review and publish"
+                    : "Up to date"}
+                </strong>
+              </Typography>
+            </Box>
+
           </Box>
         )}
         <Button

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -95,6 +95,12 @@ const Header = styled("header")(({ theme }) => ({
     border: "1px solid ${theme.palette.border.main}",
     borderWidth: "1px",
   },
+}));
+
+const Icons = styled(Box)(() => ({
+  display: "flex",
+  alignItems: "center",
+  width: "100%",
   "& svg": {
     cursor: "pointer",
     opacity: "0.7",
@@ -183,7 +189,7 @@ const Sidebar: React.FC = React.memo(() => {
             {showSidebar ? <ChevronRightIcon /> : <ChevronLeftIcon />}
           </StyledToggleButton>
           <Header>
-            <Box width="100%" display="flex">
+            <Icons>
               <input type="text" disabled value={urls.preview} />
 
               <Permission.IsPlatformAdmin>
@@ -230,7 +236,7 @@ const Sidebar: React.FC = React.memo(() => {
                   </Box>
                 </Tooltip>
               )}
-            </Box>
+            </Icons>
             <CheckForChangesToPublishButton previewURL={urls.preview} />
           </Header>
           <TabList>

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -105,6 +105,7 @@ $fontMonospace: "Source Code Pro", monospace;
 
   .card-wrapper {
     max-width: $nodeMaxWidth;
+    flex-direction: column;
     & > a {
       display: flex;
       flex-direction: column;

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -110,12 +110,18 @@ $fontMonospace: "Source Code Pro", monospace;
       display: flex;
       flex-direction: column;
     }
+    &.template-card > a {
+      background: #fff;
+    }
   }
 
   &.portal .card-wrapper {
     max-width: 260px;
     & > a {
       flex-direction: row;
+    }
+    &.template-card a {
+      background: $black;
     }
   }
 
@@ -501,6 +507,11 @@ $fontMonospace: "Source Code Pro", monospace;
       padding-right: 20px;
       .flow-locked & {
         background: #f5f4d2 !important;
+      }
+    }
+    & .template-card > a {
+      .flow-locked & {
+        background: #fffdb0 !important;
       }
     }
     // Triangle shapes to simulate paper fold on sticky note

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -109,23 +109,10 @@ $fontMonospace: "Source Code Pro", monospace;
       display: flex;
       flex-direction: column;
     }
-    &.template-card {
-      padding: 4px;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      & a {
-        background: #fff;
-      }
-    }
   }
 
   &.portal .card-wrapper {
     max-width: 260px;
-    flex-direction: column;
-    &.template-card a {
-      background: $black;
-    }
     & > a {
       flex-direction: row;
     }

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -44,8 +44,10 @@ const FlowEditor = () => {
   useScrollControlsAndRememberPosition(scrollContainerRef);
 
   const teamSlug = useStore.getState().getTeam().slug;
-  const lockedFlow = !useStore.getState().canUserEditTeam(teamSlug);
-  // TODO: use lockedFlow styling when editing templated flows
+  const isTemplatedFrom = useStore.getState().isTemplatedFrom;
+
+  const lockedFlow =
+    !useStore.getState().canUserEditTeam(teamSlug) || isTemplatedFrom;
 
   return (
     <EditorContainer id="editor-container">

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -1,23 +1,30 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import Box from "@mui/material/Box";
-import { styled } from "@mui/material/styles";
+import { styled, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import classNames from "classnames";
 import React from "react";
+import { PropsWithChildren } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-interface TemplatedNodeContainerProps {
-  children: React.ReactNode;
-  isTemplatedNode?: boolean;
-  areTemplatedNodeInstructionsRequired?: boolean;
+interface TemplatedNodeContainerProps extends PropsWithChildren {
+  isTemplatedNode: boolean;
+  areTemplatedNodeInstructionsRequired: boolean;
   isComplete?: boolean;
   showStatusHeader?: boolean;
   className?: string;
-  sx?: any;
 }
 
-const StyledContainer = styled(Box)<{
-  isTemplatedNode?: boolean;
-  areTemplatedNodeInstructionsRequired?: boolean;
+const StyledContainer = styled(Box, {
+  shouldForwardProp: (prop) =>
+    ![
+      "isTemplatedNode",
+      "areTemplatedNodeInstructionsRequired",
+      "isComplete",
+    ].includes(prop as string),
+})<{
+  isTemplatedNode: boolean;
+  areTemplatedNodeInstructionsRequired: boolean;
   isComplete?: boolean;
 }>(({
   theme,
@@ -41,8 +48,9 @@ const StyledContainer = styled(Box)<{
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
+    border: "1px solid",
+    borderColor: "transparent",
     ...(isComplete && {
-      border: "1px solid",
       borderColor: theme.palette.border.main,
     }),
   };
@@ -58,14 +66,13 @@ const StatusHeader = styled(Box)(({ theme }) => ({
 }));
 
 const getTemplatedNodeStatus = (
-  isComplete?: boolean,
   areTemplatedNodeInstructionsRequired?: boolean,
 ) => {
   if (areTemplatedNodeInstructionsRequired) return "Required";
   return "Optional";
 };
 
-const getStatusIcon = (theme: any, isComplete?: boolean) => {
+const getStatusIcon = (theme: Theme, isComplete?: boolean) => {
   if (isComplete) {
     return { color: theme.palette.success.main };
   }
@@ -82,25 +89,27 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
   isComplete = false,
   showStatusHeader = false,
   className,
-  sx = {},
 }) => {
+  const containerClasses = classNames(
+    "card-wrapper",
+    {
+      "template-card": isTemplatedNode,
+    },
+    className,
+  );
+
   if (!isTemplatedNode) {
-    return (
-      <Box className={className} sx={sx}>
-        {children}
-      </Box>
-    );
+    return <Box className={containerClasses}>{children}</Box>;
   }
 
   return (
     <StyledContainer
-      className={className}
+      className={containerClasses}
       isTemplatedNode={isTemplatedNode}
       areTemplatedNodeInstructionsRequired={
         areTemplatedNodeInstructionsRequired
       }
       isComplete={isComplete}
-      sx={sx}
     >
       {showStatusHeader && (
         <StatusHeader>
@@ -110,10 +119,7 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
               fontWeight: FONT_WEIGHT_SEMI_BOLD,
             }}
           >
-            {getTemplatedNodeStatus(
-              isComplete,
-              areTemplatedNodeInstructionsRequired,
-            )}
+            {getTemplatedNodeStatus(areTemplatedNodeInstructionsRequired)}
           </Typography>
           <CheckCircleIcon
             fontSize="small"

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -51,19 +51,28 @@ const StyledContainer = styled(Box)<{
 const StatusHeader = styled(Box)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
-  justifyContent: "center",
+  justifyContent: "space-between",
   gap: theme.spacing(0.5),
   width: "100%",
-  padding: theme.spacing(0.5),
+  padding: theme.spacing(0.5, 0.5, 0.75),
 }));
 
 const getTemplatedNodeStatus = (
   isComplete?: boolean,
   areTemplatedNodeInstructionsRequired?: boolean,
 ) => {
-  if (isComplete) return "Done";
   if (areTemplatedNodeInstructionsRequired) return "Required";
   return "Optional";
+};
+
+const getStatusIcon = (theme: any, isComplete?: boolean) => {
+  if (isComplete) {
+    return { color: theme.palette.success.main };
+  }
+  return {
+    color: theme.palette.text.primary,
+    opacity: 0.2,
+  };
 };
 
 export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
@@ -83,13 +92,6 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
     );
   }
 
-  const getStatusIcon = () => {
-    if (isComplete) {
-      return <CheckCircleIcon color="success" fontSize="small" />;
-    }
-    return undefined;
-  };
-
   return (
     <StyledContainer
       className={className}
@@ -102,16 +104,21 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
     >
       {showStatusHeader && (
         <StatusHeader>
-          {getStatusIcon()}
           <Typography
             variant="body3"
-            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            sx={{
+              fontWeight: FONT_WEIGHT_SEMI_BOLD,
+            }}
           >
             {getTemplatedNodeStatus(
               isComplete,
               areTemplatedNodeInstructionsRequired,
             )}
           </Typography>
+          <CheckCircleIcon
+            fontSize="small"
+            sx={(theme) => getStatusIcon(theme, isComplete)}
+          />
         </StatusHeader>
       )}
       {children}

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -36,6 +36,11 @@ const StyledContainer = styled(Box)<{
 
   return {
     backgroundColor: getBackgroundColor(),
+    width: "100%",
+    padding: "4px",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
     ...(isComplete && {
       border: "1px solid",
       borderColor: theme.palette.border.main,

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -1,0 +1,115 @@
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+interface TemplatedNodeContainerProps {
+  children: React.ReactNode;
+  isTemplatedNode?: boolean;
+  areTemplatedNodeInstructionsRequired?: boolean;
+  isComplete?: boolean;
+  showStatusHeader?: boolean;
+  className?: string;
+  sx?: any;
+}
+
+const StyledContainer = styled(Box)<{
+  isTemplatedNode?: boolean;
+  areTemplatedNodeInstructionsRequired?: boolean;
+  isComplete?: boolean;
+}>(({
+  theme,
+  isTemplatedNode,
+  areTemplatedNodeInstructionsRequired,
+  isComplete,
+}) => {
+  if (!isTemplatedNode) return {};
+
+  const getBackgroundColor = () => {
+    if (isComplete) return theme.palette.common.white;
+    if (areTemplatedNodeInstructionsRequired)
+      return theme.palette.template.dark;
+    return theme.palette.template.main;
+  };
+
+  return {
+    backgroundColor: getBackgroundColor(),
+    ...(isComplete && {
+      border: "1px solid",
+      borderColor: theme.palette.border.main,
+    }),
+  };
+});
+
+const StatusHeader = styled(Box)(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: theme.spacing(0.5),
+  width: "100%",
+  padding: theme.spacing(0.5),
+}));
+
+const getTemplatedNodeStatus = (
+  isComplete?: boolean,
+  areTemplatedNodeInstructionsRequired?: boolean,
+) => {
+  if (isComplete) return "Done";
+  if (areTemplatedNodeInstructionsRequired) return "Required";
+  return "Optional";
+};
+
+export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
+  children,
+  isTemplatedNode = false,
+  areTemplatedNodeInstructionsRequired = false,
+  isComplete = false,
+  showStatusHeader = false,
+  className,
+  sx = {},
+}) => {
+  if (!isTemplatedNode) {
+    return (
+      <Box className={className} sx={sx}>
+        {children}
+      </Box>
+    );
+  }
+
+  const getStatusIcon = () => {
+    if (isComplete) {
+      return <CheckCircleIcon color="success" fontSize="small" />;
+    }
+    return undefined;
+  };
+
+  return (
+    <StyledContainer
+      className={className}
+      isTemplatedNode={isTemplatedNode}
+      areTemplatedNodeInstructionsRequired={
+        areTemplatedNodeInstructionsRequired
+      }
+      isComplete={isComplete}
+      sx={sx}
+    >
+      {showStatusHeader && (
+        <StatusHeader>
+          {getStatusIcon()}
+          <Typography
+            variant="body3"
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+          >
+            {getTemplatedNodeStatus(
+              isComplete,
+              areTemplatedNodeInstructionsRequired,
+            )}
+          </Typography>
+        </StatusHeader>
+      )}
+      {children}
+    </StyledContainer>
+  );
+};


### PR DESCRIPTION
## What does this PR do?

- Sets background colour for optional vs required in graph and sidebar node cards
![image](https://github.com/user-attachments/assets/88aa943a-0c81-4b7c-a899-6b0e9e4fd8a6)

- Ensures background of Customise panel covers 100% height

- Adjusts layout of (sidebar header)
![image](https://github.com/user-attachments/assets/85aa10ef-1fda-4094-82e3-4a27d47242c4)

Testing:
https://4794.planx.pizza/a-new-team/template

Feature flagged: `window.featureFlags.toggle("TEMPLATES")`