### PR TITLE
fix: Portal tag layout

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -102,12 +102,14 @@ const ExternalPortal: React.FC<any> = (props) => {
       <li ref={ref}>
         <Box className={classNames("card", "portal", { isDragging })}>
           <Box className="card-wrapper">
-            <Link href={`/${href}`} prefetch={false} ref={drag}>
-              <span>{href}</span>
-            </Link>
-            <Link href={editHref} prefetch={false} className="portalMenu">
-              <MoreVert titleAccess="Edit Portal" />
-            </Link>
+            <Box sx={{ display: "flex", alignItems: "stretch" }}>
+              <Link href={`/${href}`} prefetch={false} ref={drag}>
+                <span>{href}</span>
+              </Link>
+              <Link href={editHref} prefetch={false} className="portalMenu">
+                <MoreVert titleAccess="Edit Portal" />
+              </Link>
+            </Box>
           </Box>
           {showTags && tagsByRole && tagsByRole.length > 0 && (
             <Box className="card-tag-list">

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -122,6 +122,7 @@ $fontMonospace: "Source Code Pro", monospace;
 
   &.portal .card-wrapper {
     max-width: 260px;
+    flex-direction: column;
     &.template-card a {
       background: $black;
     }


### PR DESCRIPTION
## What does this PR do?

Fixes content alignment of portals with tags.

**Before vs after:**
![image](https://github.com/user-attachments/assets/835f6f2f-5dcf-44db-9cc3-4034468ccbc9)
