### PR TITLE
feat(lps): Basic layout for 'Your applications'

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -211,7 +211,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
-      - run: pnpm build --mode staging
+      - run: pnpm build --mode pizza
+        env: 
+          ROOT_DOMAIN: ${{ env.FULL_DOMAIN }}
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
   build_react_app:

--- a/localplanning.services/.env.dev
+++ b/localplanning.services/.env.dev
@@ -1,2 +1,3 @@
 PUBLIC_PLANX_EDITOR_URL=http://localhost:3000
 PUBLIC_PLANX_GRAPHQL_API_URL=http://localhost:7100/v1/graphql
+PUBLIC_PLANX_REST_API_URL=http://localhost:7002

--- a/localplanning.services/.env.pizza
+++ b/localplanning.services/.env.pizza
@@ -1,0 +1,4 @@
+PUBLIC_PLANX_EDITOR_URL=https://${ROOT_DOMAIN}
+# Point to **staging** in order to avoid race conditions at build time
+PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
+PUBLIC_PLANX_REST_API_URL=https://api.${ROOT_DOMAIN}

--- a/localplanning.services/.env.staging
+++ b/localplanning.services/.env.staging
@@ -1,3 +1,4 @@
 # Used for both staging and pizza environments
 PUBLIC_PLANX_EDITOR_URL=https://editor.planx.dev
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
+PUBLIC_PLANX_REST_API_URL=https://api.editor.planx.dev

--- a/localplanning.services/.env.staging
+++ b/localplanning.services/.env.staging
@@ -1,4 +1,3 @@
-# Used for both staging and pizza environments
 PUBLIC_PLANX_EDITOR_URL=https://editor.planx.dev
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
 PUBLIC_PLANX_REST_API_URL=https://api.editor.planx.dev

--- a/localplanning.services/astro.config.mjs
+++ b/localplanning.services/astro.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
     schema: {
       PUBLIC_PLANX_EDITOR_URL: envField.string({ context: "client", access: "public", optional: false }),
       PUBLIC_PLANX_GRAPHQL_API_URL: envField.string({ context: "client", access: "public", optional: false }),
+      PUBLIC_PLANX_REST_API_URL: envField.string({ context: "client", access: "public", optional: false }),
     }
   },
   vite: {

--- a/localplanning.services/src/components/applications/EmailForm.tsx
+++ b/localplanning.services/src/components/applications/EmailForm.tsx
@@ -1,0 +1,51 @@
+import type { FormEventHandler } from "react";
+import { useResumeApplication } from "./hooks/useResumeApplication";
+
+const EmailForm: React.FC = () => {
+  const { submitEmail, isLoading, error, clearError } = useResumeApplication();
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    
+    const formData = new FormData(e.target as HTMLFormElement);
+    const email = formData.get("email")?.toString();
+    if (!email) return;
+
+    await submitEmail(email);
+  };
+
+  return (
+    <div className="max-w-3xl text-body-lg">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <label htmlFor="email" className="font-semibold text-md">
+          Enter your email address
+        </label>
+        <input
+          className="pt-2 shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          id="email"
+          type="email"
+          name="email"
+          required
+          disabled={isLoading}
+          onChange={clearError}
+        />
+
+        {error && (
+          <div className="text-red-600 mt-2" role="alert">
+            {error}
+          </div>
+        )}
+
+        <button 
+          type="submit" 
+          disabled={isLoading} 
+          className="inline-block font-semibold rounded transition m-0 bg-action-main hover:bg-action-main-hover text-body-md clamp-[py,2,3] clamp-[px,3,4] cursor-pointer w-min"
+        >
+          {isLoading ? "Submitting..." : "Submit"}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default EmailForm;

--- a/localplanning.services/src/components/applications/hooks/useResumeApplication.tsx
+++ b/localplanning.services/src/components/applications/hooks/useResumeApplication.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { PUBLIC_PLANX_REST_API_URL } from "astro:env/client";
+import { navigate } from "astro:transitions/client";
+
+type UseResumeApplication = () => {
+  submitEmail: (email: string) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+interface ResumeAPIResponse {
+  message: string;
+}
+
+export const useResumeApplication: UseResumeApplication = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitEmail = async (email: string): Promise<void> => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const response = await fetch(`${PUBLIC_PLANX_REST_API_URL}/resume-application`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ payload: email })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to submit: ${response.statusText}`);
+      }
+
+      const data: ResumeAPIResponse = await response.json();
+      // TEMP: Remove once API updated
+      console.log({ data });
+
+      navigate("/applications/check-your-inbox");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "An unexpected error occurred";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const clearError = () => setError(null);
+
+  return {
+    submitEmail,
+    isLoading,
+    error,
+    clearError
+  };
+};

--- a/localplanning.services/src/components/applications/hooks/useResumeApplication.tsx
+++ b/localplanning.services/src/components/applications/hooks/useResumeApplication.tsx
@@ -25,6 +25,7 @@ export const useResumeApplication: UseResumeApplication = () => {
       const response = await fetch(`${PUBLIC_PLANX_REST_API_URL}/resume-application`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        // TODO: PlanX API currently requires a team name
         body: JSON.stringify({ payload: email })
       });
 
@@ -33,7 +34,7 @@ export const useResumeApplication: UseResumeApplication = () => {
       }
 
       const data: ResumeAPIResponse = await response.json();
-      // TEMP: Remove once API updated
+      // TEMP: Remove once PlanX API updated
       console.log({ data });
 
       navigate("/applications/check-your-inbox");

--- a/localplanning.services/src/components/applications/hooks/useResumeApplication.tsx
+++ b/localplanning.services/src/components/applications/hooks/useResumeApplication.tsx
@@ -30,7 +30,7 @@ export const useResumeApplication: UseResumeApplication = () => {
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to submit: ${response.statusText}`);
+        throw new Error(`Failed to submit: ${response.status}`);
       }
 
       const data: ResumeAPIResponse = await response.json();

--- a/localplanning.services/src/pages/applications/check-your-inbox.astro
+++ b/localplanning.services/src/pages/applications/check-your-inbox.astro
@@ -1,0 +1,10 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Masthead from "@components/Masthead.astro";
+---
+
+<Layout>
+  <Masthead title="Check your inbox">
+    <p>We've sent you a magic link to access your applications. Please check your email inbox.</p>
+  </Masthead>
+</Layout>

--- a/localplanning.services/src/pages/applications/index.astro
+++ b/localplanning.services/src/pages/applications/index.astro
@@ -2,6 +2,7 @@
 import Layout from "@layouts/Layout.astro";
 import Container from "@components/Container.astro";
 import Masthead from "@components/Masthead.astro";
+import EmailForm from "@components/applications/EmailForm";
 ---
 
 <Layout>
@@ -9,10 +10,6 @@ import Masthead from "@components/Masthead.astro";
     <p>View applications in progress, and download sent applications.</p>
   </Masthead>
   <Container paddingY>
-    <div class="max-w-3xl text-body-lg">
-      <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Accusamus, qui. Provident, earum possimus? Explicabo natus minima quasi quos veritatis temporibus earum sapiente aliquam, eaque necessitatibus dolorum culpa possimus, perspiciatis cum.</p>
-    </div>
+    <EmailForm client:load/>
   </Container>
-
-  
 </Layout>


### PR DESCRIPTION
## What does this PR do?
 - Adds the "Your applications" page
 - Makes basic form which submits to hit PlanX API (response not possible currently, see below)
 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/62d326a3-316c-4424-ab3a-fa3c1b657b4a" />

## Why doesn't the existing API endpoint work?
Currently the PlanX `/resume-application` endpoint requires a `teamSlug`. This is used for - 
 - Email personalisation
 - Filtering list of applications to include in the "resume" email content

For LPS, we don't want this restriction (single team) in place. The email template should send a single magic link which takes the user back to LPS, where the full list of applications is displayed.

### Can we just modify the existing endpoint?
Yes, we could do this. However, I think new endpoints (grouped within an `/lps` route/module) are a cleaner and safer option in terms of maintainability going forward. Whilst the "resume" options within PlanX and LPS are fundamentally similar we don't necessarily want them closely coupled.

## Next steps...
- [ ] Create `/lps` module in API
  - [ ] POST `lps/resume` endpoint
  - [ ] GET `lps/applications?token=abc123&email=test@example.com`
- [ ] Create `magic_links` table (containing expiry dates and unique UUIDs)
- [ ] Write to LPS to hit new endpoints
- [ ] Display applications (cards / data grid / list.... TBD!)


## User journey
Once finalised, I'll make sure an updated and accurate version of this remains within the repo in a readme, and/or on Notion

```mermaid
sequenceDiagram
    participant User
    participant LPS
    participant PlanX_API as PlanX API
    participant PlanX_Frontend as PlanX Frontend

    User->>LPS: Enter email
    LPS->>PlanX_API: POST `lps/resume`
    PlanX_API->>PlanX_API: Trigger email via GovNotify
    PlanX_API->>User: Send email with link
    
    User->>LPS: Click magic link
    LPS->>PlanX_API: GET `lps/applications?token=abc123&email=test@example.com`
    PlanX_API->>PlanX_API: Validate details
    
    alt Error
        PlanX_API->>LPS: Reject

    else Success
        PlanX_API->>LPS: Return list of applications
    end

    LPS->>PlanX_Frontend: Resume single application
    PlanX_Frontend->>PlanX_API: /validate-session API call
    PlanX_API->>PlanX_Frontend: Success
 ```
