### PR TITLE
docs: readme setup update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ planx-new is a monorepo containing our full application stack. Here's a quick su
 
 1. Clone this repository
 
-2. Setup your AWS CLI client with SSO - [detailed guide here](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-aws-sso-credentials.md)
+2. Setup your AWS CLI client with SSO - [detailed guide here](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/aws/how-to-setup-aws-sso-credentials.md)
 
 3. Pull down environment secrets for running the application in staging mode by running `./scripts/pull-secrets.sh`. (NOTE: Even when running locally, API requests are routed to relevant staging servers and emails are actually processed and sent to provided addresses).
 
 4. Run `pnpm run up` from the project root to set up docker containers for the application's backend (postgres, sharedb, api and hasura server processes) and to pull seed application data from production.
+
+***Please Note***: If using a Mac running Apple silicone (M1 -M4) chips and running into Docker image compatibility issues please see our [troubleshooting guide](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/aws/how-to-setup-aws-sso-credentials.md)
 
 5. Move into the hasura directory `cd ../hasura.planx.uk` and install dependencies `pnpm i`.
 
@@ -72,7 +74,7 @@ planx-new is a monorepo containing our full application stack. Here's a quick su
 
 7. Follow steps 7-9 above to start the editor and login !
 
-At this point you'll be running the full Planx application locally in a docker container. See our Github Actions pull request workflow as an example of how to deploy via docker to a virtual linux server, or explore the `infrastructure` directory for how to deploy via Pulumi infrastructure-as-code to AWS. 
+At this point you'll be running the full Planx application locally in a docker container. See our Github Actions pull request workflow as an example of how to deploy via docker to a virtual linux server, or explore the `infrastructure` directory for how to deploy via Pulumi infrastructure-as-code to AWS.
 
 We'd love to hear what you're building on Planx, don't hesitate to get in touch with questions.
 
@@ -126,7 +128,7 @@ You'll have to temporarily turn off branch protection rules to make this change,
 
 **Unmet peer dependencies**
 
-Make sure `pnpm` is installed globally at version 10.10.0 `pnpm add -g pnpm@10.10.0`, otherwise you may hit some unmet peer dependencies issues. 
+Make sure `pnpm` is installed globally at version 10.10.0 `pnpm add -g pnpm@10.10.0`, otherwise you may hit some unmet peer dependencies issues.
 
 ## Audits
 

--- a/doc/how-to/how-to-configure-docker-for-apple-silicone.md
+++ b/doc/how-to/how-to-configure-docker-for-apple-silicone.md
@@ -1,0 +1,146 @@
+# Docker on Apple Silicon Mac: Platform Compatibility Solutions
+
+This document outlines solutions for running Docker containers that don't have native ARM64 support on Apple Silicon Macs (M1, M2, M3).
+
+## The Problem
+
+When trying to run Docker containers on an Apple Silicon Mac, you may encounter errors like:
+
+```
+Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest
+```
+
+This happens because the Docker image doesn't provide a version built for ARM64 architecture, which is what Apple Silicon Macs use.
+
+## Solution 1: Set DOCKER_DEFAULT_PLATFORM Environment Variable
+
+This approach tells Docker to automatically use emulation for all images.
+
+### Temporary (Current Terminal Session)
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+### Permanent (Add to Shell Profile)
+
+For zsh:
+```bash
+echo 'export DOCKER_DEFAULT_PLATFORM=linux/amd64' >> ~/.zshrc
+source ~/.zshrc
+```
+
+For bash:
+```bash
+echo 'export DOCKER_DEFAULT_PLATFORM=linux/amd64' >> ~/.bashrc
+source ~/.bashrc
+```
+
+### Usage Example
+
+After setting the environment variable, you can run Docker commands normally:
+
+```bash
+# For PlanX project
+pnpm run up
+
+# General Docker commands
+docker run -it postgres:15
+docker-compose up
+```
+
+### Pros
+- Simple, one-time setup
+- Works for all Docker commands automatically
+- No need to modify project files
+- Easy to disable when needed
+
+### Cons
+- Applies emulation to all containers (may affect performance)
+- May use emulation even when ARM64 versions exist
+
+## Solution 2: Docker Compose Override Files
+
+This approach uses override files to specify platform emulation only for specific services.
+
+### Step 1: Create an Override File
+
+Create a file named `docker-compose.arm64.yml`:
+
+```yaml
+services:
+  postgres:
+    platform: linux/amd64
+  metabase:
+    platform: linux/amd64
+  # Add other services that need emulation
+```
+
+### Step 2: Use the Override File
+
+```bash
+docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.arm64.yml up -d
+```
+
+### Step 3: Create Helper Scripts (Optional)
+
+Create a script named `local-up.sh`:
+
+```bash
+#!/bin/bash
+docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.arm64.yml up -d
+```
+
+Make it executable:
+```bash
+chmod +x local-up.sh
+```
+
+### Step 4: Prevent Accidental Commits
+
+Add to your local Git exclude:
+```bash
+echo "docker-compose.arm64.yml" >> .git/info/exclude
+echo "local-*.sh" >> .git/info/exclude
+```
+
+### Pros
+- Fine-grained control over which services use emulation
+- Can improve performance by only emulating when necessary
+- Can be project-specific
+- Allows mixing native ARM64 and emulated x86_64 containers
+
+### Cons
+- More complex setup
+- Requires modifying commands or creating scripts
+- Needs to be set up for each project
+
+## Which Approach Should You Choose?
+
+### Use DOCKER_DEFAULT_PLATFORM if:
+- You want a simple, system-wide solution
+- You work with mostly older Docker images that lack ARM64 support
+- You're not concerned about maximum performance
+
+### Use Docker Compose overrides if:
+- You need maximum performance from containers
+- You want selective emulation (some containers with native ARM64, others emulated)
+- You're working on a shared project where others don't use Apple Silicon
+
+## Additional Tips
+
+1. **Check for ARM64 support**: Before assuming emulation is needed, check if the image supports ARM64: 
+   ```bash
+   docker manifest inspect <image>:<tag> | grep 'arm64'
+   ```
+
+2. **Use ARM64-native alternatives**: When possible, use images that have native ARM64 support:
+   - `postgres:latest` instead of `postgis/postgis:X-Y-alpine`
+   - `arm64v8/postgres` instead of `postgres`
+
+3. **Test performance**: Emulation adds overhead. If performance is critical, benchmark the difference between emulated and native containers.
+
+4. **Disabling platform emulation**: To disable the global setting temporarily:
+   ```bash
+   unset DOCKER_DEFAULT_PLATFORM
+   ```

--- a/doc/how-to/how-to-configure-docker-for-apple-silicone.md
+++ b/doc/how-to/how-to-configure-docker-for-apple-silicone.md
@@ -22,42 +22,11 @@ This approach tells Docker to automatically use emulation for all images.
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
 ```
 
-### Permanent (Add to Shell Profile)
-
-For zsh:
-```bash
-echo 'export DOCKER_DEFAULT_PLATFORM=linux/amd64' >> ~/.zshrc
-source ~/.zshrc
-```
-
-For bash:
-```bash
-echo 'export DOCKER_DEFAULT_PLATFORM=linux/amd64' >> ~/.bashrc
-source ~/.bashrc
-```
-
-### Usage Example
-
-After setting the environment variable, you can run Docker commands normally:
-
-```bash
-# For PlanX project
-pnpm run up
-
-# General Docker commands
-docker run -it postgres:15
-docker-compose up
-```
-
-### Pros
+### Notes:
 - Simple, one-time setup
 - Works for all Docker commands automatically
-- No need to modify project files
-- Easy to disable when needed
+- Has to be set anew with each new terminal session
 
-### Cons
-- Applies emulation to all containers (may affect performance)
-- May use emulation even when ARM64 versions exist
 
 ## Solution 2: Docker Compose Override Files
 
@@ -96,7 +65,7 @@ Make it executable:
 chmod +x local-up.sh
 ```
 
-### Step 4: Prevent Accidental Commits
+### Step 4: Add to local git ignore
 
 Add to your local Git exclude:
 ```bash
@@ -104,43 +73,18 @@ echo "docker-compose.arm64.yml" >> .git/info/exclude
 echo "local-*.sh" >> .git/info/exclude
 ```
 
-### Pros
-- Fine-grained control over which services use emulation
-- Can improve performance by only emulating when necessary
-- Can be project-specific
-- Allows mixing native ARM64 and emulated x86_64 containers
-
-### Cons
-- More complex setup
-- Requires modifying commands or creating scripts
-- Needs to be set up for each project
-
-## Which Approach Should You Choose?
-
-### Use DOCKER_DEFAULT_PLATFORM if:
-- You want a simple, system-wide solution
-- You work with mostly older Docker images that lack ARM64 support
-- You're not concerned about maximum performance
-
-### Use Docker Compose overrides if:
-- You need maximum performance from containers
-- You want selective emulation (some containers with native ARM64, others emulated)
-- You're working on a shared project where others don't use Apple Silicon
+### Notes
+- Offers replacement for `docker-compose.override.yml`
+- Process can be repeated for ```docker-down``` and ```docker-restart``` scripts
 
 ## Additional Tips
 
-1. **Check for ARM64 support**: Before assuming emulation is needed, check if the image supports ARM64: 
+1. **Check for ARM64 support**: Before assuming emulation is needed, check if the image supports ARM64:
    ```bash
    docker manifest inspect <image>:<tag> | grep 'arm64'
    ```
 
-2. **Use ARM64-native alternatives**: When possible, use images that have native ARM64 support:
-   - `postgres:latest` instead of `postgis/postgis:X-Y-alpine`
-   - `arm64v8/postgres` instead of `postgres`
-
-3. **Test performance**: Emulation adds overhead. If performance is critical, benchmark the difference between emulated and native containers.
-
-4. **Disabling platform emulation**: To disable the global setting temporarily:
+2. **Disabling platform emulation**: To disable the global setting temporarily:
    ```bash
    unset DOCKER_DEFAULT_PLATFORM
    ```


### PR DESCRIPTION
This pull request updates the documentation to improve support for Apple Silicon Macs and enhance clarity in setup instructions. The most important changes include updating the AWS SSO credentials link in the `README.md`, adding a troubleshooting guide for Docker compatibility issues on Apple Silicon Macs, and introducing a new document with detailed solutions for these issues.

### Documentation Updates for Apple Silicon Mac Support:

* **Updated AWS SSO credentials link in `README.md`**: The link to the AWS SSO setup guide was updated to reflect its new location under a more specific directory structure. Additionally, a note was added to the `README.md` about Docker compatibility issues for Apple Silicon Macs, with a link to the troubleshooting guide.

* **Added new document for Docker compatibility solutions**: A new file, `doc/how-to/how-to-configure-docker-for-apple-silicone.md`, was created. It provides detailed solutions for running Docker containers on Apple Silicon Macs, including setting the `DOCKER_DEFAULT_PLATFORM` environment variable, using Docker Compose override files, and creating helper scripts for ease of use.