### PR TITLE
fix(a11y): Skip link (bypass blocks)

### DIFF
--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -46,7 +46,7 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 import { rootFlowPath } from "../../routes/utils";
 import AnalyticsDisabledBanner from "../AnalyticsDisabled/AnalyticsDisabledBanner";
 import { ConfirmationDialog } from "../ConfirmationDialog";
-import { SkipLink } from "./SkipLink";
+import SkipLink from "./SkipLink";
 
 export const HEADER_HEIGHT_PUBLIC = 74;
 export const HEADER_HEIGHT_EDITOR = 56;

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -34,7 +34,6 @@ import {
 } from "react-navi";
 import {
   borderedFocusStyle,
-  focusStyle,
   FONT_WEIGHT_SEMI_BOLD,
   LINE_HEIGHT_BASE,
 } from "theme";
@@ -47,8 +46,9 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 import { rootFlowPath } from "../../routes/utils";
 import AnalyticsDisabledBanner from "../AnalyticsDisabled/AnalyticsDisabledBanner";
 import { ConfirmationDialog } from "../ConfirmationDialog";
+import { SkipLink } from "./SkipLink";
 
-const HEADER_HEIGHT_PUBLIC = 74;
+export const HEADER_HEIGHT_PUBLIC = 74;
 export const HEADER_HEIGHT_EDITOR = 56;
 
 const Root = styled(AppBar)(({ theme }) => ({
@@ -151,26 +151,6 @@ const LogoLink = styled(Link)(() => ({
   display: "flex",
   alignItems: "center",
   "&:focus-visible": borderedFocusStyle,
-}));
-
-const SkipLink = styled("a")(({ theme }) => ({
-  tabIndex: 0,
-  width: "100vw",
-  height: HEADER_HEIGHT_PUBLIC / 2,
-  backgroundColor: theme.palette.background.dark,
-  color: theme.palette.common.white,
-  textDecoration: "underline",
-  padding: theme.spacing(1),
-  paddingLeft: theme.spacing(3),
-  // translate off-screen with absolute position
-  position: "absolute",
-  transform: "translateY(-100%)",
-  "&:focus": {
-    // bring it into view when accessed by tab
-    transform: "translateY(0%)",
-    position: "relative",
-    ...focusStyle,
-  },
 }));
 
 const ServiceTitleRoot = styled("span")(({ theme }) => ({
@@ -388,7 +368,7 @@ const PublicToolbar: React.FC<{
 
   return (
     <>
-      <SkipLink href="#main-content">Skip to main content</SkipLink>
+      <SkipLink />
       <PublicHeader disableGutters>
         <Container maxWidth={false}>
           <InnerContainer>

--- a/editor.planx.uk/src/components/Header/SkipLink.tsx
+++ b/editor.planx.uk/src/components/Header/SkipLink.tsx
@@ -6,6 +6,7 @@ import { HEADER_HEIGHT_PUBLIC } from "./Header";
 
 const Root = styled("a")(({ theme }) => ({
   width: "100vw",
+  cursor: "pointer",
   height: HEADER_HEIGHT_PUBLIC / 2,
   backgroundColor: theme.palette.background.dark,
   color: theme.palette.common.white,
@@ -26,6 +27,17 @@ const Root = styled("a")(({ theme }) => ({
 export const SkipLink: React.FC = () => {
   const handleClick = (e: SyntheticEvent<HTMLAnchorElement>) => {
     e.preventDefault();
+    handleActivation();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleActivation();
+    }
+  };
+
+  const handleActivation = () => {
     const targetElement = document.getElementById("main-content");
     if (!targetElement) return;
 
@@ -34,8 +46,10 @@ export const SkipLink: React.FC = () => {
   };
 
   return (
-    <Root onClick={handleClick} tabIndex={0}>
+    <Root onClick={handleClick} onKeyDown={handleKeyDown} tabIndex={0}>
       Skip to main content
     </Root>
   );
 };
+
+export default SkipLink;

--- a/editor.planx.uk/src/components/Header/SkipLink.tsx
+++ b/editor.planx.uk/src/components/Header/SkipLink.tsx
@@ -1,0 +1,41 @@
+import { styled } from "@mui/material/styles";
+import React, { SyntheticEvent } from "react";
+import { focusStyle } from "theme";
+
+import { HEADER_HEIGHT_PUBLIC } from "./Header";
+
+const Root = styled("a")(({ theme }) => ({
+  width: "100vw",
+  height: HEADER_HEIGHT_PUBLIC / 2,
+  backgroundColor: theme.palette.background.dark,
+  color: theme.palette.common.white,
+  textDecoration: "underline",
+  padding: theme.spacing(1),
+  paddingLeft: theme.spacing(3),
+  // translate off-screen with absolute position
+  position: "absolute",
+  transform: "translateY(-100%)",
+  "&:focus": {
+    // bring it into view when accessed by tab
+    transform: "translateY(0%)",
+    position: "relative",
+    ...focusStyle,
+  },
+}));
+
+export const SkipLink: React.FC = () => {
+  const handleClick = (e: SyntheticEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const targetElement = document.getElementById("main-content");
+    if (!targetElement) return;
+
+    targetElement.focus();
+    targetElement.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <Root onClick={handleClick} tabIndex={0}>
+      Skip to main content
+    </Root>
+  );
+};

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -11,6 +11,7 @@ import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { ApplicationPath, Session } from "types";
+import Main from "ui/shared/Main";
 
 import ErrorFallback from "../../components/Error/ErrorFallback";
 import { useStore } from "../FlowEditor/lib/store";
@@ -181,7 +182,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
       </BackBar>
 
       {node && (
-        <Box component="main" id="main-content" sx={{ width: "100%" }}>
+        <Main>
           <ErrorBoundary FallbackComponent={ErrorFallback}>
             <Node
               node={node}
@@ -189,7 +190,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
               handleSubmit={handleSubmit(node.id!)}
             />
           </ErrorBoundary>
-        </Box>
+        </Main>
       )}
     </Box>
   );

--- a/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
+++ b/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
 import { useFormik } from "formik";
@@ -8,6 +7,7 @@ import { useCurrentRoute } from "react-navi";
 import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import Main from "ui/shared/Main";
 import { object, ref, string } from "yup";
 
 const confirmEmailSchema = object({
@@ -33,7 +33,7 @@ export const ConfirmEmail: React.FC<{
   });
 
   return (
-    <Box component="main" id="main-content" width="100%">
+    <Main>
       <Card handleSubmit={formik.handleSubmit}>
         <CardHeader
           title="Enter your email address"
@@ -76,7 +76,7 @@ export const ConfirmEmail: React.FC<{
           </InputLabel>
         </InputRow>
       </Card>
-    </Box>
+    </Main>
   );
 };
 

--- a/editor.planx.uk/src/pages/layout/SaveAndReturnLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/SaveAndReturnLayout.tsx
@@ -1,8 +1,8 @@
-import Box from "@mui/material/Box";
 import { NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { PropsWithChildren } from "react";
 import { useCurrentRoute } from "react-navi";
+import Main from "ui/shared/Main";
 
 import { ApplicationPath as AppPath } from "../../types";
 import ResumePage from "../Preview/ResumePage";
@@ -24,14 +24,14 @@ const SaveAndReturnLayout = ({ children }: PropsWithChildren) => {
         {
           [AppPath.SingleSession]: children,
           [AppPath.Save]: (
-            <Box component="main" id="main-content" sx={{ width: "100%" }}>
+            <Main>
               <SavePage />
-            </Box>
+            </Main>
           ),
           [AppPath.Resume]: (
-            <Box component="main" id="main-content" sx={{ width: "100%" }}>
+            <Main>
               <ResumePage />
-            </Box>
+            </Main>
           ),
           [AppPath.SaveAndReturn]: <SaveAndReturn>{children}</SaveAndReturn>,
         }[path]

--- a/editor.planx.uk/src/routes/views/standalone.tsx
+++ b/editor.planx.uk/src/routes/views/standalone.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import gql from "graphql-tag";
 import { publicClient } from "lib/graphql";
 import { NaviRequest, NotFoundError } from "navi";
@@ -7,6 +6,7 @@ import PublicLayout from "pages/layout/PublicLayout";
 import React from "react";
 import { View } from "react-navi";
 import { Flow, GlobalSettings } from "types";
+import Main from "ui/shared/Main";
 
 import { getTeamFromDomain } from "../utils";
 
@@ -36,9 +36,9 @@ const standaloneView = async (req: NaviRequest) => {
 
   return (
     <PublicLayout>
-      <Box component="main" id="main-content" sx={{ width: "100%" }}>
+      <Main>
         <View />
-      </Box>
+      </Main>
     </PublicLayout>
   );
 };

--- a/editor.planx.uk/src/ui/shared/Main.tsx
+++ b/editor.planx.uk/src/ui/shared/Main.tsx
@@ -1,0 +1,20 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import React, { PropsWithChildren } from "react";
+
+const Root = styled(Box)(() => ({
+  width: "100%",
+  "&:focus": {
+    outline: "none",
+    boxShadow: "none",
+    border: "none",
+  },
+}));
+
+const Main: React.FC<PropsWithChildren> = ({ children }) => (
+  <Root component="main" id="main-content" tabIndex={-1}>
+    {children}
+  </Root>
+);
+
+export default Main;


### PR DESCRIPTION
## What does this PR do?
 - Resolves https://trello.com/c/N2PDqhOg/3308-bypass-blocks-a-p14
 - Refactors out the repeated `<main/>` components into a single reusable component
 - Switches skip link from a plain anchor and href to a React component in order to call `e.preventDefault()`

I've not actually worked out what the regression was the broke this, as it's previously passed an a11y audit last year. Possibly something related to routing or structure I'm missing here?

https://github.com/user-attachments/assets/7f30c689-c622-4681-b1fb-ef4337f9197b

## To test....
- First click of `tab` opens skip link
- Link can be used via keyboard or mouse
- Scrolls to the `main` element
- Shifts focus to the `main` element
  - The next `tab` press will take you to the first navigable element within the `main` component