### PR TITLE
refactor: Non-text content in UploadAndLabel

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx
@@ -21,6 +21,7 @@ import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHt
 
 import { FileUploadSlot } from "../FileUpload/model";
 import { MoreInformation } from "../shared";
+import SemanticIcon from "../shared/Icons/SemanticIcon";
 import Card from "../shared/Preview/Card";
 import { CardHeader } from "../shared/Preview/CardHeader/CardHeader";
 import { Image } from "../shared/Preview/CardHeader/styled";
@@ -309,16 +310,33 @@ const InteractiveFileListItem = (props: FileListItemProps) => {
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center" }}>
-        <CheckCircleIcon
-          data-testid={props.completed ? "complete-icon" : "incomplete-icon"}
-          color={props.completed ? "success" : "disabled"}
-          fontSize="large"
-          sx={{
-            marginRight: (theme) => theme.spacing(0.25),
-            paddingRight: (theme) => theme.spacing(0.5),
-          }}
-        />
-        <Typography variant="body1">{props.name}</Typography>
+        <SemanticIcon
+          titleAccess="Task completed icon"
+          ariaLabel={
+            props.completed
+              ? `${props.name} has been uploaded`
+              : `${props.name} has not been uploaded`
+          }
+        >
+          <CheckCircleIcon
+            data-testid={props.completed ? "complete-icon" : "incomplete-icon"}
+            color={props.completed ? "success" : "disabled"}
+            fontSize="large"
+            sx={{
+              marginRight: (theme) => theme.spacing(0.25),
+              paddingRight: (theme) => theme.spacing(0.5),
+            }}
+            // titleAccess="Task completed icon"
+            // aria-label={
+            //   props.completed
+            //     ? `${props.name} has been uploaded`
+            //     : `${props.name} has not been uploaded`
+            // }
+          />
+        </SemanticIcon>
+        <Typography component="span" variant="body1">
+          {props.name}
+        </Typography>
       </Box>
       {!!(info || policyRef || howMeasured) && (
         <InfoButton

--- a/editor.planx.uk/src/@planx/components/shared/Icons/SemanticIcon.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Icons/SemanticIcon.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface Props {
+  children: React.ReactElement;
+  titleAccess: string;
+  ariaLabel: string;
+  role?: string;
+}
+
+const SemanticIcon: React.FC<Props> = ({
+  children,
+  titleAccess,
+  ariaLabel,
+  role = "img",
+  ...props
+}) => {
+  return React.cloneElement(children, {
+    ...props,
+    titleAccess,
+    "aria-label": ariaLabel,
+    role,
+    ...children.props,
+  });
+};
+
+export default SemanticIcon;


### PR DESCRIPTION
This pull request introduces a new `SemanticIcon` component to improve accessibility for icons and updates the `InteractiveFileListItem` component to use it. This solution deviates slightly from the proposed solution in the [ticket](https://trello.com/c/iIRpAXv0/3310-non-text-content-in-uploadandlabel-a-p18?filter=label:Accessibility) in the line with the MUI [documentation on semantic icons](https://mui.com/material-ui/icons/) to achieve a similar effect using the titleAccess prop instead of directly setting the role or aria-hidden attributes. 

### Accessibility Improvements:

* **New `SemanticIcon` Component**: Added a reusable `SemanticIcon` component that wraps icons with accessible attributes like `aria-label` and `role`. This ensures better support for assistive technologies. (`editor.planx.uk/src/@planx/components/shared/Icons/SemanticIcon.tsx`)

* **Integration of `SemanticIcon` in `InteractiveFileListItem`**: Wraps the direct use of `CheckCircleIcon` with the new `SemanticIcon` component, providing meaningful `aria-label` values based on the upload status of the file. (`editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx`) [[1]](diffhunk://#diff-6fd92f406b5e2d61d235159dd04272171f3939b4c997067831053f279c84ebb7R313-R320) [[2]](diffhunk://#diff-6fd92f406b5e2d61d235159dd04272171f3939b4c997067831053f279c84ebb7R329-R339)

### Codebase Updates:

* **Imports Update**: Added the import for the `SemanticIcon` component in the `FileUploadAndLabel` module to enable its usage. (`editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public.tsx`)