### PR TITLE
feat(a11y): Keyboard access for `MapAndLabel` "Copy feature" select

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -33,7 +33,7 @@ interface MapAndLabelContextValue {
   isFeatureInvalid: (index: number) => boolean;
   addInitialFeaturesToMap: (features: Feature[]) => void;
   editFeatureInForm: (index: number) => void;
-  copyFeature: (sourceIndex: number, destinationIndex: number) => void;
+  copyFeature: (sourceLabel: string, destinationIndex: number) => void;
   removeFeature: (index: number) => void;
   mapAndLabelProps: PresentationalProps;
   errors: {
@@ -204,7 +204,9 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     }
   };
 
-  const copyFeature = (sourceIndex: number, destinationIndex: number) => {
+  const copyFeature = (sourceLabel: string, destinationIndex: number) => {
+    // Convert text label to zero-indexed integer
+    const sourceIndex = parseInt(sourceLabel, 10) - 1;
     const sourceFeature = formik.values.schemaData[sourceIndex];
     formik.setFieldValue(`schemaData[${destinationIndex}]`, {
       ...sourceFeature,

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -71,6 +71,7 @@ export const CopyFeature: React.FC<Props> = ({
         </InputLabel>
       </Box>
       <Button
+        data-testid="copyButton"
         type="submit"
         disableRipple
         sx={{ alignSelf: "flex-end", ml: 2, mb: 0.5 }}

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -1,6 +1,8 @@
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import MenuItem from "@mui/material/MenuItem";
 import { visuallyHidden } from "@mui/utils";
+import { useFormik } from "formik";
 import { Feature } from "geojson";
 import React from "react";
 import SelectInput from "ui/editor/SelectInput/SelectInput";
@@ -27,39 +29,55 @@ export const CopyFeature: React.FC<Props> = ({
     (_, sourceIndex) => sourceIndex !== destinationIndex,
   );
 
+  const formik = useFormik({
+    initialValues: {
+      sourceLabel: sourceFeatures[0]?.properties?.label,
+    },
+    onSubmit: ({ sourceLabel }) => copyFeature(sourceLabel, destinationIndex),
+  });
+
   return (
-    <Box>
-      <InputLabel label="Copy from" id={`select-${destinationIndex}`}>
-        <SelectInput
-          disabled={isDisabled}
-          aria-describedby="copy-feature-description"
-          bordered
-          required
-          title={"Copy from"}
-          value={""}
-          onChange={(e) => {
-            const label = e.target.value as string;
-            // Convert text label to zero-indexed integer
-            const sourceIndex = parseInt(label, 10) - 1;
-            copyFeature(sourceIndex, destinationIndex);
-          }}
-          name={"copyFeature"}
-          style={{ width: "200px" }}
-        >
-          <span id="copy-feature-description" style={visuallyHidden}>
-            Please add at least two features to the map in order to enable this
-            feature
-          </span>
-          {sourceFeatures.map((option) => (
-            <MenuItem
-              key={option.properties?.label}
-              value={option.properties?.label}
-            >
-              {`${schema.type} ${option.properties?.label}`}
-            </MenuItem>
-          ))}
-        </SelectInput>
-      </InputLabel>
+    <Box
+      sx={{ display: "flex" }}
+      component={"form"}
+      onSubmit={formik.handleSubmit}
+    >
+      <Box>
+        <InputLabel label="Copy from" id={`select-${destinationIndex}`}>
+          <SelectInput
+            disabled={isDisabled}
+            aria-describedby="copy-feature-description"
+            bordered
+            required
+            title={"Copy from"}
+            value={formik.values.sourceLabel}
+            onChange={formik.handleChange}
+            name={"sourceLabel"}
+            style={{ width: "200px" }}
+          >
+            <span id="copy-feature-description" style={visuallyHidden}>
+              Please add at least two features to the map in order to enable
+              this feature
+            </span>
+            {sourceFeatures.map((option) => (
+              <MenuItem
+                key={option.properties?.label}
+                value={option.properties?.label}
+              >
+                {`${schema.type} ${option.properties?.label}`}
+              </MenuItem>
+            ))}
+          </SelectInput>
+        </InputLabel>
+      </Box>
+      <Button
+        type="submit"
+        disableRipple
+        sx={{ alignSelf: "flex-end", ml: 2, mb: 0.5 }}
+        disabled={isDisabled}
+      >
+        Copy
+      </Button>
     </Box>
   );
 };

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
@@ -91,7 +91,7 @@ describe("Basic UI", () => {
 // Schema and field validation is handled in both List and Schema folders - here we're only testing the MapAndLabel specific error handling
 describe("validation and error handling", () => {
   it("shows errors for all required fields", async () => {
-    const { getByTestId, user, queryByRole, getAllByTestId } = setup(
+    const { getByTestId, user, queryByRole } = setup(
       <MapAndLabel {...props} />,
     );
     const map = getByTestId("map-and-label-map");
@@ -370,7 +370,7 @@ describe("copy feature select", () => {
   });
 
   it("copies all data from one feature to another", async () => {
-    const { getByTitle, user, getByLabelText, getByRole } = setup(
+    const { getByTitle, user, getByLabelText, getByRole, getByTestId } = setup(
       <MapAndLabel {...props} />,
     );
     addMultipleFeatures([point1, point2]);
@@ -386,8 +386,10 @@ describe("copy feature select", () => {
     await user.click(copyInput);
 
     const listItemTwo = getByRole("option", { name: "Tree 2" });
+    const copyButton = getByTestId("copyButton");
 
     await user.click(listItemTwo);
+    await user.click(copyButton);
 
     expect(getByLabelText("Species")).toHaveDisplayValue(mockTreeData.species);
     expect(getByLabelText("Proposed work (optional)")).toHaveDisplayValue(


### PR DESCRIPTION
## What does this PR do?
 - Fixes "Copy feature" dropdown to be keyboard accessible
 - Adds explicit "Copy" button to control action
 - Resolves https://trello.com/c/64ZlcVF7/3312-keyboard-a-aaa-p-23-last-prio-bc-mapandlabel

## To test...
Try using the `MapAndLabel` component in Storybook via the keyboard - https://storybook.4804.planx.pizza/?path=/docs/planx-components-mapandlabel--docs

https://github.com/user-attachments/assets/3511bee1-5e17-4346-842a-ced937ef9c0b

