### PR TITLE
refactor: updates container to use a MUI List container to contain list items

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
+import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -148,7 +149,7 @@ export const UploadedFileCard: React.FC<Props> = ({
         </FileCard>
         {tags && (
           <TagRoot>
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            <List sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
               {tags.map((tag) => (
                 <ListItem key={tag} disablePadding sx={{ width: "auto" }}>
                   <Chip
@@ -159,7 +160,7 @@ export const UploadedFileCard: React.FC<Props> = ({
                   />
                 </ListItem>
               ))}
-            </Box>
+            </List>
             <Link
               onClick={() => onChange && onChange()}
               sx={{ fontFamily: "inherit", fontSize: "inherit" }}


### PR DESCRIPTION
This pull request updates the `UploadedFileCard` component to replace the use of the `Box` component with the `List` component for rendering tags. This change improves the semantic structure of the component.

### Component updates for semantic structure:

* [`editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx`](diffhunk://#diff-754df901dc2d20a4c2aa2d07fedbb8f9ef82f742d70ca4f692a871cec2184785R7): Added the `List` import to replace the `Box` component for rendering tags.