### PR TITLE
feat: "Visibility" flow settings should show a static message for source templates and templated flows

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowVisibility/FlowVisibilitySection.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowVisibility/FlowVisibilitySection.tsx
@@ -11,10 +11,18 @@ import { Switch } from "ui/shared/Switch";
 import { useStore } from "../../../../lib/store";
 
 export const FlowVisibility = () => {
-  const [canCreateFromCopy, updateCanCreateFromCopy] = useStore((state) => [
+  const [
+    canCreateFromCopy,
+    updateCanCreateFromCopy,
+    isTemplate,
+    isTemplatedFrom,
+  ] = useStore((state) => [
     state.flowCanCreateFromCopy,
     state.updateFlowCanCreateFromCopy,
+    state.isTemplate,
+    state.isTemplatedFrom,
   ]);
+
   const toast = useToast();
 
   const form = useFormik<{ canCreateFromCopy: boolean }>({
@@ -31,6 +39,28 @@ export const FlowVisibility = () => {
     },
   });
 
+  if (isTemplate || isTemplatedFrom) {
+    return (
+      <Box mb={2}>
+        <SettingsSection>
+          <Typography variant="h2" component="h3" gutterBottom>
+            Visibility
+          </Typography>
+          <Typography variant="body1">
+            Manage the visibility of your service.
+          </Typography>
+        </SettingsSection>
+        <SettingsSection background>
+          <SettingsDescription>
+            <p>
+              {`${isTemplate ? "Source templates" : "Templated flows"} cannot be made visible for others to start "From copy". Instead, encourage others to start "From template" directly.`}
+            </p>
+          </SettingsDescription>
+        </SettingsSection>
+      </Box>
+    );
+  }
+
   return (
     <Box component="form" onSubmit={form.handleSubmit} mb={2}>
       <SettingsSection>
@@ -43,17 +73,25 @@ export const FlowVisibility = () => {
       </SettingsSection>
       <SettingsSection background>
         <Switch
-          label={form.values.canCreateFromCopy ? "Can be copied to create new services" : "Cannot be copied to create new services"}
+          label={
+            form.values.canCreateFromCopy
+              ? "Can be copied to create new services"
+              : "Cannot be copied to create new services"
+          }
           name={"service.status"}
           variant="editorPage"
           checked={form.values.canCreateFromCopy}
           onChange={() =>
-            form.setFieldValue("canCreateFromCopy", !form.values.canCreateFromCopy)
+            form.setFieldValue(
+              "canCreateFromCopy",
+              !form.values.canCreateFromCopy,
+            )
           }
         />
         <SettingsDescription>
           <p>
-            Control if this flow can be used to create new services in other teams. The flow can still be copied and modified within your team.
+            Control if this flow can be used to create new services in other
+            teams. The flow can still be copied and modified within your team.
           </p>
         </SettingsDescription>
 


### PR DESCRIPTION
Follows on from #4774 

https://trello.com/c/sngCGirg/3353-implement-internal-feedback-and-finalise-design-make-sure-live-services-are-always-up-to-date-aka-flows-copied-from-templates-sh

If a flow is a source template or templated flow, replace the usual "Visibility" settings toggle with a static message: 
![Screenshot from 2025-06-19 10-06-48](https://github.com/user-attachments/assets/a59b4902-f368-445b-b49e-250bb0ecdfc0)
