### PR TITLE
design: add templates style to comments automatically created on source update

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/TimelineItems.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/TimelineItems.tsx
@@ -113,9 +113,17 @@ export const CommentTimelineItem = ({
   inUndoScope,
 }: CommentTimelineItemProps) => (
   <TimeLineItem
-    bgcolor={(theme) =>
-      inUndoScope(i) ? theme.palette.grey[100] : theme.palette.secondary.dark
-    }
+    bgcolor={(theme) => {
+      if (inUndoScope(i)) {
+        return theme.palette.grey[100];
+      } else if (
+        event.comment.startsWith("Updated based on source template publish")
+      ) {
+        return theme.palette.template.main;
+      } else {
+        return theme.palette.secondary.dark;
+      }
+    }}
     color={inUndoScope(i) ? "GrayText" : "inherit"}
     p={1}
   >

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/AlteredNodes.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/AlteredNodes.tsx
@@ -29,15 +29,21 @@ export interface AlteredNode {
   data?: any;
 }
 
-const HistoryComment = styled(Box)(({ theme }) => ({
-  width: "100%",
-  margin: theme.spacing(0.5, 0),
-  padding: theme.spacing(1, 1.5),
-  background: theme.palette.secondary.dark,
-  color: theme.palette.text.primary,
-  borderRadius: theme.shape.borderRadius,
-  border: `1px solid rgba(0,0,0,0.08)`,
-}));
+const HistoryComment = styled(Box, {
+  shouldForwardProp: (prop) => prop != "isTemplatedFlowUpdateComment",
+})<{ isTemplatedFlowUpdateComment?: boolean }>(
+  ({ theme, isTemplatedFlowUpdateComment }) => ({
+    width: "100%",
+    margin: theme.spacing(0.5, 0),
+    padding: theme.spacing(1, 1.5),
+    background: isTemplatedFlowUpdateComment
+      ? theme.palette.template.main
+      : theme.palette.secondary.dark,
+    color: theme.palette.text.primary,
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid rgba(0,0,0,0.08)`,
+  }),
+);
 
 export const AlteredNodeListItem = (props: { node: AlteredNode }) => {
   const { node } = props;
@@ -142,7 +148,11 @@ export const AlteredNodesSummaryContent = (props: {
                       <strong>Commented</strong>{" "}
                       {`${formatLastEditDate(comment.createdAt)}`}
                     </Typography>
-                    <HistoryComment>
+                    <HistoryComment
+                      isTemplatedFlowUpdateComment={comment.comment.startsWith(
+                        "Updated based on source template publish",
+                      )}
+                    >
                       <BlockQuote>{comment.comment}</BlockQuote>
                     </HistoryComment>
                   </>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -50,8 +50,6 @@ export const CheckForChangesToPublishButton: React.FC<{
   const [lastPublishedTitle, setLastPublishedTitle] = useState<string>(
     "This flow is not published yet",
   );
-  const [templateLastPublishedTitle, setTemplateLastPublishedTitle] =
-    useState<string>();
   const [isTemplatedFlowDueToPublish, setIsTemplatedFlowDueToPublish] =
     useState<boolean>(false);
 
@@ -122,12 +120,7 @@ export const CheckForChangesToPublishButton: React.FC<{
     setLastPublishedTitle(formatLastPublishMessage(date, user));
 
     if (template) {
-      const sourceTemplateUser = await lastPublisher(template.id);
       const sourceTemplateDate = template.publishedFlows[0].publishedAt;
-      setTemplateLastPublishedTitle(
-        formatLastPublishMessage(sourceTemplateDate, sourceTemplateUser),
-      );
-
       if (date) {
         setIsTemplatedFlowDueToPublish(sourceTemplateDate > date);
       }


### PR DESCRIPTION
https://trello.com/c/sngCGirg/3353-implement-internal-feedback-and-finalise-design-make-sure-live-services-are-always-up-to-date-aka-flows-copied-from-templates-sh

**User stories:**
- As someone maintaining a templated flow, I want to know that it's being "taken care of" (receiving updates from) the source template
- As someone publishing a templated flow, I want to know which update(s) to the source template I'm reviewing that are included in my next publish (** the source template may have been published more than once since your templated flow has been published!!)

**Changes:**
- Applies the purple template color to comments that have been automatically added based on the source template update so that they're easy to distinguish from "normal" comments

![Screenshot from 2025-06-19 12-12-31](https://github.com/user-attachments/assets/49fb2fc2-b7fc-4de6-819e-b28a38d8162d)

![Screenshot from 2025-06-19 12-08-30](https://github.com/user-attachments/assets/8aac28be-95ed-452b-96b0-a0464227af8a)

**Open questions:**
- Does this satisfy a "publishing style" for templated flows? Would you expect anything else?
- The current language of these auto-comments is a bit of a mouthful - I'll raise this to content team and ask for suggestions!