### PR TITLE
feat: create submission analytics when `isSubmissionService = true`

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -1,9 +1,10 @@
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { DEFAULT_FLAG_CATEGORY } from "@opensystemslab/planx-core/types";
-import { FlowStatus } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  DEFAULT_FLAG_CATEGORY,
+  FlowStatus,
+} from "@opensystemslab/planx-core/types";
 
 import { Store } from "../store";
-import { useStore } from "../store";
 import { ALLOW_LIST } from "./provider";
 import {
   AllowListKey,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -241,12 +241,10 @@ export const getDiscretionary = (environment: Environment) => ({
 
 export const getSubmission = (
   environment: Environment,
-  flowSlug: string,
   isSubmissionService: boolean,
-  rab: ReturnType<typeof getRAB>,
 ): { id: string } | undefined => {
-  // Exclude RAB slugs (since they are technically submissions)
-  if (isSubmissionService && !rab.slugs.includes(flowSlug)) {
+  // We don't need to exclude RAB slugs here because this function is called after getRAB() and they're already excluded
+  if (isSubmissionService) {
     return {
       id: DASHBOARD_PUBLIC_IDS[environment].submission,
     };
@@ -274,12 +272,7 @@ export const generateAnalyticsLink = ({
   const foiynpp = getFOIYNPP(environment);
   const rab = getRAB(environment);
   const discretionary = getDiscretionary(environment);
-  const submission = getSubmission(
-    environment,
-    flowSlug,
-    isSubmissionService,
-    rab,
-  );
+  const submission = getSubmission(environment, isSubmissionService);
 
   if (foiynpp.slugs.includes(flowSlug)) {
     dashboardId = foiynpp.id;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -166,8 +166,7 @@ export const settingsStore: StateCreator<
       fetchPolicy: "no-cache",
     });
 
-    const isSubmissionService =
-      published_flows?.[0]?.has_send_component ?? false;
+    const isSubmissionService = published_flows[0].has_send_component;
 
     set({
       flowSettings: settings,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -11,6 +11,11 @@ import {
 } from "types";
 import type { StateCreator } from "zustand";
 
+import {
+  Environment,
+  generateAnalyticsLink,
+  getAnalyticsDashboardId,
+} from "../analytics/utils";
 import { SharedStore } from "./shared";
 import { TeamStore } from "./team";
 
@@ -129,6 +134,7 @@ export const settingsStore: StateCreator<
       data: {
         flows: [
           {
+            id,
             settings,
             status,
             description,
@@ -168,6 +174,24 @@ export const settingsStore: StateCreator<
 
     const isSubmissionService = published_flows[0].has_send_component;
 
+    const environment: Environment =
+      import.meta.env.VITE_APP_ENV === "production" ? "production" : "staging";
+
+    const dashboardId = getAnalyticsDashboardId({
+      flowStatus: status,
+      environment,
+      flowSlug,
+      isSubmissionService,
+    });
+
+    const analyticsLink = dashboardId
+      ? generateAnalyticsLink({
+          environment,
+          flowId: id,
+          dashboardId,
+        })
+      : undefined;
+
     set({
       flowSettings: settings,
       flowStatus: status,
@@ -175,7 +199,7 @@ export const settingsStore: StateCreator<
       flowSummary: summary,
       flowLimitations: limitations,
       flowCanCreateFromCopy: canCreateFromCopy,
-      isSubmissionService,
+      flowAnalyticsLink: analyticsLink,
     });
 
     return {
@@ -184,7 +208,7 @@ export const settingsStore: StateCreator<
       description,
       summary,
       limitations,
-      isSubmissionService,
+      analyticsLink,
     };
   },
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { FlowStatus } from "@opensystemslab/planx-core/types";
 import camelcaseKeys from "camelcase-keys";
 import { client } from "lib/graphql";
-import { FlowInformation, GetFlowInformation } from "pages/FlowEditor/utils";
+import { FlowInformation, RawGetFlowInformation } from "pages/FlowEditor/utils";
 import {
   AdminPanelData,
   FlowSettings,
@@ -34,6 +34,7 @@ export interface SettingsStore {
   flowLimitations?: string;
   updateFlowLimitations: (newLimitations: string) => Promise<boolean>;
   globalSettings?: GlobalSettings;
+  isSubmissionService?: boolean;
   setGlobalSettings: (globalSettings: GlobalSettings) => void;
   updateFlowSettings: (newSettings: FlowSettings) => Promise<number>;
   updateGlobalSettings: (newSettings: { [key: string]: TextContent }) => void;
@@ -67,8 +68,8 @@ export const settingsStore: StateCreator<
       set({ flowStatus: newStatus });
       return Boolean(result.id);
     } catch (error) {
-      console.error(error)
-      return false
+      console.error(error);
+      return false;
     }
   },
 
@@ -134,10 +135,11 @@ export const settingsStore: StateCreator<
             summary,
             limitations,
             canCreateFromCopy,
+            published_flows,
           },
         ],
       },
-    } = await client.query<GetFlowInformation>({
+    } = await client.query<RawGetFlowInformation>({
       query: gql`
         query GetFlow($slug: String!, $team_slug: String!) {
           flows(
@@ -151,6 +153,9 @@ export const settingsStore: StateCreator<
             status
             limitations
             canCreateFromCopy: can_create_from_copy
+            published_flows(limit: 1, order_by: { created_at: desc }) {
+              has_send_component
+            }
           }
         }
       `,
@@ -161,6 +166,9 @@ export const settingsStore: StateCreator<
       fetchPolicy: "no-cache",
     });
 
+    const isSubmissionService =
+      published_flows?.[0]?.has_send_component ?? false;
+
     set({
       flowSettings: settings,
       flowStatus: status,
@@ -168,9 +176,17 @@ export const settingsStore: StateCreator<
       flowSummary: summary,
       flowLimitations: limitations,
       flowCanCreateFromCopy: canCreateFromCopy,
+      isSubmissionService,
     });
 
-    return { settings, status, description, summary, limitations };
+    return {
+      settings,
+      status,
+      description,
+      summary,
+      limitations,
+      isSubmissionService,
+    };
   },
 
   globalSettings: undefined,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { FlowStatus } from "@opensystemslab/planx-core/types";
 import camelcaseKeys from "camelcase-keys";
 import { client } from "lib/graphql";
-import { FlowInformation, RawGetFlowInformation } from "pages/FlowEditor/utils";
+import { FlowInformation } from "pages/FlowEditor/utils";
 import {
   AdminPanelData,
   FlowSettings,
@@ -124,7 +124,7 @@ export const settingsStore: StateCreator<
     return Boolean(result?.id);
   },
 
-  getFlowInformation: async (flowSlug, teamSlug) => {
+  getFlowInformation: async (flowSlug, teamSlug): Promise<FlowInformation> => {
     const {
       data: {
         flows: [
@@ -139,7 +139,7 @@ export const settingsStore: StateCreator<
           },
         ],
       },
-    } = await client.query<RawGetFlowInformation>({
+    } = await client.query({
       query: gql`
         query GetFlow($slug: String!, $team_slug: String!) {
           flows(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -141,7 +141,7 @@ export const settingsStore: StateCreator<
             summary,
             limitations,
             canCreateFromCopy,
-            published_flows,
+            publishedFlows,
           },
         ],
       },
@@ -159,8 +159,11 @@ export const settingsStore: StateCreator<
             status
             limitations
             canCreateFromCopy: can_create_from_copy
-            published_flows(limit: 1, order_by: { created_at: desc }) {
-              has_send_component
+            publishedFlows: published_flows(
+              limit: 1
+              order_by: { created_at: desc }
+            ) {
+              hasSendComponent: has_send_component
             }
           }
         }
@@ -172,7 +175,7 @@ export const settingsStore: StateCreator<
       fetchPolicy: "no-cache",
     });
 
-    const isSubmissionService = published_flows[0].has_send_component;
+    const isSubmissionService = publishedFlows[0].hasSendComponent;
 
     const environment: Environment =
       import.meta.env.VITE_APP_ENV === "production" ? "production" : "staging";

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -9,7 +9,7 @@ export interface FlowInformation {
   summary?: string;
   limitations?: string;
   canCreateFromCopy?: boolean;
-  isSubmissionService?: boolean;
+  isSubmissionService: boolean;
 }
 
 export interface GetFlowInformation {

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -9,6 +9,20 @@ export interface FlowInformation {
   summary?: string;
   limitations?: string;
   canCreateFromCopy?: boolean;
+  isSubmissionService?: boolean;
+}
+
+export interface RawFlowInformation {
+  settings: FlowSettings;
+  status: FlowStatus;
+  description?: string;
+  summary?: string;
+  limitations?: string;
+  canCreateFromCopy?: boolean;
+  published_flows?: { has_send_component?: boolean }[];
+}
+export interface RawGetFlowInformation {
+  flows: RawFlowInformation[];
 }
 
 export interface GetFlowInformation {

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -12,19 +12,6 @@ export interface FlowInformation {
   isSubmissionService?: boolean;
 }
 
-export interface RawFlowInformation {
-  settings: FlowSettings;
-  status: FlowStatus;
-  description?: string;
-  summary?: string;
-  limitations?: string;
-  canCreateFromCopy?: boolean;
-  published_flows?: { has_send_component?: boolean }[];
-}
-export interface RawGetFlowInformation {
-  flows: RawFlowInformation[];
-}
-
 export interface GetFlowInformation {
   id: string;
   flows: FlowInformation[];

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -9,7 +9,7 @@ export interface FlowInformation {
   summary?: string;
   limitations?: string;
   canCreateFromCopy?: boolean;
-  isSubmissionService: boolean;
+  analyticsLink?: string;
 }
 
 export interface GetFlowInformation {

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -58,9 +58,6 @@ interface GetFlowEditorData {
   }[];
 }
 
-const environment: Environment =
-  import.meta.env.VITE_APP_ENV === "production" ? "production" : "staging";
-
 export const getFlowEditorData = async (
   flowSlug: string,
   team: string,
@@ -136,32 +133,9 @@ export const flowEditorView = async (req: NaviRequest) => {
     template,
   } = await getFlowEditorData(flow, req.params.team);
 
-  const getFlowInformation = useStore.getState().getFlowInformation;
-
-  const { isSubmissionService } = await getFlowInformation(
-    flow,
-    req.params.team,
-  );
-
-  const dashboardId = getAnalyticsDashboardId({
-    flowStatus,
-    environment,
-    flowSlug: flow,
-    isSubmissionService,
-  });
-
-  const flowAnalyticsLink = dashboardId
-    ? generateAnalyticsLink({
-        environment,
-        flowId: id,
-        dashboardId,
-      })
-    : undefined;
-
   useStore.setState({
     id,
     flowStatus,
-    flowAnalyticsLink,
     isFlowPublished,
     isTemplate,
     isTemplatedFrom: Boolean(templatedFrom),

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -9,6 +9,7 @@ import { client } from "../../lib/graphql";
 import {
   Environment,
   generateAnalyticsLink,
+  getAnalyticsDashboardId,
 } from "../../pages/FlowEditor/lib/analytics/utils";
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import { settingsStore } from "../../pages/FlowEditor/lib/store/settings";
@@ -137,18 +138,24 @@ export const flowEditorView = async (req: NaviRequest) => {
 
   const getFlowInformation = useStore.getState().getFlowInformation;
 
-  const { isSubmissionService } = await getFlowInformation(
-    flow,
-    req.params.team,
-  );
+  let { isSubmissionService } = await getFlowInformation(flow, req.params.team);
 
-  const flowAnalyticsLink = generateAnalyticsLink({
+  isSubmissionService = isSubmissionService ? isSubmissionService : false;
+
+  const dashboardId = getAnalyticsDashboardId({
     flowStatus,
     environment,
-    flowId: id,
     flowSlug: flow,
-    isSubmissionService: isSubmissionService ?? false,
+    isSubmissionService,
   });
+
+  const flowAnalyticsLink = dashboardId
+    ? generateAnalyticsLink({
+        environment,
+        flowId: id,
+        dashboardId,
+      })
+    : undefined;
 
   useStore.setState({
     id,

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -6,8 +6,12 @@ import React from "react";
 import { View } from "react-navi";
 
 import { client } from "../../lib/graphql";
-import { Environment, generateAnalyticsLink } from "../../pages/FlowEditor/lib/analytics/utils";
+import {
+  Environment,
+  generateAnalyticsLink,
+} from "../../pages/FlowEditor/lib/analytics/utils";
 import { useStore } from "../../pages/FlowEditor/lib/store";
+import { settingsStore } from "../../pages/FlowEditor/lib/store/settings";
 
 interface FlowEditorData {
   id: string;
@@ -121,6 +125,7 @@ export const getFlowEditorData = async (
  */
 export const flowEditorView = async (req: NaviRequest) => {
   const [flow] = req.params.flow.split(",");
+
   const {
     id,
     flowStatus,
@@ -130,12 +135,20 @@ export const flowEditorView = async (req: NaviRequest) => {
     template,
   } = await getFlowEditorData(flow, req.params.team);
 
+  const getFlowInformation = useStore.getState().getFlowInformation;
+
+  const { isSubmissionService } = await getFlowInformation(
+    flow,
+    req.params.team,
+  );
+
   const flowAnalyticsLink = generateAnalyticsLink({
-          flowStatus,
-          environment,
-          flowId: id,
-          flowSlug: flow,
-        });
+    flowStatus,
+    environment,
+    flowId: id,
+    flowSlug: flow,
+    isSubmissionService: isSubmissionService ?? false,
+  });
 
   useStore.setState({
     id,
@@ -157,4 +170,3 @@ export const flowEditorView = async (req: NaviRequest) => {
     </FlowEditorLayout>
   );
 };
-

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -133,6 +133,9 @@ export const flowEditorView = async (req: NaviRequest) => {
     template,
   } = await getFlowEditorData(flow, req.params.team);
 
+  // We need to call `getFlowInformation` here to ensure that the store updates and we have the correct analytics link showing
+  useStore.getState().getFlowInformation(flow, req.params.team);
+
   useStore.setState({
     id,
     flowStatus,

--- a/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -138,9 +138,10 @@ export const flowEditorView = async (req: NaviRequest) => {
 
   const getFlowInformation = useStore.getState().getFlowInformation;
 
-  let { isSubmissionService } = await getFlowInformation(flow, req.params.team);
-
-  isSubmissionService = isSubmissionService ? isSubmissionService : false;
+  const { isSubmissionService } = await getFlowInformation(
+    flow,
+    req.params.team,
+  );
 
   const dashboardId = getAnalyticsDashboardId({
     flowStatus,


### PR DESCRIPTION
# What does this PR do?
- Adds `isSubmissionService` to `FlowInformation` interface (`editor.planx.uk/src/pages/FlowEditor/utils.ts`)
- Updates `getSubmission()` and `generateAnalyticsLink()` in to check for `isSubmissionService = true` (`editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts`) 
- Runs `getFlowInformation` to pass `isSubmissionService` to `generateAnalyticsLink` (`editor.planx.uk/src/routes/views/flowEditor.tsx`)

# Why?
So that we can automatically create dashboards for services that have Send components without manually keeping track of an allow-list. (RAB check comes first so we'll always have the RAB dashboard if relevant.)

# Testing
Turn a non-RAB service with a Send component to 'online' in the editor (and refresh). Analytics link should be working. 