### PR TITLE
feat: when creating a templated flow, copy all "readme" fields of the source template

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -13,6 +13,8 @@ export interface GetFlowDataResponse {
   name: string;
   data: Flow["data"];
   summary: string | null;
+  description: string | null;
+  limitations: string | null;
   team_id: number;
   team: { slug: string };
   publishedFlows:
@@ -38,6 +40,8 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
           data
           name
           summary
+          description
+          limitations
           team_id
           team {
             slug
@@ -78,6 +82,8 @@ const createFlow = async ({
   copiedFrom,
   templatedFrom,
   summary,
+  description,
+  limitations,
 }: {
   teamId: number;
   slug: string;
@@ -87,6 +93,8 @@ const createFlow = async ({
   copiedFrom?: Flow["id"];
   templatedFrom?: Flow["id"];
   summary?: string;
+  description?: string;
+  limitations?: string;
 }) => {
   const { client: $client } = getClient();
   const userId = userContext.getStore()?.user?.sub;
@@ -105,6 +113,8 @@ const createFlow = async ({
           $templated_from: uuid
           $is_template: Boolean
           $summary: String
+          $description: String
+          $limitations: String
         ) {
           flow: insert_flows_one(
             object: {
@@ -117,6 +127,8 @@ const createFlow = async ({
               templated_from: $templated_from
               is_template: $is_template
               summary: $summary
+              description: $description
+              limitations: $limitations
             }
           ) {
             id
@@ -132,6 +144,8 @@ const createFlow = async ({
         templated_from: templatedFrom,
         is_template: isTemplate,
         summary: summary,
+        description: description,
+        limitations: limitations,
       },
     );
 

--- a/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
+++ b/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
@@ -11,7 +11,7 @@ const createFlowFromTemplate = async (
   const sourceTemplate = await getFlowData(templateId);
 
   // Create the new templated flow, including an associated operation and initial publish, and templated_from reference to the source templateId
-  //   The templated flow should also inherit the summary of the source template
+  //   The templated flow should also inherit the readme info of the source template
   const { id } = await createFlow({
     teamId,
     slug,
@@ -22,6 +22,12 @@ const createFlowFromTemplate = async (
     summary: isNull(sourceTemplate.summary)
       ? undefined
       : sourceTemplate.summary,
+    description: isNull(sourceTemplate.description)
+      ? undefined
+      : sourceTemplate.description,
+    limitations: isNull(sourceTemplate.limitations)
+      ? undefined
+      : sourceTemplate.limitations,
   });
 
   return { id, slug };


### PR DESCRIPTION
https://trello.com/c/sngCGirg/3353-implement-internal-feedback-and-finalise-design-make-sure-live-services-are-always-up-to-date-aka-flows-copied-from-templates-sh

Quick one! 

**Testing:**
- Create a source template
- Add a service summary, description and limitations & turn it online 
- Create a templated flow from that source
- Check that the service readme info has come through too

![Screenshot from 2025-06-19 13-25-46](https://github.com/user-attachments/assets/3c1acecd-5e43-46bf-9222-d1bc31f9b830)
