### PR TITLE
refactor: adds more descriptive accessible labeling to section progress tags

### DIFF
--- a/editor.planx.uk/src/@planx/components/Section/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Public.tsx
@@ -153,7 +153,7 @@ export function SectionsOverviewList({
     }
   };
 
-  const getTag = (section: SectionStatus) => {
+  const getTag = (section: SectionStatus, sectionTitle: string) => {
     const tagTypes: Record<SectionStatus, TagType> = {
       [SectionStatus.NeedsUpdated]: TagType.Alert,
       [SectionStatus.ReadyToStart]: TagType.Active,
@@ -170,7 +170,7 @@ export function SectionsOverviewList({
         : () => {}; // no-op
 
     return (
-      <Tag tagType={tagType} onClick={onClick}>
+      <Tag tagType={tagType} onClick={onClick} sectionTitle={sectionTitle}>
         {section}
       </Tag>
     );
@@ -207,7 +207,9 @@ export function SectionsOverviewList({
               openLinksOnNewTab
             />
           </SectionTitle>
-          <SectionState> {getTag(sectionStatuses[sectionId])} </SectionState>
+          <SectionState>
+            {getTag(sectionStatuses[sectionId], sectionNode.data.title)}
+          </SectionState>
         </SectionRow>
       ))}
     </DescriptionList>

--- a/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx
@@ -53,12 +53,13 @@ const Root = styled(MuiButtonBase, {
 export interface Props {
   id?: string;
   tagType: TagType;
+  sectionTitle?: string;
   onClick: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   children?: React.ReactNode;
 }
 
 export default function Tag(props: Props): FCReturn {
-  const { id, tagType, onClick, children } = props;
+  const { id, tagType, onClick, children, sectionTitle } = props;
 
   return (
     <Root
@@ -68,7 +69,9 @@ export default function Tag(props: Props): FCReturn {
       tagType={tagType}
     >
       <Box sx={visuallyHidden} component="span">
-        The status of this section of the application is:
+        {sectionTitle
+          ? `section ${sectionTitle}`
+          : "The status of this section of the application is:"}
       </Box>
       {children}
     </Root>


### PR DESCRIPTION
This pull request introduces changes to consistently identify the status tags on the ```SectionsOverview``` component and indicate to as screen reader user more predictable where they will be navigated too on button click.

I think this fills the brief on pg(50) of the brief, but I think the language could maybe be clearer if anyone has any thoughts on this?

### Changes to `Tag` component:

* Added a new optional `sectionTitle` prop to the `Props` interface of the `Tag` component to allow passing a section title for better contextual information. (`editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx`, [editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsxR56-R62](diffhunk://#diff-ebfaee41a8f2b0deb01968e43c75c4a22325da0b37e10492859253923a0fcaeeR56-R62))
* Updated the `Tag` component to conditionally display the `sectionTitle` in the visually hidden span for accessibility purposes, providing a more descriptive status message. (`editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsx`, [editor.planx.uk/src/@planx/components/shared/Buttons/Tag.tsxL71-R74](diffhunk://#diff-ebfaee41a8f2b0deb01968e43c75c4a22325da0b37e10492859253923a0fcaeeL71-R74))

### Updates to `SectionsOverviewList` component:

* Modified the `getTag` function to accept an additional `sectionTitle` parameter, enabling the passing of section-specific titles to the `Tag` component. (`editor.planx.uk/src/@planx/components/Section/Public.tsx`, [editor.planx.uk/src/@planx/components/Section/Public.tsxL156-R156](diffhunk://#diff-f6e0bf511a76eff265b02e7a3922382c9835fdee72691ea3c79b1e6163e96375L156-R156))
* Updated the `Tag` component usage within `SectionsOverviewList` to include the `sectionTitle` prop, ensuring that the title of each section is passed and displayed appropriately. (`editor.planx.uk/src/@planx/components/Section/Public.tsx`, [[1]](diffhunk://#diff-f6e0bf511a76eff265b02e7a3922382c9835fdee72691ea3c79b1e6163e96375L173-R173) [[2]](diffhunk://#diff-f6e0bf511a76eff265b02e7a3922382c9835fdee72691ea3c79b1e6163e96375L210-R212)