### PR TITLE
fix: React errors in `SelectMultiple`

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -56,6 +56,7 @@ const renderOption: AutocompleteProps<
   "div"
 >["renderOption"] = (props, option, state) => (
   <RenderOptionCheckbox
+    key={props.key}
     listProps={props}
     displayName={option.name}
     state={state}

--- a/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/FlagsSelect.tsx
@@ -15,7 +15,7 @@ interface Props {
   disabled?: boolean;
 }
 
-const renderOptions: AutocompleteProps<
+const renderOption: AutocompleteProps<
   Flag,
   true,
   true,
@@ -23,6 +23,7 @@ const renderOptions: AutocompleteProps<
   "div"
 >["renderOption"] = (props, flag, state) => (
   <RenderOptionCheckbox
+    key={props.key}
     listProps={props}
     displayName={flag.text}
     state={state}
@@ -80,7 +81,7 @@ export const FlagsSelect: React.FC<Props> = (props) => {
         onChange={handleChange}
         isOptionEqualToValue={(flag, value) => flag.value === value.value}
         value={value}
-        renderOption={renderOptions}
+        renderOption={renderOption}
         renderTags={renderTags}
         disabled={props.disabled}
       />

--- a/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
+++ b/editor.planx.uk/src/ui/editor/ComponentTagSelect.tsx
@@ -34,6 +34,7 @@ const renderOption: AutocompleteProps<
 
   return (
     <RenderOptionCheckbox
+      key={props.key}
       listProps={props}
       displayName={TAG_DISPLAY_VALUES[tag].displayName}
       state={state}

--- a/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx
@@ -1,24 +1,24 @@
 import { AutocompleteRenderOptionState } from "@mui/material/Autocomplete";
 import ListItem from "@mui/material/ListItem";
-import React, { ComponentProps, HTMLAttributes } from "react";
+import React, { ComponentProps } from "react";
 
 import { CustomCheckbox } from "../styles";
 
 interface RenderCheckboxProps {
-  listProps: HTMLAttributes<HTMLLIElement>;
+  listProps: React.ComponentPropsWithoutRef<"li">;
   displayName: string;
   state: AutocompleteRenderOptionState;
   checkboxProps?: ComponentProps<typeof CustomCheckbox>;
 }
 
 export const RenderOptionCheckbox = ({
-  listProps,
+  listProps: { key, ...restListProps },
   displayName,
   state,
   checkboxProps,
 }: RenderCheckboxProps) => {
   return (
-    <ListItem {...listProps}>
+    <ListItem key={key} {...restListProps}>
       <CustomCheckbox
         aria-hidden="true"
         className={state.selected ? "selected" : ""}


### PR DESCRIPTION
Fixes some issues thrown on the `SelectMultipleFileTypes` component I noticed when working on #4815 

I've cross-checked existing implementations of `renderOption` and `renderGroup` to make sure there's always an assigned key.