### PR TITLE
style: Template instructions

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
@@ -1,9 +1,9 @@
 import ListItem from "@mui/material/ListItem";
 import { useTheme } from "@mui/material/styles";
-import Typography from "@mui/material/Typography";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useCallback } from "react";
+import BlockQuote from "ui/editor/BlockQuote";
 import { NodeCard } from "ui/editor/NodeCard";
 import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
@@ -74,9 +74,7 @@ export const CustomisationCard: React.FC<Props> = ({
         showStatusHeader={true}
       >
         <NodeCard nodeId={nodeId} backgroundColor={theme.palette.common.white}>
-          <Typography variant="body2">
-            {node.data?.templatedNodeInstructions}
-          </Typography>
+          <BlockQuote>{node.data?.templatedNodeInstructions}</BlockQuote>
         </NodeCard>
       </TemplatedNodeContainer>
     </ListItem>

--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -217,7 +217,7 @@ const FormModal: React.FC<{
           <Close />
         </CloseButton>
       </DialogTitle>
-      <DialogContent dividers>
+      <DialogContent dividers sx={{ p: 0 }}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Component
             node={node}

--- a/editor.planx.uk/src/ui/editor/ModalSection.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalSection.tsx
@@ -9,7 +9,7 @@ const Root = styled(Box, {
     backgroundColor: sectionBackgroundColor
       ? sectionBackgroundColor
       : undefined,
-    padding: theme.spacing(2, 0),
+    padding: theme.spacing(2),
     "& + .modalSection": {
       borderTop: `1px solid ${theme.palette.border.main}`,
     },

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeInstructions.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeInstructions.tsx
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import { BaseNodeData } from "@planx/components/shared";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import BlockQuote from "ui/editor/BlockQuote";
 
 import ModalSection from "./ModalSection";
 import ModalSectionContent from "./ModalSectionContent";
@@ -24,7 +25,7 @@ export const TemplatedNodeInstructions = ({
         title={`Customise ${areTemplatedNodeInstructionsRequired ? `(required)` : `(optional)`}`}
         Icon={StarIcon}
       >
-        <Typography variant="body2">{templatedNodeInstructions}</Typography>
+        <BlockQuote>{templatedNodeInstructions}</BlockQuote>
       </ModalSectionContent>
     </ModalSection>
   );


### PR DESCRIPTION
## What does this PR do:

- Uses `<BlockQuote>` component for instructional text, consistent with publishing and history messages:

![image](https://github.com/user-attachments/assets/1e24dd82-4813-4800-9b1a-47d78ce03d6b)

- Removes padding from editor modal content and introduces to sections, so that background colours are not contained within padding:

![image](https://github.com/user-attachments/assets/1cdf6e73-9daa-4562-b34e-ffcbf5a8b9cc)
