### PR TITLE
design: eject from templated flow features (UI only)

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/ServiceSettings.tsx
@@ -1,19 +1,29 @@
 import Container from "@mui/material/Container";
+import { hasFeatureFlag } from "lib/featureFlags";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import { FooterLinksAndLegalDisclaimer } from "./FlowElements/FooterLinksAndLegalDisclaimer";
 import FlowStatus from "./FlowStatus";
 import { FlowVisibility } from "./FlowVisibility/FlowVisibilitySection";
+import { TemplatedFlowStatus } from "./TemplatedFlowStatus/TemplatedFlowStatusSection";
 
-const ServiceSettings: React.FC = () => (
-  <Container
-    maxWidth="formWrap"
-    sx={{ display: "flex", flexDirection: "column", gap: 2 }}
-  >
-    <FlowStatus />
-    <FlowVisibility />
-    <FooterLinksAndLegalDisclaimer />
-  </Container>
-);
+const ServiceSettings: React.FC = () => {
+  const isTemplatedFrom = useStore().isTemplatedFrom;
+
+  return (
+    <Container
+      maxWidth="formWrap"
+      sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+    >
+      <FlowStatus />
+      {hasFeatureFlag("TEMPLATES") && isTemplatedFrom && (
+        <TemplatedFlowStatus />
+      )}
+      <FlowVisibility />
+      <FooterLinksAndLegalDisclaimer />
+    </Container>
+  );
+};
 
 export default ServiceSettings;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/ServiceSettings.tsx
@@ -9,7 +9,7 @@ import { FlowVisibility } from "./FlowVisibility/FlowVisibilitySection";
 import { TemplatedFlowStatus } from "./TemplatedFlowStatus/TemplatedFlowStatusSection";
 
 const ServiceSettings: React.FC = () => {
-  const isTemplatedFrom = useStore().isTemplatedFrom;
+  const isTemplatedFrom = useStore((state) => state.isTemplatedFrom);
 
   return (
     <Container

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/TemplatedFlowStatus/TemplatedFlowStatusSection.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/TemplatedFlowStatus/TemplatedFlowStatusSection.tsx
@@ -1,0 +1,70 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import { useFormik } from "formik";
+import { useToast } from "hooks/useToast";
+import React from "react";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import SettingsSection from "ui/editor/SettingsSection";
+
+import { useStore } from "../../../../lib/store";
+
+export const TemplatedFlowStatus = () => {
+  const [sourceTemplateTeamName, flowId] = useStore((state) => [
+    state.template?.team?.name,
+    state.id,
+  ]);
+  const toast = useToast();
+
+  const form = useFormik<{}>({
+    initialValues: {},
+    onSubmit: async () => {
+      const isSuccess = true; // await ejectTemplatedFlow(flowId);
+      if (isSuccess) {
+        toast.success("Successfully ejected from template features");
+      }
+    },
+  });
+
+  return (
+    <Box component="form" onSubmit={form.handleSubmit} mb={2}>
+      <SettingsSection>
+        <Typography variant="h2" component="h3" gutterBottom>
+          Templated flow status
+        </Typography>
+        <Typography variant="body1">
+          Manage the status of your templated flow.
+        </Typography>
+      </SettingsSection>
+      <SettingsSection background>
+        <SettingsDescription>
+          <p>
+            <strong>
+              {`Your templated flow is currently receiving updates from ${sourceTemplateTeamName}.`}
+            </strong>
+          </p>
+          <p>
+            If you no longer wish to receive updates and instead make changes
+            independently, use the "Eject" button below to opt-out of templated
+            flow features.
+          </p>
+          <p>
+            Please beware that once you eject, your service will behave like a
+            "copy" and you'll be fully responsible for managing it. Opting back
+            into templated flow features is not currently supported.
+          </p>
+        </SettingsDescription>
+        <Box>
+          <Button
+            onClick={() => form.submitForm()}
+            type="submit"
+            variant="contained"
+            color="warning"
+          >
+            Eject from templated flow features
+          </Button>
+        </Box>
+      </SettingsSection>
+    </Box>
+  );
+};


### PR DESCRIPTION
Basic UI in service settings, will hook the button up to actual API endpoint & logic in a followup PR

Let's get this on staging ASAP so we can get feedback on location (is service settings where you expect? should it be de-emphasised at bottom of page?) and content copy first

![Screenshot from 2025-06-19 18-56-38](https://github.com/user-attachments/assets/845b8e26-3832-4592-b961-3a1f54b4e5a7)
