### PR TITLE
feat: disable reordering, adding, and deleting options in templated node Editor modals

### DIFF
--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -210,6 +210,7 @@ export const Question: React.FC<Props> = (props) => {
                 currentOptionVals,
               ),
             }}
+            isTemplatedNode={props.node.data?.isTemplatedNode}
           />
         </ModalSectionContent>
       </ModalSection>

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -10,6 +10,7 @@ import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { arrayMoveImmutable } from "array-move";
 import { nanoid } from "nanoid";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useRef, useState } from "react";
 import {
   DragDropContext,
@@ -41,6 +42,7 @@ export interface Props<T, EditorExtraProps = {}> {
   isFieldDisabled?: (item: T, index: number) => boolean;
   maxItems?: number;
   disabled?: boolean;
+  isTemplatedNode?: boolean;
 }
 
 const Item = styled(Box)(() => ({
@@ -110,53 +112,92 @@ export default function ListManager<T, EditorExtraProps>(
   const isMaxLength = props.values.length >= maxItems;
   const [isDragging, setIsDragging] = useState(false);
 
-  return props.noDragAndDrop ? (
-    <>
-      <Box>
-        <TransitionGroup>
-          {props.values.map((item, index) => (
-            <Collapse key={itemKeys[index]}>
-              <Item>
-                <Editor
-                  index={index}
-                  value={item}
-                  onChange={(newItem) => {
-                    props.onChange(setAt(index, newItem, props.values));
-                  }}
-                  {...(props.editorExtraProps || {})}
-                  disabled={disabled}
-                />
-                <Box sx={{ display: "flex", alignItems: "flex-start" }}>
-                  <IconButton
-                    onClick={() => {
-                      props.onChange(removeAt(index, props.values));
-                      setItemKeys((prev) => prev.filter((_, i) => i !== index));
+  const isPlatformAdmin = useStore.getState().user?.isPlatformAdmin;
+
+  // `isTemplatedNode` disables reordering, adding, and deleting options unless you're a platform admin
+  if (props.isTemplatedNode && isPlatformAdmin) {
+    return (
+      <>
+        <Box>
+          <TransitionGroup>
+            {props.values.map((item, index) => (
+              <Collapse key={itemKeys[index]} sx={{ marginTop: 2 }}>
+                <Item>
+                  <Editor
+                    index={index}
+                    value={item}
+                    onChange={(newItem) => {
+                      props.onChange(setAt(index, newItem, props.values));
                     }}
-                    aria-label="Delete"
-                    size="large"
-                    disabled={disabled || props?.isFieldDisabled?.(item, index)}
-                  >
-                    <Delete />
-                  </IconButton>
-                </Box>
-              </Item>
-            </Collapse>
-          ))}
-        </TransitionGroup>
-      </Box>
-      <Button
-        sx={{ mt: 2 }}
-        size="large"
-        onClick={() => {
-          props.onChange([...props.values, props.newValue()]);
-          setItemKeys((prev) => [...prev, nanoid()]);
-        }}
-        disabled={disabled || isMaxLength}
-      >
-        {props.newValueLabel || "add new"}
-      </Button>
-    </>
-  ) : (
+                    {...(props.editorExtraProps || {})}
+                    disabled={disabled}
+                  />
+                </Item>
+              </Collapse>
+            ))}
+          </TransitionGroup>
+        </Box>
+      </>
+    );
+  }
+
+  // `noDragAndDrop` disables reordering, but allows adding and deleting options
+  if (props.noDragAndDrop) {
+    return (
+      <>
+        <Box>
+          <TransitionGroup>
+            {props.values.map((item, index) => (
+              <Collapse key={itemKeys[index]}>
+                <Item>
+                  <Editor
+                    index={index}
+                    value={item}
+                    onChange={(newItem) => {
+                      props.onChange(setAt(index, newItem, props.values));
+                    }}
+                    {...(props.editorExtraProps || {})}
+                    disabled={disabled}
+                  />
+                  <Box sx={{ display: "flex", alignItems: "flex-start" }}>
+                    <IconButton
+                      onClick={() => {
+                        props.onChange(removeAt(index, props.values));
+                        setItemKeys((prev) =>
+                          prev.filter((_, i) => i !== index),
+                        );
+                      }}
+                      aria-label="Delete"
+                      size="large"
+                      disabled={
+                        disabled || props?.isFieldDisabled?.(item, index)
+                      }
+                    >
+                      <Delete />
+                    </IconButton>
+                  </Box>
+                </Item>
+              </Collapse>
+            ))}
+          </TransitionGroup>
+        </Box>
+        <Button
+          sx={{ mt: 2 }}
+          size="large"
+          onClick={() => {
+            props.onChange([...props.values, props.newValue()]);
+            setItemKeys((prev) => [...prev, nanoid()]);
+          }}
+          disabled={disabled || isMaxLength}
+        >
+          {props.newValueLabel || "add new"}
+        </Button>
+      </>
+    );
+  }
+
+  // Default ListManager supports reordering, adding, and deleting options
+  return (
     <DragDropContext
       onDragStart={() => setIsDragging(true)}
       onDragEnd={(dropResult: DropResult) => {


### PR DESCRIPTION
When editing templated node "options", we want to allow customising the existing inputs but disable reordering, adding, and deleting options. Since it's a template, the shape of the graph should remain locked to everynoe who's not a platform admin.

Applies to:
- Question
- Checklist (when "expandable", also includes disabling ability to add or remove groups)
- NextSteps
- TaskList
- FileUploadAndLabel

Does not apply to `ListManager` implementations in:
- Pay metadata