### PR TITLE
refactor: Border only style for template graph nodes

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -24,6 +24,7 @@ type Props = {
   type: TYPES;
   [key: string]: any;
   wasVisited?: boolean;
+  lockedFlow: boolean;
 };
 
 const Checklist: React.FC<Props> = React.memo((props) => {
@@ -101,7 +102,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           areTemplatedNodeInstructionsRequired={
             props.data?.areTemplatedNodeInstructionsRequired
           }
-          showStatus={false}
+          showStatus={!props.lockedFlow}
         >
           <Link
             href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -101,7 +101,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
           areTemplatedNodeInstructionsRequired={
             props.data?.areTemplatedNodeInstructionsRequired
           }
-          showStatusHeader={true}
+          showStatus={false}
         >
           <Link
             href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -199,7 +199,13 @@ export default function SafeNode(props: any) {
   return (
     <ErrorBoundary
       FallbackComponent={() => (
-        <Question hasFailed type="Error" id={props.id} text="Corrupted" />
+        <Question
+          hasFailed
+          type="Error"
+          id={props.id}
+          text="Corrupted"
+          lockedFlow
+        />
       )}
     >
       <Node {...props} />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -165,7 +165,7 @@ const InternalPortal: React.FC<any> = (props) => {
             areTemplatedNodeInstructionsRequired={
               props.data?.areTemplatedNodeInstructionsRequired
             }
-            showStatus={false}
+            showStatus={!props.lockedFlow}
           >
             <Box sx={{ display: "flex", alignItems: "stretch" }}>
               <Link

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -165,7 +165,7 @@ const InternalPortal: React.FC<any> = (props) => {
             areTemplatedNodeInstructionsRequired={
               props.data?.areTemplatedNodeInstructionsRequired
             }
-            showStatusHeader={true}
+            showStatus={false}
           >
             <Box sx={{ display: "flex", alignItems: "stretch" }}>
               <Link

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -81,6 +81,7 @@ const ExternalPortal: React.FC<any> = (props) => {
         type="Error"
         id={props.id}
         text="Corrupted external portal: flow no longer exists"
+        lockedFlow
       />
     );
   }

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -24,6 +24,7 @@ type Props = {
   type: TYPES | "Error";
   [key: string]: any;
   wasVisited?: boolean;
+  lockedFlow: boolean;
 };
 
 const Question: React.FC<Props> = React.memo((props) => {
@@ -91,7 +92,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           areTemplatedNodeInstructionsRequired={
             props.data?.areTemplatedNodeInstructionsRequired
           }
-          showStatus={false}
+          showStatus={!props.lockedFlow}
         >
           <Link
             href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -91,7 +91,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           areTemplatedNodeInstructionsRequired={
             props.data?.areTemplatedNodeInstructionsRequired
           }
-          showStatusHeader={true}
+          showStatus={false}
         >
           <Link
             href={href}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -13,7 +13,7 @@ export enum FlowLayout {
   LEFT_RIGHT = "left-right",
 }
 
-const Flow = ({ breadcrumbs = [] }: any) => {
+const Flow = ({ breadcrumbs = [], lockedFlow }: any) => {
   const [childNodes, getNode, flowLayout] = useStore((state) => [
     state.childNodesOf(breadcrumbs[breadcrumbs.length - 1] || ROOT_NODE_KEY),
     state.getNode,
@@ -37,11 +37,11 @@ const Flow = ({ breadcrumbs = [] }: any) => {
         {showGetStarted && <GetStarted />}
 
         {breadcrumbs.map((bc: any) => (
-          <Node key={bc.id} {...bc} />
+          <Node key={bc.id} {...bc} lockedFlow={lockedFlow} />
         ))}
 
         {childNodes.map((node) => (
-          <Node key={node.id} {...node} />
+          <Node key={node.id} {...node} lockedFlow={lockedFlow} />
         ))}
 
         <Hanger />

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/CustomisationCard.tsx
@@ -71,7 +71,7 @@ export const CustomisationCard: React.FC<Props> = ({
           node.data?.areTemplatedNodeInstructionsRequired,
         )}
         isComplete={isComplete}
-        showStatusHeader={true}
+        showStatus={true}
       >
         <NodeCard nodeId={nodeId} backgroundColor={theme.palette.common.white}>
           <BlockQuote>{node.data?.templatedNodeInstructions}</BlockQuote>

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -3,7 +3,8 @@ $nodeBorder: $black;
 $optionBorder: #b1b4b6;
 $hangerBackground: #f2f2f2;
 $focus: #ffdd00;
-$lockedBackground: #eeeeee;
+$lockedFlowBackground: rgba(0, 0, 0, 0.07);
+$lockedNodeBackground: #eee;
 $lockedBorder: #b0b0b0;
 $dataBackground: #f0f0f0;
 $lockedDataBackground: #e2e2e2;
@@ -49,7 +50,7 @@ $fontMonospace: "Source Code Pro", monospace;
   padding: $editorPadding;
 
   &.flow-locked {
-    background: $lockedBackground;
+    background: $lockedFlowBackground;
   }
 
   ol,
@@ -208,7 +209,7 @@ $fontMonospace: "Source Code Pro", monospace;
     word-break: break-word;
 
     .flow-locked & {
-      background: $lockedBackground;
+      background: $lockedNodeBackground;
       border-color: $lockedBorder;
     }
 
@@ -526,7 +527,7 @@ $fontMonospace: "Source Code Pro", monospace;
         border-bottom: 12px solid #fff;
         border-left: 12px solid transparent;
         .flow-locked & {
-          border-bottom-color: $lockedBackground;
+          border-bottom-color: $lockedNodeBackground;
         }
       }
       &::after {

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -113,6 +113,7 @@ $fontMonospace: "Source Code Pro", monospace;
     }
     &.template-card > a {
       background: #fff;
+      border-color: $nodeBorder;
     }
   }
 
@@ -513,6 +514,7 @@ $fontMonospace: "Source Code Pro", monospace;
     & .template-card > a {
       .flow-locked & {
         background: #fffdb0 !important;
+        border-color: $nodeBorder;
       }
     }
     // Triangle shapes to simulate paper fold on sticky note

--- a/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -65,7 +65,7 @@ const FlowEditor = () => {
           className={lockedFlow ? "flow-locked" : ""}
           sx={{ position: "relative" }}
         >
-          <Flow flow={flow} breadcrumbs={breadcrumbs} />
+          <Flow flow={flow} breadcrumbs={breadcrumbs} lockedFlow={lockedFlow} />
           <EditorVisualControls
             orientation="vertical"
             aria-label="Toggle node attributes"

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -11,7 +11,7 @@ interface TemplatedNodeContainerProps extends PropsWithChildren {
   isTemplatedNode: boolean;
   areTemplatedNodeInstructionsRequired: boolean;
   isComplete?: boolean;
-  showStatusHeader?: boolean;
+  showStatus?: boolean;
   className?: string;
 }
 
@@ -21,28 +21,33 @@ const StyledContainer = styled(Box, {
       "isTemplatedNode",
       "areTemplatedNodeInstructionsRequired",
       "isComplete",
+      "showStatus",
     ].includes(prop as string),
 })<{
   isTemplatedNode: boolean;
   areTemplatedNodeInstructionsRequired: boolean;
   isComplete?: boolean;
+  showStatus?: boolean;
 }>(({
   theme,
   isTemplatedNode,
   areTemplatedNodeInstructionsRequired,
   isComplete,
+  showStatus,
 }) => {
   if (!isTemplatedNode) return {};
 
-  const getBackgroundColor = () => {
-    if (isComplete) return theme.palette.common.white;
-    if (areTemplatedNodeInstructionsRequired)
-      return theme.palette.template.dark;
-    return theme.palette.template.main;
-  };
+  let backgroundColor = theme.palette.template.dark;
+  if (showStatus) {
+    if (isComplete) {
+      backgroundColor = theme.palette.common.white;
+    } else if (!areTemplatedNodeInstructionsRequired) {
+      backgroundColor = theme.palette.template.main;
+    }
+  }
 
   return {
-    backgroundColor: getBackgroundColor(),
+    backgroundColor,
     width: "100%",
     padding: "4px",
     display: "flex",
@@ -50,9 +55,10 @@ const StyledContainer = styled(Box, {
     justifyContent: "center",
     border: "1px solid",
     borderColor: "transparent",
-    ...(isComplete && {
-      borderColor: theme.palette.border.main,
-    }),
+    ...(isComplete &&
+      showStatus && {
+        borderColor: theme.palette.border.main,
+      }),
   };
 });
 
@@ -87,7 +93,7 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
   isTemplatedNode = false,
   areTemplatedNodeInstructionsRequired = false,
   isComplete = false,
-  showStatusHeader = false,
+  showStatus = false,
   className,
 }) => {
   const containerClasses = classNames(
@@ -110,8 +116,9 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
         areTemplatedNodeInstructionsRequired
       }
       isComplete={isComplete}
+      showStatus={showStatus}
     >
-      {showStatusHeader && (
+      {showStatus && (
         <StatusHeader>
           <Typography
             variant="body3"

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -37,11 +37,13 @@ const StyledContainer = styled(Box, {
 }) => {
   if (!isTemplatedNode) return {};
 
-  let backgroundColor = theme.palette.template.dark;
+  let backgroundColor;
   if (showStatus) {
     if (isComplete) {
       backgroundColor = theme.palette.common.white;
-    } else if (!areTemplatedNodeInstructionsRequired) {
+    } else if (areTemplatedNodeInstructionsRequired) {
+      backgroundColor = theme.palette.template.dark;
+    } else {
       backgroundColor = theme.palette.template.main;
     }
   }
@@ -49,7 +51,9 @@ const StyledContainer = styled(Box, {
   return {
     backgroundColor,
     width: "100%",
-    padding: "4px",
+    ...(showStatus && {
+      padding: "4px",
+    }),
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
@@ -76,16 +80,6 @@ const getTemplatedNodeStatus = (
 ) => {
   if (areTemplatedNodeInstructionsRequired) return "Required";
   return "Optional";
-};
-
-const getStatusIcon = (theme: Theme, isComplete?: boolean) => {
-  if (isComplete) {
-    return { color: theme.palette.success.main };
-  }
-  return {
-    color: theme.palette.text.primary,
-    opacity: 0.2,
-  };
 };
 
 export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
@@ -128,10 +122,12 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
           >
             {getTemplatedNodeStatus(areTemplatedNodeInstructionsRequired)}
           </Typography>
-          <CheckCircleIcon
-            fontSize="small"
-            sx={(theme) => getStatusIcon(theme, isComplete)}
-          />
+          {isComplete && (
+            <CheckCircleIcon
+              fontSize="small"
+              sx={(theme) => ({ color: theme.palette.success.main })}
+            />
+          )}
         </StatusHeader>
       )}
       {children}


### PR DESCRIPTION
## What does this PR do?

- Refactors template graph node to have only purple border (no distinction of required/optional or done)

**Testing:**
https://4823.planx.pizza/a-new-team/source-templated

- Also adds `flow-locked` background as opacity to enable TESTING watermark to be visible