### PR TITLE
fix: add missing `TemplatedNodeConfig` to Pay & Notice modals

### DIFF
--- a/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -2,12 +2,14 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { Notice } from "@planx/components/Notice/model";
 import { parseNotice } from "@planx/components/Notice/model";
 import { useFormik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import ColorPicker from "ui/editor/ColorPicker/ColorPicker";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
+import { TemplatedNodeConfiguration } from "ui/editor/TemplatedNodeConfiguration";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
@@ -30,6 +32,8 @@ export interface NoticeEditorProps {
 }
 
 const NoticeEditor: React.FC<NoticeEditorProps> = ({ formik, disabled }) => {
+  const isTemplate = useStore.getState().isTemplate;
+
   const { values, handleChange, setFieldValue } = formik;
 
   return (
@@ -94,6 +98,17 @@ const NoticeEditor: React.FC<NoticeEditorProps> = ({ formik, disabled }) => {
         value={values.tags}
         disabled={disabled}
       />
+      {isTemplate && (
+        <TemplatedNodeConfiguration
+          formik={formik}
+          isTemplatedNode={values.isTemplatedNode}
+          templatedNodeInstructions={values.templatedNodeInstructions}
+          areTemplatedNodeInstructionsRequired={
+            values.areTemplatedNodeInstructionsRequired
+          }
+          disabled={disabled}
+        />
+      )}
     </>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -6,6 +6,7 @@ import {
   validationSchema,
 } from "@planx/components/Pay/model";
 import { Form, Formik } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import { InternalNotes } from "ui/editor/InternalNotes";
@@ -13,6 +14,7 @@ import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import { MoreInformation } from "ui/editor/MoreInformation/MoreInformation";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
+import { TemplatedNodeConfiguration } from "ui/editor/TemplatedNodeConfiguration";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
@@ -26,6 +28,8 @@ import { InviteToPaySection } from "./InviteToPaySection";
 export type Props = EditorProps<TYPES.Pay, Pay>;
 
 const Component: React.FC<Props> = (props: Props) => {
+  const isTemplate = useStore.getState().isTemplate;
+
   const onSubmit = (newValues: Pay) => {
     if (props.handleSubmit) {
       props.handleSubmit({ type: TYPES.Pay, data: newValues });
@@ -132,13 +136,19 @@ const Component: React.FC<Props> = (props: Props) => {
             value={formik.values.tags}
             disabled={props.disabled}
           />
-          {/* isTemplate && (<TemplatedNodeConfiguration
-            formik={formik}
-            isTemplatedNode={values.isTemplatedNode}
-            templatedNodeInstructions={values.templatedNodeInstructions}
-            areTemplatedNodeInstructionsRequired={values.areTemplatedNodeInstructionsRequired}
-            disabled={props.disabled}
-          />) */}
+          {isTemplate && (
+            <TemplatedNodeConfiguration
+              formik={formik}
+              isTemplatedNode={formik.values.isTemplatedNode}
+              templatedNodeInstructions={
+                formik.values.templatedNodeInstructions
+              }
+              areTemplatedNodeInstructionsRequired={
+                formik.values.areTemplatedNodeInstructionsRequired
+              }
+              disabled={props.disabled}
+            />
+          )}
         </Form>
       )}
     </Formik>

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeConfiguration.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeConfiguration.tsx
@@ -2,7 +2,7 @@ import StarIcon from "@mui/icons-material/Star";
 import Typography from "@mui/material/Typography";
 import type { TemplatedNodeData } from "@opensystemslab/planx-core/types";
 import { BaseNodeData } from "@planx/components/shared";
-import { useFormik } from "formik";
+import { FormikProps, useFormik } from "formik";
 import React from "react";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
@@ -14,7 +14,7 @@ import ModalSection from "./ModalSection";
 import ModalSectionContent from "./ModalSectionContent";
 
 export type TemplatedNodeConfigurationProps<T extends BaseNodeData> = {
-  formik: ReturnType<typeof useFormik<T>>;
+  formik: ReturnType<typeof useFormik<T>> | FormikProps<T>;
   disabled?: boolean;
 } & TemplatedNodeData;
 


### PR DESCRIPTION
Per feedback https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1750424102836949 & outstanding tasks here https://trello.com/c/sngCGirg/3353-implement-internal-feedback-and-finalise-design-make-sure-live-services-are-always-up-to-date-aka-flows-copied-from-templates-sh