### PR TITLE
feat: Create table for `lps_magic_links`

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_lps_magic_links.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_lps_magic_links.yaml
@@ -1,0 +1,37 @@
+table:
+  name: lps_magic_links
+  schema: public
+insert_permissions:
+  - role: api
+    permission:
+      check: {}
+      columns:
+        - email
+        - operation
+        - created_at
+        - used_at
+        - token
+    comment: ""
+select_permissions:
+  - role: api
+    permission:
+      columns:
+        - email
+        - operation
+        - created_at
+        - used_at
+        - token
+      filter: {}
+    comment: ""
+update_permissions:
+  - role: api
+    permission:
+      columns:
+        - email
+        - operation
+        - created_at
+        - used_at
+        - token
+      filter: {}
+      check: {}
+    comment: ""

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -19,6 +19,7 @@
 - "!include public_flows.yaml"
 - "!include public_global_settings.yaml"
 - "!include public_lowcal_sessions.yaml"
+- "!include public_lps_magic_links.yaml"
 - "!include public_operations.yaml"
 - "!include public_payment_requests.yaml"
 - "!include public_payment_status.yaml"

--- a/hasura.planx.uk/migrations/default/1750770623762_create_table_public_magic_link_tokens/down.sql
+++ b/hasura.planx.uk/migrations/default/1750770623762_create_table_public_magic_link_tokens/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."lps_magic_links";

--- a/hasura.planx.uk/migrations/default/1750770623762_create_table_public_magic_link_tokens/up.sql
+++ b/hasura.planx.uk/migrations/default/1750770623762_create_table_public_magic_link_tokens/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "public"."lps_magic_links" (
+  "token" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "email" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "used_at" timestamptz,
+  "operation" text NOT NULL,
+  PRIMARY KEY ("token")
+);

--- a/hasura.planx.uk/tests/magic_links.test.js
+++ b/hasura.planx.uk/tests/magic_links.test.js
@@ -1,0 +1,104 @@
+const { introspectAs } = require("./utils");
+
+describe("lps_magic_links", () => {
+  describe("public", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("public");
+    });
+
+    test("cannot query LPS magic links", () => {
+      expect(i.queries).not.toContain("lps_magic_links");
+    });
+
+    test("cannot create, update, or delete LPS magic links", () => {
+      expect(i).toHaveNoMutationsFor("lps_magic_links");
+    });
+  });
+
+  describe("admin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("admin");
+    });
+
+    test("has full access to query and mutate LPS magic links", () => {
+      expect(i.queries).toContain("lps_magic_links");
+      expect(i.mutations).toContain("insert_lps_magic_links");
+      expect(i.mutations).toContain(
+        "update_lps_magic_links_by_pk"
+      );
+      expect(i.mutations).toContain("delete_lps_magic_links");
+    });
+  });
+
+  describe("platformAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("platformAdmin");
+    });
+
+    test("cannot query lps_magic_links", () => {
+      expect(i.queries).not.toContain("lps_magic_links");
+    });
+
+    test("cannot create, update, or delete lps_magic_links", () => {
+      expect(i).toHaveNoMutationsFor("lps_magic_links");
+    });
+  });
+
+  describe("teamEditor", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamEditor");
+    });
+
+    test("cannot query lps_magic_links", () => {
+      expect(i.queries).not.toContain("lps_magic_links");
+    });
+
+    test("cannot create, update, or delete lps_magic_links", () => {
+      expect(i).toHaveNoMutationsFor("lps_magic_links");
+    });
+  });
+
+  describe("demoUser", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("demoUser");
+    });
+
+    test("cannot query lps_magic_links", () => {
+      expect(i.queries).not.toContain("lps_magic_links");
+    });
+
+    test("cannot create, update, or delete lps_magic_links", () => {
+      expect(i).toHaveNoMutationsFor("lps_magic_links");
+    });
+  });
+
+  describe("api", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("api");
+    });
+
+    test("can query lps_magic_links", () => {
+      expect(i.queries).toContain("lps_magic_links");
+    });
+
+    test("can insert lps_magic_links", () => {
+      expect(i.mutations).toContain("insert_lps_magic_links");
+    });
+
+    test("can update  LPS magic links", () => {
+      expect(i.mutations).toContain(
+        "update_lps_magic_links_by_pk"
+      );
+    });
+
+    test("cannot delete LPS magic links", () => {
+      expect(i.mutations).not.toContain("delete_lps_magic_links");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?
 - Adds basic structure for a `magic_links` table
 - Basic introspection tests

It's likely / possible that some of the design here will change as we reach implementation and I'll be sure to come back with some proper test coverage (API, or maybe e2e/api) once the pieces are in place.

Supports the plan outlined here - https://github.com/theopensystemslab/planx-new/pull/4797

```mermaid
sequenceDiagram
    participant User
    participant LPS
    participant PlanX_API as PlanX API
    participant PlanX_Frontend as PlanX Frontend

    User->>LPS: Enter email
    LPS->>PlanX_API: POST `lps/login`
    PlanX_API->>PlanX_API: Trigger email via GovNotify
    PlanX_API->>User: Send email with link
    
    User->>LPS: Click magic link
    LPS->>PlanX_API: GET `lps/applications?token=abc123&email=test@example.com`
    PlanX_API->>PlanX_API: Validate details
    
    alt Error
        PlanX_API->>LPS: Reject

    else Success
        PlanX_API->>LPS: Return list of applications
    end

    LPS->>PlanX_Frontend: Resume single application
    PlanX_Frontend->>PlanX_API: /validate-session API call
    PlanX_API->>PlanX_Frontend: Success
 ```