### PR TITLE
refactor(lps): Create generic button classes

### DIFF
--- a/localplanning.services/src/components/Button.astro
+++ b/localplanning.services/src/components/Button.astro
@@ -13,11 +13,9 @@ const {
   external = false,
 } = Astro.props as Props;
 
-const baseClasses = "inline-block font-semibold rounded transition m-0";
-
 const variantClasses = {
-  primary: "bg-action-main hover:bg-action-main-hover",
-  secondary: "bg-action-secondary hover:bg-action-secondary-hover text-white",
+  primary: "button--primary",
+  secondary: "button--secondary",
 };
 
 const sizeClasses = {
@@ -29,7 +27,7 @@ const sizeClasses = {
 const externalClasses = external ? "after:content-['_↗']" : "";
 
 
-const classes = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${externalClasses}`;
+const classes = `button ${variantClasses[variant]} ${sizeClasses[size]} ${externalClasses}`;
 ---
 
 <a href={href} class={classes}>

--- a/localplanning.services/src/components/applications/EmailForm.tsx
+++ b/localplanning.services/src/components/applications/EmailForm.tsx
@@ -16,7 +16,7 @@ const EmailForm: React.FC = () => {
 
   return (
     <div className="max-w-3xl text-body-lg">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 items-start">
         <label htmlFor="email" className="font-semibold text-md">
           Enter your email address
         </label>
@@ -39,7 +39,7 @@ const EmailForm: React.FC = () => {
         <button 
           type="submit" 
           disabled={isLoading} 
-          className="inline-block font-semibold rounded transition m-0 bg-action-main hover:bg-action-main-hover text-body-md clamp-[py,2,3] clamp-[px,3,4] cursor-pointer w-min"
+          className="button button--primary button--medium"
         >
           {isLoading ? "Submitting..." : "Submit"}
         </button>

--- a/localplanning.services/src/styles/global.css
+++ b/localplanning.services/src/styles/global.css
@@ -39,11 +39,11 @@
 
 }
 
-/*
-/ Fluid type styles
-*/
-
 @layer components {
+
+  /*
+  / Fluid type styles
+  */
 
   /* Heading styles */
   .text-heading-xl {
@@ -94,5 +94,33 @@
   }
   .paragraph-link--external::after {
     content: " ↗";
+  }
+
+  /*
+  /  Button styles
+  */
+
+  /* Core button styles */
+  .button {
+    @apply inline-block font-semibold rounded transition cursor-pointer;
+  }
+
+  /* Button variants */
+  .button--primary {
+    @apply bg-action-main hover:bg-action-main-hover;
+  }
+  .button--secondary {
+    @apply bg-action-secondary hover:bg-action-secondary-hover text-white;
+  }
+
+  /* Button sizes */
+  .button--large {
+    @apply clamp-[text,base,lg] clamp-[py,3,4] clamp-[px,4,5];
+  }
+  .button--medium {
+    @apply clamp-[text,sm,base] clamp-[py,2,3] clamp-[px,3,4];
+  }
+  .button--small {
+    @apply clamp-[text,xs,sm] py-2 clamp-[px,2,3];
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Extracts Tailwind classes from the Astro `<Button>` component so that they can be used generically

Usage for Astro `<Button>` remains the same (code applies our custom classes rather than Tailwind):
```
<Button href="#" variant="primary" size="medium">
```

Our custom button classes can be used across any button:
```
<button href="#" class="button button--primary button--medium">
```