### PR TITLE
chore: tidy up export zip filename

### DIFF
--- a/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/api.planx.uk/modules/send/utils/exportZip.ts
@@ -213,11 +213,8 @@ export class ExportZip {
     // make a tmp directory to avoid file name collisions if simultaneous applications
     this.tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), sessionId));
 
-    // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath
-    const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
-    const __dirname = path.dirname(__filename); // get the name of the directory
     const sanitisedFilename = sanitize(`${flowSlug}-${sessionId}.zip`);
-    this.filename = path.join(__dirname, sanitisedFilename);
+    this.filename = sanitisedFilename;
   }
 
   addFile({ name, buffer }: { name: string; buffer: Buffer }) {

--- a/api.planx.uk/tests/loadOrRecordNockRequests.js
+++ b/api.planx.uk/tests/loadOrRecordNockRequests.js
@@ -21,10 +21,7 @@ function loadOrRecordNockRequests(filename, hashKey) {
     .digest("hex")
     .slice(0, 8);
 
-  // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath
-  const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
-  const __dirname = path.dirname(__filename); // get the name of the directory
-  const filePath = path.join(__dirname, "nocks", `${filename}.${hash}.json`);
+  const filePath = path.join("nocks", `${filename}.${hash}.json`);
 
   const records = [];
 


### PR DESCRIPTION
Context here https://trello.com/c/X3qm89R3/3327-can-we-do-we-want-to-shorten-submission-zip-filenames

Easy first step here which is ensure zip never downloads with prefix `_api_dist_modules_send_utils_`. 

In future if this continues to come up, as already captured on Trello ticket, we may want to get more clever and also strip off `apply-for-` or introduce service acronymns (either in editor service settings or via hardcoded lookup/ODP Schema application types??) which could be used here instead in full slug.

**Testing:**
- Spin up a quick test service on this pizza using "Send to email" 
- Configure team settings "Submission email" as your own email
- Publish your test service, make sure it's online - do a test
- Confirm you can successfully download the file (and ensure filename is consistent) from _both_ the editor submissions log & email magic link

