### PR TITLE
fix(a11y): Add "(opens in a new tab)" to OGL link

### DIFF
--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -84,7 +84,7 @@ const PublicFooter: React.FC = () => {
               color="inherit"
               target="_blank"
             >
-              Open Government Licence v3
+              Open Government Licence v3 (opens in a new tab)
             </Link>
             , except where otherwise stated
           </Typography>


### PR DESCRIPTION
## What does this PR do?
 - Adds "(opens in a new tab)" to OGL link in the footer
 - Address "Change on Request" issue in DAC report, page 64


## Issue
> “Clicking on the ‘Lambeth, Open Government Licence v3’ link will open in a new tab with no
way to back out of it. This can result in confusion especially if you already have multiple tabs
open on the window. Some type of warning placed next to it would help the user know
what is about to happen.”

> [!IMPORTANT]
> I've not addressed the additional suggestion to either remove `target="_blank" or add"(opens in a new tab)" to the logo in the header as - 
> - GDS states "a use case example [for opening in a new tab] is to stop the user losing information they’ve entered into a form" which I believe applies here ([source](https://design-system.service.gov.uk/styles/links/#opening-links-in-a-new-tab))
> - There's not a visually nice way of doing this
> - There's already meaningful alt text
> Very open to ideas and suggestions here, as I'm not sure if this would be sufficient to pass on a retest (cc @ianjon3s)