### PR TITLE
refactor: navigate to tab and focus on inputs on validataion errors

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -11,6 +11,7 @@ import { SiteAddress } from "@planx/components/FindProperty/model";
 import { SchemaFields } from "@planx/components/shared/Schema/SchemaFields";
 import { GraphError } from "components/Error/GraphError";
 import { GeoJsonObject } from "geojson";
+import { useFormErrorFocus } from "hooks/useFormErrorFoucs";
 import sortBy from "lodash/sortBy";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -76,6 +77,21 @@ const VerticalFeatureTabs: React.FC = () => {
       return Number(f.properties?.label);
     },
   ]);
+
+  const tabErrorMapping = formik.values.schemaData.map((_, index) => ({
+    tabIndex: index,
+    fieldPath: `schemaData[${index}]`,
+  }));
+
+  useFormErrorFocus({
+    errors: formik.errors,
+    isSubmitting: formik.isSubmitting,
+    isValidating: formik.isValidating,
+    submitCount: formik.submitCount,
+    onErrorInTab: editFeatureInForm,
+    activeTabIndex: activeIndex,
+    tabErrorMapping: tabErrorMapping,
+  });
 
   return (
     <Box

--- a/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
+++ b/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
@@ -1,10 +1,10 @@
 import type { FormikErrors } from "formik";
 import {
-  useRef,
-  useEffect,
   useCallback,
-  useState,
+  useEffect,
   useLayoutEffect,
+  useRef,
+  useState,
 } from "react";
 
 interface UseFormErrorFocusProps<T> {

--- a/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
+++ b/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
@@ -1,62 +1,108 @@
 import type { FormikErrors } from "formik";
-import { useEffect, useRef } from "react";
+import { useRef, useEffect, useCallback } from "react";
 
 interface UseFormErrorFocusProps<T> {
   errors: FormikErrors<T>;
   isSubmitting: boolean;
   isValidating: boolean;
   submitCount: number;
-  idPrefix?: string;
+  onErrorInTab?: (tabIndex: number) => void;
+  tabErrorMapping?: { tabIndex: number; fieldPath: string }[];
+  activeTabIndex?: number;
 }
 
+type ErrorObject = FormikErrors<unknown> | string | undefined;
 /**
- * Hook to focus on the input field associated with the first error in a form after submission
+ * Hook to focus on the input field associated with the first error in a form after submission.
+ * For tabbed interfaces, can automatically switch to the tab containing the first error.
  */
 export function useFormErrorFocus<T>({
   errors,
   isSubmitting,
   isValidating,
   submitCount,
+  onErrorInTab,
+  tabErrorMapping,
+  activeTabIndex,
 }: UseFormErrorFocusProps<T>) {
   const previousSubmitCount = useRef(0);
   const previousErrors = useRef<FormikErrors<T>>({} as FormikErrors<T>);
 
   const currentErrorKeys = Object.keys(errors).join(",");
 
-  const focusFirstErrorInput = () => {
-    const alertElements = document.querySelectorAll('[role="alert"]');
+  const findTabWithFirstError = useCallback(() => {
+    if (!tabErrorMapping || !onErrorInTab) return null;
+
+    for (const mapping of tabErrorMapping) {
+      const pathSegments = mapping.fieldPath.split(".");
+      let currentObj: any = errors;
+      let hasError = true;
+      console.log("Segment:", pathSegments);
+      console.log("currentObj", currentObj);
+      for (const segment of pathSegments) {
+        const arrayMatch = segment.match(/(\w+)\[(\d+)\]/);
+        if (arrayMatch) {
+          const [_, arrayName, indexStr] = arrayMatch;
+          const index = parseInt(indexStr);
+          currentObj = currentObj[arrayName]?.[index];
+        } else {
+          currentObj = currentObj[segment];
+        }
+
+        if (currentObj === undefined) {
+          hasError = false;
+          break;
+        }
+      }
+
+      if (hasError) {
+        return mapping.tabIndex;
+      }
+    }
+
+    return null;
+  }, [errors, tabErrorMapping, onErrorInTab]);
+
+  const focusFirstErrorInput = useCallback(() => {
+    const alertElements = Array.from(
+      document.querySelectorAll('[role="alert"]'),
+    ).filter((el) => {
+      return el.textContent && el.textContent.trim() !== "";
+    }) as HTMLElement[];
 
     if (alertElements.length > 0) {
-      for (let i = 0; i < alertElements.length; i++) {
-        const errorEl = alertElements[i] as HTMLElement;
+      const errorEl = alertElements[0];
+      const errorWrapper = errorEl.closest('[data-testid="error-wrapper"]');
+      let inputToFocus: HTMLElement | null = null;
 
-        if (errorEl.textContent && errorEl.offsetParent !== null) {
-          const errorWrapper = errorEl.closest('[data-testid="error-wrapper"]');
-          if (errorWrapper) {
-            const input = errorWrapper.querySelector("input, textarea, select");
-            if (input) {
-              console.log("Found input in error wrapper, focusing:", input);
-              (input as HTMLElement).focus();
-              (input as HTMLElement).scrollIntoView({
-                behavior: "smooth",
-                block: "center",
-              });
-              return true;
-            }
-          }
-          //Fall back to announcing the error if input not found
-          errorEl.setAttribute("tabindex", "-1");
-          errorEl.focus();
-          errorEl.scrollIntoView({
-            behavior: "smooth",
-            block: "center",
-          });
+      if (errorWrapper) {
+        inputToFocus = errorWrapper.querySelector(
+          "input, textarea, select",
+        ) as HTMLElement;
+
+        if (inputToFocus) {
+          setTimeout(() => {
+            inputToFocus?.focus();
+            inputToFocus?.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+            });
+          }, 50);
           return true;
         }
       }
+
+      // If no input found, focus the error message itself
+      errorEl.setAttribute("tabindex", "-1");
+      setTimeout(() => {
+        errorEl.focus();
+        errorEl.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 50);
+      return true;
     }
+
     return false;
-  };
+  }, []);
 
   useEffect(() => {
     const isNewSubmit = submitCount > previousSubmitCount.current;
@@ -70,14 +116,35 @@ export function useFormErrorFocus<T>({
       hasErrors &&
       (isNewSubmit || errorsChanged)
     ) {
-      setTimeout(() => {
-        focusFirstErrorInput();
-      }, 10);
+      // For tabbed interfaces, find and switch to tab with first error
+      if (tabErrorMapping && onErrorInTab) {
+        const tabWithError = findTabWithFirstError();
+
+        if (tabWithError !== null && tabWithError !== activeTabIndex) {
+          onErrorInTab(tabWithError);
+          focusFirstErrorInput();
+          previousSubmitCount.current = submitCount;
+          previousErrors.current = { ...errors };
+          return;
+        }
+      }
+      focusFirstErrorInput();
     }
 
     if (!isSubmitting) {
       previousSubmitCount.current = submitCount;
       previousErrors.current = { ...errors };
     }
-  }, [submitCount, isValidating, isSubmitting, currentErrorKeys, errors]);
+  }, [
+    submitCount,
+    isValidating,
+    isSubmitting,
+    currentErrorKeys,
+    focusFirstErrorInput,
+    findTabWithFirstError,
+    onErrorInTab,
+    activeTabIndex,
+    tabErrorMapping,
+    errors,
+  ]);
 }

--- a/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
+++ b/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
@@ -1,0 +1,83 @@
+import type { FormikErrors } from "formik";
+import { useEffect, useRef } from "react";
+
+interface UseFormErrorFocusProps<T> {
+  errors: FormikErrors<T>;
+  isSubmitting: boolean;
+  isValidating: boolean;
+  submitCount: number;
+  idPrefix?: string;
+}
+
+/**
+ * Hook to focus on the input field associated with the first error in a form after submission
+ */
+export function useFormErrorFocus<T>({
+  errors,
+  isSubmitting,
+  isValidating,
+  submitCount,
+}: UseFormErrorFocusProps<T>) {
+  const previousSubmitCount = useRef(0);
+  const previousErrors = useRef<FormikErrors<T>>({} as FormikErrors<T>);
+
+  const currentErrorKeys = Object.keys(errors).join(",");
+
+  const focusFirstErrorInput = () => {
+    const alertElements = document.querySelectorAll('[role="alert"]');
+
+    if (alertElements.length > 0) {
+      for (let i = 0; i < alertElements.length; i++) {
+        const errorEl = alertElements[i] as HTMLElement;
+
+        if (errorEl.textContent && errorEl.offsetParent !== null) {
+          const errorWrapper = errorEl.closest('[data-testid="error-wrapper"]');
+          if (errorWrapper) {
+            const input = errorWrapper.querySelector("input, textarea, select");
+            if (input) {
+              console.log("Found input in error wrapper, focusing:", input);
+              (input as HTMLElement).focus();
+              (input as HTMLElement).scrollIntoView({
+                behavior: "smooth",
+                block: "center",
+              });
+              return true;
+            }
+          }
+          //Fall back to announcing the error if input not found
+          errorEl.setAttribute("tabindex", "-1");
+          errorEl.focus();
+          errorEl.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          });
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  useEffect(() => {
+    const isNewSubmit = submitCount > previousSubmitCount.current;
+    const hasErrors = Object.keys(errors).length > 0;
+    const errorsChanged =
+      currentErrorKeys !== Object.keys(previousErrors.current).join(",");
+
+    if (
+      !isValidating &&
+      !isSubmitting &&
+      hasErrors &&
+      (isNewSubmit || errorsChanged)
+    ) {
+      setTimeout(() => {
+        focusFirstErrorInput();
+      }, 10);
+    }
+
+    if (!isSubmitting) {
+      previousSubmitCount.current = submitCount;
+      previousErrors.current = { ...errors };
+    }
+  }, [submitCount, isValidating, isSubmitting, currentErrorKeys, errors]);
+}

--- a/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
+++ b/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
@@ -1,4 +1,4 @@
-import type { FormikErrors } from "formik";
+import { type FormikErrors, getIn } from "formik";
 import {
   useCallback,
   useEffect,
@@ -31,7 +31,7 @@ export function useFormErrorFocus<T>({
   activeTabIndex,
 }: UseFormErrorFocusProps<T>) {
   const previousSubmitCount = useRef(0);
-  const previousErrors = useRef<FormikErrors<T>>({} as FormikErrors<T>);
+  const previousErrors = useRef<FormikErrors<T>>({});
   const [elementToFocus, setElementToFocus] = useState<HTMLElement | null>(
     null,
   );
@@ -42,25 +42,7 @@ export function useFormErrorFocus<T>({
     if (!tabErrorMapping || !onErrorInTab) return null;
 
     for (const mapping of tabErrorMapping) {
-      const pathSegments = mapping.fieldPath.split(".");
-      let currentObj: any = errors;
-      let hasError = true;
-
-      for (const segment of pathSegments) {
-        const arrayMatch = segment.match(/(\w+)\[(\d+)\]/);
-        if (arrayMatch) {
-          const [_, arrayName, indexStr] = arrayMatch;
-          const index = parseInt(indexStr);
-          currentObj = currentObj[arrayName]?.[index];
-        } else {
-          currentObj = currentObj[segment];
-        }
-
-        if (currentObj === undefined) {
-          hasError = false;
-          break;
-        }
-      }
+      const hasError = getIn(errors, mapping.fieldPath);
 
       if (hasError) {
         return mapping.tabIndex;

--- a/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
+++ b/editor.planx.uk/src/hooks/useFormErrorFoucs.ts
@@ -79,23 +79,12 @@ export function useFormErrorFocus<T>({
 
     if (alertElements.length > 0) {
       const errorEl = alertElements[0];
-      const errorWrapper = errorEl.closest('[data-testid="error-wrapper"]');
-      let inputToFocus: HTMLElement | null = null;
-
-      if (errorWrapper) {
-        inputToFocus = errorWrapper.querySelector(
-          "input, textarea, select",
-        ) as HTMLElement;
-
-        if (inputToFocus) {
-          return inputToFocus;
-        }
+      if (errorEl) {
+        errorEl.setAttribute("tabindex", "-1");
+        return errorEl;
       }
-      errorEl.setAttribute("tabindex", "-1");
-      return errorEl;
+      return null;
     }
-
-    return null;
   }, []);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
[Trello issue](trello.com/c/1KMx198N/3319-tabs-a-aa-p37-last-prio-bc-mapandlabel)

Ok took a bit of initiative on this one, so really open to feedback on approach and scope on this one. I  used the hook I made in this PR a few components outside the one outlined in the issue, and the idea would be to implement in all form components eventually. Should I go farther in this PR?

This pull request introduces a new hook, `useFormErrorFocus`, to enhance user experience by automatically focusing on the first form error after submission, including support for tabbed interfaces. The hook is integrated into multiple components to streamline error handling and improve accessibility.

### New Feature: `useFormErrorFocus` Hook

* [`editor.planx.uk/src/hooks/useFormErrorFoucs.ts`](diffhunk://#diff-0a00d8bc023d5e5b6c6821723464c68fe42708291b72a4f5ac1c17e83cccd3d1R1-R150): Added a custom React hook, `useFormErrorFocus`, which focuses on the first form error after submission and optionally switches to the tab containing the error for tabbed interfaces. It includes robust error detection logic and smooth scrolling for better user experience.

### Integration of `useFormErrorFocus` Hook

#### Address Input Component
* [`editor.planx.uk/src/@planx/components/AddressInput/Public.tsx`](diffhunk://#diff-c7a6dfcf94cb252c9aafb48b4c68055706cee2f3616c228591fc9a1126ec1a44R6): Imported and integrated `useFormErrorFocus` to focus on form errors in the `AddressInputComponent`. [[1]](diffhunk://#diff-c7a6dfcf94cb252c9aafb48b4c68055706cee2f3616c228591fc9a1126ec1a44R6) [[2]](diffhunk://#diff-c7a6dfcf94cb252c9aafb48b4c68055706cee2f3616c228591fc9a1126ec1a44R37-R43)

#### Map and Label Component
* [`editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx`](diffhunk://#diff-ae2da4919dc9d5f33eda496354a8c7308d8214d57937320704a448732de2bd79R14): Integrated `useFormErrorFocus` into the `VerticalFeatureTabs` component, adding support for tabbed error handling with `tabErrorMapping` and `onErrorInTab` for switching tabs. [[1]](diffhunk://#diff-ae2da4919dc9d5f33eda496354a8c7308d8214d57937320704a448732de2bd79R14) [[2]](diffhunk://#diff-ae2da4919dc9d5f33eda496354a8c7308d8214d57937320704a448732de2bd79R81-R95)

#### Text Input Component
* [`editor.planx.uk/src/@planx/components/TextInput/Public.tsx`](diffhunk://#diff-7f1d20688ee3e0de5db00110d920c62a605f92f5a66876f595def0bdc8096dfbR5): Integrated `useFormErrorFocus` into the `TextInputComponent` to focus on errors after form submission. [[1]](diffhunk://#diff-7f1d20688ee3e0de5db00110d920c62a605f92f5a66876f595def0bdc8096dfbR5) [[2]](diffhunk://#diff-7f1d20688ee3e0de5db00110d920c62a605f92f5a66876f595def0bdc8096dfbR36-R42)