### PR TITLE
fix: Sanitise both ShareDB ops and snapshots

### DIFF
--- a/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Confirmation.stories.tsx
@@ -44,7 +44,7 @@ export const Basic = {
     - to arrange a site visit, if required`,
     contactInfo: `
       You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
-      <br/><br/>
+      <br><br>
       <p><strong>What did you think of this service? Please give us your feedback on the next page.</strong></p>
     `,
     data: [],

--- a/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -75,7 +75,7 @@ export default function ConfirmationEditor(props: Props) {
       contactInfo:
         props.node?.data?.contactInfo ||
         `You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
-          <br/><br/>
+          <br><br>
           <p><strong>What did you think of this service? Please give us your feedback on the next page.</strong></p>`,
       ...parseNextSteps(props.node?.data),
     },


### PR DESCRIPTION
## What's the problem?
Creating from copy (or from template) fails if the source flow contains a `Confirmation` component. 

The API throws an "unclean HTML" error indicating that the input validation for the `flows` table has failed (the `webhooks/hasura/validate-input/jsonb/clean-html` endpoint).

## What's the cause?
The default HTML content for this component contains values which DOMPurify sanitises - 

```ts
{
  error: 'Warning: Unclean HTML submitted!',
  context: {
    input: 'You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>\n' +
      '          <br/><br/>>\n' +
      '          <p><strong>What did you think of this service? Please give us your feedback on the next page.</strong></p>',
    cleanHTML: 'You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>\n' +
      '          <br><br>&gt;\n' +
      '          <p><strong>What did you think of this service? Please give us your feedback on the next page.</strong></p>'
  }
}
```

The issue here is the conversion of `<br/>` to `<br>`. Unfortunately DOMPurify doesn't give us any sort of reason for the sanitation, we're just picking up a difference here between the two strings. In this instance the "sanitation" is just converting the XHTML string to proper HTML5.

### Why are we only hitting this input validation issue on "create from copy" and "create from template"?
This is a great question..! 😅 Input validation _should_ be triggered on both `INSERT` and `UPDATE` operations, so we should be hitting this issue when we're adding the `Confirmation` component to the flow. However, there's no issue with this - you can add `Confirmation` components with "unclean" HTML without any errors or failures.

When creating or updating nodes we're actually bypassing Hasura's input validation, and updating the DB via ShareDB. We do have DOMPurify configured for in ShareDB - but it just modifies the incoming operations instead of rejecting them (forcing clean content into the db). This is working - we can see that when a `Confirmation` component is added to a flow, the generated operation does have sanitised HTML. **The underlying issue here is that although the operation contains the sanitised HTML, the updated flow snapshot does not.**

This means that when we copy the flow, we're copying un-sanitised HTML which is then triggering Hasura's input validation, and rejecting. ❌ 

## What's the solution?
Within ShareDB we're just modifying the operations successfully, but too late in the lifecycle - the updated flow snapshot has been generated already. By simply modifying operations on the "submit" operation, we get a snapshot generated from these modified operations - 

> _**Submit**_
> _The ['submit'](https://share.github.io/sharedb/middleware/actions#submit) hook is triggered when the op has been received by the server._
> 
> _This is the earliest point in the op’s server-side lifecycle, and probably the point at which you may want to perform actions such as authenticating, validation, sanitization, etc._

[Source](https://share.github.io/sharedb/middleware/op-submission#lifecycle)

## To test - 
On staging - 
 - Add a `Confirmation` component to a flow
 - The generated operation will contain sanitised HTML (`<br><br>`)
 - The flow will still contain un-sanitised HTML (`<br/><br/>`)

Locally - 
 - Revert the default content change so that `<br/><br/>` (or any other unsafe HTML) is included within the `Confirmation` component again
 - Add a `Confirmation` component to a flow
 - The generated operation will contain sanitised HTML (`<br><br>`)
 - The flow will contain sanitised HTML (`<br><br>`)

This is not really testable on the Pizza as I've updated the default content.