### PR TITLE
fix: feedback component privacy link

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -1,5 +1,7 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import Link from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
 import { Disclaimer } from "@planx/components/shared/Disclaimer";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
@@ -11,6 +13,7 @@ import {
   insertFeedbackMutation,
 } from "lib/feedback";
 import React from "react";
+import { Link as ReactNaviLink } from "react-navi";
 import TerribleFace from "ui/images/feedback_filled-01.svg";
 import PoorFace from "ui/images/feedback_filled-02.svg";
 import NeutralFace from "ui/images/feedback_filled-03.svg";
@@ -82,6 +85,19 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         id={"DESCRIPTION_TEXT"}
         openLinksOnNewTab
       />
+      <Typography variant="body1" sx={{ marginTop: 2 }}>
+        Please do not include any personal data such as your name, email or
+        address. All feedback is processed according to our{" "}
+        <Link
+          component={ReactNaviLink}
+          href="pages/privacy"
+          prefetch={false}
+          color="primary"
+        >
+          privacy notice
+        </Link>
+        .
+      </Typography>
       <Box my={4}>
         {props.ratingQuestion && (
           <InputLabel

--- a/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
@@ -8,10 +8,8 @@ export const defaultContent: Feedback = {
   ratingQuestion:
     "<strong>How would you rate your experience with this service?</strong>",
 
-  description: `This service is a work in progress, any feedback you share about your experience will help us to improve it.
-<br>
-<br>
-Don't share any personal or financial information in your feedback. If you do we will act according to our <a href="">privacy policy</a>.`,
+  description:
+    "This service is a work in progress, any feedback you share about your experience will help us to improve it.",
 
   disclaimer:
     "The information collected here isn't monitored by planning officers. Don't use it to give extra information about your project or submission. If you do, it cannot be used to assess your project.",


### PR DESCRIPTION
The 'Feedback' component currently has an empty 'privacy policy' href in its default content. Points nowhere, so just reloads the page. This PR hardcodes the disclaimer to open the service's privacy page modal as the footer would do.

Alternative is to remove the link in the default content all together.