### PR TITLE
feat(api): `/lps/applications` endpoint

### DIFF
--- a/api.planx.uk/modules/lps/controller.ts
+++ b/api.planx.uk/modules/lps/controller.ts
@@ -1,6 +1,7 @@
 import { ServerError } from "../../errors/serverError.js";
+import { getApplications } from "./service/getApplications.js";
 import { login } from "./service/login.js";
-import type { Login } from "./types.js";
+import type { Applications, Login } from "./types.js";
 
 export const loginController: Login = async (_req, res, next) => {
   const { email } = res.locals.parsedReq.body;
@@ -14,6 +15,21 @@ export const loginController: Login = async (_req, res, next) => {
         message: `Failed to send "lps-login" email. ${
           (error as Error).message
         }`,
+      }),
+    );
+  }
+};
+
+export const applicationsController: Applications = async (_req, res, next) => {
+  const { email, token } = res.locals.parsedReq.body;
+  try {
+    const applications = await getApplications(email, token);
+    return res.status(200).json({ applications });
+  } catch (error) {
+    next(
+      new ServerError({
+        status: error instanceof ServerError ? error.status : undefined,
+        message: `Failed to fetch LPS applications for token ${token}. ${(error as Error).message}`,
       }),
     );
   }

--- a/api.planx.uk/modules/lps/docs.yaml
+++ b/api.planx.uk/modules/lps/docs.yaml
@@ -13,6 +13,15 @@ components:
         email:
           type: string
           format: email
+    ApplicationsRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        token:
+          type: string
+          format: uuid
   responses:
     LoginResponse:
       type: object
@@ -20,6 +29,55 @@ components:
         message:
           type: string
           example: success
+    ApplicationsResponse:
+      type: object
+      properties:
+        applications:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              updatedAt:
+                type: string
+                format: date-time
+              submittedAt:
+                type: string
+                format: date-time
+              service:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  slug:
+                    type: string
+                required:
+                  - name
+                  - slug
+              team:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  slug:
+                    type: string
+                required:
+                  - name
+                  - slug
+              url:
+                type: string
+                format: uri
+            required:
+              - id
+              - updatedAt
+              - submittedAt
+              - service
+              - team
+              - url
+      required:
+        - applications
 paths:
   /lps/login:
     post:
@@ -38,5 +96,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/responses/LoginResponse"
+        "500":
+          $ref: "#/components/responses/ErrorMessage"
+  /lps/applications:
+    post:
+      tags: [localplanning.services]
+      summary: Fetch applications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApplicationsRequest"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/responses/ApplicationsResponse"
         "500":
           $ref: "#/components/responses/ErrorMessage"

--- a/api.planx.uk/modules/lps/index.test.ts
+++ b/api.planx.uk/modules/lps/index.test.ts
@@ -49,7 +49,7 @@ describe("logging into LPS applications", () => {
           NOTIFY_TEST_EMAIL,
           expect.objectContaining({
             personalisation: expect.objectContaining({
-              magicLink: `https://www.localplanning.services/applications?token=${testToken}`,
+              magicLink: `https://www.localplanning.services/applications?token=${testToken}&email=${encodeURIComponent(NOTIFY_TEST_EMAIL)}`,
             }),
           }),
         );

--- a/api.planx.uk/modules/lps/routes.ts
+++ b/api.planx.uk/modules/lps/routes.ts
@@ -1,10 +1,15 @@
 import { Router } from "express";
 import { validate } from "../../shared/middleware/validate.js";
-import { loginSchema } from "./types.js";
-import { loginController } from "./controller.js";
+import { applicationsSchema, loginSchema } from "./types.js";
+import { applicationsController, loginController } from "./controller.js";
 
 const router = Router();
 
 router.post("/lps/login", validate(loginSchema), loginController);
+router.post(
+  "/lps/applications",
+  validate(applicationsSchema),
+  applicationsController,
+);
 
 export default router;

--- a/api.planx.uk/modules/lps/service/getApplications.ts
+++ b/api.planx.uk/modules/lps/service/getApplications.ts
@@ -1,0 +1,136 @@
+import { gql } from "graphql-request";
+import type { LPSApplication } from "../types.js";
+import { $api } from "../../../client/index.js";
+import { subMinutes } from "date-fns";
+import { ServerError } from "../../../errors/serverError.js";
+
+const MAGIC_LINK_EXPIRY_MINUTES =
+  process.env.NODE_ENV === "test"
+    ? 0.05 // 3s expiry for tests
+    : 10; // 10min on Pizza/Staging/Production
+
+export const getExpiry = () =>
+  subMinutes(new Date(), MAGIC_LINK_EXPIRY_MINUTES);
+
+export interface RawApplication {
+  id: string;
+  updatedAt: string;
+  submittedAt: string;
+  service: {
+    name: string;
+    slug: string;
+    team: {
+      name: string;
+      slug: string;
+      domain: string | null;
+    };
+  };
+}
+
+interface ConsumeMagicLink {
+  updateMagicLinks: {
+    returning: {
+      applications: RawApplication[];
+    }[];
+  };
+}
+
+const fetchApplicationsAndConsumeToken = async (
+  email: string,
+  token: string,
+) => {
+  try {
+    const {
+      updateMagicLinks: { returning },
+    } = await $api.client.request<ConsumeMagicLink>(
+      gql`
+        mutation ConsumeMagicLinkToken(
+          $email: String!
+          $token: uuid!
+          $expiry: timestamptz!
+        ) {
+          updateMagicLinks: update_lps_magic_links(
+            where: {
+              _and: {
+                # Find matching token...
+                email: { _eq: $email }
+                token: { _eq: $token }
+                operation: { _eq: "login" }
+                # ...which is active and unexpired
+                used_at: { _is_null: true }
+                created_at: { _gte: $expiry }
+              }
+            }
+            # Consume token
+            _set: { used_at: "now()" }
+          ) {
+            returning {
+              applications: lowcal_sessions {
+                id
+                updatedAt: updated_at
+                submittedAt: submitted_at
+                service: flow {
+                  name
+                  slug
+                  team {
+                    name
+                    slug
+                    domain
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      { token, email, expiry: getExpiry() },
+    );
+
+    if (!returning.length) return [];
+
+    return returning[0].applications;
+  } catch (error) {
+    throw new ServerError({
+      message: "GraphQL mutation ConsumeMagicLinkToken failed",
+      status: 500,
+      cause: error,
+    });
+  }
+};
+
+export const generateResumeLink = ({ service, id }: RawApplication) => {
+  const {
+    team: { slug: teamSlug, domain },
+    slug: flowSlug,
+  } = service;
+
+  // Use custom domain if available or fall back to PlanX URL
+  const serviceURL = domain
+    ? `https://${domain}/${flowSlug}`
+    : `${process.env.EDITOR_URL_EXT}/${teamSlug}/${flowSlug}/published`;
+
+  return `${serviceURL}&sessionId=${id}`;
+};
+
+export const convertToLPSApplication = (
+  raw: RawApplication,
+): LPSApplication => ({
+  id: raw.id,
+  updatedAt: raw.updatedAt,
+  submittedAt: raw.submittedAt,
+  service: {
+    name: raw.service.name,
+    slug: raw.service.slug,
+  },
+  team: raw.service.team,
+  url: generateResumeLink(raw),
+});
+
+export const getApplications = async (
+  email: string,
+  token: string,
+): Promise<LPSApplication[]> => {
+  const applications = await fetchApplicationsAndConsumeToken(email, token);
+  const lpsApplications = applications.map(convertToLPSApplication);
+  return lpsApplications;
+};

--- a/api.planx.uk/modules/lps/service/getApplications.ts
+++ b/api.planx.uk/modules/lps/service/getApplications.ts
@@ -15,7 +15,7 @@ export const getExpiry = () =>
 export interface RawApplication {
   id: string;
   updatedAt: string;
-  submittedAt: string;
+  submittedAt: string | null;
   service: {
     name: string;
     slug: string;
@@ -109,7 +109,7 @@ export const generateResumeLink = ({ service, id }: RawApplication) => {
     ? `https://${domain}/${flowSlug}`
     : `${process.env.EDITOR_URL_EXT}/${teamSlug}/${flowSlug}/published`;
 
-  return `${serviceURL}&sessionId=${id}`;
+  return `${serviceURL}?sessionId=${id}`;
 };
 
 export const convertToLPSApplication = (

--- a/api.planx.uk/modules/lps/service/login.ts
+++ b/api.planx.uk/modules/lps/service/login.ts
@@ -33,7 +33,9 @@ const createMagicLinkToken = async (email: string): Promise<string> => {
 const generateMagicLink = async (email: string) => {
   const token = await createMagicLinkToken(email);
   const url = new URL("/applications", process.env.LPS_URL_EXT!);
+  // TODO: Maybe base64 encode these as a single param?
   url.searchParams.append("token", token);
+  url.searchParams.append("email", email);
 
   return url.toString();
 };

--- a/api.planx.uk/modules/lps/service/login.ts
+++ b/api.planx.uk/modules/lps/service/login.ts
@@ -5,6 +5,7 @@ import {
   DEVOPS_EMAIL_REPLY_TO_ID,
   type TemplateRegistry,
 } from "../../../lib/notify/templates/index.js";
+import { ServerError } from "../../../errors/serverError.js";
 
 interface CreateMagicLink {
   magicLink: {
@@ -13,21 +14,29 @@ interface CreateMagicLink {
 }
 
 const createMagicLinkToken = async (email: string): Promise<string> => {
-  const {
-    magicLink: { token },
-  } = await $api.client.request<CreateMagicLink>(
-    gql`
-      mutation CreateLPSLoginToken($email: String!) {
-        magicLink: insert_lps_magic_links_one(
-          object: { email: $email, operation: "login" }
-        ) {
-          token
+  try {
+    const {
+      magicLink: { token },
+    } = await $api.client.request<CreateMagicLink>(
+      gql`
+        mutation CreateLPSLoginToken($email: String!) {
+          magicLink: insert_lps_magic_links_one(
+            object: { email: $email, operation: "login" }
+          ) {
+            token
+          }
         }
-      }
-    `,
-    { email },
-  );
-  return token;
+      `,
+      { email },
+    );
+
+    return token;
+  } catch (error) {
+    throw new ServerError({
+      message: "GraphQL query CreateLPSLoginToken failed",
+      status: 500,
+    });
+  }
 };
 
 const generateMagicLink = async (email: string) => {

--- a/api.planx.uk/modules/lps/types.ts
+++ b/api.planx.uk/modules/lps/types.ts
@@ -12,3 +12,34 @@ export const loginSchema = z.object({
 });
 
 export type Login = ValidatedRequestHandler<typeof loginSchema, LoginResponse>;
+
+export interface LPSApplication {
+  id: string;
+  updatedAt: string;
+  submittedAt: string;
+  service: {
+    name: string;
+    slug: string;
+  };
+  team: {
+    name: string;
+    slug: string;
+  };
+  url: string;
+}
+
+interface ApplicationsResponse {
+  applications: LPSApplication[];
+}
+
+export const applicationsSchema = z.object({
+  body: z.object({
+    email: z.string().email(),
+    token: z.string().uuid(),
+  }),
+});
+
+export type Applications = ValidatedRequestHandler<
+  typeof applicationsSchema,
+  ApplicationsResponse
+>;

--- a/api.planx.uk/modules/lps/types.ts
+++ b/api.planx.uk/modules/lps/types.ts
@@ -16,7 +16,7 @@ export type Login = ValidatedRequestHandler<typeof loginSchema, LoginResponse>;
 export interface LPSApplication {
   id: string;
   updatedAt: string;
-  submittedAt: string;
+  submittedAt: string | null;
   service: {
     name: string;
     slug: string;
@@ -24,6 +24,7 @@ export interface LPSApplication {
   team: {
     name: string;
     slug: string;
+    domain: string | null;
   };
   url: string;
 }

--- a/hasura.planx.uk/metadata/databases/default/tables/public_lps_magic_links.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_lps_magic_links.yaml
@@ -1,6 +1,16 @@
 table:
   name: lps_magic_links
   schema: public
+array_relationships:
+  - name: lowcal_sessions
+    using:
+      manual_configuration:
+        column_mapping:
+          email: email
+        insertion_order: null
+        remote_table:
+          name: lowcal_sessions
+          schema: public
 insert_permissions:
   - role: api
     permission:


### PR DESCRIPTION
## What does this PR do?
 - Sets up the POST `/lps/applications` endpoint on the PlanX REST API
 - Test coverage added in #4856 & #4857 (split PR up as it was getting pretty big)

This endpoint is used as part of the login flow for localplanning.services - provided with a magic link, it will return the associated sessions for a user.

### Next steps...
 - Wire up the applications page in LPS to hit this endpoint when provided with a token