### PR TITLE
fix: ensure internal and external portal modals set all `initialValues`

### DIFF
--- a/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.test.tsx
@@ -39,6 +39,9 @@ test("adding an external portal", async () => {
         flowId: "b",
         tags: [],
         notes: "",
+        isTemplatedNode: false,
+        templatedNodeInstructions: "",
+        areTemplatedNodeInstructionsRequired: false,
       },
     }),
   );
@@ -81,6 +84,9 @@ test("changing an external portal", async () => {
         flowId: "a",
         tags: [],
         notes: "",
+        isTemplatedNode: false,
+        templatedNodeInstructions: "",
+        areTemplatedNodeInstructionsRequired: false,
       },
     }),
   );

--- a/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -73,6 +73,9 @@ const ExternalPortalForm: React.FC<{
       flowId: flowId || null,
       tags,
       notes,
+      isTemplatedNode,
+      templatedNodeInstructions,
+      areTemplatedNodeInstructionsRequired,
     },
     onSubmit: (data) => {
       if (handleSubmit) {

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.test.tsx
@@ -40,6 +40,9 @@ describe("adding an internal portal", () => {
           text: "new internal portal",
           tags: [],
           notes: "",
+          isTemplatedNode: false,
+          templatedNodeInstructions: "",
+          areTemplatedNodeInstructionsRequired: false,
         },
       });
     });
@@ -133,6 +136,9 @@ test("updating an internal portal", async () => {
         text: "new val",
         tags: [],
         notes: "",
+        isTemplatedNode: false,
+        templatedNodeInstructions: "",
+        areTemplatedNodeInstructionsRequired: false,
       },
     });
   });

--- a/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -51,6 +51,9 @@ const InternalPortalForm: React.FC<{
       flowId,
       tags,
       notes,
+      isTemplatedNode,
+      templatedNodeInstructions,
+      areTemplatedNodeInstructionsRequired,
     },
     validate: (values) => {
       const errors: Record<string, string> = {};


### PR DESCRIPTION
Fixes source template bug reported here https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1750877038481739?thread_ts=1750424102.836949&cid=C04DZ1NBUMR:
> I also noticed an issue with the Allow edits toggle on portals: Internal portal nodes within a source template always open with the Allow edits toggle off within the Editor modal. They are irrespective of that correctly saved as toggled, but their instructions disappear and in order to toggle them off you'd have to double toggle them. External portal nodes within a source template do not retain their Allow edits toggle at all, and can't be toggled on or off.

Quick one - simply missed these `initialValues` in the big PR that introduced across all component types!
