### PR TITLE
chore: fill in `test.todo` & missing Swagger docs for templates endpoints

### DIFF
--- a/api.planx.uk/modules/flows/docs.yaml
+++ b/api.planx.uk/modules/flows/docs.yaml
@@ -250,6 +250,21 @@ components:
             type: object
             properties:
               $ref: "#/components/schemas/FlowData"
+    UpdateTemplatedFlow:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              data:
+                type: object
+                properties:
+                  templatedFlowData:
+                    type: object
+                  commentId:
+                    type: number
 paths:
   /flows/create:
     post:
@@ -427,5 +442,24 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/FlattenData"
+        "500":
+          $ref: "#/components/responses/ErrorMessage"
+  /flows/{sourceFlowId}/update-templated-flow/{templatedFlowId}:
+    post:
+      summary: When a source flow is published, update a flow templated from it
+      description: When a source flow is published, update a flow templated from it by reconciling any customised edits with the source
+      tags: ["flows"]
+      parameters:
+        - in: path
+          name: sourceFlowId
+          type: string
+          required: true
+        - in: path
+          name: templatedFlowId
+          type: string
+          required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/UpdateTemplatedFlow"
         "500":
           $ref: "#/components/responses/ErrorMessage"

--- a/api.planx.uk/modules/flows/publish/service.ts
+++ b/api.planx.uk/modules/flows/publish/service.ts
@@ -102,7 +102,6 @@ export const publishFlow = async (
           payload: {
             sourceFlowId: flowId,
             templatedFlowId: templatedFlowId,
-            summary: summary,
           },
           comment: `update_templated_flow_${templatedFlowId}`,
         }),

--- a/api.planx.uk/modules/flows/routes.ts
+++ b/api.planx.uk/modules/flows/routes.ts
@@ -116,7 +116,7 @@ router.get(
 );
 
 router.post(
-  "/flows/:flowId/update-templated-flow/:templatedFlowId",
+  "/flows/:sourceFlowId/update-templated-flow/:templatedFlowId",
   validate(updateTemplatedFlowEventSchema),
   updateTemplatedFlowController,
 );

--- a/api.planx.uk/modules/flows/updateTemplatedFlow/controller.ts
+++ b/api.planx.uk/modules/flows/updateTemplatedFlow/controller.ts
@@ -9,7 +9,6 @@ export const updateTemplatedFlowEventSchema = z.object({
     payload: z.object({
       sourceFlowId: z.string(),
       templatedFlowId: z.string(),
-      summary: z.string(),
     }),
   }),
 });
@@ -26,8 +25,7 @@ export type UpdateTemplatedFlowController = ValidatedRequestHandler<
 
 export const updateTemplatedFlowController: UpdateTemplatedFlowController =
   async (_req, res, next) => {
-    const { sourceFlowId, templatedFlowId, summary } =
-      res.locals.parsedReq.body.payload;
+    const { sourceFlowId, templatedFlowId } = res.locals.parsedReq.body.payload;
 
     try {
       const response = await updateTemplatedFlow(sourceFlowId, templatedFlowId);

--- a/api.planx.uk/modules/flows/updateTemplatedFlow/controller.ts
+++ b/api.planx.uk/modules/flows/updateTemplatedFlow/controller.ts
@@ -1,3 +1,4 @@
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { z } from "zod";
 
 import { ServerError } from "../../../errors/serverError.js";
@@ -15,7 +16,10 @@ export const updateTemplatedFlowEventSchema = z.object({
 
 export interface UpdateTemplatedFlowResponse {
   message: string;
-  data?: any;
+  data: {
+    templatedFlowData: FlowGraph;
+    commentId: number;
+  };
 }
 
 export type UpdateTemplatedFlowController = ValidatedRequestHandler<

--- a/api.planx.uk/modules/flows/updateTemplatedFlow/updateTemplatedFlow.test.ts
+++ b/api.planx.uk/modules/flows/updateTemplatedFlow/updateTemplatedFlow.test.ts
@@ -1,3 +1,175 @@
-it.todo("correctly updates a templated flow that has been customised");
+import supertest from "supertest";
 
-it.todo("correctly updates a templated flow that has not been customised yet");
+import app from "../../../server.js";
+import { queryMock } from "../../../tests/graphqlQueryMock.js";
+import type { Flow } from "../../../types.js";
+
+const mockSourceTemplateFlowData: Flow["data"] = {
+  _root: {
+    edges: ["Content"],
+  },
+  Content: {
+    type: 250,
+    data: {
+      text: "This a fake template",
+      isTemplatedNode: true,
+      templatedNodeInstructions: "Add help text",
+      areTemplatedNodeInstructionsRequired: false,
+    },
+  },
+};
+
+const mockTemplatedFlowEdits = {
+  Content: {
+    data: {
+      howMeasured: "This is how my council measures it",
+    },
+  },
+};
+
+// With "reconciliation" where templated_flow_edits have been applied/preserved
+const mockUpdatedTemplatedFlowData: Flow["data"] = {
+  _root: {
+    edges: ["Content"],
+  },
+  Content: {
+    type: 250,
+    data: {
+      text: "This a fake template",
+      isTemplatedNode: true,
+      templatedNodeInstructions: "Add help text",
+      areTemplatedNodeInstructionsRequired: false,
+      howMeasured: "This is how my council measures it",
+    },
+  },
+};
+
+// Triggered via Hasura webhook, so wrapped in `payload` without user or team-based auth
+const validBody = {
+  payload: {
+    sourceFlowId: "1",
+    templatedFlowId: "2",
+  },
+};
+
+const invalidBody = { payload: {} };
+
+describe("validation and error handling", () => {
+  it("returns an error if required properties are missing in the request body", async () => {
+    await supertest(app)
+      .post("/flows/1/update-templated-flow/2")
+      .send(invalidBody)
+      .expect(400)
+      .then((res) => {
+        expect(res.body).toHaveProperty("issues");
+        expect(res.body).toHaveProperty("name", "ZodError");
+      });
+  });
+});
+
+describe("success", () => {
+  beforeEach(() => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          data: mockSourceTemplateFlowData,
+          publishedFlows: [
+            {
+              id: 3,
+              summary: "Updated the source template",
+              publisher_id: 1,
+              created_at: "2025-07-01",
+              data: mockSourceTemplateFlowData,
+            },
+          ],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "InsertComment",
+      matchOnVariables: false,
+      data: {
+        comment: {
+          id: 1,
+        },
+      },
+    });
+  });
+
+  it("correctly updates a templated flow that has been customised", async () => {
+    queryMock.mockQuery({
+      name: "GetTemplatedFlowEdits",
+      matchOnVariables: false,
+      data: {
+        edits: {
+          data: mockTemplatedFlowEdits,
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "UpdateTemplatedFlowData",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          data: mockUpdatedTemplatedFlowData,
+        },
+      },
+    });
+
+    await supertest(app)
+      .post("/flows/1/update-templated-flow/2")
+      .send(validBody)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).toEqual({
+          message:
+            "Successfully updated templated flow on source publish (source ID 1, templated flow ID 2)",
+          data: {
+            templatedFlowData: mockUpdatedTemplatedFlowData,
+            commentId: 1,
+          },
+        });
+      });
+  });
+
+  it("correctly updates a templated flow that has not been customised yet", async () => {
+    // A templated flow that has not been customised yet will not have a record in `templated_flow_edits` table
+    queryMock.mockQuery({
+      name: "GetTemplatedFlowEdits",
+      matchOnVariables: false,
+      data: {
+        edits: null,
+      },
+    });
+
+    // Without edits to merge or "reconcile", then the templated flow is updated to exactly match the source data
+    queryMock.mockQuery({
+      name: "UpdateTemplatedFlowData",
+      matchOnVariables: false,
+      data: {
+        flow: {
+          data: mockSourceTemplateFlowData,
+        },
+      },
+    });
+
+    await supertest(app)
+      .post("/flows/1/update-templated-flow/2")
+      .send(validBody)
+      .expect(200)
+      .then((res) => {
+        expect(res.body).toEqual({
+          message:
+            "Successfully updated templated flow on source publish (source ID 1, templated flow ID 2)",
+          data: {
+            templatedFlowData: mockSourceTemplateFlowData,
+            commentId: 1,
+          },
+        });
+      });
+  });
+});

--- a/api.planx.uk/modules/webhooks/docs.yaml
+++ b/api.planx.uk/modules/webhooks/docs.yaml
@@ -139,6 +139,23 @@ components:
             email:
               type: string
               format: email
+    UpdateTemplatedFlowEditsEvent:
+      type: object
+      properties:
+        createdAt:
+          required: true
+          type: string
+          format: date-time
+        payload:
+          required: true
+          type: object
+          properties:
+            flowId:
+              type: string
+            templatedFrom:
+              type: string
+            data:
+              type: object
   requests:
     ValidateInputRequest:
       description: |
@@ -243,6 +260,22 @@ components:
               message:
                 type: string
                 description: A message returned to the client
+    UpdateTemplatedFlowEditsSuccess:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                required: true
+              data:
+                type: object
+                properties:
+                  flowId:
+                    type: string
+                  delta:
+                    type: object
 paths:
   /webhooks/hasura/send-slack-notification:
     post:
@@ -387,3 +420,21 @@ paths:
           $ref: "#/components/responses/InputValidationSuccess"
         "500":
           $ref: "#/components/responses/InputValidationFailure"
+  /webhooks/hasura/update-templated-flow-edits:
+    post:
+      tags: ["webhooks"]
+      security:
+        - hasuraAuth:: []
+      summary: Create templated flow edits update events
+      description: Setup event which will transform and update `templated_flow_edits` anytime a templated flow's `data` is updated
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTemplatedFlowEditsEvent"
+      responses:
+        "200":
+          $ref: "#/components/responses/UpdateTemplatedFlowEditsSuccess"
+        "500":
+          $ref: "#/components/responses/ErrorMessage"


### PR DESCRIPTION
Some API-side cleanup for templates! 

Fills in `test.todo`, adds missing Swagger docs now that endpoints have stabilised a bit, and improves a lingering `any` type. 