### PR TITLE
chore: Fix invalid default HTML in Review component [skip pizza]

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/model.ts
+++ b/editor.planx.uk/src/@planx/components/Review/model.ts
@@ -16,4 +16,4 @@ export const parseContent = (
 });
 
 export const DEFAULT_REVIEW_DISCLAIMER =
-  "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>";
+  "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul>";


### PR DESCRIPTION
Airbrake is picking up the following issue with HTML sanitation when reproducing the LDC flow ([source](https://planx.airbrake.io/projects/329753/groups/4101751176729563290?tab=notice-detail)) - 

```json
{
  "cleanHTML": "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul><p></p>",
  "input": "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul></p>"
}
```

The issue is an additional redundant closing `</p>` tag in the `DEFAULT_REVIEW_DISCLAIMER`. 

As a reminder, our current approach with DOMPurify is not directly identifying "unsafe" HTML per-se (this isn't currently possible unfortunately), but just flagging any changes from input to output as an issue.

