### PR TITLE
test(e2e): Coverage for the `/lps/applications` endpoint

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -27,3 +27,4 @@ services:
       UNIFORM_SUBMISSION_URL: http://mock-server:8080
       UNIFORM_TOKEN_URL: http://mock-server:8080
       UNIFORM_CLIENT_E2E: e2e:123
+      NODE_ENV: test

--- a/e2e/tests/api-driven/src/lps/getApplications.feature
+++ b/e2e/tests/api-driven/src/lps/getApplications.feature
@@ -1,0 +1,31 @@
+Feature: Magic link validation and expiration for localplanning.services
+
+  @regression @lps-magic-links
+  Scenario Outline: Fetching applications with an invalid token
+    Given a magic link is generated
+    When an invalid token is provided
+    Then applications can't be accessed
+
+  @regression @lps-magic-links
+  Scenario Outline: Fetching applications with an invalid email address
+    Given a magic link is generated
+    When an invalid email address is provided
+    Then applications can't be accessed
+
+  @regression @lps-magic-links
+  Scenario Outline: Fetching applications with an expired token
+    Given a magic link is generated
+    When the expiry time has passed
+    Then applications can't be accessed
+
+  @regression @lps-magic-links
+  Scenario Outline: Fetching applications successfully
+    Given a magic link is generated
+    When the correct details are provided
+    Then applications can be accessed
+
+  @regression @lps-magic-links
+  Scenario Outline: Fetching applications a single time per-link
+    Given a magic link is generated
+    When the correct details are provided
+    Then the link cannot be reused

--- a/e2e/tests/api-driven/src/lps/helpers.ts
+++ b/e2e/tests/api-driven/src/lps/helpers.ts
@@ -1,0 +1,176 @@
+import { strict as assert } from "node:assert";
+import { $admin } from "../client.js";
+import {
+  createFlow,
+  createTeam,
+  createUser,
+  safely,
+} from "../globalHelpers.js";
+import { CustomWorld } from "./steps.js";
+import { gql } from "graphql-tag";
+
+export const setup = async ({
+  email,
+}: {
+  email: string;
+}): Promise<CustomWorld["sessionIds"]> => {
+  const teamId = await createTeam();
+  const userId = await createUser();
+  const flowId = await createFlow({
+    teamId,
+    userId,
+    slug: "test-flow",
+    name: "Test Flow",
+  });
+
+  // Create other user sessions
+  await $admin.session.create({
+    flowId,
+    data: {
+      passport: { data: {} },
+      breadcrumbs: {},
+    },
+    email: "person1@example.com",
+  });
+
+  await $admin.session.create({
+    flowId,
+    data: {
+      passport: { data: {} },
+      breadcrumbs: {},
+    },
+    email: "person2@example.com",
+  });
+
+  await $admin.session.create({
+    flowId,
+    data: {
+      passport: { data: {} },
+      breadcrumbs: {},
+    },
+    email: "person3@example.com",
+  });
+
+  // Create my sessions
+  const sessionIds = await Promise.all([
+    $admin.session.create({
+      flowId,
+      data: {
+        passport: { data: {} },
+        breadcrumbs: {},
+      },
+      email,
+    }),
+
+    $admin.session.create({
+      flowId,
+      data: {
+        passport: { data: {} },
+        breadcrumbs: {},
+      },
+      email,
+    }),
+
+    $admin.session.create({
+      flowId,
+      data: {
+        passport: { data: {} },
+        breadcrumbs: {},
+      },
+      email,
+    }),
+  ]);
+
+  return sessionIds;
+};
+
+export const cleanup = async () => {
+  await $admin.flow._destroyPublishedAll();
+  await $admin.flow._destroyAll();
+  await $admin.user._destroyAll();
+  await $admin.team._destroyAll();
+
+  await safely(() =>
+    $admin.client.request(gql`
+      mutation DeleteAllMagicLinks {
+        delete_lps_magic_links(where: {}) {
+          affected_rows
+        }
+      }
+    `),
+  );
+
+  await safely(() =>
+    $admin.client.request(gql`
+      mutation DeleteAllLowcalSessions {
+        delete_lowcal_sessions(where: {}) {
+          affected_rows
+        }
+      }
+    `),
+  );
+};
+
+/**
+ * "Log in" to the LPS platform by generating a magic link via the PlanX API
+ */
+export const login = async (email: string) => {
+  const response = await fetch(`${process.env.API_URL_EXT}/lps/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+
+  if (!response.ok) {
+    assert.fail("Failed to create magic link via /lps/login endpoint");
+  }
+};
+
+interface GetLatestMagicLink {
+  lpsMagicLinks: {
+    token: string;
+    email: string;
+    usedAt: string | null;
+  }[];
+}
+
+export const getLatestMagicLink = async () => {
+  const {
+    lpsMagicLinks: [magicLinkRecord],
+  } = await safely(() =>
+    $admin.client.request<GetLatestMagicLink>(gql`
+      query GetLatestMagicLink {
+        lpsMagicLinks: lps_magic_links(
+          limit: 1
+          order_by: { created_at: desc }
+        ) {
+          token
+          email
+          usedAt: used_at
+        }
+      }
+    `),
+  );
+
+  return magicLinkRecord;
+};
+
+export const getApplications = async (email: string, token: string) => {
+  const response = await fetch(`${process.env.API_URL_EXT}/lps/applications`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email, token }),
+  });
+
+  if (!response.ok) {
+    assert.fail("Failed to get applications via /lps/applications endpoint");
+  }
+
+  const { applications }: CustomWorld = await response.json();
+
+  return applications;
+};

--- a/e2e/tests/api-driven/src/lps/steps.ts
+++ b/e2e/tests/api-driven/src/lps/steps.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from "node:assert";
+import { Given, When, Then, Before, After, World } from "@cucumber/cucumber";
+import {
+  cleanup,
+  getApplications,
+  getLatestMagicLink,
+  login,
+  setup,
+} from "./helpers.js";
+
+export class CustomWorld extends World {
+  sessionIds!: string[];
+  token!: string;
+  email!: string;
+  applications!: { id: string }[];
+}
+
+Before<CustomWorld>("@lps-magic-links", async function () {
+  this.email = "me@example.com";
+
+  const sessionIds = await setup({ email: this.email });
+  this.sessionIds = sessionIds;
+});
+
+After<CustomWorld>("@lps-magic-links", async function () {
+  await cleanup();
+});
+
+Given<CustomWorld>("a magic link is generated", async function () {
+  await login(this.email);
+  const { token, email, usedAt } = await getLatestMagicLink();
+
+  assert.equal(
+    email,
+    this.email,
+    "Generated magic link does not match test user",
+  );
+  assert(token, "Failed to fetch magic link token");
+  assert.equal(usedAt, null, "Magic link should not be consumed");
+
+  this.token = token;
+});
+
+When<CustomWorld>("an invalid token is provided", async function () {
+  const invalidToken = "bca15271-3ebf-4d57-aab2-799bfa3e41ce";
+  this.applications = await getApplications(this.email, invalidToken);
+});
+
+When<CustomWorld>("an invalid email address is provided", async function () {
+  this.applications = await getApplications(
+    "wrongEmail@example.com",
+    this.token,
+  );
+});
+
+When<CustomWorld>("the expiry time has passed", async function () {
+  // Sleep over the 3s expiry length in test envs
+  await new Promise((resolve) => setTimeout(resolve, 3_500));
+
+  this.applications = await getApplications(this.email, this.token);
+});
+
+When<CustomWorld>("the correct details are provided", async function () {
+  this.applications = await getApplications(this.email, this.token);
+});
+
+Then<CustomWorld>("applications can't be accessed", function () {
+  assert.equal(this.applications.length, 0);
+});
+
+Then<CustomWorld>("applications can be accessed", async function () {
+  assert.equal(this.applications.length, 3);
+
+  // Each application returned corresponds with the user's sessions
+  this.applications.forEach(({ id }) => {
+    assert.equal(this.sessionIds.includes(id), true);
+  });
+});
+
+Then<CustomWorld>("the link cannot be reused", async function () {
+  this.applications = await getApplications(this.email, this.token);
+  assert.equal(this.applications.length, 0);
+
+  const { usedAt } = await getLatestMagicLink();
+  assert.notEqual(usedAt, null, "Magic link should be marked as consumed");
+});


### PR DESCRIPTION
Coverage for functionality added in #4852

Regression tests running here https://github.com/theopensystemslab/planx-new/actions/runs/15980425980 🚀 