### PR TITLE
fix: omit archived templated flows when queuing up `templatedFlow` update events

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -325,7 +325,7 @@ export const getTemplatedFlows = async (flowId: string) => {
     gql`
       query GetTemplatedFlows($flow_id: uuid!) {
         flow: flows_by_pk(id: $flow_id) {
-          templatedFlows: templated_flows {
+          templatedFlows: templated_flows(where: {deleted_at: {_is_null: true}}) {
             id
             slug
             team {

--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -325,7 +325,9 @@ export const getTemplatedFlows = async (flowId: string) => {
     gql`
       query GetTemplatedFlows($flow_id: uuid!) {
         flow: flows_by_pk(id: $flow_id) {
-          templatedFlows: templated_flows(where: {deleted_at: {_is_null: true}}) {
+          templatedFlows: templated_flows(
+            where: { deleted_at: { _is_null: true } }
+          ) {
             id
             slug
             team {

--- a/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -224,6 +224,7 @@ select_permissions:
         - created_at
         - creator_id
         - data
+        - deleted_at
         - description
         - id
         - is_template
@@ -250,6 +251,7 @@ select_permissions:
         - created_at
         - creator_id
         - data
+        - deleted_at
         - description
         - id
         - is_template
@@ -290,6 +292,7 @@ select_permissions:
         - created_at
         - creator_id
         - data
+        - deleted_at
         - description
         - id
         - is_template
@@ -343,6 +346,7 @@ select_permissions:
         - created_at
         - creator_id
         - data
+        - deleted_at
         - description
         - id
         - is_template


### PR DESCRIPTION
Small bug I've noticed while testing on staging / demo'ing last couple days !

We were still queuing up and triggering "update" events on source publish for templated flows that were archived - meaning it then takes longer for updates to trickle through to 'active' children ! 