### PR TITLE
fix: hardcode feedback component default content

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -75,45 +75,28 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
 
             <InputRow>
               <InputLabel label="Rating question" htmlFor="ratingQuestion">
-                <RichTextInput
-                  placeholder={defaultContent.ratingQuestion?.replaceAll(
-                    HTML_TAG_REGEX,
-                    "",
-                  )}
-                  name="ratingQuestion"
-                  id="ratingQuestion"
+                <Input
                   value={formik.values.ratingQuestion}
                   onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  errorMessage={formik.errors.ratingQuestion}
+                  disabled
                 />
               </InputLabel>
             </InputRow>
             <InputRow>
               <InputLabel label="Freeform question" htmlFor="freeformQuestion">
-                <RichTextInput
-                  placeholder={defaultContent.freeformQuestion?.replaceAll(
-                    HTML_TAG_REGEX,
-                    "",
-                  )}
-                  name="freeformQuestion"
-                  id="freeformQuestion"
+                <Input
                   value={formik.values.freeformQuestion}
                   onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  errorMessage={formik.errors.freeformQuestion}
+                  disabled
                 />
               </InputLabel>
             </InputRow>
             <InputRow>
               <InputLabel label="Disclaimer text" htmlFor="disclaimer">
                 <RichTextInput
-                  name="disclaimer"
-                  id="disclaimer"
                   value={formik.values.disclaimer}
                   onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  errorMessage={formik.errors.disclaimer}
+                  disabled
                 />
               </InputLabel>
             </InputRow>

--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -1,5 +1,7 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import Link from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
 import { Disclaimer } from "@planx/components/shared/Disclaimer";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
@@ -11,6 +13,7 @@ import {
   insertFeedbackMutation,
 } from "lib/feedback";
 import React from "react";
+import { Link as ReactNaviLink } from "react-navi";
 import TerribleFace from "ui/images/feedback_filled-01.svg";
 import PoorFace from "ui/images/feedback_filled-02.svg";
 import NeutralFace from "ui/images/feedback_filled-03.svg";
@@ -82,6 +85,19 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         id={"DESCRIPTION_TEXT"}
         openLinksOnNewTab
       />
+      <Typography variant="body1" sx={{ marginTop: 2 }}>
+        Please do not include any personal data such as your name, email or
+        address. All feedback is processed according to our{" "}
+        <Link
+          component={ReactNaviLink}
+          href="pages/privacy"
+          prefetch={false}
+          color="primary"
+        >
+          privacy notice
+        </Link>
+        .
+      </Typography>
       <Box my={4}>
         {props.ratingQuestion && (
           <InputLabel

--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -1,10 +1,11 @@
+import ErrorOutline from "@mui/icons-material/ErrorOutline";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
-import { Disclaimer } from "@planx/components/shared/Disclaimer";
 import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
+import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import type { PublicProps } from "@planx/components/shared/types";
 import { FeedbackView } from "components/Feedback/types";
 import { useFormik } from "formik";
@@ -85,28 +86,16 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         id={"DESCRIPTION_TEXT"}
         openLinksOnNewTab
       />
-      <Typography variant="body1" sx={{ marginTop: 2 }}>
-        Please do not include any personal data such as your name, email or
-        address. All feedback is processed according to our{" "}
-        <Link
-          component={ReactNaviLink}
-          href="pages/privacy"
-          prefetch={false}
-          color="primary"
-        >
-          privacy notice
-        </Link>
-        .
-      </Typography>
       <Box my={4}>
         {props.ratingQuestion && (
           <InputLabel
             label={
-              <ReactMarkdownOrHtml
-                source={props.ratingQuestion}
-                id={"RATING_QUESTION"}
-                openLinksOnNewTab
-              />
+              <strong>
+                <ReactMarkdownOrHtml
+                  source={props.ratingQuestion}
+                  id={"RATING_QUESTION"}
+                />
+              </strong>
             }
           />
         )}
@@ -161,11 +150,12 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
         {props.freeformQuestion && (
           <InputLabel
             label={
-              <ReactMarkdownOrHtml
-                source={props.freeformQuestion}
-                id={"RATING_QUESTION"}
-                openLinksOnNewTab
-              />
+              <strong>
+                <ReactMarkdownOrHtml
+                  source={props.freeformQuestion}
+                  id={"FREEFORM_QUESTION"}
+                />
+              </strong>
             }
           />
         )}
@@ -181,7 +171,27 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
           errorMessage={formik.errors.userComment}
         />
       </Box>
-      {props.disclaimer && <Disclaimer text={props.disclaimer} />}
+      <WarningContainer>
+        <ErrorOutline />
+        <Typography
+          variant="body2"
+          component="div"
+          ml={2}
+          sx={{ "& p:first-of-type": { marginTop: 0 } }}
+        >
+          Please do not include any personal data such as your name, email or
+          address. All feedback is processed according to our{" "}
+          <Link
+            component={ReactNaviLink}
+            href="pages/privacy"
+            prefetch={false}
+            color="primary"
+          >
+            privacy notice
+          </Link>
+          .
+        </Typography>
+      </WarningContainer>
     </Card>
   );
 };

--- a/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -15,6 +15,7 @@ import {
 } from "lib/feedback";
 import React from "react";
 import { Link as ReactNaviLink } from "react-navi";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import TerribleFace from "ui/images/feedback_filled-01.svg";
 import PoorFace from "ui/images/feedback_filled-02.svg";
 import NeutralFace from "ui/images/feedback_filled-03.svg";
@@ -88,16 +89,9 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
       />
       <Box my={4}>
         {props.ratingQuestion && (
-          <InputLabel
-            label={
-              <strong>
-                <ReactMarkdownOrHtml
-                  source={props.ratingQuestion}
-                  id={"RATING_QUESTION"}
-                />
-              </strong>
-            }
-          />
+          <Box sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+            <InputLabel label={props.ratingQuestion} />
+          </Box>
         )}
         <ErrorWrapper error={formik.errors.feedbackScore}>
           <StyledToggleButtonGroup
@@ -148,16 +142,9 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
           </StyledToggleButtonGroup>
         </ErrorWrapper>
         {props.freeformQuestion && (
-          <InputLabel
-            label={
-              <strong>
-                <ReactMarkdownOrHtml
-                  source={props.freeformQuestion}
-                  id={"FREEFORM_QUESTION"}
-                />
-              </strong>
-            }
-          />
+          <Box sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+            <InputLabel label={props.freeformQuestion} />
+          </Box>
         )}
         <Input
           multiline={true}

--- a/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.accessibility.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.accessibility.test.tsx
@@ -43,6 +43,9 @@ describe("when the Feedback component is rendered", async () => {
     expect(screen.getByRole("textbox")).toHaveFocus();
 
     await user.tab();
+    expect(screen.getByRole("link")).toHaveFocus();
+
+    await user.tab();
     expect(screen.getByTestId("continue-button")).toHaveFocus();
     await user.keyboard("[Space]"); // submits
 

--- a/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
@@ -2,16 +2,14 @@ import { Feedback } from "../model";
 
 export const defaultContent: Feedback = {
   title: "Tell us what you think",
-  freeformQuestion:
-    "<strong>Please tell us more about your experience.</strong>",
+  freeformQuestion: "Please tell us more about your experience.",
 
-  ratingQuestion:
-    "<strong>How would you rate your experience with this service?</strong>",
+  ratingQuestion: "How would you rate your experience with this service?",
 
   description:
     "This service is a work in progress, any feedback you share about your experience will help us to improve it.",
 
   disclaimer:
-    "The information collected here isn't monitored by planning officers. Don't use it to give extra information about your project or submission. If you do, it cannot be used to assess your project.",
+    "Please do not include any personal data such as your name, email or address. All feedback is processed according to our privacy notice.",
   feedbackRequired: false,
 };

--- a/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/components/defaultContent.tsx
@@ -8,10 +8,8 @@ export const defaultContent: Feedback = {
   ratingQuestion:
     "<strong>How would you rate your experience with this service?</strong>",
 
-  description: `This service is a work in progress, any feedback you share about your experience will help us to improve it.
-<br>
-<br>
-Don't share any personal or financial information in your feedback. If you do we will act according to our <a href="">privacy policy</a>.`,
+  description:
+    "This service is a work in progress, any feedback you share about your experience will help us to improve it.",
 
   disclaimer:
     "The information collected here isn't monitored by planning officers. Don't use it to give extra information about your project or submission. If you do, it cannot be used to assess your project.",

--- a/editor.planx.uk/src/@planx/components/Feedback/model.ts
+++ b/editor.planx.uk/src/@planx/components/Feedback/model.ts
@@ -38,8 +38,8 @@ export const validationSchema: SchemaOf<Feedback> =
     object({
       title: string(),
       description: richText(),
-      ratingQuestion: richText(),
-      freeformQuestion: richText(),
+      ratingQuestion: string(),
+      freeformQuestion: string(),
       disclaimer: richText(),
       feedbackRequired: boolean().required(),
     }),


### PR DESCRIPTION
This PR locks all but title and description fields for the Feedback component.

This ensures consistency across content, consistent use of feedback in metrics and evaluation, and the use of the service's privacy page in the disclaimer.

More context in [original PR](https://github.com/theopensystemslab/planx-new/pull/4851).