### PR TITLE
refactor: improvement to aria label and attributes for FileUploadAndLabel component

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -73,6 +73,7 @@ const ListboxComponent = forwardRef<typeof Box, PropsWithChildren>(
       ref={ref}
       {...props}
       role="listbox"
+      aria-multiselectable="true"
       sx={{ paddingY: "0px !important" }}
     >
       {children}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -154,7 +154,23 @@ export const SelectMultipleFileTypes = (props: SelectMultipleProps) => {
       id={`select-multiple-file-tags-${uploadedFile.id}`}
       isOptionEqualToValue={(option, value) => option.name === value.name}
       key={`form-${uploadedFile.id}`}
-      label="What does this file show? (select all that apply)"
+      label={
+        <>
+          What does this file show? (select all that apply)
+          <Box
+            component="span"
+            sx={{
+              position: "absolute",
+              clip: "rect(0 0 0 0)",
+              width: "1px",
+              height: "1px",
+              overflow: "hidden",
+            }}
+          >
+            This question refers to file: {uploadedFile.file.name}
+          </Box>
+        </>
+      }
       ListboxComponent={ListboxComponent}
       onChange={handleChange}
       options={options}

--- a/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderGroupHeaderBlock.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderGroupHeaderBlock.tsx
@@ -27,7 +27,12 @@ export const RenderGroupHeaderBlock = ({
           borderColor: theme.palette.border.main,
         })}
       >
-        <Typography py={1} variant="subtitle2" component="h4">
+        <Typography
+          py={1}
+          variant="subtitle2"
+          component="span"
+          sx={{ padding: 0 }}
+        >
           {displayName}
         </Typography>
       </ListSubheader>

--- a/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx
@@ -21,6 +21,7 @@ export const RenderOptionCheckbox = ({
     <ListItem key={key} {...restListProps}>
       <CustomCheckbox
         aria-hidden="true"
+        aria-selected={state.selected ? "true" : "false"}
         className={state.selected ? "selected" : ""}
         {...checkboxProps}
       />

--- a/editor.planx.uk/src/ui/shared/ErrorWrapper.tsx
+++ b/editor.planx.uk/src/ui/shared/ErrorWrapper.tsx
@@ -12,7 +12,7 @@ export interface Props {
   id?: string;
   // "alert" - important and time-sensitive information (e.g. invalid input feedback)
   // "status" - advisory information which does not interrupt focus (e.g. file upload status)
-  role?: "alert" | "status";
+  role?: "alert" | "status" | undefined;
 }
 
 const Root = styled(Box, {
@@ -42,7 +42,7 @@ export default function ErrorWrapper({
   id,
   error,
   children,
-  role = "alert",
+  role,
 }: Props): FCReturn {
   const inputId = id ? `${ERROR_MESSAGE}-${id}` : undefined;
   const { trackEvent } = useAnalyticsTracking();

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -1,7 +1,4 @@
-import Autocomplete, {
-  autocompleteClasses,
-  AutocompleteProps,
-} from "@mui/material/Autocomplete";
+import Autocomplete, { AutocompleteProps } from "@mui/material/Autocomplete";
 import FormControl from "@mui/material/FormControl";
 import { styled } from "@mui/material/styles";
 import React from "react";
@@ -19,7 +16,7 @@ export type OptionalAutocompleteProps<T> = Partial<
 >;
 
 type WithLabel<T> = {
-  label: string;
+  label: React.ReactNode;
   placeholder?: never;
 } & RequiredAutocompleteProps<T> &
   OptionalAutocompleteProps<T>;
@@ -58,9 +55,6 @@ export function SelectMultiple<T>(props: Props<T>) {
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
       <StyledAutocomplete<T, true, true, false, "div">
         sx={{ mt: props.label ? 2 : 0 }}
-        // role="status"
-        // aria-atomic={true}
-        // aria-live="polite"
         disableClearable
         disableCloseOnSelect
         multiple

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -58,9 +58,9 @@ export function SelectMultiple<T>(props: Props<T>) {
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
       <StyledAutocomplete<T, true, true, false, "div">
         sx={{ mt: props.label ? 2 : 0 }}
-        role="status"
-        aria-atomic={true}
-        aria-live="polite"
+        // role="status"
+        // aria-atomic={true}
+        // aria-live="polite"
         disableClearable
         disableCloseOnSelect
         multiple


### PR DESCRIPTION
**This PR relates to two issues/aspects of the a11y report (pg 40 & pg 53)**

This pull request introduces accessibility improvements, refactors code for better readability, and updates type definitions in several components. The most important changes include adding ARIA attributes to improve screen reader support, refactoring labels to support React nodes, and removing unused imports.

### Accessibility Improvements:
* [`editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx`](diffhunk://#diff-e842ba0fc1b1c4e413988fdd09f2e4d323f1c5b6447d04c28db6ffaf6b98922fR76): Added `aria-multiselectable="true"` to the `ListboxComponent` and included a visually hidden span in the label for additional context about the file being referenced. [[1]](diffhunk://#diff-e842ba0fc1b1c4e413988fdd09f2e4d323f1c5b6447d04c28db6ffaf6b98922fR76) [[2]](diffhunk://#diff-e842ba0fc1b1c4e413988fdd09f2e4d323f1c5b6447d04c28db6ffaf6b98922fL156-R173)
* [`editor.planx.uk/src/ui/shared/Autocomplete/components/RenderOptionCheckbox.tsx`](diffhunk://#diff-0ea4e6273adccd6903e38684dc146f1a4e7c6575bff102c6d85d9a97b3b8cc9aR24): Added `aria-selected` attribute to `CustomCheckbox` for better screen reader support.
* [`editor.planx.uk/src/ui/shared/ErrorWrapper.tsx`](diffhunk://#diff-1f480b4bc2fb61ea3c08c2f140da0be8eccb4a306df145041c61eb60fa8ff9baL15-R15): Updated the `role` property to allow `undefined` and removed the default value to ensure proper handling of roles. [[1]](diffhunk://#diff-1f480b4bc2fb61ea3c08c2f140da0be8eccb4a306df145041c61eb60fa8ff9baL15-R15) [[2]](diffhunk://#diff-1f480b4bc2fb61ea3c08c2f140da0be8eccb4a306df145041c61eb60fa8ff9baL45-R45)

### Code Refactoring:
* [`editor.planx.uk/src/ui/shared/Autocomplete/components/RenderGroupHeaderBlock.tsx`](diffhunk://#diff-b170a30f586f3fadec1897cc13f6c7344888a6360d6539d1b1219c33579d34d8L30-R35): Changed the `Typography` component from `h4` to `span` and adjusted styles for semantic correctness and consistency.

### Type Definition Updates:
* [`editor.planx.uk/src/ui/shared/SelectMultiple.tsx`](diffhunk://#diff-716e932de46c129a2a585e4ff7be60e6fc7dbbd1db809e0c36075bf5269c1803L22-R19): Refactored the `label` type from `string` to `React.ReactNode` to allow more flexible label definitions.

### Removal of Unused Imports:
* [`editor.planx.uk/src/ui/shared/SelectMultiple.tsx`](diffhunk://#diff-716e932de46c129a2a585e4ff7be60e6fc7dbbd1db809e0c36075bf5269c1803L1-R1): Removed unused imports from `@mui/material/Autocomplete`.