### PR TITLE
feat: Internal portals as folder style

### DIFF
--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -92,7 +92,7 @@ test.describe("Flow creation, publish and preview", () => {
     await expect(editor.nodeList).toContainText(["About the property"]);
     await editor.createInternalPortal();
     await editor.populateInternalPortal();
-    await page.getByRole("link", { name: "start" }).click(); // return to main flow
+    await page.getByRole("link", { name: serviceProps.name }).click(); // return to main flow
     // await editor.createUploadAndLabel();
     await editor.createDrawBoundary();
     await editor.createPlanningConstraints();

--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -92,7 +92,7 @@ test.describe("Flow creation, publish and preview", () => {
     await expect(editor.nodeList).toContainText(["About the property"]);
     await editor.createInternalPortal();
     await editor.populateInternalPortal();
-    await page.getByRole("link", { name: serviceProps.name }).click(); // return to main flow
+    await page.getByRole("link", { name: serviceProps.name }).first().click(); // return to main flow
     // await editor.createUploadAndLabel();
     await editor.createDrawBoundary();
     await editor.createPlanningConstraints();

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Breadcrumb.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Breadcrumb.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Link } from "react-navi";
 
-const Breadcrumb: React.FC<any> = (props) => (
-  <li className="card portal breadcrumb">
+const Breadcrumb: React.FC<any> = ({ className = "", ...props }) => (
+  <li className={`card portal breadcrumb ${className}`}>
     <Link href={props.href} prefetch={false}>
       <span>{props.data.text}</span>
     </Link>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -29,6 +29,7 @@ const Node: React.FC<any> = (props) => {
     templatedNodeInstructions: node.data?.templatedNodeInstructions,
     areTemplatedNodeInsructionsRequired:
       node.data?.areTemplatedNodeInstructionsRequired,
+    className: props.className || "",
   };
 
   const type = props.type as TYPES;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -96,7 +96,11 @@ const ExternalPortal: React.FC<any> = (props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
-        <Box className={classNames("card", "portal", { isDragging })}>
+        <Box
+          className={classNames("card", "portal", "external-portal", {
+            isDragging,
+          })}
+        >
           <Box className="card-wrapper">
             <Box sx={{ display: "flex", alignItems: "stretch" }}>
               <Link href={`/${href}`} prefetch={false} ref={drag}>
@@ -161,7 +165,11 @@ const InternalPortal: React.FC<any> = (props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
-        <Box className={classNames("card", "portal", { isDragging })}>
+        <Box
+          className={classNames("card", "portal", "internal-portal", {
+            isDragging,
+          })}
+        >
           <TemplatedNodeContainer
             isTemplatedNode={props.data?.isTemplatedNode}
             areTemplatedNodeInstructionsRequired={
@@ -176,7 +184,6 @@ const InternalPortal: React.FC<any> = (props) => {
                 ref={drag}
                 onContextMenu={handleContext}
               >
-                {Icon && <Icon />}
                 <span>{props.data.text}</span>
               </Link>
               <Link href={editHref} prefetch={false} className="portalMenu">

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -1,5 +1,7 @@
+import Box from "@mui/material/Box";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import React from "react";
+import { Link } from "react-navi";
 import { rootFlowPath } from "routes/utils";
 
 import { useStore } from "../../lib/store";
@@ -34,31 +36,70 @@ const Flow = ({
   const isFlowRoot = !portals.length;
   const showGetStarted = isFlowRoot && !childNodes.length;
 
+  const flowName = useStore((state) => state.flowName);
+
   return (
     <>
-      <ol id="flow" data-layout={flowLayout} className="decisions">
+      <ol
+        id="flow"
+        data-layout={flowLayout}
+        className={`decisions${breadcrumbs.length ? " nested-decisions" : ""}`}
+      >
         <EndPoint text="start" />
+
+        {breadcrumbs.length ? (
+          <li className="root-node-link">
+            <Link href={rootFlowPath(false)} prefetch={false}>
+              {flowName}
+            </Link>
+          </li>
+        ) : null}
+
         {showGetStarted && <GetStarted />}
 
-        {breadcrumbs.map((bc: any) => (
-          <Node
-            key={bc.id}
-            {...bc}
-            lockedFlow={lockedFlow}
-            showTemplatedNodeStatus={showTemplatedNodeStatus}
-          />
-        ))}
+        {breadcrumbs.map((bc: any, index: number) => {
+          let className = "";
 
-        {childNodes.map((node) => (
-          <Node
-            key={node.id}
-            {...node}
-            lockedFlow={lockedFlow}
-            showTemplatedNodeStatus={showTemplatedNodeStatus}
-          />
-        ))}
+          if (index === 0) {
+            className += "breadcrumb--first";
+          }
 
-        <Hanger />
+          if (index === breadcrumbs.length - 1) {
+            className += className
+              ? " breadcrumb--active"
+              : "breadcrumb--active";
+          }
+
+          return (
+            <Node
+              key={bc.id}
+              {...bc}
+              lockedFlow={lockedFlow}
+              showTemplatedNodeStatus={showTemplatedNodeStatus}
+              className={className}
+            />
+          );
+        })}
+
+        <Box className="flow-child-nodes">
+          {childNodes.map((node) => (
+            <Node
+              key={node.id}
+              {...node}
+              lockedFlow={lockedFlow}
+              showTemplatedNodeStatus={showTemplatedNodeStatus}
+            />
+          ))}
+
+          <Hanger />
+        </Box>
+        {breadcrumbs.length ? (
+          <li className="root-node-link root-node-link--end">
+            <Link href={rootFlowPath(false)} prefetch={false}>
+              {flowName}
+            </Link>
+          </li>
+        ) : null}
         <EndPoint text="end" />
       </ol>
     </>

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -42,6 +42,21 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
+@mixin folderStyle($width) {
+  &::before {
+    content: "";
+    position: absolute;
+    top: -5px;
+    left: 0;
+    width: $width;
+    height: 8px;
+    background-color: #666;
+    clip-path: polygon(0 0, 90% 0, 100% 100%, 0% 100%);
+    border-top-left-radius: 2px;
+    z-index: -1;
+  }
+}
+
 // ------------------------------------------------
 
 #editor {
@@ -284,7 +299,7 @@ $fontMonospace: "Source Code Pro", monospace;
     content: "";
     position: absolute;
     top: 50%;
-    height: 2px;
+    height: $lineWidth;
     margin-top: -1px;
     width: calc(100% + ($editorPadding * 2));
     z-index: -1;
@@ -295,11 +310,11 @@ $fontMonospace: "Source Code Pro", monospace;
       transparent 40%,
       transparent 100%
     );
-    background-size: 12px 2px;
+    background-size: 12px $lineWidth;
     border: none;
     [data-layout="left-right"] & {
       top: unset;
-      width: 2px;
+      width: $lineWidth;
       height: 100vh;
       left: 50%;
       background-image: linear-gradient(
@@ -309,7 +324,7 @@ $fontMonospace: "Source Code Pro", monospace;
         transparent 50%,
         transparent 100%
       );
-      background-size: 2px 12px;
+      background-size: $lineWidth 12px;
     }
   }
 }
@@ -335,6 +350,30 @@ $fontMonospace: "Source Code Pro", monospace;
   text-align: center;
   text-decoration: none;
   cursor: pointer;
+}
+
+.root-node-link {
+  background-image: $pixel;
+  background-position: top center;
+  background-size: $lineWidth;
+  background-repeat: repeat-y;
+  padding-top: ($padding * 2) !important;
+  &--end {
+    padding-bottom: ($padding * 2) !important;
+  }
+  > a {
+    display: block;
+    text-decoration: none;
+    cursor: pointer;
+    padding: $padding;
+    color: $black;
+    background: white;
+    border-radius: 3px;
+    border: 1px solid $optionBorder;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+    font-weight: 600;
+    font-size: 14px;
+  }
 }
 
 .option {
@@ -413,6 +452,15 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
+.flow-child-nodes {
+  width: 100%;
+  .nested-decisions & {
+    border: $lineWidth dashed $lockedBorder;
+    margin-top: -$lineWidth;
+    padding: 0 ($padding * 2);
+  }
+}
+
 .portal {
   display: flex;
   flex-direction: column;
@@ -433,24 +481,56 @@ $fontMonospace: "Source Code Pro", monospace;
     background-image: $pixel;
     background-repeat: no-repeat;
     background-color: transparent;
+    min-width: 100%;
+    &--active {
+      min-width: 100%;
+    }
+    &:not(&--first) {
+      border: $lineWidth dashed $lockedBorder;
+      border-width: 0 $lineWidth 0 $lineWidth;
+    }
     [data-layout="top-down"] & {
       background-position: center top;
-      background-size: $lineWidth $padding;
+      background-size: $lineWidth ($padding * 2);
       > a {
-        margin: $padding 0 0;
+        margin: ($padding * 2) 0 0;
+        width: 100%;
         color: #fff;
+        span {
+          max-width: 100%;
+        }
       }
     }
     [data-layout="left-right"] & {
       background-position: left center;
       background-size: $padding $lineWidth;
+
       > a {
         margin: 0 0 0 $padding;
       }
     }
     > a {
-      background: #666;
+      background: $black;
       text-align: center;
+      @include folderStyle(60px);
+      &::before {
+        left: -1px;
+      }
+    }
+  }
+  &.internal-portal {
+    background: $black;
+    @include folderStyle(40px);
+  }
+
+  &.internal-portal.node-card {
+    align-items: flex-start;
+    @include folderStyle(75px);
+    &::before {
+      z-index: 1;
+      top: -10px;
+      height: 6px;
+      left: -4px;
     }
   }
   .portalMenu {

--- a/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
+++ b/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
@@ -16,7 +16,7 @@ const Root = styled(ListItemButton, {
     !["portalId", "backgroundColor"].includes(prop as string),
 })<{ portalId?: string; backgroundColor?: string }>(
   ({ theme, portalId, backgroundColor }) => ({
-    border: `1px solid ${theme.palette.common.black}`,
+    border: `1px solid ${theme.palette.text.primary}`,
     display: "block",
     maxWidth: "100%",
     padding: 0,
@@ -34,25 +34,22 @@ const HeaderRoot = styled(Box)(({ theme }) => ({
   padding: [theme.spacing(1), theme.spacing(0.5)],
   display: "flex",
   alignItems: "center",
-  backgroundColor: theme.palette.common.black,
+  backgroundColor: theme.palette.text.primary,
   color: theme.palette.common.white,
   width: "100%",
-  borderColor: theme.palette.common.black,
+  borderColor: theme.palette.text.primary,
   borderWidth: 4,
 }));
 
 const InternalPortalHeader: React.FC<{ portalId: string }> = ({ portalId }) => {
   const portalName = useStore((state) => state.flow)[portalId].data?.text;
-  const Icon = ICONS[ComponentType.InternalPortal];
 
   return (
-    <HeaderRoot>
-      {Icon && <Icon />}
+    <HeaderRoot className="node-card portal internal-portal">
       <Typography
         variant="body2"
         fontSize={14}
         fontWeight={FONT_WEIGHT_SEMI_BOLD}
-        ml={1}
       >
         {portalName}
       </Typography>


### PR DESCRIPTION
## What does this PR do?

- Updates internal portals to have a "folder" style as root components
- When inside an internal portal:
  - root flow name is displayed as a link, which appears before and after the portal contents
  - any parent internal portals are added to the hierarchy as folder breadcrumbs
  - folder styling is extended to "encompass" internal portal contents
- Also updates search for internal portals to have folder style

**Testing:**
https://4896.planx.pizza/a-new-team/testing-nesting

**Real-world deep example:**
https://4896.planx.pizza/opensystemslab/permitteddevelopment,GkLVVIasqD,4sdQOdsv6G,zmgKVgZFA0,7nb1Ns0Xyn,XUrPURgXtu,QGbTxfHGcx,lHPhZSPP8f

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/5ad291a0-b38f-4541-b095-d1d795c7c274" />

<img width="499" alt="image" src="https://github.com/user-attachments/assets/dddc0d60-8e42-47a8-a1c4-54a363a05acc" />

One small styling bug (which I think we can live with, when building a source template the folder marker appears on the top of the wrapper:
<img width="253" alt="image" src="https://github.com/user-attachments/assets/1e91f11d-fb1e-4719-bebf-ee4c260ecf59" />

