### PR TITLE
fix(a11y): specify `(opens in a new tab)` in map attributions

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -301,7 +301,7 @@ export default function Component(props: Props) {
                     import.meta.env.VITE_APP_API_URL
                   }/proxy/ordnance-survey`}
                   osCopyright={`Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
-                  drawGeojsonDataCopyright={`<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank" style="color:#0010A4;">Title boundary</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`}
+                  drawGeojsonDataCopyright={`<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank" style="color:#0010A4;">Title boundary (opens in a new tab)</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`}
                   collapseAttributions={
                     self.innerWidth < 500 ? true : undefined
                   }

--- a/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -161,7 +161,7 @@ export function Presentational(props: PresentationalProps) {
           geojsonColor="#0010A4"
           geojsonBuffer={30}
           osCopyright={`Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`}
-          geojsonDataCopyright={`<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank" style="color:#0010A4;">Title boundary</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`}
+          geojsonDataCopyright={`<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank" style="color:#0010A4;">Title boundary (opens in a new tab)</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`}
           collapseAttributions={window.innerWidth < 500 ? true : undefined}
         />
       </MapContainer>


### PR DESCRIPTION
https://trello.com/c/Q7NC4QF8/3340-change-on-request-3-map-attribution-aaa-p67

> Issue: 
> Links open a new tab or window when activated without making users aware that this is the 
> case prior to activation. Users may not be aware that they have been navigated to a new tab 
> and may not be aware of why they cannot navigate back to the previous page using the 
> ‘back’ button.
> 
> Solution: 
> Where possible, it is advisable to avoid opening resources in a new tab. Otherwise, inform a 
> user that the resource will open in a new tab by adding ‘(opens in a new tab)’ to the visible 
> label.

**Now**
![Screenshot from 2025-07-08 10-09-30](https://github.com/user-attachments/assets/9e1f4fff-64c1-4960-96d0-b164ff74f98f)