### PR TITLE
feat(lps): Universal input styles

### DIFF
--- a/localplanning.services/src/components/applications/LoginForm.tsx
+++ b/localplanning.services/src/components/applications/LoginForm.tsx
@@ -21,7 +21,6 @@ const LoginForm: React.FC = () => {
           Enter your email address to log in
         </label>
         <input
-          className="input--text"
           id="email"
           type="email"
           name="email"

--- a/localplanning.services/src/components/applications/LoginForm.tsx
+++ b/localplanning.services/src/components/applications/LoginForm.tsx
@@ -21,7 +21,7 @@ const LoginForm: React.FC = () => {
           Enter your email address to log in
         </label>
         <input
-          className="pt-2 shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          className="input--text"
           id="email"
           type="email"
           name="email"

--- a/localplanning.services/src/pages/directory.astro
+++ b/localplanning.services/src/pages/directory.astro
@@ -14,7 +14,6 @@ import Accordion from "@components/Accordion.astro";
       <input
         type="search"
         id="search"
-        class="input--text"
         placeholder="Type to search"
       />
     </section>

--- a/localplanning.services/src/pages/directory.astro
+++ b/localplanning.services/src/pages/directory.astro
@@ -14,7 +14,7 @@ import Accordion from "@components/Accordion.astro";
       <input
         type="search"
         id="search"
-        class="w-full max-w-md p-3 text-body-md border border-black border-2"
+        class="input--text"
         placeholder="Type to search"
       />
     </section>

--- a/localplanning.services/src/styles/global.css
+++ b/localplanning.services/src/styles/global.css
@@ -34,8 +34,21 @@
   --default-font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
 
   /*
-  / Layout styles
+  / Form styles
   */
+
+  --input-width: 100%;
+  --input-max-width: 28rem;
+  --input-height: 48px;
+  --input-padding-y: clamp(0.5rem, 2vw, 0.75rem);
+  --input-padding-x: clamp(0.5rem, 2vw, 0.75rem);
+  --input-font-size: clamp(1rem, 2vw, 1.125rem);
+  --input-border-width: 2px;
+  --input-border-color: var(--color-black);
+
+  --input-focus-outline: rgb(255, 221, 0) solid 3px;
+  --input-focus-outline-offset: 0px;
+  --input-focus-box-shadow: 0px 0px 0px 2px inset;
 
 }
 
@@ -123,4 +136,34 @@
   .button--small {
     @apply clamp-[text,xs,sm] py-2 clamp-[px,2,3];
   }
+
+  /*
+  /  Form styles
+  */
+
+  .input--text {
+    width: var(--input-width);
+    max-width: var(--input-max-width);
+    height: var(--input-height);
+    padding: var(--input-padding-y) var(--input-padding-x);
+    font-size: var(--input-font-size);
+    border: var(--input-border-width) solid var(--input-border-color);
+  }
+
+  .input--text:focus {
+    outline: var(--input-focus-outline);
+    outline-offset: var(--input-focus-outline-offset);
+    box-shadow: var(--input-focus-box-shadow);
+  }
 }
+
+:root {
+  --postcode__input__height: var(--input-height);
+  --postcode__input__padding: var(--input-padding-y) var(--input-padding-x);
+  --postcode__font-family: var(--default-font-family);
+  --postcode__input__font-size: var(--input-font-size);
+  --postcode__input__border: var(--input-border-width) solid var(--input-border-color);
+  --postcode__input__width: var(--input-width);
+  --postcode__input__max-width: var(--input-max-width);
+}
+

--- a/localplanning.services/src/styles/global.css
+++ b/localplanning.services/src/styles/global.css
@@ -141,7 +141,9 @@
   /  Form styles
   */
 
-  .input--text {
+  input[type="text"],
+  input[type="email"],
+  input[type="search"] {
     width: var(--input-width);
     max-width: var(--input-max-width);
     height: var(--input-height);
@@ -150,7 +152,9 @@
     border: var(--input-border-width) solid var(--input-border-color);
   }
 
-  .input--text:focus {
+  input[type="text"]:focus,
+  input[type="email"]:focus,
+  input[type="search"]:focus {
     outline: var(--input-focus-outline);
     outline-offset: var(--input-focus-outline-offset);
     box-shadow: var(--input-focus-box-shadow);


### PR DESCRIPTION
## What does this PR do?

- Introduces custom properties (CSS variables) to control input styling across Astro, React and GOV.UK web components
- Uses the GOV.UK postcode lookup web component style as a base, adding custom properties where needed
- Works across Astro and React components with the class `input--text`

Using custom properties allows us to reach web components through the shadow DOM, the compromise is that we can't use Tailwind classes for custom properties, however it does mean we can have a universally defined set of styles for inputs.

Still to do in follow up work: standardise label styles

**Web component:**

<img width="516" alt="image" src="https://github.com/user-attachments/assets/b45733a1-b59a-4ff4-9719-384159fa2a66" />

<img width="516" alt="image" src="https://github.com/user-attachments/assets/a834257a-5864-4132-801f-d8995718215a" />

**Astro component:**

<img width="516" alt="image" src="https://github.com/user-attachments/assets/64bc8470-1cbb-4f42-8d3f-ebab4d0f87d4" />

<img width="516" alt="image" src="https://github.com/user-attachments/assets/13388110-5afc-4fc8-ad16-e086f24e901a" />

React component:

<img width="516" alt="image" src="https://github.com/user-attachments/assets/aa747da1-1c45-4b79-adb4-cf572125f57e" />

<img width="516" alt="image" src="https://github.com/user-attachments/assets/91acb9f8-09a2-449d-9f6c-41704ef5dc43" />




