### PR TITLE
feat: Editor validation schemas (cont.)

### DIFF
--- a/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -11,7 +11,7 @@ import InputRow from "ui/shared/InputRow";
 
 import { ICONS } from "../shared/icons";
 import { EditorProps } from "../shared/types";
-import { parseContent, Review } from "./model";
+import { parseContent, Review, validationSchema } from "./model";
 
 type Props = EditorProps<TYPES.Review, Review>;
 
@@ -24,6 +24,9 @@ function Component(props: Props) {
         data: newValues,
       });
     },
+    validationSchema,
+    validateOnChange: false,
+    validateOnBlur: false,
   });
 
   return (
@@ -45,6 +48,7 @@ function Component(props: Props) {
               value={formik.values.title}
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.title}
             />
           </InputRow>
           <InputRow>
@@ -54,6 +58,7 @@ function Component(props: Props) {
               value={formik.values.description}
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.description}
             />
           </InputRow>
         </ModalSectionContent>
@@ -65,6 +70,7 @@ function Component(props: Props) {
               value={formik.values.disclaimer}
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.disclaimer}
             />
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -8,12 +8,11 @@ import { sortBreadcrumbs } from "pages/FlowEditor/lib/store/preview";
 import type { HandleSubmit } from "pages/Preview/Node";
 import React from "react";
 
+import { Review } from "../model";
+
 export default Component;
 
-interface Props {
-  title: string;
-  description: string;
-  disclaimer: string;
+interface Props extends Review {
   breadcrumbs: Store.Breadcrumbs;
   flow: Store.Flow;
   passport: Store.Passport;

--- a/editor.planx.uk/src/@planx/components/Review/model.ts
+++ b/editor.planx.uk/src/@planx/components/Review/model.ts
@@ -1,9 +1,12 @@
-import { BaseNodeData } from "../shared";
+import { richText } from "lib/yupExtensions";
+import { object, SchemaOf, string } from "yup";
+
+import { BaseNodeData, baseNodeDataValidationSchema } from "../shared";
 
 export interface Review extends BaseNodeData {
   title: string;
-  description: string;
-  disclaimer: string;
+  description?: string;
+  disclaimer?: string;
 }
 
 export const parseContent = (
@@ -17,3 +20,11 @@ export const parseContent = (
 
 export const DEFAULT_REVIEW_DISCLAIMER =
   "<p>Changing this answer means you will need to confirm any other answers after it. This is because: </p><ul><li>a different answer might mean the service asks new questions</li><li>your planning officer needs the right information to assess your application</li></ul>";
+
+export const validationSchema: SchemaOf<Review> = baseNodeDataValidationSchema.concat(
+  object({
+    title: string().required(),
+    description: richText(),
+    disclaimer: richText(),
+  })
+);

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -11,7 +11,7 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 
 import { ICONS } from "../shared/icons";
-import { parseSection, Section } from "./model";
+import { parseSection, Section, validationSchema } from "./model";
 
 type Props = EditorProps<TYPES.Section, Section>;
 
@@ -26,6 +26,9 @@ function SectionComponent(props: Props) {
         data: newValues,
       });
     },
+    validationSchema,
+    validateOnBlur: false,
+    validateOnChange: false,
   });
 
   return (

--- a/editor.planx.uk/src/@planx/components/Section/model.ts
+++ b/editor.planx.uk/src/@planx/components/Section/model.ts
@@ -1,7 +1,9 @@
+import { richText } from "lib/yupExtensions";
 import type { Store } from "pages/FlowEditor/lib/store";
 import { SectionNode, SectionStatus } from "types";
+import { object,SchemaOf, string } from "yup";
 
-import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { BaseNodeData, baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface Section extends BaseNodeData {
   title: string;
@@ -83,3 +85,8 @@ export function computeSectionStatuses({
 
   return sectionStatuses;
 }
+
+export const validationSchema: SchemaOf<Section> = baseNodeDataValidationSchema.concat(object({
+  title: string().required(),
+  description: richText(),
+}))

--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -17,18 +17,17 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
-import { array, object } from "yup";
 
 import { ICONS } from "../shared/icons";
 import { WarningContainer } from "../shared/Preview/WarningContainer";
 import { EditorProps } from "../shared/types";
-import { parseContent, Send } from "./model";
+import { parseSend, Send, validationSchema } from "./model";
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
 const SendComponent: React.FC<Props> = (props) => {
   const formik = useFormik<Send>({
-    initialValues: parseContent(props.node?.data),
+    initialValues: parseSend(props.node?.data),
     onSubmit: (newValues) => {
       if (props.handleSubmit) {
         props.handleSubmit({ type: TYPES.Send, data: newValues });
@@ -36,17 +35,7 @@ const SendComponent: React.FC<Props> = (props) => {
     },
     validateOnBlur: false,
     validateOnChange: true,
-    validationSchema: object({
-      destinations: array()
-        .required()
-        .test({
-          name: "atLeastOneChecked",
-          message: "Select at least one destination",
-          test: (destinations?: Array<SendIntegration>) => {
-            return Boolean(destinations && destinations.length > 0);
-          },
-        }),
-    }),
+    validationSchema,
   });
 
   const [teamSlug, flowSlug, submissionEmail] = useStore((state) => [

--- a/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -76,6 +76,7 @@ const SendComponent: React.FC<Props> = (props) => {
               placeholder="Editor title"
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.title}
             />
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -1,6 +1,5 @@
-import { SEND_INTEGRATIONS, SendIntegration } from "@opensystemslab/planx-core/types";
-import { string } from "mathjs";
-import { array, mixed, object, SchemaOf } from "yup";
+import { SendIntegration } from "@opensystemslab/planx-core/types";
+import { array, mixed, object, SchemaOf, string } from "yup";
 
 import type { Store } from "../../../pages/FlowEditor/lib/store";
 import { BaseNodeData, baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
@@ -15,7 +14,7 @@ interface EventPayload {
 }
 
 export interface Send extends BaseNodeData {
-  title?: string;
+  title: string;
   destinations: SendIntegration[];
 }
 
@@ -80,7 +79,7 @@ export function getCombinedEventsPayload({
 
 export const validationSchema: SchemaOf<Send> = baseNodeDataValidationSchema.concat(
   object({
-    title: string(),
+    title: string().required(),
     destinations: array(
       mixed().oneOf(["email", "bops", "uniform", "s3", "idox"])
     ).min(1, "Select at least one destination"),

--- a/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -1,7 +1,9 @@
-import { SendIntegration } from "@opensystemslab/planx-core/types";
+import { SEND_INTEGRATIONS, SendIntegration } from "@opensystemslab/planx-core/types";
+import { string } from "mathjs";
+import { array, mixed, object, SchemaOf } from "yup";
 
 import type { Store } from "../../../pages/FlowEditor/lib/store";
-import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { BaseNodeData, baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 type CombinedEventsPayload = Partial<Record<SendIntegration, EventPayload>>;
 
@@ -13,14 +15,14 @@ interface EventPayload {
 }
 
 export interface Send extends BaseNodeData {
-  title: string;
+  title?: string;
   destinations: SendIntegration[];
 }
 
 export const DEFAULT_TITLE = "Send";
 export const DEFAULT_DESTINATION = "email";
 
-export const parseContent = (data: Record<string, any> | undefined): Send => ({
+export const parseSend = (data: Record<string, any> | undefined): Send => ({
   ...parseBaseNodeData(data),
   title: data?.title || DEFAULT_TITLE,
   destinations: data?.destinations || [DEFAULT_DESTINATION],
@@ -75,3 +77,12 @@ export function getCombinedEventsPayload({
 
   return payload;
 }
+
+export const validationSchema: SchemaOf<Send> = baseNodeDataValidationSchema.concat(
+  object({
+    title: string(),
+    destinations: array(
+      mixed().oneOf(["email", "bops", "uniform", "s3", "idox"])
+    ).min(1, "Select at least one destination"),
+  })
+);

--- a/editor.planx.uk/src/@planx/components/SetFee/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetFee/Editor.tsx
@@ -2,7 +2,7 @@ import Code from "@mui/icons-material/Code";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
-import { FormikErrors, useFormik } from "formik";
+import { useFormik } from "formik";
 import { FormattedResponse } from "pages/FlowEditor/components/Submissions/components/FormattedResponse";
 import { Store } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -22,6 +22,7 @@ import {
   DEFAULT_SERVICE_CHARGE_THRESHOLD,
   parseSetFee,
   SetFee,
+  validationSchema,
   VAT_PERCENTAGE,
 } from "./model";
 import { handleSetFees } from "./utils";
@@ -46,13 +47,7 @@ function SetFeeComponent(props: Props) {
         data: newValues,
       });
     },
-    validate: (values) => {
-      const errors: FormikErrors<SetFee> = {};
-      if (values.fastTrackFeeAmount < 0) {
-        errors.fastTrackFeeAmount = "Fast Track fee amount must be positive";
-      }
-      return errors;
-    },
+    validationSchema,
     validateOnBlur: false,
     validateOnChange: true,
   });

--- a/editor.planx.uk/src/@planx/components/SetFee/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetFee/model.ts
@@ -1,5 +1,7 @@
+import { boolean, number, object, SchemaOf, string } from "yup";
+
 import { PAY_FN } from "../Pay/model";
-import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { BaseNodeData, baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface SetFee extends BaseNodeData {
   applyCalculatedVAT: boolean;
@@ -26,3 +28,17 @@ export const DEFAULT_SERVICE_CHARGE_AMOUNT = 40; // £40
 export const DEFAULT_SERVICE_CHARGE_THRESHOLD = 100; // £100
 export const DEFAULT_PAYMENT_PROCESSING_PERCENTAGE = 0.01; // 1%
 export const VAT_PERCENTAGE = 0.2; // 20%
+
+export const validationSchema: SchemaOf<SetFee> = baseNodeDataValidationSchema.concat(
+  object({
+    applyCalculatedVAT: boolean().required(),
+    fastTrackFeeAmount: number()
+      .positive()
+      .required("Fast Track fee amount must be positive"),
+    applyServiceCharge: boolean().required(),
+    serviceChargeAmount: number().required(),
+    applyPaymentProcessingFee: boolean().required(),
+    paymentProcessingFeePercentage: number().required(),
+    fn: string().nullable().required(),
+  })
+);

--- a/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/SetValue/Editor.tsx
@@ -14,7 +14,7 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 
 import { DataFieldAutocomplete } from "../shared/DataFieldAutocomplete";
-import { parseSetValue, SetValue } from "./model";
+import { parseSetValue, SetValue, validationSchema } from "./model";
 
 type Props = EditorProps<TYPES.SetValue, SetValue>;
 
@@ -87,6 +87,9 @@ function SetValueComponent(props: Props) {
         data: newValues,
       });
     },
+    validationSchema,
+    validateOnBlur: false,
+    validateOnChange: false,
   });
 
   const handleRadioChange = (event: React.SyntheticEvent<Element, Event>) => {

--- a/editor.planx.uk/src/@planx/components/SetValue/model.ts
+++ b/editor.planx.uk/src/@planx/components/SetValue/model.ts
@@ -1,4 +1,6 @@
-import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { object, string } from "yup";
+
+import { BaseNodeData, baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface BaseSetValue extends BaseNodeData {
   fn: string;
@@ -24,3 +26,7 @@ export const parseSetValue = (
   operation: data?.operation || "replace",
   ...parseBaseNodeData(data),
 });
+
+export const validationSchema = baseNodeDataValidationSchema.concat(object({
+  fn: string().nullable().required(),
+}));

--- a/editor.planx.uk/src/@planx/components/TaskList/model.ts
+++ b/editor.planx.uk/src/@planx/components/TaskList/model.ts
@@ -1,5 +1,8 @@
+import { richText } from "lib/yupExtensions";
+import { array, object, string } from "yup";
+
 import type { BaseNodeData } from "../shared";
-import { parseBaseNodeData } from "../shared";
+import { baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface TaskList extends BaseNodeData {
   title: string;
@@ -19,10 +22,27 @@ export interface Task {
 }
 
 export const parseTaskList = (
-  data: Record<string, any> | undefined,
+  data: Record<string, any> | undefined
 ): TaskList => ({
   tasks: data?.taskList?.tasks || data?.tasks || [],
   title: data?.title || "",
   description: data?.description || "",
   ...parseBaseNodeData(data),
 });
+
+const taskSchema = object({
+  title: string().required("Title is a required filed"),
+  description: richText(),
+});
+
+export const validationSchema =
+  baseNodeDataValidationSchema.concat(
+    object({
+      title: string().required(),
+      description: richText(),
+      tasks: array(taskSchema).required().min(1),
+      taskList: object({
+        tasks: array(taskSchema).min(1),
+      }).optional(),
+    })
+  );

--- a/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -32,7 +32,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
       }
     },
     validateOnChange: false,
-    validationSchema: editorValidationSchema(),
+    validationSchema: editorValidationSchema,
   });
 
   const handleRadioChange = (event: React.SyntheticEvent<Element, Event>) => {
@@ -59,6 +59,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
               placeholder="Title"
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.title}
             />
           </InputRow>
           <InputRow>
@@ -68,6 +69,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
               value={formik.values.description}
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.description}
             />
           </InputRow>
           <DataFieldAutocomplete

--- a/editor.planx.uk/src/@planx/components/TextInput/model.ts
+++ b/editor.planx.uk/src/@planx/components/TextInput/model.ts
@@ -1,6 +1,7 @@
-import { object, string } from "yup";
+import { richText } from "lib/yupExtensions";
+import { mixed, object, string } from "yup";
 
-import { BaseNodeData, parseBaseNodeData } from "../shared";
+import { BaseNodeData, baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export type UserData = string;
 
@@ -36,8 +37,19 @@ export const emailRegex =
   // eslint-disable-next-line
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-export const editorValidationSchema = () =>
+export const editorValidationSchema = baseNodeDataValidationSchema.concat(
   object({
+    title: string().required(),
+    description: richText(),
+    fn: string().nullable(),
+    type: mixed().oneOf([
+      "short",
+      "long",
+      "extraLong",
+      "email",
+      "phone",
+      "custom"
+    ]),
     customLength: string().when("type", {
       is: "custom",
       then: string()
@@ -52,7 +64,7 @@ export const editorValidationSchema = () =>
           },
         }),
     }),
-  });
+  }));
 
 export const textInputValidationSchema = ({
   data: { type, customLength },

--- a/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -1,5 +1,5 @@
 import { BaseNodeData } from "@planx/components/shared";
-import { useFormik } from "formik";
+import { FormikProps, useFormik } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { InternalNotes } from "ui/editor/InternalNotes";
@@ -9,7 +9,7 @@ import { ComponentTagSelect } from "./ComponentTagSelect";
 import { TemplatedNodeConfiguration } from "./TemplatedNodeConfiguration";
 
 interface Props<T extends BaseNodeData> {
-  formik: ReturnType<typeof useFormik<T>>;
+  formik: ReturnType<typeof useFormik<T>> | FormikProps<T>;
   showMoreInformation?: boolean;
   showInternalNotes?: boolean;
   showTags?: boolean;


### PR DESCRIPTION
This PR adds formik-level validation of the following batch of components - 

 - `Review`
 - `Section`
 - `Send`
 - `SetFee`
 - `SetValue`
 - `TaskList`
 - `TextInput`

The only outstanding ones now either have other open PRs, or are more complex and involve the `ListManager` (FileUpload, FileUploadAndLabel).
