### PR TITLE
feat: Rich text validation for settings pages

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowElements/FooterLinksAndLegalDisclaimer.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowElements/FooterLinksAndLegalDisclaimer.tsx
@@ -1,17 +1,63 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-import { useFormik } from "formik";
+import { getIn, useFormik } from "formik";
 import { useToast } from "hooks/useToast";
+import { richText } from "lib/yupExtensions";
 import React from "react";
 import InputGroup from "ui/editor/InputGroup";
 import InputLegend from "ui/editor/InputLegend";
 import SettingsSection from "ui/editor/SettingsSection";
 import InputRow from "ui/shared/InputRow";
+import { boolean, object, string } from "yup";
 
 import type { FlowSettings } from "../../../../../../types";
 import { useStore } from "../../../../lib/store";
 import { TextInput } from "./components/TextInput";
+
+const validationSchema = object({
+  elements: object({
+    legalDisclaimer: object({
+      heading: string().when("show", {
+        is: true,
+        then: string().required("Heading is required"),
+        otherwise: string().optional()
+      }),
+      content: string().when("show", {
+        is: true,
+        then: string().required("Content is required"),
+        otherwise: string().optional()
+      }),
+      show: boolean(),
+    }).optional(),
+    help: object({
+      heading: string().when("show", {
+        is: true,
+        then: string().required("Heading is required"),
+        otherwise: string().optional()
+      }),
+      content: richText().when("show", {
+        is: true,
+        then: richText().required("Content is required"),
+        otherwise: richText().optional()
+      }),
+      show: boolean(),
+    }).optional(),
+    privacy: object({
+      heading: string().when("show", {
+        is: true,
+        then: string().required("Heading is required"),
+        otherwise: string().optional()
+      }),
+      content: richText().when("show", {
+        is: true,
+        then: richText().required("Content is required"),
+        otherwise: richText().optional()
+      }),
+      show: boolean(),
+    }).optional(),
+  }).optional()
+})
 
 export const FooterLinksAndLegalDisclaimer = () => {
   const [flowStatus, flowSettings, updateFlowSettings, setFlowSettings] =
@@ -50,7 +96,9 @@ export const FooterLinksAndLegalDisclaimer = () => {
       toast.success("Service settings updated successfully");
       resetForm({ values });
     },
-    validate: () => {},
+    validationSchema,
+    validateOnBlur: false,
+    validateOnChange: false,
   });
   return (
     <Box component="form" onSubmit={elementsForm.handleSubmit} mb={2}>
@@ -75,11 +123,13 @@ export const FooterLinksAndLegalDisclaimer = () => {
             name: "elements.legalDisclaimer.heading",
             value: elementsForm.values.elements?.legalDisclaimer?.heading,
             onChange: elementsForm.handleChange,
+            errorMessage: getIn(elementsForm.errors, "elements.legalDisclaimer.heading")
           }}
           contentInputProps={{
             name: "elements.legalDisclaimer.content",
             value: elementsForm.values.elements?.legalDisclaimer?.content,
             onChange: elementsForm.handleChange,
+            errorMessage: getIn(elementsForm.errors, "elements.legalDisclaimer.content")
           }}
         />
       </SettingsSection>
@@ -100,11 +150,13 @@ export const FooterLinksAndLegalDisclaimer = () => {
                 name: "elements.help.heading",
                 value: elementsForm.values.elements?.help?.heading,
                 onChange: elementsForm.handleChange,
+                errorMessage: getIn(elementsForm.errors, "elements.help.heading")
               }}
               contentInputProps={{
                 name: "elements.help.content",
                 value: elementsForm.values.elements?.help?.content,
                 onChange: elementsForm.handleChange,
+                errorMessage: getIn(elementsForm.errors, "elements.help.content")
               }}
             />
           </InputRow>
@@ -133,11 +185,13 @@ export const FooterLinksAndLegalDisclaimer = () => {
                 name: "elements.privacy.heading",
                 value: elementsForm.values.elements?.privacy?.heading,
                 onChange: elementsForm.handleChange,
+                errorMessage: getIn(elementsForm.errors, "elements.privacy.heading")
               }}
               contentInputProps={{
                 name: "elements.privacy.content",
                 value: elementsForm.values.elements?.privacy?.content,
                 onChange: elementsForm.handleChange,
+                errorMessage: getIn(elementsForm.errors, "elements.privacy.content")
               }}
             />
           </InputRow>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowElements/components/TextInput.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/FlowElements/components/TextInput.tsx
@@ -14,8 +14,8 @@ export const TextInput: React.FC<{
   richText?: boolean;
   description?: string;
   switchProps?: SwitchProps;
-  headingInputProps?: InputProps;
-  contentInputProps?: InputProps;
+  headingInputProps: InputProps;
+  contentInputProps: InputProps;
 }> = ({
   title,
   richText = false,
@@ -52,6 +52,7 @@ export const TextInput: React.FC<{
               placeholder="Text"
               multiline
               rows={6}
+              errorMessage={contentInputProps.errorMessage || ""}
               {...contentInputProps}
             />
           ) : (

--- a/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
+++ b/editor.planx.uk/src/ui/editor/ListManager/ListManager.tsx
@@ -9,6 +9,7 @@ import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { arrayMoveImmutable } from "array-move";
+import { FormikErrors } from "formik";
 import { nanoid } from "nanoid";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useRef, useState } from "react";
@@ -26,6 +27,7 @@ import { insertAt, removeAt, setAt } from "../../../utils";
 
 export interface EditorProps<T> {
   index: number;
+  errors: string | string[] | FormikErrors<T> | undefined
   value: T;
   onChange: (newValue: T) => void;
   disabled?: boolean;
@@ -33,6 +35,7 @@ export interface EditorProps<T> {
 
 export interface Props<T, EditorExtraProps = {}> {
   values: Array<T>;
+  errors?: string | string[] | FormikErrors<T>[] | undefined
   onChange: (newValues: Array<T>) => void;
   newValue: () => T;
   newValueLabel?: string;
@@ -134,6 +137,7 @@ export default function ListManager<T, EditorExtraProps>(
                     }}
                     {...(props.editorExtraProps || {})}
                     disabled={disabled}
+                    errors={props.errors?.[index]}
                   />
                 </Item>
               </Collapse>
@@ -161,6 +165,7 @@ export default function ListManager<T, EditorExtraProps>(
                     }}
                     {...(props.editorExtraProps || {})}
                     disabled={disabled}
+                    errors={props.errors?.[index]}
                   />
                   <Box sx={{ display: "flex", alignItems: "flex-start" }}>
                     <IconButton
@@ -281,6 +286,7 @@ export default function ListManager<T, EditorExtraProps>(
                             }}
                             {...(props.editorExtraProps || {})}
                             disabled={disabled}
+                            errors={props.errors?.[index]}
                           />
                           <Box>
                             <IconButton


### PR DESCRIPTION
## What does this PR do?
Applies rich text validation to the global settings and flow settings pages

## Why?
- Continuation of #4831 
- We should make the `errorMessage` property on the `RichTextInput` field required - this will ensure we always have to apply a validation schema in order to catch a11y content checks. To do this, we need to target all instances of this component and there are a few here outside the usual scope the Editor modal


![image](https://github.com/user-attachments/assets/a573f5a8-b26a-4c2a-9560-f0deeb3a249e)


![image](https://github.com/user-attachments/assets/bc8ad2fc-4ed9-4ad0-979f-07888067192a)
