### PR TITLE
fix(a11y): Apply correct aria labels to grouped checkboxes

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklist.tsx
@@ -103,7 +103,7 @@ export const GroupedChecklist: React.FC<PublicChecklistProps> = (props) => {
             spacing={layout === ChecklistLayout.Images ? 2 : 0}
             component="fieldset"
           >
-            <legend style={visuallyHidden}>{text}</legend>
+            <legend style={visuallyHidden} id="whole-group-heading">{text}</legend>
             {nonExclusiveOptionGroups && (
               <GroupedChecklistOptions
                 groupedOptions={nonExclusiveOptionGroups}

--- a/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklistOptions.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Public/components/GroupedChecklistOptions.tsx
@@ -47,9 +47,10 @@ export const GroupedChecklistOptions = ({
                 <Box
                   pt={0.5}
                   pb={2}
-                  aria-labelledby={`group-${index}-heading`}
+                  aria-labelledby={`whole-group-heading group-${index}-heading`}
                   id={`group-${index}-content`}
                   data-testid={`group-${index}${isExpanded ? "-expanded" : ""}`}
+                  role="group"
                 >
                   {group.children.map((option) => (
                     <ChecklistItem


### PR DESCRIPTION
## What does this PR do?
This PR addresses the following issue in the report (page 29) - 

> _All the checkboxes are grouped under one group: ‘List the changes involved in the project’.
The radio buttons are split into collapsable sub-groups. An aria-labelledby attribute has
been applied to a parent div element without a role so these subgroups are not
programmatically determined._

This now matches the example markdown provided - 

<img width="637" alt="image" src="https://github.com/user-attachments/assets/4bc63eba-0c7f-428a-a455-efff9e01c511" />

## Next steps...
 - Link checkboxes programmatically via data values
 - Formik validation - ensure that if repeated data values are used across subgroups, the label text is consistent