### PR TITLE
chore: Require `errorMessage` prop for `RichTextInput`

### DIFF
--- a/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -15,11 +15,9 @@ import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
 
 import { defaultContent } from "../components/defaultContent";
-import { Feedback, parseFeedback } from "../model";
+import { Feedback, parseFeedback, validationSchema } from "../model";
 
 type FeedbackEditorProps = EditorProps<TYPES.Feedback, Feedback>;
-
-const HTML_TAG_REGEX = /<[^>]*>/g;
 
 export const FeedbackEditor = (props: FeedbackEditorProps) => {
   const formik = useFormik<Feedback>({
@@ -32,6 +30,9 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
         });
       }
     },
+    validationSchema,
+    validateOnBlur: false,
+    validateOnChange: false,
   });
 
   return (
@@ -97,6 +98,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
                   value={formik.values.disclaimer}
                   onChange={formik.handleChange}
                   disabled
+                  errorMessage={formik.errors.disclaimer}
                 />
               </InputLabel>
             </InputRow>

--- a/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -61,6 +61,7 @@ function SectionComponent(props: Props) {
               onChange={formik.handleChange}
               disabled={props.disabled}
               variant="paragraphContent"
+              errorMessage={formik.errors.description}
             />
           </InputRow>
         </ModalSectionContent>

--- a/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.stories.tsx
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.stories.tsx
@@ -47,6 +47,7 @@ export const Basic = () => {
               onChange={(ev) => {
                 setValue(ev.target.value);
               }}
+              errorMessage={undefined}
             />
           </Box>
           <Box>

--- a/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
+++ b/editor.planx.uk/src/ui/editor/RichTextInput/types.ts
@@ -51,7 +51,7 @@ export interface Props extends InputBaseProps {
   className?: string;
   onChange?: (ev: ChangeEvent<HTMLInputElement>) => void;
   bordered?: boolean;
-  errorMessage?: string;
+  errorMessage: string | undefined;
   disabled?: boolean;
   variant?: Variant;
   classname?: string;


### PR DESCRIPTION
At last, the final step in https://trello.com/c/REGig63B/3309-non-text-content-a-p16

This should now mean that each time we reach for a `RichTextInput` we have to have a viable validation schema to cover a11y issues.

Also in this PR are a few fixes caught by making the type stricter! 🚀 