### PR TITLE
feat(lps): Size variant for masthead

### DIFF
--- a/localplanning.services/src/components/Masthead.astro
+++ b/localplanning.services/src/components/Masthead.astro
@@ -3,17 +3,17 @@ import Container from "@components/Container.astro";
 
 interface Props {
   title: string;
-  variant?: "default" | "large";
+  size?: "default" | "large";
 }
 
 const {
   title,
-  variant = "default",
-} = Astro.props as Props;
+  size = "default",
+} = Astro.props;
 
 const baseClasses = " bg-bg-main";
 
-const variantClasses = {
+const sizeClasses = {
   default: "clamp-[py,10,20] clamp-[pb,5,10]",
   large: "clamp-[py,10,20]",
 };
@@ -23,12 +23,12 @@ const h1Classes = {
   large: "text-heading-xl",
 };
 
-const classes = `${baseClasses} ${variantClasses[variant]}`;
+const classes = `${baseClasses} ${sizeClasses[size]}`;
 ---
 
 <section class={classes}>
   <Container class="text-center">
-    <h1 class={`${h1Classes[variant]} text-action-secondary`}>{title}</h1>
+    <h1 class={`${h1Classes[size]} text-action-secondary`}>{title}</h1>
     <div class="text-text-secondary text-body-lg max-w-2xl">
       <slot />
     </div>

--- a/localplanning.services/src/components/Masthead.astro
+++ b/localplanning.services/src/components/Masthead.astro
@@ -11,7 +11,7 @@ const {
   size = "default",
 } = Astro.props;
 
-const baseClasses = " bg-bg-main";
+const baseClasses = "bg-bg-main";
 
 const sizeClasses = {
   default: "clamp-[py,10,20] clamp-[pb,5,10]",

--- a/localplanning.services/src/components/Masthead.astro
+++ b/localplanning.services/src/components/Masthead.astro
@@ -1,11 +1,34 @@
 ---
 import Container from "@components/Container.astro";
-const { title } = Astro.props;
+
+interface Props {
+  title: string;
+  variant?: "default" | "large";
+}
+
+const {
+  title,
+  variant = "default",
+} = Astro.props as Props;
+
+const baseClasses = " bg-bg-main";
+
+const variantClasses = {
+  default: "clamp-[py,10,20] clamp-[pb,5,10]",
+  large: "clamp-[py,10,20]",
+};
+
+const h1Classes = {
+  default: "text-heading-lg",
+  large: "text-heading-xl",
+};
+
+const classes = `${baseClasses} ${variantClasses[variant]}`;
 ---
 
-<section class="clamp-[py,10,20] bg-bg-main">
+<section class={classes}>
   <Container class="text-center">
-    <h1 class="text-heading-xl text-action-secondary">{title}</h1>
+    <h1 class={`${h1Classes[variant]} text-action-secondary`}>{title}</h1>
     <div class="text-text-secondary text-body-lg max-w-2xl">
       <slot />
     </div>

--- a/localplanning.services/src/pages/index.astro
+++ b/localplanning.services/src/pages/index.astro
@@ -7,7 +7,7 @@ import { cards } from "@content/index/cards";
 ---
 
 <Layout>
-  <Masthead title="Find local planning services">
+  <Masthead title="Find local planning services" size="large">
     <p>Modern digital services  to send planning applications, reports and notices directly to local planning authorities.</p>
     <p>A project by <a class="paragraph-link paragraph-link--external" href="https://opendigitalplanning.org/">Open Digital Planning</a>, powered by <a class="paragraph-link paragraph-link--external" href="https://www.planx.uk/">PlanX</a>.</p>
   </Masthead>


### PR DESCRIPTION
## What does this PR do?

Adds a size variant to the masthead.

**Default size:**
https://localplanning.4922.planx.pizza/about/
<img width="1626" alt="image" src="https://github.com/user-attachments/assets/420eea34-7175-4869-98ca-748a3d047f14" />


**Large size:**
https://localplanning.4922.planx.pizza/
<img width="1626" alt="image" src="https://github.com/user-attachments/assets/37153292-481f-4a8a-bca9-f7ffd0f46051" />