### PR TITLE
chore(api): Drop redundant metabase tag in Swagger docs

### DIFF
--- a/api.planx.uk/modules/analytics/docs.yaml
+++ b/api.planx.uk/modules/analytics/docs.yaml
@@ -5,7 +5,6 @@ info:
 
 tags:
   - name: analytics
-  - name: metabase
 
 components:
   responses:


### PR DESCRIPTION
There's a leftover "metabase" tag in the API docs from where we had both `/module/analytics` and `/modules/metabase`.

<img width="1439" height="635" alt="image" src="https://github.com/user-attachments/assets/581833f2-4e09-4504-ab66-efa537dfb4ac" />
