### PR TITLE
fix: rename "New flow" to "From scratch" in the "Add new" modal

### DIFF
--- a/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
@@ -31,7 +31,7 @@ export type CreateFlow = {
 export const CREATE_FLOW_MODES = [
   {
     mode: "new",
-    title: "New flow",
+    title: "From scratch",
   },
   {
     mode: "template",


### PR DESCRIPTION
See https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1752485557025489?thread_ts=1750424102.836949&cid=C04DZ1NBUMR