### PR TITLE
fix(infra): Support 4096-bit keys for ACM [skip pizza]

### DIFF
--- a/doc/how-to/how-to-setup-custom-subdomains.md
+++ b/doc/how-to/how-to-setup-custom-subdomains.md
@@ -11,7 +11,6 @@ This guide will walk through the process of setting a custom domain for a new te
     > ⚠️ **Requirements**
     >
     > AWS CloudFront has a few restrictions which are listed in the public documentation above which are shared with the IT Team, notably - 
-    >  - Keys can be a maximum of 2048-bit ([AWS Docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html))
     >  - Self signed certificates are not accepted ([AWS Docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-cloudfront-to-custom-origin.html))
     >
     > The steps below will show how to validate the above.
@@ -20,7 +19,7 @@ This guide will walk through the process of setting a custom domain for a new te
 
     **How to generate a CSR**
     ```shell
-    openssl req -new -newkey rsa:2048 -nodes -keyout <TEAM_NAME>.key -out <TEAM_NAME>.csr
+    openssl req -new -newkey rsa:4096 -nodes -keyout <TEAM_NAME>.key -out <TEAM_NAME>.csr
     ```
 
     The `<TEAM_NAME>.csr` file can then passed along to the IT team who should respond with a certificate and intermediary/chain certificate (next step). 
@@ -66,7 +65,6 @@ This guide will walk through the process of setting a custom domain for a new te
       - Import certificate (copy cert, key and chain into form)
       - Check the following after import - 
         - Subdomain is correct ✅
-        - Key algorithm is RSA 2048 ✅
         - CloudFront is listed under "Can be used with" heading ✅
       - If the above checks pass, delete the test certificate from the AWS Certificate Manager dashboard, and proceed to the next step
 

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -668,6 +668,7 @@ export = async () => {
         },
         {
           provider: usEast1,
+          replaceOnChanges: ["privateKey"],
         }
       );
       const cdn = createCdn({ domain, acmCertificateArn: certificate.arn });


### PR DESCRIPTION
## What does this PR do?
 - Updates documentation to support 4096-bit keys
 - Allows Pulumi to regenerate certificates, not just update certificates, when the key changes (e.g. from 2048 to 4096)
 
 ## Context
The following error was thrown when deploying #4933 to production - 

```
ValidationException: New certificate has a key of RSA_4096 which is different from RSA_2048 in the current certificate
```

This happened because -
 - Epsom and Ewell did not use our CSR which specifies as 2048-bit key
 - I missed the check in AWS Staging for the key size

[AWS CloudFront now supports 4096-bit keys](https://aws.amazon.com/about-aws/whats-new/2023/12/amazon-cloudfront-4096-bit-rsa-tls-certificates/) ([docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html)) which are more secure, so we don't need to go back to E&E here and try to get them to regenerate this with a different key.