### PR TITLE
feat: add `application.fee.serviceCharge` to `ALLOW_LIST`

### DIFF
--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
@@ -19,6 +19,7 @@ const ALLOW_LIST = [
   "applicant.researchOptIn",
   "application.declaration.connection",
   "application.fastTrack",
+  "application.fee.serviceCharge",
   "application.information.harmful",
   "application.information.sensitive",
   "application.type",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -48,6 +48,7 @@ export const ALLOW_LIST = [
   "applicant.researchOptIn",
   "application.declaration.connection",
   "application.fastTrack",
+  "application.fee.serviceCharge",
   "application.information.harmful",
   "application.information.sensitive",
   "application.type",


### PR DESCRIPTION
In order to show service charges accumulated in the editor over all time, we need a mechanism to maintain info about the service charge outside of our normal 6 month data retention policy. 

At minimimum we need to know: 
- The amount of the service charge (default £40, but may be configurable per council in future)
- The associated session ID & submission date

I think adding to `lowcal_sessions.allow_list` is best option for a couple reasons:
- Populated on submit only (so forthcoming "Subscription" page will always show service charges accumulated up to _yesterday_)
- This passport variable writes a number, so the (pre-VAT) amount can be referenced/summed for "Subscription" page, while also having option to treat as boolean (service charge applied/not applied) for other analytics purposes if useful too
- `payment_requests`, which do include fee breakdown info, are only retained for the last 6 months so not a reliable option
- `payment_status` audit records are retained forever but do not include fee breakdown info

**Next:**
- Create a summary view (which only `teamAdmin` role will have read-access to) of all sessions with applicable service charges using a baseline filtering condition like this: 
```sql
SELECT * FROM lowcal_sessions WHERE allow_list->'application.fee.serviceCharge' IS NOT NULL
```