### PR TITLE
chore: improve unoccupied buildings list item legibility

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/schemas/CIL/UnoccupiedCIL.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/CIL/UnoccupiedCIL.ts
@@ -2,7 +2,7 @@ import { Schema } from "@planx/components/shared/Schema/model";
 import { TextInputType } from "@planx/components/TextInput/model";
 
 export const UnoccupiedBuildingsCIL: Schema = {
-  type: "Building",
+  type: "Temporary or unoccupied building",
   fields: [
     {
       type: "text",


### PR DESCRIPTION
Improves UnoccupiedCIL list item legibility from 'Building' to more specific 'Temporary or unoccupied building' in the CIL section.