### PR TITLE
fix: Checkbox clickable area

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -22,11 +22,8 @@ const TextLabelRoot = styled(Box)(({ theme }) => ({
   borderTop: "none",
   display: "flex",
   flexGrow: 1,
-  alignItems: "center",
+  alignItems: "flex-start",
   padding: theme.spacing(1.5),
-  "& > p": {
-    color: theme.palette.text.secondary,
-  },
 }));
 
 const TextLabel = (props: Props): FCReturn => {
@@ -54,7 +51,7 @@ const TextLabel = (props: Props): FCReturn => {
       border={(theme) => borderStyle(theme, selected)}
     >
       <Checkbox id={id} checked={selected} onChange={onClick} />
-      <Typography variant="body1" ml={1.5}>
+      <Typography variant="body1" ml={1.5} mt={0.9}>
         {title}
       </Typography>
     </TextLabelRoot>

--- a/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
+++ b/editor.planx.uk/src/ui/shared/Checkbox/Checkbox.tsx
@@ -37,12 +37,13 @@ const Root = styled(Box, {
 const Input = styled("input")<{ variant?: "default" | "compact" }>(
   ({ variant }) => ({
     opacity: 0,
-    width: 24,
-    height: 24,
+    margin: "-2px",
+    width: 44,
+    height: 44,
     cursor: "pointer",
     ...(variant === "compact" && {
-      width: 16,
-      height: 16,
+      width: 24,
+      height: 24,
     }),
   }),
 );

--- a/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -12,14 +12,13 @@ const Root = styled(Box)(({ theme }) => ({
   marginBottom: theme.spacing(1),
   display: "flex",
   alignItems: "center",
-  cursor: "pointer",
 }));
 
 const Label = styled(Typography)(({ theme }) => ({
   display: "flex",
-  flexGrow: 2,
   cursor: "pointer",
   padding: theme.spacing(0.75, 1.5),
+  alignSelf: "flex-start",
 })) as typeof Typography;
 
 interface Props {
@@ -54,7 +53,7 @@ export default function ChecklistItem({
         disabled={disabled}
       />
       {description ? (
-        <Box>
+        <Box display="flex" flexDirection="column" width="100%">
           <Label
             variant="body1"
             color="text.primary"


### PR DESCRIPTION
## What does this PR do?

- Fixes clickable area of checkboxes so that the full bordered box is clickable

Before changes:
https://editor.planx.dev/testing/checkboxes/preview

After changes:
https://4943.planx.pizza/testing/checkboxes/preview

### Also fixes

- Clickable area of checkboxes labels with descriptions (only the label text should be clickable), to match https://design-system.service.gov.uk/components/checkboxes/error/

- Alignment of labels for checkboxes with images (before vs after):

<img width="3184" height="1064" alt="image" src="https://github.com/user-attachments/assets/8c449c5d-4058-41dd-81a0-37f6bd783aa5" />


