### PR TITLE
chore(lps): Install Inter locally to resolve font flash on page load

### DIFF
--- a/localplanning.services/package.json
+++ b/localplanning.services/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^4.2.7",
+    "@fontsource-variable/inter": "^5.2.6",
     "@opensystemslab/map": "1.0.0-alpha.5",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.81.5",

--- a/localplanning.services/pnpm-lock.yaml
+++ b/localplanning.services/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.2.7
         version: 4.2.7(@types/node@22.15.21)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(yaml@2.8.0)
+      '@fontsource-variable/inter':
+        specifier: ^5.2.6
+        version: 5.2.6
       '@opensystemslab/map':
         specifier: 1.0.0-alpha.5
         version: 1.0.0-alpha.5
@@ -389,6 +392,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/inter@5.2.6':
+    resolution: {integrity: sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg==}
 
   '@iconify/tools@4.1.2':
     resolution: {integrity: sha512-q6NzLQYEN9zkDfcyBqD3vItHcZw97w/s++3H3TBxUORr57EfHxj6tOW6fyufDjMq+Vl56WXWaPx1csBPYlI5CA==}
@@ -3276,6 +3282,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.4':
     optional: true
+
+  '@fontsource-variable/inter@5.2.6': {}
 
   '@iconify/tools@4.1.2':
     dependencies:

--- a/localplanning.services/src/layouts/Layout.astro
+++ b/localplanning.services/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import { ClientRouter } from "astro:transitions";
+import "@fontsource-variable/inter";
 import "@styles/global.css";
 import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";

--- a/localplanning.services/src/styles/global.css
+++ b/localplanning.services/src/styles/global.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap");
 @import "tailwindcss";
 @plugin "tailwind-clamp";
 


### PR DESCRIPTION
## What does this PR do?
 - Follow the setup suggested in the Astro docs for installing fonts, ensuring they're available at build time
 - This stops font-flash on initial page load - currently we send a request to `https://fonts.googleapis.com` to fetch Inter