### PR TITLE
fix: Interactive map width

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -249,6 +249,7 @@ export default function Component(props: Props) {
           ref={drawViewRef}
           tabIndex={-1}
           sx={{
+            maxWidth: "none",
             "&:focus": {
               outline: "none",
             },
@@ -325,7 +326,7 @@ export default function Component(props: Props) {
                   onClick={() => setPage("upload")}
                   data-testid="upload-file-button"
                 >
-                  <Typography variant="body1">
+                  <Typography variant="body1" align="right">
                     Upload a location plan instead
                   </Typography>
                 </Link>


### PR DESCRIPTION
## What does this PR do?

Fixes a small regression introduced in https://github.com/theopensystemslab/planx-new/pull/4843 where the map no longer fills the width of the content container.

**Testing:**
https://4952.planx.pizza/a-new-team/interactive-map/preview