### PR TITLE
Nich/text break

### DIFF
--- a/editor.planx.uk/src/pages/Preview/SavePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/SavePage.tsx
@@ -1,3 +1,4 @@
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import axios from "axios";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
@@ -25,19 +26,27 @@ export const SaveSuccess: React.FC<{
     buttonText="Start a new application"
     onButtonClick={removeSessionIdSearchParam}
   >
-    <Typography variant="body2">
-      We have sent a link to {saveToEmail}. Use the link to continue your
-      application.
-      <br />
-      <br />
-      You have until {expiryDate} to complete this application.
-      <br />
-      <br />
-      Your application will be deleted if you do not complete it by this date.
-      <br />
-      <br />
-      You may now close this tab.
-    </Typography>
+    <Stack spacing={1}>
+      <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+        We have sent a link to:
+      </Typography>
+      <Typography
+        component="span"
+        variant="body2"
+        sx={{
+          wordBreak: "break-word",
+          overflowWrap: "anywhere",
+        }}
+      >
+        {saveToEmail}.
+      </Typography>
+      <Typography variant="body2">
+        Use the link to continue your application. You have until {expiryDate}{" "}
+        to complete this application. Your application will be deleted if you do
+        not complete it by this date.
+      </Typography>
+      <Typography variant="body2">You may now close this tab.</Typography>
+    </Stack>
   </StatusPage>
 );
 

--- a/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
@@ -30,6 +30,9 @@ const styles = (theme: Theme) => ({
       fontWeight: "inherit",
     },
   },
+  "&": {
+    wordBreak: "break-word",
+  },
 });
 
 const HTMLRoot = styled(Box)(({ theme }) => styles(theme));


### PR DESCRIPTION
This pull request includes updates to improve the user interface and enhance text formatting in the application. The most significant changes involve restructuring the layout for the `SaveSuccess` component and adding word-break styling to ensure better text display.

<img width="322" height="569" alt="Screenshot 2025-07-16 at 11 25 02" src="https://github.com/user-attachments/assets/9e148bb9-0c8b-420a-b96e-d2dbfd5b6625" />
<img width="318" height="723" alt="Screenshot 2025-07-16 at 11 25 21" src="https://github.com/user-attachments/assets/55d46c94-9a32-4e9d-99cb-8a091ff0ffed" />

### UI improvements:

* [`editor.planx.uk/src/pages/Preview/SavePage.tsx`](diffhunk://#diff-a1c978a91cd2fa2e95fd8c9fd6c0b70260edcb42397cd5d394ea5fb781f244aaR29-R49): Refactored the `SaveSuccess` component to use a `Stack` layout for better spacing and readability. Added bold styling to the email link section and improved the text structure for clarity.

### Text formatting enhancements:

* [`editor.planx.uk/src/pages/Preview/SavePage.tsx`](diffhunk://#diff-a1c978a91cd2fa2e95fd8c9fd6c0b70260edcb42397cd5d394ea5fb781f244aaR1): Imported `Stack` from MUI to support the new layout structure.
* [`editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx`](diffhunk://#diff-c10cd1cf2eb642df39c78d4c88d8f680843a62add1f68a65ebc580f0a5ba900cR33-R35): Added `wordBreak: "break-word"` styling to ensure long text strings break appropriately within the `ReactMarkdownOrHtml` component.