### PR TITLE
refactor(lps): Refine header layout

### DIFF
--- a/localplanning.services/src/components/Header.astro
+++ b/localplanning.services/src/components/Header.astro
@@ -10,18 +10,18 @@ import SkipLink from "./a11y/SkipLink.astro";
   <SkipLink />
   <Container>
     <div
-      class="flex flex-col lg:flex-row justify-between lg:items-center py-6 gap-4"
+      class="flex flex-col sm:flex-row justify-between sm:items-center pt-6 pb-4 sm:py-6 sm:gap-4 relative"
     >
       <a href="/">
         <Image
           src={lpsLogo}
           alt="Local planning services logo"
-          class="clamp-[w,24,32] text-bg-light"
+          class="clamp-[w,24,32] text-bg-light absolute top-5 left-0 sm:relative sm:top-0"
           loading="eager"
         />
       </a>
-      <nav class="flex items-center clamp-[gap,7,8]">
-        <ul class="flex clamp-[gap,6,8]">
+      <nav class="flex items-end sm:items-center gap-4 sm:clamp-[gap,4,10] flex-col-reverse sm:flex-row">
+        <ul class="flex clamp-[gap,4,6] xs:clamp-[gap,4,10] items-center justify-between xs:justify-end sm:justify-start w-full xs:w-auto">
           <li>
             <a class="paragraph-link font-semibold text-body-md" href="/"
               >Home</a>
@@ -39,7 +39,10 @@ import SkipLink from "./a11y/SkipLink.astro";
               >About</a>
           </li>
         </ul>
-        <Button href="/applications" variant="secondary" size="small"
+        <Button 
+          href="/applications" 
+          variant="secondary" 
+          size="small"
           >Your applications</Button
         >
       </nav>

--- a/localplanning.services/src/styles/global.css
+++ b/localplanning.services/src/styles/global.css
@@ -4,6 +4,9 @@
 
 @theme {
 
+  /* Custom xs breakpoint */
+  --breakpoint-xs: 26rem;
+
   /*
   / Color palette
   */


### PR DESCRIPTION
## What does this PR do?

Reorganises responsive header layout to take into account extra menu item ("Find services").

Sizes increasing from 320px:

<img width="1166" height="734" alt="image" src="https://github.com/user-attachments/assets/8a5022a4-d818-4ea7-ab88-c181c7294eef" />

<img width="1166" height="734" alt="image" src="https://github.com/user-attachments/assets/f00d801b-40e4-495a-8292-a0f252fa0561" />

<img width="1166" height="734" alt="image" src="https://github.com/user-attachments/assets/4041808f-7fff-424d-afed-dc23901d1d2d" />

<img width="1166" height="734" alt="image" src="https://github.com/user-attachments/assets/ddde15fd-3699-4d97-9f91-a7eaed55c66a" />

<img width="1166" height="734" alt="image" src="https://github.com/user-attachments/assets/a0b68eb8-3f80-43b9-ba70-6de702c2739c" />
