### PR TITLE
chore: Use Alpine 3.22 for e2e image

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -8,7 +8,7 @@ services:
       - "${E2E_MOCK_SERVER_INTERFACE_PORT}:8081"
 
   test-ready:
-    image: alpine:3.17
+    image: alpine:3.22
     restart: unless-stopped
     depends_on:
       mock-server:


### PR DESCRIPTION
Small bump for CyberEssentials to match version used on Vultr.