### PR TITLE
fix(e2e): Use test notify email address

### DIFF
--- a/e2e/tests/api-driven/src/lps/steps.ts
+++ b/e2e/tests/api-driven/src/lps/steps.ts
@@ -7,6 +7,7 @@ import {
   login,
   setup,
 } from "./helpers.js";
+import { TEST_EMAIL } from "../globalHelpers.js";
 
 interface Success {
   status: 200;
@@ -28,7 +29,7 @@ export class CustomWorld extends World {
 }
 
 Before<CustomWorld>("@lps-magic-links", async function () {
-  this.email = "me@example.com";
+  this.email = TEST_EMAIL;
 
   const sessionIds = await setup({ email: this.email });
   this.sessionIds = sessionIds;


### PR DESCRIPTION
## What does this PR do?
Updates the email used in E2E tests for LPS login to use the GovNotify smoke test email ([docs](https://docs.notifications.service.gov.uk/rest-api.html#smoke-testing)). When I logged in to Notify just now I noticed we're triggering real email when these run.

<img width="749" height="662" alt="image" src="https://github.com/user-attachments/assets/573f9c2a-601e-4484-8fac-84bb4a30bd6a" />

<img width="263" height="247" alt="image" src="https://github.com/user-attachments/assets/7cb04d05-0ad0-4636-86a2-9b49dde40641" />
