### PR TITLE
chore: Migrate checklist tests to validation schema

### DIFF
--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.test.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.test.tsx
@@ -343,5 +343,5 @@ describe("Checklist editor component", () => {
         ),
       ).toBeInTheDocument(),
     );
-  }, 20_000);
+  }, 30_000);
 });

--- a/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Checklist/Editor/Editor.tsx
@@ -76,40 +76,6 @@ export const ChecklistEditor: React.FC<ChecklistProps> = (props) => {
         alert(JSON.stringify({ type, ...values, options }, null, 2));
       }
     },
-    validate: ({ options, groupedOptions, allRequired, ...values }) => {
-      const errors: FormikErrors<FormikValues> = {};
-
-      // Account for flat or expandable Checklist options
-      options = options || groupedOptions?.flatMap((group) => group.children);
-
-      const exclusiveOptions: Option[] | undefined = options?.filter(
-        (option) => option.data.exclusive,
-      );
-      if (allRequired && exclusiveOptions && exclusiveOptions.length > 0) {
-        errors.allRequired =
-          'Cannot configure exclusive "or" option alongside "all required" setting';
-      }
-      if (values.fn && !options?.some((option) => option.data.val)) {
-        errors.fn = "At least one option must also set a data field";
-      }
-      if (exclusiveOptions && exclusiveOptions.length > 1) {
-        errors.options =
-          "There should be a maximum of one exclusive option configured";
-      }
-      if (values.alwaysAutoAnswerBlank && !values.fn) {
-        errors.alwaysAutoAnswerBlank =
-          "Set a data field for the Checklist and all options but one when never putting to user";
-      }
-      if (
-        values.alwaysAutoAnswerBlank &&
-        values.fn &&
-        options?.filter((option) => !option.data.val).length !== 1
-      ) {
-        errors.alwaysAutoAnswerBlank =
-          "Exactly one option should have a blank data field when never putting to user";
-      }
-      return errors;
-    },
     validationSchema,
     validateOnBlur: false,
     validateOnChange: false,

--- a/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -136,7 +136,44 @@ describe("Editor validation", () => {
     );
   });
 
-  test("Data fields can be set for each option", async () => {
+  test("checklists - data fields can be set for each option", async () => {
+    const result = validationSchema.validate({
+      allRequired: false,
+      neverAutoAnswer: false,
+      alwaysAutoAnswerBlank: false,
+      description: "",
+      fn: "test",
+      groupedOptions: [
+        {
+          title: "Section 1",
+          children: [
+            {
+              data: {
+                val: "abc",
+                text: "ABC",
+              },
+            },
+          ],
+        },
+        {
+          title: "Section 2 ",
+          children: [
+            {
+              data: {
+                val: "def",
+                text: "DEF",
+              },
+            },
+          ],
+        },
+      ],
+      text: "Test",
+    });
+
+    expect(result).toBeDefined();
+  });
+
+  test("grouped checklists - data fields can be set for each option", async () => {
     const result = validationSchema.validate({
       title: "Test",
       alwaysAutoAnswerBlank: false,

--- a/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -136,6 +136,26 @@ describe("Editor validation", () => {
     );
   });
 
+  test("Data fields can be set for each option", async () => {
+    const result = validationSchema.validate({
+      title: "Test",
+      alwaysAutoAnswerBlank: false,
+      fn: "test",
+      options: [
+        {
+          id: "a",
+          data: { text: "Option A", val: "A" },
+        },
+        {
+          id: "b",
+          data: { text: "Option B", val: "B" },
+        },
+      ],
+    });
+
+    expect(result).toBeDefined();
+  });
+
   describe("unique labels", () => {
     describe("options without data values", () => {
       test.todo("checklists - unique labels must be used for each option");

--- a/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -1,4 +1,4 @@
-import { checklistInputValidationSchema } from "./model";
+import { checklistInputValidationSchema, validationSchema } from "./model";
 
 describe("Checklist - validation", () => {
   describe("optional checklist fields in schema", () => {
@@ -23,7 +23,136 @@ describe("Checklist - validation", () => {
 
     it("validates optional fields with a value", async () => {
       await expect(() => validationSchema.validate(["test1"])).rejects.toThrow(
-        /All options must be checked/
+        /All options must be checked/,
+      );
+    });
+  });
+});
+
+describe("Editor validation", () => {
+  test("both 'allRequired' and 'exclusiveOr' cannot be toggled on together", async () => {
+    await expect(() =>
+      validationSchema.validate({
+        title: "Test",
+        allRequired: true,
+        options: [
+          {
+            id: "a",
+            data: { text: "Option A", exclusive: true },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      'Cannot configure exclusive "or" option alongside "all required" setting',
+    );
+  });
+
+  test("only one exclusive option is permitted", async () => {
+    await expect(() =>
+      validationSchema.validate({
+        title: "Test",
+        allRequired: false,
+        options: [
+          {
+            id: "a",
+            data: { text: "Option A", exclusive: true },
+          },
+          {
+            id: "b",
+            data: { text: "Option B", exclusive: true },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      "There should be a maximum of one exclusive option configured",
+    );
+  });
+
+  test("options must set data values if the component does", async () => {
+    await expect(() =>
+      validationSchema.validate({
+        title: "Test",
+        fn: "topLevelFn",
+        allRequired: false,
+        options: [
+          {
+            id: "a",
+            data: { text: "Option A" },
+          },
+          {
+            id: "b",
+            data: { text: "Option B" },
+          },
+        ],
+      }),
+    ).rejects.toThrow("At least one option must also set a data field");
+  });
+
+  test("fn is required for alwaysAutoAnswerBlank", async () => {
+    await expect(() =>
+      validationSchema.validate({
+        title: "Test",
+        alwaysAutoAnswerBlank: true,
+        fn: null,
+        options: [
+          {
+            id: "a",
+            data: { text: "Option A" },
+          },
+          {
+            id: "b",
+            data: { text: "Option B" },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      "Set a data field for the Checklist and all options but one when never putting to user",
+    );
+  });
+
+  test("alwaysAutoAnswerBlank allows only one blank value", async () => {
+    await expect(() =>
+      validationSchema.validate({
+        title: "Test",
+        alwaysAutoAnswerBlank: true,
+        fn: "test",
+        options: [
+          {
+            id: "a",
+            data: { text: "Option A", val: "A" },
+          },
+          {
+            id: "b",
+            data: { text: "Option B" },
+          },
+          {
+            id: "c",
+            data: { text: "Option C" },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      "Exactly one option should have a blank data field when never putting to user",
+    );
+  });
+
+  describe("unique labels", () => {
+    describe("options without data values", () => {
+      test.todo("checklists - unique labels must be used for each option");
+      test.todo("grouped checklists - labels must be unique within groups");
+      test.todo("grouped checklists - labels can be repeated across groups");
+    });
+
+    describe("options with data values", () => {
+      test.todo("checklists - unique labels must be used for each option");
+      test.todo("checklists - unique data values must be used for each option");
+      test.todo("grouped checklists - labels must be unique within groups");
+      test.todo(
+        "grouped checklists - data values must be unique within groups",
+      );
+      test.todo("grouped checklists - labels can be repeated across groups");
+      test.todo(
+        "grouped checklists - data values can be repeated across groups",
       );
     });
   });

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -177,7 +177,7 @@ export const validationSchema = baseNodeDataValidationSchema.concat(
     ).optional(),
     allRequired: boolean(),
     options: array(optionValidationSchema).optional(),
-    fn: string(),
+    fn: string().nullable(),
     text: string(),
     img: string(),
     categories: array(

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -1,6 +1,6 @@
 import { richText } from "lib/yupExtensions";
 import { partition } from "lodash";
-import { array, object, string } from "yup";
+import { array, boolean, mixed, number, object, SchemaOf, string } from "yup";
 
 import { BaseNodeData, baseNodeDataValidationSchema, Option } from "../shared";
 
@@ -154,11 +154,128 @@ export const checklistInputValidationSchema = ({
     });
 };
 
+const optionValidationSchema = object({
+  id: string(),
+  data: object({
+    description: string(),
+    flags: array(string()),
+    img: string(),
+    text: string().required(),
+    val: string(),
+    exclusive: mixed().oneOf([true, undefined]),
+  }),
+});
+
 export const validationSchema = baseNodeDataValidationSchema.concat(
   object({
     description: richText(),
-    groupedOptions: array(object({
-      title: string().required("Section title is a required field")
-    }).required()).optional()
-  }),
+    groupedOptions: array(
+      object({
+        title: string().required("Section title is a required field"),
+        children: array(optionValidationSchema).required(),
+      }).required(),
+    ).optional(),
+    allRequired: boolean(),
+    options: array(optionValidationSchema).optional(),
+    fn: string(),
+    text: string(),
+    img: string(),
+    categories: array(
+      object({
+        title: string(),
+        count: number(),
+      }),
+    ),
+    neverAutoAnswer: boolean(),
+    alwaysAutoAnswerBlank: boolean(),
+    autoAnswers: array(string()),
+  })
+    .test({
+      name: "notExclusiveAndAllRequired",
+      test: function ({ allRequired, options }) {
+        if (!allRequired) return true;
+
+        const exclusiveOptions = options?.filter(({ data }) => data.exclusive);
+
+        if (!exclusiveOptions || !exclusiveOptions.length) return true;
+
+        return this.createError({
+          path: "allRequired",
+          message:
+            'Cannot configure exclusive "or" option alongside "all required" setting',
+        });
+      },
+    })
+    .test({
+      name: "onlyOneExclusiveOption",
+      test: function ({ options }) {
+        const exclusiveOptions = options?.filter(({ data }) => data.exclusive);
+
+        if (!exclusiveOptions?.length) return true;
+        if (exclusiveOptions.length === 1) return true;
+
+        return this.createError({
+          path: "options",
+          message:
+            "There should be a maximum of one exclusive option configured",
+        });
+      },
+    })
+    .test({
+      name: "atLeastOneDataField",
+      test: function ({ fn, options, groupedOptions }) {
+        if (!fn) return true;
+        const allOptions =
+          options || groupedOptions?.flatMap((group) => group.children);
+
+        if (!allOptions) return true;
+
+        const optionsWithDataValues = allOptions?.filter(
+          (option) => option?.data.val,
+        );
+
+        if (optionsWithDataValues?.length) return true;
+
+        return this.createError({
+          path: "fn",
+          message: "At least one option must also set a data field",
+        });
+      },
+    })
+    .test({
+      name: "",
+      test: function ({ alwaysAutoAnswerBlank, fn }) {
+        if (!alwaysAutoAnswerBlank) return true;
+        if (fn) return true;
+
+        return this.createError({
+          path: "alwaysAutoAnswerBlank",
+          message:
+            "Set a data field for the Checklist and all options but one when never putting to user",
+        });
+      },
+    })
+    .test({
+      name: "onlyOneBlank",
+      test: function ({ alwaysAutoAnswerBlank, options, groupedOptions, fn }) {
+        if (!alwaysAutoAnswerBlank && !fn) return true;
+
+        const allOptions =
+          options || groupedOptions?.flatMap((group) => group.children);
+
+        if (!allOptions) return true;
+
+        const optionsWithoutDataValues = allOptions?.filter(
+          (option) => !option?.data.val,
+        );
+
+        if (optionsWithoutDataValues.length === 1) return true;
+
+        return this.createError({
+          path: "alwaysAutoAnswerBlank",
+          message:
+            "Exactly one option should have a blank data field when never putting to user",
+        });
+      },
+    }),
 );

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -223,10 +223,12 @@ export const validationSchema = baseNodeDataValidationSchema.concat(
     })
     .test({
       name: "atLeastOneDataField",
-      test: function ({ fn, options, groupedOptions }) {
+      test: function ({ fn, options = [], groupedOptions = [] }) {
         if (!fn) return true;
-        const allOptions =
-          options || groupedOptions?.flatMap((group) => group.children);
+        const allOptions = [
+          ...options,
+          ...groupedOptions.flatMap((group) => group.children),
+        ];
 
         if (!allOptions) return true;
 
@@ -257,11 +259,18 @@ export const validationSchema = baseNodeDataValidationSchema.concat(
     })
     .test({
       name: "onlyOneBlank",
-      test: function ({ alwaysAutoAnswerBlank, options, groupedOptions, fn }) {
+      test: function ({
+        alwaysAutoAnswerBlank,
+        options = [],
+        groupedOptions = [],
+        fn,
+      }) {
         if (!alwaysAutoAnswerBlank || !fn) return true;
 
-        const allOptions =
-          options || groupedOptions?.flatMap((group) => group.children);
+        const allOptions = [
+          ...options,
+          ...groupedOptions.flatMap((group) => group.children),
+        ];
 
         if (!allOptions) return true;
 

--- a/editor.planx.uk/src/@planx/components/Checklist/model.ts
+++ b/editor.planx.uk/src/@planx/components/Checklist/model.ts
@@ -258,7 +258,7 @@ export const validationSchema = baseNodeDataValidationSchema.concat(
     .test({
       name: "onlyOneBlank",
       test: function ({ alwaysAutoAnswerBlank, options, groupedOptions, fn }) {
-        if (!alwaysAutoAnswerBlank && !fn) return true;
+        if (!alwaysAutoAnswerBlank || !fn) return true;
 
         const allOptions =
           options || groupedOptions?.flatMap((group) => group.children);

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -71,25 +71,6 @@ export const Question: React.FC<Props> = (props) => {
         alert(JSON.stringify({ type, ...values, children }, null, 2));
       }
     },
-    validate: ({ options, ...values }) => {
-      const errors: FormikErrors<FormikValues> = {};
-      if (values.fn && !options.some((option) => option.data.val)) {
-        errors.fn = "At least one option must also set a data field";
-      }
-      if (values.alwaysAutoAnswerBlank && !values.fn) {
-        errors.alwaysAutoAnswerBlank =
-          "Set a data field for the Question and all options but one when never putting to user";
-      }
-      if (
-        values.alwaysAutoAnswerBlank &&
-        values.fn &&
-        options.filter((option) => !option.data.val).length !== 1
-      ) {
-        errors.alwaysAutoAnswerBlank =
-          "Exactly one option should have a blank data field when never putting to user";
-      }
-      return errors;
-    },
     validationSchema,
     validateOnChange: false,
     validateOnBlur: false,

--- a/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -71,6 +71,25 @@ export const Question: React.FC<Props> = (props) => {
         alert(JSON.stringify({ type, ...values, children }, null, 2));
       }
     },
+    validate: ({ options, ...values }) => {
+      const errors: FormikErrors<FormikValues> = {};
+      if (values.fn && !options.some((option) => option.data.val)) {
+        errors.fn = "At least one option must also set a data field";
+      }
+      if (values.alwaysAutoAnswerBlank && !values.fn) {
+        errors.alwaysAutoAnswerBlank =
+          "Set a data field for the Question and all options but one when never putting to user";
+      }
+      if (
+        values.alwaysAutoAnswerBlank &&
+        values.fn &&
+        options.filter((option) => !option.data.val).length !== 1
+      ) {
+        errors.alwaysAutoAnswerBlank =
+          "Exactly one option should have a blank data field when never putting to user";
+      }
+      return errors;
+    },
     validationSchema,
     validateOnChange: false,
     validateOnBlur: false,

--- a/editor.planx.uk/src/@planx/components/shared/index.ts
+++ b/editor.planx.uk/src/@planx/components/shared/index.ts
@@ -54,7 +54,7 @@ const nodeTagsSchema: SchemaOf<NodeTags> = object({
     .of(
       string()
         .oneOf([...NODE_TAGS], "Invalid tag")
-        .required("Tag cannot be empty")
+        .required("Tag cannot be empty"),
     )
     .optional()
     .default([]),
@@ -63,10 +63,8 @@ const nodeTagsSchema: SchemaOf<NodeTags> = object({
 /**
  * Yup validation schema describing BaseNodeData fields
  */
-export const baseNodeDataValidationSchema: SchemaOf<BaseNodeData> = 
-  nodeTagsSchema
-    .concat(moreInformationSchema)
-    .concat(templatedNodeSchema);
+export const baseNodeDataValidationSchema: SchemaOf<BaseNodeData> =
+  nodeTagsSchema.concat(moreInformationSchema).concat(templatedNodeSchema);
 
 export interface Option {
   id: string;


### PR DESCRIPTION
## What does this PR do?
Migrates existing validation checks from `FormikConfig["test"]` to `FormikConfig["validationSchema"]`.

This PR does not (intentionally!) change the current behaviour and is just a migration from one type of validation to another.

Please see https://github.com/theopensystemslab/planx-new/pull/4978 for further context.
