### PR TITLE
refactor(lps): Add LPS link to save and return

### DIFF
--- a/editor.planx.uk/src/pages/Preview/SavePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/SavePage.tsx
@@ -1,3 +1,4 @@
+import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import axios from "axios";
@@ -38,12 +39,21 @@ export const SaveSuccess: React.FC<{
           overflowWrap: "anywhere",
         }}
       >
-        {saveToEmail}.
+        {saveToEmail}
       </Typography>
       <Typography variant="body2">
         Use the link to continue your application. You have until {expiryDate}{" "}
         to complete this application. Your application will be deleted if you do
         not complete it by this date.
+      </Typography>
+      <Typography variant="body2">
+        To see all of your applications visit{" "}
+        <Link
+          href="https://localplanning.4962.planx.pizza/applications/"
+          target="_blank"
+        >
+          Local planning services (opens in a new tab)
+        </Link>
       </Typography>
       <Typography variant="body2">You may now close this tab.</Typography>
     </Stack>


### PR DESCRIPTION
## What does this PR do?

Adds LPS link to save & return page

<img width="812" height="568" alt="image" src="https://github.com/user-attachments/assets/52c90787-9277-46f0-bd4d-0cd782e8a865" />
