### PR TITLE
feat(lps): Content and image updates

### DIFF
--- a/localplanning.services/src/components/LpaMasthead.astro
+++ b/localplanning.services/src/components/LpaMasthead.astro
@@ -21,8 +21,7 @@ const { title, lpaName, backgroundColour, logo } = Astro.props;
       {logo && (
         <Image
           src={logo}
-          width={40}
-          height={40}
+          inferSize={true}
           alt={`${lpaName} logo`}
           class="clamp-[w,28,40]"
         />

--- a/localplanning.services/src/components/Masthead.astro
+++ b/localplanning.services/src/components/Masthead.astro
@@ -14,7 +14,7 @@ const {
 const baseClasses = "bg-bg-main";
 
 const sizeClasses = {
-  default: "clamp-[py,10,20] clamp-[pb,5,10]",
+  default: "clamp-[py,10,20] clamp-[pb,5,8]",
   large: "clamp-[py,10,20]",
 };
 

--- a/localplanning.services/src/pages/404.astro
+++ b/localplanning.services/src/pages/404.astro
@@ -1,11 +1,15 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import Masthead from "@components/Masthead.astro";
+import Container from "@components/Container.astro";
 ---
 
 <Layout>
-  <Masthead title="Page not found">
-    <p>If you typed the web address, check it is correct.</p>
-    <p>If you pasted the web address, check you copied the entire address.</p>
-  </Masthead>
+  <Masthead title="Page not found" />
+  <Container paddingY>
+    <section class="styled-content">
+      <p>If you typed the web address, check it is correct.</p>
+      <p>If you pasted the web address, check you copied the entire address.</p>
+    </section>
+  </Container>
 </Layout>

--- a/localplanning.services/src/pages/applications/check-your-inbox.astro
+++ b/localplanning.services/src/pages/applications/check-your-inbox.astro
@@ -1,10 +1,14 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import Masthead from "@components/Masthead.astro";
+import Container from "@components/Container.astro";
 ---
 
 <Layout>
-  <Masthead title="Check your inbox">
-    <p>We've sent you a magic link to access your applications. Please check your email inbox.</p>
-  </Masthead>
+  <Masthead title="Check your inbox" />
+  <Container paddingY>
+    <section class="styled-content">
+      <p>We've sent you a magic link to access your applications. Please check your email inbox.</p>
+    </section>
+  </Container>
 </Layout>


### PR DESCRIPTION
## What does this PR do

Few small updates to LPS:
- Move copy for 404 and login sent pages to page content (out of masthead)
- Reduce height of masthead slightly
- Use `inferSize={true}` on LPA masthead image to prevent layout shift when loading