### PR TITLE
feat(lps): Wire up print button

### DIFF
--- a/localplanning.services/src/pages/applications/mock-application.astro
+++ b/localplanning.services/src/pages/applications/mock-application.astro
@@ -1,7 +1,6 @@
 ---
 import BlankLayout from "@layouts/BlankLayout.astro";
 import Container from "@components/Container.astro";
-import Button from "@components/Button.astro";
 import { Image } from "astro:assets";
 import mockBoundary from "/public/mock-boundary.jpg";
 


### PR DESCRIPTION
## What does this PR do?

Wires up the print button on LPS demo mock-application page.

I've used the native `<button>` element as our Astro `<Button>` is configured to render an `<a>` tag

https://localplanning.4991.planx.pizza/applications/mock-application/