### PR TITLE
chore: Standarise implementation of `FileUpload` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -12,31 +12,14 @@ import InputRow from "ui/shared/InputRow";
 
 import { DataFieldAutocomplete } from "../shared/DataFieldAutocomplete";
 import { ICONS } from "../shared/icons";
-import { validationSchema } from "./model";
+import { EditorProps } from "../shared/types";
+import { FileUpload, parseFileUpload, validationSchema } from "./model";
 
-function Component(props: any) {
-  const formik = useFormik<{
-    color: string;
-    definitionImg: string;
-    description: string;
-    fn?: string;
-    howMeasured: string;
-    info: string;
-    notes: string;
-    policyRef: string;
-    title: string;
-  }>({
-    initialValues: {
-      color: props.node?.data?.color || "#EFEFEF",
-      definitionImg: props.node?.data?.definitionImg,
-      description: props.node?.data?.description || "",
-      fn: props.node?.data?.fn || "",
-      howMeasured: props.node?.data?.howMeasured,
-      info: props.node?.data?.info,
-      notes: props.node?.data?.notes || "",
-      policyRef: props.node?.data?.policyRef,
-      title: props.node?.data?.title || "",
-    },
+type Props = EditorProps<TYPES.FileUpload, FileUpload>;
+
+function Component(props: Props) {
+  const formik = useFormik<FileUpload>({
+    initialValues: parseFileUpload(props.node?.data),
     onSubmit: (newValues) => {
       if (props.handleSubmit) {
         props.handleSubmit({ type: TYPES.FileUpload, data: newValues });
@@ -57,10 +40,10 @@ function Component(props: any) {
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <TemplatedNodeInstructions
-        isTemplatedNode={props.isTemplatedNode}
-        templatedNodeInstructions={props.templatedNodeInstructions}
+        isTemplatedNode={formik.values.isTemplatedNode}
+        templatedNodeInstructions={formik.values.templatedNodeInstructions}
         areTemplatedNodeInstructionsRequired={
-          props.areTemplatedNodeInstructionsRequired
+          formik.values.areTemplatedNodeInstructionsRequired
         }
       />
       <ModalSection>

--- a/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -6,10 +6,13 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import { PASSPORT_REQUESTED_FILES_KEY } from "../FileUploadAndLabel/model";
 import { PrivateFileUpload } from "../shared/PrivateFileUpload/PrivateFileUpload";
+import { PublicProps } from "../shared/types";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import { FileUpload, FileUploadSlot, slotsSchema } from "./model";
 
-const FileUploadComponent: React.FC<FileUpload> = (props) => {
+type Props = PublicProps<FileUpload>;
+
+const FileUploadComponent: React.FC<Props> = (props) => {
   const recoveredSlots = getPreviouslySubmittedData(props)?.map(
     (slot: FileUploadSlot) => slot.cachedSlot,
   );
@@ -52,12 +55,13 @@ const FileUploadComponent: React.FC<FileUpload> = (props) => {
     slotsSchema
       .validate(slots)
       .then(() => {
-        props.handleSubmit({
-          data: {
-            ...uploadedFiles(slots).data,
-            ...updatedRequestedFiles(),
-          },
-        });
+        props.handleSubmit &&
+          props.handleSubmit({
+            data: {
+              ...uploadedFiles(slots).data,
+              ...updatedRequestedFiles(),
+            },
+          });
       })
       .catch((err) => {
         setValidationError(err.message);

--- a/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -1,20 +1,16 @@
 import {
   BaseNodeData,
   baseNodeDataValidationSchema,
+  parseBaseNodeData,
 } from "@planx/components/shared";
 import { richText } from "lib/yupExtensions";
-import { Store } from "pages/FlowEditor/lib/store";
-import type { HandleSubmit } from "pages/Preview/Node";
 import { FileWithPath } from "react-dropzone";
 import { array, object } from "yup";
 
 export interface FileUpload extends BaseNodeData {
-  id?: string;
   title?: string;
   fn: string;
   description?: string;
-  handleSubmit: HandleSubmit;
-  previouslySubmittedData?: Store.UserData;
 }
 
 export interface FileUploadSlot {
@@ -25,6 +21,20 @@ export interface FileUploadSlot {
   url?: string;
   cachedSlot?: Omit<FileUploadSlot, "cachedSlot">;
 }
+
+export const parseFileUpload = (
+  data: Record<string, any> | undefined,
+): FileUpload => ({
+  definitionImg: data?.definitionImg,
+  description: data?.description || "",
+  fn: data?.fn || "",
+  howMeasured: data?.howMeasured,
+  info: data?.info,
+  notes: data?.notes || "",
+  policyRef: data?.policyRef,
+  title: data?.title || "",
+  ...parseBaseNodeData(data),
+});
 
 export const slotsSchema = array()
   .required()


### PR DESCRIPTION
##What does this PR do?
Updates the `FileUpload` component to use the standard component setup [laid out in our docs](https://github.com/theopensystemslab/planx-new/blob/main/editor.planx.uk/docs/adding-a-new-component.md).

## Motivation
Prior to starting on [adding a `FileUploadField` to the `List` and `Page` components](https://trello.com/c/62VNikY9/3304-add-a-fileupload-field-to-the-page-and-list-components), we need to do a bit of catch up / tidy up here.