### PR TITLE
fix: annouces dialog open and give description

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -6,7 +6,8 @@ import DialogContent from "@mui/material/DialogContent";
 import { Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import React, { useState } from "react";
+import { visuallyHidden } from "@mui/utils";
+import React, { useEffect, useRef, useState } from "react";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { ValidationError } from "yup";
 
@@ -35,6 +36,13 @@ export const FileTaggingModal = ({
   const fullScreen = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down("md"),
   );
+  const initialFocusRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (initialFocusRef.current) {
+      initialFocusRef.current.focus();
+    }
+  }, []);
 
   const closeModal = (_event: any, reason?: string) => {
     if (reason && reason == "backdropClick") {
@@ -66,8 +74,24 @@ export const FileTaggingModal = ({
     >
       <DialogContent>
         <Box sx={{ mt: 1, mb: 4 }}>
-          <Typography variant="h3" component="h2" id="dialog-heading">
+          <Typography
+            variant="h3"
+            component="h2"
+            id="dialog-heading"
+            ref={initialFocusRef}
+            tabIndex={-1}
+            sx={{ outline: "none" }}
+          >
             Tell us what these files show
+            <Typography
+              component="span"
+              id="dialog-description"
+              sx={visuallyHidden}
+            >
+              . You are in a dialog, for each uploaded file, select what type of
+              information it contains. You can close this dialog by pressing
+              escape.
+            </Typography>
           </Typography>
         </Box>
         {uploadedFiles.map((slot) => (


### PR DESCRIPTION
This pull request enhances the accessibility of the `FileTaggingModal` component in the `editor.planx.uk` project. The changes ensure better focus management and provide additional context for screen readers.

### Accessibility Improvements:

* **Focus Management**: Added a `useRef` hook to manage focus on the dialog heading when the modal opens, ensuring accessibility for keyboard and screen reader users. (`editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx`, [editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsxR39-R45](diffhunk://#diff-2179ec7a9c915f453803c1f3746fe6e986eb85813c489e7d0856549d13806e31R39-R45))
* **Screen Reader Context**: Included a visually hidden `Typography` element with additional instructions for screen reader users, describing the purpose of the dialog and how to navigate it. (`editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx`, [editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsxL69-R94](diffhunk://#diff-2179ec7a9c915f453803c1f3746fe6e986eb85813c489e7d0856549d13806e31L69-R94))
