### PR TITLE
refactor: chages how lable is associated with number input

### DIFF
--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
@@ -3,13 +3,12 @@ import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHead
 import { PublicProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
 import isNil from "lodash/isNil";
-import React, { useEffect, useRef } from "react";
-import InputLabel from "ui/public/InputLabel";
+import React, { useEffect, useId, useRef } from "react";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
-import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../shared/constants";
+import { ERROR_MESSAGE } from "../shared/constants";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { NumberInput } from "./model";
 import { parseNumber, publicValidationSchema } from "./model";
@@ -17,6 +16,10 @@ import { parseNumber, publicValidationSchema } from "./model";
 export type Props = PublicProps<NumberInput>;
 
 export default function NumberInputComponent(props: Props): FCReturn {
+  const uniqueId = useId();
+  const inputId = `number-input-${uniqueId}`;
+  const labelId = `input-label-${uniqueId}`;
+
   const formik = useFormik({
     initialValues: {
       value: getPreviouslySubmittedData(props) ?? "",
@@ -50,27 +53,27 @@ export default function NumberInputComponent(props: Props): FCReturn {
         howMeasured={props.howMeasured}
       />
       <InputRow>
-        <InputLabel label={props.title} hidden htmlFor="number-input">
-          <Input
-            ref={inputRef}
-            bordered
-            name="value"
-            type="number"
-            value={formik.values.value}
-            onChange={formik.handleChange}
-            errorMessage={formik.errors.value as string}
-            inputProps={{
-              "aria-describedby": [
-                props.description ? DESCRIPTION_TEXT : "",
-                formik.errors.value ? `${ERROR_MESSAGE}-${props.id}` : "",
-              ]
-                .filter(Boolean)
-                .join(" "),
-            }}
-            id="number-input"
-          />
-        </InputLabel>
-        {props.units && <InputRowLabel>{props.units}</InputRowLabel>}
+        <Input
+          ref={inputRef}
+          bordered
+          name="value"
+          type="number"
+          value={formik.values.value}
+          onChange={formik.handleChange}
+          errorMessage={formik.errors.value as string}
+          inputProps={{
+            "aria-describedby": formik.errors.value
+              ? `${ERROR_MESSAGE}-${props.id}`
+              : "",
+            "aria-labelledby": labelId,
+          }}
+          id={inputId}
+        />
+        {props.units && (
+          <InputRowLabel inputProps={{ id: labelId }}>
+            {props.units}
+          </InputRowLabel>
+        )}
       </InputRow>
     </Card>
   );


### PR DESCRIPTION
This pull request refactors the `NumberInputComponent` in `Public.tsx` to improve accessibility and code maintainability. The changes focus on dynamically generating unique IDs for input elements, simplifying `aria-describedby` logic, and restructuring how labels are handled.

### Accessibility Improvements:
* Introduced `useId` to dynamically generate unique IDs for input and label elements, ensuring better accessibility and avoiding potential ID conflicts. (`[editor.planx.uk/src/@planx/components/NumberInput/Public.tsxL6-R22](diffhunk://#diff-a05895331276d30c6db914f0148d5fec10a8abe017bf510dae0eef1833c5b974L6-R22)`)
* Updated the `aria-describedby` property to simplify its logic and ensure it references the correct error message or label dynamically. (`[editor.planx.uk/src/@planx/components/NumberInput/Public.tsxL63-R76](diffhunk://#diff-a05895331276d30c6db914f0148d5fec10a8abe017bf510dae0eef1833c5b974L63-R76)`)
* Added the `aria-labelledby` property to associate the input with its label for improved screen reader compatibility. (`[editor.planx.uk/src/@planx/components/NumberInput/Public.tsxL63-R76](diffhunk://#diff-a05895331276d30c6db914f0148d5fec10a8abe017bf510dae0eef1833c5b974L63-R76)`)

### Code Restructuring:
* Removed the `InputLabel` wrapper around the `Input` component and replaced it with a more direct association using dynamically generated IDs. (`[editor.planx.uk/src/@planx/components/NumberInput/Public.tsxL53](diffhunk://#diff-a05895331276d30c6db914f0148d5fec10a8abe017bf510dae0eef1833c5b974L53)`)
* Updated the `InputRowLabel` to include `inputProps` with the dynamically generated label ID, aligning it with the new accessibility structure. (`[editor.planx.uk/src/@planx/components/NumberInput/Public.tsxL63-R76](diffhunk://#diff-a05895331276d30c6db914f0148d5fec10a8abe017bf510dae0eef1833c5b974L63-R76)`)

