### PR TITLE
fix: correctly set aria attribute to input rather then label

### DIFF
--- a/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -48,7 +48,10 @@ export default function ChecklistItem({
         checked={checked}
         id={id}
         onChange={onChange}
-        inputProps={inputProps}
+        inputProps={{
+          ...inputProps,
+          "aria-describedby": `checkbox-description-${id}`,
+        }}
         variant={variant}
         disabled={disabled}
       />
@@ -60,7 +63,6 @@ export default function ChecklistItem({
             className="label"
             component={"label"}
             htmlFor={id}
-            aria-describedby={`checkbox-description-${id}`}
             pb={0}
           >
             {label}


### PR DESCRIPTION
Moves aria describe by when a description is present to the checkbox input instead of the label element.