### PR TITLE
fix(a11y): Set `disablePortal` prop on MUI `Autocomplete` to resolve iOS VoiceOver issues

### DIFF
--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -274,6 +274,11 @@ const getThemeOptions = ({
           },
         },
       },
+      MuiAutocomplete: {
+        defaultProps: {
+          disablePortal: true,
+        },
+      },
       MuiContainer: {
         styleOverrides: {
           root: {

--- a/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderFieldInputs.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderFieldInputs.tsx
@@ -21,6 +21,7 @@ export const RenderDataFieldInput = ({
       {...params}
       InputProps={{
         ...params.InputProps,
+        onBlur: undefined,
         notched: false,
       }}
       label={label}
@@ -42,6 +43,7 @@ export const RenderTextFieldInput = ({
       InputProps={{
         ...params.InputProps,
         notched: false,
+        onBlur: undefined,
       }}
       label={label}
       placeholder={placeholder}

--- a/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderFieldInputs.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/components/RenderFieldInputs.tsx
@@ -1,5 +1,5 @@
 import { AutocompleteRenderInputParams } from "@mui/material/Autocomplete";
-import React from "react";
+import React, { FocusEvent } from "react";
 
 import { StyledDataField, StyledTextField } from "../styles";
 
@@ -21,7 +21,10 @@ export const RenderDataFieldInput = ({
       {...params}
       InputProps={{
         ...params.InputProps,
-        onBlur: undefined,
+        onBlur: (e) =>
+          setTimeout(() => {
+            params.inputProps.onBlur?.(e as FocusEvent<HTMLInputElement>);
+          }, 0),
         notched: false,
       }}
       label={label}
@@ -43,7 +46,10 @@ export const RenderTextFieldInput = ({
       InputProps={{
         ...params.InputProps,
         notched: false,
-        onBlur: undefined,
+        onBlur: (e) =>
+          setTimeout(() => {
+            params.inputProps.onBlur?.(e as FocusEvent<HTMLInputElement>);
+          }, 0),
       }}
       label={label}
       placeholder={placeholder}

--- a/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
@@ -1,7 +1,7 @@
 import FormControl from "@mui/material/FormControl";
 import TextField from "@mui/material/TextField";
 import { GridFilterFormProps } from "@mui/x-data-grid";
-import React from "react";
+import React, { FocusEvent } from "react";
 import {
   OptionalAutocompleteProps,
   RequiredAutocompleteProps,
@@ -35,7 +35,10 @@ export function MultipleOptionSelectFilter<T>(props: Props<T>) {
             variant="standard"
             InputProps={{
               ...params.InputProps,
-              onBlur: undefined,
+              onBlur: (e) =>
+                setTimeout(() => {
+                  params.inputProps.onBlur?.(e as FocusEvent<HTMLInputElement>);
+                }, 0),
             }}
           />
         )}

--- a/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
+++ b/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
@@ -35,6 +35,7 @@ export function MultipleOptionSelectFilter<T>(props: Props<T>) {
             variant="standard"
             InputProps={{
               ...params.InputProps,
+              onBlur: undefined,
             }}
           />
         )}

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -65,6 +65,7 @@ export function SelectMultiple<T>(props: Props<T>) {
             {...params}
             InputProps={{
               ...params.InputProps,
+              onBlur: undefined,
               notched: false,
             }}
             label={props.label}

--- a/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -1,7 +1,7 @@
 import Autocomplete, { AutocompleteProps } from "@mui/material/Autocomplete";
 import FormControl from "@mui/material/FormControl";
 import { styled } from "@mui/material/styles";
-import React from "react";
+import React, { FocusEvent } from "react";
 
 import { StyledTextField } from "./Autocomplete/styles";
 import { PopupIcon } from "./PopUpIcon";
@@ -65,7 +65,10 @@ export function SelectMultiple<T>(props: Props<T>) {
             {...params}
             InputProps={{
               ...params.InputProps,
-              onBlur: undefined,
+              onBlur: (e) =>
+                setTimeout(() => {
+                  params.inputProps.onBlur?.(e as FocusEvent<HTMLInputElement>);
+                }, 0),
               notched: false,
             }}
             label={props.label}


### PR DESCRIPTION
From the docs - 

> VoiceOver on iOS Safari doesn't support the `aria-owns` attribute very well. You can work around the issue with the `disablePortal` prop.

Source: https://material-ui.netlify.app/material-ui/react-autocomplete/#ios-voiceover