### PR TITLE
fix(a11y): Dropzone focus style

### DIFF
--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -8,6 +8,7 @@ import { uploadPrivateFile } from "api/upload";
 import { nanoid } from "nanoid";
 import React from "react";
 import { FileWithPath, useDropzone } from "react-dropzone";
+import { borderedFocusStyle } from "theme";
 
 interface Props {
   setSlots: React.Dispatch<React.SetStateAction<FileUploadSlot[]>>;
@@ -63,6 +64,11 @@ const Root = styled(Box, {
         duration: "0.2s",
       }),
     ],
+  },
+  "&:focus": {
+    ...borderedFocusStyle,
+    boxShadow: "none",
+    borderStyle: "solid",
   },
 }));
 


### PR DESCRIPTION
## What does this PR do?

Addresses a11y issue p62 `DAC_Contrast_Enhanced_01`
Trello issue: https://trello.com/c/au0wFUGz/3337-enhanced-contrast-aaa-p62

- Adds "input" style focus state to dropzone