### PR TITLE
refactor(a11y): Use checkboxes for upload and label

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -71,6 +71,11 @@ export const FileTaggingModal = ({
       maxWidth="xl"
       aria-labelledby="dialog-heading"
       fullScreen={fullScreen}
+      PaperProps={{
+        sx: {
+          overflow: "hidden",
+        },
+      }}
     >
       <DialogContent>
         <Box sx={{ mt: 1, mb: 4 }}>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -102,6 +102,7 @@ export const FileTaggingModal = ({
                   {...slot}
                   key={slot.id}
                   removeFile={() => removeFile(slot)}
+                  sx={{ borderBottom: "none" }}
                 />
                 <SelectMultipleFileTypes
                   uploadedFile={slot}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -102,7 +102,9 @@ export const FileTaggingModal = ({
                   {...slot}
                   key={slot.id}
                   removeFile={() => removeFile(slot)}
-                  sx={{ borderBottom: "none" }}
+                  FileCardProps={{
+                    sx: { borderBottom: "none" },
+                  }}
                 />
                 <SelectMultipleFileTypes
                   uploadedFile={slot}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import capitalize from "lodash/capitalize";
@@ -26,6 +27,16 @@ interface ChecklistProps {
 interface Option extends UserFile {
   category: keyof FileList;
 }
+
+const Root = styled(Box)(({ theme }) => ({
+  width: "100%",
+  backgroundColor: theme.palette.background.default,
+  borderColor: theme.palette.border.main,
+  borderStyle: "solid",
+  borderWidth: "1px",
+  borderTopColor: theme.palette.border.light,
+  padding: theme.spacing(2),
+}));
 
 // Sanitize function to create valid IDs (no spaces)
 const sanitizeId = (str: string): string => {
@@ -56,57 +67,39 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
   /**
    * Group options by category for rendering
    */
-  const groupedOptions = useMemo(() => {
-    const groups: Record<string, Option[]> = {};
-    options.forEach((option) => {
-      if (!groups[option.category]) {
-        groups[option.category] = [];
-      }
-      groups[option.category].push(option);
-    });
-    return groups;
-  }, [options]);
+  const groupedOptions = useMemo(
+    () => Object.groupBy(options, ({ category }) => category),
+    [options],
+  );
 
   /**
    * Handle individual checkbox change
    */
-  const handleCheckboxChange =
-    (option: Option) =>
-    (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      const isCurrentlyChecked = initialTags.includes(option.name);
-      const newCheckedState = !isCurrentlyChecked;
+  const handleCheckboxChange = (option: Option) => {
+    const isCurrentlyChecked = initialTags.includes(option.name);
+    const newCheckedState = !isCurrentlyChecked;
 
-      if (newCheckedState) {
-        // Add the tag
-        const updatedFileList = addOrAppendSlots(
-          [option.name],
-          uploadedFile,
-          fileList,
-        );
-        setFileList(updatedFileList);
-      } else {
-        // Remove the tag
-        const updatedFileList = removeSlots(
-          [option.name],
-          uploadedFile,
-          fileList,
-        );
-        setFileList(updatedFileList);
-      }
-    };
+    if (newCheckedState) {
+      // Add the tag
+      const updatedFileList = addOrAppendSlots(
+        [option.name],
+        uploadedFile,
+        fileList,
+      );
+      setFileList(updatedFileList);
+    } else {
+      // Remove the tag
+      const updatedFileList = removeSlots(
+        [option.name],
+        uploadedFile,
+        fileList,
+      );
+      setFileList(updatedFileList);
+    }
+  };
 
   return (
-    <Box
-      sx={(theme) => ({
-        width: "100%",
-        backgroundColor: theme.palette.background.default,
-        borderColor: theme.palette.border.main,
-        borderStyle: "solid",
-        borderWidth: "1px",
-        borderTopColor: theme.palette.border.light,
-        padding: theme.spacing(2),
-      })}
-    >
+    <Root>
       <Typography variant="h3" mb={3} id={titleId}>
         What does this file show? (select all that apply)
         <Box component="span" sx={visuallyHidden}>
@@ -138,15 +131,15 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
             {categoryOptions.map((option) => (
               <ChecklistItem
                 key={`${category}-${option.name}`}
-                id={`${sanitizeId(uploadedFile.id)}-${sanitizeId(category)}-${sanitizeId(option.name)}`}
+                id={sanitizeId(`${uploadedFile.id}-${category}-${option.name}`)}
                 label={option.name}
                 checked={initialTags.includes(option.name)}
-                onChange={handleCheckboxChange(option)}
+                onChange={() => handleCheckboxChange(option)}
               />
             ))}
           </Box>
         </FormControl>
       ))}
-    </Box>
+    </Root>
   );
 };

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -27,6 +27,11 @@ interface Option extends UserFile {
   category: keyof FileList;
 }
 
+// Sanitize function to create valid IDs (no spaces)
+const sanitizeId = (str: string): string => {
+  return str.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9-_]/g, "");
+};
+
 export const SelectMultipleFileTypes = (props: ChecklistProps) => {
   const { uploadedFile, fileList, setFileList } = props;
 
@@ -133,7 +138,7 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
             {categoryOptions.map((option) => (
               <ChecklistItem
                 key={`${category}-${option.name}`}
-                id={`${uploadedFile.id}-${category}-${option.name}`}
+                id={`${sanitizeId(uploadedFile.id)}-${sanitizeId(category)}-${sanitizeId(option.name)}`}
                 label={option.name}
                 checked={initialTags.includes(option.name)}
                 onChange={handleCheckboxChange(option)}

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -475,7 +475,7 @@ describe("Adding tags and syncing state", () => {
 
     // Find the "Heritage statement" checkbox using data-testid
     const heritageStatementCheckbox = within(fileTaggingModal).getByTestId(
-      /.*-.*-Heritage statement$/,
+      /.*-.*-Heritage-statement$/,
     );
     expect(heritageStatementCheckbox).toBeInTheDocument();
 
@@ -646,7 +646,7 @@ describe("Error handling", () => {
       "file-tagging-dialog",
     );
     const utilityBillCheckbox =
-      within(fileTaggingModal).getByTestId(/.*-.*-Utility bill$/);
+      within(fileTaggingModal).getByTestId(/.*-.*-Utility-bill$/);
     expect(utilityBillCheckbox).toBeInTheDocument();
 
     // Apply tag to this file

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -404,11 +404,9 @@ describe("Adding tags and syncing state", () => {
     const submitModalButton = getByRole("button", { name: /Done/ });
     expect(submitModalButton).toBeVisible();
 
-    // Find the "Roof plan" checkbox using data-testid which includes the file ID
-    // The pattern is: ${fileId}-${category}-${optionName}
+    // Find the "Roof plan" checkbox using label text
     const roofPlanCheckbox =
-      within(fileTaggingModal).getByTestId(/.*-.*-Roof-plan$/);
-    expect(roofPlanCheckbox).toBeInTheDocument();
+      within(fileTaggingModal).getByLabelText("Roof plan");
 
     // Apply tag to this file
     await user.click(roofPlanCheckbox);
@@ -474,10 +472,8 @@ describe("Adding tags and syncing state", () => {
     expect(uploadedFileCards).toHaveLength(1);
 
     // Find the "Heritage statement" checkbox using data-testid
-    const heritageStatementCheckbox = within(fileTaggingModal).getByTestId(
-      /.*-.*-Heritage-statement$/,
-    );
-    expect(heritageStatementCheckbox).toBeInTheDocument();
+    const heritageStatementCheckbox =
+      within(fileTaggingModal).getByLabelText("Heritage statement");
 
     // Apply tag to this file
     await user.click(heritageStatementCheckbox);
@@ -646,8 +642,7 @@ describe("Error handling", () => {
       "file-tagging-dialog",
     );
     const utilityBillCheckbox =
-      within(fileTaggingModal).getByTestId(/.*-.*-Utility-bill$/);
-    expect(utilityBillCheckbox).toBeInTheDocument();
+      within(fileTaggingModal).getByLabelText("Utility bill");
 
     // Apply tag to this file
     await user.click(utilityBillCheckbox);
@@ -668,7 +663,7 @@ describe("Submitting data", () => {
 
   it("records the user uploaded files", async () => {
     const handleSubmit = vi.fn();
-    const { getByText, getByLabelText, user } = setup(
+    const { getByText, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         handleSubmit={handleSubmit}
@@ -696,7 +691,7 @@ describe("Submitting data", () => {
 
   it("records the full file type list presented to the user", async () => {
     const handleSubmit = vi.fn();
-    const { getByText, getByLabelText, user } = setup(
+    const { getByText, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         handleSubmit={handleSubmit}
@@ -769,7 +764,7 @@ describe("Submitting data", () => {
     act(() => setState({ flow, breadcrumbs }));
 
     const handleSubmit = vi.fn();
-    const { getByText, getByLabelText, user } = setup(
+    const { getByText, user } = setup(
       <FileUploadAndLabelComponent
         title="Test title"
         handleSubmit={handleSubmit}
@@ -813,10 +808,8 @@ const uploadAndTagSingleFile = async (user: UserEvent) => {
     "file-tagging-dialog",
   );
 
-  // Find the "Roof plan" checkbox using data-testid
-  const roofPlanCheckbox =
-    within(fileTaggingModal).getByTestId(/.*-.*-Roof-plan$/);
-  expect(roofPlanCheckbox).toBeInTheDocument();
+  // Find the "Roof plan" checkbox using label text
+  const roofPlanCheckbox = within(fileTaggingModal).getByLabelText("Roof plan");
   await user.click(roofPlanCheckbox);
 
   const submitModalButton = await within(fileTaggingModal).findByText("Done");

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -407,7 +407,7 @@ describe("Adding tags and syncing state", () => {
     // Find the "Roof plan" checkbox using data-testid which includes the file ID
     // The pattern is: ${fileId}-${category}-${optionName}
     const roofPlanCheckbox =
-      within(fileTaggingModal).getByTestId(/.*-.*-Roof plan$/);
+      within(fileTaggingModal).getByTestId(/.*-.*-roof-plan$/);
     expect(roofPlanCheckbox).toBeInTheDocument();
 
     // Apply tag to this file
@@ -815,7 +815,7 @@ const uploadAndTagSingleFile = async (user: UserEvent) => {
 
   // Find the "Roof plan" checkbox using data-testid
   const roofPlanCheckbox =
-    within(fileTaggingModal).getByTestId(/.*-.*-Roof plan$/);
+    within(fileTaggingModal).getByTestId(/.*-.*-roof-plan$/);
   expect(roofPlanCheckbox).toBeInTheDocument();
   await user.click(roofPlanCheckbox);
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -407,7 +407,7 @@ describe("Adding tags and syncing state", () => {
     // Find the "Roof plan" checkbox using data-testid which includes the file ID
     // The pattern is: ${fileId}-${category}-${optionName}
     const roofPlanCheckbox =
-      within(fileTaggingModal).getByTestId(/.*-.*-roof-plan$/);
+      within(fileTaggingModal).getByTestId(/.*-.*-Roof-plan$/);
     expect(roofPlanCheckbox).toBeInTheDocument();
 
     // Apply tag to this file
@@ -815,7 +815,7 @@ const uploadAndTagSingleFile = async (user: UserEvent) => {
 
   // Find the "Roof plan" checkbox using data-testid
   const roofPlanCheckbox =
-    within(fileTaggingModal).getByTestId(/.*-.*-roof-plan$/);
+    within(fileTaggingModal).getByTestId(/.*-.*-Roof-plan$/);
   expect(roofPlanCheckbox).toBeInTheDocument();
   await user.click(roofPlanCheckbox);
 

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -471,7 +471,7 @@ describe("Adding tags and syncing state", () => {
     });
     expect(uploadedFileCards).toHaveLength(1);
 
-    // Find the "Heritage statement" checkbox using data-testid
+    // Find the "Heritage statement" checkbox using label text
     const heritageStatementCheckbox =
       within(fileTaggingModal).getByLabelText("Heritage statement");
 
@@ -637,7 +637,7 @@ describe("Error handling", () => {
     });
     expect(uploadedFileCards).toHaveLength(1);
 
-    // Find the "Utility bill" checkbox using data-testid
+    // Find the "Utility bill" checkbox using label text
     const fileTaggingModal = await within(document.body).findByTestId(
       "file-tagging-dialog",
     );

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -1,6 +1,6 @@
 import FileIcon from "@mui/icons-material/AttachFile";
 import DeleteIcon from "@mui/icons-material/DeleteOutline";
-import Box from "@mui/material/Box";
+import Box, { BoxProps } from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
@@ -18,7 +18,7 @@ interface Props extends FileUploadSlot {
   removeFile: () => void;
   onChange?: () => void;
   tags?: string[];
-  sx?: React.CSSProperties;
+  FileCardProps?: BoxProps;
 }
 
 const Root = styled(Box)(({ theme }) => ({
@@ -95,7 +95,7 @@ export const UploadedFileCard: React.FC<Props> = ({
   onChange,
   tags,
   status,
-  sx,
+  FileCardProps,
 }) => (
   <Root>
     <ErrorWrapper
@@ -106,7 +106,7 @@ export const UploadedFileCard: React.FC<Props> = ({
       }
     >
       <>
-        <FileCard sx={{ ...sx }}>
+        <FileCard {...FileCardProps}>
           <ProgressBar
             width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
             role="progressbar"

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -18,10 +18,10 @@ interface Props extends FileUploadSlot {
   removeFile: () => void;
   onChange?: () => void;
   tags?: string[];
+  sx?: React.CSSProperties;
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  marginBottom: theme.spacing(0.5),
   marginTop: theme.spacing(5),
 }));
 
@@ -95,6 +95,7 @@ export const UploadedFileCard: React.FC<Props> = ({
   onChange,
   tags,
   status,
+  sx,
 }) => (
   <Root>
     <ErrorWrapper
@@ -105,7 +106,7 @@ export const UploadedFileCard: React.FC<Props> = ({
       }
     >
       <>
-        <FileCard>
+        <FileCard sx={{ ...sx }}>
           <ProgressBar
             width={`${Math.min(Math.ceil(progress * 100), 100)}%`}
             role="progressbar"


### PR DESCRIPTION
## What does this PR do?

- Refactors Upload + label component to use checkboxes rather than an autocomplete combobox

**Demo:**
https://5043.planx.pizza/a-new-team/upload-label/preview