### PR TITLE
fix(a11y): Broken aria on checkboxes

### DIFF
--- a/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -50,7 +50,9 @@ export default function ChecklistItem({
         onChange={onChange}
         inputProps={{
           ...inputProps,
-          "aria-describedby": `checkbox-description-${id}`,
+          ...(description && {
+            "aria-describedby": `checkbox-description-${id}`,
+          }),
         }}
         variant={variant}
         disabled={disabled}


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where `aria-describedby` pointing at checkbox descriptions is a broken ref if the description is not present. Adds logic to qualify description before adding aria ref.