### PR TITLE
fix(a11y): Improvements to feedback drawer

### DIFF
--- a/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.test.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from "react";
+import React from "react";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
@@ -18,8 +18,6 @@ describe("FeedbackPhaseBanner presentation and functionality", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={handleFeedbackClick}
         handleReportAnIssueClick={handleReportAnIssueClick}
-        feedbackButtonRef={createRef()}
-        reportIssueButtonRef={createRef()}
       />,
     );
 
@@ -33,8 +31,6 @@ describe("FeedbackPhaseBanner presentation and functionality", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={handleFeedbackClick}
         handleReportAnIssueClick={handleReportAnIssueClick}
-        feedbackButtonRef={createRef()}
-        reportIssueButtonRef={createRef()}
       />,
     );
 
@@ -47,8 +43,6 @@ describe("FeedbackPhaseBanner presentation and functionality", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={handleFeedbackClick}
         handleReportAnIssueClick={handleReportAnIssueClick}
-        feedbackButtonRef={createRef()}
-        reportIssueButtonRef={createRef()}
       />,
     );
 
@@ -63,8 +57,6 @@ describe("FeedbackPhaseBanner accessibility", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={vi.fn()}
         handleReportAnIssueClick={vi.fn()}
-        feedbackButtonRef={createRef()}
-        reportIssueButtonRef={createRef()}
       />,
     );
 

--- a/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.test.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
@@ -18,6 +18,8 @@ describe("FeedbackPhaseBanner presentation and functionality", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={handleFeedbackClick}
         handleReportAnIssueClick={handleReportAnIssueClick}
+        feedbackButtonRef={createRef()}
+        reportIssueButtonRef={createRef()}
       />,
     );
 
@@ -31,6 +33,8 @@ describe("FeedbackPhaseBanner presentation and functionality", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={handleFeedbackClick}
         handleReportAnIssueClick={handleReportAnIssueClick}
+        feedbackButtonRef={createRef()}
+        reportIssueButtonRef={createRef()}
       />,
     );
 
@@ -43,6 +47,8 @@ describe("FeedbackPhaseBanner presentation and functionality", () => {
       <FeedbackPhaseBanner
         handleFeedbackClick={handleFeedbackClick}
         handleReportAnIssueClick={handleReportAnIssueClick}
+        feedbackButtonRef={createRef()}
+        reportIssueButtonRef={createRef()}
       />,
     );
 
@@ -55,8 +61,10 @@ describe("FeedbackPhaseBanner accessibility", () => {
   test("should have no accessibility violations", async () => {
     const { container } = setup(
       <FeedbackPhaseBanner
-        handleFeedbackClick={() => {}}
-        handleReportAnIssueClick={() => {}}
+        handleFeedbackClick={vi.fn()}
+        handleReportAnIssueClick={vi.fn()}
+        feedbackButtonRef={createRef()}
+        reportIssueButtonRef={createRef()}
       />,
     );
 

--- a/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
@@ -4,7 +4,7 @@ import Container from "@mui/material/Container";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import React, { RefObject } from "react";
 
 const Root = styled(Box)(({ theme }) => ({
   width: "100%",
@@ -56,6 +56,8 @@ const BetaFlag = styled(Box)(({ theme }) => ({
 interface Props {
   handleFeedbackClick: () => void;
   handleReportAnIssueClick: () => void;
+  feedbackButtonRef: RefObject<HTMLAnchorElement>
+  reportIssueButtonRef: RefObject<HTMLButtonElement>
 }
 
 export default function PhaseBanner(props: Props): FCReturn {
@@ -95,13 +97,14 @@ export default function PhaseBanner(props: Props): FCReturn {
                 href="#"
                 sx={{ verticalAlign: "top" }}
                 onClick={handleFeedbackClick}
+                ref={props.feedbackButtonRef}
               >
                 feedback
               </Link>{" "}
               will help us improve it.
             </Typography>
           </PhaseWrap>
-          <ReportButton onClick={() => props.handleReportAnIssueClick()}>
+          <ReportButton onClick={() => props.handleReportAnIssueClick()} ref={props.reportIssueButtonRef}>
             Report an issue with this page
           </ReportButton>
         </Inner>

--- a/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
+++ b/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.tsx
@@ -4,7 +4,7 @@ import Container from "@mui/material/Container";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import React, { RefObject } from "react";
+import React from "react";
 
 const Root = styled(Box)(({ theme }) => ({
   width: "100%",
@@ -56,8 +56,6 @@ const BetaFlag = styled(Box)(({ theme }) => ({
 interface Props {
   handleFeedbackClick: () => void;
   handleReportAnIssueClick: () => void;
-  feedbackButtonRef: RefObject<HTMLAnchorElement>
-  reportIssueButtonRef: RefObject<HTMLButtonElement>
 }
 
 export default function PhaseBanner(props: Props): FCReturn {
@@ -97,14 +95,13 @@ export default function PhaseBanner(props: Props): FCReturn {
                 href="#"
                 sx={{ verticalAlign: "top" }}
                 onClick={handleFeedbackClick}
-                ref={props.feedbackButtonRef}
               >
                 feedback
               </Link>{" "}
               will help us improve it.
             </Typography>
           </PhaseWrap>
-          <ReportButton onClick={() => props.handleReportAnIssueClick()} ref={props.reportIssueButtonRef}>
+          <ReportButton onClick={() => props.handleReportAnIssueClick()}>
             Report an issue with this page
           </ReportButton>
         </Inner>

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -359,6 +359,7 @@ const Feedback: React.FC = () => {
       <Drawer 
         aria-label="Feedback triage and submission form"
         open={isDrawerOpen} 
+        onClose={closeDrawer}
       >
         <Feedback />
       </Drawer>

--- a/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/editor.planx.uk/src/components/Feedback/index.tsx
@@ -8,14 +8,13 @@ import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
-import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import {
   getInternalFeedbackMetadata,
   insertFeedbackMutation,
 } from "lib/feedback";
 import { BackButton } from "pages/Preview/Questions";
-import React, { RefObject, useRef, useState } from "react";
+import React, { useState } from "react";
 import { usePrevious } from "react-use";
 import FeedbackOption from "ui/public/FeedbackOption";
 
@@ -37,28 +36,32 @@ import {
   UserFeedback,
 } from "./types";
 
+const FeedbackPhaseBannerView: React.FC<{ 
+  handleFeedbackViewClick: (event: ClickEvents) => void }
+  > = ({ handleFeedbackViewClick }) => {
+  return (
+    <FeedbackWrapper>
+      <FeedbackPhaseBanner
+        handleFeedbackClick={() =>
+          handleFeedbackViewClick("triage")
+        }
+        handleReportAnIssueClick={() =>
+          handleFeedbackViewClick("issue")
+        }
+      />
+    </FeedbackWrapper>
+  );
+}
+
 const Feedback: React.FC = () => {
-  const theme = useTheme();
   const [currentFeedbackView, setCurrentFeedbackView] =
     useState<FeedbackView | null>(null);
   const previousFeedbackView = usePrevious(currentFeedbackView);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
-  // Track how the drawer was opened so that we can return focus
-  const feedbackButtonRef = useRef<HTMLAnchorElement>(null);
-  const reportIssueButtonRef = useRef<HTMLButtonElement>(null);
-  const [focusTargetRef, setFocusTargetRef] = useState<RefObject<HTMLAnchorElement | HTMLButtonElement> | null>(null);
-
   const closeDrawer = () => {
     setIsDrawerOpen(false);
     setCurrentFeedbackView(null);
-    
-    // Manually reset focus once drawer has closed
-    setTimeout(() => {
-      if (focusTargetRef && focusTargetRef.current) {
-        focusTargetRef.current.focus()
-      }
-    }, theme.transitions.duration.leavingScreen);
   }
 
   function handleFeedbackViewClick(event: ClickEvents) {
@@ -152,25 +155,6 @@ const Feedback: React.FC = () => {
         Icon={WarningIcon}
         title="Report an issue with this service"
       />
-    );
-  }
-
-  function FeedbackPhaseBannerView(): FCReturn {
-    return (
-      <FeedbackWrapper>
-        <FeedbackPhaseBanner
-          handleFeedbackClick={() => {
-            setFocusTargetRef(feedbackButtonRef)
-            handleFeedbackViewClick("triage")}
-          }
-          handleReportAnIssueClick={() => {
-            setFocusTargetRef(reportIssueButtonRef)
-            handleFeedbackViewClick("issue")}
-          }
-          feedbackButtonRef={feedbackButtonRef}
-          reportIssueButtonRef={reportIssueButtonRef}
-        />
-      </FeedbackWrapper>
     );
   }
 
@@ -376,10 +360,10 @@ const Feedback: React.FC = () => {
 
   return (
     <Box>
-      <FeedbackPhaseBannerView />
-      <Drawer 
+      <FeedbackPhaseBannerView handleFeedbackViewClick={handleFeedbackViewClick}/>
+      <Drawer
         aria-label="Feedback triage and submission form"
-        open={isDrawerOpen} 
+        open={isDrawerOpen}
         onClose={closeDrawer}
       >
         <Feedback />


### PR DESCRIPTION
Follow up to #5039, responding to [the following comment](https://github.com/theopensystemslab/planx-new/pull/5039#issuecomment-3144940766) - 

> Coming in with late feedback here @DafyddLlyr , looks and works superb! There's a couple of follow up tasks I've spotted:
>
> - ESC key to close the drawer, similar to help text drawer
> - Returning focus to the correct place on the page when the drawer is closed (which I believe was the original feedback)

https://github.com/user-attachments/assets/fdea3689-a282-4a3a-b75e-a6ccc81dfc05

