### PR TITLE
feat: Scroll to file card on "change" click

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileCard.tsx
@@ -1,0 +1,64 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import { FileUploadSlot } from "@planx/components/FileUpload/model";
+import React, { useEffect, useRef } from "react";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
+
+import { UploadedFileCard } from "../../shared/PrivateFileUpload/UploadedFileCard";
+import { FileList } from "../model";
+import { SelectMultipleFileTypes } from "./SelectMultipleFileTypes";
+
+const Root = styled(Box)(({ theme }) => ({
+  scrollMarginTop: theme.spacing(2),
+}));
+
+interface Props {
+  slot: FileUploadSlot;
+  errors: Record<string, string> | undefined;
+  fileList: FileList;
+  setFileList: (value: React.SetStateAction<FileList>) => void;
+  removeFile: (slot: FileUploadSlot) => void;
+  selectedSlotId: string | null;
+}
+
+export const FileCard: React.FC<Props> = ({
+  slot,
+  errors,
+  removeFile,
+  fileList,
+  setFileList,
+  selectedSlotId,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (selectedSlotId === slot.id && ref.current) {
+      ref.current.scrollIntoView({
+        behavior: "instant",
+        block: "start",
+      });
+    }
+  }, [selectedSlotId, slot.id]);
+
+  return (
+    <Root ref={ref}>
+      <ErrorWrapper error={errors?.[slot.id]}>
+        <>
+          <UploadedFileCard
+            {...slot}
+            key={slot.id}
+            removeFile={() => removeFile(slot)}
+            FileCardProps={{
+              sx: { borderBottom: "none" },
+            }}
+          />
+          <SelectMultipleFileTypes
+            uploadedFile={slot}
+            fileList={fileList}
+            setFileList={setFileList}
+          />
+        </>
+      </ErrorWrapper>
+    </Root>
+  );
+};

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -9,29 +9,32 @@ import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { visuallyHidden } from "@mui/utils";
 import React, { useEffect, useRef, useState } from "react";
-import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { ValidationError } from "yup";
 
 import { FileUploadSlot } from "../../FileUpload/model";
-import { UploadedFileCard } from "../../shared/PrivateFileUpload/UploadedFileCard";
 import { FileList } from "../model";
 import { fileLabelSchema, formatFileLabelSchemaErrors } from "../schema";
-import { SelectMultipleFileTypes } from "./SelectMultipleFileTypes";
+import { FileCard } from "./FileCard";
 
 interface FileTaggingModalProps {
   uploadedFiles: FileUploadSlot[];
   fileList: FileList;
   setFileList: (value: React.SetStateAction<FileList>) => void;
-  setShowModal: (value: React.SetStateAction<boolean>) => void;
+  closeModal: (
+    _event: unknown,
+    reason?: "backdropClick" | "escapeKeyDown",
+  ) => void;
   removeFile: (slot: FileUploadSlot) => void;
+  selectedSlotId: string | null;
 }
 
 export const FileTaggingModal = ({
   uploadedFiles,
   fileList,
   setFileList,
-  setShowModal,
+  closeModal,
   removeFile,
+  selectedSlotId,
 }: FileTaggingModalProps) => {
   const [errors, setErrors] = useState<Record<string, string> | undefined>();
   const fullScreen = useMediaQuery((theme: Theme) =>
@@ -45,12 +48,11 @@ export const FileTaggingModal = ({
     }
   }, []);
 
-  const closeModal = (_event: any, reason?: string) => {
-    if (reason && reason == "backdropClick") {
-      return;
+  useEffect(() => {
+    if (initialFocusRef.current) {
+      initialFocusRef.current.focus();
     }
-    setShowModal(false);
-  };
+  }, []);
 
   const handleValidation = () => {
     fileLabelSchema
@@ -102,26 +104,15 @@ export const FileTaggingModal = ({
         </Box>
         <Stack spacing={2}>
           {uploadedFiles.map((slot) => (
-            <ErrorWrapper
-              error={errors?.[slot.id]}
+            <FileCard
               key={`tags-per-file-container-${slot.id}`}
-            >
-              <>
-                <UploadedFileCard
-                  {...slot}
-                  key={slot.id}
-                  removeFile={() => removeFile(slot)}
-                  FileCardProps={{
-                    sx: { borderBottom: "none" },
-                  }}
-                />
-                <SelectMultipleFileTypes
-                  uploadedFile={slot}
-                  fileList={fileList}
-                  setFileList={setFileList}
-                />
-              </>
-            </ErrorWrapper>
+              slot={slot}
+              errors={errors}
+              fileList={fileList}
+              setFileList={setFileList}
+              removeFile={removeFile}
+              selectedSlotId={selectedSlotId}
+            />
           ))}
         </Stack>
       </DialogContent>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -68,6 +68,7 @@ export const FileTaggingModal = ({
 
   return (
     <Dialog
+      scroll={"paper"}
       open
       onClose={closeModal}
       data-testid="file-tagging-dialog"
@@ -76,7 +77,7 @@ export const FileTaggingModal = ({
       fullScreen={fullScreen}
       PaperProps={{
         sx: {
-          overflow: "hidden",
+          position: "unset",
         },
       }}
     >

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -21,6 +21,8 @@ const mockedAxios = vi.mocked(axios, true);
 
 window.URL.createObjectURL = vi.fn();
 
+Element.prototype.scrollIntoView = vi.fn();
+
 describe("Basic state and setup", () => {
   test("renders correctly", async () => {
     const { getAllByRole, getByTestId, getByText } = setup(

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -112,6 +112,7 @@ function Component(props: Props) {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [isUserReturningToNode, setIsUserReturningToNode] =
     useState<boolean>(false);
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
 
   const validateAndSubmit = () => {
     Promise.all([
@@ -142,9 +143,10 @@ function Component(props: Props) {
       });
   };
 
-  const onUploadedFileCardChange = () => {
+  const onUploadedFileCardChange = (slotId: string) => {
     setFileListError(undefined);
     setFileLabelErrors(undefined);
+    setSelectedSlotId(slotId);
     setShowModal(true);
   };
 
@@ -171,6 +173,14 @@ function Component(props: Props) {
       fileList,
     );
     setFileList(updatedFileList);
+  };
+
+  const closeModal = (_event: unknown, reason?: string) => {
+    if (reason && reason == "backdropClick") {
+      return;
+    }
+    setShowModal(false);
+    setSelectedSlotId(null);
   };
 
   return (
@@ -235,8 +245,9 @@ function Component(props: Props) {
                 uploadedFiles={slots}
                 fileList={fileList}
                 setFileList={setFileList}
-                setShowModal={setShowModal}
+                closeModal={closeModal}
                 removeFile={removeFile}
+                selectedSlotId={selectedSlotId}
               />
             )}
             <Stack spacing={2}>
@@ -249,7 +260,7 @@ function Component(props: Props) {
                   <UploadedFileCard
                     {...slot}
                     tags={getTagsForSlot(slot.id, fileList)}
-                    onChange={onUploadedFileCardChange}
+                    onChange={() => onUploadedFileCardChange(slot.id)}
                     removeFile={() => removeFile(slot)}
                   />
                 </ErrorWrapper>


### PR DESCRIPTION
## What does this PR do?
 - Scrolls to a selected file when the "change" button is hit in file upload and label

## Motivation
 - Raised as usability issue in the accessibility audit
 - More useful than ever now that there's a lot more vertical space within the modal

## Questions
 - Should we keep the modal title in view at all times?

https://github.com/user-attachments/assets/09053238-9dc0-40c1-add1-a306a2144656

