### PR TITLE
refactor(a11y): Improve and tidy up file upload

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -3,6 +3,7 @@ import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import Stack from "@mui/material/Stack";
 import { Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -99,27 +100,29 @@ export const FileTaggingModal = ({
             </Typography>
           </Typography>
         </Box>
-        {uploadedFiles.map((slot) => (
-          <Box sx={{ mb: 4 }} key={`tags-per-file-container-${slot.id}`}>
-            <ErrorWrapper error={errors?.[slot.id]}>
-              <>
-                <UploadedFileCard
-                  {...slot}
-                  key={slot.id}
-                  removeFile={() => removeFile(slot)}
-                  FileCardProps={{
-                    sx: { borderBottom: "none" },
-                  }}
-                />
-                <SelectMultipleFileTypes
-                  uploadedFile={slot}
-                  fileList={fileList}
-                  setFileList={setFileList}
-                />
-              </>
-            </ErrorWrapper>
-          </Box>
-        ))}
+        <Stack spacing={2}>
+          {uploadedFiles.map((slot) => (
+            <Box key={`tags-per-file-container-${slot.id}`}>
+              <ErrorWrapper error={errors?.[slot.id]}>
+                <>
+                  <UploadedFileCard
+                    {...slot}
+                    key={slot.id}
+                    removeFile={() => removeFile(slot)}
+                    FileCardProps={{
+                      sx: { borderBottom: "none" },
+                    }}
+                  />
+                  <SelectMultipleFileTypes
+                    uploadedFile={slot}
+                    fileList={fileList}
+                    setFileList={setFileList}
+                  />
+                </>
+              </ErrorWrapper>
+            </Box>
+          ))}
+        </Stack>
       </DialogContent>
       <DialogActions
         sx={{

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/Modal.tsx
@@ -102,25 +102,26 @@ export const FileTaggingModal = ({
         </Box>
         <Stack spacing={2}>
           {uploadedFiles.map((slot) => (
-            <Box key={`tags-per-file-container-${slot.id}`}>
-              <ErrorWrapper error={errors?.[slot.id]}>
-                <>
-                  <UploadedFileCard
-                    {...slot}
-                    key={slot.id}
-                    removeFile={() => removeFile(slot)}
-                    FileCardProps={{
-                      sx: { borderBottom: "none" },
-                    }}
-                  />
-                  <SelectMultipleFileTypes
-                    uploadedFile={slot}
-                    fileList={fileList}
-                    setFileList={setFileList}
-                  />
-                </>
-              </ErrorWrapper>
-            </Box>
+            <ErrorWrapper
+              error={errors?.[slot.id]}
+              key={`tags-per-file-container-${slot.id}`}
+            >
+              <>
+                <UploadedFileCard
+                  {...slot}
+                  key={slot.id}
+                  removeFile={() => removeFile(slot)}
+                  FileCardProps={{
+                    sx: { borderBottom: "none" },
+                  }}
+                />
+                <SelectMultipleFileTypes
+                  uploadedFile={slot}
+                  fileList={fileList}
+                  setFileList={setFileList}
+                />
+              </>
+            </ErrorWrapper>
           ))}
         </Stack>
       </DialogContent>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -249,7 +249,9 @@ describe("Modal trigger", () => {
     );
     expect(fileTaggingModal).toBeVisible();
 
-    expect(await within(fileTaggingModal).findByText("test.png")).toBeVisible();
+    expect(
+      await within(fileTaggingModal).findByTestId("test.png"),
+    ).toBeVisible();
   });
 
   test("Modal opens when multiple files are uploaded", async () => {
@@ -290,10 +292,10 @@ describe("Modal trigger", () => {
       "file-tagging-dialog",
     );
     expect(
-      await within(fileTaggingModal).findByText("test1.png"),
+      await within(fileTaggingModal).findByTestId("test1.png"),
     ).toBeVisible();
     expect(
-      await within(fileTaggingModal).findByText("test2.png"),
+      await within(fileTaggingModal).findByTestId("test2.png"),
     ).toBeVisible();
   });
 
@@ -340,11 +342,11 @@ describe("Modal trigger", () => {
     await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
 
     // Uploaded files displayed as cards
-    expect(getByText("test1.png")).toBeVisible();
-    expect(getByText("test2.png")).toBeVisible();
+    expect(getByTestId("test1.png")).toBeVisible();
+    expect(getByTestId("test2.png")).toBeVisible();
 
     // Delete the second file
-    user.click(getByLabelText("Delete test2.png"));
+    user.click(getByTestId("delete-test2.png"));
 
     // Card removed from screen
     await waitFor(() =>
@@ -416,7 +418,7 @@ describe("Adding tags and syncing state", () => {
     expect(fileTaggingModal).not.toBeVisible();
 
     // Uploaded file displayed as card with chip tags
-    expect(getByText("test1.png")).toBeVisible();
+    expect(getByTestId("test1.png")).toBeVisible();
     const chips = getAllByTestId("uploaded-file-chip");
     expect(chips).toHaveLength(1);
     expect(chips[0]).toHaveTextContent("Roof plan");
@@ -483,7 +485,7 @@ describe("Adding tags and syncing state", () => {
     await waitFor(() => expect(fileTaggingModal).not.toBeVisible());
 
     // Uploaded file displayed as card with chip tags
-    expect(getByText("test1.png")).toBeVisible();
+    expect(getByTestId("test1.png")).toBeVisible();
     const chips = getAllByTestId("uploaded-file-chip");
     expect(chips).toHaveLength(1);
     expect(chips[0]).toHaveTextContent("Heritage statement");

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListSubheader from "@mui/material/ListSubheader";
+import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { PublicProps } from "@planx/components/shared/types";
@@ -238,22 +239,24 @@ function Component(props: Props) {
                 removeFile={removeFile}
               />
             )}
-            {slots.map((slot) => {
-              return (
-                <ErrorWrapper
-                  error={fileLabelErrors?.[slot.id]}
-                  id={slot.id}
-                  key={slot.id}
-                >
-                  <UploadedFileCard
-                    {...slot}
-                    tags={getTagsForSlot(slot.id, fileList)}
-                    onChange={onUploadedFileCardChange}
-                    removeFile={() => removeFile(slot)}
-                  />
-                </ErrorWrapper>
-              );
-            })}
+            <Stack spacing={2}>
+              {slots.map((slot) => {
+                return (
+                  <ErrorWrapper
+                    error={fileLabelErrors?.[slot.id]}
+                    id={slot.id}
+                    key={slot.id}
+                  >
+                    <UploadedFileCard
+                      {...slot}
+                      tags={getTagsForSlot(slot.id, fileList)}
+                      onChange={onUploadedFileCardChange}
+                      removeFile={() => removeFile(slot)}
+                    />
+                  </ErrorWrapper>
+                );
+              })}
+            </Stack>
           </Box>
         </ErrorWrapper>
       </FullWidthWrapper>

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -240,22 +240,20 @@ function Component(props: Props) {
               />
             )}
             <Stack spacing={2}>
-              {slots.map((slot) => {
-                return (
-                  <ErrorWrapper
-                    error={fileLabelErrors?.[slot.id]}
-                    id={slot.id}
-                    key={slot.id}
-                  >
-                    <UploadedFileCard
-                      {...slot}
-                      tags={getTagsForSlot(slot.id, fileList)}
-                      onChange={onUploadedFileCardChange}
-                      removeFile={() => removeFile(slot)}
-                    />
-                  </ErrorWrapper>
-                );
-              })}
+              {slots.map((slot) => (
+                <ErrorWrapper
+                  error={fileLabelErrors?.[slot.id]}
+                  id={slot.id}
+                  key={slot.id}
+                >
+                  <UploadedFileCard
+                    {...slot}
+                    tags={getTagsForSlot(slot.id, fileList)}
+                    onChange={onUploadedFileCardChange}
+                    removeFile={() => removeFile(slot)}
+                  />
+                </ErrorWrapper>
+              ))}
             </Stack>
           </Box>
         </ErrorWrapper>

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
@@ -33,20 +33,18 @@ export const PrivateFileUpload: React.FC<PrivateFileUploadProps> = ({
         />
       )}
       <Stack spacing={2} sx={{ marginTop: 2 }}>
-        {slots.map((slot) => {
-          return (
-            <UploadedFileCard
-              {...slot}
-              key={slot.id}
-              removeFile={() => {
-                setSlots(
-                  slots.filter((currentSlot) => currentSlot.file !== slot.file),
-                );
-                setFileUploadStatus(`${slot.file.path} was deleted`);
-              }}
-            />
-          );
-        })}
+        {slots.map((slot) => (
+          <UploadedFileCard
+            {...slot}
+            key={slot.id}
+            removeFile={() => {
+              setSlots(
+                slots.filter((currentSlot) => currentSlot.file !== slot.file),
+              );
+              setFileUploadStatus(`${slot.file.path} was deleted`);
+            }}
+          />
+        ))}
       </Stack>
       <FileStatus status={fileUploadStatus} />
     </>

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
@@ -1,3 +1,4 @@
+import Stack from "@mui/material/Stack";
 import { FileUploadSlot } from "@planx/components/FileUpload/model";
 import { Dropzone } from "@planx/components/shared/PrivateFileUpload/Dropzone";
 import { UploadedFileCard } from "@planx/components/shared/PrivateFileUpload/UploadedFileCard";
@@ -31,20 +32,22 @@ export const PrivateFileUpload: React.FC<PrivateFileUploadProps> = ({
           maxFiles={maxFiles}
         />
       )}
-      {slots.map((slot) => {
-        return (
-          <UploadedFileCard
-            {...slot}
-            key={slot.id}
-            removeFile={() => {
-              setSlots(
-                slots.filter((currentSlot) => currentSlot.file !== slot.file),
-              );
-              setFileUploadStatus(`${slot.file.path} was deleted`);
-            }}
-          />
-        );
-      })}
+      <Stack spacing={2} sx={{ marginTop: 2 }}>
+        {slots.map((slot) => {
+          return (
+            <UploadedFileCard
+              {...slot}
+              key={slot.id}
+              removeFile={() => {
+                setSlots(
+                  slots.filter((currentSlot) => currentSlot.file !== slot.file),
+                );
+                setFileUploadStatus(`${slot.file.path} was deleted`);
+              }}
+            />
+          );
+        })}
+      </Stack>
       <FileStatus status={fileUploadStatus} />
     </>
   );

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -1,5 +1,5 @@
 import FileIcon from "@mui/icons-material/AttachFile";
-import DeleteIcon from "@mui/icons-material/DeleteOutline";
+import DeleteIcon from "@mui/icons-material/Delete";
 import Box, { BoxProps } from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
@@ -21,16 +21,18 @@ interface Props extends FileUploadSlot {
   FileCardProps?: BoxProps;
 }
 
-const Root = styled(Box)(({ theme }) => ({
-  marginTop: theme.spacing(5),
-}));
-
 const FileCard = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   position: "relative",
   height: "auto",
   display: "flex",
-  alignItems: "center",
+  flexDirection: "column",
+  alignItems: "flex-end",
+  gap: theme.spacing(1),
+  [theme.breakpoints.up("md")]: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
   padding: theme.spacing(0.5, 1.5),
   "& > *": {
     zIndex: 1,
@@ -41,7 +43,6 @@ const FilePreview = styled(Box)(({ theme }) => ({
   height: theme.spacing(10),
   width: theme.spacing(10),
   marginLeft: theme.spacing(-1),
-  marginRight: theme.spacing(1.5),
   opacity: 0.75,
   position: "relative",
   overflow: "hidden",
@@ -79,7 +80,8 @@ const FileSize = styled(Typography)(({ theme }) => ({
 
 const TagRoot = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
-  borderTop: `1px solid ${theme.palette.border.main}`,
+  border: `1px solid ${theme.palette.border.main}`,
+  borderTop: "none",
   display: "flex",
   justifyContent: "space-between",
   flexWrap: "wrap",
@@ -97,7 +99,7 @@ export const UploadedFileCard: React.FC<Props> = ({
   status,
   FileCardProps,
 }) => (
-  <Root>
+  <Box>
     <ErrorWrapper
       error={
         status === "error"
@@ -113,20 +115,22 @@ export const UploadedFileCard: React.FC<Props> = ({
             aria-valuenow={progress * 100 || 0}
             aria-label={file.name}
           />
-          <FilePreview>
-            {file instanceof File && file?.type?.includes("image") ? (
-              <ImagePreview file={file} url={url} />
-            ) : (
-              <FileIcon />
-            )}
-          </FilePreview>
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
+              justifyContent: "flex-start",
+              gap: 1,
+              alignItems: "center",
               width: "100%",
             }}
           >
+            <FilePreview>
+              {file instanceof File && file?.type?.includes("image") ? (
+                <ImagePreview file={file} url={url} />
+              ) : (
+                <FileIcon />
+              )}
+            </FilePreview>
             <Box mr={2}>
               <Typography
                 variant="body1"
@@ -137,17 +141,19 @@ export const UploadedFileCard: React.FC<Props> = ({
               </Typography>
               <FileSize variant="body2">{formatBytes(file.size)}</FileSize>
             </Box>
-            {removeFile && (
-              <IconButton
-                size="small"
-                aria-label={`Delete ${file.name}`}
-                title={`Delete ${file.name}`}
-                onClick={removeFile}
-              >
-                <DeleteIcon />
-              </IconButton>
-            )}
           </Box>
+          {removeFile && (
+            <IconButton
+              size="small"
+              aria-label={`Delete ${file.name}`}
+              title={`Delete ${file.name}`}
+              onClick={removeFile}
+              sx={{ gap: "3px" }}
+            >
+              <DeleteIcon color="warning" />
+              Delete
+            </IconButton>
+          )}
         </FileCard>
         {tags && (
           <TagRoot>
@@ -183,7 +189,7 @@ export const UploadedFileCard: React.FC<Props> = ({
         )}
       </>
     </ErrorWrapper>
-  </Root>
+  </Box>
 );
 
 function formatBytes(a: number, b = 2) {

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -145,13 +145,12 @@ export const UploadedFileCard: React.FC<Props> = ({
           {removeFile && (
             <IconButton
               size="small"
-              aria-label={`Delete ${file.name}`}
               title={`Delete ${file.name}`}
               onClick={removeFile}
               sx={{ gap: "3px" }}
             >
               <DeleteIcon color="warning" />
-              Delete
+              Delete <span style={visuallyHidden}>{file.name}</span>
             </IconButton>
           )}
         </FileCard>

--- a/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -136,6 +136,7 @@ export const UploadedFileCard: React.FC<Props> = ({
                 variant="body1"
                 pb="0.25em"
                 sx={{ overflowWrap: "break-word", wordBreak: "break-all" }}
+                data-testid={file.name}
               >
                 {file.name}
               </Typography>
@@ -148,6 +149,7 @@ export const UploadedFileCard: React.FC<Props> = ({
               title={`Delete ${file.name}`}
               onClick={removeFile}
               sx={{ gap: "3px" }}
+              data-testid={`delete-${file.name}`}
             >
               <DeleteIcon color="warning" />
               Delete <span style={visuallyHidden}>{file.name}</span>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/AddCommentDialog.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/AddCommentDialog.tsx
@@ -79,7 +79,7 @@ export const AddCommentDialog = ({
             </InputLabel>
           </Box>
         </DialogContent>
-        <DialogActions sx={{ paddingX: 2 }}>
+        <DialogActions>
           <Button disableRipple onClick={() => setDialogOpen(false)}>
             BACK
           </Button>

--- a/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -105,9 +105,9 @@ export const AddFlow: React.FC = () => {
                 >
                   <BaseFormSection />
                 </DialogContent>
-                <DialogActions sx={{ paddingX: 2 }}>
-                  <Button 
-                    disableRipple 
+                <DialogActions>
+                  <Button
+                    disableRipple
                     onClick={() => setDialogOpen(false)}
                     disabled={isSubmitting}
                   >

--- a/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
+++ b/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
@@ -21,13 +21,17 @@ interface Props {
   isDialogOpen: boolean;
   handleClose: () => void;
   sourceFlow: {
-    name: string,
-    slug: string,
-    id: string,
-  }
+    name: string;
+    slug: string;
+    id: string;
+  };
 }
 
-export const CopyDialog: React.FC<Props> = ({ isDialogOpen, handleClose, sourceFlow }) => {
+export const CopyDialog: React.FC<Props> = ({
+  isDialogOpen,
+  handleClose,
+  sourceFlow,
+}) => {
   const { teamId, createFlowFromCopy } = useStore();
 
   const initialValues: CreateFlow = {
@@ -42,11 +46,14 @@ export const CopyDialog: React.FC<Props> = ({ isDialogOpen, handleClose, sourceF
 
   const toast = useToast();
 
-  const onSubmit: FormikConfig<CreateFlow>["onSubmit"] = async ({ flow }, { setFieldError }) => {
+  const onSubmit: FormikConfig<CreateFlow>["onSubmit"] = async (
+    { flow },
+    { setFieldError },
+  ) => {
     try {
       await createFlowFromCopy(flow);
       handleClose();
-      toast.success(`Created new flow "${flow.name}"`)
+      toast.success(`Created new flow "${flow.name}"`);
     } catch (error) {
       if (isAxiosError(error)) {
         const message = error?.response?.data?.error;
@@ -67,7 +74,14 @@ export const CopyDialog: React.FC<Props> = ({ isDialogOpen, handleClose, sourceF
       validateOnChange={false}
       validationSchema={validationSchema}
     >
-      {({ resetForm, isSubmitting, getFieldProps, setFieldValue, errors, values }) => (
+      {({
+        resetForm,
+        isSubmitting,
+        getFieldProps,
+        setFieldValue,
+        errors,
+        values,
+      }) => (
         <Dialog
           open={isDialogOpen}
           onClose={() => {
@@ -113,7 +127,7 @@ export const CopyDialog: React.FC<Props> = ({ isDialogOpen, handleClose, sourceF
                   />
                 </InputLabel>
               </DialogContent>
-              <DialogActions sx={{ paddingX: 2 }}>
+              <DialogActions>
                 <Button
                   disableRipple
                   onClick={handleClose}

--- a/editor.planx.uk/src/pages/Team/components/RenameDialog.tsx
+++ b/editor.planx.uk/src/pages/Team/components/RenameDialog.tsx
@@ -26,10 +26,10 @@ interface Props {
   isDialogOpen: boolean;
   handleClose: () => void;
   flow: {
-    name: string,
-    slug: string,
-    id: string,
-  }
+    name: string;
+    slug: string;
+    id: string;
+  };
 }
 
 const validationSchema = object().shape({
@@ -37,10 +37,17 @@ const validationSchema = object().shape({
   flowSlug: string().trim().required("Slug is required"),
 });
 
-export const RenameDialog: React.FC<Props> = ({ isDialogOpen, handleClose, flow }) => {
+export const RenameDialog: React.FC<Props> = ({
+  isDialogOpen,
+  handleClose,
+  flow,
+}) => {
   const toast = useToast();
 
-  const onSubmit: FormikConfig<RenameFlow>["onSubmit"] = async ({ flowName, flowSlug }, { setFieldError, setSubmitting }) => {
+  const onSubmit: FormikConfig<RenameFlow>["onSubmit"] = async (
+    { flowName, flowSlug },
+    { setFieldError, setSubmitting },
+  ) => {
     try {
       await client.mutate({
         mutation: gql`
@@ -64,12 +71,12 @@ export const RenameDialog: React.FC<Props> = ({ isDialogOpen, handleClose, flow 
         },
       });
       handleClose();
-      toast.success(`Renamed flow to "${flowName}"`)
+      toast.success(`Renamed flow to "${flowName}"`);
     } catch (error) {
-      const isUniqueSlugError = 
-        error instanceof Error 
-        && isApolloError(error)
-        && error.message.includes("Uniqueness violation");
+      const isUniqueSlugError =
+        error instanceof Error &&
+        isApolloError(error) &&
+        error.message.includes("Uniqueness violation");
 
       if (isUniqueSlugError) {
         setFieldError("flowName", "Flow name must be unique");
@@ -90,7 +97,14 @@ export const RenameDialog: React.FC<Props> = ({ isDialogOpen, handleClose, flow 
       validateOnChange={false}
       validationSchema={validationSchema}
     >
-      {({ resetForm, isSubmitting, getFieldProps, setFieldValue, errors, values }) => (
+      {({
+        resetForm,
+        isSubmitting,
+        getFieldProps,
+        setFieldValue,
+        errors,
+        values,
+      }) => (
         <Dialog
           open={isDialogOpen}
           onClose={() => {
@@ -136,7 +150,7 @@ export const RenameDialog: React.FC<Props> = ({ isDialogOpen, handleClose, flow 
                   />
                 </InputLabel>
               </DialogContent>
-              <DialogActions sx={{ paddingX: 2 }}>
+              <DialogActions>
                 <Button
                   disableRipple
                   onClick={handleClose}

--- a/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -125,11 +125,11 @@ export const AddTeamButton: React.FC = () => {
                   />
                   <Typography variant="body2" mt={-2}>
                     A trial account has limited access to PlanX functionality
-                    (e.g. turning services online). Trial accounts can be promoted to
-                    having full access via the settings panel.
+                    (e.g. turning services online). Trial accounts can be
+                    promoted to having full access via the settings panel.
                   </Typography>
                 </DialogContent>
-                <DialogActions sx={{ paddingX: 2 }}>
+                <DialogActions>
                   <Button
                     disableRipple
                     disabled={isSubmitting}

--- a/editor.planx.uk/src/theme.ts
+++ b/editor.planx.uk/src/theme.ts
@@ -543,7 +543,28 @@ const getThemeOptions = ({
             borderRadius: 0,
             borderTop: `20px solid ${palette.primary.main}`,
             background: theme.palette.background.paper,
-            margin: theme.spacing(2),
+            margin: theme.spacing(1),
+          }),
+        },
+      },
+      MuiDialogContent: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            padding: theme.spacing(2),
+          }),
+        },
+      },
+      MuiDialogActions: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            padding: theme.spacing(2),
+          }),
+        },
+      },
+      MuiDialogTitle: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            padding: theme.spacing(2),
           }),
         },
       },
@@ -850,7 +871,7 @@ const generateTeamTheme = (
     linkColour: DEFAULT_PRIMARY_COLOR,
     logo: null,
     favicon: null,
-  }
+  },
 ): MUITheme => {
   const themeOptions = getThemeOptions(teamTheme);
   const theme = responsiveFontSizes(createTheme(themeOptions), { factor: 3 });


### PR DESCRIPTION
## What does this PR do?

Address a usability issue and tides up layout and styles for files upload cards (upload and upload & label).

- Adds "delete" text to delete button (usability fix https://trello.com/c/SgOvRdxF/3347-icons-and-labels-usability-p79)
- Refactors layout to accommodate for text
- Simplifies card layout using semantic React `<Stack>`
- Sets default dialog padding in theme for `dialogContent`, `dialogTitle` and `dialogActions` to improve small screen usability and prevent overrides

**Testing:**
https://5055.planx.pizza/a-new-team/uploading/preview