### PR TITLE
fix: date input usability improvements

### DIFF
--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import { visuallyHidden } from "@mui/utils";
 import {
   DateInput,
   dateInputValidationSchema,
@@ -9,7 +8,7 @@ import Card from "@planx/components/shared/Preview/Card";
 import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
 import { PublicProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
-import React from "react";
+import React, { useId } from "react";
 import DateInputComponent from "ui/shared/DateInput/DateInput";
 import InputRow from "ui/shared/InputRow";
 import { object } from "yup";
@@ -20,6 +19,8 @@ import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 export type Props = PublicProps<DateInput>;
 
 const DateInputPublic: React.FC<Props> = (props) => {
+  const componentId = useId();
+
   const formik = useFormik({
     initialValues: {
       date: getPreviouslySubmittedData(props) ?? "",
@@ -37,7 +38,6 @@ const DateInputPublic: React.FC<Props> = (props) => {
   return (
     <Card handleSubmit={formik.handleSubmit}>
       <Box
-        component="fieldset"
         role="group"
         aria-describedby={[
           props.description ? DESCRIPTION_TEXT : "",
@@ -46,7 +46,6 @@ const DateInputPublic: React.FC<Props> = (props) => {
           .filter(Boolean)
           .join(" ")}
       >
-        <legend style={visuallyHidden}>{props.title}</legend>
         <CardHeader
           title={props.title}
           description={props.description}
@@ -63,7 +62,7 @@ const DateInputPublic: React.FC<Props> = (props) => {
               formik.setFieldValue("date", paddedDate(newDate, eventType));
             }}
             error={formik.errors.date as string}
-            id={props.id}
+            id={componentId}
           />
         </InputRow>
       </Box>

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -19,7 +19,8 @@ import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 export type Props = PublicProps<DateInput>;
 
 const DateInputPublic: React.FC<Props> = (props) => {
-  const componentId = useId();
+  const uniqueId = useId();
+  const componentId = props.id ? props.id : uniqueId;
 
   const formik = useFormik({
     initialValues: {


### PR DESCRIPTION
DAC (pg 71)

This PR fixes various labels being repeatedly read aloud by screen readers. It removes the visually hidden legend element as this information is repeated in the card header and also corrects the fact that sometime the element was not being correctly passes an id so the id used the correct the label to the input was undefined and was causing some unexpected behaviors.

**Testing and accessibility improvements:**

* The test for accessibility violations in `DateInput` now dynamically finds all error elements and checks that they are empty before submission, and ensures that after triggering an error, at least one error message appears with the correct `role="alert"` attribute. This makes the test more robust and less dependent on hardcoded IDs.

**Component code improvements:**

* The `DateInputPublic` component now uses React's `useId` hook to generate a unique ID for the component instance, replacing the use of the `id` prop for the input element. This helps prevent ID collisions when multiple instances are rendered. [[1]](diffhunk://#diff-c234a774f5774bf9aa9a4ee7590633c72ed0f0d66b93ecbad652b02e2b5fbd06L12-R11) [[2]](diffhunk://#diff-c234a774f5774bf9aa9a4ee7590633c72ed0f0d66b93ecbad652b02e2b5fbd06R22-R23) [[3]](diffhunk://#diff-c234a774f5774bf9aa9a4ee7590633c72ed0f0d66b93ecbad652b02e2b5fbd06L66-R65)
* The unnecessary import of `visuallyHidden` from `@mui/utils` was removed, and the visually hidden `<legend>` element was also removed from the markup, simplifying the component structure. [[1]](diffhunk://#diff-c234a774f5774bf9aa9a4ee7590633c72ed0f0d66b93ecbad652b02e2b5fbd06L2) [[2]](diffhunk://#diff-c234a774f5774bf9aa9a4ee7590633c72ed0f0d66b93ecbad652b02e2b5fbd06L49)
* The `fieldset` element was removed from the `Box` component wrapper, further simplifying the DOM structure and improving semantic clarity. 