### PR TITLE
feat: Show progress indicator to users

### DIFF
--- a/editor.planx.uk/src/components/AnalyticsDisabled/AnalyticsDisabledBanner.tsx
+++ b/editor.planx.uk/src/components/AnalyticsDisabled/AnalyticsDisabledBanner.tsx
@@ -36,7 +36,7 @@ const AnalyticsDisabledBanner: React.FC = () => {
       {isAnalyticsDisabled() && showAnalyticsWarning && (
         <AnalyticsWarning>
           <Container
-            maxWidth={false}
+            maxWidth="contentWrap"
             sx={{
               display: "flex",
               alignItems: "center",

--- a/editor.planx.uk/src/components/Footer/Footer.tsx
+++ b/editor.planx.uk/src/components/Footer/Footer.tsx
@@ -54,19 +54,21 @@ export default function Footer(props: Props) {
 
   return (
     <Root>
-      <Container maxWidth={false}>
-        {lastPublishedDate && 
+      <Container maxWidth="contentWrap">
+        {lastPublishedDate && (
           <Box pb={2}>
             <Typography variant="body2">
               {formatServiceLastUpdated(lastPublishedDate)}
             </Typography>
           </Box>
-        }
+        )}
         {items && items.length > 0 && (
           <ButtonGroup pb={2.5}>
             {items
               ?.filter((item) => item.title)
-              .map((item) => <FooterItem {...item} key={item.title} />)}
+              .map((item) => (
+                <FooterItem {...item} key={item.title} />
+              ))}
           </ButtonGroup>
         )}
         <Box>{children}</Box>

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -312,7 +312,7 @@ const PublicToolbar: React.FC<{
     <>
       <SkipLink />
       <PublicHeader disableGutters>
-        <Container maxWidth={false}>
+        <Container maxWidth="contentWrap">
           <InnerContainer>
             <LeftBox>
               {teamTheme?.logo ? <TeamLogo /> : <Breadcrumbs />}

--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -20,7 +20,6 @@ import { styled, Theme } from "@mui/material/styles";
 import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import axios from "axios";
 import { clearLocalFlowIdb } from "lib/local.idb";
 import { capitalize } from "lodash";
@@ -46,6 +45,7 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 import { rootFlowPath } from "../../routes/utils";
 import AnalyticsDisabledBanner from "../AnalyticsDisabled/AnalyticsDisabledBanner";
 import { ConfirmationDialog } from "../ConfirmationDialog";
+import { SectionNavBar } from "./Sections/NavBar";
 import SkipLink from "./SkipLink";
 
 export const HEADER_HEIGHT_PUBLIC = 74;
@@ -169,22 +169,6 @@ const ServiceTitleRoot = styled("span")(({ theme }) => ({
   },
 }));
 
-const StyledNavBar = styled("nav")(({ theme }) => ({
-  backgroundColor: theme.palette.primary.dark,
-  fontSize: 16,
-  paddingTop: theme.spacing(1),
-  paddingBottom: theme.spacing(1),
-}));
-
-const SectionName = styled(Typography)(() => ({
-  fontSize: "inherit",
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,
-}));
-
-const SectionCount = styled(Typography)(() => ({
-  fontSize: "inherit",
-}));
-
 const TeamLogo: React.FC = () => {
   const [teamSettings, teamName, teamTheme] = useStore((state) => [
     state.teamSettings,
@@ -282,48 +266,6 @@ const Breadcrumbs: React.FC = () => {
   );
 };
 
-const NavBar: React.FC = () => {
-  const [index, sectionCount, title, hasSections, saveToEmail, path, node] =
-    useStore((state) => [
-      state.currentSectionIndex,
-      state.sectionCount,
-      state.currentSectionTitle,
-      state.hasSections,
-      state.saveToEmail,
-      state.path,
-      state.currentCard,
-    ]);
-  const isSaveAndReturnLandingPage =
-    path !== ApplicationPath.SingleSession && !saveToEmail;
-  const isContentPage = useCurrentRoute()?.data?.isContentPage;
-  const isSectionCard = node?.type == TYPES.Section;
-  const isVisible =
-    hasSections &&
-    !isSaveAndReturnLandingPage &&
-    !isContentPage &&
-    !isSectionCard;
-
-  return (
-    <>
-      {isVisible && (
-        <StyledNavBar data-testid="navigation-bar">
-          <Container
-            maxWidth={false}
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-            }}
-          >
-            <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
-            <SectionName>{capitalize(title)}</SectionName>
-          </Container>
-        </StyledNavBar>
-      )}
-    </>
-  );
-};
-
 const PublicToolbar: React.FC<{
   showResetButton?: boolean;
 }> = ({ showResetButton = true }) => {
@@ -407,7 +349,7 @@ const PublicToolbar: React.FC<{
           <ServiceTitle />
         </Container>
       )}
-      <NavBar />
+      <SectionNavBar />
       <AnalyticsDisabledBanner />
       <ConfirmationDialog
         open={isDialogOpen}

--- a/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
@@ -28,25 +28,35 @@ const SectionCount = styled(Typography)(() => ({
 }));
 
 export const SectionNavBar: React.FC = () => {
-  const [index, sectionCount, title, hasSections, saveToEmail, path, node] =
-    useStore((state) => [
-      state.currentSectionIndex,
-      state.sectionCount,
-      state.currentSectionTitle,
-      state.hasSections,
-      state.saveToEmail,
-      state.path,
-      state.currentCard,
-    ]);
+  const [
+    index,
+    sectionCount,
+    title,
+    hasSections,
+    saveToEmail,
+    path,
+    node,
+    isFinalCard,
+  ] = useStore((state) => [
+    state.currentSectionIndex,
+    state.sectionCount,
+    state.currentSectionTitle,
+    state.hasSections,
+    state.saveToEmail,
+    state.path,
+    state.currentCard,
+    state.isFinalCard(),
+  ]);
   const isSaveAndReturnLandingPage =
     path !== ApplicationPath.SingleSession && !saveToEmail;
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
-  const isSectionCard = node?.type == TYPES.Section;
+  // const isSectionCard = node?.type == TYPES.Section;
   const isVisible =
     hasSections &&
     !isSaveAndReturnLandingPage &&
     !isContentPage &&
-    !isSectionCard;
+    // !isSectionCard &&
+    !isFinalCard;
 
   if (!isVisible) return null;
 

--- a/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
@@ -62,6 +62,7 @@ export const SectionNavBar: React.FC = () => {
       >
         <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
         <SectionName>{capitalize(title)}</SectionName>
+        <ProgressBar />
       </Container>
     </StyledNavBar>
   );

--- a/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
@@ -1,7 +1,7 @@
+import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { capitalize } from "lodash";
 import React from "react";
 import { useCurrentRoute } from "react-navi";
@@ -13,18 +13,7 @@ import { ProgressBar } from "./ProgressBar";
 
 const StyledNavBar = styled("nav")(({ theme }) => ({
   backgroundColor: theme.palette.primary.dark,
-  fontSize: 16,
-  paddingTop: theme.spacing(1),
-  paddingBottom: theme.spacing(1),
-}));
-
-const SectionName = styled(Typography)(() => ({
-  fontSize: "inherit",
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,
-}));
-
-const SectionCount = styled(Typography)(() => ({
-  fontSize: "inherit",
+  padding: theme.spacing(1.5, 0),
 }));
 
 export const SectionNavBar: React.FC = () => {
@@ -49,15 +38,29 @@ export const SectionNavBar: React.FC = () => {
   return (
     <StyledNavBar data-testid="navigation-bar">
       <Container
-        maxWidth={false}
+        maxWidth="contentWrap"
         sx={{
           display: "flex",
           flexDirection: "column",
-          justifyContent: "center",
+          gap: 0.5,
         }}
       >
-        <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
-        <SectionName>{capitalize(title)}</SectionName>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 1,
+          }}
+        >
+          <Typography
+            variant="body2"
+            sx={{ whiteSpace: "nowrap" }}
+          >{`Section ${index} of ${sectionCount}`}</Typography>
+          <Typography component="span">—</Typography>
+          <Typography variant="body2" fontWeight={FONT_WEIGHT_SEMI_BOLD}>
+            {capitalize(title)}
+          </Typography>
+        </Box>
         <ProgressBar />
       </Container>
     </StyledNavBar>

--- a/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
@@ -1,0 +1,68 @@
+import Container from "@mui/material/Container";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { capitalize } from "lodash";
+import React from "react";
+import { useCurrentRoute } from "react-navi";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { ApplicationPath } from "types";
+
+import { useStore } from "../../../pages/FlowEditor/lib/store";
+import { ProgressBar } from "./ProgressBar";
+
+const StyledNavBar = styled("nav")(({ theme }) => ({
+  backgroundColor: theme.palette.primary.dark,
+  fontSize: 16,
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
+}));
+
+const SectionName = styled(Typography)(() => ({
+  fontSize: "inherit",
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+}));
+
+const SectionCount = styled(Typography)(() => ({
+  fontSize: "inherit",
+}));
+
+export const SectionNavBar: React.FC = () => {
+  const [index, sectionCount, title, hasSections, saveToEmail, path, node] =
+    useStore((state) => [
+      state.currentSectionIndex,
+      state.sectionCount,
+      state.currentSectionTitle,
+      state.hasSections,
+      state.saveToEmail,
+      state.path,
+      state.currentCard,
+    ]);
+  const isSaveAndReturnLandingPage =
+    path !== ApplicationPath.SingleSession && !saveToEmail;
+  const isContentPage = useCurrentRoute()?.data?.isContentPage;
+  const isSectionCard = node?.type == TYPES.Section;
+  const isVisible =
+    hasSections &&
+    !isSaveAndReturnLandingPage &&
+    !isContentPage &&
+    !isSectionCard;
+
+  if (!isVisible) return null;
+
+  return (
+    <StyledNavBar data-testid="navigation-bar">
+      <Container
+        maxWidth={false}
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <SectionCount>{`Section ${index} of ${sectionCount}`}</SectionCount>
+        <SectionName>{capitalize(title)}</SectionName>
+      </Container>
+    </StyledNavBar>
+  );
+};

--- a/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
@@ -28,35 +28,21 @@ const SectionCount = styled(Typography)(() => ({
 }));
 
 export const SectionNavBar: React.FC = () => {
-  const [
-    index,
-    sectionCount,
-    title,
-    hasSections,
-    saveToEmail,
-    path,
-    node,
-    isFinalCard,
-  ] = useStore((state) => [
-    state.currentSectionIndex,
-    state.sectionCount,
-    state.currentSectionTitle,
-    state.hasSections,
-    state.saveToEmail,
-    state.path,
-    state.currentCard,
-    state.isFinalCard(),
-  ]);
+  const [index, sectionCount, title, hasSections, saveToEmail, path] = useStore(
+    (state) => [
+      state.currentSectionIndex,
+      state.sectionCount,
+      state.currentSectionTitle,
+      state.hasSections,
+      state.saveToEmail,
+      state.path,
+    ],
+  );
   const isSaveAndReturnLandingPage =
     path !== ApplicationPath.SingleSession && !saveToEmail;
   const isContentPage = useCurrentRoute()?.data?.isContentPage;
-  // const isSectionCard = node?.type == TYPES.Section;
   const isVisible =
-    hasSections &&
-    !isSaveAndReturnLandingPage &&
-    !isContentPage &&
-    // !isSectionCard &&
-    !isFinalCard;
+    hasSections && !isSaveAndReturnLandingPage && !isContentPage;
 
   if (!isVisible) return null;
 

--- a/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
@@ -1,0 +1,40 @@
+import LinearProgress, {
+  linearProgressClasses,
+} from "@mui/material/LinearProgress";
+import { styled } from "@mui/material/styles";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+const Root = styled(LinearProgress)(({ theme }) => ({
+  marginTop: theme.spacing(0.5),
+  height: theme.spacing(1),
+  // Background
+  [`& .${linearProgressClasses.dashed}`]: {
+    animation: "none",
+    backgroundImage: "none",
+    backgroundColor: theme.palette.background.paper,
+  },
+  // Completed
+  [`& .${linearProgressClasses.bar1Buffer}`]: {
+    backgroundColor: theme.palette.primary.light,
+  },
+  // Current
+  [`& .${linearProgressClasses.bar2Buffer}`]: {
+    backgroundColor: theme.palette.action,
+  },
+}));
+
+export const ProgressBar: React.FC = () => {
+  const { completed, current } = useStore((state) =>
+    state.getSectionProgress(),
+  );
+
+  return (
+    // TODO: a11y
+    <Root
+      variant="buffer"
+      value={completed}
+      valueBuffer={current + completed}
+    />
+  );
+};

--- a/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
@@ -6,21 +6,22 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 const Root = styled(LinearProgress)(({ theme }) => ({
-  marginTop: theme.spacing(0.5),
-  height: theme.spacing(1),
+  height: theme.spacing(2),
   // Background
   [`& .${linearProgressClasses.dashed}`]: {
     animation: "none",
     backgroundImage: "none",
-    backgroundColor: theme.palette.background.paper,
+    backgroundColor: `rgba(255, 255, 255, 0.3)`,
   },
   // Completed
   [`& .${linearProgressClasses.bar1Buffer}`]: {
-    backgroundColor: theme.palette.primary.light,
+    backgroundColor: theme.palette.common.white,
   },
   // Current
   [`& .${linearProgressClasses.bar2Buffer}`]: {
-    backgroundColor: theme.palette.action,
+    backgroundColor: "transparent",
+    backgroundImage: `linear-gradient(135deg, rgba(255, 255, 255, 0.9) 12.50%, transparent 12.50%, transparent 50%, rgba(255, 255, 255, 0.9) 50%, rgba(255, 255, 255, 0.9) 62.50%, transparent 62.50%, transparent 100%)`,
+    backgroundSize: "4.24px 4.24px",
   },
 }));
 

--- a/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
@@ -7,6 +7,7 @@ import React from "react";
 
 const Root = styled(LinearProgress)(({ theme }) => ({
   height: theme.spacing(2),
+  borderRadius: theme.spacing(2),
   // Background
   [`& .${linearProgressClasses.dashed}`]: {
     animation: "none",

--- a/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
@@ -30,11 +30,11 @@ export const ProgressBar: React.FC = () => {
   );
 
   return (
-    // TODO: a11y
     <Root
       variant="buffer"
       value={completed}
       valueBuffer={current + completed}
+      aria-label="Section progress bar"
     />
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -171,7 +171,7 @@ export const navigationStore: StateCreator<
     const index = currentSectionIndex - 1;
 
     const sectionWeights = Object.values(sectionNodes).map(
-      ({ data: { size } }) => SECTION_WEIGHTS[size],
+      ({ data: { size = "medium" } }) => SECTION_WEIGHTS[size],
     );
     const totalWeight = sum(sectionWeights);
     const currentWeight = sectionWeights[index];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -177,8 +177,6 @@ export const navigationStore: StateCreator<
     const currentWeight = sectionWeights[index];
     const currentPercentage = (currentWeight / totalWeight) * 100;
 
-    if (!index) return { completed: 0, current: currentPercentage };
-
     const completedWeight = sum(sectionWeights.slice(0, index));
     const completedPercentage = (completedWeight / totalWeight) * 100;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -187,7 +187,7 @@ export const navigationStore: StateCreator<
     const index = currentSectionIndex - 1;
 
     const sectionWeights = Object.values(sectionNodes).map(
-      ({ data: { size = "medium" } }) => SECTION_WEIGHTS[size],
+      ({ data: { length = "medium" } }) => SECTION_WEIGHTS[length],
     );
     const totalWeight = sum(sectionWeights);
     const currentWeight = sectionWeights[index];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -72,7 +72,7 @@ export const navigationStore: StateCreator<
    * Triggered when going backwards, forwards, or changing answer
    */
   updateSectionData: () => {
-    const { breadcrumbs, sectionNodes, hasSections } = get();
+    const { breadcrumbs, sectionNodes, hasSections, currentCard } = get();
     // Sections not being used, do not proceed
     if (!hasSections) return;
 
@@ -87,9 +87,14 @@ export const navigationStore: StateCreator<
     // No sections in breadcrumbs, first section values already set in store
     if (!mostRecentSectionId) return;
 
-    // Update section
     const currentSectionTitle = sectionNodes[mostRecentSectionId].data.title;
-    const currentSectionIndex = sectionIds.indexOf(mostRecentSectionId) + 1;
+    let currentSectionIndex = sectionIds.indexOf(mostRecentSectionId) + 1;
+
+    // Transition to a new section index as soon as a section is reached
+    // It won't yet be in the breadcrumbs but should count as the starting point of the next section
+    const isSectionCardReached = currentCard?.type === TYPES.Section;
+    if (isSectionCardReached) currentSectionIndex++;
+
     set({ currentSectionTitle, currentSectionIndex });
     console.debug("section state updated"); // used as a transition trigger in e2e tests
   },
@@ -166,7 +171,9 @@ export const navigationStore: StateCreator<
   },
 
   getSectionProgress: () => {
-    const { sectionNodes, currentSectionIndex } = get();
+    const { sectionNodes, currentSectionIndex, isFinalCard } = get();
+    if (isFinalCard()) return { completed: 100, current: 100 };
+
     // Account for offset index
     const index = currentSectionIndex - 1;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -79,6 +79,20 @@ export const navigationStore: StateCreator<
     const breadcrumbIds = Object.keys(breadcrumbs);
     const sectionIds = Object.keys(sectionNodes);
 
+    const hasPassedFirstSection = Boolean(
+      findLast(breadcrumbIds, (breadcrumbId: string) =>
+        sectionIds.includes(breadcrumbId),
+      ),
+    );
+
+    // No sections in breadcrumbs, first section values already set in store
+    if (!hasPassedFirstSection) return;
+
+    // Transition to a new section index as soon as a section is reached
+    // It won't yet be in the breadcrumbs but should count as the starting point of the next section
+    const isSectionCardReached = currentCard?.type === TYPES.Section;
+    if (isSectionCardReached) breadcrumbIds.push(currentCard.id);
+
     const mostRecentSectionId = findLast(
       breadcrumbIds,
       (breadcrumbId: string) => sectionIds.includes(breadcrumbId),
@@ -88,12 +102,7 @@ export const navigationStore: StateCreator<
     if (!mostRecentSectionId) return;
 
     const currentSectionTitle = sectionNodes[mostRecentSectionId].data.title;
-    let currentSectionIndex = sectionIds.indexOf(mostRecentSectionId) + 1;
-
-    // Transition to a new section index as soon as a section is reached
-    // It won't yet be in the breadcrumbs but should count as the starting point of the next section
-    const isSectionCardReached = currentCard?.type === TYPES.Section;
-    if (isSectionCardReached) currentSectionIndex++;
+    const currentSectionIndex = sectionIds.indexOf(mostRecentSectionId) + 1;
 
     set({ currentSectionTitle, currentSectionIndex });
     console.debug("section state updated"); // used as a transition trigger in e2e tests

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -207,7 +207,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   return (
     <Box width="100%">
       <BackBar hidden={!showBackBar}>
-        <Container maxWidth={false}>
+        <Container maxWidth="contentWrap">
           <BackButton
             variant="link"
             hidden={!showBackButton}


### PR DESCRIPTION
## What does this PR do?
- Refactor: Move `NavBar` to its own file and out of `Header.tsx`
- Adds a `<ProgressBar/>` component to the section nav bar
  - Styles by @ianjon3s - https://github.com/theopensystemslab/planx-new/pull/5060
- Progress is measured by section weight, which is then converted to a percentage for the MUI `LinearProgress` component
  - The current section is shown as a "buffer" to indicate the relative size
  - Weights are scaled exponentially - in future if we find we need more categories or a different scale we can easily amend this
 - Persists the section navbar when section nodes are reached for a more consistent experience. Previously I believe this was hidden as we didn't have a solution for how to count a section node as being the start of the next section. See proposed solution here - 

https://github.com/theopensystemslab/planx-new/blob/5703844f5024a68221e808f41f0429298df31587/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts#L91-L94

https://github.com/user-attachments/assets/435a3e0c-dade-47fe-92f8-1d45fc3e467d