### PR TITLE
fix: display flow name when archiving a flow

### DIFF
--- a/editor.planx.uk/src/pages/Team/components/ArchiveDialog.tsx
+++ b/editor.planx.uk/src/pages/Team/components/ArchiveDialog.tsx
@@ -33,10 +33,10 @@ export const ArchiveDialog = ({
         <DialogContentText>{content}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} color="primary">
+        <Button onClick={onClose} color="secondary" variant="contained">
           Cancel
         </Button>
-        <Button onClick={onConfirm} color="primary">
+        <Button onClick={onConfirm} color="warning" variant="contained">
           {submitLabel}
         </Button>
       </DialogActions>

--- a/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
+++ b/editor.planx.uk/src/pages/Team/components/FlowCard.tsx
@@ -198,14 +198,14 @@ const FlowCard: React.FC<FlowCardProps> = ({
     <>
       {isArchiveDialogOpen && (
         <ArchiveDialog
-          title="Archive service"
+          title={`Archive "${flow.name}"`}
           open={isArchiveDialogOpen}
-          content={`Archiving this service will remove it from PlanX. Services can be restored by an admin`}
+          content={`Are you sure you want to archive "${flow.name}"? Once archived, a flow is no longer able to be viewed in the editor and can only be restored by a developer.`}
           onClose={() => {
             setIsArchiveDialogOpen(false);
           }}
           onConfirm={handleArchive}
-          submitLabel="Archive Service"
+          submitLabel="Archive this flow"
         />
       )}
       {isCopyDialogOpen && (


### PR DESCRIPTION
I'm in the process of cleaning up old services in the "Testing" team and finding it quite unhelpful how generic the existing "Archive" dialog is - so suggesting a few quick sytle updates here! 

**Changes:**
- Clearly display name of flow you're about to archive
- "Warning" button style for "Archive" action
- Update "remove it from PlanX" language as this isn't really technically accurate!

**Before:**
<img width="789" height="230" alt="Screenshot from 2025-08-06 13-17-25" src="https://github.com/user-attachments/assets/c34484e4-5dc9-4997-98d0-878359d00cfa" />

**After:**
<img width="800" height="296" alt="Screenshot from 2025-08-06 13-17-09" src="https://github.com/user-attachments/assets/6b57f0e6-e9bc-434d-8545-1c49dea7d6c9" />