### PR TITLE
chore: bump Metabase load balancer timeout [skip pizza]

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -161,6 +161,7 @@ export = async () => {
     external: true,
     vpc,
     subnets: networking.requireOutput("publicSubnetIds"),
+    idleTimeout: 120,
     securityGroups: [
       new awsx.ec2.SecurityGroup("metabase-custom-port", {
         vpc,


### PR DESCRIPTION
Adds a new `idleTimeout: 120` prop to `lbMetabase` to try and rule out load balancing issues in new permissions error (see [Slack thread](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1754561194131359))