### PR TITLE
chore: update Metabase to v0.55.10 [skip pizza]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   metabase:
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.53.7
+    image: metabase/metabase:v0.55.10
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -211,7 +211,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.53.7",
+        image: "metabase/metabase:v0.55.10",
         portMappings: [metabaseListenerHttp],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
Updates Metabase from 0.53.7 to 0.55.10. Follows #5062 in troubleshooting new permissions errors, hoping version bump will address it.