### PR TITLE
refactor(lps): Move directory from header to be linked

### DIFF
--- a/localplanning.services/src/components/Footer.astro
+++ b/localplanning.services/src/components/Footer.astro
@@ -27,9 +27,12 @@ const legalPages = await getCollection("legal");
         </div>
       </div>
        <div class="flex gap-8">
+          <a class="paragraph-link text-body-md" href="/directory">
+            Directory of local planning authorities
+          </a>
         {
           legalPages.map((page) => (
-            <a class="underline capitalize text-body-md" href={`/${page.slug}`}>
+            <a class="paragraph-link capitalize text-body-md" href={`/${page.slug}`}>
               {page.slug}
             </a>
           ))

--- a/localplanning.services/src/components/Header.astro
+++ b/localplanning.services/src/components/Header.astro
@@ -21,7 +21,7 @@ import SkipLink from "./a11y/SkipLink.astro";
         />
       </a>
       <nav class="flex items-end sm:items-center gap-4 sm:clamp-[gap,4,10] flex-col-reverse sm:flex-row">
-        <ul class="flex clamp-[gap,4,6] xs:clamp-[gap,4,10] items-center justify-between xs:justify-end sm:justify-start w-full xs:w-auto">
+        <ul class="flex clamp-[gap,4,6] xs:clamp-[gap,4,10] items-center justify-end sm:justify-start w-full xs:w-auto">
           <li>
             <a class="paragraph-link font-semibold text-body-md" href="/"
               >Home</a>
@@ -29,10 +29,6 @@ import SkipLink from "./a11y/SkipLink.astro";
           <li>
             <a class="paragraph-link font-semibold text-body-md" href="/search"
               >Find services</a>
-          </li>
-          <li>
-            <a class="paragraph-link font-semibold text-body-md" href="/directory"
-              >Directory</a>
           </li>
           <li>
             <a class="paragraph-link font-semibold text-body-md" href="/about"

--- a/localplanning.services/src/layouts/SearchLayout.astro
+++ b/localplanning.services/src/layouts/SearchLayout.astro
@@ -22,6 +22,9 @@ const { action }: { action?: Action }= Astro.params;
   <Container paddingY>
     <section class="mb-4">
       <PostcodeSearch client:load action={action}/>
+      <div class="styled-content mt-8">
+        <p>or see the <a href="/directory" class="paragraph-link">directory of local planning authorities</a></p>
+      </div>
     </section>
   </Container>
   <ApplicationsBanner />

--- a/localplanning.services/src/pages/directory.astro
+++ b/localplanning.services/src/pages/directory.astro
@@ -11,14 +11,8 @@ const lpas = await fetchAllLPAs();
 ---
 
 <Layout>
-  <Masthead title="Local planning services directory" />
+  <Masthead title="Directory of local planning authorities" />
   <Container paddingY>
-    <section class="flex flex-col mb-6">
-      <label for="search" class="text-body-lg"
-        >Search for a local planning authority</label
-      >
-      <input type="search" id="search" placeholder="Type to search" />
-    </section>
     <section class="flex flex-col gap-4">
       {
         lpas.map((lpa) => (

--- a/localplanning.services/src/styles/global.css
+++ b/localplanning.services/src/styles/global.css
@@ -111,10 +111,12 @@
   .styled-content ol {
     @apply text-text-secondary;
   }
+  .styled-content p {
+     margin-bottom: 0.5em;
+  }
   .styled-content p a {
     @apply text-text-main;
   }
-
   .styled-content {
     @apply max-w-3xl;
     @apply clamp-[text,base,lg];


### PR DESCRIPTION
## What does this PR do?

- Removes `directory` link from header
- Adds to footer with the descriptive title `Directory of local planning authorities`
- Updates page title to the above and removes search box
- Links to directory from search page

https://localplanning.5064.planx.pizza/