### PR TITLE
fix: Ensure restart button handles IDB storage

### DIFF
--- a/editor.planx.uk/src/components/Header/Header.tsx
+++ b/editor.planx.uk/src/components/Header/Header.tsx
@@ -22,7 +22,7 @@ import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import axios from "axios";
-import { clearLocalFlow } from "lib/local";
+import { clearLocalFlowIdb } from "lib/local.idb";
 import { capitalize } from "lodash";
 import { Route } from "navi";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
@@ -353,7 +353,7 @@ const PublicToolbar: React.FC<{
         flowDirection: "reset",
       });
       if (path === ApplicationPath.SingleSession) {
-        clearLocalFlow(id);
+        clearLocalFlowIdb(id);
         window.location.reload();
       } else {
         // Save & Return flow


### PR DESCRIPTION
## What's the problem?
When navigating through a flow which uses IndexedDB to hold local breadcrumbs (any guidance service such as https://editor.planx.dev/camden/find-out-if-you-need-planning-permission/published?analytics=false), it's not possible to "Restart" your journey.

After pressing the button the page refreshes but the user resumes in the same place - not getting reset to the start of the journey. In order to reset I need to clear the `flows` table in IDB.

https://github.com/user-attachments/assets/551d4cd6-e6d8-4393-934e-aed485fbccf6

## What's the solution?
The action triggered on "Restart" just clears local storage (which is no longer used). I've now updated this to clear IDB storage.

https://github.com/user-attachments/assets/9e0201a6-f6a4-49cc-9fbf-1b407b3b5191

## Next steps...
We've now exceeded 28 days since local storage was retired, so there should now be no sessions in the wild which have not been migrated to IDB. We should probably revisit this to remove references to local storage, and remove migration handling (they can no longer be triggered).