### PR TITLE
chore: hard delete all archived flows in "Testing" team

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -25,6 +25,13 @@ object_relationships:
           name: templated_flow_edits
           schema: public
 array_relationships:
+  - name: analytics
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: analytics
+          schema: public
   - name: comments
     using:
       manual_configuration:
@@ -41,6 +48,20 @@ array_relationships:
         table:
           name: flow_document_templates
           schema: public
+  - name: feedback
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: feedback
+          schema: public
+  - name: flow_status_histories
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: flow_status_history
+          schema: public
   - name: lowcal_sessions
     using:
       manual_configuration:
@@ -56,6 +77,13 @@ array_relationships:
         column: flow_id
         table:
           name: operations
+          schema: public
+  - name: payment_statuses
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: payment_status
           schema: public
   - name: published_flows
     using:

--- a/hasura.planx.uk/migrations/default/1754640310630_hard_delete_archived_testing_team_flows/down.sql
+++ b/hasura.planx.uk/migrations/default/1754640310630_hard_delete_archived_testing_team_flows/down.sql
@@ -1,0 +1,2 @@
+-- Intentionally no equivalent down migration
+-- See this Trello ticket for context https://trello.com/c/OQhyVSjp/3372-templates-remove-customisation-tags

--- a/hasura.planx.uk/migrations/default/1754640310630_hard_delete_archived_testing_team_flows/up.sql
+++ b/hasura.planx.uk/migrations/default/1754640310630_hard_delete_archived_testing_team_flows/up.sql
@@ -1,0 +1,1 @@
+DELETE FROM flows WHERE team_id = 5 and deleted_at IS NOT NULL;


### PR DESCRIPTION
Final step in clean up here https://trello.com/c/OQhyVSjp/3372-templates-remove-customisation-tags & here https://opensystemslab.slack.com/archives/C07F7215W7P/p1754493778238819

Adds all Hasura-"suggested" relationships to `flows` table first so that deletion naturally cascades correctly.

**Pizza testing:**
- Manually confirm the editor still displays the same 56 flows as production 
<img width="1114" height="515" alt="Screenshot from 2025-08-08 10-15-35" src="https://github.com/user-attachments/assets/afd26d1b-e6b8-43d0-9e5c-28af25d4a7af" />

- Run the following snippets in the Hasura console's `Raw SQL` window and confirm each return exactly 0
```sql
SELECT COUNT(*) FROM flows
WHERE team_id = 5 -- Testing
AND deleted_at IS NOT NULL;

SELECT COUNT(*) 
FROM operations -- sub in 'published_flows', 'lowcal_sessions', flow_status_history', 'analytics' etc
WHERE flow_id NOT IN (
   SELECT id
   FROM flows
);
```