### PR TITLE
fix(a11y): Associate label to `SelectInput` (`DAC_Labels_not_Programmatically_Associated_02`)

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -43,16 +43,16 @@ export const CopyFeature: React.FC<Props> = ({
       onSubmit={formik.handleSubmit}
     >
       <Box>
-        <InputLabel label="Copy from" id={`select-${destinationIndex}`}>
+        <InputLabel label="Copy from" id={`select-${destinationIndex}-label`}>
           <SelectInput
             disabled={isDisabled}
+            name={`select-${destinationIndex}`}
             aria-describedby="copy-feature-description"
             bordered
             required
             title={"Copy from"}
             value={formik.values.sourceLabel}
             onChange={formik.handleChange}
-            name={"sourceLabel"}
             sx={{ width: { xs: "150px", md: "200px" } }}
           >
             <span id="copy-feature-description" style={visuallyHidden}>

--- a/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
+++ b/editor.planx.uk/src/ui/editor/Filter/FiltersColumn.tsx
@@ -42,6 +42,7 @@ export const FiltersColumn = <T extends object>(
         />
       ) : (
         <SelectInput
+          visuallyHiddenLabel
           value={selectedValue}
           name={props.name}
           onChange={(event) =>

--- a/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
+++ b/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
@@ -1,6 +1,7 @@
 import ArrowIcon from "@mui/icons-material/KeyboardArrowDown";
 import Select, { selectClasses, SelectProps } from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
+import { visuallyHidden } from "@mui/utils";
 import React, { ReactNode } from "react";
 
 import Input from "../../shared/Input/Input";
@@ -10,6 +11,7 @@ export type Props = SelectProps & {
   children?: ReactNode;
   onChange?: SelectProps["onChange"];
   bordered?: boolean;
+  visuallyHiddenLabel?: boolean;
 };
 
 const PREFIX = "SelectInput";
@@ -79,38 +81,49 @@ export default function SelectInput({
   name,
   onChange,
   bordered,
+  visuallyHiddenLabel,
   ...props
 }: Props): FCReturn {
   return (
-    <Root
-      variant="standard"
-      value={value}
-      labelId={`${name?.replaceAll(" ", "-")}-label`}
-      classes={{
-        select: classes.rootSelect,
-        icon: classes.icon,
-      }}
-      onChange={onChange}
-      IconComponent={ArrowIcon}
-      input={<Input bordered={bordered} />}
-      inputProps={{
-        name,
-        classes: {
-          select: classes.inputSelect,
-        },
-      }}
-      MenuProps={{
-        anchorOrigin: {
-          vertical: "bottom",
-          horizontal: "center",
-        },
-        classes: {
-          paper: classes.menuPaper,
-        },
-      }}
-      {...props}
-    >
-      {children}
-    </Root>
+    <>
+      {visuallyHiddenLabel && (
+        <label
+          id={`${name?.replaceAll(" ", "-")}-label`}
+          style={visuallyHidden}
+        >
+          {name}
+        </label>
+      )}
+      <Root
+        variant="standard"
+        value={value}
+        labelId={`${name?.replaceAll(" ", "-")}-label`}
+        classes={{
+          select: classes.rootSelect,
+          icon: classes.icon,
+        }}
+        onChange={onChange}
+        IconComponent={ArrowIcon}
+        input={<Input bordered={bordered} />}
+        inputProps={{
+          name,
+          classes: {
+            select: classes.inputSelect,
+          },
+        }}
+        MenuProps={{
+          anchorOrigin: {
+            vertical: "bottom",
+            horizontal: "center",
+          },
+          classes: {
+            paper: classes.menuPaper,
+          },
+        }}
+        {...props}
+      >
+        {children}
+      </Root>
+    </>
   );
 }

--- a/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
+++ b/editor.planx.uk/src/ui/editor/SelectInput/SelectInput.tsx
@@ -1,7 +1,6 @@
 import ArrowIcon from "@mui/icons-material/KeyboardArrowDown";
 import Select, { selectClasses, SelectProps } from "@mui/material/Select";
 import { styled } from "@mui/material/styles";
-import { visuallyHidden } from "@mui/utils";
 import React, { ReactNode } from "react";
 
 import Input from "../../shared/Input/Input";
@@ -83,40 +82,35 @@ export default function SelectInput({
   ...props
 }: Props): FCReturn {
   return (
-    <>
-      <label id={`${name?.replaceAll(" ", "-")}-label`} style={visuallyHidden}>
-        {name}
-      </label>
-      <Root
-        variant="standard"
-        value={value}
-        labelId={`${name?.replaceAll(" ", "-")}-label`}
-        classes={{
-          select: classes.rootSelect,
-          icon: classes.icon,
-        }}
-        onChange={onChange}
-        IconComponent={ArrowIcon}
-        input={<Input bordered={bordered} />}
-        inputProps={{
-          name,
-          classes: {
-            select: classes.inputSelect,
-          },
-        }}
-        MenuProps={{
-          anchorOrigin: {
-            vertical: "bottom",
-            horizontal: "center",
-          },
-          classes: {
-            paper: classes.menuPaper,
-          },
-        }}
-        {...props}
-      >
-        {children}
-      </Root>
-    </>
+    <Root
+      variant="standard"
+      value={value}
+      labelId={`${name?.replaceAll(" ", "-")}-label`}
+      classes={{
+        select: classes.rootSelect,
+        icon: classes.icon,
+      }}
+      onChange={onChange}
+      IconComponent={ArrowIcon}
+      input={<Input bordered={bordered} />}
+      inputProps={{
+        name,
+        classes: {
+          select: classes.inputSelect,
+        },
+      }}
+      MenuProps={{
+        anchorOrigin: {
+          vertical: "bottom",
+          horizontal: "center",
+        },
+        classes: {
+          paper: classes.menuPaper,
+        },
+      }}
+      {...props}
+    >
+      {children}
+    </Root>
   );
 }

--- a/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
+++ b/editor.planx.uk/src/ui/editor/SortControl/SortControl.tsx
@@ -101,6 +101,7 @@ export const SortControl = <T extends object>({
   return (
     <Box display={"flex"} gap={1}>
       <StyledSelectInput
+        visuallyHiddenLabel
         value={selectedDisplaySlug}
         onChange={(e) => {
           const targetKey = e.target.value as string;


### PR DESCRIPTION
## What's the problem?
> _The accessible name of the Copy from combobox is “sourceLabel” which doesn’t describe its purpose or align with the visible label._

Trello: https://trello.com/c/FgwFBbwM/3391-a-labels-not-programmatically-associated-2-p16

## What's the solution?
 - Remove redundant label
 - Correctly associate label and select