### PR TITLE
fix(a11y): Focus order (`DAC_Focus_Order_01`)

### DIFF
--- a/editor.planx.uk/src/@planx/components/Content/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Content/Public.tsx
@@ -7,7 +7,7 @@ import type { Content } from "@planx/components/Content/model";
 import Card from "@planx/components/shared/Preview/Card";
 import { PublicProps } from "@planx/components/shared/types";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import React from "react";
+import React, { useEffect } from "react";
 import { getContrastTextColor } from "styleUtils";
 import { emptyContent } from "ui/editor/RichTextInput/utils";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
@@ -57,6 +57,18 @@ const ContentComponent: React.FC<Props> = (props) => {
     setOpen(true);
     trackEvent({ event: "helpClick", metadata: {} }); // This returns a promise but we don't need to await for it
   };
+
+  // a11y: On navigation (change of card title) take initial focus to the main heading
+  useEffect(() => {
+    const contentEl = document.querySelector('[data-testid="content"]');
+    if (!contentEl) return;
+
+    const firstH1 = contentEl.querySelector("h1");
+    if (firstH1 instanceof HTMLElement) {
+      firstH1.setAttribute("tabindex", "-1");
+      firstH1.focus();
+    }
+  }, []);
 
   return (
     <Card handleSubmit={handleSubmit} isValid>

--- a/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -11,7 +11,7 @@ import Card, {
 } from "@planx/components/shared/Preview/Card";
 import { PublicProps } from "@planx/components/shared/types";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { getContrastTextColor } from "styleUtils";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { emptyContent } from "ui/editor/RichTextInput/utils";
@@ -106,6 +106,15 @@ const NoticeComponent: React.FC<Props> = (props) => {
     props.resetPreview && props.resetPreview();
   };
 
+  // a11y: When this card is reached, take initial focus to the main heading
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.setAttribute("tabindex", "-1");
+      titleRef.current.focus();
+    }
+  }, []);
+
   return (
     <Card handleSubmit={handleSubmit} isValid>
       <>
@@ -113,7 +122,12 @@ const NoticeComponent: React.FC<Props> = (props) => {
           <Content>
             <TitleWrap>
               <ErrorOutline sx={{ width: 34, height: 34 }} />
-              <Title variant="h3" component="h1">
+              <Title
+                variant="h3"
+                component="h1"
+                ref={titleRef}
+                sx={{ outline: "none" }}
+              >
                 {props.title}
               </Title>
             </TitleWrap>

--- a/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/CardHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/CardHeader.tsx
@@ -1,7 +1,7 @@
 import HelpIcon from "@mui/icons-material/Help";
 import Typography from "@mui/material/Typography";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { emptyContent } from "ui/editor/RichTextInput/utils";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
@@ -28,6 +28,15 @@ export const CardHeader: React.FC<ICardHeader> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
   const { trackEvent } = useAnalyticsTracking();
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  // a11y: On navigation (change of card title) take initial focus to the main heading
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.setAttribute("tabindex", "-1");
+      titleRef.current.focus();
+    }
+  }, [title]);
 
   const handleHelpClick = () => {
     setOpen(true);
@@ -43,7 +52,8 @@ export const CardHeader: React.FC<ICardHeader> = ({
             role="heading"
             aria-level={1}
             component="h1"
-            sx={{ textWrap: "balance" }}
+            sx={{ textWrap: "balance", outline: "none" }}
+            ref={titleRef}
           >
             {title}
           </Typography>

--- a/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
+++ b/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
@@ -7,7 +7,10 @@ import { FONT_WEIGHT_SEMI_BOLD, linkStyle } from "theme";
 
 const styles = (theme: Theme) => ({
   "& a": linkStyle(theme.palette.link.main),
-  "& h1": theme.typography.h2,
+  "& h1": {
+    ...theme.typography.h2,
+    outline: "none",
+  },
   "& h2": theme.typography.h3,
   "& h3": theme.typography.h4,
   "& strong": {


### PR DESCRIPTION
## What's the problem?
From latest a11y audit, issue `DAC_Focus_Order_01` (page 19) - 

> _When the pages load, focus is not taken to the start of the page. This may be navigationally disorientating for users reliant on the use of the keyboard alone to navigate. This issue is throughout._

Trello ticket - https://trello.com/c/tMNFxDG2/3393-a-focus-order-p19

## Solution
There’s not much detail on this one, and focus seems to be behaving correctly. Here’s what they may possibly be referring to -

- [Building a robust frontend using progressive enhancement](https://www.gov.uk/service-manual/technology/using-progressive-enhancement#single-page-applications)

- [Other keyboard focus considerations — Web Accessibility Guide — NZ Government](https://govtnz.github.io/web-a11y-guidance/ka/accessible-ux-best-practices/keyboard-a11y/keyboard-focus/other-keyboard-focus-considerations.html?utm_source=chatgpt.com#focus-in-single-page-applications-spas)

As there’s no route change when the “Continue” button is pressed there’s no indicator other than the title change. When a user navigates the service going from card to card, the focus seems to go back to body on each card change (tested with `document.activeElement`).

I've solved this by making the `CardHeader` take initial focus - the `h1` (`title`) element. Where components do not use this (`Notice`, `Content`) I've implemented a custom check.

## Questions
I’m not totally sure on the above so it’s worth another pair of eyes here and maybe a question back to DAC to confirm.

 - Does this actually identify and fix the described issue?
 - Would it actually be sufficient to (more simply) make the `<MainContent/>` element have this behaviour? I think this would not work as this component is stable on navigation to the next card
 - Are there components I've missed?