### PR TITLE
fix(a11y): Associate `DateInput` header with form group label

### DIFF
--- a/e2e/tests/ui-driven/src/helpers/userActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/userActions.ts
@@ -270,9 +270,9 @@ export async function answerDateInput(
   },
 ) {
   await expect(page.locator("h1", { hasText: expectedQuestion })).toBeVisible();
-  await page.getByLabel("Day").fill(day.toString());
-  await page.getByLabel("Month").fill(month.toString());
-  await page.getByLabel("Year").fill(year.toString());
+  await page.getByRole("textbox", { name: "Day" }).fill(day.toString());
+  await page.getByRole("textbox", { name: "Month" }).fill(month.toString());
+  await page.getByRole("textbox", { name: "Year" }).fill(year.toString());
 
   if (continueToNext) {
     await clickContinue({ page });

--- a/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -40,14 +40,18 @@ const DateInputPublic: React.FC<Props> = (props) => {
     <Card handleSubmit={formik.handleSubmit}>
       <Box
         role="group"
-        aria-describedby={[
-          props.description ? DESCRIPTION_TEXT : "",
-          formik.errors.date ? ERROR_MESSAGE : "",
-        ]
-          .filter(Boolean)
-          .join(" ")}
+        aria-labelledby="group-label"
+        aria-describedby={
+          [
+            props.description ? DESCRIPTION_TEXT : "",
+            formik.errors.date ? ERROR_MESSAGE : "",
+          ]
+            .filter(Boolean)
+            .join(" ") || undefined
+        }
       >
         <CardHeader
+          titleId="group-label"
           title={props.title}
           description={props.description}
           info={props.info}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/CardHeader.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/CardHeader.tsx
@@ -25,6 +25,7 @@ export const CardHeader: React.FC<ICardHeader> = ({
   howMeasured,
   definitionImg,
   img,
+  titleId,
 }) => {
   const [open, setOpen] = React.useState(false);
   const { trackEvent } = useAnalyticsTracking();
@@ -39,6 +40,7 @@ export const CardHeader: React.FC<ICardHeader> = ({
       {title && (
         <TitleWrapper mr={1} pt={0.5}>
           <Typography
+            id={titleId}
             variant="h2"
             role="heading"
             aria-level={1}

--- a/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/types.ts
+++ b/editor.planx.uk/src/@planx/components/shared/Preview/CardHeader/types.ts
@@ -6,4 +6,5 @@ export interface ICardHeader {
   howMeasured?: string;
   definitionImg?: string;
   img?: string;
+  titleId?: string;
 }


### PR DESCRIPTION
<img width="522" height="463" alt="image" src="https://github.com/user-attachments/assets/f45dabaf-a312-4df0-b39d-34b5aa71b3c3" />

Structure now matches suggestion in audit report. No change is required for the `DateInputField` on pages as this already uses a `fieldset` and `legend`.

Trello ticket: https://trello.com/c/Zc3wCtRm/3392-a-form-groups-p17