### PR TITLE
fix(a11y):  Number input labels (`DAC_Labels_not_Programmatically_Associated_01`)

### DIFF
--- a/e2e/tests/ui-driven/src/helpers/userActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/userActions.ts
@@ -244,8 +244,8 @@ export async function answerNumberInput(
     continueToNext: boolean;
   },
 ) {
-  await expect(page.locator("h1", { hasText: expectedQuestion })).toBeVisible();
-  await page.locator("div input[type='number']").fill(answer.toString());
+  await expect(page.locator("p", { hasText: expectedQuestion })).toBeVisible();
+  await page.locator("label div input[type='number']").fill(answer.toString());
   if (continueToNext) {
     await clickContinue({ page });
   }

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -11,17 +11,12 @@ test("renders correctly", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput
-      fn="num"
-      title="Numberwang!"
-      units="wangs"
-      handleSubmit={handleSubmit}
-    />,
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
 
-  await user.type(screen.getByLabelText("wangs"), "3");
+  await user.type(screen.getByLabelText("Numberwang!"), "3");
   await user.click(screen.getByTestId("continue-button"));
 
   expect(handleSubmit).toHaveBeenCalledWith({ data: { num: 3 } });
@@ -31,17 +26,12 @@ test("allows 0 to be input as a valid number", async () => {
   const handleSubmit = vi.fn();
 
   const { user } = setup(
-    <NumberInput
-      fn="num"
-      title="Numberwang!"
-      units="wangs"
-      handleSubmit={handleSubmit}
-    />,
+    <NumberInput fn="num" title="Numberwang!" handleSubmit={handleSubmit} />,
   );
 
   expect(screen.getByRole("heading")).toHaveTextContent("Numberwang!");
 
-  await user.type(screen.getByLabelText("wangs"), "0");
+  await user.type(screen.getByLabelText("Numberwang!"), "0");
   await user.click(screen.getByTestId("continue-button"));
 
   expect(handleSubmit).toHaveBeenCalledWith({ data: { num: 0 } });
@@ -55,7 +45,6 @@ test("requires a positive number to be input by default", async () => {
       fn="doors"
       title="How many doors are you adding?"
       handleSubmit={handleSubmit}
-      units="units"
     />,
   );
 
@@ -63,7 +52,10 @@ test("requires a positive number to be input by default", async () => {
     "How many doors are you adding?",
   );
 
-  await user.type(screen.getByLabelText("units"), "-1");
+  await user.type(
+    screen.getByLabelText("How many doors are you adding?"),
+    "-1",
+  );
   await user.click(screen.getByTestId("continue-button"));
 
   expect(screen.getByText(/Enter a positive number/)).toBeInTheDocument();
@@ -79,7 +71,6 @@ test("allows negative numbers to be input when toggled on by editor", async () =
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       allowNegatives={true}
-      units="degrees"
     />,
   );
 
@@ -87,7 +78,7 @@ test("allows negative numbers to be input when toggled on by editor", async () =
     "What's the temperature?",
   );
 
-  await user.type(screen.getByLabelText("degrees"), "-10");
+  await user.type(screen.getByLabelText("What's the temperature?"), "-10");
   await user.click(screen.getByTestId("continue-button"));
 
   expect(handleSubmit).toHaveBeenCalledWith({ data: { fahrenheit: -10 } });
@@ -102,7 +93,6 @@ test("a clear error is shown if decimal value added when onlyWholeNumbers is tog
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       isInteger={true}
-      units="degrees"
     />,
   );
 
@@ -110,7 +100,7 @@ test("a clear error is shown if decimal value added when onlyWholeNumbers is tog
     "What's the temperature?",
   );
 
-  const textArea = screen.getByLabelText("degrees");
+  const textArea = screen.getByLabelText("What's the temperature?");
 
   await user.type(textArea, "10.06");
   await user.click(screen.getByTestId("continue-button"));
@@ -128,7 +118,6 @@ test("allows only whole numbers to be submitted when toggled on by editor", asyn
       title="What's the temperature?"
       handleSubmit={handleSubmit}
       isInteger={true}
-      units="degrees"
     />,
   );
 
@@ -136,7 +125,7 @@ test("allows only whole numbers to be submitted when toggled on by editor", asyn
     "What's the temperature?",
   );
 
-  const textArea = screen.getByLabelText("degrees");
+  const textArea = screen.getByLabelText("What's the temperature?");
 
   await user.type(textArea, "10");
   await user.click(screen.getByTestId("continue-button"));
@@ -202,9 +191,7 @@ test("recovers previously submitted number when clicking the back button even if
 });
 
 it("should not have any accessibility violations", async () => {
-  const { container } = setup(
-    <NumberInput fn="num" title="Numberwang!" units="wangs" />,
-  );
+  const { container } = setup(<NumberInput fn="num" title="Numberwang!" />);
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });

--- a/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/NumberInput/Public.tsx
@@ -3,12 +3,13 @@ import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHead
 import { PublicProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
 import isNil from "lodash/isNil";
-import React, { useEffect, useId, useRef } from "react";
+import React, { useEffect, useRef } from "react";
+import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowLabel from "ui/shared/InputRowLabel";
 
-import { ERROR_MESSAGE } from "../shared/constants";
+import { DESCRIPTION_TEXT, ERROR_MESSAGE } from "../shared/constants";
 import { getPreviouslySubmittedData, makeData } from "../shared/utils";
 import type { NumberInput } from "./model";
 import { parseNumber, publicValidationSchema } from "./model";
@@ -16,10 +17,6 @@ import { parseNumber, publicValidationSchema } from "./model";
 export type Props = PublicProps<NumberInput>;
 
 export default function NumberInputComponent(props: Props): FCReturn {
-  const uniqueId = useId();
-  const inputId = `number-input-${uniqueId}`;
-  const labelId = `input-label-${uniqueId}`;
-
   const formik = useFormik({
     initialValues: {
       value: getPreviouslySubmittedData(props) ?? "",
@@ -53,27 +50,27 @@ export default function NumberInputComponent(props: Props): FCReturn {
         howMeasured={props.howMeasured}
       />
       <InputRow>
-        <Input
-          ref={inputRef}
-          bordered
-          name="value"
-          type="number"
-          value={formik.values.value}
-          onChange={formik.handleChange}
-          errorMessage={formik.errors.value as string}
-          inputProps={{
-            "aria-describedby": formik.errors.value
-              ? `${ERROR_MESSAGE}-${props.id}`
-              : "",
-            "aria-labelledby": labelId,
-          }}
-          id={inputId}
-        />
-        {props.units && (
-          <InputRowLabel inputProps={{ id: labelId }}>
-            {props.units}
-          </InputRowLabel>
-        )}
+        <InputLabel label={props.title} hidden htmlFor="number-input">
+          <Input
+            ref={inputRef}
+            bordered
+            name="value"
+            type="number"
+            value={formik.values.value}
+            onChange={formik.handleChange}
+            errorMessage={formik.errors.value as string}
+            inputProps={{
+              "aria-describedby": [
+                props.description ? DESCRIPTION_TEXT : "",
+                formik.errors.value ? `${ERROR_MESSAGE}-${props.id}` : "",
+              ]
+                .filter(Boolean)
+                .join(" "),
+            }}
+            id="number-input"
+          />
+        </InputLabel>
+        {props.units && <InputRowLabel>{props.units}</InputRowLabel>}
       </InputRow>
     </Card>
   );


### PR DESCRIPTION
This is aiming to resolve a new "A" issue flagged by the audit - `DAC_Labels_not_Programmatically_Associated_01`

> _The label provided to enable users to identify the purpose of the edit field is not fully programmatically associated with the component. Screen reader users encountering the field ‘out of context’, for example, when filtering the page by element type, will encounter the component as ‘units’. Users would have to switch navigational methods, and search through the surrounding page content in order to identify the purpose of the control._

Trello ticket: https://trello.com/c/7MidNreB/3390-a-labels-not-programmatically-associated-1-p13

I believe this was a regression introduced here - https://github.com/theopensystemslab/planx-new/pull/5020

I'm proposing that we just revert this usability fix in order to resolve the new "A" issue. Ideally we'd circle back here and also address the usability issue also.