### PR TITLE
fix: focus order management on step change

### DIFF
--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -9,7 +9,13 @@ import { getLocalFlowIdb, setLocalFlowIdb } from "lib/local.idb";
 import * as NEW from "lib/local.new";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { ApplicationPath, Session } from "types";
 import Main from "ui/shared/Main";
@@ -76,6 +82,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   const [gotFlow, setGotFlow] = useState(false);
   const isUsingLocalStorage =
     useStore((state) => state.path) === ApplicationPath.SingleSession;
+  const isInitialLoad = useRef(true);
 
   useEffect(
     () => setPreviewEnvironment(previewEnvironment),
@@ -161,6 +168,21 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [breadcrumbs]);
+
+  // manage focus on form step changes
+  useEffect(() => {
+    const contentEl = document.querySelector('[data-testid="content"]');
+    if (!contentEl) return;
+
+    if (contentEl instanceof HTMLElement) {
+      contentEl.setAttribute("tabindex", "-1");
+
+      if (!isInitialLoad.current) {
+        contentEl.focus();
+      }
+    }
+    isInitialLoad.current = false;
+  }, [node?.id]);
 
   const handleSubmit =
     (id: string): HandleSubmit =>

--- a/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -9,7 +9,7 @@ import Typography from "@mui/material/Typography";
 import ErrorFallback from "components/Error/ErrorFallback";
 import Feedback from "components/Feedback";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useEffect, useRef } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useCurrentRoute } from "react-navi";
 import { generateTeamTheme } from "theme";
@@ -101,13 +101,15 @@ const PublicLayout: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={teamMUITheme}>
-        <Header />
-        <MainContainer>
-          <ErrorBoundary FallbackComponent={ErrorFallback}>
-            {children}
-          </ErrorBoundary>
-        </MainContainer>
-        <PublicFooter />
+        <Box data-testid="content">
+          <Header />
+          <MainContainer>
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
+              {children}
+            </ErrorBoundary>
+          </MainContainer>
+          <PublicFooter />
+        </Box>
       </ThemeProvider>
     </StyledEngineProvider>
   );


### PR DESCRIPTION
## What's the problem?
From latest a11y audit, issue `DAC_Focus_Order_01` (page 19) - 

> _When the pages load, focus is not taken to the start of the page. This may be navigationally disorientating for users reliant on the use of the keyboard alone to navigate. This issue is throughout._

Trello ticket - https://trello.com/c/tMNFxDG2/3393-a-focus-order-p19


**Solution:**

This pull request introduces improvements to accessibility and user experience in the flow preview and public layout pages. The main changes focus on managing focus when navigating between form steps, ensuring that keyboard users and screen readers can more easily follow context changes. Additionally, a new wrapper element is added to facilitate this focus management.

* Added logic in `Questions.tsx` to automatically focus the main content area (`[data-testid="content"]`) when the form step changes, except on initial load. This improves navigation for keyboard and screen reader users.
* Introduced a `useRef` hook to track whether the page is in its initial load state, ensuring focus is only set after the first render.
* Updated imports in `Questions.tsx` to include `useRef` for the new focus management logic.

**Layout and DOM structure:**

* Wrapped the main content of `PublicLayout.tsx` in a `Box` element with `data-testid="content"`, providing a consistent target for focus and accessibility improvements.