### PR TITLE
chore: allow list `proposal.description`

### DIFF
--- a/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
+++ b/api.planx.uk/modules/webhooks/service/analyzeSessions/operations.ts
@@ -32,6 +32,7 @@ const ALLOW_LIST = [
   "property.type",
   "property.type.userProvided",
   "propertyInformation.action",
+  "proposal.description",
   "proposal.projectType",
   "rab.exitReason",
   "send.analytics.userAgent",

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -60,6 +60,7 @@ export const ALLOW_LIST = [
   "property.constraints.planning",
   "property.type",
   "propertyInformation.action",
+  "proposal.description",
   "proposal.projectType",
   "rab.exitReason",
   "send.analytics.userAgent",


### PR DESCRIPTION
Quick followup to Dan & Christine's plan for generating/validating proposal descriptions ! See https://opensystemslab.slack.com/archives/C01E3AC0C03/p1755186717313679

Going forward, this will allow us to query the associated `proposal.description` for any submission (_before_ assessment) via:
```
select allow_list_answers ->> 'proposal.description' from lowcal_sessions;
```
(may want to add to `submission_services_summary` analytics view in future, but not strictly necessary unless we ever want to expose on Metabase!)