### PR TITLE
pull custom caddy image from Vultr CR to speed up pizza builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ AWS_SECRET_KEY=👻
 # Vultr API key for pizzas to handle DNS challenge
 VULTR_API_KEY=👻
 
+# Vultr container registry credentials
+VULTR_CR_URN=lhr.vultrcr.com/planx
+VULTR_CR_ID=👻
+VULTR_CR_API_KEY=👻
+
 # User-uploaded S3 files require token-based access (token is used internally and shared with BOPS; local and pull request environments use the staging token)
 FILE_API_KEY=👻
 FILE_API_KEY_NEXUS=👻

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -204,15 +204,15 @@ jobs:
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/pnpm-lock.yaml"
+          cache: 'pnpm'
+          cache-dependency-path: './${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/pnpm-lock.yaml'
       - name: Setup .gitconfig
         run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
       - run: pnpm build --mode pizza
-        env: 
+        env:
           ROOT_DOMAIN: ${{ env.FULL_DOMAIN }}
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
@@ -376,6 +376,7 @@ jobs:
             rc-update add docker default
             service docker start
             apk add docker-cli-compose
+            docker login ${{ secrets.VULTR_CR_URN }} -u ${{ secrets.VULTR_CR_ID }} -p ${{ secrets.VULTR_CR_API_KEY }}
 
             apk add git
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
@@ -412,6 +413,7 @@ jobs:
             rc-update add docker default
             service docker start
             apk add docker-cli-compose
+            docker login ${{ secrets.VULTR_CR_URN }} -u ${{ secrets.VULTR_CR_ID }} -p ${{ secrets.VULTR_CR_API_KEY }}
 
             apk add git
             git clone "${{ secrets.AUTHENTICATED_REPO_URL }}"
@@ -538,7 +540,7 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: e2e
       - name: Code checks
-        run:  pnpm check
+        run: pnpm check
         working-directory: e2e
       - name: Install Playwright Dependencies
         run: pnpm playwright install --with-deps
@@ -546,7 +548,7 @@ jobs:
       - name: Start test containers
         run: ./scripts/start-containers-for-tests.sh
       - name: End-to-end Tests
-        run:  pnpm test
+        run: pnpm test
         working-directory: e2e
       - name: Archive Playwright Test Results
         if: ${{ failure() }}

--- a/ci/caddy/README.md
+++ b/ci/caddy/README.md
@@ -25,3 +25,9 @@ To see verbose logs for the caddy container, add the `debug` directive to the gl
 The propagation knobs should be understood like so: wait for `propagation_delay` before starting poll of DNS records (after attempting to write them to Vultr), then keep trying to verify success for `propagation_timeout`, before handing over to the ACME server.
 
 Note also that Docker's embedded DNS breaks CertMagic polling, meaning Caddy can't verify the successful writing of appropriate DNS records, so we explicitly set public [resolvers](https://caddyserver.com/docs/caddyfile/directives/tls#resolvers) (specifically Cloudflare and Google).
+
+## Building the image
+
+We bake the caddy-dns/vultr plugin into a standard caddy image using [xcaddy](https://caddyserver.com/docs/build#xcaddy), as per the `Dockerfile`. This means the final image doesn't require a Go installation, saving several GB.
+
+See also comprehensive documentation and examples from Vultr [here](https://docs.vultr.com/how-to-build-a-docker-image).

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -34,8 +34,11 @@ services:
     entrypoint: "/goStatic -port 8044 -fallback /index.html"
 
   caddy:
+    # prefer to pull image from private Vultr registry, but build if not found
     build:
       context: ./ci/caddy
+    image: lhr.vultrcr.com/planx/caddy-vultr:latest
+    pull_policy: always
     container_name: caddy
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Relates to ticket: https://trello.com/c/A4PLVgCD

We have to build a custom caddy image which includes the [caddy-dns/vultr](https://github.com/caddy-dns/vultr) module to enable the DNS challenge for wilcard cert issuance (see #5030), and this can take several minutes.

This image will rarely change so we should build it in advance (as per `ci/caddy/README.md`), upload to [VCR](https://docs.vultr.com/products/container-registry) and then pull them from on pizzas.