### PR TITLE
chore: Add LPS project to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,20 @@ updates:
         patterns:
           - "@tiptap/*"
 
+  # localplanning.services
+  - package-ecosystem: "npm"
+    directory: "/localplanning.services"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "lps"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "theopensystemslab/planx"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+
   # Hasura
   - package-ecosystem: "npm"
     directory: "/hasura.planx.uk"


### PR DESCRIPTION
Noticed when working on https://github.com/theopensystemslab/planx-new/pull/5090 that we haven't configured dependabot here yet.