### PR TITLE
feat: Migrate application/staging secrets to Pulumi ESC

### DIFF
--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -1,90 +1,16 @@
+environment:
+  - application/staging
 config:
-  application:airbrake-project-id:
-    secure: AAABABxcp8r3CZAw1kXuXkwPZ8cKRDQyOg4+gVvqzKuCFWb8BEU=
-  application:airbrake-project-key:
-    secure: AAABABujxMHxU8Abj4QpyQTz7bLt3AP2wBFaypVkDZ2khzc6eh6lHLljTEkzpLUncno3gNNDXnrmxzXvqKnQdQ==
-  application:cloudflare-zone-id:
-    secure: AAABAPZz/bzFCZEZd+jzPpYP4HXAOLYQmLGf2YLQE2YPfMBUtDC83KCo2l2DJ4AL4OKL+jFFx8wrrJc6DDwXJQ==
-  application:db-host:
-    secure: AAABAMwwPy7/bMKC+iEonzpc0HrzblNfFBXBi60LiSTcoF1KxQkd+vkEUfBfhY96Tx4Nf8/JML6EBhtesIjoGN+r4Y1EcpW+thJoJa/g3Ssv4Dc=
-  application:db-password:
-    secure: AAABAAVV2tpNt1KK6I/h1PqHYZf5iDySr+GJOXy1cdMbIfO6cXNxel8Rv9EwmmAaPkPh7Z4vEZHIHSJqHrPDOA==
-  application:encryption-key:
-    secure: AAABAFTW2eRwQnXJq/IboPWtStOWXiF9WcsUKEiuosmp7TLZt52uKE3L+NrEGgsThOl3NkvFW2HhFa2XL6aB5w==
-  application:file-api-key:
-    secure: AAABAN0LjLOgxCkr5ZqQLn6FkZPcrPlvNG4fbNZ02W2qC1VVYVee/3aToZQuXuokVwnIPNbbe2w=
-  application:file-api-key-barnet:
-    secure: AAABAFpZq81zy3CKFXUgi9oEGIGp7LDVD3TNlYkZD4liX0bxOrmMJYdDpMmyGt4aGARF63nEUmo=
-  application:file-api-key-doncaster:
-    secure: AAABAIZjfr4tVG+HG9+83bPYQjgD1hmK5P+SbYpq4qGue07rHA02kciAkTMCyxD5Lzb0WX0K6fm5cvH2tof5mmX7gJGTkMVc
-  application:file-api-key-epsom-ewell:
-    secure: AAABAD1/nlJ2EOEglLiiNsOLbOd3KWCONhNhJAIdZQVnrSRsNIzX2luszOreQf20EYl8AZ4L1TiheqUHSt22e5z1FiLWoCtY
-  application:file-api-key-gateshead:
-    secure: AAABAC40pz4+QnXhA2QOYP2F33dc4bCnpL0Njd6hgxR4sTtzt1xF4+2HJpMGdptL2zVrbmdH+cMzrizu6cTmGELrsAoUIEvB
-  application:file-api-key-gloucester:
-    secure: AAABAEGJ0WyUrlevwy3gZV058bHabSBNItu//nWvzRVlIjGMaJ8X//DmEDtYFvdMC+RqCUkUXlo7zh3tap9Zz9/8wWQpXsQR
-  application:file-api-key-lambeth:
-    secure: AAABALQTeIf/uScxASJkhmoPRhewQT94Guad4iJ7GRk0DcND8wDUG0eNxDU4+XwUQZqCnL2DP+E=
-  application:file-api-key-medway:
-    secure: AAABABCpSTmTDJU81pG7U57Igr4OtBbX6VuqRooq9Ipzoq1peTenbNQYBWacZn6lyg7ceLAgbiHQgT7LqX2tKN1QwON/BSQh
-  application:file-api-key-nexus:
-    secure: AAABAJFgaBoTWNmZyXDkGRngwU8KpOt6CeBLxGBgBG0JFMsKK7rWT39TsjJ9pL1wZaBoT0YZhCg=
-  application:file-api-key-southwark:
-    secure: AAABAK8LsYKKNgIS4fepW5Sh6+WKxNopxsos51eBttT7O8E8K0HYOswgrIWuYJ0R1eJHDLKRHqQ=
-  application:file-api-key-tewkesbury:
-    secure: AAABALlStpxyNG5SRQFVYJMGmCyteUkoU9XBTBJn2kcf6APdqO1JwxU4jiU9Qo6a6aZQXK60an7xbkuD2hla/UvjR7Wu7cXY
   application:google-client-id: 987324067365-vpsk3kgeq5n32ihjn760ihf8l7m5rhh8.apps.googleusercontent.com
-  application:google-client-secret:
-    secure: AAABAGQuqQDU4S+vR+cQaFoa6xAeWU9clVaNonQ/dq0R8Dke+o0y7ALOmYMy4fOX4Pa6HiZl85npU/cbwy8HdMYaiA==
-  application:govuk-notify-api-key:
-    secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
-  application:hasura-admin-secret:
-    secure: AAABACnU/Z5aGH2DaNQ29YkJqx8bKKRYFEdXvJm0yswo0pK2Iqnz09j7H2kOaZOzY2fSfEDu8rU=
   application:hasura-cpu: "1024"
   application:hasura-memory: "2048"
-  application:hasura-planx-api-key:
-    secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
   application:hasura-proxy-cpu: "512"
   application:hasura-proxy-memory: "1024"
   application:hasura-service-scaling-maximum: "2"
   application:hasura-service-scaling-minimum: "1"
-  application:idox-nexus-client:
-    secure: AAABABprDQomVM9wJQkTMTVtUKvj9lVVVJLdpEBR5p3ibZYvSMedTOb2jztPa0vm6UCH2hilyOV2fsd+akYd3sP8Up5G26mkEKSLSSN4Nc9fu/Hi3Apn1rXHnw==
   application:idox-nexus-submission-url: https://dev.identity.idoxgroup.com/agw/submission-api
   application:idox-nexus-token-url: https://dev.identity.idoxgroup.com/uaa/oauth/token
-  application:jwt-secret:
-    secure: AAABAOo4AlDxNYjUfyS2yp8VjbhmziWGQvA54PfnGYOyi5i6o3Lt9GLwAeUCrQYnr663MFjWw49+0wXVdeumyvtRF49cdFEb
-  application:mapbox-access-token:
-    secure: AAABAMWf2zVq5/mKCLynpgzAidNsnbUEBpb47n7MRWp2xzRgwaf3kzOvnZax9N04ZScQqU6I5/tEKTBAbSb8MIBJ8mU2iTZbPg8FD6wYsetRyftm1K39KBsIl9aS7fXvZFOG7BsC4qMDEhlDkH8gbV2HTev3VvvRUe3lzVhjNGNHqQ==
-  application:metabase-api-key:
-    secure: AAABAFf+hW09AWupsY6adrPAJHCkrTMeRX7/gaUHLYXi3QS77MVelPp9K0L4zyUL8u7zDanjuE9G/bfIlcVXLwiLLKAJkt5to9knKJqTXg==
-  application:metabase-encryption-secret-key:
-    secure: AAABAGmfVICD8sR+IE6mHC8BNUY1WQXGCbv5F3C1fSgA+1ADiRem3GNrwY0YRZociRYuPIo3MIRS0aIg44jt10SBCE0ik58wHamcKA==
-  application:metabasePgPassword:
-    secure: AAABADfCkSRtVTdU8wi1F+nwuHl8OeI3bm9ZzaNkIY4yOGB9dsOqS30tkD8W7GZlNoWDZT2ojoP3zOFPuTLWbQ==
-  application:microsoft-client-id:
-    secure: AAABAN/jlejEkv8Rf+u6nzbXy2yTIUNwWK7cw1Rz1P1DQTvvOYsPwhMYqo4Jjt9UAAx+b2FWPoUvrIOUm1dT+xpnqbU=
-  application:microsoft-client-secret:
-    secure: AAABAJLeBiZ77GkBfHod1t/0zh2e7azba5b/YZ0O3lKYex25VZCI7YzuzuOaGk+SRmfNz7GZbuGYWgfAE/XrIUBiggs+7pnW
-  application:ordnance-survey-api-key:
-    secure: AAABAMqkRWGvu4THnzddRYpNddFfIFFKCqEE3gm9DkYuVJRCjZBCWpKogsT+X4j3R2f9V8OyeZxHK53yIpl8rQ==
-  application:session-secret:
-    secure: AAABALL3iIm9+wB88/0ig7H+Y8Rmhb9OqaIz6sSTHmb5jf8+vBvXzY79z4pG6mJq9YPCxg==
-  application:skip-rate-limit-secret:
-    secure: AAABANwjBmGN73bwF6nqQP5i8tKMe3mi0NMBdae4uaLasG2VfPvC1D4mk7QWIFqVnzsD5jCN20Eqos/r2B+EAo2rAws3JeD/
-  application:slack-internal-errors-webhook:
-    secure: AAABAPkO1mBzTkXVWjpzAeP9ZbkifOiBwxj+rL5OONBu6DY87Pw1FualS6jSmQ5yeoGovZowNy3iMsArq4lxSX2BnBAur4O4a90Qou5zGUFACSTfLkZOgsyImvbdwRRnFPBBskfQ+bqwX9OZjO5AAXkEa9bqu3ViFQ==
-  application:slack-webhook-url:
-    secure: AAABALzK5KLP5po8giGePS/+ZpcWQHf8LfvCcdlY/oSv6NvC3y6D44CeIAiUdDXTB7VeUX5JFeaceDyZ9C1N5CAWFOLPCCKvuLjuDtk7QZe/rczqd2QnMDLh+Q9wPlQSb4PIoK8jWNEmvQC3QMgq
-  application:uniform-client-buckinghamshire:
-    secure: AAABAPJ3rc8HnuLMUhYQF0/8wVsakM42etWUDET4BuGYnsLxAx5tXz7L1aKZ7yzkhnDRaUUT6AU77RBDD1Y=
-  application:uniform-client-lambeth:
-    secure: AAABAA5D9I/HLWmzyqq+mK6wjyagZgne4akWVCtGaoR4HPkw1M8WqlM26RM5o6KjwPTjFkLH55ltHLZHdA==
-  application:uniform-client-southwark:
-    secure: AAABALWeaw3/BHLqTXaV4YWbC4f6YF4R3uOq0KPM4a23K5tYiTNOPjGE458CM7TIYiPX0R58Xf/8rIml3sfN
   application:uniform-submission-url: https://staging.identity.idoxgroup.com/agw/submission-api
   application:uniform-token-url: https://staging.identity.idoxgroup.com/uaa/oauth/token
   aws:region: eu-west-2
   certificates:cloudflare-zone-id: dc27ac531ff8862559ed9ab5016c4953
-  cloudflare:apiToken:
-    secure: AAABABWhDm+7RstbxLXd1D8CcxkylHS6UKMqk4kOaY7Y0E7FJS4bZfvyGs0nks80hl3vjENH4eDuFbUgA82/sA4SmDlfpNXr


### PR DESCRIPTION
## What does this PR do?
This is an initial test of a migration of Pulumi secrets from config files, to the remotely hosted [Pulumi ESC](https://www.pulumi.com/product/secrets-management/) environment. This is required as we're now hitting limits on the size of our Pulumi config files (please see https://github.com/theopensystemslab/planx-new/pull/5022).

I've approached the migration as follows - 
 - Secrets should be stored in Pulumi ESC
 - Environmental variables can be in config files (e.g. `pulumi.staging.yaml`)

There's no clear indication if it's better to store everything on ESC but I'd say it makes sense to have certain environmental variables exposed and public in the repository as opposed to hidden when these are not secrets in any sense. We can monitor this over time to see if it's going to be simpler to maintain these in one place.

I've migrated using `pulumi config env init --stack staging` which moved all variables to ESC, and I've then manually added pure env vars back to `pulumi.staging.yaml` ([docs](https://www.pulumi.com/docs/esc/integrations/infrastructure/pulumi-iac/#convert-existing-stack-config-to-an-esc-environment)).

## How does Pulumi ESC work?
Rather than secrets being encoded within our config files, they'll be stored on the Pulumi ESC platform (other options also available such as Amazon Secrets Manager, 1Password etc). From a Pulumi IaC point-of-view though there's no change - `pulumi.getConfig()` works in the same way - just reading from ESC instead of the YAML config file.

[Documentation](https://www.pulumi.com/docs/esc/) is pretty good (and relatively simple) - it's worth a scan through. Once I've tested this actually works via a staging deploy, the next PR will be a write up of which commands to use, how this works etc.

## Migration plan
Initially, I'd like to test out this PR as-is just to ensure that `pulumi.getConfig()` is actually able to still access these secrets. This will be tested by having a successful staging deploy, and still being able to access these secrets (e.g. via AWS Fargate, or functional testing of the application).

Once this has been tested and we have confidence in the method I propose we take the following next steps - 

- Write documentation (e.g. update references to `pulumi config set`, explain how ESC works)
- Get another dev to test secrets from the application/staging stack can still be accessed locally and via the web platform
- Convert other staging stacks (data, certificates etc)
- Deploy to staging again, test
- Migrate production
- Deploy to production