### PR TITLE
feat: Save progress to flow data

### DIFF
--- a/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
@@ -27,9 +27,13 @@ const Root = styled(LinearProgress)(({ theme }) => ({
 }));
 
 export const ProgressBar: React.FC = () => {
-  const { completed, current } = useStore((state) =>
+  const progress = useStore((state) =>
     state.getSectionProgress(),
   );
+
+  if (!progress) return;
+
+  const { completed, current } = progress;
 
   return (
     <Root

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -13,6 +13,11 @@ export interface SectionNode extends Store.Node {
   data: Section;
 }
 
+export interface Progress { 
+  completed: number;
+  current: number;
+}
+
 export interface NavigationStore {
   currentSectionIndex: number;
   sectionCount: number;
@@ -24,10 +29,7 @@ export interface NavigationStore {
   filterFlowByType: (type: TYPES) => Store.Flow;
   getSortedBreadcrumbsBySection: () => Store.Breadcrumbs[];
   getSectionForNode: (nodeId: string) => SectionNode;
-  getSectionProgress: () => {
-    completed: number;
-    current: number;
-  };
+  getSectionProgress: () => Progress | undefined;
 }
 
 export const navigationStore: StateCreator<
@@ -180,7 +182,10 @@ export const navigationStore: StateCreator<
   },
 
   getSectionProgress: () => {
-    const { sectionNodes, currentSectionIndex, isFinalCard } = get();
+    const { sectionNodes, currentSectionIndex, isFinalCard, sectionCount } =
+      get();
+    if (!sectionCount) return;
+
     if (isFinalCard()) return { completed: 100, current: 100 };
 
     // Account for offset index

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -62,6 +62,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     getType,
     node,
     setCurrentCard,
+    progress,
   ] = useStore((state) => [
     state.previousCard,
     state.record,
@@ -76,6 +77,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.getType,
     state.currentCard,
     state.setCurrentCard,
+    state.getSectionProgress(),
   ]);
   const isStandalone = previewEnvironment === "standalone";
   const { createAnalytics, trackEvent } = useAnalyticsTracking();
@@ -136,6 +138,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
       passport,
       sessionId,
       govUkPayment,
+      progress,
     };
 
     const saveFlowData = async () => {
@@ -162,6 +165,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     govUkPayment,
     isStandalone,
     isUsingLocalStorage,
+    progress,
   ]);
 
   // scroll to top on any update to breadcrumbs

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -71,8 +71,8 @@ export type Session = {
   // TODO: replace `id` with `flow: { id, published_flow_id }`
   id: SharedStore["id"];
   govUkPayment?: GovUKPayment;
-  // Only present on sessions for flow which utilise "Section" components
-  progress?: Progress
+  /** Only present on sessions for flow which utilise "Section" components */
+  progress?: Progress;
 };
 
 export interface ReconciliationResponse {

--- a/editor.planx.uk/src/types.ts
+++ b/editor.planx.uk/src/types.ts
@@ -7,6 +7,7 @@ import {
 import { SectionLength } from "@planx/components/Section/model";
 import { OT } from "@planx/graph/types";
 import { useFormik } from "formik";
+import { Progress } from "pages/FlowEditor/lib/store/navigation";
 
 import { Store } from "./pages/FlowEditor/lib/store/index";
 import { SharedStore } from "./pages/FlowEditor/lib/store/shared";
@@ -70,6 +71,8 @@ export type Session = {
   // TODO: replace `id` with `flow: { id, published_flow_id }`
   id: SharedStore["id"];
   govUkPayment?: GovUKPayment;
+  // Only present on sessions for flow which utilise "Section" components
+  progress?: Progress
 };
 
 export interface ReconciliationResponse {


### PR DESCRIPTION
## What does this PR do?
Adds `Progress` object to user's session data.

## Motivation
Required to show progress in LPS. There's no need to read this data within PlanX directly - we can always just calculate it via the store as we do currently.

<img width="1244" height="708" alt="image" src="https://github.com/user-attachments/assets/76189766-1ad9-43b0-9662-9f3771e78f3d" />
