### PR TITLE
Revert "chore: Bump `HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT`"

### DIFF
--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -156,7 +156,7 @@ export const createHasuraService = async ({
             // extend timeout for migrations during setup to 3 mins (default is 30s)
             {
               name: "HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT",
-              value: "360",
+              value: "180",
             },
             // ensure migrations run sequentially (to manage CPU load)
             {


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#5100

I think this was a red herring yesterday as the issue was a DB lock - there's no benefit to having this unnecessarily higher than we need it.