### PR TITLE
fix: On resume, sort breadcrumbs by depth

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/computePassport.test.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/computePassport.test.ts
@@ -1,5 +1,6 @@
 import { FullStore, useStore } from "../store";
 import { flowWithDuplicatePassportVars } from "./mocks/computePassport/flowWithDuplicatePassportVars";
+import { flowWithMultipleSetValues } from "./mocks/computePassport/flowWithMultipleSetValues";
 
 const { getState, setState } = useStore;
 
@@ -63,5 +64,75 @@ describe("breadcrumbs where multiple nodes set the same passport value", () => {
     expect(output.data?.[duplicateKey]).toEqual(
       expect.arrayContaining(["test", "true"])
     );
+  });
+});
+
+/**
+ * computePassport() does not sort breadcrumbs by flow depth before each calculation
+ * This would be both expensive and redundant (as breadcrumbs are ordered within the Zustand store)
+ * 
+ * Hasura sorts JSONB data alphabetically by key value on insert/update to lowcal_session.data
+ * When fetching breadcrumb data from the DB, it is vital that we always re-sort breadcrumbs by flow depth on resume
+ * Otherwise, computePassport() will return inconsistent results (see tests below)
+ * 
+ * See: resumeSession() - https://github.com/theopensystemslab/planx-new/blob/main/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts#L450
+ */
+describe("breadcrumb order is significant when computing the passport", () => {
+  it("returns passport based on alphabetical breadcrumb order", () => {
+    const breadcrumbsByAlphabeticalOrder = {
+      "3XgE43ozeR": {
+        auto: true,
+        data: {
+          "application.fee.payable": ["456"],
+        },
+      },
+      MEi1WhBeua: {
+        auto: true,
+        data: {
+          "application.fee.payable": ["123"],
+        },
+      },
+    };
+
+    setState({
+      flow: flowWithMultipleSetValues,
+      breadcrumbs: breadcrumbsByAlphabeticalOrder,
+    });
+    const duplicateKey = "application.fee.payable";
+
+    const output = computePassport();
+    expect(output.data).toHaveProperty(duplicateKey);
+
+    // "Last" breadcrumb
+    expect(output.data?.[duplicateKey][0]).toEqual("123");
+  });
+
+  it("returns passport based on flow order (breadcrumb depth)", () => {
+    const breadcrumbsByFlowDepth = {
+      MEi1WhBeua: {
+        auto: true,
+        data: {
+          "application.fee.payable": ["123"],
+        },
+      },
+      "3XgE43ozeR": {
+        auto: true,
+        data: {
+          "application.fee.payable": ["456"],
+        },
+      },
+    };
+
+    setState({
+      flow: flowWithMultipleSetValues,
+      breadcrumbs: breadcrumbsByFlowDepth,
+    });
+    const duplicateKey = "application.fee.payable";
+
+    const output = computePassport();
+    expect(output.data).toHaveProperty(duplicateKey);
+
+    // "Last" breadcrumb
+    expect(output.data?.[duplicateKey][0]).toEqual("456");
   });
 });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/computePassport/flowWithMultipleSetValues.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/mocks/computePassport/flowWithMultipleSetValues.ts
@@ -1,0 +1,66 @@
+
+import { Store } from "pages/FlowEditor/lib/store";
+
+export const flowWithMultipleSetValues: Store.Flow = {
+  _root: {
+    edges: ["MEi1WhBeua", "3XgE43ozeR", "1uz1zK0H8V", "3rJKnFuJQ4"],
+  },
+  "1uz1zK0H8V": {
+    data: {
+      fn: "application.fee.payable",
+      tags: [],
+      title: "Pay for your application",
+      hidePay: false,
+      bannerTitle: "The planning fee for this application is",
+      description:
+        '<p>The planning fee covers the cost of processing your application.    <a target="_self" href="https://www.gov.uk/guidance/fees-for-planning-applications">Find out more about how planning fees are calculated</a> (opens in new tab).</p>',
+      nomineeTitle: "Details of the person paying",
+      govPayMetadata: [
+        {
+          key: "flow",
+          value: "SetFee passport order",
+        },
+        {
+          key: "source",
+          value: "PlanX",
+        },
+        {
+          key: "paidViaInviteToPay",
+          value: "@paidViaInviteToPay",
+        },
+      ],
+      allowInviteToPay: false,
+      yourDetailsLabel: "Your name or organisation name",
+      yourDetailsTitle: "Your details",
+      instructionsTitle: "How to pay",
+      secondaryPageTitle: "Invite someone else to pay for this application",
+      instructionsDescription:
+        "<p>You can pay for your application by using GOV.UK Pay.</p>    <p>Your application will be sent after you have paid the fee.     Wait until you see an application sent message before closing your browser.</p>",
+    },
+    type: 400,
+  },
+  "3XgE43ozeR": {
+    data: {
+      fn: "application.fee.payable",
+      val: "456",
+      operation: "replace",
+    },
+    type: 380,
+  },
+  "3rJKnFuJQ4": {
+    data: {
+      title: "Send",
+      destinations: ["email"],
+    },
+    type: 650,
+  },
+  MEi1WhBeua: {
+    data: {
+      fn: "application.fee.payable",
+      val: "123",
+      tags: [],
+      operation: "replace",
+    },
+    type: 380,
+  },
+};

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -448,8 +448,9 @@ export const previewStore: StateCreator<
   },
 
   resumeSession(session: Session) {
-    // TODO: Explain the importance of this
-    // TODO: Explain computePassport() relies on **sorted** breadcrumbs
+    // Hasura sorts JSONB data alphabetically by key value on insert/update
+    // It is vital that we always re-sort breadcrumbs data (by flow depth) on resume
+    // Without this, the user's passport will not generate correctly
     const sortedBreadcrumbs = sortBreadcrumbs(session.breadcrumbs, get().flow);
 
     set({ ...session, breadcrumbs: sortedBreadcrumbs });

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -448,7 +448,11 @@ export const previewStore: StateCreator<
   },
 
   resumeSession(session: Session) {
-    set({ ...session });
+    // TODO: Explain the importance of this
+    // TODO: Explain computePassport() relies on **sorted** breadcrumbs
+    const sortedBreadcrumbs = sortBreadcrumbs(session.breadcrumbs, get().flow);
+
+    set({ ...session, breadcrumbs: sortedBreadcrumbs });
     get().setCurrentCard();
     get().updateSectionData();
   },


### PR DESCRIPTION
## What's the problem?
It was reported that a user took the following path and was presented with two different final payment amounts on their service -
 - Navigate through flow
 - Proceed to GovPay
 - Cancel payment, return to PlanX
 - On return to the pay component, the amount was incorrect ❌ 

Source (ODP Slack): https://opendigitalplanning.slack.com/archives/C07491E8W68/p1755707732186779

## What's the cause of this?
After a lot of debugging and head scratching it turned out to be a bug based on the order in which breadcrumbs are processed when calculating a user's passport. In this instance the following was happening - 
 - User navigates through journey, reaches the Pay component
 - Passport is correct, breadcrumbs are stored in the Zustand store by flow depth / order of questions seen by user
   - If you log these values out using `window.api.getState().breadcrumbs`, Chrome (and other browsers) will sort them in the dev tools which confuses matters. Our JSON preview, or the preview in the dev tools prove this
   - See https://stackoverflow.com/questions/70850355/order-of-keys-in-expanded-vs-collapsed-view-in-chrome-console
 - User goes to GovPay
 - Returns to PlanX
 - Session is validated, breadcrumbs restored, but sorted alphabetically by key (more on this later)
 - Passport calculated, based on alphabetical order
 - Passport is incorrect due to this

In the example raised, the breadcrumbs responsible for setting the fee amount were ordered one direction by flow depth, but the opposite order alphabetically. This lead to the fee displaying as incorrect.

It's important to stress that this bug is not related to the `SetFee` or `SetValue` components in any way, but applies to all breadcrumbs on any "resume" operation to PlanX. This very likely explains an entire category of navigational error we've not been able to recreate in the past.

## What's the solution?
We need to maintain breadcrumbs which are sorted in the correct order - they are taken out of sync when a session is resumed. There are many possible solutions (many discussed before in a different context).
 - Store breadcrumbs in an ordered data structure (e.g. array)
 - Index breadcrumbs (e.g. with timestamp)
 - Always sort breadcrumbs when computing passport (this is expensive and generally redundant)

I've opted for a more light touch solution here initially (though I'd love to return to the first two options above in more depth). As the issue is that breadcrumbs are sorted incorrectly on resume, **we can simply sort them once after a session is validated**.

## Context
### Why does `computePassport()` work like this?
By design, breadcrumbs are intended to be additive (e.g. append to an array of responses) or destructive (e.g. replace a previous answer with a new one). As a user navigates through a flow, we give more weight to later answers (by flow depth). As breadcrumbs are always in the correct order, sorting is both an expensive and redundant step.

### Why aren't breadcrumbs persisted in the correct order?
Postgres automatically re-arranges objects in JSONB columns for internal optimisation (this would not be the case if we used a plain JSON column). This means that when we write to the DB, we're not guaranteed the same JSON back.

> _Because the json type stores an exact copy of the input text, it will preserve semantically-insignificant white space between tokens, as well as the order of keys within JSON objects. Also, if a JSON object within the value contains the same key more than once, all the key/value pairs are kept. (The processing functions consider the last value as the operative one.) By contrast, jsonb does not preserve white space, **does not preserve the order of object keys**, and does not keep duplicate object keys. If duplicate keys are specified in the input, only the last value is kept._

Source: https://www.postgresql.org/docs/current/datatype-json.html

I think the correct discussion to have here is - 
 - Should be break up the `lowcal_session.data` column? It has a fixed schema that can be broken into other columns.
 - What's the right data structure for breadcrumbs?