### PR TITLE
chore: Remove over-active ShareDB logout, add Airbrake logging

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
@@ -1,3 +1,4 @@
+import { logger } from "airbrake";
 import { toast, ToastOptions } from "react-toastify";
 import ReconnectingWebSocket from "reconnecting-websocket";
 import type { Doc } from "sharedb";
@@ -36,17 +37,9 @@ const createWSConnection = () => {
   /** Fallback for unhandled ShareDB errors - log user out to prevent silent failures */
   socket.addEventListener("error", ({ error, message }) => {
     console.error("Unhandled ShareDB error: ", { error, message });
-
-    // Only display a single toast at a time
-    if (toast.isActive("sharedb_jwt_expiry")) return;
-
-    toast.error(
-      "[ShareDB error]: Unhandled error, redirecting to login page...",
-      {
-        toastId: "sharedb_error",
-        ...toastConfig,
-      },
-    );
+    // Take no user action, allow them to remain logged in
+    // Report to Airbrake in order to further debug this issue, as it appears that "error" is triggering frequently
+    logger.notify(`Unhandled ShareDB error: ${message}. Error: ${error}.`);
   });
 
   return socket;


### PR DESCRIPTION
It appears that automatically triggering a logout on ShareDB "error" event is a little too aggressive - users are reporting that this happens frequently.

This was initially put in place to avoid silent ShareDB failures - I've added additional Airbrake logging to get more insight here.

Trello ticket: https://trello.com/c/RIyEHTcc/3400-fix-sharedb-logout-bug