### PR TITLE
fix: quadruple caddy `propagation_delay` to 120s

### DIFF
--- a/ci/caddy/Caddyfile
+++ b/ci/caddy/Caddyfile
@@ -8,7 +8,7 @@
 	# wilcard certs require a DNS challenge
 	tls {
 		dns vultr {$VULTR_API_KEY}
-		propagation_delay 30s # default 0s (NB. Vultr gives 300s as DNS record TTL)
+		propagation_delay 120s # default 0s (NB. Vultr gives 300s as DNS record TTL)
 		propagation_timeout 5m # default 2mins (-1 indicates to not conduct propagation check, just handover to ACME after delay)
 		resolvers 1.1.1.1 8.8.8.8
 	}


### PR DESCRIPTION
Attempts to fix CI/pizza builds failing (more often that not!) by extending the `propagation_delay` knob four-fold to 2 minutes (if this doesn't work, we could try extending it further). I'm not convinced this is necessarily the issue, but it will help us rule out Vultr simply taking a long time to provision the requested TXT records.

Relevant ticket: https://trello.com/c/YopMVSYl