### PR TITLE
fix: Do not block user journey for failed Send events

### DIFF
--- a/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -1,6 +1,7 @@
 import ErrorOutline from "@mui/icons-material/ErrorOutline";
 import Typography from "@mui/material/Typography";
 import { SendIntegration } from "@opensystemslab/planx-core/types";
+import { logger } from "airbrake";
 import axios, { AxiosResponse } from "axios";
 import Bowser from "bowser";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
@@ -121,7 +122,12 @@ const CreateSendEvents: React.FC<Props> = ({
   }, [loading, error, value, destinations, props]);
 
   // Throw errors so that they're caught by our error boundaries and Airbrake
-  if (error) throw error;
+  // User will not be blocked, and will proceed to next node (Confirmation)
+  if (error) {
+    logger.notify(
+      `Failed to create send events for session ${sessionId}. Error: ${error}`
+    )
+  }
 
   if (loading) {
     return (


### PR DESCRIPTION
This PR improves both UX and DX relating to failed send events. We will not block the user, but allow them to proceed to the confirmation page - they'll receive an email later once any issues on our side have been resolved.

| Before | After |
|--------|--------|
| Generic "Network error" show to user | No error shown to user, they proceed to `Confirmation` |
| Generic "Network error" logged to Airbrake | Meaningful error logged to Airbrake |
| No send breadcrumb | Send breadcrumb (with error) |
