### PR TITLE
fix: Drop document templates from OneApp payload generation

### DIFF
--- a/api.planx.uk/modules/send/email/index.test.ts
+++ b/api.planx.uk/modules/send/email/index.test.ts
@@ -22,7 +22,6 @@ vi.mock("@opensystemslab/planx-core", async () => {
   const mockCoreDomainClient = class extends actualCore.CoreDomainClient {
     constructor() {
       super();
-      this.getDocumentTemplateNamesForSession = vi.fn();
       this.export.csvData = () => mockGenerateCSVData();
     }
   };

--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#bec2515",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b3b3608",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.11.0",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.701.0
         version: 3.876.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#bec2515
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@19.1.11)
+        specifier: git+https://github.com/theopensystemslab/planx-core#b3b3608
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@19.1.11)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1015,8 +1015,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608}
     version: 1.0.0
 
   '@paralleldrive/cuid2@2.2.2':
@@ -5244,7 +5244,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@19.1.11)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@19.1.11)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.11)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.11)(react@18.3.1))(@types/react@19.1.11)(react@18.3.1)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.10.0",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#bec2515",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b3b3608",
     "axios": "^1.11.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.1.1
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#bec2515
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@19.1.8)
+        specifier: git+https://github.com/theopensystemslab/planx-core#b3b3608
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@19.1.8)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -383,8 +383,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2191,7 +2191,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@19.1.8)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@19.1.8)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.8)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@18.3.1))(@types/react@19.1.8)(react@18.3.1)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#bec2515",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b3b3608",
     "axios": "^1.11.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#bec2515
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@19.1.8)
+        specifier: git+https://github.com/theopensystemslab/planx-core#b3b3608
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@19.1.8)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -313,8 +313,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608}
     version: 1.0.0
 
   '@playwright/test@1.54.1':
@@ -1846,7 +1846,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@19.1.8)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@19.1.8)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.8)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@18.3.1))(@types/react@19.1.8)(react@18.3.1)

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -17,7 +17,7 @@
     "@mui/utils": "^5.15.11",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.6",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#bec2515",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#b3b3608",
     "@tiptap/core": "^3.0.7",
     "@tiptap/extension-emoji": "^3.0.7",
     "@tiptap/extension-image": "^3.0.7",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6(preact@8.5.3)
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#bec2515
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@18.3.23)
+        specifier: git+https://github.com/theopensystemslab/planx-core#b3b3608
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@18.3.23)
       '@tiptap/core':
         specifier: ^3.0.7
         version: 3.0.7(@tiptap/pm@3.0.7)
@@ -2221,8 +2221,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.6':
     resolution: {integrity: sha512-EBOgrgBRFNg8p+7nDFvh+K7N4NFQ7+epBXjE9w7h0u87q4M+nOpBwXNc67+UdDs+j8Mi+vQ2R+uJBIKF25NQ7g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -9984,7 +9984,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bec2515(@types/react@18.3.23)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b3b3608(@types/react@18.3.23)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)


### PR DESCRIPTION
Relies on https://github.com/theopensystemslab/planx-core

Follow up to https://github.com/theopensystemslab/planx-new/pull/5127 which resolves [failing regression tests](https://github.com/theopensystemslab/planx-new/actions/runs/17287276070).