### PR TITLE
further extend caddy prop delay further to 300s 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ __pycache__
 **/*.p7b
 **/*.pem
 **/*.zip
+
+# Tooling
+.aider*

--- a/ci/caddy/Caddyfile
+++ b/ci/caddy/Caddyfile
@@ -8,9 +8,9 @@
 	# wilcard certs require a DNS challenge
 	tls {
 		dns vultr {$VULTR_API_KEY}
-		propagation_delay 120s # default 0s (NB. Vultr gives 300s as DNS record TTL)
+		propagation_delay 300s # default 0s (NB. Vultr gives 300s as DNS record TTL)
 		propagation_timeout 5m # default 2mins (-1 indicates to not conduct propagation check, just handover to ACME after delay)
-		resolvers 1.1.1.1 8.8.8.8
+		resolvers 1.1.1.1 8.8.8.8 8.8.4.4
 	}
 
 	# since caddy is inside docker network, ports given here should match right side of host:container in compose files


### PR DESCRIPTION
#5126 did not resolve failure of some pizzas to provision certs, so we further extend `propagation_delay` in the `Caddyfile` to equal the DNS TTL given by Vultr (300s).

Hopefully this should resolve issues with CI builds! If not, we can be fairly certain that slow DNS propagation is not the issue.