### PR TITLE
chore: Optimisations for progress bar rendering

### DIFF
--- a/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
+++ b/editor.planx.uk/src/components/Header/Sections/ProgressBar.tsx
@@ -27,9 +27,7 @@ const Root = styled(LinearProgress)(({ theme }) => ({
 }));
 
 export const ProgressBar: React.FC = () => {
-  const progress = useStore((state) =>
-    state.getSectionProgress(),
-  );
+  const progress = useStore((state) => state.sectionProgress);
 
   if (!progress) return;
 

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -29,7 +29,8 @@ export interface NavigationStore {
   filterFlowByType: (type: TYPES) => Store.Flow;
   getSortedBreadcrumbsBySection: () => Store.Breadcrumbs[];
   getSectionForNode: (nodeId: string) => SectionNode;
-  getSectionProgress: () => Progress | undefined;
+  _calculateSectionProgress: (currentSectionIndex: number) => Progress | undefined;
+  sectionProgress: Progress | undefined;
 }
 
 export const navigationStore: StateCreator<
@@ -61,11 +62,15 @@ export const navigationStore: StateCreator<
     const hasSections = Boolean(sectionCount);
     const currentSectionTitle = Object.values(sectionNodes)[0]?.data.title;
 
+    const { currentSectionIndex, _calculateSectionProgress } = get();
+    const sectionProgress = _calculateSectionProgress(currentSectionIndex);
+
     set({
       sectionNodes,
       sectionCount,
       hasSections,
       currentSectionTitle,
+      sectionProgress,
     });
   },
 
@@ -74,21 +79,19 @@ export const navigationStore: StateCreator<
    * Triggered when going backwards, forwards, or changing answer
    */
   updateSectionData: () => {
-    const { breadcrumbs, sectionNodes, hasSections, currentCard } = get();
+    const {
+      breadcrumbs,
+      sectionNodes,
+      hasSections,
+      currentCard,
+      _calculateSectionProgress,
+    } = get();
     // Sections not being used, do not proceed
     if (!hasSections) return;
 
     const breadcrumbIds = Object.keys(breadcrumbs);
     const sectionIds = Object.keys(sectionNodes);
-
-    const hasPassedFirstSection = Boolean(
-      findLast(breadcrumbIds, (breadcrumbId: string) =>
-        sectionIds.includes(breadcrumbId),
-      ),
-    );
-
-    // No sections in breadcrumbs, first section values already set in store
-    if (!hasPassedFirstSection) return;
+    const sectionIdsSet = new Set(sectionIds);
 
     // Transition to a new section index as soon as a section is reached
     // It won't yet be in the breadcrumbs but should count as the starting point of the next section
@@ -97,16 +100,22 @@ export const navigationStore: StateCreator<
 
     const mostRecentSectionId = findLast(
       breadcrumbIds,
-      (breadcrumbId: string) => sectionIds.includes(breadcrumbId),
+      (breadcrumbId: string) => sectionIdsSet.has(breadcrumbId)
     );
+
+    const hasPassedFirstSection = Boolean(mostRecentSectionId);
+
+    // No sections in breadcrumbs, first section values already set in store
+    if (!hasPassedFirstSection) return;
 
     // No sections in breadcrumbs, first section values already set in store
     if (!mostRecentSectionId) return;
 
     const currentSectionTitle = sectionNodes[mostRecentSectionId].data.title;
     const currentSectionIndex = sectionIds.indexOf(mostRecentSectionId) + 1;
+    const sectionProgress = _calculateSectionProgress(currentSectionIndex);
 
-    set({ currentSectionTitle, currentSectionIndex });
+    set({ currentSectionTitle, currentSectionIndex, sectionProgress });
     console.debug("section state updated"); // used as a transition trigger in e2e tests
   },
 
@@ -181,9 +190,10 @@ export const navigationStore: StateCreator<
     return section;
   },
 
-  getSectionProgress: () => {
-    const { sectionNodes, currentSectionIndex, isFinalCard, sectionCount } =
-      get();
+  sectionProgress: undefined,
+
+  _calculateSectionProgress: (currentSectionIndex: number) => {
+    const { sectionNodes, isFinalCard, sectionCount } = get();
     if (!sectionCount) return;
 
     if (isFinalCard()) return { completed: 100, current: 100 };

--- a/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -77,7 +77,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.getType,
     state.currentCard,
     state.setCurrentCard,
-    state.getSectionProgress(),
+    state.sectionProgress,
   ]);
   const isStandalone = previewEnvironment === "standalone";
   const { createAnalytics, trackEvent } = useAnalyticsTracking();


### PR DESCRIPTION
This is a companion to #5141 - just a few small improvements I noticed when digging deeper into optimising the `record()` function.

I'm not convinced this makes a real noticeable difference, but it is slightly less computationally heavy (and results in fewer re-renders).