### PR TITLE
chore: Fix React errors on `PlanningConstraint` component

### DIFF
--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/List.tsx
@@ -53,6 +53,7 @@ const StyledAccordion = styled(Accordion, {
       "content",
       "data",
       "inaccurateConstraints",
+      "setInaccurateConstraints",
     ].includes(prop as string),
 })<StyledAccordionProps>(({ theme, category }) => ({
   borderLeft: `5px solid ${CATEGORY_COLORS[category]}`,

--- a/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
+++ b/editor.planx.uk/src/@planx/components/PlanningConstraints/Modal.tsx
@@ -184,9 +184,8 @@ export const OverrideEntitiesModal = ({
                 </Typography>
                 {Boolean(entities?.length) &&
                   entities?.map((e) => (
-                    <Grid item xs={12} sx={{ pointerEvents: "auto" }}>
+                    <Grid item xs={12} sx={{ pointerEvents: "auto" }} key={`${e.entity}`}>
                       <ChecklistItem
-                        key={`${e.entity}`}
                         id={`entity-checkbox-${e.entity}`}
                         label={formatEntityName(e, metadata)}
                         checked={


### PR DESCRIPTION
Two small issues I spotted when working on #5142 

<img width="802" height="116" alt="image" src="https://github.com/user-attachments/assets/9a3d839a-7516-4e78-a1b1-7b03b0c24240" />
