### PR TITLE
chore: return payment request ID in summary admin endpoint

### DIFF
--- a/api.planx.uk/modules/admin/session/summary.ts
+++ b/api.planx.uk/modules/admin/session/summary.ts
@@ -71,7 +71,7 @@ interface SessionSummary {
     >[];
     invitations_to_pay?: Pick<
       PaymentRequest,
-      "createdAt" | "govPayPaymentId" | "paymentAmount" | "paidAt"
+      "id" | "createdAt" | "govPayPaymentId" | "paymentAmount" | "paidAt"
     >[];
   };
 }
@@ -107,6 +107,7 @@ const getSessionSummaryById = async (
             status
           }
           invitations_to_pay: payment_requests(order_by: { created_at: desc }) {
+            id
             created_at
             govpay_payment_id
             payment_amount


### PR DESCRIPTION
Recently noticed while troubleshooting invite to pay questions - we need the `payment_request.id` in order to reconstruct the invite-to-pay magic link for an application (`<servicedomain>/pay?paymentRequestId=<id>`). Returning it here saves an extra database query !

