### PR TITLE
feat: Create `lowcal_session.status` computed field

### DIFF
--- a/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
@@ -52,10 +52,7 @@ const validateRequest = async (
         lowcalSessions: lowcal_sessions(
           where: {
             email: { _eq: $email }
-            deleted_at: { _is_null: true }
-            locked_at: { _is_null: true }
-            submitted_at: { _is_null: true }
-            sanitised_at: { _is_null: true }
+            user_status: { _eq: "draft" }
             flow: { team: { slug: { _eq: $teamSlug } } }
           }
           order_by: { flow: { slug: asc }, created_at: asc }

--- a/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
+++ b/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
@@ -204,8 +204,7 @@ export async function findSession({
           where: {
             id: { _eq: $sessionId }
             email: { _eq: $email }
-            submitted_at: { _is_null: true }
-            deleted_at: { _is_null: true }
+            user_status: { _in: ["draft", "awaiting-payment"] }
           }
           limit: 1
         ) {

--- a/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
@@ -28,6 +28,17 @@ array_relationships:
         remote_table:
           name: payment_status
           schema: public
+computed_fields:
+  - name: user_status
+    definition:
+      function:
+        name: lowcal_sessions_user_status
+        schema: public
+  - name: system_status
+    definition:
+      function:
+        name: lowcal_sessions_system_status
+        schema: public
 insert_permissions:
   - role: public
     permission:
@@ -55,6 +66,9 @@ select_permissions:
         - allow_list_answers
         - has_user_saved
         - sanitised_at
+      computed_fields:
+        - user_status
+        - system_status
       filter: {}
   - role: public
     permission:
@@ -66,6 +80,9 @@ select_permissions:
         - id
         - submitted_at
         - updated_at
+      computed_fields:
+        - user_status
+        - system_status
       filter:
         _and:
           - id:

--- a/hasura.planx.uk/migrations/default/1756743433814_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/default/1756743433814_run_sql_migration/down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS public.lowcal_sessions_user_status;
+DROP FUNCTION IF EXISTS public.lowcal_sessions_system_status;

--- a/hasura.planx.uk/migrations/default/1756743433814_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/default/1756743433814_run_sql_migration/up.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE FUNCTION public.lowcal_sessions_user_status(
+  lowcal_session_row lowcal_sessions
+) RETURNS TEXT AS
+$$
+SELECT
+  CASE
+    WHEN lowcal_session_row.submitted_at IS NOT NULL THEN 'submitted'
+    WHEN lowcal_session_row.locked_at IS NOT NULL THEN 'awaiting-payment'
+    WHEN lowcal_session_row.deleted_at IS NOT NULL THEN 'expired'
+  ELSE 'draft'
+END;
+$$ LANGUAGE sql STABLE;
+
+CREATE OR REPLACE FUNCTION public.lowcal_sessions_system_status(
+  lowcal_session_row lowcal_sessions
+) RETURNS TEXT AS
+$$
+SELECT
+  CASE
+    WHEN lowcal_session_row.sanitised_at IS NULL 
+      THEN 'active' 
+      ELSE 'sanitised'
+  END;
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
## What does this PR do?
This PR adds a new `status` [computed field](https://hasura.io/docs/2.0/schema/postgres/computed-fields/) to the `lowcal_sessions` table, and then references it in a few queries. It's very possible that there are a few other examples here I've missed.

## Motivation
This has come up as a good idea a few times - in reference to the complex LPS query, as well as migration scripts. I'm picking this up now as it will enable me to refactor the more LPS query to match the requirements of the new designs.

Regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/17398793228 ✅ 