### PR TITLE
fix: Flow data does not load when navigating back from child page

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
@@ -1,4 +1,5 @@
 import classnames from "classnames";
+import isEmpty from "lodash/isEmpty";
 import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
@@ -51,8 +52,11 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
   ]);
 
   useEffect(() => {
+    // Flow might not be loaded via ShareDB (e.g. user has navigated directly to :flow/somePage)
+    if (isEmpty(flow)) return;
+
     if (!orderedFlow) setOrderedFlow();
-  }, [orderedFlow, setOrderedFlow]);
+  }, [orderedFlow, setOrderedFlow, flow]);
 
   // useStore.getState().getTeam().slug undefined here, use window instead
   const teamSlug = window.location.pathname.split("/")[1];

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -293,8 +293,6 @@ export const editorStore: StateCreator<
   },
 
   connectTo: async (id) => {
-    if (id === get().id) return; // already connected to this ID
-
     console.log("connecting to", id, get().id);
 
     doc = getFlowConnection(id);


### PR DESCRIPTION
## What's the problem?
When navigating directly to `:flow/someChild` back to `:flow/` routes, ShareDB is not hit, and flow data is not loaded. 

This triggers a number of errors which rely on flow data - including displaying flow data.

https://github.com/user-attachments/assets/f73f4445-c8c9-46a5-8f1e-1860b3ada206

This appears as a frequent bug on Airbrake, and may be related to the recently reported issues regarding mismatched flow slug and data (this is how I began investigating this one).

Note: This will only appear if `:flow/someChild` is directly navigated to (or refreshed on). Any routing that first goes via `:flow/` will not hit this issue.

## What's the solution?
Remove the redundant check for an existing flow ID - these predated nested pages. There will be a flow ID in the store if you first visit a child page (e.g. submissions).

We could also make flow data `undefined` and not `{}` when the store is instantiated, but this introduces a lot of cascading type issues for what is generally an edge case.

