### PR TITLE
chore: add event audit view `templated_flow_update_requests`

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_templated_flow_update_requests.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_templated_flow_update_requests.yaml
@@ -1,0 +1,3 @@
+table:
+  name: templated_flow_update_requests
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -40,6 +40,7 @@
 - "!include public_teams_summary.yaml"
 - "!include public_temp_data_migrations_audit.yaml"
 - "!include public_templated_flow_edits.yaml"
+- "!include public_templated_flow_update_requests.yaml"
 - "!include public_uniform_applications.yaml"
 - "!include public_user_roles.yaml"
 - "!include public_users.yaml"

--- a/hasura.planx.uk/migrations/default/1756972534375_create_view_templated_flow_update_requests/down.sql
+++ b/hasura.planx.uk/migrations/default/1756972534375_create_view_templated_flow_update_requests/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS templated_flow_update_requests;

--- a/hasura.planx.uk/migrations/default/1756972534375_create_view_templated_flow_update_requests/up.sql
+++ b/hasura.planx.uk/migrations/default/1756972534375_create_view_templated_flow_update_requests/up.sql
@@ -1,0 +1,19 @@
+CREATE VIEW templated_flow_update_requests AS (
+    SELECT 
+      hse.payload ->> 'sourceFlowId' as source_template_id,
+      hse.payload ->> 'templatedFlowId' as templated_flow_id,
+      hse.id as event_id,
+      hse.created_at as event_created_at,
+    	hse.scheduled_time as event_scheduled_at,
+    	il.created_at as event_invoked_at,
+    	hse.status as event_status,
+    	hse.tries,
+    	hse.next_retry_at,
+    	hse.webhook_conf as request_webhook,
+    	il.status as request_status,
+    	il.request,
+    	il.response
+    FROM hdb_catalog.hdb_scheduled_events hse
+        JOIN hdb_catalog.hdb_scheduled_event_invocation_logs il ON hse.id = il.event_id
+    WHERE comment LIKE 'update_templated_flow_%'
+);


### PR DESCRIPTION
Trying to get to the bottom of August's reports of inconsistent update/reconciliation behavior when updating templated flows after a source template publish - this view helps expose the status & responses of those requests! Intended to be internal reference only, no plans to expose in editor for now.

More context in this thread https://opensystemslab.slack.com/archives/C01E3AC0C03/p1756717835046789