### PR TITLE
feat: Toggle within PlanX allowing users to list services on LPS

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.stories.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/ReadMePage/ReadMePage.stories.tsx
@@ -21,6 +21,7 @@ export const Basic = {
       summary: "A short blurb",
       limitations: "",
       settings: {},
+      isListedOnLPS: false,
     },
   },
 } satisfies Story;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/LPS/LPSListingSection.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/LPS/LPSListingSection.tsx
@@ -85,7 +85,7 @@ export const LPSListing = () => {
           </p>
           <p>
             Listing your service requires a description and summary. These can
-            we provided on{" "}
+            be provided on{" "}
             <Link href="../about">the "About this flow" page</Link>.
           </p>
         </SettingsDescription>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/LPS/LPSListingSection.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/LPS/LPSListingSection.tsx
@@ -1,0 +1,84 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import { useFormik } from "formik";
+import { useToast } from "hooks/useToast";
+import React from "react";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import SettingsSection from "ui/editor/SettingsSection";
+import { Switch } from "ui/shared/Switch";
+
+import { useStore } from "../../../../lib/store";
+
+export const LPSListing = () => {
+  const [isListedOnLPS, setIsListedOnLPS] = useStore((state) => [
+    state.isFlowListedOnLPS,
+    state.setIsFlowListedOnLPS,
+  ]);
+
+  const toast = useToast();
+
+  const form = useFormik<{ isListedOnLPS: boolean }>({
+    initialValues: {
+      isListedOnLPS: isListedOnLPS ?? false,
+    },
+    // TODO: Validation - must be online, must have description...
+    onSubmit: async (values, { resetForm }) => {
+      const isSuccess = await setIsListedOnLPS(values.isListedOnLPS);
+      if (isSuccess) {
+        toast.success("Service settings updated successfully");
+        // Reset "dirty" status to disable Save & Reset buttons
+        resetForm({ values });
+      }
+    },
+  });
+
+  return (
+    <Box component="form" onSubmit={form.handleSubmit} mb={2}>
+      <SettingsSection>
+        <Typography variant="h2" component="h3" gutterBottom>
+          LocalPlanning.services
+        </Typography>
+        <Typography variant="body1">
+          Manage how this service is listed on localplanning.services
+        </Typography>
+      </SettingsSection>
+      <SettingsSection background>
+        <Switch
+          label={
+            form.values.isListedOnLPS
+              ? "Service is listed on localplanning.services"
+              : "Service is not listed on localplanning.services"
+          }
+          name={"service.status"}
+          variant="editorPage"
+          checked={form.values.isListedOnLPS}
+          onChange={() =>
+            form.setFieldValue(
+              "isListedOnLPS",
+              !form.values.isListedOnLPS,
+            )
+          }
+        />
+        <SettingsDescription>
+          <p>Control if this service will be listed on localplanning.services. By listing your service you allow applicants and agents to browse the services which you offer via PlanX.</p>
+        </SettingsDescription>
+        <Box>
+          <Button type="submit" variant="contained" disabled={!form.dirty}>
+            Save
+          </Button>
+          <Button
+            onClick={() => form.resetForm()}
+            type="reset"
+            variant="contained"
+            disabled={!form.dirty}
+            color="secondary"
+            sx={{ ml: 1.5 }}
+          >
+            Reset changes
+          </Button>
+        </Box>
+      </SettingsSection>
+    </Box>
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/LPS/LPSListingSection.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/LPS/LPSListingSection.tsx
@@ -4,17 +4,23 @@ import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { useToast } from "hooks/useToast";
 import React from "react";
+import { Link } from "react-navi";
 import SettingsDescription from "ui/editor/SettingsDescription";
 import SettingsSection from "ui/editor/SettingsSection";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { Switch } from "ui/shared/Switch";
 
 import { useStore } from "../../../../lib/store";
 
 export const LPSListing = () => {
-  const [isListedOnLPS, setIsListedOnLPS] = useStore((state) => [
-    state.isFlowListedOnLPS,
-    state.setIsFlowListedOnLPS,
-  ]);
+  const [isListedOnLPS, setIsListedOnLPS, description, summary] = useStore(
+    (state) => [
+      state.isFlowListedOnLPS,
+      state.setIsFlowListedOnLPS,
+      state.flowDescription,
+      state.flowSummary,
+    ],
+  );
 
   const toast = useToast();
 
@@ -22,7 +28,18 @@ export const LPSListing = () => {
     initialValues: {
       isListedOnLPS: isListedOnLPS ?? false,
     },
-    // TODO: Validation - must be online, must have description...
+    validate: () => {
+      if (!description)
+        return {
+          isListedOnLPS:
+            "Service description required - please set via the 'About this flow' tab",
+        };
+      if (!summary)
+        return {
+          isListedOnLPS:
+            "Service summary required  - please set via the 'About this flow' tab",
+        };
+    },
     onSubmit: async (values, { resetForm }) => {
       const isSuccess = await setIsListedOnLPS(values.isListedOnLPS);
       if (isSuccess) {
@@ -37,10 +54,10 @@ export const LPSListing = () => {
     <Box component="form" onSubmit={form.handleSubmit} mb={2}>
       <SettingsSection>
         <Typography variant="h2" component="h3" gutterBottom>
-          LocalPlanning.services
+          Listings
         </Typography>
         <Typography variant="body1">
-          Manage how this service is listed on localplanning.services
+          Manage how this service is listed and indexed
         </Typography>
       </SettingsSection>
       <SettingsSection background>
@@ -54,30 +71,45 @@ export const LPSListing = () => {
           variant="editorPage"
           checked={form.values.isListedOnLPS}
           onChange={() =>
-            form.setFieldValue(
-              "isListedOnLPS",
-              !form.values.isListedOnLPS,
-            )
+            form.setFieldValue("isListedOnLPS", !form.values.isListedOnLPS)
           }
         />
         <SettingsDescription>
-          <p>Control if this service will be listed on localplanning.services. By listing your service you allow applicants and agents to browse the services which you offer via PlanX.</p>
+          <p>
+            Control if this service will be listed on{" "}
+            <a href="https://www.localplanning.services">
+              localplanning.service (opens in a new tab)
+            </a>
+            . By listing your service you allow applicants and agents to browse
+            the services which you offer via PlanX.
+          </p>
+          <p>
+            Listing your service requires a description and summary. These can
+            we provided on{" "}
+            <Link href="../about">the "About this flow" page</Link>.
+          </p>
         </SettingsDescription>
-        <Box>
-          <Button type="submit" variant="contained" disabled={!form.dirty}>
-            Save
-          </Button>
-          <Button
-            onClick={() => form.resetForm()}
-            type="reset"
-            variant="contained"
-            disabled={!form.dirty}
-            color="secondary"
-            sx={{ ml: 1.5 }}
-          >
-            Reset changes
-          </Button>
-        </Box>
+        <ErrorWrapper
+          error={
+            (form.dirty && form.submitCount && form.errors.isListedOnLPS) || ""
+          }
+        >
+          <Box>
+            <Button type="submit" variant="contained" disabled={!form.dirty}>
+              Save
+            </Button>
+            <Button
+              onClick={() => form.resetForm()}
+              type="reset"
+              variant="contained"
+              disabled={!form.dirty}
+              color="secondary"
+              sx={{ ml: 1.5 }}
+            >
+              Reset changes
+            </Button>
+          </Box>
+        </ErrorWrapper>
       </SettingsSection>
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/ServiceSettings.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/ServiceSettings/ServiceSettings.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { FooterLinksAndLegalDisclaimer } from "./FlowElements/FooterLinksAndLegalDisclaimer";
 import FlowStatus from "./FlowStatus";
 import { FlowVisibility } from "./FlowVisibility/FlowVisibilitySection";
+import { LPSListing } from "./LPS/LPSListingSection";
 import { TemplatedFlowStatus } from "./TemplatedFlowStatus/TemplatedFlowStatusSection";
 
 const ServiceSettings: React.FC = () => {
@@ -21,6 +22,7 @@ const ServiceSettings: React.FC = () => {
       <FlowStatus />
       {!isTemplatedFrom && !isTemplate && <FlowVisibility />}
       <FooterLinksAndLegalDisclaimer />
+      <LPSListing/>
       {isTemplatedFrom && <TemplatedFlowStatus />}
     </Container>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -217,6 +217,7 @@ export const settingsStore: StateCreator<
       summary,
       limitations,
       analyticsLink,
+      isListedOnLPS,
     };
   },
 
@@ -296,7 +297,7 @@ export const settingsStore: StateCreator<
     const { id } = get();
 
     try {
-      const { data } = await client.mutate<{ flow: { id: string }}>({
+      const { data } = await client.mutate<{ flow: { id: string } }>({
         mutation: gql`
           mutation UpdateIsFlowListedOnLPS(
             $id: uuid!
@@ -316,7 +317,8 @@ export const settingsStore: StateCreator<
         },
       });
 
-      if (!data?.flow?.id) throw Error("Failed to update flow listing for localplanning.services");
+      if (!data?.flow?.id)
+        throw Error("Failed to update flow listing for localplanning.services");
       set({ isFlowListedOnLPS: isListed });
       return Boolean(data.flow.id);
     } catch (error) {

--- a/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -16,6 +16,7 @@ export interface FlowInformation {
   limitations?: string;
   canCreateFromCopy?: boolean;
   analyticsLink?: string;
+  isListedOnLPS: boolean;
 }
 
 export interface GetFlowInformation {

--- a/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -114,6 +114,7 @@ insert_permissions:
         - data
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -179,6 +180,7 @@ insert_permissions:
         - data
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -217,6 +219,7 @@ insert_permissions:
         - data
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -248,6 +251,7 @@ select_permissions:
         - deleted_at
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -316,6 +320,7 @@ select_permissions:
         - deleted_at
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -342,6 +347,7 @@ select_permissions:
         - data
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -370,6 +376,7 @@ select_permissions:
         - deleted_at
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -398,6 +405,7 @@ update_permissions:
         - data
         - description
         - id
+        - is_listed_on_lps
         - limitations
         - name
         - settings
@@ -490,6 +498,7 @@ update_permissions:
         - data
         - deleted_at
         - description
+        - is_listed_on_lps
         - is_template
         - limitations
         - name
@@ -526,6 +535,7 @@ update_permissions:
         - data
         - deleted_at
         - description
+        - is_listed_on_lps
         - limitations
         - name
         - settings

--- a/hasura.planx.uk/migrations/default/1756979341323_alter_table_public_flows_add_column_is_indexed_on_lps/down.sql
+++ b/hasura.planx.uk/migrations/default/1756979341323_alter_table_public_flows_add_column_is_indexed_on_lps/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."flows"."is_listed_on_lps" is NULL;
+
+ALTER TABLE "public"."flows" DROP COLUMN "is_listed_on_lps";

--- a/hasura.planx.uk/migrations/default/1756979341323_alter_table_public_flows_add_column_is_indexed_on_lps/up.sql
+++ b/hasura.planx.uk/migrations/default/1756979341323_alter_table_public_flows_add_column_is_indexed_on_lps/up.sql
@@ -1,0 +1,4 @@
+alter table "public"."flows" add column "is_listed_on_lps" boolean
+ not null default 'false';
+
+comment on column "public"."flows"."is_listed_on_lps" is E'Controls if this flow can be listed on localplanning.services';

--- a/localplanning.services/src/lib/lpa-api/query.ts
+++ b/localplanning.services/src/lib/lpa-api/query.ts
@@ -16,7 +16,7 @@ export const GET_LPAS_QUERY = gql`
       applyServices: flows(
         where: {
           status: { _eq: online }
-          is_listed_on_lps: { _eq: true }
+          # is_listed_on_lps: { _eq: true }
           slug: { _nin: $notifyServiceSlugs }
           published_flows: { has_send_component: { _eq: true } }
         }
@@ -27,7 +27,7 @@ export const GET_LPAS_QUERY = gql`
       guidanceServices: flows(
         where: {
           status: { _eq: online }
-          is_listed_on_lps: { _eq: true }
+          # is_listed_on_lps: { _eq: true }
           published_flows: { has_send_component: { _eq: false } }
         }
         order_by: { name: asc }
@@ -37,7 +37,7 @@ export const GET_LPAS_QUERY = gql`
       notifyServices: flows(
         where: {
           status: { _eq: online }
-          is_listed_on_lps: { _eq: true }
+          # is_listed_on_lps: { _eq: true }
           slug: { _in: $notifyServiceSlugs }
           published_flows: { has_send_component: { _eq: true } }
         }

--- a/localplanning.services/src/lib/lpa-api/query.ts
+++ b/localplanning.services/src/lib/lpa-api/query.ts
@@ -16,6 +16,7 @@ export const GET_LPAS_QUERY = gql`
       applyServices: flows(
         where: {
           status: { _eq: online }
+          is_listed_on_lps: { _eq: true }
           slug: { _nin: $notifyServiceSlugs }
           published_flows: { has_send_component: { _eq: true } }
         }
@@ -26,6 +27,7 @@ export const GET_LPAS_QUERY = gql`
       guidanceServices: flows(
         where: {
           status: { _eq: online }
+          is_listed_on_lps: { _eq: true }
           published_flows: { has_send_component: { _eq: false } }
         }
         order_by: { name: asc }
@@ -35,6 +37,7 @@ export const GET_LPAS_QUERY = gql`
       notifyServices: flows(
         where: {
           status: { _eq: online }
+          is_listed_on_lps: { _eq: true }
           slug: { _in: $notifyServiceSlugs }
           published_flows: { has_send_component: { _eq: true } }
         }


### PR DESCRIPTION
## What does this PR do?
Adds to a toggle allowing Editors to control if their service will be listed on LPS, alongside basic validation.

Notably, we still have checks in place on LPS for slugs, so this isn't yet entirely configurable here. The next step would have to be a way within PlanX to categorise a service.

```ts
const NOTIFY_SERVICE_SLUGS = [
  "report-a-planning-breach",
  "camden-report-a-planning-breach",
];
```

<img width="572" height="397" alt="image" src="https://github.com/user-attachments/assets/042f5d26-58d8-4141-80f4-9e8440398362" />
