### PR TITLE
fix: MapAndLabel 'copy feature' selection

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -52,7 +52,9 @@ export const CopyFeature: React.FC<Props> = ({
             required
             title={"Copy from"}
             value={formik.values.sourceLabel}
-            onChange={formik.handleChange}
+            onChange={(e) =>
+              formik.setFieldValue("sourceLabel", e.target.value)
+            }
             sx={{ width: { xs: "150px", md: "200px" } }}
           >
             <span id="copy-feature-description" style={visuallyHidden}>

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
@@ -371,22 +371,21 @@ describe("copy feature select", () => {
     const { getByTitle, user, getByLabelText, getByRole, getByTestId } = setup(
       <MapAndLabel {...props} />,
     );
-    addMultipleFeatures([point1, point2]);
-    const tabOne = getByRole("tab", { name: /Tree 1/ });
+    addMultipleFeatures([point1, point2, point3]);
+    const tabTwo = getByRole("tab", { name: /Tree 2/ });
 
     await fillOutForm(user);
 
-    await user.click(tabOne);
-
+    await user.click(tabTwo);
     const copyTitle = getByTitle("Copy from");
     const copyInput = getByRole("combobox", copyTitle);
 
     await user.click(copyInput);
 
-    const listItemTwo = getByRole("option", { name: "Tree 2" });
+    const listItemThree = getByRole("option", { name: "Tree 3" });
     const copyButton = getByTestId("copyButton");
 
-    await user.click(listItemTwo);
+    await user.click(listItemThree);
     await user.click(copyButton);
 
     expect(getByLabelText("Species")).toHaveDisplayValue(mockTreeData.species);


### PR DESCRIPTION
## What's the problem?
When using the "copy feature" select in the `MapAndLabel` component, it's only possible to select the first item. The `onChange()` handler is not working as expected.

Reported here (video and write up) by @augustlindemer - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1756986067330309

## What's the cause?
This regression was introduced here - https://github.com/theopensystemslab/planx-new/pull/5072

When we updated the `name` property to meet a11y requirements, we missed the fact that this is also used by formik internally for it's build in `handleChange` function.

## Why wasn't this caught by unit tests?
We actually have pretty good coverage here, but the example used for "copy feature" relied on the first option of the select being clicked - this didn't actually trigger a failing call to `handleChange()`. I've now updated the tests to account for this.

## What's the solution?
Use a custom function for `handleChange()` which does not rely on the `name` property directly. This now meets both accessibility and functional requirements.
