### PR TITLE
feat: create aggregated analytics view

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_aggregated_materialized.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_aggregated_materialized.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_aggregated_materialized
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_analytics.yaml"
+- "!include public_analytics_aggregated_materialized.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_summary.yaml"
 - "!include public_analytics_summary_materialized.yaml"

--- a/hasura.planx.uk/migrations/default/1757000523136_create_aggregated_analytics_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757000523136_create_aggregated_analytics_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_aggregated_materialized";

--- a/hasura.planx.uk/migrations/default/1757000523136_create_aggregated_analytics_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757000523136_create_aggregated_analytics_view/up.sql
@@ -1,0 +1,40 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_aggregated_materialized";
+
+CREATE MATERIALIZED VIEW "public"."analytics_aggregated_materialized" AS
+SELECT 
+    analytics_id,
+    MAX(team_slug) AS team_slug,
+    MAX(service_slug) AS service_slug,
+    MAX(flow_id::text)::uuid AS flow_id,  
+    MAX(analytics_created_at) AS analytics_created_at,
+    MAX(analytics_type) AS analytics_type,
+    MAX(application_type) AS application_type,
+    MAX(referrer) AS referrer,
+    STRING_AGG(DISTINCT user_role, ', ' ORDER BY user_role) AS user_role,
+    MAX(platform) AS platform,
+    
+    STRING_AGG(project_type, ', ' ORDER BY analytics_log_created_at) AS project_types,
+    STRING_AGG(node_title, ', ' ORDER BY analytics_log_created_at) AS node_titles,
+    STRING_AGG(node_type, ', ' ORDER BY analytics_log_created_at) AS node_types,
+    
+    (ARRAY_AGG(node_title ORDER BY analytics_log_created_at))[ARRAY_UPPER(ARRAY_AGG(node_title ORDER BY analytics_log_created_at), 1)] AS last_node_title,
+    
+    BOOL_OR(has_clicked_save) AS has_clicked_save,
+    BOOL_OR(is_user_exit) AS tracked_exit,
+    
+    STRING_AGG(result_text, ', ' ORDER BY analytics_log_created_at) AS results
+
+FROM analytics_summary a
+LEFT JOIN LATERAL (
+    SELECT jsonb_array_elements_text(a.proposal_project_type::jsonb) AS project_type
+    WHERE a.proposal_project_type IS NOT NULL
+) pt ON true
+LEFT JOIN LATERAL (
+    SELECT (a.result_flag::jsonb->>'text') AS result_text
+    WHERE a.result_flag IS NOT NULL
+) rf ON true
+
+GROUP BY analytics_id
+ORDER BY analytics_id;
+
+GRANT SELECT ON "public"."analytics_aggregated_materialized" TO metabase_read_only;


### PR DESCRIPTION
Following [conversations on Metabase performance](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1756899876949039?thread_ts=1756897333.705039&cid=C01E3AC0C03) and the recent [materialized view test](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1756899876949039?thread_ts=1756897333.705039&cid=C01E3AC0C03), this PR has a proposed view that I think will be useful based on the kinds of questions / queries we're running in Metabase. 

# Why?
This shape is one that I think will meet most of the needs of analytics queries. It would take the referenced table from 6.8m rows to 286k. 

With the way the dashboards are designed, I don't know that time-partitioned views will be that relevant. (Most queries show all-time by default and councils filter by a specific period for reporting if they need to. Occasionally we might show a figure for the last week or last month, but not that often.) 

# How are columns aggregated?
This view aggregates relevant fields by `analytics_id`. 

Some columns will have the same value throughout (eg `referrer` and so it just uses `MAX` to get the one value). 

Some columns will have a range of values (eg `node_type` and so it aggregates with `STRING_AGG(node_type, ', ' ORDER BY analytics_log_created_at) AS node_types,`.) 

Columns like `has_clicked_save` or `is_user_exit` are aggregated with `BOOL_OR` because we just want to know if the session was saved at all, or if an exit was tracked for this session. 

# Questions
I just made this using `analytics_summary` since that's the shape I'm most familiar with but should this be SELECTing from an actual table (eg `analytics` or `analytics_logs`) instead of a view? 