### PR TITLE
chore(iac): Refactor existing CDN code in preparation for creating new CDN for localplanning.services

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -10,11 +10,13 @@ import * as mime from "mime";
 import * as tldjs from "tldjs";
 
 import {
-  DEFAULT_POSTGRES_PORT,
   addRedirectToCloudFlareListenerRule,
-  generateTeamSecrets,
+  createCdn,
+  DEFAULT_POSTGRES_PORT,
   generateCORSAllowList,
-  getPostgresDbUrl
+  generateTeamSecrets,
+  getPostgresDbUrl,
+  usEast1,
 } from "./utils";
 import { createHasuraService } from "./services/hasura";
 import { CustomDomains } from "../common/teams";
@@ -632,17 +634,6 @@ export = async () => {
     acl: "private",
   });
 
-  // Generate Origin Access Identity to access the private s3 bucket.
-  const originAccessIdentity = new aws.cloudfront.OriginAccessIdentity(
-    "originAccessIdentity",
-    {
-      comment: "This is needed to setup s3 polices and make s3 not public.",
-    }
-  );
-
-  // XXX: Originally, our certificate (generated in the `certificates` stack) was created in eu-west-2 (London), however, later we wanted to add CloudFront which only accepts certificates generated in the us-east-1 region. Hence, this here is duplicate code which should be merged into the `certificate` stack.
-  const usEast1 = new aws.Provider("useast1", { region: "us-east-1" });
-
   const customDomains = ((): Array<any> => {
     return CUSTOM_DOMAINS.map(createCustomDomain);
 
@@ -671,7 +662,7 @@ export = async () => {
           replaceOnChanges: ["privateKey"],
         }
       );
-      const cdn = createCdn({ domain, acmCertificateArn: certificate.arn });
+      const cdn = createCdn({ domain, acmCertificateArn: certificate.arn, bucket: frontendBucket, logsBucket });
       return { domain, cname: cdn.domainName };
     }
   })();
@@ -713,7 +704,7 @@ export = async () => {
     },
     { provider: usEast1 }
   );
-  const cdn = createCdn({ domain: DOMAIN, acmCertificateArn: sslCert.arn });
+  const cdn = createCdn({ domain: DOMAIN, acmCertificateArn: sslCert.arn, bucket: frontendBucket, logsBucket });
 
   const frontendDnsRecord = new cloudflare.Record("frontend", {
     name: tldjs.getSubdomain(DOMAIN) || "@",
@@ -723,123 +714,6 @@ export = async () => {
     ttl: 1,
     proxied: false, // This was causing infinite HTTPS redirects, so let's just use CloudFront only
   });
-
-  function createCdn({
-    domain,
-    acmCertificateArn,
-  }: {
-    domain: string;
-    acmCertificateArn: pulumi.Input<string>;
-  }) {
-    return new aws.cloudfront.Distribution(`${domain}-cdn`, {
-      enabled: true,
-      // Could include `www.${domain}` here if the `www` subdomain is desired
-      aliases: [domain],
-      origins: [
-        {
-          originId: frontendBucket.arn,
-          domainName: frontendBucket.bucketRegionalDomainName,
-          s3OriginConfig: {
-            originAccessIdentity:
-              originAccessIdentity.cloudfrontAccessIdentityPath,
-          },
-        },
-      ],
-
-      defaultRootObject: "index.html",
-
-      // A CloudFront distribution can configure different cache behaviors based on the request path.
-      // Here we just specify a single, default cache behavior which is just read-only requests to S3.
-      defaultCacheBehavior: {
-        targetOriginId: frontendBucket.arn,
-        viewerProtocolPolicy: "redirect-to-https",
-        allowedMethods: ["GET", "HEAD", "OPTIONS"],
-        cachedMethods: ["GET", "HEAD", "OPTIONS"],
-        forwardedValues: {
-          cookies: { forward: "none" },
-          queryString: false,
-        },
-        compress: true,
-        minTtl: 0,
-        defaultTtl: 60 * 10,
-        maxTtl: 60 * 10,
-        responseHeadersPolicyId: new aws.cloudfront.ResponseHeadersPolicy(
-          `${domain.replace(/[^a-z0-9_-]/g, "_")}-policy`,
-          {
-            corsConfig: {
-              // XXX: might need to turn this back on because the editor side uses cookies
-              //      but when this is true, AllowHeaders can't be `*` so will need to dive deeper
-              accessControlAllowCredentials: false,
-              accessControlAllowHeaders: {
-                items: ["*"],
-              },
-              accessControlAllowMethods: {
-                items: ["GET", "HEAD", "OPTIONS"],
-              },
-              // TODO: Narrow this down to the list of domain names we're actually using
-              accessControlAllowOrigins: {
-                items: ["*"],
-              },
-              originOverride: true,
-            },
-            securityHeadersConfig: {
-              // Prevent iFrames
-              frameOptions: {
-                frameOption: "DENY",
-                override: true,
-              },
-              // Implements HTTP Strict Transport Security
-              strictTransportSecurity: {
-                accessControlMaxAgeSec: 63072000, // maximum (2 years)
-                override: true,
-                includeSubdomains: true,
-                preload: true,
-              },
-              // Set X-Content-Type-Options = "nosniff"
-              contentTypeOptions: { 
-                override: true,
-              },
-            },
-          }
-        ).id,
-      },
-
-      // "All" is the most broad distribution, and also the most expensive.
-      // "100" is the least broad, and also the least expensive.
-      priceClass: "PriceClass_100",
-
-      // You can customize error responses. When CloudFront receives an error from the origin (e.g. S3 or some other
-      // web service) it can return a different error code, and return the response for a different resource.
-      customErrorResponses: [
-        {
-          errorCode: 404,
-          responseCode: 200,
-          responsePagePath: "/index.html",
-        },
-        // XXX: CloudFront seems to be returning `403 AccessDenied` when files aren't found. Because the front-end is a Single Page Application (SPA) we need to redirect those errors to `index.html`.
-        {
-          errorCode: 403,
-          responseCode: 200,
-          responsePagePath: "/index.html",
-        },
-      ],
-      restrictions: {
-        geoRestriction: {
-          restrictionType: "none",
-        },
-      },
-      viewerCertificate: {
-        acmCertificateArn,
-        sslSupportMethod: "sni-only",
-        minimumProtocolVersion: "TLSv1.2_2021",
-      },
-      loggingConfig: {
-        bucket: logsBucket.bucketDomainName,
-        includeCookies: false,
-        prefix: `${domain}/`,
-      },
-    });
-  }
 
   return {
     customDomains,

--- a/infrastructure/application/utils/createCDN.ts
+++ b/infrastructure/application/utils/createCDN.ts
@@ -1,0 +1,133 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+export const createCdn = ({
+  domain,
+  acmCertificateArn,
+  bucket,
+  logsBucket,
+}: {
+  domain: string;
+  acmCertificateArn: pulumi.Input<string>;
+  bucket: aws.s3.Bucket;
+  logsBucket: aws.s3.Bucket;
+}) => {
+  // Generate Origin Access Identity to access the private s3 bucket.
+  const originAccessIdentity = new aws.cloudfront.OriginAccessIdentity(
+    "originAccessIdentity",
+    {
+      comment: "This is needed to setup s3 polices and make s3 not public.",
+    }
+  );
+
+  const cdn = new aws.cloudfront.Distribution(`${domain}-cdn`, {
+    enabled: true,
+    // Could include `www.${domain}` here if the `www` subdomain is desired
+    aliases: [domain],
+    origins: [
+      {
+        originId: bucket.arn,
+        domainName: bucket.bucketRegionalDomainName,
+        s3OriginConfig: {
+          originAccessIdentity:
+            originAccessIdentity.cloudfrontAccessIdentityPath,
+        },
+      },
+    ],
+
+    defaultRootObject: "index.html",
+
+    // A CloudFront distribution can configure different cache behaviors based on the request path.
+    // Here we just specify a single, default cache behavior which is just read-only requests to S3.
+    defaultCacheBehavior: {
+      targetOriginId: bucket.arn,
+      viewerProtocolPolicy: "redirect-to-https",
+      allowedMethods: ["GET", "HEAD", "OPTIONS"],
+      cachedMethods: ["GET", "HEAD", "OPTIONS"],
+      forwardedValues: {
+        cookies: { forward: "none" },
+        queryString: false,
+      },
+      compress: true,
+      minTtl: 0,
+      defaultTtl: 60 * 10,
+      maxTtl: 60 * 10,
+      responseHeadersPolicyId: new aws.cloudfront.ResponseHeadersPolicy(
+        `${domain.replace(/[^a-z0-9_-]/g, "_")}-policy`,
+        {
+          corsConfig: {
+            // XXX: might need to turn this back on because the editor side uses cookies
+            //      but when this is true, AllowHeaders can't be `*` so will need to dive deeper
+            accessControlAllowCredentials: false,
+            accessControlAllowHeaders: {
+              items: ["*"],
+            },
+            accessControlAllowMethods: {
+              items: ["GET", "HEAD", "OPTIONS"],
+            },
+            // TODO: Narrow this down to the list of domain names we're actually using
+            accessControlAllowOrigins: {
+              items: ["*"],
+            },
+            originOverride: true,
+          },
+          securityHeadersConfig: {
+            // Prevent iFrames
+            frameOptions: {
+              frameOption: "DENY",
+              override: true,
+            },
+            // Implements HTTP Strict Transport Security
+            strictTransportSecurity: {
+              accessControlMaxAgeSec: 63072000, // maximum (2 years)
+              override: true,
+              includeSubdomains: true,
+              preload: true,
+            },
+            // Set X-Content-Type-Options = "nosniff"
+            contentTypeOptions: {
+              override: true,
+            },
+          },
+        }
+      ).id,
+    },
+
+    // "All" is the most broad distribution, and also the most expensive.
+    // "100" is the least broad, and also the least expensive.
+    priceClass: "PriceClass_100",
+
+    // You can customize error responses. When CloudFront receives an error from the origin (e.g. S3 or some other
+    // web service) it can return a different error code, and return the response for a different resource.
+    customErrorResponses: [
+      {
+        errorCode: 404,
+        responseCode: 200,
+        responsePagePath: "/index.html",
+      },
+      // XXX: CloudFront seems to be returning `403 AccessDenied` when files aren't found. Because the front-end is a Single Page Application (SPA) we need to redirect those errors to `index.html`.
+      {
+        errorCode: 403,
+        responseCode: 200,
+        responsePagePath: "/index.html",
+      },
+    ],
+    restrictions: {
+      geoRestriction: {
+        restrictionType: "none",
+      },
+    },
+    viewerCertificate: {
+      acmCertificateArn,
+      sslSupportMethod: "sni-only",
+      minimumProtocolVersion: "TLSv1.2_2021",
+    },
+    loggingConfig: {
+      bucket: logsBucket.bucketDomainName,
+      includeCookies: false,
+      prefix: `${domain}/`,
+    },
+  });
+
+  return cdn;
+};

--- a/infrastructure/application/utils/index.ts
+++ b/infrastructure/application/utils/index.ts
@@ -3,3 +3,5 @@ export * from "./failureNotification";
 export * from "./generateCORSAllowList";
 export * from "./generateTeamSecrets";
 export * from "./helpers";
+export * from "./createCDN";
+export * from "./providers";

--- a/infrastructure/application/utils/providers.ts
+++ b/infrastructure/application/utils/providers.ts
@@ -1,0 +1,4 @@
+import * as aws from "@pulumi/aws";
+
+// XXX: Originally, our certificate (generated in the `certificates` stack) was created in eu-west-2 (London), however, later we wanted to add CloudFront which only accepts certificates generated in the us-east-1 region. Hence, this here is duplicate code which should be merged into the `certificate` stack.
+export const usEast1 = new aws.Provider("useast1", { region: "us-east-1" });


### PR DESCRIPTION
## What does this PR do?
Refactors some functionality from the very long `applications/index.ts` into helper functions. This PR should introduce no new resources, and make no functional changes.

The Pulumi Preview (staging) output is as expected - no changes to certificates, CDNs etc - https://app.pulumi.com/planx/application/staging/previews/f96468ac-2b27-447c-926b-53055c73421b

The functions split out here are ones which I'll need to create a Cloudfront CDN for LPS, I'd just like to get this refactor done independently first to have full certainty before generating new LPS resources.