### PR TITLE
feat: add discharge conditions schema

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -23,6 +23,7 @@ import { AmendDocuments } from "./schemas/AmendDocuments";
 import { ExistingBuildingsCIL } from "./schemas/CIL/ExistingCIL";
 import { MezzanineCIL } from "./schemas/CIL/MezzanineCIL";
 import { UnoccupiedBuildingsCIL } from "./schemas/CIL/UnoccupiedCIL";
+import { DischargeConditions } from "./schemas/DischargeConditions";
 import { NonResidentialFloorspace } from "./schemas/Floorspace";
 import { BuildingDetailsGLA } from "./schemas/GLA/BuildingDetails";
 import { CommunalSpaceGLA } from "./schemas/GLA/CommunalSpace";
@@ -88,6 +89,7 @@ export const SCHEMAS = [
     schema: OwnershipCertificateOwners,
   },
   { name: "Amend documents", schema: AmendDocuments },
+  { name: "Discharge conditions", schema: DischargeConditions },
   { name: "Sketch Plan (testing only)", schema: Trees },
 ];
 

--- a/editor.planx.uk/src/@planx/components/List/schemas/DischargeConditions.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/DischargeConditions.ts
@@ -1,0 +1,64 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const DischargeConditions: Schema = {
+  type: "Condition",
+  fields: [
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Condition number",
+        description:
+          "This is the number of the condition as shown on the decision notice.",
+        fn: "number",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Condition description",
+        description:
+          "This is the exact wording of the condition as shown on the decision notice.",
+        fn: "description",
+        type: TextInputType.Long,
+      },
+    },
+    {
+      type: "question",
+      data: {
+        title:
+          "Are you submitting details for the full condition or part of it?",
+        fn: "scope",
+        options: [
+          { id: "full", data: { text: "The full condition", val: "full" } },
+          {
+            id: "part",
+            data: { text: "Part of the condition", val: "part" },
+          },
+        ],
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Which part of the condition are you submitting details for?",
+        fn: "scope.description",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "fileUpload",
+      data: {
+        title: "Supporting documents",
+        description:
+          "The documents should detail how you intend to meet this condition.",
+        fn: "otherSupporting",
+      },
+    },
+  ],
+  min: 1,
+  max: 12,
+} as const;


### PR DESCRIPTION
This PR adds a _discharge conditions_ schema to the list component to be used in the statutory 'Submit details required by a condition' service.