### PR TITLE
fix pizza CI failures by sleeping longer before healthcheck

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -204,8 +204,8 @@ jobs:
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
-          cache-dependency-path: './${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/pnpm-lock.yaml'
+          cache: "pnpm"
+          cache-dependency-path: "./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/pnpm-lock.yaml"
       - name: Setup .gitconfig
         run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
@@ -461,7 +461,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('localplanning.services/pnpm-lock.yaml', 'localplanning.services/src/**', 'localplanning.services/public/**') }}
             ${{ runner.os }}-
-  
+
       - name: upload built localplanning.services
         uses: appleboy/scp-action@master
         with:
@@ -494,8 +494,8 @@ jobs:
     needs: [create_or_update_vultr_instance]
     runs-on: ubuntu-22.04
     steps:
-      - name: Wait for Vultr to warm up
-        run: bash -c "sleep 30s"
+      - name: Wait for caddy reverse-proxy server to provision TLS certs for pizza
+        run: bash -c "sleep 180s"
       - name: API healthcheck
         run: |
           timeout 150s bash -c "until curl --fail https://api.${{ env.FULL_DOMAIN }}; do sleep 1; done"

--- a/ci/caddy/README.md
+++ b/ci/caddy/README.md
@@ -10,13 +10,14 @@ In order to allow the caddy container to solve the [DNS-01 challenge](https://le
 
 ## Debugging
 
-To see verbose logs for the caddy container, add the `debug` directive to the global options. If testing the setup, you can also make use of the LetsEncrypt's staging server using the `acme_ca` directive. For example:
+To see verbose logs for the caddy container, add the `debug` directive to the global options. If testing the setup, you can also make use of the LetsEncrypt's staging server using the `acme_ca` directive. To access the admin API from the pizza (but outside the container), use the `admin` directive. For example:
 
 ```
 {
-	email {$TLS_EMAIL}
-	debug
-	acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+  email {$TLS_EMAIL}
+  debug
+  acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+  admin 0.0.0.0:2019
 }
 ```
 

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -46,6 +46,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "2019:2019"
     environment:
       - TLS_EMAIL=${TLS_EMAIL}
       - ROOT_DOMAIN=${ROOT_DOMAIN}


### PR DESCRIPTION
as per title - relevant [ticket](https://trello.com/c/YopMVSYl)

The final step in the `pull-request.yaml` GHA CI was failing on some occasions, basically down to a lucky dip of whether the pizza's caddy server had provisioned TLS certs in time.

In various logs I looked at, it's clear that the caddy container begins `trying to solve challenge` within a couple of seconds of being created, and in general updates with `authorization finalized` just over 300s later.

This is the behaviour we'd expect since we've set the caddyfile `propagation_delay` value to 300s, to allow time for Vultr to provision the DNS certs required for the DNS-01 validation check. Less than this seemed to be insufficient for Vultr to have completed this operation in time for caddy to begin polling for said certs.

The healthcheck was likely failing on only _some_ occasions because of variability in how long the create/update step takes beyond when the caddy container is initialised.

We fix this by sleeping for 180s before running the final healthcheck step, which together with the 150s timeout for the request to the API, should be more than generous to ensure that the healthcheck never fails simply because the caddy propagation timeout is still pending.