### PR TITLE
feat(iac): Create staging CDN for localplanning.services 

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,8 +15,8 @@ env:
   DEPLOYMENT_ENVIRONMENT: staging
 
 jobs:
-  build_react:
-    name: Build React
+  build_planx_frontend:
+    name: Build PlanX frontend
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -64,16 +64,65 @@ jobs:
           VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           VITE_APP_HASURA_WEBSOCKET: wss://hasura.editor.planx.dev/v1/graphql
           VITE_APP_SHAREDB_URL: wss://sharedb.editor.planx.dev
-      - name: Upload Build Artifact
+      - name: Upload PlanX frontend build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build
+          name: planx_frontend_build
           path: ./editor.planx.uk/build
+          if-no-files-found: error
+
+  build_localplanning_services:
+    name: Build localplanning.services
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+      # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
+      - name: NPM cache
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-npm
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: PNPM cache
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-pnpm
+        with:
+          # pnpm cache files are stored in `~/.local/share/pnpm/store` on Linux
+          path: ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
+      - name: Setup .gitconfig
+        run: mv .gitconfig ~/.gitconfig
+      - run: pnpm install --frozen-lockfile
+        working-directory: localplanning.services
+      - run: pnpm build --mode staging
+        working-directory: localplanning.services
+      - name: Upload LocalPlanning.services build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: localplanning_services_build
+          path: ./localplanning.services/dist
           if-no-files-found: error
 
   preview:
     name: Pulumi Up
-    needs: build_react
+    needs: 
+      - build_planx_frontend
+      - build_localplanning_services
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -90,11 +139,16 @@ jobs:
         working-directory: infrastructure/application
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
-      - name: Download Build Artifact
+      - name: Download PlanX frontend build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build
+          name: planx_frontend_build
           path: ./editor.planx.uk/build
+      - name: Download LocalPlanning.services build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: localplanning_services_build
+          path: ./localplanning.services/dist
       - uses: pulumi/actions@v5
         with:
           command: up

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -88,3 +88,4 @@ config:
   certificates:cloudflare-zone-id: dc27ac531ff8862559ed9ab5016c4953
   cloudflare:apiToken:
     secure: AAABABWhDm+7RstbxLXd1D8CcxkylHS6UKMqk4kOaY7Y0E7FJS4bZfvyGs0nks80hl3vjENH4eDuFbUgA82/sA4SmDlfpNXr
+  application:lps-domain: localplanning.editor.planx.dev

--- a/infrastructure/application/services/lps.ts
+++ b/infrastructure/application/services/lps.ts
@@ -1,0 +1,75 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import * as fsWalk from "@nodelib/fs.walk";
+import * as mime from "mime";
+
+import { createCdn } from "../utils"
+
+const config = new pulumi.Config();
+
+const createLPSBucket = (domain: string) => {
+  const lpsBucket = new aws.s3.Bucket(domain, {
+    bucket: domain,
+    website: {
+      indexDocument: "index.html",
+      errorDocument: "404.html",
+    },
+  });
+
+  return lpsBucket;
+};
+
+const createLogsBucket = (domain: string) => {
+  const logsBucket = new aws.s3.Bucket("lpsRequestLogs", {
+    bucket: `${domain}-logs`,
+    acl: "private",
+  });
+
+  return logsBucket;
+};
+
+const uploadBuildSiteToBucket = (bucket: aws.s3.Bucket) => {
+  fsWalk
+    .walkSync("../../localplanning.services/dist/", {
+      basePath: "",
+      entryFilter: (e) => !e.dirent.isDirectory(),
+    })
+    .forEach(({ path }) => {
+      const relativeFilePath = `../../localplanning.services/build/${path}`;
+      const contentType = mime.getType(relativeFilePath) || "";
+      const contentFile = new aws.s3.BucketObject(
+        relativeFilePath,
+        {
+          key: path,
+          acl: "public-read",
+          bucket,
+          contentType,
+          source: new pulumi.asset.FileAsset(relativeFilePath),
+          cacheControl: contentType.includes("html")
+            ? "no-cache"
+            : `max-age=${1}, stale-while-revalidate=${60 * 60 * 24}`,
+        },
+        {
+          parent: bucket,
+        }
+      );
+    });
+};
+
+export const createLocalPlanningServices = () => {
+  const domain = config.get("lps-domain");
+  if (!domain) return;
+
+  const lpsBucket = createLPSBucket(domain);
+  const logsBucket = createLogsBucket(domain);
+
+  uploadBuildSiteToBucket(lpsBucket);
+
+  const cdn = createCdn({
+    bucket: lpsBucket,
+    logsBucket,
+    domain,
+  });
+
+  return cdn;
+};

--- a/infrastructure/application/utils/createCDN.ts
+++ b/infrastructure/application/utils/createCDN.ts
@@ -8,7 +8,7 @@ export const createCdn = ({
   logsBucket,
 }: {
   domain: string;
-  acmCertificateArn: pulumi.Input<string>;
+  acmCertificateArn?: pulumi.Input<string>;
   bucket: aws.s3.Bucket;
   logsBucket: aws.s3.Bucket;
 }) => {


### PR DESCRIPTION
## What does this PR do?
- Builds LPS (or refers to existing cache) on deploy to `main` branch
- Creates a bucket to hold static files for the site
- Uploads built site to this bucket
- Created a Cloudfront CDN

Notably, I'm not handling SSL certificates here yet - the output of this should just be a CND at abc123.cloudfront.net for staging and production.

### Next steps...
 - Deploy to `main`, test that a CDN is created
 - Open PR to repeat steps for production
 - Handle SSL certs so that these CDNs can live at `localplanning.editor.planx.dev` and `localplanning.services` respectively
 - Env vars and CORS - I'll need to set up a value for `LPS_URL_EXT` once certificates are sorted