### PR TITLE
fix: Map validated slots to payload

### DIFF
--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -121,7 +121,7 @@ function Component(props: Props) {
       fileListSchema.validate(fileList, { context: { slots } }),
     ])
       .then(() => {
-        const payload = generatePayload(fileList);
+        const payload = generatePayload(fileList, slots);
         props.handleSubmit?.(payload);
       })
       .catch((err) => {

--- a/editor.planx.uk/src/@planx/components/FileUploadAndLabel/mocks.ts
+++ b/editor.planx.uk/src/@planx/components/FileUploadAndLabel/mocks.ts
@@ -100,6 +100,37 @@ export const mockFileTypesUniqueKeys: FileType[] = [
   },
 ];
 
+export const mockSlots = [
+  {
+    file: {
+      path: "./PXL_20230511_093922923.jpg",
+      name: "PXL_20230511_093922923.jpg",
+    },
+    status: "success",
+    progress: 1,
+    id: "EFGI1yU8s5s_cSBxnnYau",
+    url: "http://localhost:7002/file/private/jjpmkz8g/PXL_20230511_093922923.jpg",
+  },
+  {
+    file: {
+      path: "PXL_20230507_150205350~2.jpg",
+    },
+    status: "success",
+    progress: 1,
+    id: "ZrGNE4siV36zvA7u1QZQD",
+    url: "http://localhost:7002/file/private/82wo7bev/PXL_20230507_150205350~2.jpg",
+  },
+  {
+    file: {
+      path: "PXL_20230511_093922923.jpg",
+    },
+    status: "success",
+    progress: 1,
+    id: "6bZBneLnY-L6qiqOblu8t",
+    url: "http://localhost:7002/file/private/truap5az/PXL_20230511_093922923.jpg",
+  },
+] as FileUploadSlot[];
+
 export const mockFileList = {
   required: [
     {
@@ -108,18 +139,7 @@ export const mockFileList = {
       rule: {
         condition: "AlwaysRequired",
       },
-      slots: [
-        {
-          file: {
-            path: "./PXL_20230511_093922923.jpg",
-            name: "PXL_20230511_093922923.jpg",
-          },
-          status: "success",
-          progress: 1,
-          id: "EFGI1yU8s5s_cSBxnnYau",
-          url: "http://localhost:7002/file/private/jjpmkz8g/PXL_20230511_093922923.jpg",
-        },
-      ],
+      slots: [mockSlots[0]],
     },
   ],
   recommended: [
@@ -129,17 +149,7 @@ export const mockFileList = {
       rule: {
         condition: "AlwaysRecommended",
       },
-      slots: [
-        {
-          file: {
-            path: "PXL_20230507_150205350~2.jpg",
-          },
-          status: "success",
-          progress: 1,
-          id: "ZrGNE4siV36zvA7u1QZQD",
-          url: "http://localhost:7002/file/private/82wo7bev/PXL_20230507_150205350~2.jpg",
-        },
-      ],
+      slots: [mockSlots[1]],
     },
   ],
   optional: [
@@ -149,20 +159,43 @@ export const mockFileList = {
       rule: {
         condition: "NotRequired",
       },
-      slots: [
-        {
-          file: {
-            path: "PXL_20230511_093922923.jpg",
-          },
-          status: "success",
-          progress: 1,
-          id: "6bZBneLnY-L6qiqOblu8t",
-          url: "http://localhost:7002/file/private/truap5az/PXL_20230511_093922923.jpg",
-        },
-      ],
+      slots: [mockSlots[2]],
     },
   ],
 } as FileList;
+
+export const mockSlotsMultiple = [
+  {
+    file: {
+      name: "first.jpg",
+      path: "./first.jpg",
+    },
+    status: "success",
+    progress: 1,
+    id: "001",
+    url: "http://localhost:7002/file/private/jjpmkz8g/first.jpg",
+  },
+  {
+    file: {
+      name: "second.jpg",
+      path: "./second.jpg",
+    },
+    status: "success",
+    progress: 1,
+    id: "002",
+    url: "http://localhost:7002/file/private/jjpmkz8g/second.jpg",
+  },
+  {
+    file: {
+      name: "third.jpg",
+      path: "./third.jpg",
+    },
+    status: "success",
+    progress: 1,
+    id: "003",
+    url: "http://localhost:7002/file/private/jjpmkz8g/third.jpg",
+  },
+] as FileUploadSlot[];
 
 export const mockFileListMultiple = {
   required: [


### PR DESCRIPTION
## What's the problem?
Users are reporting that some applications do not have all associated files in the the payload zip. When searching S3 we can see that all files were successfully uploaded, but the breadcrumbs/passport do not reflect this. Files in the passport have a status of "uploading" despite a validation check for exactly this.

## What's the case?
If a file is still in an "uploading" status when it's tagged, a snapshot is taken at that current moment which is mapped to the payload, not just a reference. On submit, we validate that all files are uploaded, but not that the generated payload has been updated with the most recent status of each file (which includes the generated URL).

## What's the solution?
When the payload is build, use the ID which was associated when the file was labelled to map the validated file slots. This ensures that the final payload is composed of a validated file list, and validated file slots.

