### PR TITLE
fix: Handle sanitising sessions without files

### DIFF
--- a/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
+++ b/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
@@ -108,8 +108,8 @@ export const deleteApplicationFiles: Operation = async () => {
     if (!session) {
       throw Error(`Unable to find session matching id ${sessionId}`);
     }
-    const files = new Passport(session.data.passport).files;
-    if (files.length) {
+    const files = new Passport(session.data.passport)?.files;
+    if (files?.length) {
       const fileURLs = files.map((file) => file.url);
       const deleted = await deleteFilesByURL(fileURLs);
       deletedFiles.push(...deleted);


### PR DESCRIPTION
Small bug I noticed when looking into [this issue](https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1757214000706329).

Currently, if a session without files is sanitised this operation will thow an error, causing the entire process to return a 500.  This will lead to false positives here - failures will get reported to Slack when there's no real issue.

All other operations are still completed successfully, so this PR just fixes an edge case and how it's reported - there's no real functional problem here.