### PR TITLE
feat: Don't prompt for additional email when redirecting from LPS

### DIFF
--- a/api.planx.uk/modules/lps/index.test.ts
+++ b/api.planx.uk/modules/lps/index.test.ts
@@ -323,7 +323,7 @@ describe("fetching applications", () => {
               name: "Team Name",
             },
             serviceUrl:
-              "https://www.example.com/team-slug/service-slug/published?sessionId=1",
+              "https://www.example.com/team-slug/service-slug/published?sessionId=1&email=simulate-delivered%40notifications.service.gov.uk",
           });
 
           expect(res.body.submitted).toHaveLength(1);

--- a/api.planx.uk/modules/lps/service/getApplications/index.test.ts
+++ b/api.planx.uk/modules/lps/service/getApplications/index.test.ts
@@ -4,33 +4,39 @@ import { generateResumeLink } from "./index.js";
 describe("generateResumeLink() helper function", () => {
   it("generates a valid URL for teams with a custom subdomain", () => {
     const expected =
-      "https://planningservices.mycouncil.gov/my-flow?sessionId=123";
-    const actual = generateResumeLink({
-      id: "123",
-      service: {
-        slug: "my-flow",
-        team: {
-          domain: "planningservices.mycouncil.gov",
+      "https://planningservices.mycouncil.gov/my-flow?sessionId=123&email=test%40example.com";
+    const actual = generateResumeLink(
+      {
+        id: "123",
+        service: {
+          slug: "my-flow",
+          team: {
+            domain: "planningservices.mycouncil.gov",
+          },
         },
-      },
-    } as Application);
+      } as Application,
+      "test@example.com",
+    );
 
     expect(actual).toEqual(expected);
   });
 
   it("generates a valid URL for teams without a custom subdomain", () => {
     const expected =
-      "https://www.example.com/my-team/my-flow/published?sessionId=123";
-    const actual = generateResumeLink({
-      id: "123",
-      service: {
-        slug: "my-flow",
-        team: {
-          slug: "my-team",
-          domain: null,
+      "https://www.example.com/my-team/my-flow/published?sessionId=123&email=test%40example.com";
+    const actual = generateResumeLink(
+      {
+        id: "123",
+        service: {
+          slug: "my-flow",
+          team: {
+            slug: "my-team",
+            domain: null,
+          },
         },
-      },
-    } as Application);
+      } as Application,
+      "test@example.com",
+    );
 
     expect(actual).toEqual(expected);
   });

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -213,17 +213,18 @@ const getInitialEmailValue = (emailQueryParam?: string) => {
 
 /**
  * Component which handles the "Resume" page used for Save & Return
- * The user can access this page via three "paths"
+ * The user can access this page via four "paths"
  * 1. Directly via PlanX, user enters email to trigger "dashboard" email with resume magic links
  * 2. Magic link in email with a sessionId, user enters email to continue application
  * 3. Redirect back from GovPay - sessionId and email come from query params
+ * 4. Redirect from localplanning.services - sessionId and email come from query params
  */
 const ResumePage: React.FC = () => {
   const route = useCurrentRoute();
 
   const [pageStatus, setPageStatus] = useState<Status>(Status.EmailRequired);
   const [email, setEmail] = useState<string>(
-    getInitialEmailValue(route.url.query.email),
+    getInitialEmailValue(decodeURIComponent(route.url.query.email)),
   );
   const [paymentRequest, setPaymentRequest] = useState<MinPaymentRequest>();
   const sessionId = useCurrentRoute().url.query.sessionId;

--- a/editor.planx.uk/src/pages/Preview/ResumePage.tsx
+++ b/editor.planx.uk/src/pages/Preview/ResumePage.tsx
@@ -186,16 +186,28 @@ export const LockedSession: React.FC<{
 
 /**
  * If an email is passed in as a query param, do not prompt a user for this
- * Currently only used for redirects back from GovUK Pay
+ *
+ * This means there's not an additional step of friction from logging into LPS,
+ * or redirecting back from GOV.UK Pay
+ *
  * XXX: Won't work locally as referrer is stripped from the browser when navigating from HTTPS to HTTP (localhost)
  */
 const getInitialEmailValue = (emailQueryParam?: string) => {
-  const isRedirectFromGovPay = [
+  const trustedAddresses = [
     "https://www.payments.service.gov.uk/",
     "https://card.payments.service.gov.uk/",
-  ].includes(document.referrer);
+    "https://www.localplanning.services/",
+  ];
 
-  if (isRedirectFromGovPay && emailQueryParam) return emailQueryParam;
+  const trustedPatterns = [
+    /^https:\/\/localplanning\.\d{4,5}\.planx\.pizza\/$/,
+  ];
+
+  const isRedirectFromTrustedSource =
+    trustedAddresses.includes(document.referrer) ||
+    trustedPatterns.some((pattern) => pattern.test(document.referrer));
+
+  if (isRedirectFromTrustedSource && emailQueryParam) return emailQueryParam;
   return "";
 };
 

--- a/localplanning.services/src/lib/utils.ts
+++ b/localplanning.services/src/lib/utils.ts
@@ -15,3 +15,4 @@ export const getServiceURL = ({
   domain
     ? `https://${domain}/${serviceSlug}`
     : `${PUBLIC_PLANX_EDITOR_URL}/${lpaSlug}/${serviceSlug}/published`;
+


### PR DESCRIPTION
This improves the login and resume user journey for LPS (details below) - this was flagged as a pain point during UR.

I'm of the opinion that this does not introduce an additional element of risk as the user is already authenticated by proving they have access to their inbox.

**Before**
- User has to enter email address on LPS
- Navigate to their inbox
- Click magic link, navigate to LPS
- Find application in list, navigate to PlanX
- Re-enter email address
- Proceed with application

**Now**
- User has to enter email address on LPS
- Navigate to their inbox
- Click magic link, navigate to LPS
- Find application in list, navigate to PlanX
- ~Re-enter email address~ ❌ 
- Proceed with application


https://github.com/user-attachments/assets/e8ec4c1e-a053-430e-9a1a-f010dc310507

