### PR TITLE
feat: Create Hasura REST endpoint to delete session

### DIFF
--- a/hasura.planx.uk/metadata/query_collections.yaml
+++ b/hasura.planx.uk/metadata/query_collections.yaml
@@ -10,3 +10,10 @@
               usersLast30Days: users_last_30_days
             }
           }
+      - name: LPS - Delete application
+        query: |
+          mutation SoftDeleteLowcalSessionLPS ($applicationId: uuid!) {
+            applications: update_lowcal_sessions_by_pk(pk_columns: {id:$applicationId}, _set: {deleted_at:"now()"}) {
+              id
+            }
+          }

--- a/hasura.planx.uk/metadata/rest_endpoints.yaml
+++ b/hasura.planx.uk/metadata/rest_endpoints.yaml
@@ -1,3 +1,15 @@
+- comment: |-
+    Allows a user to abandon their LPS application via a REST endpoint.
+
+    Requires the x-hasura-lowcal-session-id and x-hasura-lowcal-email headers in order for the public role to have permission to execute this route.
+  definition:
+    query:
+      collection_name: allowed-queries
+      query_name: LPS - Delete application
+  methods:
+    - DELETE
+  name: LPS - Delete application
+  url: lps/application/:applicationId
 - comment: ""
   definition:
     query:


### PR DESCRIPTION
## What does this PR do?
This PR creates a Hasura REST endpoint allowing users to delete their LPS applications, which will be called from the "Delete" button on application cards. The UI is not yet in place for this feature.

<img width="674" height="299" alt="image" src="https://github.com/user-attachments/assets/e359923f-a05f-4051-9f38-0962e7ff7376" />

This uses the same public permissions as the current "reset" button uses within PlanX when `clearLocalFlow()` is called - https://github.com/theopensystemslab/planx-new/blob/ae460ebeeba3ca526ba23f564e48f0a492ffb54f/editor.planx.uk/src/lib/lowcalStorage.ts#L36-L54

To test - 
 - Create a lowcal session record on the Pizza
 - Hit `https://api.5195.planx.pizza/api/rest/lps/application/:applicationId` with the required params

Example cURL - 
```sh
curl -X DELETE 'https://hasura.5195.planx.pizza/api/rest/lps/application/<SESSION_ID>' \
-H 'x-hasura-lowcal-session-id: <SESSION_ID>' \
-H 'x-hasura-lowcal-email: <EMAIL>'
```

Examply Bruno `.bru` file - 
```bru
meta {
  name: Delete LPS application
  type: http
  seq: 1
}

delete {
  url: https://hasura.5195.planx.pizza/api/rest/lps/application/:applicationId
  body: none
  auth: inherit
}

params:path {
  applicationId: <SESSION_ID>
}

headers {
  x-hasura-lowcal-session-id: <SESSION_ID>
  x-hasura-lowcal-email: <EMAIL>
}

settings {
  encodeUrl: true
}
```

