### PR TITLE
fix(infra): Ensure we use a unique `OriginAccessIdentity`

### DIFF
--- a/infrastructure/application/utils/createCDN.ts
+++ b/infrastructure/application/utils/createCDN.ts
@@ -14,7 +14,7 @@ export const createCdn = ({
 }) => {
   // Generate Origin Access Identity to access the private s3 bucket.
   const originAccessIdentity = new aws.cloudfront.OriginAccessIdentity(
-    "originAccessIdentity",
+    `${domain.replace(/[^a-z0-9_-]/g, "_")}-originAccessIdentity`,
     {
       comment: "This is needed to setup s3 polices and make s3 not public.",
     }


### PR DESCRIPTION
Resolves the following issue from the latest staging deploy -

```sh
 @ Updating.....
   +  aws:s3:Bucket localplanning.editor.planx.dev created (3s) 
      aws:cloudfront:OriginAccessIdentity originAccessIdentity **failed** error: Duplicate resource URN 'urn:pulumi:staging::application::aws:cloudfront/originAccessIdentity:OriginAccessIdentity::originAccessIdentity'; try giving it a unique name
   +  aws:s3:Bucket lpsRequestLogs created (2s) 
  @ Updating....
      pulumi:pulumi:Stack application-staging  
  Diagnostics:
    aws:cloudfront:OriginAccessIdentity (originAccessIdentity):
      error: Duplicate resource URN 'urn:pulumi:staging::application::aws:cloudfront/originAccessIdentity:OriginAccessIdentity::originAccessIdentity'; try giving it a unique name

  ```