### PR TITLE
fix(infra): Replace ACL with bucket policy

### DIFF
--- a/infrastructure/application/services/lps.ts
+++ b/infrastructure/application/services/lps.ts
@@ -16,6 +16,23 @@ const createLPSBucket = (domain: string) => {
     },
   });
 
+  new aws.s3.BucketPolicy("lpsBucketPolicy", {
+    bucket: lpsBucket.id,
+    policy: pulumi.all([lpsBucket.arn, lpsBucket.id]).apply(([ arn ]) =>
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: `${arn}/*`,
+          },
+        ],
+      })
+    ),
+  });
+
   return lpsBucket;
 };
 
@@ -41,7 +58,6 @@ const uploadBuildSiteToBucket = (bucket: aws.s3.Bucket) => {
         relativeFilePath,
         {
           key: path,
-          acl: "public-read",
           bucket,
           contentType,
           source: new pulumi.asset.FileAsset(relativeFilePath),


### PR DESCRIPTION
Should resolve this next issue 🔨 

S3 buckets no longer recommend / allow the use of ACLs - the code used for the PlanX frontend which I copied does have this legacy set up in place.

```sh
  Diagnostics:
    aws:s3:BucketObject (../../localplanning.services/dist/_astro/ApplicationsAuth._JE2sRcZ.js):
      error: 1 error occurred:
      	* Error uploading object to S3 bucket (localplanning.editor.planx.dev): AccessControlListNotSupported: The bucket does not allow ACLs
```