### PR TITLE
feat: add tree description list schemas

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -43,6 +43,8 @@ import { ResidentialUnitsGLAGained } from "./schemas/ResidentialUnits/GLA/Gained
 import { ResidentialUnitsGLALost } from "./schemas/ResidentialUnits/GLA/Lost";
 import { ResidentialUnitsPreviousLDCE } from "./schemas/ResidentialUnits/PreviousLDCE";
 import { ResidentialUnitsProposed } from "./schemas/ResidentialUnits/Proposed";
+import { TreeDescriptionCA } from "./schemas/TreeDescriptionCA";
+import { TreeDescriptionTPO } from "./schemas/TreeDescriptionTPO";
 import { Trees } from "./schemas/Trees";
 
 type Props = EditorProps<TYPES.List, List>;
@@ -90,7 +92,8 @@ export const SCHEMAS = [
   },
   { name: "Amend documents", schema: AmendDocuments },
   { name: "Discharge conditions", schema: DischargeConditions },
-  { name: "Sketch Plan (testing only)", schema: Trees },
+  { name: "Tree description - Conservation Area", schema: TreeDescriptionCA },
+  { name: "Tree description - TPO", schema: TreeDescriptionTPO },
 ];
 
 function ListComponent(props: Props) {

--- a/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionCA.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionCA.ts
@@ -1,0 +1,36 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const TreeDescriptionCA: Schema = {
+  type: "Tree",
+  fields: [
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Tree reference number",
+        description: "This is the tree's number as shown on your sketch plan.",
+        fn: "referenceNumber",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Species",
+        fn: "species",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Proposed work",
+        fn: "work",
+        type: TextInputType.Short,
+      },
+    },
+  ],
+  min: 1,
+} as const;

--- a/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionTPO.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionTPO.ts
@@ -1,0 +1,45 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const TreeDescriptionTPO: Schema = {
+  type: "Tree",
+  fields: [
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Tree reference number",
+        description: "This is the tree's number as shown on your sketch plan.",
+        fn: "referenceNumber",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Species",
+        fn: "species",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Proposed work",
+        fn: "work",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      required: false,
+      data: {
+        title: "Reasons for the proposed work",
+        fn: "reason",
+        type: TextInputType.Short,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
This PR adds two schemas to the List component to to describe the works to trees. This allows applicants of Apply for Works to Trees who already have a sketch plan to skip interacting with the Map and Label component. Through these schemas they can provide the descriptions of works individually per tree instead of (as currently) having to use a singular text input.