### PR TITLE
feat: create aggregated analytics view v2

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_aggregated_materialized.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_aggregated_materialized.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_aggregated_materialized
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_analytics.yaml"
+- "!include public_analytics_aggregated_materialized.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_summary.yaml"
 - "!include public_analytics_summary_materialized.yaml"

--- a/hasura.planx.uk/migrations/default/1757428020212_create_aggregated_analytics_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757428020212_create_aggregated_analytics_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW "public"."analytics_aggregated_materialized";

--- a/hasura.planx.uk/migrations/default/1757428020212_create_aggregated_analytics_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757428020212_create_aggregated_analytics_view/up.sql
@@ -1,0 +1,39 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_aggregated_materialized";
+CREATE MATERIALIZED VIEW "public"."analytics_aggregated_materialized" AS 
+SELECT a.id AS analytics_id,
+    max(t.slug) AS team_slug,
+    max(f.slug) AS service_slug,
+    a.flow_id AS flow_id,
+    max(a.created_at) AS analytics_created_at,
+    max(a.type) AS analytics_type,
+    max((al.allow_list_answers -> 'application.type'::text) ->> 0) AS application_type,
+    max(a.referrer) AS referrer,
+    string_agg(DISTINCT ((al.allow_list_answers -> 'user.role'::text))::text, ', '::text ORDER BY ((al.allow_list_answers -> 'user.role'::text))::text) AS user_role,
+    max(((a.user_agent -> 'platform'::text) ->> 'type'::text)) AS platform,
+    string_agg(pt.project_type, ', '::text ORDER BY al.created_at) AS project_types,
+    string_agg(al.node_title, ', '::text ORDER BY al.created_at) AS node_titles,
+    string_agg(al.node_type, ', '::text ORDER BY al.created_at) AS node_types,
+    (array_agg(al.node_title ORDER BY al.created_at))[array_upper(array_agg(al.node_title ORDER BY al.created_at), 1)] AS last_node_title,
+    bool_or(al.has_clicked_save) AS has_clicked_save,
+    bool_or(al.user_exit) AS tracked_exit,
+    string_agg(rf.result_text, ', '::text ORDER BY al.created_at) AS results
+FROM ((((analytics a
+    LEFT JOIN analytics_logs al ON ((a.id = al.analytics_id)))
+    LEFT JOIN flows f ON ((a.flow_id = f.id)))
+    LEFT JOIN teams t ON ((t.id = f.team_id)))
+    LEFT JOIN LATERAL ( 
+        SELECT jsonb_array_elements_text(al.allow_list_answers -> 'proposal.projectType') AS project_type
+        WHERE al.allow_list_answers IS NOT NULL 
+          AND al.allow_list_answers -> 'proposal.projectType' IS NOT NULL
+          AND jsonb_typeof(al.allow_list_answers -> 'proposal.projectType') = 'array'
+    ) pt ON (true))
+    LEFT JOIN LATERAL ( 
+        SELECT (((al.metadata ->> 'flag'::text))::jsonb ->> 'text'::text) AS result_text
+        WHERE al.metadata IS NOT NULL 
+          AND (al.metadata ->> 'flag'::text) IS NOT NULL
+          AND (al.metadata ->> 'flag'::text) != 'null'
+    ) rf ON (true)
+GROUP BY a.id, a.flow_id
+ORDER BY a.id;
+
+GRANT SELECT ON "public"."analytics_aggregated_materialized" TO metabase_read_only;


### PR DESCRIPTION
This is a new version of #5185 that selects from `analytics` and `analytics_logs` tables instead of `analytics_summary` view. The `select` has been tested on production (using a read only role through pgAdmin) and works as expected. 

As of dev call today, we discussed merging this and #5225 and then testing in Metabase to determine what to keep & use.

Following [conversations on Metabase performance](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1756899876949039?thread_ts=1756897333.705039&cid=C01E3AC0C03) and the recent [materialized view test](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1756899876949039?thread_ts=1756897333.705039&cid=C01E3AC0C03), this PR has a proposed view that I think will be useful based on the kinds of questions / queries we're running in Metabase.

# Why?
This shape is one that I think will meet most of the needs of analytics queries. It would take the referenced table from 6.8m rows to 286k.

With the way the dashboards are designed, I don't know that time-partitioned views will be that relevant. (Most queries show all-time by default and councils filter by a specific period for reporting if they need to. Occasionally we might show a figure for the last week or last month, but not that often.)

# How are columns aggregated?
This view aggregates relevant fields by analytics_id.

Some columns will have the same value throughout (eg referrer and so it just uses MAX to get the one value).

Some columns will have a range of values (eg node_type and so it aggregates with STRING_AGG(node_type, ', ' ORDER BY analytics_log_created_at) AS node_types,.)

Columns like has_clicked_save or is_user_exit are aggregated with BOOL_OR because we just want to know if the session was saved at all, or if an exit was tracked for this session.
