### PR TITLE
fix: remove "(testing only)" disclaimer from MapAndLabel component selection

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -78,7 +78,7 @@ const NodeTypeSelect: React.FC<{
         <option value={TYPES.ContactInput}>Contact input</option>
         <option value={TYPES.List}>List</option>
         <option value={TYPES.Page}>Page</option>
-        <option value={TYPES.MapAndLabel}>Map and label (testing only)</option>
+        <option value={TYPES.MapAndLabel}>Map and label</option>
         <option value={TYPES.Feedback}>Feedback</option>
       </optgroup>
       <optgroup label="Information">


### PR DESCRIPTION
Missed this in #5189 - now that we have payload documents and recently incorporated a11y usability feedback, I think we're happy to consider this as "ready" as any other component type ! 