### PR TITLE
fix: when validating that all required templated nodes have been updated on publish, fetch templated node edits from all nested templated flows too

### DIFF
--- a/api.planx.uk/helpers.ts
+++ b/api.planx.uk/helpers.ts
@@ -17,6 +17,7 @@ export interface GetFlowDataResponse {
   limitations: string | null;
   team_id: number;
   team: { slug: string };
+  templatedFrom: string | null;
   publishedFlows:
     | {
         data: Flow["data"];
@@ -46,6 +47,7 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
           team {
             slug
           }
+          templatedFrom: templated_from
           publishedFlows: published_flows(
             limit: 1
             order_by: { created_at: desc }
@@ -418,6 +420,7 @@ const dataMerged = async (
         data: {
           text: `${team.slug}/${slug}`,
           flattenedFromExternalPortal: true,
+          templatedFrom: response.templatedFrom,
           // add extra metadata about latest published version when applicable
           ...(!draftDataOnly && {
             publishedFlowId: publishedFlows?.[0]?.id,


### PR DESCRIPTION
Reported via South Gloc - see thread here: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1757411128487319