### PR TITLE
fix: on unhandled ShareDB errors, re-introduce toast and forced logout to prevent lost edits

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/sharedb.ts
@@ -36,6 +36,17 @@ const createWSConnection = () => {
   /** Fallback for unhandled ShareDB errors */
   socket.addEventListener("error", (errorEvent) => {
     console.error("Unhandled ShareDB error: ", { errorEvent });
+
+    // Only display a single toast at a time
+    if (toast.isActive("sharedb_jwt_expiry")) return;
+
+    toast.error(
+      "[ShareDB error]: Unhandled error, redirecting to login page...",
+      {
+        toastId: "sharedb_error",
+        ...toastConfig,
+      },
+    );
   });
 
   return socket;


### PR DESCRIPTION
Manually reverts https://github.com/theopensystemslab/planx-new/pull/5123 after new reports of lost edits (3 hours worth). Frequent login has got to be better than silent errors & lost work until we strike right balance here ! 

See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1757515479421829