### PR TITLE
fix: Ensure branched components display template wrapper

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -142,7 +142,11 @@ const Checklist: React.FC<Props> = React.memo((props) => {
                 <span>{title}</span>
                 <ol className="options">
                   {children.map((child: any) => (
-                    <Node key={child.id} {...child} />
+                    <Node
+                      key={child.id}
+                      {...child}
+                      showTemplatedNodeStatus={props.showTemplatedNodeStatus}
+                    />
                   ))}
                 </ol>
               </li>
@@ -151,7 +155,11 @@ const Checklist: React.FC<Props> = React.memo((props) => {
         ) : (
           <ol className="options">
             {childNodes.map((child: any) => (
-              <Node key={child.id} {...child} />
+              <Node
+                key={child.id}
+                {...child}
+                showTemplatedNodeStatus={props.showTemplatedNodeStatus}
+              />
             ))}
           </ol>
         )}

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
@@ -71,7 +71,11 @@ const Filter: React.FC<Props> = React.memo((props) => {
         </Link>
         <ol className="options">
           {childNodes.map((child: any) => (
-            <Node key={child.id} {...child} />
+            <Node
+              key={child.id}
+              {...child}
+              showTemplatedNodeStatus={props.showTemplatedNodeStatus}
+            />
           ))}
         </ol>
       </li>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -19,8 +19,8 @@ const Option: React.FC<any> = (props) => {
   try {
     // Question & Checklist Options set zero or many flag values under "data.flags"
     if (props.data?.flags) {
-      flags = flatFlags.filter(
-        ({ value }) => props.data?.flags?.includes(value),
+      flags = flatFlags.filter(({ value }) =>
+        props.data?.flags?.includes(value),
       );
     }
 
@@ -31,7 +31,7 @@ const Option: React.FC<any> = (props) => {
         flags = flatFlags.filter(({ value }) => props.data.val === value);
       }
     }
-  } catch (e) { }
+  } catch (e) {}
 
   return (
     <li
@@ -57,7 +57,14 @@ const Option: React.FC<any> = (props) => {
         )}
       </Link>
       <ol className="decisions">
-        {childNodes.map((child: any) => (<Node key={child.id} parent={props.id} {...child} />))}
+        {childNodes.map((child: any) => (
+          <Node
+            key={child.id}
+            parent={props.id}
+            {...child}
+            showTemplatedNodeStatus={props.showTemplatedNodeStatus}
+          />
+        ))}
         <Hanger parent={props.id} />
       </ol>
     </li>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -127,7 +127,11 @@ const Question: React.FC<Props> = React.memo((props) => {
         </TemplatedNodeContainer>
         <ol className="options">
           {childNodes.map((child: any) => (
-            <Node key={child.id} {...child} />
+            <Node
+              key={child.id}
+              {...child}
+              showTemplatedNodeStatus={props.showTemplatedNodeStatus}
+            />
           ))}
         </ol>
       </li>

--- a/editor.planx.uk/src/ui/editor/TemplatedNodeInstructions.tsx
+++ b/editor.planx.uk/src/ui/editor/TemplatedNodeInstructions.tsx
@@ -1,6 +1,5 @@
 import StarIcon from "@mui/icons-material/Star";
 import { useTheme } from "@mui/material/styles";
-import Typography from "@mui/material/Typography";
 import { BaseNodeData } from "@planx/components/shared";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";


### PR DESCRIPTION
## Issue

[Reported by Jonny in Slack.
](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1757512373915809)

When viewing a source template, components placed on branches do not currently show the correct wrapper/label if `allow edits` = true.

## Solution

Ensure that `showTemplatedNodeStatus` is correctly passed down every time child nodes are rendered.