### PR TITLE
fix: Ensure nested flows display template status

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -83,7 +83,7 @@ const ExternalPortal: React.FC<any> = (props) => {
         id={props.id}
         text="Corrupted external portal: flow no longer exists"
         lockedFlow
-        showTemplatedNodeStatus
+        showTemplatedNodeStatus={props.showTemplatedNodeStatus}
       />
     );
   }
@@ -102,7 +102,13 @@ const ExternalPortal: React.FC<any> = (props) => {
             isDragging,
           })}
         >
-          <Box className="card-wrapper">
+          <TemplatedNodeContainer
+            isTemplatedNode={props.data?.isTemplatedNode}
+            areTemplatedNodeInstructionsRequired={
+              props.data?.areTemplatedNodeInstructionsRequired
+            }
+            showStatus={props.showTemplatedNodeStatus}
+          >
             <Box sx={{ display: "flex", alignItems: "stretch" }}>
               <Link href={`/${href}`} prefetch={false} ref={drag}>
                 <EditorIcon />
@@ -112,7 +118,7 @@ const ExternalPortal: React.FC<any> = (props) => {
                 <MoreVert titleAccess="Edit Portal" />
               </Link>
             </Box>
-          </Box>
+          </TemplatedNodeContainer>
           {showTags && props.data?.tags?.length > 0 && (
             <Box className="card-tag-list">
               {props.data.tags.map((tag: NodeTag) => (


### PR DESCRIPTION
## Issue
[Reported by August in Slack.](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1757512373915809)

When viewing a source template, nested flows do not currently show the correct wrapper/label if allow edits = true.

## Solution
Ensure that portals are correctly wrapped in `TemplatedNodeContainer`.

**Source template:**
https://5223.planx.pizza/a-new-team/templated-nodes

**Template in use:**
https://5223.planx.pizza/a-new-team/templated-nodes-templated