### PR TITLE
feat: create smaller materialized analytics views

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_action_nodes.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_action_nodes.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_action_nodes
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_aggregated_mini.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_aggregated_mini.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_aggregated_mini
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_exits.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_exits.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_exits
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_journey_results.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_journey_results.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_journey_results
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_sessions.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_sessions.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_sessions
+  schema: public

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_analytics.yaml"
+- "!include public_analytics_action_nodes.yaml"
 - "!include public_analytics_aggregated_mini.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_sessions.yaml"

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,6 +1,7 @@
 - "!include public_analytics.yaml"
 - "!include public_analytics_action_nodes.yaml"
 - "!include public_analytics_aggregated_mini.yaml"
+- "!include public_analytics_exits.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_sessions.yaml"
 - "!include public_analytics_summary.yaml"

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,6 +1,7 @@
 - "!include public_analytics.yaml"
 - "!include public_analytics_aggregated_mini.yaml"
 - "!include public_analytics_logs.yaml"
+- "!include public_analytics_sessions.yaml"
 - "!include public_analytics_summary.yaml"
 - "!include public_analytics_summary_materialized.yaml"
 - "!include public_blpu_codes.yaml"

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,5 @@
 - "!include public_analytics.yaml"
+- "!include public_analytics_aggregated_mini.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_summary.yaml"
 - "!include public_analytics_summary_materialized.yaml"
@@ -40,7 +41,6 @@
 - "!include public_teams_summary.yaml"
 - "!include public_temp_data_migrations_audit.yaml"
 - "!include public_templated_flow_edits.yaml"
-- "!include public_templated_flow_update_requests.yaml"
 - "!include public_uniform_applications.yaml"
 - "!include public_user_roles.yaml"
 - "!include public_users.yaml"

--- a/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -2,6 +2,7 @@
 - "!include public_analytics_action_nodes.yaml"
 - "!include public_analytics_aggregated_mini.yaml"
 - "!include public_analytics_exits.yaml"
+- "!include public_analytics_journey_results.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_sessions.yaml"
 - "!include public_analytics_summary.yaml"

--- a/hasura.planx.uk/migrations/default/1757588463488_create_materialized_analytics_aggregated_mini_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757588463488_create_materialized_analytics_aggregated_mini_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_aggregated_mini";

--- a/hasura.planx.uk/migrations/default/1757588463488_create_materialized_analytics_aggregated_mini_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757588463488_create_materialized_analytics_aggregated_mini_view/up.sql
@@ -11,8 +11,11 @@ FROM analytics a
     LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
     LEFT JOIN flows f ON (a.flow_id = f.id)
     LEFT JOIN LATERAL (
-        SELECT jsonb_array_elements_text((al.allow_list_answers -> 'proposal.projectType'::text)::jsonb) AS project_type
-    ) pt ON (al.allow_list_answers -> 'proposal.projectType'::text IS NOT NULL)
+        SELECT jsonb_array_elements_text(al.allow_list_answers -> 'proposal.projectType') AS project_type
+        WHERE al.allow_list_answers IS NOT NULL 
+          AND al.allow_list_answers -> 'proposal.projectType' IS NOT NULL
+          AND jsonb_typeof(al.allow_list_answers -> 'proposal.projectType') = 'array'
+    ) pt ON (true)
 GROUP BY a.id
 ORDER BY a.id;
 

--- a/hasura.planx.uk/migrations/default/1757588463488_create_materialized_analytics_aggregated_mini_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757588463488_create_materialized_analytics_aggregated_mini_view/up.sql
@@ -1,0 +1,19 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_aggregated_mini";
+CREATE MATERIALIZED VIEW "public"."analytics_aggregated_mini" AS 
+SELECT a.id AS analytics_id,
+    a.flow_id AS flow_id,
+    max(a.created_at) AS analytics_created_at,
+    string_agg(pt.project_type, ', '::text ORDER BY al.created_at) AS project_types,
+    string_agg(al.node_title, ', '::text ORDER BY al.created_at) AS node_titles,
+    string_agg(al.node_type, ', '::text ORDER BY al.created_at) AS node_types,
+    (array_agg(al.node_title ORDER BY al.created_at))[array_upper(array_agg(al.node_title ORDER BY al.created_at), 1)] AS last_node_title
+FROM analytics a
+    LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
+    LEFT JOIN flows f ON (a.flow_id = f.id)
+    LEFT JOIN LATERAL (
+        SELECT jsonb_array_elements_text((al.allow_list_answers -> 'proposal.projectType'::text)::jsonb) AS project_type
+    ) pt ON (al.allow_list_answers -> 'proposal.projectType'::text IS NOT NULL)
+GROUP BY a.id
+ORDER BY a.id;
+
+GRANT SELECT ON "public"."analytics_aggregated_mini" TO metabase_read_only;

--- a/hasura.planx.uk/migrations/default/1757588698614_create_analytics_sessions_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757588698614_create_analytics_sessions_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_sessions";

--- a/hasura.planx.uk/migrations/default/1757588698614_create_analytics_sessions_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757588698614_create_analytics_sessions_view/up.sql
@@ -1,0 +1,19 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_sessions";
+CREATE MATERIALIZED VIEW "public"."analytics_sessions" AS 
+SELECT a.id AS analytics_id,
+    a.flow_id AS flow_id,
+    max(a.type) AS analytics_type,
+    count(DISTINCT al.id) AS number_logs,
+    max((al.allow_list_answers -> 'application.type'::text) ->> 0) AS application_type,
+    max(a.created_at) AS analytics_created_at,
+    max(((a.user_agent -> 'platform'::text) ->> 'type'::text)) AS platform,
+    max(((a.user_agent -> 'os'::text) ->> 'name'::text)) AS operating_system,
+    max(a.referrer) AS referrer,
+    bool_or(al.has_clicked_save) AS has_clicked_save,
+    string_agg(DISTINCT ((al.allow_list_answers -> 'user.role'::text))::text, ', '::text ORDER BY ((al.allow_list_answers -> 'user.role'::text))::text) AS user_role
+FROM analytics a
+    LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
+GROUP BY a.id, a.flow_id
+ORDER BY a.id;
+
+GRANT SELECT ON "public"."analytics_sessions" TO metabase_read_only;

--- a/hasura.planx.uk/migrations/default/1757589349869_create_analytics_actions_nodes_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757589349869_create_analytics_actions_nodes_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_action_nodes";

--- a/hasura.planx.uk/migrations/default/1757589349869_create_analytics_actions_nodes_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757589349869_create_analytics_actions_nodes_view/up.sql
@@ -1,0 +1,17 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_action_nodes";
+CREATE MATERIALIZED VIEW "public"."analytics_action_nodes" AS 
+SELECT 
+    a.flow_id,
+    a.id AS analytics_id,
+    (al.allow_list_answers -> 'drawBoundary.action'::text)::text AS draw_boundary_action,
+    al.node_type,
+    al.input_errors,
+    al.has_clicked_save,
+    al.has_clicked_help
+FROM analytics a
+LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
+WHERE (al.allow_list_answers -> 'drawBoundary.action'::text) IS NOT NULL 
+   OR al.has_clicked_save = true
+   OR al.has_clicked_help = true;
+   
+GRANT SELECT ON "public"."analytics_action_nodes" TO metabase_read_only;

--- a/hasura.planx.uk/migrations/default/1757589349869_create_analytics_actions_nodes_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757589349869_create_analytics_actions_nodes_view/up.sql
@@ -5,6 +5,7 @@ SELECT
     a.id AS analytics_id,
     (al.allow_list_answers -> 'drawBoundary.action'::text)::text AS draw_boundary_action,
     al.node_type,
+    al.node_title,
     al.input_errors,
     al.has_clicked_save,
     al.has_clicked_help

--- a/hasura.planx.uk/migrations/default/1757589801902_create_analytics_exits_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757589801902_create_analytics_exits_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_exits";

--- a/hasura.planx.uk/migrations/default/1757589801902_create_analytics_exits_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757589801902_create_analytics_exits_view/up.sql
@@ -1,0 +1,23 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_exits";
+CREATE MATERIALIZED VIEW "public"."analytics_exits" AS 
+SELECT 
+    a.id AS analytics_id,
+    a.type AS analytics_type,
+    last_log.user_exit AS is_user_exit,
+    last_log.node_title AS last_node_title,
+    last_log.node_type AS last_node_type,
+    bool_or(al.has_clicked_save) AS has_clicked_save,
+    max((al.allow_list_answers -> 'rab.exitReason'::text)::text) AS positive_exit_reason
+FROM analytics a
+LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
+LEFT JOIN LATERAL (
+    SELECT al2.user_exit, al2.node_title, al2.node_type
+    FROM analytics_logs al2 
+    WHERE al2.analytics_id = a.id 
+    ORDER BY al2.created_at DESC 
+    LIMIT 1
+) last_log ON true
+GROUP BY a.id, a.type, last_log.user_exit, last_log.node_title, last_log.node_type
+ORDER BY a.id;
+
+GRANT SELECT ON "public"."analytics_exits" TO metabase_read_only;

--- a/hasura.planx.uk/migrations/default/1757590230990_create_analytics_journey_results_view/down.sql
+++ b/hasura.planx.uk/migrations/default/1757590230990_create_analytics_journey_results_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_journey_results";

--- a/hasura.planx.uk/migrations/default/1757590230990_create_analytics_journey_results_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757590230990_create_analytics_journey_results_view/up.sql
@@ -2,14 +2,15 @@ DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_journey_results";
 CREATE MATERIALIZED VIEW "public"."analytics_journey_results" AS 
 SELECT a.id AS analytics_id,
     a.flow_id AS flow_id,
-    max(a.created_at) AS analytics_created_at,
-    string_agg(rf.result_text, ', '::text ORDER BY al.created_at) AS results
+    a.created_at AS analytics_created_at,
+    al.created_at AS analytics_log_created_at,
+    rf.result_text
 FROM analytics a
     LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
     LEFT JOIN LATERAL (
         SELECT (((al.metadata ->> 'flag'::text))::jsonb ->> 'text'::text) AS result_text
     ) rf ON ((al.metadata ->> 'flag'::text) IS NOT NULL)
-GROUP BY a.id, a.flow_id
-ORDER BY a.id;
+WHERE rf.result_text IS NOT NULL
+ORDER BY a.id, al.created_at;
 
 GRANT SELECT ON "public"."analytics_journey_results" TO metabase_read_only;

--- a/hasura.planx.uk/migrations/default/1757590230990_create_analytics_journey_results_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1757590230990_create_analytics_journey_results_view/up.sql
@@ -1,0 +1,15 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_journey_results";
+CREATE MATERIALIZED VIEW "public"."analytics_journey_results" AS 
+SELECT a.id AS analytics_id,
+    a.flow_id AS flow_id,
+    max(a.created_at) AS analytics_created_at,
+    string_agg(rf.result_text, ', '::text ORDER BY al.created_at) AS results
+FROM analytics a
+    LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
+    LEFT JOIN LATERAL (
+        SELECT (((al.metadata ->> 'flag'::text))::jsonb ->> 'text'::text) AS result_text
+    ) rf ON ((al.metadata ->> 'flag'::text) IS NOT NULL)
+GROUP BY a.id, a.flow_id
+ORDER BY a.id;
+
+GRANT SELECT ON "public"."analytics_journey_results" TO metabase_read_only;


### PR DESCRIPTION
After dev call today I've tested (and amended) the queries using the read only db role through pgAdmin. Happy with these data shapes--I think the next step is merging this and #5211 so that we can test the different shapes in Metabase (and eventually get rid of the ones we won't use, and set up cron jobs to update the views). 

This is possibly an alternative to #5211 (which creates one aggregated, materialised analytics view to satisfy most analytics needs), creating multiple smaller views. This creates 5 different materialized views.

`analytics_aggregated_mini`
A version of `analytics_aggregated_materialized` as created in #5211 but without half of the columns (as the rest have been split into other views). 

`analytics_sessions`
A summary of sessions. Shows `analytics_type`, `number_logs` (number of logs per session), `application_type`, `analytics_created_at`, `platform`, `operating_system`, `referrer` etc. 

`analytics_action_nodes`
This is the one I'm least sure about. I don't know that the shape is intuitive--should they be split into separate views? It's for slightly more granular queries to do with specific nodes: either action on `drawBoundary` or where users clicked for help or encountered errors. Shows results when `input_error` > 0, `has_clicked_help` = `true`, `has_clicked_save` = `true` OR `drawBoundary.action` is not null. `node_type` and `node_title` are columns. 

`analytics_exits`
Shows if `is_user_exit` = true (so whether Beacon API counted it as an exit or not), as well as last node type & title that the user encountered. Also contains `rab.exitReason`. 

`analytics_journey_results`
Basically for anything that has flags. One row per result (so one analytics ID may have multiple results)