### PR TITLE
fix: apply team boundary override to new Strategic Local Plan team

### DIFF
--- a/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -72,8 +72,9 @@ export default function Component(props: Props) {
   // Buffer applied to the address point to clip this map extent
   //   and applied to the site boundary and written to the passport to later clip the map extent in overview documents
   let bufferInMeters: number = area && area > 15000 ? 300 : 120;
-  if (["strategic-local-plan", "tewkesbury"].includes(teamSlug)) {
-    // "Strategic Local Plan" teams uniquely support a joint boundary which requires larger buffer
+  if (["strategic-and-local-plan", "tewkesbury"].includes(teamSlug)) {
+    // Cheltenham, Gloucester and Tewkesbury share a Strategic Local Plan
+    //   These teams uniquely support a joint boundary which requires larger buffer
     bufferInMeters = 10000;
   }
 

--- a/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Settings/GeneralSettings/BoundaryForm.tsx
@@ -156,7 +156,7 @@ export default function BoundaryForm({ formikConfig, onSuccess }: FormProps) {
 
   // Cheltenham, Gloucester and Tewkesbury share a Strategic Local Plan
   //  This joint boundary is not hosted on PD, so we override the usual self-service input
-  const isSLPTeam = ["strategic-local-plan", "tewkesbury"].includes(teamSlug);
+  const isSLPTeam = ["strategic-and-local-plan", "tewkesbury"].includes(teamSlug);
 
   if (isSLPTeam) return <SLPInfo geojsonData={formik.values.boundaryBBox} />;
 


### PR DESCRIPTION
See thread https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1757325815807699

To test: confirm that team settings page for "Strategic Local Plan" and "Tewkesbury" display the joint boundary rather than the usual self-service form with URL input.

Once merged, I'll additionally manually update `team_settings.boundary_bbox` with correct boundary on prod and sync to staging.