### PR TITLE
chore: Bump @opensystemlab/map to v1.0.0-alpha.10

### DIFF
--- a/localplanning.services/package.json
+++ b/localplanning.services/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^4.2.7",
-    "@opensystemslab/map": "1.0.0-alpha.9",
+    "@opensystemslab/map": "1.0.0-alpha.10",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.81.5",
     "@types/react": "^19.1.5",

--- a/localplanning.services/pnpm-lock.yaml
+++ b/localplanning.services/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.2.7
         version: 4.3.1(@types/node@24.3.1)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jiti@2.5.1)(lightningcss@1.30.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(yaml@2.8.1)
       '@opensystemslab/map':
-        specifier: 1.0.0-alpha.9
-        version: 1.0.0-alpha.9
+        specifier: 1.0.0-alpha.10
+        version: 1.0.0-alpha.10
       '@tailwindcss/vite':
         specifier: ^4.1.7
         version: 4.1.13(vite@6.3.6(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
@@ -687,8 +687,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/map@1.0.0-alpha.9':
-    resolution: {integrity: sha512-kWuDN5e1EjleLEbgGVTPkD/R+UlzRmc2XCrjDfN3OKXZT+pJ59CAz9/prc7qz3rS0gzgW7DZmcFndOQFcAEZtg==}
+  '@opensystemslab/map@1.0.0-alpha.10':
+    resolution: {integrity: sha512-h4IDgQp3VbzWdmaPnMlI5e2Qersy2M6zMqLq/f5CJj4vRI6mBC/nyOCi8AhPhTuIUNsyt1PMZlokPmprhPFqVA==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -3557,7 +3557,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/map@1.0.0-alpha.9':
+  '@opensystemslab/map@1.0.0-alpha.10':
     dependencies:
       '@turf/helpers': 7.2.0
       '@turf/union': 7.2.0


### PR DESCRIPTION
Bump map lib to v1.0.0-alpha.10 ([release notes](https://github.com/theopensystemslab/map/releases/tag/v1.0.0-alpha.10)) in order to pick up style changes to `geocode-autocomplete`.