### PR TITLE
fix: set default 0 service charge anytime SetFee has "apply service charge" toggled on for Gov Pay metadata reporting

### DIFF
--- a/editor.planx.uk/src/@planx/components/SetFee/utils.test.ts
+++ b/editor.planx.uk/src/@planx/components/SetFee/utils.test.ts
@@ -201,7 +201,7 @@ describe("handleSetFees() function", () => {
       });
     });
 
-    it("does not add service charge if total payable after Fast Track is less than £100", () => {
+    it("adds £0 service charge if the SetFee toggle is `on` and total payable inclusive of VAT after Fast Track is less than £100", () => {
       const incomingPassport: Store.Passport = {
         data: {
           "application.fee.calculated": 200,
@@ -225,6 +225,8 @@ describe("handleSetFees() function", () => {
         "application.fee.payable.VAT": 10,
         "application.fee.fastTrack": 50,
         "application.fee.fastTrack.VAT": 10,
+        "application.fee.serviceCharge": 0,
+        "application.fee.serviceCharge.VAT": 0,
       });
     });
 

--- a/editor.planx.uk/src/routes/subscription.tsx
+++ b/editor.planx.uk/src/routes/subscription.tsx
@@ -35,7 +35,10 @@ const subscriptionRoutes = compose(
                   fiscal_year_quarter: desc
                   paid_at: desc
                 }
-                where: { team_slug: { _eq: $teamSlug } }
+                where: { 
+                  team_slug: { _eq: $teamSlug }, 
+                  service_charge_amount: { _gt: 0 }}
+                }
               ) {
                 flowName: flow_name
                 sessionId: session_id


### PR DESCRIPTION
Per David's latest report here: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1757691398442419

Now also more consistent with how we handle Fast Track passport variables.