### PR TITLE
chore(lps): Configure CORS for LPS staging

### DIFF
--- a/infrastructure/application/utils/generateCORSAllowList.ts
+++ b/infrastructure/application/utils/generateCORSAllowList.ts
@@ -1,22 +1,28 @@
 import * as awsx from "@pulumi/awsx";
+import * as pulumi from "@pulumi/pulumi";
 
 import { CustomDomains } from "../../common/teams";
+
+const config = new pulumi.Config();
 
 export const generateCORSAllowList = (customDomains: CustomDomains, domain: string): awsx.ecs.KeyValuePair => {
   const customDomainURLs = customDomains.map(team => `https://${team.domain}`);
   const editorURL = `https://${domain}`;
   const apiURL = `https://api.${domain}`; // Required for requests from API docs
   const hasuraURL = `https://hasura.${domain}`; // Required for proxied auth requests
-  // TODO: Configure when staging / production infra for LPS is put in place
-  // const lpsURL = "https://localplanning.services"
+
+  const lpsDomain = config.get("lps-domain")
+  const lpsURL = lpsDomain && `https://${lpsDomain}`;
+
   const microsoftLoginURLs = ["https://login.live.com, https://login.microsoftonline.com"];
   const corsAllowList = [
     ...customDomainURLs,
     editorURL,
     apiURL,
     hasuraURL,
+    lpsURL,
     ...microsoftLoginURLs,
-  ];
+  ].filter(Boolean);
 
   const secret: awsx.ecs.KeyValuePair = {
     name: "CORS_ALLOWLIST",


### PR DESCRIPTION
Now that the staging site https://localplanning.editor.planx.dev/ is in place, we need to allow it to access to API via CORS.

This is already in place for Pizza ✅ 🍕 