### PR TITLE
feat(lps): Fallback message for empty service accordions

### DIFF
--- a/localplanning.services/src/pages/[lpa].astro
+++ b/localplanning.services/src/pages/[lpa].astro
@@ -23,6 +23,10 @@ const { lpaData } = Astro.props;
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
 if (!lpaData) return Astro.redirect("/404");
+
+// Fallback message function
+const getFallbackMessage = (serviceType: string) => 
+  `Currently there are no ${serviceType} services offered by ${lpaData.name}.`;
 ---
 
 <Layout>
@@ -35,40 +39,54 @@ if (!lpaData) return Astro.redirect("/404");
   <Container>
     <div class="flex flex-col gap-4 clamp-[py,4,6]">
       <Accordion title="Start a planning application" id="apply-accordion">
-        <ul class="flex flex-col gap-4">
-          {
-            lpaData.applyServices.map((service) => (
+        {lpaData.applyServices && lpaData.applyServices.length > 0 ? (
+          <ul class="flex flex-col gap-4">
+            {lpaData.applyServices.map((service) => (
               <ServiceCard
                 service={service}
                 team={{ domain: lpaData.domain }}
               />
-            ))
-          }
-        </ul>
+            ))}
+          </ul>
+        ) : (
+          <p class="text-body-xl m-0 clamp-[px,1,2] py-4">
+            {getFallbackMessage("planning application")}
+          </p>
+        )}
       </Accordion>
+      
       <Accordion title="Notify your authority" id="notify-accordion">
-        <ul class="flex flex-col gap-4">
-          {
-            lpaData.notifyServices.map((service) => (
+        {lpaData.notifyServices && lpaData.notifyServices.length > 0 ? (
+          <ul class="flex flex-col gap-4">
+            {lpaData.notifyServices.map((service) => (
               <ServiceCard
                 service={service}
                 team={{ domain: lpaData.domain }}
               />
-            ))
-          }
-        </ul>
+            ))}
+          </ul>
+        ) : (
+          <p class="text-body-xl m-0 clamp-[px,1,2] py-4">
+            {getFallbackMessage("notification")}
+          </p>
+        )}
       </Accordion>
+      
       <Accordion title="Get planning guidance" id="guidance-accordion">
-        <ul class="flex flex-col gap-4">
-          {
-            lpaData.guidanceServices.map((service) => (
+        {lpaData.guidanceServices && lpaData.guidanceServices.length > 0 ? (
+          <ul class="flex flex-col gap-4">
+            {lpaData.guidanceServices.map((service) => (
               <ServiceCard
                 service={service}
                 team={{ domain: lpaData.domain }}
               />
-            ))
-          }
-        </ul>
+            ))}
+          </ul>
+        ) : (
+          <p class="text-body-xl m-0 clamp-[px,1,2] py-4">
+            {getFallbackMessage("planning guidance")}
+          </p>
+        )}
       </Accordion>
     </div>
   </Container>


### PR DESCRIPTION
## What does this PR do?

- Introduces a fallback message for empty service type accordions, when searching for services.

<img width="1082" height="634" alt="image" src="https://github.com/user-attachments/assets/9e10ac1a-fc05-40ca-92cc-c282bc359874" />

Testing (with `.html` appended due to known build error, unrelated to this PR):
https://localplanning.5246.planx.pizza/lambeth.html