### PR TITLE
fix `templated_flow_update_requests` migration script

### DIFF
--- a/hasura.planx.uk/migrations/default/1730730955039_application_type_as_text_in_view/up.sql
+++ b/hasura.planx.uk/migrations/default/1730730955039_application_type_as_text_in_view/up.sql
@@ -1,6 +1,6 @@
 DROP VIEW IF EXISTS "public"."submission_services_summary";
 
-CREATE VIEW "public"."submission_services_summary" AS 
+CREATE OR REPLACE VIEW "public"."submission_services_summary" AS 
  WITH resumes_per_session AS (
          SELECT reconciliation_requests.session_id,
             count(reconciliation_requests.id) AS number_times_resumed
@@ -102,7 +102,7 @@ CREATE VIEW "public"."submission_services_summary" AS
 
 DROP VIEW IF EXISTS "public"."analytics_summary";
 
-CREATE VIEW "public"."analytics_summary" AS 
+CREATE OR REPLACE VIEW "public"."analytics_summary" AS 
  SELECT a.id AS analytics_id,
     al.id AS analytics_log_id,
     f.slug AS service_slug,

--- a/hasura.planx.uk/migrations/default/1748596202549_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/default/1748596202549_run_sql_migration/up.sql
@@ -1,4 +1,4 @@
-CREATE VIEW "public"."planx_website_stats" AS
+CREATE OR REPLACE VIEW "public"."planx_website_stats" AS
 SELECT
   (
     SELECT

--- a/hasura.planx.uk/migrations/default/1749120614777_run_sql_migration/down.sql
+++ b/hasura.planx.uk/migrations/default/1749120614777_run_sql_migration/down.sql
@@ -1,6 +1,6 @@
 -- Previous iteration from hasura.planx.uk/migrations/default/1748596202549_run_sql_migration/up.sql
 
-CREATE VIEW "public"."planx_website_stats" AS
+CREATE OR REPLACE VIEW "public"."planx_website_stats" AS
 SELECT
   (
     SELECT

--- a/hasura.planx.uk/migrations/default/1749120614777_run_sql_migration/up.sql
+++ b/hasura.planx.uk/migrations/default/1749120614777_run_sql_migration/up.sql
@@ -1,6 +1,6 @@
 DROP VIEW "public"."planx_website_stats";
 
-CREATE VIEW "public"."planx_website_stats" AS
+CREATE OR REPLACE VIEW "public"."planx_website_stats" AS
 SELECT
   (
     SELECT

--- a/hasura.planx.uk/migrations/default/1756972534375_create_view_templated_flow_update_requests/up.sql
+++ b/hasura.planx.uk/migrations/default/1756972534375_create_view_templated_flow_update_requests/up.sql
@@ -1,4 +1,4 @@
-CREATE VIEW templated_flow_update_requests AS (
+CREATE OR REPLACE VIEW "public"."templated_flow_update_requests" AS (
     SELECT 
       hse.payload ->> 'sourceFlowId' as source_template_id,
       hse.payload ->> 'templatedFlowId' as templated_flow_id,


### PR DESCRIPTION
When building the stack on local (including just on latest from `main`), my Hasura console was reporting inconsistent metadata, like so:

<img width="978" height="350" alt="Screenshot From 2025-09-16 17-10-09" src="https://github.com/user-attachments/assets/2173da4f-7e7b-4cdf-85d9-fe23f4f6030a" />

I raised this on Slack [here](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1758024700227139).

After some poking around I eventually noticed that the `up.sql` file for the relevant migration (introduced in #5175) does not explicitly specify the schema to which the view should be applied. The first commit here fixes that.

The second commit is just a minor addendum to ensure that all migrations concerning views are idempotent (i.e. any instance of `CREATE VIEW` is replaced by `CREATE OR REPLACE VIEW`), so will not fail if the view has already been instantiated. This is just good practice but could be discarded if we like. It's mostly a hangover from an initial theory I had as to the issue at hand.

## Testing

Try building the stack from this branch and head to `http://localhost:7100/console/data/default/schema/public` to check that no error is reported and `templated_flow_update_requests` is visible in the list.