### PR TITLE
fix(lps): Conditionally called `files` build option on staging and production

### DIFF
--- a/localplanning.services/.env.dev
+++ b/localplanning.services/.env.dev
@@ -1,3 +1,4 @@
 PUBLIC_PLANX_EDITOR_URL=http://localhost:3000
 PUBLIC_PLANX_GRAPHQL_API_URL=http://localhost:7100/v1/graphql
 PUBLIC_PLANX_REST_API_URL=http://localhost:7002
+PUBLIC_LPS_URL=http://localhost:4321

--- a/localplanning.services/.env.pizza
+++ b/localplanning.services/.env.pizza
@@ -2,3 +2,4 @@ PUBLIC_PLANX_EDITOR_URL=https://${ROOT_DOMAIN}
 # Point to **staging** in order to avoid race conditions at build time
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
 PUBLIC_PLANX_REST_API_URL=https://api.${ROOT_DOMAIN}
+PUBLIC_LPS_URL=http://localplanning.${ROOT_DOMAIN}

--- a/localplanning.services/.env.staging
+++ b/localplanning.services/.env.staging
@@ -1,3 +1,4 @@
 PUBLIC_PLANX_EDITOR_URL=https://editor.planx.dev
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
 PUBLIC_PLANX_REST_API_URL=https://api.editor.planx.dev
+PUBLIC_LPS_URL=http://localplanning.editor.planx.dev

--- a/localplanning.services/astro.config.mjs
+++ b/localplanning.services/astro.config.mjs
@@ -1,19 +1,21 @@
-// @ts-check
 import { defineConfig, envField, fontProviders } from "astro/config";
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
-
+import { loadEnv } from "vite";
 import icon from "astro-icon";
+
+const { PUBLIC_LPS_URL, MODE } = loadEnv(process.env.NODE_ENV, process.cwd(), "");
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [react(), icon()],
-  site: "https://localplanning.services",
+  site: PUBLIC_LPS_URL,
   env: {
     schema: {
       PUBLIC_PLANX_EDITOR_URL: envField.string({ context: "client", access: "public", optional: false }),
       PUBLIC_PLANX_GRAPHQL_API_URL: envField.string({ context: "client", access: "public", optional: false }),
       PUBLIC_PLANX_REST_API_URL: envField.string({ context: "client", access: "public", optional: false }),
+      PUBLIC_LPS_URL: envField.string({ context: "client", access: "public", optional: false }),
     }
   },
   vite: {
@@ -32,9 +34,11 @@ export default defineConfig({
       },
     ]
   },
-  build: {
-    // This generates directory.html instead of directory/index.astro
+  ...(MODE === "production" && {
+    // This generates directory.html instead of directory/index.html
     // Required for AWS Cloudfront
-    format: "file"
-  }
+    build: {
+      format: "file"
+    }
+  })
 });

--- a/localplanning.services/astro.config.mjs
+++ b/localplanning.services/astro.config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
       },
     ]
   },
-  ...(MODE === "production" && {
+  ...(["staging", "production"].includes(MODE) && {
     // This generates directory.html instead of directory/index.html
     // Required for AWS Cloudfront
     build: {

--- a/localplanning.services/package.json
+++ b/localplanning.services/package.json
@@ -28,5 +28,8 @@
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.10.0",
+  "devDependencies": {
+    "vite": "^7.1.5"
+  }
 }

--- a/localplanning.services/pnpm-lock.yaml
+++ b/localplanning.services/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.0.0-alpha.10
       '@tailwindcss/vite':
         specifier: ^4.1.7
-        version: 4.1.13(vite@6.3.6(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
+        version: 4.1.13(vite@7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@tanstack/react-query':
         specifier: ^5.81.5
         version: 5.87.4(react@19.1.1)
@@ -59,6 +59,10 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
+    devDependencies:
+      vite:
+        specifier: ^7.1.5
+        version: 7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
 packages:
 
@@ -2617,6 +2621,46 @@ packages:
       yaml:
         optional: true
 
+  vite@7.1.5:
+    resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.1:
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
@@ -3574,12 +3618,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@6.3.6(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.13(vite@7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 6.3.6(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
   '@tanstack/query-core@5.87.4': {}
 
@@ -5751,6 +5795,21 @@ snapshots:
       vfile-message: 4.0.3
 
   vite@6.3.6(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.4.0
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      yaml: 2.8.1
+
+  vite@7.1.5(@types/node@24.4.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)


### PR DESCRIPTION
- Generate sitemaps by defining a `site` value in the Astro config
- Only configures the required `file` build on AWS environments, which fixes routing on Pizza environments (served using goStatic)