### PR TITLE
chore: update metabase to v56.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   metabase:
     container_name: metabase
     # if changing, also check infrastructure/application/index.ts
-    image: metabase/metabase:v0.56.2
+    image: metabase/metabase:v0.56.6
     profiles: ["analytics"]
     ports:
       - "${METABASE_PORT}:${METABASE_PORT}"

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -213,7 +213,7 @@ export = async () => {
       }),
       container: {
         // if changing, also check docker-compose.yml
-        image: "metabase/metabase:v0.56.2",
+        image: "metabase/metabase:v0.56.6",
         portMappings: [metabaseListenerHttp],
         // When changing `memory`, also update `JAVA_OPTS` below
         memory: 4096 /*MB*/,


### PR DESCRIPTION
A minor version bump for Metabase, from 0.56.2 to 0.56.6, which [should resolve the duplicate alert issue](https://github.com/metabase/metabase/issues/63189#issuecomment-3301727111). As per Slack thread, we decided to [wait and fix forward](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1757090263045689?thread_ts=1756806892.786279&cid=C01E3AC0C03) rather than roll back. 

After this merges to prod I'll wait Friday 3pm UTC (to see if the phantom alerts run) before configuring any new ones.