### PR TITLE
feat: add describe documents schema

### DIFF
--- a/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -23,6 +23,7 @@ import { AmendDocuments } from "./schemas/AmendDocuments";
 import { ExistingBuildingsCIL } from "./schemas/CIL/ExistingCIL";
 import { MezzanineCIL } from "./schemas/CIL/MezzanineCIL";
 import { UnoccupiedBuildingsCIL } from "./schemas/CIL/UnoccupiedCIL";
+import { DescribeDocuments } from "./schemas/DescribeDocuments";
 import { DischargeConditions } from "./schemas/DischargeConditions";
 import { NonResidentialFloorspace } from "./schemas/Floorspace";
 import { BuildingDetailsGLA } from "./schemas/GLA/BuildingDetails";
@@ -91,6 +92,7 @@ export const SCHEMAS = [
     schema: OwnershipCertificateOwners,
   },
   { name: "Amend documents", schema: AmendDocuments },
+  { name: "Describe documents", schema: DescribeDocuments },
   { name: "Discharge conditions", schema: DischargeConditions },
   { name: "Tree description - Conservation Area", schema: TreeDescriptionCA },
   { name: "Tree description - TPO", schema: TreeDescriptionTPO },

--- a/editor.planx.uk/src/@planx/components/List/schemas/DescribeDocuments.ts
+++ b/editor.planx.uk/src/@planx/components/List/schemas/DescribeDocuments.ts
@@ -1,0 +1,24 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const DescribeDocuments: Schema = {
+  type: "Document",
+  fields: [
+    {
+      type: "fileUpload",
+      data: {
+        title: "Upload a document",
+        fn: "otherDocument",
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "Describe the document",
+        fn: "description",
+        type: TextInputType.Short,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
This PR adds a 'Describe Documents' list schema that captures file uploads with user generated descriptions.

Request originally raised [here for the general enquiries service](https://opendigitalplanning.slack.com/archives/C01AD3YPZ24/p1758099144732219), but the schema is generic enough to be used in any case where we want a user generated description to one or multiple files.