### PR TITLE
fix(lps): Handle site and mode env vars in Astro config

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -211,7 +211,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
-      - run: pnpm build --mode pizza
+      - run: pnpm build --mode pizza --site "https://localplanning.${{ env.FULL_DOMAIN }}"
         env:
           ROOT_DOMAIN: ${{ env.FULL_DOMAIN }}
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -109,7 +109,7 @@ jobs:
         run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: localplanning.services
-      - run: pnpm build --mode staging
+      - run: pnpm build --mode staging --site https://localplanning.editor.planx.dev
         working-directory: localplanning.services
       - name: Upload LocalPlanning.services build artifact
         uses: actions/upload-artifact@v4

--- a/localplanning.services/.env.dev
+++ b/localplanning.services/.env.dev
@@ -1,4 +1,3 @@
 PUBLIC_PLANX_EDITOR_URL=http://localhost:3000
 PUBLIC_PLANX_GRAPHQL_API_URL=http://localhost:7100/v1/graphql
 PUBLIC_PLANX_REST_API_URL=http://localhost:7002
-PUBLIC_LPS_URL=http://localhost:4321

--- a/localplanning.services/.env.pizza
+++ b/localplanning.services/.env.pizza
@@ -2,4 +2,3 @@ PUBLIC_PLANX_EDITOR_URL=https://${ROOT_DOMAIN}
 # Point to **staging** in order to avoid race conditions at build time
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
 PUBLIC_PLANX_REST_API_URL=https://api.${ROOT_DOMAIN}
-PUBLIC_LPS_URL=http://localplanning.${ROOT_DOMAIN}

--- a/localplanning.services/.env.staging
+++ b/localplanning.services/.env.staging
@@ -1,4 +1,3 @@
 PUBLIC_PLANX_EDITOR_URL=https://editor.planx.dev
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.dev/v1/graphql
 PUBLIC_PLANX_REST_API_URL=https://api.editor.planx.dev
-PUBLIC_LPS_URL=http://localplanning.editor.planx.dev

--- a/localplanning.services/astro.config.mjs
+++ b/localplanning.services/astro.config.mjs
@@ -4,18 +4,19 @@ import tailwindcss from "@tailwindcss/vite";
 import { loadEnv } from "vite";
 import icon from "astro-icon";
 
-const { PUBLIC_LPS_URL, MODE } = loadEnv(process.env.NODE_ENV, process.cwd(), "");
+// Check args to access Astro mode
+// Env var is not available in Astro config files
+const mode = process.argv.at(-1).replaceAll("-", "")
+const isCloudfrontBuild = ["staging", "production"].includes(mode);
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [react(), icon()],
-  site: PUBLIC_LPS_URL,
   env: {
     schema: {
       PUBLIC_PLANX_EDITOR_URL: envField.string({ context: "client", access: "public", optional: false }),
       PUBLIC_PLANX_GRAPHQL_API_URL: envField.string({ context: "client", access: "public", optional: false }),
       PUBLIC_PLANX_REST_API_URL: envField.string({ context: "client", access: "public", optional: false }),
-      PUBLIC_LPS_URL: envField.string({ context: "client", access: "public", optional: false }),
     }
   },
   vite: {
@@ -34,11 +35,10 @@ export default defineConfig({
       },
     ]
   },
-  ...(["staging", "production"].includes(MODE) && {
-    // This generates directory.html instead of directory/index.html
-    // Required for AWS Cloudfront
-    build: {
-      format: "file"
-    }
-  })
+  build: {
+    // AWS Cloudfront requires /about.html not /about/index.html
+    format: isCloudfrontBuild 
+      ? "file"
+      : "directory"
+  }
 });


### PR DESCRIPTION
A follow up to https://github.com/theopensystemslab/planx-new/pull/5251 as this approach didn't quite work as planned.

This PR now - 
 - Passes in a `--site` flag at runtime for the build, so that we don't have to work around env vars in the config file
 - Parses `mode` from the runtime build command, so that we can reliably build in `"files"` or `"folder"` mode based on this
 
 This should result in - 
  - Proper sitemaps
  - Correct routing in dev, pizza (docker) and staging/prod (AWS Cloudfront)