### PR TITLE
fix(ci): Preserve correct argument order for Astro config

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -211,7 +211,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
-      - run: pnpm build --mode pizza --site "https://localplanning.${{ env.FULL_DOMAIN }}"
+      - run: pnpm build --site "https://localplanning.${{ env.FULL_DOMAIN }}" --mode pizza
         env:
           ROOT_DOMAIN: ${{ env.FULL_DOMAIN }}
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -109,7 +109,7 @@ jobs:
         run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: localplanning.services
-      - run: pnpm build --mode staging --site https://localplanning.editor.planx.dev
+      - run: pnpm build --site https://localplanning.editor.planx.dev --mode staging
         working-directory: localplanning.services
       - name: Upload LocalPlanning.services build artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The following snippet relies on the `--mode` argument being the last one, which I missed when also adding the `--site` flag - 

https://github.com/theopensystemslab/planx-new/blob/85971ea3ab1d200feada4ee89cc29be6d6b6fd4f/localplanning.services/astro.config.mjs#L7-L10