### PR TITLE
fix: Don't return LPS applications for non-existent flows

### DIFF
--- a/api.planx.uk/modules/lps/service/getApplications/mutation.ts
+++ b/api.planx.uk/modules/lps/service/getApplications/mutation.ts
@@ -23,7 +23,12 @@ export const CONSUME_MAGIC_LINK_MUTATION = gql`
     ) {
       returning {
         applications: lowcal_sessions(
-          where: { user_status: { _neq: "expired" } }
+          where: {
+            # Fetch non-expired sessions...
+            user_status: { _neq: "expired" }
+            # ..for services which still exist
+            flow: { id: { _is_null: false } }
+          }
           order_by: { updated_at: asc }
         ) {
           id


### PR DESCRIPTION
Hitting an edge case on staging where I have sessions for flows which are now deleted. This is likely the sort of edge case that generally only testers and devs should hit. Without this check the request fails as we're not able to map service name, team name etc.