### PR TITLE
fix(lps): Do not allow retries when fetching applications

### DIFF
--- a/localplanning.services/src/components/applications/hooks/useFetchApplications.tsx
+++ b/localplanning.services/src/components/applications/hooks/useFetchApplications.tsx
@@ -64,7 +64,9 @@ export const useFetchApplications = () => {
     // Data could only be refetch with a new magic link
     staleTime: Infinity,
     gcTime: Infinity,
-    retry: 2,
+    // Do not allow retries - this is a single use endpoint
+    // Failures on retry may return a false error message, not matching the original reason for failure
+    retry: false,
   }, queryClient);
 
   return {


### PR DESCRIPTION
This resolves the following process which is currently possible on staging - 
 1. Make a request, hit an API error (500)
 2. Retry, hit a validation error (410)
 3. Retry again, hit the same validation error (410)
 
 This results in the end user being told that their magic link has expired, when there's actually a server-side error.