### PR TITLE
feat: add 'Relevant demolition' to fee breakdown exemptions

### DIFF
--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -33,6 +33,7 @@ type FeeBreakdownRow = React.FC<IFeeBreakdown>;
 const exemptionsReductionLookup: Record<string, string> = {
   resubmission: "Resubmission",
   disability: "Access for disabled persons",
+  demolition: "Relevant demolition in a conservation area",
   parishCouncil: "Parish or community council",
   alternative: "Alternative proposal",
   sports: "Sports club",


### PR DESCRIPTION
'Relevant demolition' is a fee exemption for various application types exempting the application from any planning fee. When applicable, we want to show this exemption in the fee breakdown.

Unsure if this single line addition covers all our bases. If not, please flag additional req (tests, mocks etc.)!