### PR TITLE
feat: add 'Relevant demolition' to fee breakdown exemptions

### DIFF
--- a/api.planx.uk/package.json
+++ b/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dd0c34c",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a92c2d3",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.12.2",

--- a/api.planx.uk/pnpm-lock.yaml
+++ b/api.planx.uk/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.701.0
         version: 3.888.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#dd0c34c
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@19.1.13)
+        specifier: git+https://github.com/theopensystemslab/planx-core#a92c2d3
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@19.1.13)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1018,8 +1018,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3}
     version: 1.0.0
 
   '@paralleldrive/cuid2@2.2.2':
@@ -5261,7 +5261,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@19.1.13)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@19.1.13)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.13)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react@18.3.1)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.10.0",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dd0c34c",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a92c2d3",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.1.1
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#dd0c34c
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@19.1.13)
+        specifier: git+https://github.com/theopensystemslab/planx-core#a92c2d3
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@19.1.13)
       axios:
         specifier: ^1.12.2
         version: 1.12.2
@@ -383,8 +383,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2192,7 +2192,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@19.1.13)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@19.1.13)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.13)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react@18.3.1)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dd0c34c",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a92c2d3",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#dd0c34c
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@19.1.13)
+        specifier: git+https://github.com/theopensystemslab/planx-core#a92c2d3
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@19.1.13)
       axios:
         specifier: ^1.12.2
         version: 1.12.2
@@ -313,8 +313,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3}
     version: 1.0.0
 
   '@playwright/test@1.55.0':
@@ -1851,7 +1851,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@19.1.13)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@19.1.13)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.13)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react@18.3.1)

--- a/editor.planx.uk/package.json
+++ b/editor.planx.uk/package.json
@@ -18,7 +18,7 @@
     "@mui/x-charts": "^8.9.0",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.6",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#dd0c34c",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#a92c2d3",
     "@tiptap/core": "^3.0.7",
     "@tiptap/extension-emoji": "^3.0.7",
     "@tiptap/extension-image": "^3.0.7",

--- a/editor.planx.uk/pnpm-lock.yaml
+++ b/editor.planx.uk/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#dd0c34c
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@18.3.24)
+        specifier: git+https://github.com/theopensystemslab/planx-core#a92c2d3
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@18.3.24)
       '@tiptap/core':
         specifier: ^3.0.7
         version: 3.4.3(@tiptap/pm@3.4.3)
@@ -2266,8 +2266,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.6':
     resolution: {integrity: sha512-EBOgrgBRFNg8p+7nDFvh+K7N4NFQ7+epBXjE9w7h0u87q4M+nOpBwXNc67+UdDs+j8Mi+vQ2R+uJBIKF25NQ7g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -10202,7 +10202,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/dd0c34c(@types/react@18.3.24)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a92c2d3(@types/react@18.3.24)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)

--- a/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -33,6 +33,7 @@ type FeeBreakdownRow = React.FC<IFeeBreakdown>;
 const exemptionsReductionLookup: Record<string, string> = {
   resubmission: "Resubmission",
   disability: "Access for disabled persons",
+  demolition: "Relevant demolition in a conservation area",
   parishCouncil: "Parish or community council",
   alternative: "Alternative proposal",
   sports: "Sports club",


### PR DESCRIPTION
'Relevant demolition' is a fee exemption for various application types exempting the application from any planning fee. When applicable, we want to show this exemption in the fee breakdown.

Unsure if this single line addition covers all our bases. If not, please flag additional req (tests, mocks etc.)!