### PR TITLE
Revert "feat: Create Hasura REST endpoint to delete session"

### DIFF
--- a/hasura.planx.uk/metadata/query_collections.yaml
+++ b/hasura.planx.uk/metadata/query_collections.yaml
@@ -10,10 +10,3 @@
               usersLast30Days: users_last_30_days
             }
           }
-      - name: LPS - Delete application
-        query: |
-          mutation SoftDeleteLowcalSessionLPS ($applicationId: uuid!) {
-            applications: update_lowcal_sessions_by_pk(pk_columns: {id:$applicationId}, _set: {deleted_at:"now()"}) {
-              id
-            }
-          }

--- a/hasura.planx.uk/metadata/rest_endpoints.yaml
+++ b/hasura.planx.uk/metadata/rest_endpoints.yaml
@@ -1,15 +1,3 @@
-- comment: |-
-    Allows a user to abandon their LPS application via a REST endpoint.
-
-    Requires the x-hasura-lowcal-session-id and x-hasura-lowcal-email headers in order for the public role to have permission to execute this route.
-  definition:
-    query:
-      collection_name: allowed-queries
-      query_name: LPS - Delete application
-  methods:
-    - DELETE
-  name: LPS - Delete application
-  url: lps/application/:applicationId
 - comment: ""
   definition:
     query:


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#5195

Unfortunately this won't be a viable option for our requirements - I'm hitting issues with the implementation in https://github.com/theopensystemslab/planx-new/pull/5261

It turns out that the generated endpoint only supports the selected method, in this case `DELETE`. It does not support an `OPTIONS` request which is required by the browser when we're using custom headers (e.g. `x-hasura-lowcal-session-id` or `x-hasura-lowcal-email`).

```sh
curl https://hasura.5261.planx.pizza/api/rest/lps/application \
  -X OPTIONS
{"error":"Method OPTIONS not supported.","path":"$","code":"bad-request"}%   
```

I can't find anything in the docs stating this, so I'll open a GH issue on the Hasura repo to flag this.

The plan of action here is just to revert this, and in #5261 I'll make a GraphQL request for the same operation 👍 