### PR TITLE
test(api): Unskip `/admin/session/:id/html` tests

### DIFF
--- a/api.planx.uk/modules/admin/session/html.test.ts
+++ b/api.planx.uk/modules/admin/session/html.test.ts
@@ -2,26 +2,30 @@ import supertest from "supertest";
 import app from "../../../server.js";
 import type * as planxCore from "@opensystemslab/planx-core";
 import { authHeader } from "../../../tests/mockJWT.js";
+import { queryMock } from "../../../tests/graphqlQueryMock.js";
 
 const endpoint = (strings: TemplateStringsArray) =>
   `/admin/session/${strings[0]}/html`;
 
-const mockGenerateHTMLData = vi.fn().mockResolvedValue({
-  responses: [
-    {
-      question: "Is this a test?",
-      responses: [{ value: "Yes" }],
-      metadata: {},
-    },
-  ],
-});
+const mockGenerateHTMLData = vi.fn().mockResolvedValue([
+  {
+    question: "Planning Application Reference",
+    responses: "56841432-b654-4d64-ab54-5d23d007a034",
+  },
+  { question: "Property Address", responses: "" },
+  {
+    question: "application_type",
+    responses: "Request a building control quote",
+  },
+  { question: "result", responses: {} },
+]);
 
 vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const { CoreDomainClient: OriginalCoreDomainClient } =
-    await importOriginal<typeof planxCore>();
+  const originalModule = await importOriginal<typeof planxCore>();
 
   return {
-    CoreDomainClient: class extends OriginalCoreDomainClient {
+    ...originalModule,
+    CoreDomainClient: class extends originalModule.CoreDomainClient {
       constructor() {
         super();
         this.export.csvData = () => mockGenerateHTMLData();
@@ -31,7 +35,7 @@ vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
 });
 
 describe("HTML data admin endpoint", () => {
-  it("requires a user to be logged in", () => {
+  it("requires a user to be logged in", async () => {
     return supertest(app)
       .get(endpoint`123`)
       .expect(401)
@@ -42,21 +46,48 @@ describe("HTML data admin endpoint", () => {
       );
   });
 
-  it("requires a user to have the 'platformAdmin' role", () => {
+  it("requires a user to have the 'platformAdmin' role", async () => {
     return supertest(app)
       .get(endpoint`123`)
       .set(authHeader({ role: "teamViewer" }))
       .expect(403);
   });
 
-  it.skip("returns a HTML-formatted payload", () => {
+  it("returns a HTML-formatted payload", async () => {
+    queryMock.mockQuery({
+      name: "GetSessionById",
+      matchOnVariables: false,
+      data: {
+        lowcal_sessions_by_pk: {
+          id: 123,
+          data: {
+            id: "cc1a89cb-c552-4a52-a3b5-5a32ecadf18e",
+            passport: {},
+            sessionId: "56841432-b654-4d64-ab54-5d23d007a034",
+            breadcrumbs: {},
+          },
+          flow: {
+            id: "cc1a89cb-c552-4a52-a3b5-5a32ecadf18e",
+            slug: "request-a-building-control-quote",
+            name: "Request a building control quote",
+          },
+        },
+      },
+    });
+
     return supertest(app)
       .get(endpoint`123`)
       .set(authHeader({ role: "platformAdmin" }))
       .expect(200)
       .expect("content-type", "text/html; charset=utf-8")
-      .then((res) =>
-        expect(res.text).toContain("<dt>Is this a test?</dt><dd>Yes</dd>"),
-      );
+      .then((res) => {
+        // HTML response returned
+        expect(res.headers["content-type"]).toMatch(/text\/html/);
+        expect(res).toHaveProperty("text");
+
+        // Expected HTML document
+        expect(res.text).toMatch(/^<html>.*<\/html>$/s);
+        expect(res.text).toMatch(/PlanX Submission Overview/);
+      });
   });
 });

--- a/api.planx.uk/modules/admin/session/html.ts
+++ b/api.planx.uk/modules/admin/session/html.ts
@@ -27,7 +27,7 @@ export const getHTMLExport: HTMLExportHandler = async (req, res, next) => {
     if (!session) throw Error(`Unable to find session ${req.params.sessionId}`);
 
     const responses = await $api.export.csvData(req.params.sessionId);
-    const boundingBox = session.data.passport.data["proposal.site.buffered"];
+    const boundingBox = session.data.passport.data?.["proposal.site.buffered"];
     const userAction = session.data.passport.data?.[
       "drawBoundary.action"
     ] as unknown as DrawBoundaryUserAction | undefined;


### PR DESCRIPTION
Quick fix I noticed when working on https://github.com/theopensystemslab/planx-new/pull/5273 🧪 