### PR TITLE
style(lps): Restrict map image max-width

### DIFF
--- a/localplanning.services/src/components/Masthead.astro
+++ b/localplanning.services/src/components/Masthead.astro
@@ -28,15 +28,15 @@ const classes = `${baseClasses} ${sizeClasses[size]}`;
 
 <section class={classes}>
   <Container class="text-center">
-    <div class="flex flex-col gap-5 xl:flex-row xl:items-center">
-      <div class="w-full xl:max-w-7/12">
+    <div class="flex flex-col gap-5 lg:flex-row lg:items-center">
+      <div class="w-full lg:max-w-1/2 xl:max-w-7/12">
         <h1 class={`${h1Classes[size]} text-action-secondary`}>{title}</h1>
         <div class="text-text-secondary text-body-lg max-w-2xl">
           <slot />
         </div>
       </div>
       {size === "large" && (
-        <div class="w-full xl:max-w-5/12">
+        <div class="w-full max-w-lg lg:max-w-1/2 xl:max-w-5/12">
           <slot name="map" />
         </div>
        )}


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Refactor styles of homepage masthead so that the map image does not become to large in single column layout