### PR TITLE
feat(lps): Wire up download HTML endpoint, display data within LPS

### DIFF
--- a/api.planx.uk/modules/lps/service/getApplications/index.ts
+++ b/api.planx.uk/modules/lps/service/getApplications/index.ts
@@ -79,6 +79,7 @@ const mapSharedFields = (raw: Application) => ({
   },
   team: {
     name: raw.service.team.name,
+    slug: raw.service.team.slug,
   },
   address: raw.addressLine || raw.addressTitle,
 });

--- a/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
@@ -91,8 +91,6 @@ select_permissions:
               _eq: x-hasura-lowcal-email
           - email:
               _neq: ""
-          - submitted_at:
-              _is_null: true
           - deleted_at:
               _is_null: true
 update_permissions:

--- a/localplanning.services/src/components/applications/ApplicationCard.tsx
+++ b/localplanning.services/src/components/applications/ApplicationCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Application } from "./hooks/useFetchApplications";
 import { useDeleteApplication } from "./hooks/useDeleteApplication";
 import { formatDate } from "@lib/date";
+import { useSearchParams } from "./hooks/useSearchParams";
 
 const ProgressText: React.FC<Application> = (application) => {
   const progressText = (() => {
@@ -128,6 +129,18 @@ const DeleteButton: React.FC<Application> = ({ id }) => {
     >
       Delete
     </button>
+  )
+}
+
+const ViewApplicationButton: React.FC<Application> = (application) => {
+  // TODO: Nanostores!
+  const { email } = useSearchParams();
+  const url = `applications/${application.team.slug}?applicationId=${application.id}&email=${email}`;
+
+  return (
+    <a href={url} className="button button--primary button--small button-focus-style paragraph-link--external">
+      View application
+    </a>
   )
 }
 

--- a/localplanning.services/src/components/applications/ApplicationCard.tsx
+++ b/localplanning.services/src/components/applications/ApplicationCard.tsx
@@ -1,6 +1,7 @@
-import { formatDate } from "@lib/date";
+import React from "react";
 import type { Application } from "./hooks/useFetchApplications";
 import { useDeleteApplication } from "./hooks/useDeleteApplication";
+import { formatDate } from "@lib/date";
 
 const ProgressText: React.FC<Application> = (application) => {
   const progressText = (() => {
@@ -158,13 +159,7 @@ const ActionButtons: React.FC<Application> = (application) => {
           </>
         )
       case "submitted":
-        return (
-          <>
-            <a href="#" className="button button--primary button--small button-focus-style paragraph-link--external">
-              View application
-            </a>
-          </>
-        )
+       return <ViewApplicationButton {...application}/>
     }
   })();
 

--- a/localplanning.services/src/components/applications/ApplicationCard.tsx
+++ b/localplanning.services/src/components/applications/ApplicationCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Application } from "./hooks/useFetchApplications";
 import { useDeleteApplication } from "./hooks/useDeleteApplication";
 import { formatDate } from "@lib/date";
-import { useSearchParams } from "./hooks/useSearchParams";
+import { $applicationId } from "@stores/applicationId";
 
 const ProgressText: React.FC<Application> = (application) => {
   const progressText = (() => {
@@ -133,9 +133,8 @@ const DeleteButton: React.FC<Application> = ({ id }) => {
 }
 
 const ViewApplicationButton: React.FC<Application> = (application) => {
-  // TODO: Nanostores!
-  const { email } = useSearchParams();
-  const url = `applications/${application.team.slug}?applicationId=${application.id}&email=${email}`;
+  $applicationId.set(application.id)
+  const url = `applications/${application.team.slug}`
 
   return (
     <a href={url} className="button button--primary button--small button-focus-style paragraph-link--external">

--- a/localplanning.services/src/components/applications/ApplicationViewer.tsx
+++ b/localplanning.services/src/components/applications/ApplicationViewer.tsx
@@ -1,0 +1,23 @@
+import { useHtmlDownload } from "./hooks/useHTMLDownload";
+
+export const ApplicationViewer = () => {
+  const applicationId = new URLSearchParams(window.location.search).get("applicationId")
+  const { htmlContent, loading, error, fetchHtml } = useHtmlDownload(applicationId);
+
+  if (loading) return <p>Loading application...</p>
+
+  if (error) {
+    return (
+      <div>
+        <h2>Failed to load application</h2>
+        <p>Error: {error}</p>
+        <button onClick={fetchHtml} className="button button--primary button--medium button-focus-style">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  // HTML content already sanitised using DOMPurify on the backend
+  return <div dangerouslySetInnerHTML={{ __html: htmlContent }}/>
+};

--- a/localplanning.services/src/components/applications/ApplicationViewer.tsx
+++ b/localplanning.services/src/components/applications/ApplicationViewer.tsx
@@ -1,8 +1,12 @@
+import { useEffect } from "react";
 import { useHtmlDownload } from "./hooks/useHTMLDownload";
+import { $applicationId } from "@stores/applicationId";
 
 export const ApplicationViewer = () => {
-  const applicationId = new URLSearchParams(window.location.search).get("applicationId")
-  const { htmlContent, loading, error, fetchHtml } = useHtmlDownload(applicationId);
+  const { htmlContent, loading, error, fetchHtml } = useHtmlDownload();
+
+  // Reset applicationId on unmount
+  useEffect(() => () => $applicationId.set(null), [])  
 
   if (loading) return <p>Loading application...</p>
 

--- a/localplanning.services/src/components/applications/hooks/useDeleteApplication.tsx
+++ b/localplanning.services/src/components/applications/hooks/useDeleteApplication.tsx
@@ -2,9 +2,10 @@ import { useMutation } from "@tanstack/react-query";
 import { queryClient } from "@lib/queryClient";
 import type { ApplicationsResponse } from "./useFetchApplications";
 import { PUBLIC_PLANX_GRAPHQL_API_URL } from "astro:env/client";
-import { useSearchParams } from "./useSearchParams";
 import gql from "graphql-tag";
 import { print } from "graphql";
+import { useStore } from "@nanostores/react";
+import { $session } from "@stores/session";
 
 const MUTATION = gql`
   mutation SoftDeleteLowcalSessionLPS($applicationId: uuid!) {
@@ -18,7 +19,7 @@ const MUTATION = gql`
 `;
 
 export const useDeleteApplication = () => {
-  const { email } = useSearchParams();
+  const { email } = useStore($session);
   if (!email) throw Error("Unable to find email in search params");
 
   const { mutate: deleteApplication } = useMutation({

--- a/localplanning.services/src/components/applications/hooks/useFetchApplications.tsx
+++ b/localplanning.services/src/components/applications/hooks/useFetchApplications.tsx
@@ -10,6 +10,7 @@ interface BaseApplication {
     name: string;
   };
   team: {
+    slug: string;
     name: string;
   };
   address: string | null;

--- a/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
+++ b/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
@@ -1,12 +1,15 @@
 import { PUBLIC_PLANX_REST_API_URL } from "astro:env/client";
 import { useState, useEffect, useTransition } from "react";
-import { useSearchParams } from "./useSearchParams";
+import { useStore } from "@nanostores/react";
+import { $session } from "@stores/session";
+import { $applicationId } from "@stores/applicationId";
 
-export const useHtmlDownload = (sessionId: string | null) => {
+export const useHtmlDownload = () => {
   const [ htmlContent, setHtmlContent ] = useState("");
   const [ error, setError ] = useState<string | null>(null);
   const [ isPending, startTransition ] = useTransition();
-  const { email } = useSearchParams();
+  const { email } = useStore($session);
+  const applicationId = useStore($applicationId);
 
   const fetchHtml = async () => {
     startTransition(async () => {
@@ -19,7 +22,7 @@ export const useHtmlDownload = (sessionId: string | null) => {
           { 
             method: "POST",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify({ email, sessionId }) 
+            body: JSON.stringify({ email, sessionId: applicationId }) 
           }
         );
         if (!tokenResponse.ok) {
@@ -35,7 +38,7 @@ export const useHtmlDownload = (sessionId: string | null) => {
             "Authorization": `Bearer ${token}`,
             "content-type": "application/json"
           },
-          body: JSON.stringify({ email, sessionId })
+          body: JSON.stringify({ email, sessionId: applicationId })
         });
 
         if (!htmlResponse.ok) {
@@ -54,17 +57,17 @@ export const useHtmlDownload = (sessionId: string | null) => {
 
   useEffect(() => {
     if (!email) {
-      setError("Missing email parameter");
+      setError("Missing email value from store");
       return;
     }
 
-    if (!sessionId) {
-      setError("Missing applicationId parameter");
+    if (!applicationId) {
+      setError("Missing applicationId value from store");
       return;
     }
 
     fetchHtml();
-  }, [sessionId, email]);
+  }, [applicationId, email]);
 
   return {
     htmlContent,

--- a/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
+++ b/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
@@ -8,9 +8,6 @@ export const useHtmlDownload = (sessionId: string | null) => {
   const [ isPending, startTransition ] = useTransition();
   const { email } = useSearchParams();
 
-  if (!email) setError("Missing email parameter");
-  if (!sessionId) setError("Missing applicationId parameter");
-
   const fetchHtml = async () => {
     startTransition(async () => {
       setError(null);
@@ -56,8 +53,18 @@ export const useHtmlDownload = (sessionId: string | null) => {
   };
 
   useEffect(() => {
-    if (sessionId && email) fetchHtml();
-  }, []);
+    if (!email) {
+      setError("Missing email parameter");
+      return;
+    }
+
+    if (!sessionId) {
+      setError("Missing applicationId parameter");
+      return;
+    }
+
+    fetchHtml();
+  }, [sessionId, email]);
 
   return {
     htmlContent,

--- a/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
+++ b/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
@@ -1,0 +1,68 @@
+import { PUBLIC_PLANX_REST_API_URL } from "astro:env/client";
+import { useState, useEffect, useTransition } from "react";
+import { useSearchParams } from "./useSearchParams";
+
+export const useHtmlDownload = (sessionId: string | null) => {
+  const [ htmlContent, setHtmlContent ] = useState("");
+  const [ error, setError ] = useState<string | null>(null);
+  const [ isPending, startTransition ] = useTransition();
+  const { email } = useSearchParams();
+
+  if (!email) setError("Missing email parameter");
+  if (!sessionId) setError("Missing applicationId parameter");
+
+  const fetchHtml = async () => {
+    startTransition(async () => {
+      setError(null);
+
+      try {
+        // Step 1: Get access token
+        const tokenResponse = await fetch(
+          `${PUBLIC_PLANX_REST_API_URL}/lps/download/token`, 
+          { 
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ email, sessionId }) 
+          }
+        );
+        if (!tokenResponse.ok) {
+          throw new Error(`Token request failed: ${tokenResponse.status}`);
+        }
+
+        const { token } = await tokenResponse.json();
+
+        // Step 2: Use token to fetch HTML
+        const htmlResponse = await fetch(`${PUBLIC_PLANX_REST_API_URL}/lps/download/html`, {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${token}`,
+            "content-type": "application/json"
+          },
+          body: JSON.stringify({ email, sessionId })
+        });
+
+        if (!htmlResponse.ok) {
+          throw new Error(`HTML request failed: ${htmlResponse.status}`);
+        }
+
+        const html = await htmlResponse.text();
+        setHtmlContent(html);
+
+      } catch (err) {
+        setError((err as Error).message);
+        setHtmlContent("");
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (sessionId && email) fetchHtml();
+  }, []);
+
+  return {
+    htmlContent,
+    loading: isPending,
+    error,
+    fetchHtml,
+  };
+};

--- a/localplanning.services/src/pages/applications/[lpa].astro
+++ b/localplanning.services/src/pages/applications/[lpa].astro
@@ -1,0 +1,36 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Container from "@components/Container.astro";
+import { ApplicationViewer } from "@components/applications/ApplicationViewer";
+import { fetchAllLPAs } from "@lib/lpa-api";
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
+import LpaMasthead from "@components/LpaMasthead.astro";
+
+export const getStaticPaths = (async () => {
+  const lpas = await fetchAllLPAs();
+  return lpas.map((lpa) => ({
+    params: { lpa: lpa.slug },
+    props: { lpaData: lpa },
+  }));
+}) satisfies GetStaticPaths;
+
+const { lpaData } = Astro.props;
+
+// TODO: Pass title as prop into layout?
+// type Params = InferGetStaticParamsType<typeof getStaticPaths>;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+if (!lpaData) return Astro.redirect("/404");
+---
+
+<Layout>
+  <LpaMasthead
+    title="Your application"
+    lpaName={lpaData.name}
+    logo={lpaData.theme.logo}
+    backgroundColour={lpaData.theme?.primaryColour}
+  />
+  <Container paddingY>
+    <ApplicationViewer client:only="react" />
+  </Container>
+</Layout>

--- a/localplanning.services/src/pages/applications/viewer.astro
+++ b/localplanning.services/src/pages/applications/viewer.astro
@@ -1,0 +1,13 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Masthead from "@components/Masthead.astro";
+import Container from "@components/Container.astro";
+import { ApplicationViewer } from "@components/applications/ApplicationViewer";
+---
+
+<Layout>
+  <Masthead title="Your application" />
+  <Container paddingY>
+    <ApplicationViewer client:only="react" />
+  </Container>
+</Layout>

--- a/localplanning.services/src/stores/applicationId.ts
+++ b/localplanning.services/src/stores/applicationId.ts
@@ -1,0 +1,3 @@
+import { atom } from "nanostores";
+
+export const $applicationId = atom<string | null>(null);


### PR DESCRIPTION
## What does this PR do?
 - Final part of the process laid out here - https://github.com/theopensystemslab/planx-new/pull/5273
 - Creates a custom React hook to wrap the `/lps/download/token` and `/lps/download/html` endpoints
 - Display this within the LPS Asto application as `application/:lpa` (branded by team)


https://github.com/user-attachments/assets/728670bb-d6c1-49e8-8e8c-4f22c4ba3388



