### PR TITLE
chore(api): Sanitise HTML before returning

### DIFF
--- a/api.planx.uk/modules/admin/session/html.ts
+++ b/api.planx.uk/modules/admin/session/html.ts
@@ -1,3 +1,5 @@
+import { JSDOM } from "jsdom";
+import createDOMPurify, { type WindowLike } from "dompurify";
 import { generateApplicationHTML } from "@opensystemslab/planx-core";
 import type {
   DrawBoundaryUserAction,
@@ -38,8 +40,13 @@ export const getHTMLExport: HTMLExportHandler = async (req, res, next) => {
       userAction,
     });
 
+    // Sanitise output
+    const window = new JSDOM("").window;
+    const DOMPurify = createDOMPurify(window as unknown as WindowLike);
+    const cleanHTML = DOMPurify.sanitize(html, { WHOLE_DOCUMENT: true });
+
     res.header("Content-type", "text/html");
-    res.send(html);
+    res.send(cleanHTML);
   } catch (error) {
     return next({
       message: "Failed to build HTML: " + (error as Error).message,

--- a/api.planx.uk/modules/lps/service/generateHTML.ts
+++ b/api.planx.uk/modules/lps/service/generateHTML.ts
@@ -1,3 +1,5 @@
+import { JSDOM } from "jsdom";
+import createDOMPurify, { type WindowLike } from "dompurify";
 import { subMinutes } from "date-fns";
 import { $api, $public } from "../../../client/index.js";
 import type {
@@ -55,5 +57,10 @@ export const generateHTML = async (sessionId: string, email: string) => {
     userAction,
   });
 
-  return html;
+  // Sanitise output
+  const window = new JSDOM("").window;
+  const DOMPurify = createDOMPurify(window as unknown as WindowLike);
+  const cleanHTML = DOMPurify.sanitize(html, { WHOLE_DOCUMENT: true });
+
+  return cleanHTML;
 };


### PR DESCRIPTION
A dose of healthy paranoia! As we're generating the HTML it _should_ be fine, but better safe than sorry as the underlying data is originally user-provided.