### PR TITLE
chore(lps): Style directory fallback message to match `[lpa].astro` fallback message

### DIFF
--- a/localplanning.services/src/pages/directory.astro
+++ b/localplanning.services/src/pages/directory.astro
@@ -38,7 +38,9 @@ const hasListedServices = (lpa: LPA) =>
               lpa={lpa}
             />
             {!hasListedServices(lpa) && (
-              <p>{lpa.name} doesn't yet have any services listed.</p>
+              <p class="text-body-xl m-0 clamp-[px,1,2] py-4">
+                Currently {lpa.name} doesn't have any services listed.
+              </p>
             )}
           </Accordion>
         ))


### PR DESCRIPTION
Quick follow up to https://github.com/theopensystemslab/planx-new/pull/5272 to improve content and style, this should now more closely match the other fallback content we have.

**`directory.asto`**
<img width="1087" height="522" alt="image" src="https://github.com/user-attachments/assets/5cacdadb-841f-4746-8a29-60e679a921f6" />


**`[lpa].astro`**
<img width="1077" height="259" alt="image" src="https://github.com/user-attachments/assets/13938624-5803-4b63-be63-73150fc565c3" />
