### PR TITLE
fix: persist `analytics`, `feedback` and `payment_status` records on staging

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
@@ -29,15 +29,15 @@ array_relationships:
           name: payment_status
           schema: public
 computed_fields:
-  - name: user_status
-    definition:
-      function:
-        name: lowcal_sessions_user_status
-        schema: public
   - name: system_status
     definition:
       function:
         name: lowcal_sessions_system_status
+        schema: public
+  - name: user_status
+    definition:
+      function:
+        name: lowcal_sessions_user_status
         schema: public
 insert_permissions:
   - role: public

--- a/hasura.planx.uk/migrations/default/1758286709087_set_fk_public_analytics_flow_id/down.sql
+++ b/hasura.planx.uk/migrations/default/1758286709087_set_fk_public_analytics_flow_id/down.sql
@@ -1,0 +1,17 @@
+alter table "public"."analytics" drop constraint "analytics_flow_id_fkey",
+  add constraint "analytics_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update cascade on delete cascade;
+
+alter table "public"."feedback" drop constraint "feedback_flow_id_fkey",
+  add constraint "feedback_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update cascade on delete cascade;
+
+alter table "public"."payment_status" drop constraint "payment_status_flow_id_fkey",
+  add constraint "payment_status_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update cascade on delete cascade;

--- a/hasura.planx.uk/migrations/default/1758286709087_set_fk_public_analytics_flow_id/up.sql
+++ b/hasura.planx.uk/migrations/default/1758286709087_set_fk_public_analytics_flow_id/up.sql
@@ -1,0 +1,19 @@
+-- Our nightly staging data sync truncates `flows`, but we want to persist
+--   analytics, feedback, and payments so fkeys should have 'no action' rather than 'cascade'
+alter table "public"."analytics" drop constraint "analytics_flow_id_fkey",
+  add constraint "analytics_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update no action on delete no action;
+
+alter table "public"."feedback" drop constraint "feedback_flow_id_fkey",
+  add constraint "feedback_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update no action on delete no action;
+
+alter table "public"."payment_status" drop constraint "payment_status_flow_id_fkey",
+  add constraint "payment_status_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update no action on delete no action;


### PR DESCRIPTION
**Why:**
Our nightly data sync truncates the `flows` table and re-populates it, which "cascades" to each `analytics`, `feedback` and `payment_status` via foreign key relationships - which means these records are _not_ persisted on staging. 

I think there's lots of benefits to persisting like: 
- Easier to test/catch analytics-related data changes before prod
- Can test and view in-editor "Feedback" features and exports
- Staging "Submissions" log will correctly show submissions _and payments_ like production
- Can test and view in-editor "Subscription" page if testing service charges on staging

**Changes:**
This PR keeps the foreign keys, but updates them from "cascade" to "no action" on update and delete events which I _think_ will allow them to persist when flows are truncted while still correctly validating that newly inserted records into this table match an existing flow ID.

What I'm less sure of is if any data sanitation scripts are relying on this foreign key "cascade" to drop/sanitise associated records? Analytics should be persisted over all time, and `payment_status` records don't contain personal data themselves so I don't _think so_, but would be good to confirm @freemvmt ? 