### PR TITLE
fix(lps): Applications banner link

### DIFF
--- a/localplanning.services/src/components/ApplicationsBanner.astro
+++ b/localplanning.services/src/components/ApplicationsBanner.astro
@@ -7,6 +7,6 @@ import Button from "@components/Button.astro";
   <Container class="text-center">
     <h3 class="text-heading-md">Your applications</h3>
     <p class="text-text-secondary text-body-lg mb-6">View your planning applications in progress, and download sent applications.</p>
-    <Button href="/applications/" variant="secondary" size="medium">View your applications</Button>
+    <Button href="/applications" variant="secondary" size="medium">View your applications</Button>
   </Container> 
 </section>


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Removes trailing slash from URL in applications banner to prevent 404 on staging