### PR TITLE
fix: Allow teamEditors to select from `team_members`

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
@@ -52,9 +52,7 @@ select_permissions:
         - user_id
         - role
         - id
-      filter:
-        user_id:
-          _eq: x-hasura-user-id
+      filter: {}
 update_permissions:
   - role: platformAdmin
     permission:


### PR DESCRIPTION
**Before**
`teamEditors` can view the team members page, but can only see themselves listed.

**Now**
`teamEditors` can view the team members page, and see all team members.

I'm not quite sure what the original motivation here was really, seems to be an oversight? The `users` table is already accessible for `teamEditors` across all teams.

Regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/17884761003 ✅ 