### PR TITLE
chore(ci): Add retry to flakey Reacts tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -177,7 +177,7 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
         working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm test:silent
+      - run: pnpm test:silent --retry 1
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   build_localplanning_services:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -122,7 +122,7 @@ jobs:
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
         working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm test:silent
+      - run: pnpm test:silent --retry 1
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
   end_to_end_tests:


### PR DESCRIPTION
This test suite often fails in CI on the first run through - we should get to the bottom of this properly but this might be a good stop-gap in the meantime!