### PR TITLE
feat: Enable tags and data fields by default on the graph

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -88,7 +88,7 @@ export const editorUIStore: StateCreator<
       set({ flowCardView: view });
     },
 
-    showTags: false,
+    showTags: true,
 
     toggleShowTags: () => set({ showTags: !get().showTags }),
 
@@ -96,7 +96,7 @@ export const editorUIStore: StateCreator<
 
     toggleShowImages: () => set({ showImages: !get().showImages }),
 
-    showDataFields: false,
+    showDataFields: true,
 
     toggleShowDataFields: () => set({ showDataFields: !get().showDataFields }),
 


### PR DESCRIPTION
Came up as a suggestion at roadmap!