### PR TITLE
fix: Display clone style for folders

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -166,8 +166,6 @@ const InternalPortal: React.FC<any> = (props) => {
     copyNode(props.id);
   };
 
-  const Icon = ICONS[ComponentType.InternalPortal];
-
   const ref = useScrollOnPreviousURLMatch<HTMLLIElement>(props.id);
 
   return (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -137,7 +137,8 @@ const InternalPortal: React.FC<any> = (props) => {
 
   const parent = getParentId(props.parent);
 
-  const { copyNode, showTags } = useStore((state) => ({
+  const { isClone, copyNode, showTags } = useStore((state) => ({
+    isClone: state.isClone,
     copyNode: state.copyNode,
     showTags: state.showTags,
   }));
@@ -172,7 +173,12 @@ const InternalPortal: React.FC<any> = (props) => {
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
-      <li ref={ref}>
+      <li 
+        className={classNames("folder", {
+          isClone: isClone(props.id),
+        })}
+        ref={ref}
+      >
         <Box
           className={classNames("card", "portal", "internal-portal", {
             isDragging,

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -61,7 +61,7 @@ $fontMonospace: "Source Code Pro", monospace;
   content: "";
   position: absolute;
   left: -5px;
-  top: -5px;
+  bottom: -5px;
   width: 100%;
   height: 100%;
   background: white;
@@ -190,17 +190,18 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 
   &.isClone > div {
-    margin-top: 3px;
+    margin-bottom: 3px;
     position: relative;
     a::before {
       @include cloneStyle;
     }
   }
 
-  // Increase offset of clone styling when visit styling is also applied
-  &.isClone.wasVisited a::before {
+  // Increase offset of clone styling when visited or focused
+  &.isClone.wasVisited a::before,
+  &.isClone a:focus::before {
     left: -8px;
-    top: -8px;
+    bottom: -8px;
   }
 
   &.hasFailed {
@@ -340,8 +341,12 @@ $fontMonospace: "Source Code Pro", monospace;
     &::before {
       @include cloneStyle;
       z-index: 0;
-      left: -3px;
-      top: -4px;
+      left: -4px;
+      bottom: -4px;
+    }
+    &:focus-within::before {
+      left: -8px;
+      bottom: -8px;
     }
   }
 }

--- a/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -57,6 +57,22 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
+@mixin cloneStyle {
+  content: "";
+  position: absolute;
+  left: -5px;
+  top: -5px;
+  width: 100%;
+  height: 100%;
+  background: white;
+  border: $lineWidth dashed $nodeBorder;
+  z-index: -1;
+  .flow-locked & {
+    border-color: $lockedBorder;
+    background: transparent;
+  }
+}
+
 // ------------------------------------------------
 
 #editor {
@@ -177,19 +193,7 @@ $fontMonospace: "Source Code Pro", monospace;
     margin-top: 3px;
     position: relative;
     a::before {
-      content: "";
-      position: absolute;
-      left: -4px;
-      top: -4px;
-      width: 100%;
-      height: 100%;
-      background: white;
-      border: $nodeBorderWidth dashed $nodeBorder;
-      z-index: -1;
-      .flow-locked & {
-        border-color: $lockedBorder;
-        background: transparent;
-      }
+      @include cloneStyle;
     }
   }
 
@@ -325,6 +329,19 @@ $fontMonospace: "Source Code Pro", monospace;
         transparent 100%
       );
       background-size: $lineWidth 12px;
+    }
+  }
+}
+
+// Dedicated clone styling for folders
+.folder {
+  position: relative;
+  &.isClone {
+    &::before {
+      @include cloneStyle;
+      z-index: 0;
+      left: -3px;
+      top: -4px;
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Extends clone style to folders
- Reposition to bottom to accommodate for folder tab
- Handle focus and visited states
- Increases contrast (border-width) of clone marker

<img width="386" height="245" alt="image" src="https://github.com/user-attachments/assets/4b702e26-863c-4b7c-afa7-252ebe24ad85" />

<img width="386" height="99" alt="image" src="https://github.com/user-attachments/assets/73d22840-7942-4972-a4a5-795faebb56f9" />

**Testing:**
https://5296.planx.pizza/a-new-team/clones