### PR TITLE
fix(ci): Pass env var as string to AWS `HASURA_GRAPHQL_CORS_DOMAIN`

### DIFF
--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -127,7 +127,7 @@ export const createHasuraService = async ({
               value: [...CUSTOM_DOMAINS.map((x: any) => x.domain), DOMAIN]
                 .map((x) => `https://*.${x}, https://${x}`)
                 .concat(
-                  config.require("lps-domain"),
+                  config.require("lps-domain").toString(),
                   "https://planx-website.webflow.io",
                   "https://www.planx.uk",
                 )


### PR DESCRIPTION
Fix for failed staging deploy https://github.com/theopensystemslab/planx-new/actions/runs/18008866754 introduced by #5261 