### PR TITLE
fix: Missing Pulumi prod value for `lps-domain`

### DIFF
--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -127,10 +127,12 @@ export const createHasuraService = async ({
               value: [...CUSTOM_DOMAINS.map((x: any) => x.domain), DOMAIN]
                 .map((x) => `https://*.${x}, https://${x}`)
                 .concat(
-                  config.require("lps-domain").toString(),
+                  // TODO: Simplify once production CDN is configured
+                  config.get("lps-domain")?.toString() || "",
                   "https://planx-website.webflow.io",
                   "https://www.planx.uk",
                 )
+                .filter(Boolean)
                 .join(", "),
             },
             {


### PR DESCRIPTION
Fix for [failing prod deploy](https://github.com/theopensystemslab/planx-new/actions/runs/18088379223/job/51463476707), regression introduced [here](https://github.com/theopensystemslab/planx-new/pull/5261/files).

Currently `lps-domain` is only setup on staging until https://github.com/theopensystemslab/planx-new/pull/5202 is progressed.