### PR TITLE
chore: make hasSendComponent check more defensive

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -178,7 +178,8 @@ export const settingsStore: StateCreator<
       fetchPolicy: "no-cache",
     });
 
-    const isSubmissionService = publishedFlows[0].hasSendComponent;
+    // Default to no send component as not all flows will be in the table, over time as all flows get published we can revise this
+    const isSubmissionService = Boolean(publishedFlows[0]?.hasSendComponent);
 
     const environment = import.meta.env.VITE_APP_ENV;
 

--- a/editor.planx.uk/src/ui/editor/SettingsSection.tsx
+++ b/editor.planx.uk/src/ui/editor/SettingsSection.tsx
@@ -1,7 +1,9 @@
 import Box, { BoxProps } from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
+import ErrorFallback from "components/Error/ErrorFallback";
 import React, { ReactNode } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 
 const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== "background",
@@ -27,5 +29,11 @@ const Root = styled(Box, {
 export default function SettingsSection(
   props: { children: ReactNode; background?: boolean } & Partial<BoxProps>,
 ) {
-  return <Root {...props}>{props.children}</Root>;
+  return (
+    <Root {...props}>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        {props.children}
+      </ErrorBoundary>
+    </Root>
+  );
 }


### PR DESCRIPTION
Ensures that `isSubmissionService` is never `undefined`. 

Do we actually need an `ErrorBoundary` as discussed [here](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1759241431170869?thread_ts=1759240207.118589&cid=C088K9ZL8EA)? I took a look at it but since `flowInformation` was being accessed before any components were being rendered, the `ReadMePage` page would have broken before getting to the `ErrorBoundary` anyway.