### PR TITLE
fix(lps): Click handler for viewer link

### DIFF
--- a/localplanning.services/src/components/applications/ApplicationCard.tsx
+++ b/localplanning.services/src/components/applications/ApplicationCard.tsx
@@ -133,11 +133,11 @@ const DeleteButton: React.FC<Application> = ({ id }) => {
 }
 
 const ViewApplicationButton: React.FC<Application> = (application) => {
-  $applicationId.set(application.id)
+  const handleClick = () => $applicationId.set(application.id);
   const url = `applications/${application.team.slug}`
 
   return (
-    <a href={url} className="button button--primary button--small button-focus-style paragraph-link--external">
+    <a href={url} className="button button--primary button--small button-focus-style paragraph-link--external" onClick={handleClick}>
       View application
     </a>
   )

--- a/localplanning.services/src/components/applications/ApplicationsList.tsx
+++ b/localplanning.services/src/components/applications/ApplicationsList.tsx
@@ -8,6 +8,7 @@ import { UnhandledError } from "./errors/UnhandledError";
 import { NoApplications } from "./errors/NoApplications";
 import { ApplicationCard } from "./ApplicationCard";
 import { ApplicationFilters, type FilterState } from "./ApplicationFilters";
+import { $applicationId } from "@stores/applicationId";
 
 export const ApplicationsList: React.FC = () => {
   const { applications, isLoading, error } = useFetchApplications();
@@ -17,6 +18,9 @@ export const ApplicationsList: React.FC = () => {
   const handleFilterChange = (newFilters: FilterState) => {
     setFilters(newFilters);
   };
+
+  // Clear any existing application ID from the store
+  $applicationId.set(null);
 
   // TODO: Better UI - skeleton or spinner? 
   if (isLoading) return <p>Loading your applications...</p>;


### PR DESCRIPTION
## What's the problem?
ApplicationId persists on back navigation, which doesn't allow user to return to list of applications via the browser "back" button.

## What's the solution?
Application ID should only be set on click, and we should aggressively clear it when navigating back.