### PR TITLE
feat(lps): Show progress bar as completed for all "submitted" or "awaiting-payment" applications

### DIFF
--- a/localplanning.services/src/components/applications/ApplicationCard.tsx
+++ b/localplanning.services/src/components/applications/ApplicationCard.tsx
@@ -51,7 +51,9 @@ const ProgressBar: React.FC<Application> = (application) => {
     }
   })();
 
-  const progressValue = application.progress?.completed ?? 0;
+  const progressValue = ["submitted", "awaitingPayment"].includes(application.status) 
+    ? 100
+    : (application.progress?.completed ?? 0);
   
   const getProgressLabel = () => {
     switch (application.status) {


### PR DESCRIPTION
## What's the problem?
Progress bars are empty for submitted or ITP applications as they rely on section data.

## What's the solution?
If submitted or awaiting payment, set `progressValue` to 100 even if the flow doesn't use sections.

## Next steps...
We should have a fallback for flows without sections - either remove the progress bar or have some sort of "indeterminate" state.
