### PR TITLE
fix: docker compose down during pizza update

### DIFF
--- a/docker-compose.pizza.failover.yml
+++ b/docker-compose.pizza.failover.yml
@@ -1,4 +1,4 @@
 services:
   caddy:
     # build custom caddy from scratch when pull from registry fails
-    pull_policy: missing
+    pull_policy: never

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -37,8 +37,8 @@ services:
     build:
       context: ./ci/caddy
     image: lhr.vultrcr.com/planx/caddy-vultr:latest
-    # default to always pulling image from private Vultr registry
-    pull_policy: always
+    # default to pulling image from private Vultr registry (if not available)
+    pull_policy: missing
     container_name: caddy
     restart: unless-stopped
     volumes:

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -36,4 +36,4 @@ docker compose \
   -f docker-compose.yml \
   -f docker-compose.pizza.yml $PIZZA_FAILOVER \
   -f docker-compose.seed.yml \
-  up --build  --wait
+  up --build --wait

--- a/scripts/pullrequest/update.sh
+++ b/scripts/pullrequest/update.sh
@@ -16,8 +16,15 @@ if ! docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
   PIZZA_FAILOVER="-f docker-compose.pizza.failover.yml"
 fi
 
+# explicitly drop containers in case provenance of caddy container is changed
 docker compose \
   -f docker-compose.yml \
   -f docker-compose.pizza.yml $PIZZA_FAILOVER \
   -f docker-compose.seed.yml \
-  up --build --renew-anon-volumes --force-recreate --remove-orphans --wait
+  down --remove-orphans
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.pizza.yml $PIZZA_FAILOVER \
+  -f docker-compose.seed.yml \
+  up --build --renew-anon-volumes --force-recreate --wait


### PR DESCRIPTION
Further issues arose after merging #5316, seemingly about different containers having the same name.

Doing an explicit `docker compose down` in the update script seems to resolve this.

I note that `pull_policy` really doesn't behave as described [in the docs](https://docs.docker.com/reference/compose-file/services/#pull_policy), e.g. if you don't include it, or use `missing`, Docker does not attempt to pull down the image, even if there is nothing cached. Similarly, using `never` does not cause Docker to report an error/failure if no cached image is found - it just builds it instead (which is the behaviour we want, but not what the docs describe).