### PR TITLE
chore: planx_website_stats use tables not views

### DIFF
--- a/hasura.planx.uk/migrations/default/1759398740126_generate_website_stats_from_tables_not_views/down.sql
+++ b/hasura.planx.uk/migrations/default/1759398740126_generate_website_stats_from_tables_not_views/down.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW "public"."planx_website_stats" AS 
+ SELECT ( SELECT count(*) AS count
+           FROM ( SELECT analytics_summary.analytics_id,
+                    count(*) AS count
+                   FROM analytics_summary
+                  WHERE ((analytics_summary.analytics_created_at >= (now() + '-30 days'::interval)) AND (analytics_summary.analytics_created_at < now()))
+                  GROUP BY analytics_summary.analytics_id
+                  ORDER BY analytics_summary.analytics_id) source) AS users_last_30_days,
+    ( SELECT count(*) AS count
+           FROM submission_services_summary
+          WHERE ((submission_services_summary.submitted_at IS NOT NULL) AND (submission_services_summary.submitted_at >= (now() + '-30 days'::interval)) AND (submission_services_summary.submitted_at < now()))) AS submissions_last_30_days,
+    ( SELECT count(*) AS count
+           FROM (teams t
+             JOIN team_settings ts ON ((t.id = ts.team_id)))
+          WHERE ((t.slug = ANY (ARRAY['barking-and-dagenham'::text, 'barnet'::text, 'birmingham'::text, 'braintree'::text, 'bromley'::text, 'buckinghamshire'::text, 'camden'::text, 'canterbury'::text, 'doncaster'::text, 'epsom-and-ewell'::text, 'gateshead'::text, 'gloucester'::text, 'horsham'::text, 'kingston'::text, 'lambeth'::text, 'medway'::text, 'newcastle'::text, 'south-gloucestershire'::text, 'southwark'::text, 'st-albans'::text, 'tewkesbury'::text, 'west-berkshire'::text])) AND (ts.is_trial <> true))) AS active_lpas;

--- a/hasura.planx.uk/migrations/default/1759398740126_generate_website_stats_from_tables_not_views/up.sql
+++ b/hasura.planx.uk/migrations/default/1759398740126_generate_website_stats_from_tables_not_views/up.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW "public"."planx_website_stats" AS 
+ SELECT ( SELECT count(*) AS count
+           FROM ( SELECT analytics.id,
+                    count(*) AS count
+                   FROM analytics
+                  WHERE ((analytics.created_at >= (now() + '-30 days'::interval)) AND (analytics.created_at < now()))
+                  GROUP BY analytics.id
+                  ORDER BY analytics.id) source) AS users_last_30_days,
+    ( SELECT count(*) AS count
+           FROM lowcal_sessions
+          WHERE ((lowcal_sessions.submitted_at IS NOT NULL) AND (lowcal_sessions.submitted_at >= (now() + '-30 days'::interval)) AND (lowcal_sessions.submitted_at < now()))) AS submissions_last_30_days,
+    ( SELECT count(*) AS count
+           FROM (teams t
+             JOIN team_settings ts ON ((t.id = ts.team_id)))
+          WHERE ((t.slug = ANY (ARRAY['barking-and-dagenham'::text, 'barnet'::text, 'birmingham'::text, 'braintree'::text, 'bromley'::text, 'buckinghamshire'::text, 'camden'::text, 'canterbury'::text, 'doncaster'::text, 'epsom-and-ewell'::text, 'gateshead'::text, 'gloucester'::text, 'horsham'::text, 'kingston'::text, 'lambeth'::text, 'medway'::text, 'newcastle'::text, 'south-gloucestershire'::text, 'southwark'::text, 'st-albans'::text, 'tewkesbury'::text, 'west-berkshire'::text])) AND (ts.is_trial <> true))) AS active_lpas;


### PR DESCRIPTION
When altering `analytics_summary` in #5339 I realised there is a view that is `select`ing from another view, which as we've discussed at a dev call before is a dependency we'd like to avoid. 

This rewrites the view to pull from the source tables that `analytics_summary` and `submission_services_summary` pull from (`analytics` and `lowcal_sessions`)