### PR TITLE
feat: new breach locations schema for map and label

### DIFF
--- a/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -27,6 +27,7 @@ import { SketchPlanCA } from "./schemas/SketchPlanCA";
 import { SketchPlanFullDescriptionCA } from "./schemas/SketchPlanFullDescriptionCA";
 import { SketchPlanFullDescriptionTPO } from "./schemas/SketchPlanFullDescriptionTPO";
 import { SketchPlanTPO } from "./schemas/SketchPlanTPO";
+import { BreachLocations } from "./schemas/BreachLocations";
 
 type Props = EditorProps<TYPES.MapAndLabel, MapAndLabel>;
 
@@ -40,6 +41,10 @@ export const SCHEMAS = [
   {
     name: "Sketch plan (full description) - TPO",
     schema: SketchPlanFullDescriptionTPO,
+  },
+  {
+    name: "Report a Breach - breach locations",
+    schema: BreachLocations,
   },
 ];
 

--- a/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/BreachLocations
+++ b/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/BreachLocations
@@ -1,0 +1,17 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+export const BreachLocations: Schema = {
+  type: "Breach",
+  fields: [
+    {
+      type: "text",
+      data: {
+        title: "Breach description",
+        fn: "referenceDescription",
+        type: TextInputType.Short,
+      },
+    },
+  ],
+  min: 1,
+} as const;


### PR DESCRIPTION
Added a new schema for the map and label component for users to add locations of suspected breaches as part of Report a Breach services.