### PR TITLE
fix(lps): Handle deleted flows

### DIFF
--- a/api.planx.uk/modules/lps/service/getApplications/mutation.ts
+++ b/api.planx.uk/modules/lps/service/getApplications/mutation.ts
@@ -27,7 +27,9 @@ export const CONSUME_MAGIC_LINK_MUTATION = gql`
             # Fetch non-expired sessions...
             user_status: { _neq: "expired" }
             # ..for services which still exist
-            flow: { id: { _is_null: false } }
+            flow: {
+              _or: { id: { _is_null: false }, deleted_at: { _is_null: false } }
+            }
           }
           order_by: { updated_at: desc }
         ) {


### PR DESCRIPTION
Updates "get applications" query to correctly ignore services which can't be resumed.