### PR TITLE
feat: Enable tags and data fields by default on the graph

### DIFF
--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -177,6 +177,7 @@ const createBaseComponent = async (
   }
 
   await page.locator('button[form="modal"][type="submit"]').click();
+  await page.getByRole("dialog").waitFor({ state: "detached" });
 };
 
 export const createQuestionWithOptions = async (

--- a/e2e/tests/ui-driven/src/pages/Editor.ts
+++ b/e2e/tests/ui-driven/src/pages/Editor.ts
@@ -261,10 +261,10 @@ export class PlaywrightEditor {
     await createFilter(this.page, this.getNextNode());
     // select the branch filter and add some content
     const filteredBranch = this.page
-      .locator("li")
-      .filter({ hasText: /Material change of use$/ })
       .getByRole("listitem")
-      .getByRole("link");
+      .filter({ hasText: /^Material change of useflag\.mcou\.true$/ })
+      .getByRole("link")
+      .nth(1);
 
     await createContent(
       this.page,

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -88,7 +88,7 @@ export const editorUIStore: StateCreator<
       set({ flowCardView: view });
     },
 
-    showTags: false,
+    showTags: true,
 
     toggleShowTags: () => set({ showTags: !get().showTags }),
 
@@ -96,7 +96,7 @@ export const editorUIStore: StateCreator<
 
     toggleShowImages: () => set({ showImages: !get().showImages }),
 
-    showDataFields: false,
+    showDataFields: true,
 
     toggleShowDataFields: () => set({ showDataFields: !get().showDataFields }),
 


### PR DESCRIPTION
Came up as a suggestion at roadmap!

This PR will enable tags and data values by default on the graph view.