### PR TITLE
fix(lps): Logical bug in GQL query

### DIFF
--- a/api.planx.uk/modules/lps/service/getApplications/mutation.ts
+++ b/api.planx.uk/modules/lps/service/getApplications/mutation.ts
@@ -28,7 +28,10 @@ export const CONSUME_MAGIC_LINK_MUTATION = gql`
             user_status: { _neq: "expired" }
             # ..for services which still exist
             flow: {
-              _or: { id: { _is_null: false }, deleted_at: { _is_null: false } }
+              _and: [
+                { id: { _is_null: false } }
+                { deleted_at: { _is_null: true } }
+              ]
             }
           }
           order_by: { updated_at: desc }


### PR DESCRIPTION
Fixes incorrect GQL mutation syntax for LPS (regression introduced [here](https://github.com/theopensystemslab/planx-new/pull/5345)).

Once we upgrade eslint (or change to something else like Biome) we need to take a look at gql linting - I've tried a few times with ourx current setup and can't quite get it working (we're on a legacy ESLint config file type).