### PR TITLE
feat(wip): track next steps in analytics

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/mutations.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/mutations.ts
@@ -86,6 +86,17 @@ export const UPDATE_FLOW_DIRECTION = gql`
   }
 `;
 
+export const UPDATE_NEXT_STEP_TAKEN = gql`
+  mutation UpdateNextStepTaken($id: bigint!, $metadata: jsonb = {}) {
+    update_analytics_logs_by_pk(
+      pk_columns: { id: $id }
+      _set: { next_step: $metadata }
+    ) {
+      id
+    }
+  }
+`;
+
 export const INSERT_NEW_ANALYTICS = gql`
   mutation InsertNewAnalytics(
     $type: String

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/provider.tsx
@@ -17,6 +17,7 @@ import {
   UPDATE_HAS_CLICKED_HELP,
   UPDATE_HAS_CLICKED_SAVE,
   UPDATE_NEXT_LOG_CREATED_AT,
+  UPDATE_NEXT_STEP_TAKEN,
 } from "./mutations";
 import {
   AnalyticsLogDirection,
@@ -283,6 +284,8 @@ export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({
         updateMetadata(UPDATE_HAS_CLICKED_SAVE);
         return;
       case "nextStepsClick":
+        updateMetadata(UPDATE_NEXT_STEP_TAKEN, eventData.metadata);
+        return;
       case "helpTextFeedback":
         updateMetadata(UPDATE_ANALYTICS_LOG_METADATA, eventData.metadata);
         return;

--- a/editor.planx.uk/src/pages/FlowEditor/lib/analytics/types.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/analytics/types.ts
@@ -32,6 +32,8 @@ export type AllowListKey = (typeof ALLOW_LIST)[number];
  */
 export type HelpClickMetadata = Record<string, string>;
 
+export type NextStepsMetadata = Record<string, string[]>;
+
 export type SelectedUrlsMetadata = Record<"selectedUrls", string[]>;
 
 export type BackwardsNavigationInitiatorType = "change" | "back";
@@ -83,6 +85,7 @@ export type Metadata =
   | BackwardsNavigationMetadata
   | SelectedUrlsMetadata
   | HelpClickMetadata
+  | NextStepsMetadata
   | HelpTextFeedbackMetadata;
 
 /**

--- a/hasura.planx.uk/metadata/databases/default/tables/public_analytics_logs.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_analytics_logs.yaml
@@ -22,6 +22,7 @@ insert_permissions:
         - id
         - input_errors
         - metadata
+        - next_step
         - node_id
         - node_title
         - node_type
@@ -47,6 +48,7 @@ update_permissions:
         - input_errors
         - metadata
         - next_log_created_at
+        - next_step
         - user_exit
       filter:
         analytic:

--- a/hasura.planx.uk/migrations/default/1759496338016_alter_table_public_analytics_logs_add_column_next_step/down.sql
+++ b/hasura.planx.uk/migrations/default/1759496338016_alter_table_public_analytics_logs_add_column_next_step/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."analytics_logs" drop column "next_step" jsonb;

--- a/hasura.planx.uk/migrations/default/1759496338016_alter_table_public_analytics_logs_add_column_next_step/up.sql
+++ b/hasura.planx.uk/migrations/default/1759496338016_alter_table_public_analytics_logs_add_column_next_step/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."analytics_logs" add column "next_step" jsonb
+ null;


### PR DESCRIPTION
I'll look into if we can achieve the intended outcome using Beacon but in the meantime / as promised, here's where I got to. 

Clicking on a next step was throwing this error:
```
http://localhost:7002/analytics/log-user-resume?analyticsLogId=56 net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin 204 (No Content)
```

Subsequently no network requests were being made, despite no code changes!