### PR TITLE
refactor(lps): Use `@tanstack/react-query` for custom `useHTMLDownload()` hook

### DIFF
--- a/api.planx.uk/modules/lps/controller.ts
+++ b/api.planx.uk/modules/lps/controller.ts
@@ -66,13 +66,7 @@ export const downloadHTMLController: DownloadHTML = async (_req, res, next) => {
   const { sessionId, email } = res.locals.parsedReq.body;
   try {
     const html = await generateHTML(sessionId, email);
-    return (
-      res
-        // Cache for 2hrs - submitted applications can't change so the data will not become stale
-        .setHeader("Cache-Control", "private, max-age=7200")
-        .header("Content-type", "text/html")
-        .send(html)
-    );
+    return res.header("Content-type", "text/html").send(html);
   } catch (error) {
     next(
       new ServerError({

--- a/localplanning.services/src/components/applications/ApplicationViewer.tsx
+++ b/localplanning.services/src/components/applications/ApplicationViewer.tsx
@@ -2,16 +2,16 @@ import { useHtmlDownload } from "./hooks/useHTMLDownload";
 import styles from "./ApplicationViewer.module.css";
 
 export const ApplicationViewer = () => {
-  const { htmlContent, loading, error, fetchHtml } = useHtmlDownload();
+  const { data: htmlContent, isPending, error, refetch } = useHtmlDownload();
 
-  if (loading) return <p>Loading application...</p>
+  if (isPending) return <p>Loading application...</p>
 
-  if (error) {
+  if (error || !htmlContent) {
     return (
       <div className="styled-content">
         <h2>Failed to load application</h2>
-        <p>Error: {error}</p>
-        <button onClick={fetchHtml} className="button button--primary button--medium button-focus-style">
+        <p>Error: {error?.message || "Unknown error"}</p>
+        <button onClick={() => refetch()} className="button button--primary button--medium button-focus-style">
           Retry
         </button>
       </div>

--- a/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
+++ b/localplanning.services/src/components/applications/hooks/useHTMLDownload.tsx
@@ -1,78 +1,69 @@
 import { PUBLIC_PLANX_REST_API_URL } from "astro:env/client";
-import { useState, useEffect, useTransition } from "react";
 import { useStore } from "@nanostores/react";
 import { $session } from "@stores/session";
 import { $applicationId } from "@stores/applicationId";
+import { useQuery } from "@tanstack/react-query";
+import { queryClient } from "@lib/queryClient";
 
 export const useHtmlDownload = () => {
-  const [ htmlContent, setHtmlContent ] = useState("");
-  const [ error, setError ] = useState<string | null>(null);
-  const [ isPending, startTransition ] = useTransition();
   const { email } = useStore($session);
   const applicationId = useStore($applicationId);
 
-  const fetchHtml = async () => {
-    startTransition(async () => {
-      setError(null);
+  let inputError: Error | null = null;
+  if (!email) {
+    inputError = new Error("Missing email value from store");
+  } else if (!applicationId) {
+    inputError = new Error("Missing applicationId value from store");
+  }
 
-      try {
-        // Step 1: Get access token
-        const tokenResponse = await fetch(
-          `${PUBLIC_PLANX_REST_API_URL}/lps/download/token`, 
-          { 
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ email, sessionId: applicationId }) 
-          }
-        );
-        if (!tokenResponse.ok) {
-          throw new Error(`Token request failed: ${tokenResponse.status}`);
-        }
+  // Step 1: Get access token
+  const tokenQuery = useQuery({
+    queryKey: ["downloadToken", email, applicationId],
+    queryFn: async () => {
+      const response = await fetch(`${PUBLIC_PLANX_REST_API_URL}/lps/download/token`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, sessionId: applicationId })
+      });
+      if (!response.ok) throw new Error(`Token request failed: ${response.status}`);
+      const { token } = await response.json();
+      return token;
+    },
+    enabled: !!email && !!applicationId,
+    // The token is single use, do not refetch unless invalidated
+    staleTime: Infinity,
+  }, queryClient);
 
-        const { token } = await tokenResponse.json();
+  // Step 2: Use token to fetch HTML
+  const htmlQuery = useQuery({
+    queryKey: ["downloadHtml", email, applicationId],
+    queryFn: async () => {
+      const token = tokenQuery.data;
+      const response = await fetch(`${PUBLIC_PLANX_REST_API_URL}/lps/download/html`, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ email, sessionId: applicationId })
+      });
+      if (!response.ok) throw new Error(`HTML request failed: ${response.status}`);
+      return response.text();
+    },
+    enabled: !!tokenQuery.data,
+    // Never refetch HTML once we have a copy in the cache
+    staleTime: Infinity,
+  }, queryClient);
 
-        // Step 2: Use token to fetch HTML
-        const htmlResponse = await fetch(`${PUBLIC_PLANX_REST_API_URL}/lps/download/html`, {
-          method: "POST",
-          headers: {
-            "Authorization": `Bearer ${token}`,
-            "content-type": "application/json"
-          },
-          body: JSON.stringify({ email, sessionId: applicationId })
-        });
-
-        if (!htmlResponse.ok) {
-          throw new Error(`HTML request failed: ${htmlResponse.status}`);
-        }
-
-        const html = await htmlResponse.text();
-        setHtmlContent(html);
-
-      } catch (err) {
-        setError((err as Error).message);
-        setHtmlContent("");
-      }
-    });
+  const refetchAll = () => {
+    queryClient.invalidateQueries({ queryKey: ["downloadToken", email, applicationId] });
+    queryClient.invalidateQueries({ queryKey: ["downloadHtml", email, applicationId] });
   };
 
-  useEffect(() => {
-    if (!email) {
-      setError("Missing email value from store");
-      return;
-    }
-
-    if (!applicationId) {
-      setError("Missing applicationId value from store");
-      return;
-    }
-
-    fetchHtml();
-  }, [applicationId, email]);
-
   return {
-    htmlContent,
-    loading: isPending,
-    error,
-    fetchHtml,
+    data: htmlQuery.data,
+    isPending: tokenQuery.isPending || htmlQuery.isPending,
+    error: inputError || tokenQuery.error || htmlQuery.error,
+    refetch: refetchAll,
   };
 };


### PR DESCRIPTION
## What does this PR do?
 - Replaces React primitive management and boilerplate (`useState()`, `useEffect()`) with `@tanstack/react-query`

## Motivations
- More clear and declarative state management and data fetching
- Good practice / upskilling for integration of `@tanstack/react-query` into the Editor
- Better performance and reliability server-side caching attempted in https://github.com/theopensystemslab/planx-new/pull/5333

## To test...
(On staging) Hit "View application" multiple times for the same application ID - slow re-load, repeated server fetch (and generation!) of the same data

(On Pizza) Hit "View application" multiple times for the same application ID - quick re-load, no external HTTPS calls, data re-served from `@tanstack/react-query` local cache.