### PR TITLE
feat: add 'To review' tab to sidebar

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/ReviewCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/ReviewCard.tsx
@@ -1,9 +1,17 @@
 import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
 import React from "react";
 import { NodeCard } from "ui/editor/NodeCard";
 
-export const ReviewCard: React.FC<{ nodeId: string }> = ({ nodeId }) => (
-  <ListItem sx={{ pb: 1, pt: 0, px: 0 }}>
-    <NodeCard nodeId={nodeId} backgroundColor="#fff" />
+export const ReviewCard: React.FC<{ nodeId: string; notes?: string }> = ({
+  nodeId,
+  notes,
+}) => (
+  <ListItem>
+    <NodeCard nodeId={nodeId} backgroundColor="#fff">
+      {notes && (
+        <Typography variant="body2">Internal notes - {notes}</Typography>
+      )}
+    </NodeCard>
   </ListItem>
 );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/ReviewCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/ReviewCard.tsx
@@ -1,17 +1,19 @@
 import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { NodeCard } from "ui/editor/NodeCard";
 
-export const ReviewCard: React.FC<{ nodeId: string; notes?: string }> = ({
-  nodeId,
-  notes,
-}) => (
-  <ListItem>
-    <NodeCard nodeId={nodeId} backgroundColor="#fff">
-      {notes && (
-        <Typography variant="body2">Internal notes - {notes}</Typography>
-      )}
-    </NodeCard>
-  </ListItem>
-);
+export const ReviewCard: React.FC<{ nodeId: string }> = ({ nodeId }) => {
+  const node = useStore((state) => state.getNode(nodeId));
+  const notes = node?.data?.notes;
+  return (
+    <ListItem>
+      <NodeCard nodeId={nodeId} backgroundColor="#fff">
+        {notes && (
+          <Typography variant="body2">Internal notes - {notes}</Typography>
+        )}
+      </NodeCard>
+    </ListItem>
+  );
+};

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/ReviewCard.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/ReviewCard.tsx
@@ -1,0 +1,9 @@
+import ListItem from "@mui/material/ListItem";
+import React from "react";
+import { NodeCard } from "ui/editor/NodeCard";
+
+export const ReviewCard: React.FC<{ nodeId: string }> = ({ nodeId }) => (
+  <ListItem sx={{ pb: 1, pt: 0, px: 0 }}>
+    <NodeCard nodeId={nodeId} backgroundColor="#fff" />
+  </ListItem>
+);

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -20,11 +20,17 @@ const Reviews = () => {
       <Typography variant="h4" mb={1}>
         {`Nodes with a 'To review' tag`}
       </Typography>
-      <List sx={{ mt: 1 }}>
-        {sortedReviewNodeIds.map((nodeId) => (
-          <ReviewCard key={nodeId} nodeId={nodeId} />
-        ))}
-      </List>
+      {sortedReviewNodeIds.length ? (
+        <List sx={{ mt: 1 }}>
+          {sortedReviewNodeIds.map((nodeId) => (
+            <ReviewCard key={nodeId} nodeId={nodeId} />
+          ))}
+        </List>
+      ) : (
+        <Typography variant="body1" color="text.secondary" mt={2}>
+          No nodes are currently tagged 'To review'.
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -1,0 +1,37 @@
+import Box from "@mui/material/Box";
+import List from "@mui/material/List";
+import Typography from "@mui/material/Typography";
+import { sortIdsDepthFirst } from "@planx/graph";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+import { ReviewCard } from "./ReviewCard";
+
+const Reviews = () => {
+  const flow = useStore((state) => state.flow);
+
+  // Get the nodes within this flow that are tagged as 'To review' and  sort them top-down to match graph
+  const reviewNodeIds = new Set(
+    Object.entries(flow)
+      .filter(([_nodeId, nodeData]) =>
+        Boolean(nodeData.data?.tags?.includes("toReview")),
+      )
+      .map(([nodeId]) => nodeId),
+  );
+  const sortedReviewNodeIds = sortIdsDepthFirst(flow)(reviewNodeIds);
+
+  return (
+    <Box p={2} sx={{ backgroundColor: "background.paper", minHeight: "100%" }}>
+      <Typography variant="h4" mb={1}>
+        {`Nodes with a 'To review' tag`}
+      </Typography>
+      <List sx={{ mt: 1 }}>
+        {sortedReviewNodeIds.map((nodeId) => (
+          <ReviewCard key={nodeId} nodeId={nodeId} />
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default Reviews;

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -26,9 +26,11 @@ const Reviews = () => {
         {`Nodes with a 'To review' tag`}
       </Typography>
       <List sx={{ mt: 1 }}>
-        {sortedReviewNodeIds.map((nodeId) => (
-          <ReviewCard key={nodeId} nodeId={nodeId} />
-        ))}
+        {sortedReviewNodeIds.map((nodeId) => {
+          const node = flow[nodeId];
+          const notes = node?.data?.notes || "";
+          return <ReviewCard key={nodeId} nodeId={nodeId} notes={notes} />;
+        })}
       </List>
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -1,24 +1,19 @@
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import Typography from "@mui/material/Typography";
-import { sortIdsDepthFirst } from "@planx/graph";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useMemo } from "react";
 
 import { ReviewCard } from "./ReviewCard";
 
 const Reviews = () => {
   const flow = useStore((state) => state.flow);
+  const filterFlowByTag = useStore((state) => state.filterFlowByTag);
 
-  // Get the nodes within this flow that are tagged as 'To review' and  sort them top-down to match graph
-  const reviewNodeIds = new Set(
-    Object.entries(flow)
-      .filter(([_nodeId, nodeData]) =>
-        Boolean(nodeData.data?.tags?.includes("toReview")),
-      )
-      .map(([nodeId]) => nodeId),
+  const sortedReviewNodeIds = useMemo(
+    () => Object.keys(filterFlowByTag("toReview")),
+    [flow, filterFlowByTag],
   );
-  const sortedReviewNodeIds = sortIdsDepthFirst(flow)(reviewNodeIds);
 
   return (
     <Box p={2} sx={{ backgroundColor: "background.paper", minHeight: "100%" }}>
@@ -26,11 +21,9 @@ const Reviews = () => {
         {`Nodes with a 'To review' tag`}
       </Typography>
       <List sx={{ mt: 1 }}>
-        {sortedReviewNodeIds.map((nodeId) => {
-          const node = flow[nodeId];
-          const notes = node?.data?.notes;
-          return <ReviewCard key={nodeId} nodeId={nodeId} notes={notes} />;
-        })}
+        {sortedReviewNodeIds.map((nodeId) => (
+          <ReviewCard key={nodeId} nodeId={nodeId} />
+        ))}
       </List>
     </Box>
   );

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -28,7 +28,7 @@ const Reviews = () => {
       <List sx={{ mt: 1 }}>
         {sortedReviewNodeIds.map((nodeId) => {
           const node = flow[nodeId];
-          const notes = node?.data?.notes || "";
+          const notes = node?.data?.notes;
           return <ReviewCard key={nodeId} nodeId={nodeId} notes={notes} />;
         })}
       </List>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -7,12 +7,13 @@ import React, { useMemo } from "react";
 import { ReviewCard } from "./ReviewCard";
 
 const Reviews = () => {
-  const flow = useStore((state) => state.flow);
-  const filterFlowByTag = useStore((state) => state.filterFlowByTag);
+  const [flow, filterFlowByTag] = useStore((state) => [state.flow, state.filterFlowByTag]);
 
+ // Only re-run filter when flow changes
   const sortedReviewNodeIds = useMemo(
     () => Object.keys(filterFlowByTag("toReview")),
-    [flow, filterFlowByTag],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [flow],
   );
 
   return (

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -20,6 +20,7 @@ import { DebugConsole } from "./DebugConsole";
 import EditHistory from "./EditHistory";
 import { PreviewBrowser } from "./PreviewBrowser";
 import { CheckForChangesToPublishButton } from "./Publish/CheckForChangesButton";
+import Reviews from "./Review";
 import Search from "./Search";
 import StyledTab from "./StyledTab";
 
@@ -28,7 +29,8 @@ type SidebarTabs =
   | "History"
   | "Search"
   | "Console"
-  | "Customise";
+  | "Customise"
+  | "Review";
 
 const SIDEBAR_WIDTH = "500px";
 const SIDEBAR_WIDTH_MINIMISED = "20px";
@@ -226,6 +228,10 @@ const Sidebar: React.FC = React.memo(() => {
               <StyledTab value="PreviewBrowser" label="Preview" />
               <StyledTab value="History" label="History" />
               <StyledTab value="Search" label="Search" />
+              {/* Hide from templated flows due to tabs width constraints */}
+              {!isTemplatedFrom && (
+                <StyledTab value="Review" label="To review" />
+              )}
               <StyledTab value="Console" label="Console" />
             </Tabs>
           </TabList>
@@ -252,6 +258,11 @@ const Sidebar: React.FC = React.memo(() => {
           {activeTab === "Console" && (
             <SidebarContainer>
               <DebugConsole />
+            </SidebarContainer>
+          )}
+          {activeTab === "Review" && (
+            <SidebarContainer>
+              <Reviews />
             </SidebarContainer>
           )}
         </SidebarWrapper>

--- a/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -228,7 +228,6 @@ const Sidebar: React.FC = React.memo(() => {
               <StyledTab value="PreviewBrowser" label="Preview" />
               <StyledTab value="History" label="History" />
               <StyledTab value="Search" label="Search" />
-              {/* Hide from templated flows due to tabs width constraints */}
               {!isTemplatedFrom && (
                 <StyledTab value="Review" label="To review" />
               )}

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -157,7 +157,7 @@ export const navigationStore: StateCreator<
    * Get a subset of the full flow by tag
    * Returned in depth-first order
    */
-  filterFlowByTag: (tag: (typeof NODE_TAGS)[number]): Store.Flow => {
+  filterFlowByTag: (tag) => {
     // Filter the full flow
     const flow = get().flow;
     const filteredFlow = Object.fromEntries(

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -30,7 +30,7 @@ export interface NavigationStore {
   initNavigationStore: () => void;
   updateSectionData: () => void;
   filterFlowByType: (type: TYPES) => Store.Flow;
-  filterFlowByTag: (tag: (typeof NODE_TAGS)[number]) => Store.Flow;
+  filterFlowByTag: (tag: NodeTag) => Store.Flow;
   getSortedBreadcrumbsBySection: () => Store.Breadcrumbs[];
   getSectionForNode: (nodeId: string) => SectionNode;
   _calculateSectionProgress: (

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -1,4 +1,7 @@
-import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType as TYPES,
+  NODE_TAGS,
+} from "@opensystemslab/planx-core/types";
 import { Section } from "@planx/components/Section/model";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { findLast, pick, sum } from "lodash";
@@ -27,6 +30,7 @@ export interface NavigationStore {
   initNavigationStore: () => void;
   updateSectionData: () => void;
   filterFlowByType: (type: TYPES) => Store.Flow;
+  filterFlowByTag: (tag: (typeof NODE_TAGS)[number]) => Store.Flow;
   getSortedBreadcrumbsBySection: () => Store.Breadcrumbs[];
   getSectionForNode: (nodeId: string) => SectionNode;
   _calculateSectionProgress: (
@@ -130,6 +134,36 @@ export const navigationStore: StateCreator<
     const flow = get().flow;
     const filteredFlow = Object.fromEntries(
       Object.entries(flow).filter(([_key, value]) => value.type === type),
+    );
+
+    // Sort IDs-only depth-first
+    const filteredNodeIds = Object.entries(filteredFlow).map(
+      (entry) => entry[0],
+    );
+    const sortedFilteredNodeIds = sortIdsDepthFirst(flow)(
+      new Set(filteredNodeIds),
+    );
+
+    // Reconstruct the full node objects preserving depth-first sorted order
+    const sortedFilteredFlow: { [k: string]: Store.Node } = {};
+    sortedFilteredNodeIds.forEach(
+      (id) => (sortedFilteredFlow[id] = filteredFlow[id]),
+    );
+
+    return sortedFilteredFlow;
+  },
+
+  /**
+   * Get a subset of the full flow by tag
+   * Returned in depth-first order
+   */
+  filterFlowByTag: (tag: (typeof NODE_TAGS)[number]): Store.Flow => {
+    // Filter the full flow
+    const flow = get().flow;
+    const filteredFlow = Object.fromEntries(
+      Object.entries(flow).filter(([_key, value]) =>
+        Boolean(value.data?.tags?.includes(tag)),
+      ),
     );
 
     // Sort IDs-only depth-first

--- a/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
+++ b/editor.planx.uk/src/pages/FlowEditor/lib/store/navigation.ts
@@ -1,7 +1,5 @@
-import {
-  ComponentType as TYPES,
-  NODE_TAGS,
-} from "@opensystemslab/planx-core/types";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { NodeTag } from "@opensystemslab/planx-core/types";
 import { Section } from "@planx/components/Section/model";
 import { sortIdsDepthFirst } from "@planx/graph";
 import { findLast, pick, sum } from "lodash";


### PR DESCRIPTION
This PR adds a 'To review' tab to the sidebar that lists all nodes in the current flow tagged 'To review'. It displays them together with any 'Internal notes' on the node.

The tab helps editors to more easily find and navigate to nodes in need of reviewing. Internal notes are displayed because these are currently used by editors to provide context on what is to be reviewed.

The tab does not display on flows that are _templated_.

To be revised during future development of a wider in-editor notification and user tagging system.