### PR TITLE
fix: Migration to reset Hasura

### DIFF
--- a/hasura.planx.uk/migrations/default/1759847178671_alter_table_public_users_update_comment/down.sql
+++ b/hasura.planx.uk/migrations/default/1759847178671_alter_table_public_users_update_comment/down.sql
@@ -1,0 +1,1 @@
+comment on table "public"."users" is E'Grants access to the Editor, currently requires a Google email for single sign-on';

--- a/hasura.planx.uk/migrations/default/1759847178671_alter_table_public_users_update_comment/up.sql
+++ b/hasura.planx.uk/migrations/default/1759847178671_alter_table_public_users_update_comment/up.sql
@@ -1,0 +1,1 @@
+comment on table "public"."users" is E'Grants access to the Editor, currently requires a Google or Microsoft email for single sign-on';


### PR DESCRIPTION
It looks like Hasura metadata / migrations are not up to date despite being in a healthy condition.

We're using user-facing errors due to the permissions on the `lowcal_session.has_section_data` column. There are granted on staging (introduced in #5224), but are not currently present on Hasura.

I'm hoping that a deploy to production of a new migration will clear this out.