### PR TITLE
fix: Allow demo users to access `flow.is_listed_on_lps` column

### DIFF
--- a/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -279,6 +279,7 @@ select_permissions:
         - deleted_at
         - description
         - id
+        - is_listed_on_lps
         - is_template
         - limitations
         - name


### PR DESCRIPTION
Small bug I just hit - without this, demo users cannot load flows correctly.