### PR TITLE
fix(editor): Type fixes fror Autocomplete `freeSolo` prop

### DIFF
--- a/editor.planx.uk/src/@planx/components/ExternalPortal/types.ts
+++ b/editor.planx.uk/src/@planx/components/ExternalPortal/types.ts
@@ -11,6 +11,6 @@ export type FlowAutocompleteListProps = AutocompleteProps<
   Flow,
   false,
   false,
-  true,
+  boolean,
   "div"
 >;

--- a/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
+++ b/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
@@ -24,7 +24,7 @@ const renderOptions: AutocompleteProps<
   string,
   false,
   false,
-  true,
+  boolean,
   "div"
 >["renderOption"] = (props, option) => {
   return (
@@ -98,7 +98,7 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
           }}
           renderOption={renderOptions}
           useDataFieldInput={true}
-          {...(allowCustomValues ? { freeSolo: true } : {})}
+          freeSolo={allowCustomValues}
           selectOnFocus
           clearOnEscape
           handleHomeEndKeys

--- a/editor.planx.uk/src/ui/shared/Autocomplete/AutocompleteInput.tsx
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/AutocompleteInput.tsx
@@ -19,7 +19,7 @@ export default function AutocompleteInput<T>({
 
   return (
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
-      <StyledAutocomplete<T, false, false, true, "div">
+      <StyledAutocomplete<T, false, false, boolean, "div">
         role="status"
         aria-atomic={true}
         aria-live="polite"

--- a/editor.planx.uk/src/ui/shared/Autocomplete/types.ts
+++ b/editor.planx.uk/src/ui/shared/Autocomplete/types.ts
@@ -1,12 +1,12 @@
 import { AutocompleteProps } from "@mui/material/Autocomplete";
 
 type RequiredAutocompleteProps<T> = Pick<
-  AutocompleteProps<T, false, false, true, "div">,
+  AutocompleteProps<T, false, false, boolean, "div">,
   "options" | "onChange"
 >;
 
 type OptionalAutocompleteProps<T> = Partial<
-  AutocompleteProps<T, false, false, true, "div">
+  AutocompleteProps<T, false, false, boolean, "div">
 > & { useDataFieldInput?: boolean };
 
 export type WithLabel<T> = {


### PR DESCRIPTION
Follow up to this conversation - https://github.com/theopensystemslab/planx-new/pull/5374/files#r2414709265

I wrote a comment on this thread but never hit submit it seems 🤦 

`feeSolo` is a generic argument passed into the `Autocomplete` type. We're hardcoding this as `true` currently via the generics we use for the component currently.

```ts
const renderOptions: AutocompleteProps<
  string,
  false,
  false,
  // This is freeSolo! 👇 
  true,
  "div"
>["renderOption"] = (props, option) => {
```

As a result, we can't set freeSolo to `false` without updating this.

Docs: https://mui.com/material-ui/react-autocomplete/#free-solo