### PR TITLE
feat: Custom copy and clone icons

### DIFF
--- a/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
+++ b/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
@@ -1,4 +1,3 @@
-import ContentCopy from "@mui/icons-material/ContentCopy";
 import ContentPaste from "@mui/icons-material/ContentPaste";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -9,6 +8,8 @@ import Paper from "@mui/material/Paper";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import { useStore } from "pages/FlowEditor/lib/store";
 import * as React from "react";
+import CloneIcon from "ui/icons/Clone";
+import CopyIcon from "ui/icons/Copy";
 
 export type ContextMenuSource = "node" | "hanger" | null;
 
@@ -37,7 +38,7 @@ export const ContextMenu: React.FC = () => {
     cloneNode,
     pasteNode,
     pasteClonedNode,
-    getNode
+    getNode,
   ] = useStore((state) => [
     state.contextMenuSource,
     state.contextMenuPosition,
@@ -49,18 +50,24 @@ export const ContextMenu: React.FC = () => {
     state.cloneNode,
     state.pasteNode,
     state.pasteClonedNode,
-    state.getNode
+    state.getNode,
   ]);
 
   const handleCopy = () => {
-    if (!self) return alert("Unable to copy, missing value for relationship 'self' (nodeId)")
+    if (!self)
+      return alert(
+        "Unable to copy, missing value for relationship 'self' (nodeId)",
+      );
 
     copyNode(self);
     closeMenu();
   };
 
   const handleClone = () => {
-    if (!self) return alert("Unable to clone, missing value for relationship 'self' (nodeId)")
+    if (!self)
+      return alert(
+        "Unable to clone, missing value for relationship 'self' (nodeId)",
+      );
 
     cloneNode(self);
     closeMenu();
@@ -70,9 +77,8 @@ export const ContextMenu: React.FC = () => {
     if (copiedNode) {
       pasteNode(parent, before);
       return closeMenu();
-
     }
-    
+
     if (clonedNodeId) {
       pasteClonedNode(parent, before);
       return closeMenu();
@@ -94,14 +100,14 @@ export const ContextMenu: React.FC = () => {
         {
           id: "copy",
           label: "Copy",
-          icon: <ContentCopy fontSize="small" />,
+          icon: <CopyIcon fontSize="small" />,
           disabled: false,
           onClick: handleCopy,
         },
         {
           id: "clone",
           label: "Clone",
-          icon: <ContentCopy fontSize="small" />,
+          icon: <CloneIcon fontSize="small" />,
           disabled: false,
           onClick: handleClone,
         },

--- a/editor.planx.uk/src/ui/icons/Clone.tsx
+++ b/editor.planx.uk/src/ui/icons/Clone.tsx
@@ -1,0 +1,10 @@
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+import * as React from "react";
+
+export default function CopyIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <path d="M16.15.98H7.13c-.9,0-1.64.74-1.64,1.64v11.49c0,.9.74,1.64,1.64,1.64h9.03c.9,0,1.64-.74,1.64-1.64V2.62c0-.9-.74-1.64-1.64-1.64ZM16.15,14.11H7.13V2.62h9.03v11.49ZM3.85,10.64v2.01h-1.64v-2.01h1.64ZM3.85,13.92v2.01h-1.64v-2.01h1.64ZM4.03,17.21v1.83h-.19c-.9,0-1.64-.74-1.64-1.64v-.19h1.83ZM7.31,17.39v1.64h-2.01v-1.64h2.01ZM10.6,17.39v1.64h-2.01v-1.64h2.01ZM13.88,17.39v1.64h-2.01v-1.64h2.01ZM3.85,7.36v2.01h-1.64v-2.01h1.64ZM3.85,4.08v2.01h-1.64v-2.01h1.64Z" />
+    </SvgIcon>
+  );
+}

--- a/editor.planx.uk/src/ui/icons/Copy.tsx
+++ b/editor.planx.uk/src/ui/icons/Copy.tsx
@@ -1,0 +1,10 @@
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+import * as React from "react";
+
+export default function CopyIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <path d="M13.69,17.39H3.85V4.26h-1.64v13.13c0,.9.74,1.64,1.64,1.64h9.85v-1.64ZM16.15,15.75c.9,0,1.64-.74,1.64-1.64V2.62c0-.9-.74-1.64-1.64-1.64H7.13c-.9,0-1.64.74-1.64,1.64v11.49c0,.9.74,1.64,1.64,1.64h9.03M16.15,14.11H7.13V2.62h9.03v11.49Z" />
+    </SvgIcon>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

- Adds custom copy and clone icons for the new context menu, to mirror our style of clone border (dashed, bottom-left)

<img width="178" height="80" alt="image" src="https://github.com/user-attachments/assets/ec1ea958-d1e0-4a90-a993-e184286828a0" />
