### PR TITLE
adr: Reorganise S3 storage for session files

### DIFF
--- a/doc/architecture/decisions/0012-reorganise-s3-storage-for-session-files.md
+++ b/doc/architecture/decisions/0012-reorganise-s3-storage-for-session-files.md
@@ -1,18 +1,18 @@
 # 11. Reorganise S3 storage for session files
 
-Date: 2025-10-07
+Date: 2025-10-17
 
 ## Status
 
-Proposed
+Approved
 
 ## Context
 
 ### Current State
 - All files are currently stored with flat structure: `/:nanoId/filename.jpg`
-  - This applies to files uploaded by users ("private") and files uploaded by editors ("public")
+  - This applies to files uploaded by users ("private"), files uploaded by editors ("public"), and generated submission files (e.g. for Power Automate)
 - Files are co-located regardless of team, service, or context
-- File grouping requires querying user passports to get list of files
+- File grouping requires querying user passports, submission audit logs, or flows, to get list of files
 - No ability to limit API access per-team
 - Generated files are recreated on each request (both slow and computationally expensive)
 - No lifecycle rules - we manually sanitise via data held in user's passport - leaving orphaned files


### PR DESCRIPTION
A long overdue set of ideas / plan around reorganising file storage for user-uploaded data.

Also available here as a Google doc for a much nicer editing / commenting experience - https://docs.google.com/document/d/1fpvRkE_zkS0KfL_YpUxLWqzpfdjoz0fhQt-wqUYv1uA/edit?usp=sharing