### PR TITLE
fix(api): Remove stack trace from response

### DIFF
--- a/api.planx.uk/shared/middleware/validate.ts
+++ b/api.planx.uk/shared/middleware/validate.ts
@@ -32,7 +32,7 @@ export const validate =
       return next();
     } catch (error) {
       console.error(error);
-      return res.status(400).json(error);
+      return res.status(400).json((error as Error).message);
     }
   };
 


### PR DESCRIPTION
Resolves https://github.com/theopensystemslab/planx-new/security/code-scanning/86

Currently, a stack trace is returned (e.g. `admin/:sessionId/digital-planning-application`).

On a related note, the latest version of Zod has much nicer in-built error handling which would be nice to leverage in this middleware 👀 https://zod.dev/error-formatting