### PR TITLE
[CI] fix: force pull of caddy image on every build

### DIFF
--- a/docker-compose.pizza.failover.yml
+++ b/docker-compose.pizza.failover.yml
@@ -1,4 +1,6 @@
 services:
   caddy:
     # build custom caddy from scratch when pull from registry fails
+    build:
+      context: ./ci/caddy
     pull_policy: never

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -34,8 +34,6 @@ services:
     entrypoint: "/goStatic -port 8044 -fallback /index.html"
 
   caddy:
-    build:
-      context: ./ci/caddy
     image: lhr.vultrcr.com/planx/caddy-vultr:latest
     # default to pulling image from private Vultr registry (if not available)
     pull_policy: missing

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -25,8 +25,11 @@ source .env.pizza
 DOCKER_BUILDKIT=1
 set +o allexport
 
+# fallback to building caddy image if pull fails
 PIZZA_FAILOVER=""
-if ! docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
+if docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
+  echo "Caddy image pulled successfully"
+else
   echo "Failed to pull caddy image, building from source..."
   PIZZA_FAILOVER="-f docker-compose.pizza.failover.yml"
 fi

--- a/scripts/pullrequest/update.sh
+++ b/scripts/pullrequest/update.sh
@@ -10,8 +10,11 @@ source .env.pizza
 DOCKER_BUILDKIT=1
 set +o allexport
 
+# fallback to building caddy image if pull fails
 PIZZA_FAILOVER=""
-if ! docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
+if docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
+  echo "Caddy image pulled successfully"
+else
   echo "Failed to pull caddy image, building from source..."
   PIZZA_FAILOVER="-f docker-compose.pizza.failover.yml"
 fi


### PR DESCRIPTION
#5337 introduced changes which are causing caddy to be built fresh on every CI run, regardless of whether or not the Vultr registry can be reached.

It seems that using the `--build` argument to `docker compose` overrules the `pull_policy` (even if it's set to `always` instead of `missing`), so here we actually strip the build config from the default docker compose and put it in the failover (so that Docker really has no choice except to pull the image).

Also emitting more logs to allow for more easily checking whether failover switch is tripped.