### PR TITLE
chore(iac): Provide stable path and alias for Editor s3 files

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -619,7 +619,7 @@ export = async () => {
       const relativeFilePath = `../../editor.planx.uk/build/${path}`;
       const contentType = mime.getType(relativeFilePath) || "";
       const contentFile = new aws.s3.BucketObject(
-        relativeFilePath,
+        path,
         {
           key: path,
           acl: "public-read",
@@ -633,6 +633,8 @@ export = async () => {
         },
         {
           parent: frontendBucket,
+          // Temp transition alias
+          aliases: [{ name: `../../editor.planx.uk/build/${path}` }]
         }
       );
     });


### PR DESCRIPTION
Please see thread - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1760375499730809 (OSL Slack)

We're currently using the unstable `relativePath` for a unique name in s3 - when we change the directories (e.g. as part of the monorepo rollout) S3 fails to correctly diff and update the files. Using a stable name and alias should resolve this.

Once we've updated the name to just `path` on staging and prod, we should be able to drop the alias and roll out https://github.com/theopensystemslab/planx-new/pull/5432 again.

If this proves to be successful, I'll make the same change for LPS.