### PR TITLE
fix: Tooltips overflowing viewport

### DIFF
--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -840,6 +840,17 @@ const getThemeOptions = ({
       MuiTooltip: {
         defaultProps: {
           arrow: true,
+          PopperProps: {
+            modifiers: [
+              {
+                // Ensure tooltips are padded from viewport edge
+                name: "preventOverflow",
+                options: {
+                  padding: 10,
+                },
+              },
+            ],
+          },
         },
         styleOverrides: {
           arrow: {


### PR DESCRIPTION
Issue reported by @DafyddLlyr in Slack 
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1758277300239749

Tooltip for view public flow icon, is causing overflow / conflict with page scrollbars on Chrome.