### PR TITLE
fix: HTML markup in feedback page text

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -93,8 +93,12 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
       />
       <Box my={4}>
         {props.ratingQuestion && (
-          <Box sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
-            <InputLabel label={props.ratingQuestion} />
+          <Box
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            component="label"
+            htmlFor="feedbackButtonGroup"
+          >
+            <ReactMarkdownOrHtml source={props.ratingQuestion} />
           </Box>
         )}
         <ErrorWrapper error={formik.errors.feedbackScore}>
@@ -146,20 +150,26 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
           </StyledToggleButtonGroup>
         </ErrorWrapper>
         {props.freeformQuestion && (
-          <Box sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
-            <InputLabel label={props.freeformQuestion} />
+          <Box
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            component="label"
+            htmlFor="userComment"
+          >
+            <ReactMarkdownOrHtml source={props.freeformQuestion} />
           </Box>
         )}
         <Input
           multiline={true}
           rows={3}
           name="userComment"
+          id="userComment"
           value={formik.values.userComment}
           bordered
           onChange={formik.handleChange}
           aria-label="user comment"
           data-testid="user-comment"
           errorMessage={formik.errors.userComment}
+          sx={{ mt: 1 }}
         />
       </Box>
       <WarningContainer>


### PR DESCRIPTION
## Issue

- A change was made to hardcode text into the feedback component https://github.com/theopensystemslab/planx-new/pull/4882
- Due to the change in output any existing feedback that had rich text applied had this locked into the copy
- This affects any feedback pages that haven't yet migrated to the new confirmation page flow setup (of which there are several still live)

<img width="3164" height="1436" alt="image" src="https://github.com/user-attachments/assets/c8612003-01f9-49d8-b715-4ab8071ff21d" />

- This is rendering as HTML markup on the public interface:

<img width="3164" height="1340" alt="image" src="https://github.com/user-attachments/assets/ce1d1b58-2529-44c3-ba9f-fa576d908102" />

- Additionally the change in markup causes an a11y error due to non-association of the label:

<img width="1274" height="220" alt="image" src="https://github.com/user-attachments/assets/0e83c55d-cf3f-44de-85f8-a4e1d47130ff" />

## Solution

- Revert to rendering with `ReactMarkdownOrHtml` so that HTML markup is not displayed:

<img width="3164" height="1340" alt="image" src="https://github.com/user-attachments/assets/17e32573-f553-4066-9c7f-b3d5add2e759" />

- Fix label association to input