### PR TITLE
feat: persist `analytics` and `payment_status` data on staging

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics.yaml
@@ -4,7 +4,13 @@ table:
 object_relationships:
   - name: flow
     using:
-      foreign_key_constraint_on: flow_id
+      manual_configuration:
+        column_mapping:
+          flow_id: id
+        insertion_order: null
+        remote_table:
+          name: flows
+          schema: public
 insert_permissions:
   - role: public
     permission:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -27,9 +27,11 @@ object_relationships:
 array_relationships:
   - name: analytics
     using:
-      foreign_key_constraint_on:
-        column: flow_id
-        table:
+      manual_configuration:
+        column_mapping:
+          id: flow_id
+        insertion_order: null
+        remote_table:
           name: analytics
           schema: public
   - name: comments
@@ -75,9 +77,11 @@ array_relationships:
           schema: public
   - name: payment_statuses
     using:
-      foreign_key_constraint_on:
-        column: flow_id
-        table:
+      manual_configuration:
+        column_mapping:
+          id: flow_id
+        insertion_order: null
+        remote_table:
           name: payment_status
           schema: public
   - name: published_flows

--- a/apps/hasura.planx.uk/migrations/default/1760625282507_delete_fk_public_payment_status_payment_status_team_slug_fkey/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1760625282507_delete_fk_public_payment_status_payment_status_team_slug_fkey/down.sql
@@ -1,0 +1,17 @@
+alter table "public"."analytics"
+  add constraint "analytics_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update cascade on delete cascade;
+
+alter table "public"."payment_status"
+  add constraint "payment_status_flow_id_fkey"
+  foreign key ("flow_id")
+  references "public"."flows"
+  ("id") on update cascade on delete cascade;
+
+alter table "public"."payment_status"
+  add constraint "payment_status_team_slug_fkey"
+  foreign key ("team_slug")
+  references "public"."teams"
+  ("slug") on update cascade on delete cascade;

--- a/apps/hasura.planx.uk/migrations/default/1760625282507_delete_fk_public_payment_status_payment_status_team_slug_fkey/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1760625282507_delete_fk_public_payment_status_payment_status_team_slug_fkey/up.sql
@@ -1,0 +1,3 @@
+alter table "public"."analytics" drop constraint "analytics_flow_id_fkey";
+alter table "public"."payment_status" drop constraint "payment_status_flow_id_fkey";
+alter table "public"."payment_status" drop constraint "payment_status_team_slug_fkey";


### PR DESCRIPTION
Follows on from #5441
