### PR TITLE
refactor: Logout handler

### DIFF
--- a/apps/editor.planx.uk/src/api/auth/requests.ts
+++ b/apps/editor.planx.uk/src/api/auth/requests.ts
@@ -1,0 +1,3 @@
+import apiClient from "api/client";
+
+export const logout = async () => await apiClient.post("auth/logout");

--- a/apps/editor.planx.uk/src/components/Header/Header.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.tsx
@@ -20,7 +20,8 @@ import { styled, Theme } from "@mui/material/styles";
 import MuiToolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import axios from "axios";
+import { useMutation } from "@tanstack/react-query";
+import { logout } from "api/auth/requests";
 import { clearLocalFlowIdb } from "lib/local.idb";
 import { capitalize } from "lodash";
 import { Route } from "navi";
@@ -400,7 +401,7 @@ const EditorToolbar: React.FC<{
 }> = ({ headerRef }) => {
   const { navigate } = useNavigation();
   const [open, setOpen] = useState(false);
-  const [user, token] = useStore((state) => [state.getUser(), state.jwt]);
+  const user = useStore((state) => state.getUser());
 
   const handleClose = () => {
     setOpen(false);
@@ -410,13 +411,13 @@ const EditorToolbar: React.FC<{
     setOpen(!open);
   };
 
-  const logout = async () => {
-    const authRequestHeader = { Authorization: `Bearer ${token}` };
-    await axios.post(`${import.meta.env.VITE_APP_API_URL}/auth/logout`, null, {
-      headers: authRequestHeader,
-    });
-    navigate("/logout");
-  };
+  const logoutMutation = useMutation({
+    mutationKey: ["logout", user?.id],
+    mutationFn: logout,
+    onSuccess: () => navigate("/logout"),
+  });
+
+  const handleLogout = () => logoutMutation.mutate();
 
   return (
     <>
@@ -483,7 +484,7 @@ const EditorToolbar: React.FC<{
               </ListItemIcon>
               <ListItemText>{user.email}</ListItemText>
             </MenuItem>
-            <MenuItem onClick={logout}>Log out</MenuItem>
+            <MenuItem onClick={handleLogout}>Log out</MenuItem>
           </StyledPaper>
         </StyledPopover>
       )}

--- a/apps/editor.planx.uk/src/testUtils.tsx
+++ b/apps/editor.planx.uk/src/testUtils.tsx
@@ -1,11 +1,25 @@
 /* eslint-disable no-restricted-imports */
 import { ThemeProvider } from "@mui/material";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, RenderResult } from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import { defaultTheme } from "./theme";
+
+const testQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      gcTime: 0,
+      staleTime: 0,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
 
 /**
  * Setup @testing-library/react environment with userEvent
@@ -15,5 +29,9 @@ export const setup = (
   jsx: JSX.Element,
 ): Record<"user", UserEvent> & RenderResult => ({
   user: userEvent.setup(),
-  ...render(<ThemeProvider theme={defaultTheme}>{jsx}</ThemeProvider>),
+  ...render(
+    <QueryClientProvider client={testQueryClient}>
+      <ThemeProvider theme={defaultTheme}>{jsx}</ThemeProvider>
+    </QueryClientProvider>,
+  ),
 });


### PR DESCRIPTION
## What does this PR do?
 - Refactors the logout handler to replace `axios` with `useMutation()`
 - Moves API logic and associated types to `/api`

## Context
Part of implementing https://github.com/theopensystemslab/planx-new/blob/main/doc/architecture/decisions/0011-standardised-data-fetching-and-state-management.md which is being tracked here - https://github.com/orgs/theopensystemslab/projects/7/views/1
