### PR TITLE
refactor: Download submission files

### DIFF
--- a/apps/editor.planx.uk/src/api/downloadApplicationFiles/requests.tsx
+++ b/apps/editor.planx.uk/src/api/downloadApplicationFiles/requests.tsx
@@ -1,0 +1,23 @@
+import apiClient from "api/client";
+
+interface DownloadApplicationFiles {
+  sessionId: string;
+  email: string;
+  localAuthority: string;
+}
+
+export const downloadApplicationFiles = async ({
+  email,
+  localAuthority,
+  sessionId,
+}: DownloadApplicationFiles) => {
+  const { data } = await apiClient.get(
+    `/download-application-files/${sessionId}`,
+    {
+      responseType: "arraybuffer",
+      params: { email, localAuthority },
+    },
+  );
+
+  return data;
+};

--- a/apps/editor.planx.uk/src/pages/SubmissionDownload/tests/mockDownloadApplicationFile.ts
+++ b/apps/editor.planx.uk/src/pages/SubmissionDownload/tests/mockDownloadApplicationFile.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
-import { DOWNLOAD_APPLICATION_FILE_URL } from "pages/SubmissionDownload/VerifySubmissionEmail";
+
+const DOWNLOAD_APPLICATION_FILE_URL = `${import.meta.env.VITE_APP_API_URL}/download-application-files`;
 
 export const mockData = new ArrayBuffer(100); // a byte number is needed
 

--- a/apps/editor.planx.uk/src/testUtils.tsx
+++ b/apps/editor.planx.uk/src/testUtils.tsx
@@ -1,11 +1,25 @@
 /* eslint-disable no-restricted-imports */
 import { ThemeProvider } from "@mui/material";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, RenderResult } from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import { defaultTheme } from "./theme";
+
+const testQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      gcTime: 0,
+      staleTime: 0,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
 
 /**
  * Setup @testing-library/react environment with userEvent
@@ -15,5 +29,9 @@ export const setup = (
   jsx: JSX.Element,
 ): Record<"user", UserEvent> & RenderResult => ({
   user: userEvent.setup(),
-  ...render(<ThemeProvider theme={defaultTheme}>{jsx}</ThemeProvider>),
+  ...render(
+    <QueryClientProvider client={testQueryClient}>
+      <ThemeProvider theme={defaultTheme}>{jsx}</ThemeProvider>
+    </QueryClientProvider>,
+  ),
 });


### PR DESCRIPTION
## What does this PR do?
 - Refactors the `/download-application-files` endpoint handler from using `axios` directly to implementing the `useMutation()` hook
 - Moves API logic and associated types to `/api`

## Context
Part of implementing https://github.com/theopensystemslab/planx-new/blob/main/doc/architecture/decisions/0011-standardised-data-fetching-and-state-management.md which is being tracked here - https://github.com/orgs/theopensystemslab/projects/7/views/1
