### PR TITLE
fix(lps): Add missing env var

### DIFF
--- a/apps/localplanning.services/.env.production
+++ b/apps/localplanning.services/.env.production
@@ -1,3 +1,4 @@
 PUBLIC_PLANX_EDITOR_URL=https://editor.planx.uk
 PUBLIC_PLANX_GRAPHQL_API_URL=https://hasura.editor.planx.uk/v1/graphql
+PUBLIC_PLANX_BUILD_TIME_GRAPHQL_API_URL=${PUBLIC_PLANX_GRAPHQL_API_URL}
 PUBLIC_PLANX_REST_API_URL=https://api.editor.planx.uk


### PR DESCRIPTION
Lost in a rebase of https://github.com/theopensystemslab/planx-new/pull/5456 and not spotted...!

Running the `pnpm build --mode production --site https://localplanning.services` command locally works and builds ✅ 