### PR TITLE
chore(lps): Turn on CloudFlare proxying for production

### DIFF
--- a/infrastructure/application/services/lps.ts
+++ b/infrastructure/application/services/lps.ts
@@ -203,7 +203,7 @@ const createCNAMERecords = (domain: string, cdn: aws.cloudfront.Distribution) =>
       zoneId: config.require("lps-cloudflare-zone-id"),
       value: cdn.domainName,
       ttl: 1,
-      proxied: false,
+      proxied: true,
     });
 
     new cloudflare.Record("localplanningservices-www", {
@@ -212,7 +212,7 @@ const createCNAMERecords = (domain: string, cdn: aws.cloudfront.Distribution) =>
       zoneId: config.require("lps-cloudflare-zone-id"),
       value: cdn.domainName,
       ttl: 1,
-      proxied: false,
+      proxied: true,
     });
   }
 }


### PR DESCRIPTION
Toggled this manually via the CF console and I'm not hitting the infinite HTTP redirects I was expecting here. Worth turning on proxying as it gives us a number of benefits.