### PR TITLE
fix: Layout shift in flow due to loading external portals

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from "@apollo/client";
 import MoreVert from "@mui/icons-material/MoreVert";
 import Box from "@mui/material/Box";
-import { ComponentType, NodeTag } from "@opensystemslab/planx-core/types";
-import { ICONS } from "@planx/components/shared/icons";
+import { NodeTag } from "@opensystemslab/planx-core/types";
 import classNames from "classnames";
 import gql from "graphql-tag";
 import { useContextMenu } from "hooks/useContextMenu";
@@ -104,6 +103,7 @@ const ExternalPortal: React.FC<any> = (props) => {
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li ref={ref}>
         <Box
+          data-loading={href==="Loading..."}
           className={classNames("card", "portal", "external-portal", {
             isDragging,
           })}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -156,6 +156,9 @@ $fontMonospace: "Source Code Pro", monospace;
     &.template-card a {
       background: $black;
     }
+    .flow-locked & {
+      background: #555;
+    }
   }
 
   .card-title {
@@ -560,6 +563,13 @@ $fontMonospace: "Source Code Pro", monospace;
       left: -4px;
     }
   }
+
+  &.external-portal {
+    &[data-loading="true"] {
+      width: 260px;
+    }
+  }
+  
   .portalMenu {
     border-left: $nodeBorderWidth solid #aaa;
     display: flex;


### PR DESCRIPTION
## What does this PR do?
 - Minimises layout shift when loading flow by giving an external portal a min-width whilst loading

This means that instead of multiple portals going from the short "Loading..." to the longer string "opensystemslab/some-service-slug" (and causing a number of layout shifts as each one loads), we pre-set them to the max-width to 260px. 

This is still not perfect as there's some vertical shift (`team/slug` stretching over multiple lines) and some "spring" back (`team/slug` being shorter than 260px), but hopefully it's a step in the right direction...!