### PR TITLE
chore: Cleanup revoked JWTs daily

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1761225081009_daily-revoked-jwt-cleanup/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761225081009_daily-revoked-jwt-cleanup/down.sql
@@ -1,0 +1,1 @@
+SELECT cron.unschedule('daily-revoked-jwt-cleanup');

--- a/apps/hasura.planx.uk/migrations/default/1761225081009_daily-revoked-jwt-cleanup/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761225081009_daily-revoked-jwt-cleanup/up.sql
@@ -1,0 +1,5 @@
+SELECT cron.schedule(
+  'daily-revoked-jwt-cleanup',
+  '0 2 * * *',
+  $$DELETE FROM revoked_tokens WHERE expires_at < now()$$
+);


### PR DESCRIPTION
## What does this PR do?
 - Each night at 2am, clean up the revoked JWT table to remove expired tokens