### PR TITLE
chore: Cleanup LPS magic links

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1761225817269_daily-lps-magic-link-cleanup/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761225817269_daily-lps-magic-link-cleanup/down.sql
@@ -1,0 +1,1 @@
+SELECT cron.unschedule('daily-lps-magic-link-cleanup');

--- a/apps/hasura.planx.uk/migrations/default/1761225817269_daily-lps-magic-link-cleanup/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761225817269_daily-lps-magic-link-cleanup/up.sql
@@ -1,0 +1,5 @@
+SELECT cron.schedule(
+  'daily-lps-magic-link-cleanup',  
+  '0 2 * * *',           
+  $$DELETE FROM lps_magic_links WHERE used_at IS NOT NULL OR created_at < now() - INTERVAL '15 minutes'$$
+);


### PR DESCRIPTION
## What does this PR do?
 - Each night at 2am, clean up the LPS magic links table to remove consumed links