### PR TITLE
refactor: Use queryClient for flattened flow data

### DIFF
--- a/apps/editor.planx.uk/src/api/flow/requests.ts
+++ b/apps/editor.planx.uk/src/api/flow/requests.ts
@@ -1,3 +1,4 @@
+import { FlowGraph } from "@opensystemslab/planx-core/types";
 import apiClient from "api/client";
 
 import { CreateFlowResponse, NewFlow } from "./types";
@@ -59,3 +60,11 @@ export const moveFlow = async ({
   );
   return data;
 };
+
+export const getFlattenedFlowData = async({ flowId, isDraft = false }: { flowId: string, isDraft?: boolean }) => {
+  const { data } = await apiClient.get<FlowGraph>(
+    `/flows/${flowId}/flatten-data`, 
+    { params: { draft: isDraft } }
+  );
+  return data;
+}

--- a/apps/editor.planx.uk/src/index.tsx
+++ b/apps/editor.planx.uk/src/index.tsx
@@ -6,13 +6,11 @@ import { ApolloProvider } from "@apollo/client";
 import CssBaseline from "@mui/material/CssBaseline";
 import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 import { MyMap } from "@opensystemslab/map";
-import {
-  QueryClient,
-  QueryClientProvider,
-} from "@tanstack/react-query"
+import { QueryClientProvider } from "@tanstack/react-query"
 import { ToastContextProvider } from "contexts/ToastContext";
 import { getCookie, setCookie } from "lib/cookie";
 import { initFeatureFlags } from "lib/featureFlags";
+import { queryClient } from "lib/queryClient";
 import ErrorPage from "pages/ErrorPage/ErrorPage";
 import { AnalyticsProvider } from "pages/FlowEditor/lib/analytics/provider";
 import React, { Suspense, useEffect } from "react";
@@ -64,8 +62,6 @@ const hasJWT = (): boolean | void => {
   // TODO: observe any redirect in secure fashion
   window.location.href = "/";
 };
-
-const queryClient = new QueryClient()
 
 const Layout: React.FC<{
   children: React.ReactNode;

--- a/apps/editor.planx.uk/src/lib/queryClient.ts
+++ b/apps/editor.planx.uk/src/lib/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/apps/editor.planx.uk/src/routes/views/draft.tsx
+++ b/apps/editor.planx.uk/src/routes/views/draft.tsx
@@ -1,7 +1,7 @@
-import { FlowGraph } from "@opensystemslab/planx-core/types";
-import axios from "axios";
+import { getFlattenedFlowData } from "api/flow/requests";
 import gql from "graphql-tag";
 import { publicClient } from "lib/graphql";
+import { queryClient } from "lib/queryClient";
 import { NaviRequest, NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import PublicLayout from "pages/layout/PublicLayout";
@@ -31,7 +31,10 @@ export const draftView = async (req: NaviRequest) => {
   const flow = data.flows[0];
   if (!flow) throw new NotFoundError();
 
-  const flowData = await fetchDraftFlattenedFlowData(flow.id);
+  const flowData = await queryClient.fetchQuery({
+    queryKey: ["flattenedFlowData", "preview", flow.id],
+    queryFn: () => getFlattenedFlowData({ flowId: flow.id, isDraft: true }),
+  });
 
   const state = useStore.getState();
   state.setFlow({ id: flow.id, flow: flowData, flowSlug, flowName: flow.name });
@@ -106,21 +109,6 @@ const fetchSettingsForDraftView = async (
     return result.data;
   } catch (error) {
     console.error(error);
-    throw new NotFoundError();
-  }
-};
-
-const fetchDraftFlattenedFlowData = async (
-  flowId: string,
-): Promise<FlowGraph> => {
-  const url = `${
-    import.meta.env.VITE_APP_API_URL
-  }/flows/${flowId}/flatten-data?draft=true`;
-  try {
-    const { data } = await axios.get<FlowGraph>(url);
-    return data;
-  } catch (error) {
-    console.log(error);
     throw new NotFoundError();
   }
 };

--- a/apps/editor.planx.uk/src/routes/views/preview.tsx
+++ b/apps/editor.planx.uk/src/routes/views/preview.tsx
@@ -1,5 +1,5 @@
-import { FlowGraph } from "@opensystemslab/planx-core/types";
-import axios, { AxiosError } from "axios";
+import { getFlattenedFlowData } from "api/flow/requests";
+import { queryClient } from "lib/queryClient";
 import { NaviRequest, NotFoundError } from "navi";
 import { useStore } from "pages/FlowEditor/lib/store";
 import PublicLayout from "pages/layout/PublicLayout";
@@ -26,8 +26,10 @@ export const previewView = async (req: NaviRequest) => {
   if (!flow)
     throw new NotFoundError(`Flow ${flowSlug} not found for ${teamSlug}`);
 
-  // /preview fetches draft data of this flow and the latest published version of each external portal
-  const flowData = await fetchFlattenedFlowData(flow.id);
+  const flowData = await queryClient.fetchQuery({
+    queryKey: ["flattenedFlowData", "preview", flow.id],
+    queryFn: () => getFlattenedFlowData({ flowId: flow.id }),
+  });
 
   const state = useStore.getState();
   state.setFlow({
@@ -48,22 +50,4 @@ export const previewView = async (req: NaviRequest) => {
       </TestWarningPage>
     </PublicLayout>
   );
-};
-
-const fetchFlattenedFlowData = async (flowId: string): Promise<FlowGraph> => {
-  const url = `${
-    import.meta.env.VITE_APP_API_URL
-  }/flows/${flowId}/flatten-data`;
-  try {
-    const { data } = await axios.get<FlowGraph>(url);
-    return data;
-  } catch (error) {
-    console.log(error);
-    if (error instanceof AxiosError) {
-      alert(
-        `Cannot open this view, navigate back to the graph to keep editing. \n\n${error.response?.data?.error}`,
-      );
-    }
-    throw new NotFoundError();
-  }
 };


### PR DESCRIPTION
## What does this PR do?
 - Move `queryClient` to `/lib`
 - Make call to `flow/:id/flatten-data` via API layer and queryClient

Lots more room for improvement here in future - very much thinking of https://github.com/theopensystemslab/planx-new/pull/5440 - I think probably best to have a proper crack at this once the new router is in place.

Part of https://github.com/orgs/theopensystemslab/projects/7