### PR TITLE
chore: Update staging sync to accommodate wider timezones

### DIFF
--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -4,8 +4,8 @@ permissions: read-all
 
 on:
   schedule:
-    # Runs nightly at 00:00 (https://crontab.guru/#0_0_*_*_*)
-    - cron: '0 0 * * *'
+    # Runs nightly at 04:00 (https://crontab.guru/#0_4_*_*_*)
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The current sync at 12:00 UTC means 5pm in Portland, Oregon which is unideal...! This shifts if +4 hours which should work for both the UK and US west coast.

In the medium term this is not very sustainable clearly, so let's have a proper think about this again at some point. In the short tem this feels quick and pragmatic enough as a sticking plaster 👍 