### PR TITLE
chore(lps): Remove unused `description` property from the `Service` model

### DIFF
--- a/apps/localplanning.services/src/lib/lpa-api/index.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/index.ts
@@ -5,7 +5,6 @@ import { print } from "graphql";
 export interface Service {
   name: string;
   slug: string;
-  description: string | null;
   summary: string | null;
 }
 

--- a/apps/localplanning.services/src/lib/lpa-api/query.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/query.ts
@@ -52,6 +52,5 @@ export const GET_LPAS_QUERY = gql`
     name
     slug
     summary
-    description
   }
 `;


### PR DESCRIPTION
This is never used, so does not need to be fetched.

Alongside this, @augustlindemer will be improving the copy and validation within PlanX.

For further context please see - 
 - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1761552522770389 (OSL Slack)
 - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1761562617618979 (OSL Slack)