### PR TITLE
chore: change section copy from 'application' to 'form' [skip pizza]

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Section/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Public/index.test.tsx
@@ -19,7 +19,7 @@ describe("Section component", () => {
       />,
     );
 
-    expect(screen.getByText("Application incomplete.")).toBeInTheDocument();
+    expect(screen.getByText("Form incomplete.")).toBeInTheDocument();
     expect(screen.getByText("Continue")).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
   });

--- a/apps/editor.planx.uk/src/@planx/components/Section/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Public/index.tsx
@@ -89,7 +89,7 @@ export const Root = ({
     <CardHeader title={flowName} />
     <Box>
       <Typography variant="h3" component="h2" pb="0.25em">
-        Application incomplete.
+        Form incomplete.
       </Typography>
       <Typography variant="subtitle2" component="h3">
         {`You have completed ${


### PR DESCRIPTION
Sections are not only used in applications. 'Form' covers more bases.