### PR TITLE
fix(e2e): Handle missing resume page `ValidationSuccess` component

### DIFF
--- a/apps/editor.planx.uk/src/api/client.ts
+++ b/apps/editor.planx.uk/src/api/client.ts
@@ -2,6 +2,12 @@ import axios, { type AxiosError, type InternalAxiosRequestConfig } from "axios";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { toast } from "react-toastify";
 
+export interface APIError<T> {
+  message: string;
+  statusCode: number
+  data: T
+}
+
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_APP_API_URL,
   headers: {
@@ -41,7 +47,8 @@ apiClient.interceptors.response.use(
       return Promise.reject({
         message: "Unauthenticated",
         statusCode: 401,
-      });
+        data: error.response?.data,
+      } as APIError<unknown>);
     }
 
     if (status === 403) {
@@ -54,15 +61,15 @@ apiClient.interceptors.response.use(
       return Promise.reject({
         message: "Unauthorised",
         statusCode: 403,
-      });
+        data: error.response?.data,
+      } as APIError<unknown>);
     }
 
     const apiError = {
-      message:
-        error.message || error.response?.data || "An unexpected error occurred",
+      message: error.message || "An unexpected error occurred",
       statusCode: status,
       data: error.response?.data,
-    };
+    } as APIError<unknown>
 
     console.error("[API Error]:", apiError);
     return Promise.reject(apiError);


### PR DESCRIPTION
Regression introduced here - https://github.com/theopensystemslab/planx-new/pull/5469

When mapping across the various `ResumePage` states, I missed out `ValidationSuccess` - luckily caught by E2E tests.

Passing locally, passing on CI here - https://github.com/theopensystemslab/planx-new/actions/runs/18841285607 ✅ 