### PR TITLE
fix(lps): Improve page titles for home and search page

### DIFF
--- a/apps/localplanning.services/src/layouts/SearchLayout.astro
+++ b/apps/localplanning.services/src/layouts/SearchLayout.astro
@@ -14,7 +14,7 @@ const { title, description } = Astro.props;
 ---
 
 <Layout
-  title={title} 
+  title="Search"
   {...(description && { description: description })}
 >
   <Masthead title={title}>

--- a/apps/localplanning.services/src/pages/index.astro
+++ b/apps/localplanning.services/src/pages/index.astro
@@ -11,7 +11,7 @@ import lpaMap from "/public/planx-lpa-map.svg";
 const title = "Find local planning services";
 ---
 
-<Layout title={title}>
+<Layout>
   <Masthead title={title} size="large">
     <p>
       Modern digital services to send planning applications, reports and notices


### PR DESCRIPTION
Currently, both the home and search pages have titles of `"Find local planning services | Find local planning services"`

<img width="658" height="103" alt="image" src="https://github.com/user-attachments/assets/8e3f95a0-b322-4370-936e-0795b4fdb44f" />

<img width="423" height="132" alt="image" src="https://github.com/user-attachments/assets/51cd1bd2-cc6d-497d-96bd-78e82c9f2ff7" />
