### PR TITLE
chore: Replace hasura-cli

### DIFF
--- a/apps/hasura.planx.uk/package.json
+++ b/apps/hasura.planx.uk/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "hasura-cli": "^2.36.1"
+    "@kirillvakalov/hasura-cli": "^2.48.1"
   },
   "scripts": {
     "start": "hasura console --envfile ./../../.env"
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.10.0",
   "pnpm": {
     "onlyBuiltDependencies": [
-      "hasura-cli"
+      "@kirillvakalov/hasura-cli"
     ]
   }
 }

--- a/apps/hasura.planx.uk/pnpm-lock.yaml
+++ b/apps/hasura.planx.uk/pnpm-lock.yaml
@@ -8,92 +8,28 @@ importers:
 
   .:
     devDependencies:
-      hasura-cli:
-        specifier: ^2.36.1
-        version: 2.36.1
+      '@kirillvakalov/hasura-cli':
+        specifier: ^2.48.1
+        version: 2.48.1
 
 packages:
 
-  ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
-
-  axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-
-  chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
-
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
-
-  hasura-cli@2.36.1:
-    resolution: {integrity: sha512-h8MHlkkgjlnmFsjzJ+FYDecIB0zswtdvFszXLPsSsyOuCuIIGejAx3rSPFVIxyiZVXohbsJcgjJBe7r91BV3Wg==}
-    engines: {node: '>=8'}
+  '@kirillvakalov/hasura-cli@2.48.1':
+    resolution: {integrity: sha512-imcdv+ynHvHW7yQEX3UtlZyWIrRcacwOdvM5aMoEiXmV3glGgCPg7nx+knaQD+fl9Har1U4p0VTRvlDxXRv3hQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64, x64]
+    os: [darwin, linux, win32]
     hasBin: true
 
-  supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
 
 snapshots:
 
-  ansi-styles@3.2.1:
+  '@kirillvakalov/hasura-cli@2.48.1':
     dependencies:
-      color-convert: 1.9.3
+      semver: 7.7.3
 
-  axios@0.21.4:
-    dependencies:
-      follow-redirects: 1.15.11
-    transitivePeerDependencies:
-      - debug
-
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
-  color-name@1.1.3: {}
-
-  escape-string-regexp@1.0.5: {}
-
-  follow-redirects@1.15.11: {}
-
-  has-flag@3.0.0: {}
-
-  hasura-cli@2.36.1:
-    dependencies:
-      axios: 0.21.4
-      chalk: 2.4.2
-    transitivePeerDependencies:
-      - debug
-
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
+  semver@7.7.3: {}


### PR DESCRIPTION
Replaces https://www.npmjs.com/package/hasura-cli with https://www.npmjs.com/package/@kirillvakalov/hasura-cli

This is a pretty new package in terms of adoption, but the current `hasura-cli` is seemingly abandoned. I reckon we give it a try for a while and see how we get on.

Just as a sense check I'd appreciate if another dev could please - 
 - Pull branch `dp/alternate-hasura-cli` locally
 - `cd apps/hasura.plan.uk && pnpm i`
 - `pnpm start`
 - See Hasura start locally on port 9695 without issue, still creates migration scripts if you make a random local change

Moving away from `hasura-cli` will fix - 
 - https://github.com/theopensystemslab/planx-new/security/dependabot/291
 - https://github.com/theopensystemslab/planx-new/security/dependabot/292
 - https://github.com/theopensystemslab/planx-new/security/dependabot/293