### PR TITLE
feat: create indexes on analytics mvs

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1761662164335_create_analytics_mv_indexes/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761662164335_create_analytics_mv_indexes/down.sql
@@ -1,0 +1,15 @@
+
+DROP INDEX IF EXISTS analytics_action_nodes_flow_id_idx
+  ON analytics_action_nodes (flow_id);
+
+DROP INDEX IF EXISTS analytics_exits_flow_id_idx
+  ON analytics_exits (flow_id);
+
+DROP INDEX IF EXISTS analytics_journeys_aggregated_flow_id_idx
+  ON analytics_journeys_aggregated (flow_id);
+
+DROP INDEX IF EXISTS analytics_results_flow_id_idx
+  ON analytics_results (flow_id);
+
+DROP INDEX IF EXISTS analytics_sessions_flow_id_idx
+  ON analytics_sessions (flow_id);

--- a/apps/hasura.planx.uk/migrations/default/1761662164335_create_analytics_mv_indexes/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761662164335_create_analytics_mv_indexes/up.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IF NOT EXISTS analytics_action_nodes_flow_id_idx
+  ON analytics_action_nodes (flow_id);
+
+CREATE INDEX IF NOT EXISTS analytics_exits_flow_id_idx
+  ON analytics_exits (flow_id);
+
+CREATE INDEX IF NOT EXISTS analytics_journeys_aggregated_flow_id_idx
+  ON analytics_journeys_aggregated (flow_id);
+
+CREATE INDEX IF NOT EXISTS analytics_results_flow_id_idx
+  ON analytics_results (flow_id);
+  
+CREATE INDEX IF NOT EXISTS analytics_sessions_flow_id_idx
+  ON analytics_sessions (flow_id);


### PR DESCRIPTION
As discussed in dev call, creates indexes on `flow_id` for the new materialized analytics views. No need to use `concurrently` because we'll be updating the views once a night anyway.