### PR TITLE
feat: set up cron jobs to refresh mvs

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1761736920627_refresh_analytics_mvs/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761736920627_refresh_analytics_mvs/down.sql
@@ -1,0 +1,5 @@
+SELECT cron.unschedule('refresh_analytics_action_nodes');
+SELECT cron.unschedule('refresh_analytics_exits');
+SELECT cron.unschedule('refresh_analytics_sessions');
+SELECT cron.unschedule('refresh_analytics_results');
+SELECT cron.unschedule('refresh_analytics_journeys_aggregated');

--- a/apps/hasura.planx.uk/migrations/default/1761736920627_refresh_analytics_mvs/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761736920627_refresh_analytics_mvs/up.sql
@@ -1,0 +1,29 @@
+SELECT cron.schedule(
+  'refresh_analytics_action_nodes',
+  '0 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_action_nodes$$
+);
+
+SELECT cron.schedule(
+  'refresh_analytics_exits',
+  '5 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_exits$$
+);
+
+SELECT cron.schedule(
+  'refresh_analytics_sessions',
+  '10 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_sessions$$
+);
+
+SELECT cron.schedule(
+  'refresh_analytics_results',
+  '15 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_results$$
+);
+
+SELECT cron.schedule(
+  'refresh_analytics_journeys_aggregated',
+  '20 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_journeys_aggregated$$
+);


### PR DESCRIPTION
Sets up cron jobs to refresh materialized views nightly around 3am (spaced out by 5 min). 

I'm wondering how we'd check that these are set up correctly afterwards--checking AWS console? 