### PR TITLE
feat: use cron schema to track jobs in Hasura

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/cron_job.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/cron_job.yaml
@@ -1,0 +1,3 @@
+table:
+  name: job
+  schema: cron

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/cron_job_run_details.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/cron_job_run_details.yaml
@@ -1,0 +1,3 @@
+table:
+  name: job_run_details
+  schema: cron

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -1,3 +1,5 @@
+- "!include cron_job.yaml"
+- "!include cron_job_run_details.yaml"
 - "!include public_analytics.yaml"
 - "!include public_analytics_action_nodes.yaml"
 - "!include public_analytics_exits.yaml"


### PR DESCRIPTION
Following [Daf's comment](https://github.com/theopensystemslab/planx-new/pull/5546#issuecomment-3461058904) on #5546, uses Hasura's cron schema to track jobs. 

I made a job run every 5 min and then viewed the logs in Hasura & checked the mv it updated (where my logs showed correctly)--nice and easy for observability indeed!
<img width="2246" height="112" alt="Screenshot 2025-10-29 114946" src="https://github.com/user-attachments/assets/8e5124a4-1de3-4f21-aa54-3b10f890666e" />
