### PR TITLE
style(lps): Align option card buttons to bottom

### DIFF
--- a/apps/localplanning.services/src/components/OptionCard.astro
+++ b/apps/localplanning.services/src/components/OptionCard.astro
@@ -12,7 +12,7 @@ const { action } = Astro.props;
 const { title, description } = actions[action];
 ---
 
-<div class="w-full lg:w-1/3 bg-bg-light clamp-[py,5,8] clamp-[px,4,8] rounded">
+<div class="w-full lg:w-1/3 bg-bg-light clamp-[py,5,8] clamp-[px,4,8] rounded flex flex-col justify-start">
   <div class="clamp-[mb,4,6]">
     <h2 class="text-heading-sm">{title}</h2>
     <p class="text-text-secondary text-body-md">
@@ -24,6 +24,7 @@ const { title, description } = actions[action];
     variant="primary"
     data-action-button
     data-action={action}
+    class="m-0 mt-auto self-start"
   >
     Find local planning services
   </Button>


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Aligns buttons of option cards to bottom (suggestion via Slack)

**Before:**
<img width="1197" height="308" alt="image" src="https://github.com/user-attachments/assets/1ef7642a-21af-4cfa-a64b-b482d9b0f51a" />


**After:**
<img width="1197" height="308" alt="image" src="https://github.com/user-attachments/assets/5e689c51-5086-4b5e-97a9-400f5c46489d" />

