### PR TITLE
fix(editor): Clear cached flows and improve restart within Editor

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PreviewBrowser/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PreviewBrowser/index.tsx
@@ -23,9 +23,10 @@ const ResetToggle = styled(Button)(({ theme }) => ({
 }));
 
 export const PreviewBrowser: React.FC = () => {
-  const [resetPreview, flow] = useStore((state) => [
+  const [resetPreview, flow, currentCard] = useStore((state) => [
     state.resetPreview,
     state.flow,
+    state.currentCard,
   ]);
   const isLoading = isEmpty(flow);
 
@@ -62,7 +63,7 @@ export const PreviewBrowser: React.FC = () => {
           text="Loading flow data..."
         />
       ) : (
-        <Questions previewEnvironment="editor" />
+        <Questions previewEnvironment="editor" key={currentCard?.id} />
       )}
     </ThemeProvider>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -88,6 +88,7 @@ export const sharedStore: StateCreator<
       restore: false,
       changedNode: undefined,
       saveToEmail: "",
+      currentCard: null,
     });
 
     removeSessionIdSearchParam();

--- a/apps/editor.planx.uk/src/routes/team.tsx
+++ b/apps/editor.planx.uk/src/routes/team.tsx
@@ -41,9 +41,16 @@ const routes = compose(
   })),
 
   withContext(async (req) => {
-    const { initTeamStore, teamSlug: currentSlug } = useStore.getState();
+    const {
+      initTeamStore,
+      teamSlug: currentSlug,
+      resetPreview,
+    } = useStore.getState();
     const routeSlug =
       req.params.team || (await getTeamFromDomain(window.location.hostname));
+
+    // Clear any cached data from previous flows
+    resetPreview();
 
     if (currentSlug !== routeSlug) {
       try {

--- a/apps/editor.planx.uk/src/utils.ts
+++ b/apps/editor.planx.uk/src/utils.ts
@@ -70,9 +70,12 @@ export const isLiveEnv = () =>
 
 export const removeSessionIdSearchParam = () => {
   const currentURL = new URL(window.location.href);
-  currentURL.searchParams.delete("sessionId");
-  window.history.pushState({}, document.title, currentURL);
-  window.location.reload();
+  // Only reload page on public interface of PlanX, not Editor interface
+  if (currentURL.searchParams.get("sessionId")) {
+    currentURL.searchParams.delete("sessionId");
+    window.history.pushState({}, document.title, currentURL);
+    window.location.reload();
+  }
 };
 
 export const exhaustiveCheck = (type: never): never => {


### PR DESCRIPTION
_🍒 Cherry-picked from https://github.com/theopensystemslab/planx-new/pull/5521 to avoid large messy rebase!_

## What does this PR do?
 - Fixes common `"id {nodeId} not found"` error which occurs when a new flow is navigated to
 - Improves "restart" within the Editor - we don't need to refresh the whole page here, we can just reset the relevant store

This PR points to https://github.com/theopensystemslab/planx-new/pull/5437 as that's where I started to work on this, and I wanted to ensure there were no other flow loading issues competing with this on `main`.

### Problem
Here's the underlying problem which this PR fixes - we're relying on a stale nodeID within the `<Questions/>` component. On load, this ID is not found, and an error is thrown.

The first thing `<Questions/>` does is to reset this ID, via a call to `setCurrentCard()` - 

```ts
  // Initial setup
  useEffect(() => {
    setCurrentCard();
    ...
  })
```

This function does reset the node id to null, but the component is relying on the existing nodeId from the store and throws and error before this value is updated.

```ts
const Questions = ({ previewEnvironment }: QuestionsProps) => {
  const [
    // other imports
    node, // <-- This is a stale, static, node from the **previous** flow
    setCurrentCard,
    progress,
  ] = useStore((state) => [
    // other imports
    state.currentCard,
    state.setCurrentCard,
    state.sectionProgress,
  ]);
```

### Solution
Explicitly reset `currentCard` to `null` when navigating out of a flow. Initially I tried to tie this to the unmount of the `<Questions/>` component and not associate it with the route. This worked, and hid the issue from the interface, but the error was still thrown in the console (and will be sent to Airbrake).


## To test...
### "id {nodeId} not found" error
**On staging**
- Navigate to https://editor.planx.dev/buckinghamshire/confirmation-pages (flow 1)
- Navigate back to the Bucks team
- Navigate to a different Bucks flow (flow 2)
- Error appears referring to node from flow 1 ❌ 

**On pizza**
- Navigate to https://5550.planx.pizza/buckinghamshire/confirmation-pages (flow 1)
- Navigate back to the Bucks team
- Navigate to a different Bucks flow (flow 2)
- No error ✅ 

### Full page reload when Editor hits "restart"
**On staging**
- Navigate to https://editor.planx.dev/buckinghamshire/confirmation-pages
- Answer a few questions
- Hit "restart"
- Whole page reloads ❌ 
- "Restart" works as expected on `/draft`, `/preview` and `/published ✅ 

**On pizza**
- Navigate to https://5550.planx.pizza/buckinghamshire/confirmation-pages 
- Answer a few questions
- Hit "restart"
- Only the `PreviewEditor` reloads ✅ 
- "Restart" works as expected on `/draft`, `/preview` and `/published ✅ 


<img width="846" height="806" alt="image" src="https://github.com/user-attachments/assets/972c2df3-2773-4618-a080-4ba07d73f76f" />
