### PR TITLE
poc(hasura): Publish list of services via Hasura REST endpoint

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -107,6 +107,11 @@ computed_fields:
         name: compile_flow_portals
         schema: public
     comment: Flow data with portals merged in
+  - name: url
+    definition:
+      function:
+        name: flow_url
+        schema: public
 insert_permissions:
   - role: api
     permission:
@@ -271,6 +276,7 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - url
       filter:
         deleted_at:
           _is_null: true
@@ -299,6 +305,7 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - url
       filter:
         _and:
           - _or:
@@ -341,6 +348,7 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - url
       filter:
         deleted_at:
           _is_null: true
@@ -368,6 +376,7 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - url
       filter:
         deleted_at:
           _is_null: true
@@ -397,6 +406,7 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - url
       filter:
         deleted_at:
           _is_null: true

--- a/apps/hasura.planx.uk/metadata/query_collections.yaml
+++ b/apps/hasura.planx.uk/metadata/query_collections.yaml
@@ -10,3 +10,14 @@
               usersLast30Days: users_last_30_days
             }
           }
+      - name: GetServicesByTeamSlug
+        query: |
+          query GetServicesByTeamSlug ($teamSlug: String!) {
+            services: flows(where: {status:{_eq:online},team:{slug:{_eq:$teamSlug}}}, order_by: {name:asc}) {
+              name
+              url
+              summary
+              description
+              limitations
+            }
+          }

--- a/apps/hasura.planx.uk/metadata/rest_endpoints.yaml
+++ b/apps/hasura.planx.uk/metadata/rest_endpoints.yaml
@@ -6,7 +6,7 @@
   methods:
     - GET
   name: GetServicesByTeamSlug
-  url: :teamSlug/services
+  url: v1/:teamSlug/services
 - comment: ""
   definition:
     query:

--- a/apps/hasura.planx.uk/metadata/rest_endpoints.yaml
+++ b/apps/hasura.planx.uk/metadata/rest_endpoints.yaml
@@ -2,6 +2,15 @@
   definition:
     query:
       collection_name: allowed-queries
+      query_name: GetServicesByTeamSlug
+  methods:
+    - GET
+  name: GetServicesByTeamSlug
+  url: :teamSlug/services
+- comment: ""
+  definition:
+    query:
+      collection_name: allowed-queries
       query_name: PlanX website stats
   methods:
     - GET

--- a/apps/hasura.planx.uk/migrations/default/1761856043668_run_sql_migration/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761856043668_run_sql_migration/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.flow_url;

--- a/apps/hasura.planx.uk/migrations/default/1761856043668_run_sql_migration/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1761856043668_run_sql_migration/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION public.flow_url(flow_row flows)
+RETURNS TEXT AS $$
+  SELECT 
+    CASE 
+      WHEN t.domain IS NOT NULL AND t.domain != '' 
+      THEN 'https://' || t.domain || '/' || flow_row.slug
+      ELSE 'https://editor.planx.uk/' || t.slug || '/' || flow_row.slug || '/published'
+    END
+  FROM teams t
+  WHERE t.id = flow_row.team_id
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
Quick proof-of-concept on publishing list of available flows via Hasura REST. I'm really not sure what the best line to draw is here - surely it's not too much of a barrier for people to integrate via GraphQL? I sort of see these endpoint as cheap/easy docs - we can pre-bake certain queries at certain paths and easily expose without any additional documentation or framing.

Exposing the limitations and descriptions might be an issue as we explicitly say "this is not visible to users" - is that the same as "this is not public"? Currently, I'd expect an Editor to think this field is private.

<img width="1096" height="1252" alt="image" src="https://github.com/user-attachments/assets/8f0bebfe-a4db-4d42-aa20-e48b1aebd0bb" />
