### PR TITLE
fix: Retain sidebar state when navigating within a flow

### DIFF
--- a/apps/editor.planx.uk/src/routes/team.tsx
+++ b/apps/editor.planx.uk/src/routes/team.tsx
@@ -41,16 +41,9 @@ const routes = compose(
   })),
 
   withContext(async (req) => {
-    const {
-      initTeamStore,
-      teamSlug: currentSlug,
-      resetPreview,
-    } = useStore.getState();
+    const { initTeamStore, teamSlug: currentSlug } = useStore.getState();
     const routeSlug =
       req.params.team || (await getTeamFromDomain(window.location.hostname));
-
-    // Clear any cached data from previous flows
-    resetPreview();
 
     if (currentSlug !== routeSlug) {
       try {
@@ -62,10 +55,17 @@ const routes = compose(
   }),
 
   mount({
-    "/": route(() => ({
-      title: makeTitle(useStore.getState().teamName),
-      view: <Team />,
-    })),
+    "/": compose(
+      withContext(async () => {
+        // Clear any cached data from previous flows
+        useStore.getState().resetPreview();
+      }),
+
+      route(() => ({
+        title: makeTitle(useStore.getState().teamName),
+        view: <Team />,
+      })),
+    ),
 
     "/:flow": lazy(async (req) => {
       const [slug] = req.params.flow.split(",");


### PR DESCRIPTION
## What's the problem?
When navigating within a flow (for example, into a folder) the sidebar state is reset. It should retain your current position whilst within the context of a single flow.

This regression was introduced here - https://github.com/theopensystemslab/planx-new/pull/5550

## What's the cause?
`resetPreview()` is being mistakenly called within the root `withContext()` of the team routes - meaning it's called on _each_ change of navigation. We can see that opening a modal on staging currently also exhibits this behaviour - the sidebar state is reset.

## What's the solution?
Only call `resetPreview()` when navigating to a brand new route (change of flow) - this ensures the preview state is maintained.

## Testing
1. The steps outlined in https://github.com/theopensystemslab/planx-new/pull/5550 can still be repeated - 

   - Navigate to https://5560.planx.pizza/buckinghamshire/confirmation-pages (flow 1)
   - Navigate back to the Bucks team
   - Navigate to a different Bucks flow (flow 2)
   - No error ✅
 
2. I can navigate through a few questions, open an Editor modal, and the sidebar state is preserved

3. I can navigate through a few questions, open a folder, and the sidebar state is preserved