### PR TITLE
make instance type interchangeable as a config input

### DIFF
--- a/infrastructure/ml/Pulumi.staging.yaml
+++ b/infrastructure/ml/Pulumi.staging.yaml
@@ -5,3 +5,4 @@ config:
     tags:
       project: ml
   ml:ssh-devops-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIib33oz+oCvapvEMqXoYGLdtrUGuxdaL3LMRHgd5rGm devops@opensystemslab.io
+  ml:training-instance-type: g6.xlarge


### PR DESCRIPTION
We may use instances other than `g6.xlarge` from time to time (e.g. `g4dn.xlarge` for experimentation, `g5.2xlarge` for big runs), so pulling instance type out as an input and fixing the README accordingly.