### PR TITLE
fix: Remove template team trigger from sync script

### DIFF
--- a/scripts/seed-database/write/users.sql
+++ b/scripts/seed-database/write/users.sql
@@ -13,11 +13,6 @@ CREATE TEMPORARY TABLE sync_users (
 
 \copy sync_users FROM '/tmp/users.csv'  WITH (FORMAT csv, DELIMITER ';');
 
--- Do not automatically generate team_member records for the templates team
--- We manually truncate and replace the team_members table in another step
-ALTER TABLE
-  users DISABLE TRIGGER grant_new_user_template_team_access;
-
 INSERT INTO users (
   id,
   first_name,
@@ -44,8 +39,5 @@ SET
   is_platform_admin = EXCLUDED.is_platform_admin,
   is_staging_only = EXCLUDED.is_staging_only,
   is_analyst = EXCLUDED.is_analyst;
-
-ALTER TABLE
-  users ENABLE TRIGGER grant_new_user_template_team_access;
 
 SELECT setval('users_id_seq', max(id)) FROM users;


### PR DESCRIPTION
## What's the problem?
The db sync process is failing with the current error - 

```sh
Beginning write transaction...
psql:/tmp/sync.sql:1: NOTICE:  truncate cascades to table "operations"
psql:/tmp/sync.sql:1: NOTICE:  truncate cascades to table "published_flows"
psql:/tmp/sync.sql:1: NOTICE:  truncate cascades to table "sessions"
psql:/tmp/sync.sql:1: NOTICE:  truncate cascades to table "flow_status_history"
psql:/tmp/sync.sql:1: NOTICE:  truncate cascades to table "templated_flow_edits"
psql:write/users.sql:19: ERROR:  trigger "grant_new_user_template_team_access" for table "users" does not exist
Database sync failed!
```

## What's the solution?
The current sync script toggles the `grant_new_user_template_team_access` trigger which was removed in https://github.com/theopensystemslab/planx-new/pull/5454.

Removing this from the scripts (as it's also removed from Hasura) solves this.