### PR TITLE
feat(editor): Add optional rules to `Question` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Question/OptionsEditor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/OptionsEditor.tsx
@@ -20,6 +20,7 @@ const QuestionOptionsEditor: React.FC<BaseOptionsEditorProps> = ({
       showValueField={showValueField}
       showDescriptionField
       index={index}
+      showRuleBuilder={true}
     />
   );
 };

--- a/apps/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
@@ -44,40 +44,40 @@ const responses: { [key in QuestionLayout]: PublicQuestion["responses"] } = {
   [QuestionLayout.Basic]: [
     {
       id: "pizza_id",
-      responseKey: "pizza",
-      title: "Pizza",
+      responseKey: 1,
+      text: "Pizza",
     },
     {
       id: "celery_id",
-      responseKey: "celery",
-      title: "Celery",
+      responseKey: 2,
+      text: "Celery",
     },
   ],
   [QuestionLayout.Images]: [
     {
       id: "pizza_id",
-      responseKey: "pizza",
-      title: "Pizza",
+      responseKey: 1,
+      text: "Pizza",
       img: "pizza.jpg",
     },
     {
       id: "celery_id",
-      responseKey: "celery",
-      title: "Celery",
+      responseKey: 2,
+      text: "Celery",
       img: "celery.jpg",
     },
   ],
   [QuestionLayout.Descriptions]: [
     {
       id: "pizza_id",
-      responseKey: "pizza",
-      title: "Pizza",
+      responseKey: 1,
+      text: "Pizza",
       description: "This is a pizza",
     },
     {
       id: "celery_id",
-      responseKey: "celery",
-      title: "Celery",
+      responseKey: 2,
+      text: "Celery",
       description: "This is celery",
     },
   ],

--- a/apps/editor.planx.uk/src/@planx/components/Question/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Public.tsx
@@ -132,7 +132,7 @@ const QuestionComponent: React.FC<PublicProps<PublicQuestion>> = (props) => {
                             <BasicRadio
                               {...buttonProps}
                               {...response}
-                              label={response.title}
+                              label={response.text}
                               data-testid="basic-radio"
                               key={`basic-radio-${response.id}`}
                             />

--- a/apps/editor.planx.uk/src/@planx/components/Question/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Public.tsx
@@ -16,6 +16,7 @@ import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import { mixed, object, string } from "yup";
 
+import { useConditionalResponses } from "../shared/RuleBuilder/hooks/useConditionalResponses";
 import { PublicProps } from "../shared/types";
 import { PublicQuestion } from "./model";
 
@@ -35,6 +36,8 @@ const QuestionComponent: React.FC<PublicProps<PublicQuestion>> = (props) => {
   const previousResponseKey = props.responses.find(
     (response) => response.id === previousResponseId,
   )?.responseKey;
+
+  const responses = useConditionalResponses(props.responses);
 
   const formik = useFormik({
     initialValues: {
@@ -61,17 +64,15 @@ const QuestionComponent: React.FC<PublicProps<PublicQuestion>> = (props) => {
   });
 
   let layout = QuestionLayout.Basic;
-  if (props.responses.find((r) => r.img && r.img.length)) {
+  if (responses.find((r) => r.img && r.img.length)) {
     layout = QuestionLayout.Images;
-  } else if (
-    props.responses.find((r) => r.description && r.description.length)
-  ) {
+  } else if (responses.find((r) => r.description && r.description.length)) {
     layout = QuestionLayout.Descriptions;
   }
 
   // Auto-answered Questions still set a breadcrumb even though they render null
   useEffect(() => {
-    if (isStickyNote || props.autoAnswers) {
+    if (isStickyNote || props.autoAnswers || !responses.length) {
       props.handleSubmit?.({
         answers: props.autoAnswers,
         auto: true,
@@ -80,7 +81,7 @@ const QuestionComponent: React.FC<PublicProps<PublicQuestion>> = (props) => {
   }, [isStickyNote, props.autoAnswers]);
 
   // Auto-answered Questions are not publicly visible
-  if (isStickyNote || props.autoAnswers) {
+  if (isStickyNote || props.autoAnswers || !responses.length) {
     return null;
   }
 
@@ -115,7 +116,7 @@ const QuestionComponent: React.FC<PublicProps<PublicQuestion>> = (props) => {
                 spacing={layout === QuestionLayout.Images ? 2 : 0}
                 alignItems="stretch"
               >
-                {props.responses?.map((response) => {
+                {responses?.map((response) => {
                   const onChange = () => {
                     formik.setFieldValue("selected.id", response.id);
                     formik.setFieldValue("selected.a", response.responseKey);

--- a/apps/editor.planx.uk/src/@planx/components/Question/Question.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Question.stories.tsx
@@ -22,18 +22,18 @@ export const Basic = {
       "**Flat** includes maisonettes (a flat with more than one storey that is within a shared building)",
     handleSubmit: () => {},
     responses: [
-      { id: "House", responseKey: "House", title: "House" },
+      { id: "House", responseKey: 1, text: "House" },
       {
         id: "Flat",
-        responseKey: "Flat",
-        title: "Flat (or building containing flats)",
+        responseKey: 2,
+        text: "Flat (or building containing flats)",
       },
       {
         id: "HMO",
-        responseKey: "HMO",
-        title: "A house in multiple occupation (HMO)",
+        responseKey: 3,
+        text: "A house in multiple occupation (HMO)",
       },
-      { id: "Other", responseKey: "Other", title: "Something else" },
+      { id: "Other", responseKey: 4, text: "Something else" },
     ],
   },
 } satisfies Story;
@@ -46,28 +46,28 @@ export const WithDescriptions = {
     responses: [
       {
         id: "Detached",
-        responseKey: "Detached",
-        title: "Detached",
+        responseKey: 1,
+        text: "Detached",
         description: "A detached house is not joined to another property.",
       },
       {
         id: "Semi-detached",
-        responseKey: "Semi-detached",
-        title: "Semi-detached",
+        responseKey: 2,
+        text: "Semi-detached",
         description:
           "A semi-detached house is joined to 1 other property which, in turn, is not attached to any other properties. So together, the 2 properties form a pair.",
       },
       {
         id: "Terrace",
-        responseKey: "Terrace",
-        title: "Terrace",
+        responseKey: 3,
+        text: "Terrace",
         description:
           "A terrace is a building that forms part of a row of 3 or more adjoining properties.",
       },
       {
         id: "End terrace",
-        responseKey: "End terrace",
-        title: "End terrace",
+        responseKey: 4,
+        text: "End terrace",
         description:
           "An end terrace is the building at the end of the row of a terrace.",
       },
@@ -83,26 +83,26 @@ export const WithImages = {
     responses: [
       {
         id: "Detached",
-        responseKey: "Detached",
-        title: "Detached",
+        responseKey: 1,
+        text: "Detached",
         img: "https://api.editor.planx.uk/file/public/pk8f4g4h/housetypes_detached.png",
       },
       {
         id: "Semi-detached",
-        responseKey: "Semi-detached",
-        title: "Semi-detached",
+        responseKey: 1,
+        text: "Semi-detached",
         img: "https://api.editor.planx.uk/file/public/2jpkk6ei/housetypes_semiDetached.png",
       },
       {
         id: "Terrace",
-        responseKey: "Terrace",
-        title: "Terrace",
+        responseKey: 3,
+        text: "Terrace",
         img: "https://api.editor.planx.uk/file/public/btyxwr2j/housetypes_midterrace.png",
       },
       {
         id: "End terrace",
-        responseKey: "End terrace",
-        title: "End terrace",
+        responseKey: 4,
+        text: "End terrace",
         img: "https://api.editor.planx.uk/file/public/u0lwhiv2/housetypes_endterrace.png",
       },
     ],

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
@@ -20,6 +20,10 @@ export interface BaseOptionsEditorProps {
   children?: ReactNode;
   disabled?: boolean;
   index: number;
+  /**
+   * Temp prop to allow the RuleBuilder to be hidden on the Checklist component
+   */
+  showRuleBuilder?: boolean;
 }
 
 export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
@@ -112,19 +116,21 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
         });
       }}
     />
-    <RuleBuilder
-      conditions={[Condition.AlwaysRequired, Condition.RequiredIf]}
-      disabled={props.disabled}
-      rule={props.value.data.rule || DEFAULT_RULE}
-      onChange={(rule) =>
-        props.onChange({
-          ...props.value,
-          data: {
-            ...props.value.data,
-            rule,
-          },
-        })
-      }
-    />
+    {props.showRuleBuilder && (
+      <RuleBuilder
+        conditions={[Condition.AlwaysRequired, Condition.RequiredIf]}
+        disabled={props.disabled}
+        rule={props.value.data.rule || DEFAULT_RULE}
+        onChange={(rule) =>
+          props.onChange({
+            ...props.value,
+            data: {
+              ...props.value.data,
+              rule,
+            },
+          })
+        }
+      />
+    )}
   </div>
 );

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor.tsx
@@ -4,9 +4,11 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import InputRowItem from "ui/shared/InputRowItem";
 
-import { Option } from ".";
+import { DEFAULT_RULE, Option } from ".";
 import { DataFieldAutocomplete } from "./DataFieldAutocomplete";
 import { FlagsSelect } from "./FlagsSelect";
+import { RuleBuilder } from "./RuleBuilder";
+import { Condition } from "./RuleBuilder/types";
 
 export interface BaseOptionsEditorProps {
   value: Option;
@@ -109,6 +111,20 @@ export const BaseOptionsEditor: React.FC<BaseOptionsEditorProps> = (props) => (
           },
         });
       }}
+    />
+    <RuleBuilder
+      conditions={[Condition.AlwaysRequired, Condition.RequiredIf]}
+      disabled={props.disabled}
+      rule={props.value.data.rule || DEFAULT_RULE}
+      onChange={(rule) =>
+        props.onChange({
+          ...props.value,
+          data: {
+            ...props.value.data,
+            rule,
+          },
+        })
+      }
     />
   </div>
 );

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.stories.tsx
@@ -13,7 +13,8 @@ export default meta;
 
 export const Basic = {
   args: {
-    title: "Prior approval",
+    text: "Prior approval",
+    responseKey: 1,
     description: "This option has a description underneath.",
     onChange: () => console.log("Radio changed"),
     id: "1",

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
@@ -5,10 +5,9 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-export interface Props {
-  id?: string;
-  title: string;
-  description?: string;
+import { Response } from "../..";
+
+export interface Props extends Response {
   onChange: RadioProps["onChange"];
 }
 
@@ -19,7 +18,7 @@ const StyledFormLabel = styled(FormLabel)(({ theme }) => ({
 }));
 
 const DescriptionRadio: React.FC<Props> = ({
-  title,
+  text,
   description,
   onChange,
   id,
@@ -29,7 +28,7 @@ const DescriptionRadio: React.FC<Props> = ({
       <Radio value={id} onChange={onChange} />
       <Box>
         <Typography color="text.primary" variant="body1" pt={0.95}>
-          {title}
+          {text}
         </Typography>
         <Typography variant="body2" pt={0.5}>
           {description}

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio/ImageRadio.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio/ImageRadio.stories.tsx
@@ -13,7 +13,8 @@ export default meta;
 
 export const Basic = {
   args: {
-    title: "Prior approval",
+    text: "Prior approval",
+    responseKey: 1,
     img: "https://planx-temp.s3.eu-west-2.amazonaws.com/production/mdc5c7eb/Terrace_wraparound.svg",
     onChange: () => console.log("Radio changed"),
     description: "This option has a description underneath.",

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio/ImageRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio/ImageRadio.tsx
@@ -7,12 +7,9 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React, { useLayoutEffect, useRef, useState } from "react";
 
-export interface Props {
-  id?: string;
-  title: string;
-  description?: string;
-  responseKey?: string | number;
-  img?: string;
+import { Response } from "../..";
+
+export interface Props extends Response {
   onChange: RadioProps["onChange"];
 }
 
@@ -89,7 +86,7 @@ const StyledFormLabel = styled(FormLabel, {
 }));
 
 const TextLabel = (props: Props): FCReturn => {
-  const { title, id, onChange, description } = props;
+  const { text, id, onChange, description } = props;
   const [multiline, setMultiline] = useState(false);
 
   const textContentEl = useRef<HTMLDivElement>(null);
@@ -113,7 +110,7 @@ const TextLabel = (props: Props): FCReturn => {
     >
       <TextLabelContainer>
         <Radio value={id} onChange={onChange} />
-        <Typography>{title}</Typography>
+        <Typography>{text}</Typography>
       </TextLabelContainer>
       <Typography variant="body2">{description}</Typography>
     </TextLabelRoot>

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.test.tsx
@@ -52,7 +52,7 @@ describe("no rules", () => {
       {
         id: "response-3",
         responseKey: 3,
-        text: "Budgee",
+        text: "Budgie",
       },
       {
         id: "response-4",
@@ -90,7 +90,7 @@ describe("simple rules (Condition.AlwaysRequired)", () => {
       {
         id: "response-3",
         responseKey: 3,
-        text: "Budgee",
+        text: "Budgie",
         rule: { condition: Condition.NotRequired },
       },
     ];
@@ -128,7 +128,7 @@ describe("condition rules (Condition.RequiredIf)", () => {
     {
       id: "response-3",
       responseKey: 3,
-      text: "Budgee",
+      text: "Budgie",
       rule: {
         condition: Condition.RequiredIf,
         operator: Operator.Equals,
@@ -162,7 +162,7 @@ describe("condition rules (Condition.RequiredIf)", () => {
 
     // Only matching responses displayed
     expect(result.current).toHaveLength(1);
-    expect(result.current[0].text).toEqual("Budgee");
+    expect(result.current[0].text).toEqual("Budgie");
   });
 
   it("filters out responses if the rules are not met", () => {

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.test.tsx
@@ -1,0 +1,181 @@
+import { renderHook } from "@testing-library/react";
+import { logger } from "airbrake";
+import { FullStore, useStore } from "pages/FlowEditor/lib/store";
+
+import { Response } from "../..";
+import { Condition, Operator } from "../types";
+import { useConditionalResponses } from "./useConditionalResponses";
+
+vi.mock("pages/FlowEditor/lib/store");
+
+const mockUseStore = (passportData = {}) => {
+  const mockComputePassport = vi.fn(() => passportData);
+  const mockGetState = vi.fn(
+    () =>
+      ({
+        computePassport: mockComputePassport,
+      }) as unknown as FullStore,
+  );
+
+  vi.mocked(useStore).mockImplementation((selector) =>
+    selector({
+      computePassport: mockComputePassport,
+    } as unknown as FullStore),
+  );
+
+  vi.mocked(useStore).getState = mockGetState;
+};
+
+vi.mock("airbrake", () => ({
+  logger: {
+    notify: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("no rules", () => {
+  it("returns all responses", () => {
+    const input: Response[] = [
+      {
+        id: "response-1",
+        responseKey: 1,
+        text: "Dog",
+      },
+      {
+        id: "response-2",
+        responseKey: 2,
+        text: "Cat",
+      },
+      {
+        id: "response-3",
+        responseKey: 3,
+        text: "Budgee",
+      },
+      {
+        id: "response-4",
+        responseKey: 4,
+        text: "Goldfish",
+      },
+      {
+        id: "response-5",
+        responseKey: 5,
+        text: "Hamster",
+      },
+    ];
+
+    const { result } = renderHook(() => useConditionalResponses(input));
+
+    expect(result.current).toMatchObject(input);
+  });
+});
+
+describe("simple rules (Condition.AlwaysRequired)", () => {
+  it("returns all responses", () => {
+    const input: Response[] = [
+      {
+        id: "response-1",
+        responseKey: 1,
+        text: "Dog",
+        rule: { condition: Condition.AlwaysRecommended },
+      },
+      {
+        id: "response-2",
+        responseKey: 2,
+        text: "Cat",
+        rule: { condition: Condition.AlwaysRequired },
+      },
+      {
+        id: "response-3",
+        responseKey: 3,
+        text: "Budgee",
+        rule: { condition: Condition.NotRequired },
+      },
+    ];
+
+    const { result } = renderHook(() => useConditionalResponses(input));
+
+    expect(result.current).toMatchObject(input);
+  });
+});
+
+describe("condition rules (Condition.RequiredIf)", () => {
+  const responsesWithConditions: Response[] = [
+    {
+      id: "response-1",
+      responseKey: 1,
+      text: "Dog",
+      rule: {
+        condition: Condition.RequiredIf,
+        operator: Operator.Equals,
+        fn: "pet",
+        val: "size.large",
+      },
+    },
+    {
+      id: "response-2",
+      responseKey: 2,
+      text: "Cat",
+      rule: {
+        condition: Condition.RequiredIf,
+        operator: Operator.Equals,
+        fn: "pet",
+        val: "size.medium",
+      },
+    },
+    {
+      id: "response-3",
+      responseKey: 3,
+      text: "Budgee",
+      rule: {
+        condition: Condition.RequiredIf,
+        operator: Operator.Equals,
+        fn: "pet",
+        val: "size.small",
+      },
+    },
+  ];
+
+  it("returns all responses if the all rules are met", () => {
+    // User has answered previous questions so that all responses should be displayed
+    mockUseStore({
+      data: { pet: ["size.small.cute", "size.medium", "size.large.cuddly"] },
+    });
+
+    const { result } = renderHook(() =>
+      useConditionalResponses(responsesWithConditions),
+    );
+
+    // All responses displayed
+    expect(result.current).toMatchObject(responsesWithConditions);
+  });
+
+  it("returns some responses if the some of the rules are met", () => {
+    // User has answered previous questions so that only some responses should be displayed
+    mockUseStore({ data: { pet: "size.small" } });
+
+    const { result } = renderHook(() =>
+      useConditionalResponses(responsesWithConditions),
+    );
+
+    // Only matching responses displayed
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].text).toEqual("Budgee");
+  });
+
+  it("filters out responses if the rules are not met", () => {
+    // User has answered previous questions so that no responses should be displayed
+    mockUseStore();
+    const loggerSpy = vi.spyOn(logger, "notify");
+
+    const { result } = renderHook(() =>
+      useConditionalResponses(responsesWithConditions),
+    );
+
+    // No responses displayed
+    expect(result.current).toHaveLength(0);
+    expect(loggerSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.ts
@@ -4,6 +4,15 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { DEFAULT_RULE, Response } from "../..";
 import { isRuleMet } from "../utils";
 
+/**
+ * Determines which responses should be shown to the user
+ *
+ * Allow us to limit which responses the user sees, based on their responses
+ * so far. Uses the passport to evaluate each response's rule.
+ *
+ * @param responses All possible responses for the Question node
+ * @returns Subset of responses which the user should see
+ */
 export const useConditionalResponses = (responses: Response[]): Response[] => {
   const passport = useStore((state) => state.computePassport());
   const conditionalResponses = responses.filter((response) =>

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.ts
@@ -1,0 +1,25 @@
+import { logger } from "airbrake";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+import { DEFAULT_RULE, Response } from "../..";
+import { isRuleMet } from "../utils";
+
+export const useConditionalResponses = (responses: Response[]): Response[] => {
+  const passport = useStore((state) => state.computePassport());
+  const conditionalResponses = responses.filter((response) =>
+    isRuleMet(passport, response.rule || DEFAULT_RULE),
+  );
+
+  if (!conditionalResponses.length) {
+    // TODO: Test this!
+    logger.notify({
+      message:
+        "[QuestionComponent]: User was presented with no conditional options",
+      passport,
+      responses,
+      conditionalResponses,
+    });
+  }
+
+  return conditionalResponses;
+};

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/hooks/useConditionalResponses.ts
@@ -11,13 +11,13 @@ export const useConditionalResponses = (responses: Response[]): Response[] => {
   );
 
   if (!conditionalResponses.length) {
-    // TODO: Test this!
     logger.notify({
       message:
         "[QuestionComponent]: User was presented with no conditional options",
       passport,
       responses,
-      conditionalResponses,
+      flowId: useStore.getState().id,
+      nodeId: useStore.getState().currentCard?.id,
     });
   }
 

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.test.ts
@@ -1,83 +1,117 @@
 import { Store } from "pages/FlowEditor/lib/store";
 
-import { Condition, ConditionalRule, Operator } from "./types";
+import { Condition, ConditionalRule, Operator, Rule } from "./types";
 import { isRuleMet } from "./utils";
 
 describe("isRuleMet function", () => {
-  const mockRule: ConditionalRule<Condition.RecommendedIf> = {
-    condition: Condition.RecommendedIf,
-    val: "testValue",
-    fn: "testFn",
-    operator: Operator.Equals,
-  };
+  describe("simple rules", () => {
+    it("evaluates to true for 'AlwaysRequired' rules", () => {
+      const mockPassport: Store.Passport = { data: { testFn: "testValue" } };
+      const mockRule: Rule = {
+        condition: Condition.AlwaysRequired,
+      };
+      const result = isRuleMet(mockPassport, mockRule);
 
-  it("matches on an exact value", () => {
-    const mockPassport: Store.Passport = { data: { testFn: "testValue" } };
-    const result = isRuleMet(mockPassport, mockRule);
+      expect(result).toBe(true);
+    });
 
-    expect(result).toBe(true);
+    it("evaluates to true for 'AlwaysRecommended' rules", () => {
+      const mockPassport: Store.Passport = { data: { testFn: "testValue" } };
+      const mockRule: Rule = {
+        condition: Condition.AlwaysRecommended,
+      };
+      const result = isRuleMet(mockPassport, mockRule);
+
+      expect(result).toBe(true);
+    });
+
+    it("evaluates to true for 'NotRequired' rules", () => {
+      const mockPassport: Store.Passport = { data: { testFn: "testValue" } };
+      const mockRule: Rule = {
+        condition: Condition.NotRequired,
+      };
+      const result = isRuleMet(mockPassport, mockRule);
+
+      expect(result).toBe(true);
+    });
   });
 
-  it("does not match if an exact value is not present", () => {
-    const mockPassport: Store.Passport = { data: { testFn: "missingValue" } };
-    const result = isRuleMet(mockPassport, mockRule);
-
-    expect(result).toBe(false);
-  });
-
-  it("does not match if the passport key is not present", () => {
-    const mockPassport: Store.Passport = {
-      data: { missingKey: "missingValue" },
+  describe("conditional rules", () => {
+    const mockRule: ConditionalRule<Condition.RecommendedIf> = {
+      condition: Condition.RecommendedIf,
+      val: "testValue",
+      fn: "testFn",
+      operator: Operator.Equals,
     };
-    const result = isRuleMet(mockPassport, mockRule);
 
-    expect(result).toBe(false);
-  });
+    it("matches on an exact value", () => {
+      const mockPassport: Store.Passport = { data: { testFn: "testValue" } };
+      const result = isRuleMet(mockPassport, mockRule);
 
-  it("matches on an exact value in an array", () => {
-    const mockPassport: Store.Passport = {
-      data: { testFn: ["value1", "value2", "testValue"] },
-    };
-    const result = isRuleMet(mockPassport, mockRule);
+      expect(result).toBe(true);
+    });
 
-    expect(result).toBe(true);
-  });
+    it("does not match if an exact value is not present", () => {
+      const mockPassport: Store.Passport = { data: { testFn: "missingValue" } };
+      const result = isRuleMet(mockPassport, mockRule);
 
-  it("matches on an granular value", () => {
-    const mockPassport: Store.Passport = {
-      data: {
-        testFn: ["value1.more.value", "value2", "testValue.more.detail"],
-      },
-    };
-    const result = isRuleMet(mockPassport, mockRule);
+      expect(result).toBe(false);
+    });
 
-    expect(result).toBe(true);
-  });
+    it("does not match if the passport key is not present", () => {
+      const mockPassport: Store.Passport = {
+        data: { missingKey: "missingValue" },
+      };
+      const result = isRuleMet(mockPassport, mockRule);
 
-  it("does not match on a partial granular value (prefix)", () => {
-    const mockPassport: Store.Passport = {
-      data: { testFn: ["somethingtestValue.more.detail"] },
-    };
-    const result = isRuleMet(mockPassport, mockRule);
+      expect(result).toBe(false);
+    });
 
-    expect(result).toBe(false);
-  });
+    it("matches on an exact value in an array", () => {
+      const mockPassport: Store.Passport = {
+        data: { testFn: ["value1", "value2", "testValue"] },
+      };
+      const result = isRuleMet(mockPassport, mockRule);
 
-  it("does not match on a partial granular value (suffix)", () => {
-    const mockPassport: Store.Passport = {
-      data: { testFn: ["testValueSomething.more.detail"] },
-    };
-    const result = isRuleMet(mockPassport, mockRule);
+      expect(result).toBe(true);
+    });
 
-    expect(result).toBe(false);
-  });
+    it("matches on an granular value", () => {
+      const mockPassport: Store.Passport = {
+        data: {
+          testFn: ["value1.more.value", "value2", "testValue.more.detail"],
+        },
+      };
+      const result = isRuleMet(mockPassport, mockRule);
 
-  it("does not match on a granular which is not a 'parent'", () => {
-    const mockPassport: Store.Passport = {
-      data: { testFn: ["parent.child.testValue"] },
-    };
-    const result = isRuleMet(mockPassport, mockRule);
+      expect(result).toBe(true);
+    });
 
-    expect(result).toBe(false);
+    it("does not match on a partial granular value (prefix)", () => {
+      const mockPassport: Store.Passport = {
+        data: { testFn: ["somethingtestValue.more.detail"] },
+      };
+      const result = isRuleMet(mockPassport, mockRule);
+
+      expect(result).toBe(false);
+    });
+
+    it("does not match on a partial granular value (suffix)", () => {
+      const mockPassport: Store.Passport = {
+        data: { testFn: ["testValueSomething.more.detail"] },
+      };
+      const result = isRuleMet(mockPassport, mockRule);
+
+      expect(result).toBe(false);
+    });
+
+    it("does not match on a granular which is not a 'parent'", () => {
+      const mockPassport: Store.Passport = {
+        data: { testFn: ["parent.child.testValue"] },
+      };
+      const result = isRuleMet(mockPassport, mockRule);
+
+      expect(result).toBe(false);
+    });
   });
 });

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
@@ -25,7 +25,6 @@ export interface Props {
   disabled?: boolean;
   onChange: (rule: Rule) => void;
   conditions?: Condition[];
-  dataSchema?: string[];
 }
 
 export const RuleBuilder: React.FC<Props> = ({
@@ -33,7 +32,6 @@ export const RuleBuilder: React.FC<Props> = ({
   rule,
   disabled,
   onChange,
-  dataSchema,
   conditions = Object.values(Condition),
 }) => {
   const isConditionalRule = checkIfConditionalRule(rule.condition);

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
@@ -19,12 +19,17 @@ const Operator = styled(Typography)(({ theme }) => ({
   marginLeft: -5,
 }));
 
+Operator.defaultProps = {
+  variant: "body2",
+};
+
 export interface Props {
   modalSubtitle?: string;
   rule: Rule;
   disabled?: boolean;
   onChange: (rule: Rule) => void;
   conditions?: Condition[];
+  dataSchema?: string[];
 }
 
 export const RuleBuilder: React.FC<Props> = ({
@@ -32,6 +37,7 @@ export const RuleBuilder: React.FC<Props> = ({
   rule,
   disabled,
   onChange,
+  dataSchema,
   conditions = Object.values(Condition),
 }) => {
   const isConditionalRule = checkIfConditionalRule(rule.condition);

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/utils.ts
@@ -1,9 +1,9 @@
 import { Store } from "pages/FlowEditor/lib/store";
 
-import { Condition, Operator, Rule } from "./types";
+import { Condition, Rule } from "./types";
 
 export const isRuleMet = (passport: Store.Passport, rule: Rule): boolean => {
-  // TODO: Tests
+  // Simple (non-conditional) rules always evaluate to true
   if (rule.condition === Condition.AlwaysRequired) return true;
   if (rule.condition === Condition.AlwaysRecommended) return true;
   if (rule.condition === Condition.NotRequired) return true;
@@ -24,19 +24,10 @@ export const isRuleMet = (passport: Store.Passport, rule: Rule): boolean => {
 export const checkIfConditionalRule = (condition: Condition) =>
   [Condition.RecommendedIf, Condition.RequiredIf].includes(condition);
 
-export const formatRule = (
-  newCondition: Condition,
-  { fn, val }: Rule,
-): Rule => {
+export const formatRule = (newCondition: Condition, rule: Rule): Rule => {
   const isConditionalRule = checkIfConditionalRule(newCondition);
+  if (isConditionalRule) return { ...rule, condition: newCondition } as Rule;
 
   // Drop fields which are only required for ConditionalRules
-  const updatedRule = {
-    condition: newCondition,
-    operator: isConditionalRule ? Operator.Equals : undefined,
-    fn: isConditionalRule ? fn : undefined,
-    val: isConditionalRule ? val : undefined,
-  } as Rule;
-
-  return updatedRule;
+  return { condition: newCondition } as Rule;
 };

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/utils.ts
@@ -1,11 +1,13 @@
 import { Store } from "pages/FlowEditor/lib/store";
 
-import { Condition, ConditionalRule, Operator, Rule } from "./types";
+import { Condition, Operator, Rule } from "./types";
 
-export const isRuleMet = (
-  passport: Store.Passport,
-  rule: ConditionalRule<Condition.RequiredIf | Condition.RecommendedIf>,
-): boolean => {
+export const isRuleMet = (passport: Store.Passport, rule: Rule): boolean => {
+  // TODO: Tests
+  if (rule.condition === Condition.AlwaysRequired) return true;
+  if (rule.condition === Condition.AlwaysRecommended) return true;
+  if (rule.condition === Condition.NotRequired) return true;
+
   const passportVal = passport.data?.[rule.fn];
   if (!passportVal) return false;
 

--- a/apps/editor.planx.uk/src/@planx/components/shared/index.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/index.ts
@@ -98,13 +98,10 @@ export const DEFAULT_RULE: Rule = {
   condition: Condition.AlwaysRequired,
 };
 
-export interface Response {
+export type Response = Option["data"] & {
   id: string;
-  responseKey: string | number;
-  title: string;
-  description?: string;
-  img?: string;
-}
+  responseKey: number;
+};
 
 export const parseFormValues = (ob: any, defaultValues = {}) =>
   ob.reduce((acc: any, [k, v]: any) => {

--- a/apps/editor.planx.uk/src/@planx/components/shared/index.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/index.ts
@@ -9,6 +9,8 @@ import trim from "lodash/trim";
 import { Store } from "pages/FlowEditor/lib/store";
 import { array, boolean, mixed, object, SchemaOf, string } from "yup";
 
+import { Condition, Rule } from "./RuleBuilder/types";
+
 /** Shared properties across all node types */
 export type BaseNodeData = NodeTags & TemplatedNodeData & MoreInformation;
 
@@ -75,6 +77,7 @@ export interface Option {
     text: string;
     val?: string;
     exclusive?: true;
+    rule?: Rule;
   };
 }
 
@@ -87,8 +90,13 @@ export const optionValidationSchema = object({
     text: string().required().trim(),
     val: string(),
     exclusive: mixed().oneOf([true, undefined]),
+    // TODO: rule validation?
   }),
 });
+
+export const DEFAULT_RULE: Rule = {
+  condition: Condition.AlwaysRequired,
+};
 
 export interface Response {
   id: string;

--- a/apps/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -64,7 +64,7 @@ import type { SetFee } from "@planx/components/SetFee/model";
 import SetFeeComponent from "@planx/components/SetFee/Public";
 import type { SetValue } from "@planx/components/SetValue/model";
 import SetValueComponent from "@planx/components/SetValue/Public";
-import { Option } from "@planx/components/shared";
+import { Option, Response } from "@planx/components/shared";
 import type { TaskList } from "@planx/components/TaskList/model";
 import TaskListComponent from "@planx/components/TaskList/Public";
 import type { TextInput } from "@planx/components/TextInput/model";
@@ -261,16 +261,16 @@ const Node: React.FC<Props> = (props) => {
     case TYPES.Question: {
       const questionProps = getComponentProps<Question>();
       const autoAnswers = nodeId ? autoAnswerableOptions(nodeId) : undefined;
+      const responses = childNodesOf(nodeId).map((node, i) => ({
+        id: node.id,
+        responseKey: i + 1,
+        ...node.data,
+      })) as Response[];
 
       return (
         <QuestionComponent
           {...questionProps}
-          responses={childNodesOf(nodeId).map((n, i) => ({
-            id: n.id!,
-            responseKey: i + 1,
-            title: n.data?.text,
-            ...n.data,
-          }))}
+          responses={responses}
           autoAnswers={autoAnswers}
         />
       );


### PR DESCRIPTION
## What does this PR do?
Adds optional rules to the the `Question` component. Editors can set rules, and then the public interface will apply these at runtime based on the user's responses so far.

Originally, we had planned there to be separate `ResponsiveQuestion` and `ResponsiveChecklist` components, but I'm hoping that this PR lets us validate that assumption (either way!) - is it actually simpler to have this integrated into the current components? I think there's some valid UI questions around how this appears within the modal to be discussed, but I'm most interested in working out if we need two additional components before getting much further here.

### Changes
 - Model: adds optional `rule` property to `Option`
 - Model: simplifies the `Response` type
 - UI: Adds `<RuleBuilder/>` to the `<BaseOptionsEditor/>` component
   - This allows us to add rules to both the `Checklist` and `Question` model, but this is just implemented within `Question` currently