### PR TITLE
chore: bump planx-core

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e57d16d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#551755e",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.12.2",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.701.0
         version: 3.918.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#e57d16d
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@19.2.2)
+        specifier: git+https://github.com/theopensystemslab/planx-core#551755e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@19.2.2)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1027,8 +1027,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e}
     version: 1.0.0
 
   '@paralleldrive/cuid2@2.3.1':
@@ -5231,7 +5231,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@19.2.2)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@19.2.2)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.2)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@18.3.1))(@types/react@19.2.2)(react@18.3.1)

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -18,7 +18,7 @@
     "@mui/x-charts": "^8.9.0",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.6",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e57d16d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#551755e",
     "@tanstack/react-query": "^5.90.2",
     "@tiptap/core": "3.0.7",
     "@tiptap/extension-emoji": "3.0.7",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#e57d16d
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@18.3.26)
+        specifier: git+https://github.com/theopensystemslab/planx-core#551755e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@18.3.26)
       '@tanstack/react-query':
         specifier: ^5.90.2
         version: 5.90.2(react@18.3.1)
@@ -2065,8 +2065,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.6':
     resolution: {integrity: sha512-EBOgrgBRFNg8p+7nDFvh+K7N4NFQ7+epBXjE9w7h0u87q4M+nOpBwXNc67+UdDs+j8Mi+vQ2R+uJBIKF25NQ7g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -9379,7 +9379,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@18.3.26)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@18.3.26)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.26)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.26)(react@18.3.1))(@types/react@18.3.26)(react@18.3.1)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.10.0",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e57d16d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#551755e",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.1.1
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#e57d16d
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@19.1.13)
+        specifier: git+https://github.com/theopensystemslab/planx-core#551755e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@19.1.13)
       axios:
         specifier: ^1.12.2
         version: 1.12.2
@@ -383,8 +383,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2146,7 +2146,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@19.1.13)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@19.1.13)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.13)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react@18.3.1)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#e57d16d",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#551755e",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#e57d16d
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@19.1.13)
+        specifier: git+https://github.com/theopensystemslab/planx-core#551755e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@19.1.13)
       axios:
         specifier: ^1.12.2
         version: 1.12.2
@@ -313,8 +313,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e}
     version: 1.0.0
 
   '@playwright/test@1.56.1':
@@ -1805,7 +1805,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/e57d16d(@types/react@19.1.13)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/551755e(@types/react@19.1.13)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.13)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react@18.3.1)


### PR DESCRIPTION
See https://github.com/theopensystemslab/planx-core/pull/853

**Testing:**
I've added Ben's staging session to this pizza for comparison
- On staging we've failed to pickup `data.applicant.siteContact`: https://api.editor.planx.dev/admin/session/4aed29b8-3eeb-4756-a3e8-5577a7ecf345/digital-planning-application
- On this pizza we have correctly picked it up: https://api.5580.planx.pizza/admin/session/4aed29b8-3eeb-4756-a3e8-5577a7ecf345/digital-planning-application

<img width="532" height="885" alt="Screenshot from 2025-11-02 10-25-03" src="https://github.com/user-attachments/assets/e72177c8-b093-4ce4-8e97-1f80d9231476" />