### PR TITLE
fix: only reverse remove ops, not additions

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/TimelineItems.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/TimelineItems.tsx
@@ -58,7 +58,9 @@ export const OperationTimelineItem = ({
 
   let uniqueFormattedOps = [...new Set(formatOps(flow, event.data))];
   // When removing nodes (eg Folder and all containing nodes), display in reverse order so Folder is first rather than last
-  if (uniqueFormattedOps[0].startsWith("Removed")) {
+  if (
+    uniqueFormattedOps.every((formattedOp) => formattedOp.startsWith("Removed"))
+  ) {
     uniqueFormattedOps = uniqueFormattedOps.reverse();
   }
 


### PR DESCRIPTION
Quick follow-on to #5578 based on latest feedback https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1761926570384479

**Now:**
<img width="522" height="854" alt="Screenshot from 2025-11-03 08-01-43" src="https://github.com/user-attachments/assets/9a1bf943-8be4-4f52-804c-8d156275a35a" />
