### PR TITLE
chore: add general-enquiries to analytics allow list [skip pizza]

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/analytics/utils.ts
@@ -232,6 +232,7 @@ const discretionaryDashboard = {
     "check-constraints-on-a-property",
     "check-whether-you-need-a-building-control-application",
     "check-your-planning-constraints",
+    "general-enquiries",
     "heritage-constraints",
     "notify-us-of-any-high-efficiency-alternative-energy-systems",
     "report-a-potential-dangerous-structure",


### PR DESCRIPTION
To support dashboard creation for the `general-enquiries` service