### PR TITLE
feat: add Date Input support for full and abbreviated month names

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
@@ -31,7 +31,7 @@ test("submits a date", async () => {
 
   await user.click(screen.getByTestId("continue-button"));
 
-  expect(handleSubmit).toHaveBeenCalledExactlyOnceWith({
+  expect(handleSubmit).toHaveBeenCalledWith({
     data: {
       [componentId]: "2010-05-22",
     },
@@ -57,7 +57,7 @@ test("recovers previously submitted date when clicking the back button", async (
 
   await user.click(screen.getByTestId("continue-button"));
 
-  expect(handleSubmit).toHaveBeenCalledExactlyOnceWith({
+  expect(handleSubmit).toHaveBeenCalledWith({
     data: {
       [componentId]: "2010-05-22",
     },
@@ -85,7 +85,7 @@ test("recovers previously submitted date when clicking the back button even if a
 
   await user.click(screen.getByTestId("continue-button"));
 
-  expect(handleSubmit).toHaveBeenCalledExactlyOnceWith({
+  expect(handleSubmit).toHaveBeenCalledWith({
     data: {
       [dataField]: "2010-05-22",
     },

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
@@ -31,7 +31,7 @@ test("submits a date", async () => {
 
   await user.click(screen.getByTestId("continue-button"));
 
-  expect(handleSubmit).toHaveBeenCalledWith({
+  expect(handleSubmit).toHaveBeenCalledExactlyOnceWith({
     data: {
       [componentId]: "2010-05-22",
     },
@@ -57,7 +57,7 @@ test("recovers previously submitted date when clicking the back button", async (
 
   await user.click(screen.getByTestId("continue-button"));
 
-  expect(handleSubmit).toHaveBeenCalledWith({
+  expect(handleSubmit).toHaveBeenCalledExactlyOnceWith({
     data: {
       [componentId]: "2010-05-22",
     },
@@ -85,7 +85,7 @@ test("recovers previously submitted date when clicking the back button even if a
 
   await user.click(screen.getByTestId("continue-button"));
 
-  expect(handleSubmit).toHaveBeenCalledWith({
+  expect(handleSubmit).toHaveBeenCalledExactlyOnceWith({
     data: {
       [dataField]: "2010-05-22",
     },
@@ -136,7 +136,7 @@ test("date fields have a max length set", async () => {
   const year = screen.getByLabelText("Year") as HTMLInputElement;
 
   expect(day.maxLength).toBe(2);
-  expect(month.maxLength).toBe(2);
+  expect(month.maxLength).toBe(9);
   expect(year.maxLength).toBe(4);
 });
 

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Public.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import {
   DateInput,
   dateInputValidationSchema,
+  normalizeDate,
   paddedDate,
   UserData,
 } from "@planx/components/DateInput/model";
@@ -28,7 +29,8 @@ const DateInputPublic: React.FC<Props> = (props) => {
       date: getPreviouslySubmittedData(props) ?? "",
     },
     onSubmit: (values) => {
-      props.handleSubmit?.(makeData(props, values.date));
+      const normalizedDate = normalizeDate(values.date);
+      props.handleSubmit?.(makeData(props, normalizedDate));
     },
     validateOnBlur: false,
     validateOnChange: false,

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/model.test.ts
@@ -1,4 +1,10 @@
-import { dateInputValidationSchema, dateSchema, paddedDate, parseDate } from "./model";
+import {
+  dateInputValidationSchema,
+  dateSchema,
+  normalizeDate,
+  paddedDate,
+  parseDate,
+} from "./model";
 
 describe("parseDate helper function", () => {
   it("returns a day value", () => {
@@ -34,7 +40,7 @@ describe("parseDate helper function", () => {
   });
 
   it("handles partial inputs", () => {
-    const result = parseDate("2024-MM-05");
+    const result = parseDate("2024--05");
     expect(result.day).toEqual(5);
     expect(result.month).not.toBeDefined();
     expect(result.year).toEqual(2024);
@@ -43,12 +49,8 @@ describe("parseDate helper function", () => {
 
 describe("dateSchema", () => {
   test("basic validation", async () => {
-    expect(await dateSchema().isValid("2021-03-23")).toBe(
-      true,
-    );
-    expect(await dateSchema().isValid("2021-23-03")).toBe(
-      false,
-    );
+    expect(await dateSchema().isValid("2021-03-23")).toBe(true);
+    expect(await dateSchema().isValid("2021-23-03")).toBe(false);
   });
 
   const validate = async (date?: string) =>
@@ -78,12 +80,17 @@ describe("dateSchema", () => {
 
   it("throws an error for an invalid day", async () => {
     const errors = await validate("2024-12-32");
-    expect(errors[0]).toMatch(/Day must be valid/);
+    expect(errors[0]).toMatch(/Day must be a real day/);
   });
 
   it("throws an error for an invalid month", async () => {
     const errors = await validate("2024-13-25");
-    expect(errors[0]).toMatch(/Month must be valid/);
+    expect(errors[0]).toMatch(/Month must be a real month/);
+  });
+
+  it("throws an error for an invalid month name", async () => {
+    const errors = await validate("2024-Novee-25");
+    expect(errors[0]).toMatch(/Month must be a real month/);
   });
 
   it("throws an error for an invalid date (30th Feb)", async () => {
@@ -107,7 +114,7 @@ describe("dateInputValidationSchema", () => {
           max: "1999-12-31",
         },
         required: true,
-      }).isValid("1995-06-15")
+      }).isValid("1995-06-15"),
     ).toBe(true);
     expect(
       await dateInputValidationSchema({
@@ -184,4 +191,21 @@ test("padding on blur", () => {
   // Leaves single 0 alone
   expect(paddedDate("2021-0-2", "blur")).toBe("2021-0-02");
   expect(paddedDate("2021-10-0", "blur")).toBe("2021-10-0");
+});
+
+test("normalizes month names", () => {
+  // Normalizes full month names
+  expect(normalizeDate("2021-November-15")).toBe("2021-11-15");
+  expect(normalizeDate("2021-January-01")).toBe("2021-01-01");
+  expect(normalizeDate("2021-December-25")).toBe("2021-12-25");
+
+  // Normalizes abbreviated month names
+  expect(normalizeDate("2021-Nov-15")).toBe("2021-11-15");
+  expect(normalizeDate("2021-Jan-01")).toBe("2021-01-01");
+  expect(normalizeDate("2021-Dec-25")).toBe("2021-12-25");
+
+  // Normalizes irrespective of case
+  expect(normalizeDate("2021-NOVEMBER-15")).toBe("2021-11-15");
+  expect(normalizeDate("2021-november-15")).toBe("2021-11-15");
+  expect(normalizeDate("2021-NoVeMbEr-15")).toBe("2021-11-15");
 });

--- a/apps/editor.planx.uk/src/ui/shared/DateInput/DateInput.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DateInput/DateInput.tsx
@@ -87,7 +87,7 @@ export default function DateInput(props: Props): FCReturn {
           </Label>
           <Input
             value={month || ""}
-            inputProps={{ maxLength: "2" }}
+            inputProps={{ maxLength: "9" }}
             bordered={props.bordered}
             id={`${props.id}-month`}
             onInput={(ev: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
This PR enables the date input component to receive full and abbreviated month names while maintaining the existing data structure and validation.

This approach is an alternative to enforcing input format and using on-page information to explain to a user what the expected format is.

It follows [GOV.UK Design System guidance on date input](https://design-system.service.gov.uk/components/date-input/), in particular:

> Accept month names written out in full or abbreviated form (for example, ‘january’ or ‘jan’) as some users may enter months in this way.

I intentionally kept the month input field width the same 65px. Increasing it suggests visually that a format other than MM is expected. The trade-off is that for inputs other than in MM format the text gets clipped due to overflow. Open to other suggestions!

Expands on https://github.com/theopensystemslab/planx-new/pull/3816 in addressing usability issues regarding date formatting.