### PR TITLE
chore(lps): Allow-list Camden EE service

### DIFF
--- a/apps/localplanning.services/src/lib/lpa-api/index.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/index.ts
@@ -54,6 +54,7 @@ const NOTIFY_SERVICE_SLUGS = [
 const GUIDANCE_SERVICE_SLUGS = [
   "general-enquiries",
   "find-out-if-you-need-planning-permission",
+  "find-out-if-you-need-planning-permission-energy-efficiency"
 ];
 
 export async function fetchAllLPAs(): Promise<LPA[]> {


### PR DESCRIPTION
Still using a hacky allow-list workaround here to categorise these - we probably want to think about introducing this as an option in PlanX alongside "services" vs "flows".