### PR TITLE
[hasura] apply `soft_delete_stray_sessions` migration

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1762358514038_soft_delete_stray_sessions/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1762358514038_soft_delete_stray_sessions/down.sql
@@ -1,0 +1,7 @@
+UPDATE public.lowcal_sessions
+SET deleted_at = NULL
+WHERE
+    submitted_at IS NULL
+    AND deleted_at = created_at + INTERVAL '28 days'
+    AND locked_at IS NULL
+    AND created_at < TIMESTAMPTZ '2025-10-05 02:00:00+00:00';

--- a/apps/hasura.planx.uk/migrations/default/1762358514038_soft_delete_stray_sessions/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1762358514038_soft_delete_stray_sessions/up.sql
@@ -1,0 +1,7 @@
+UPDATE public.lowcal_sessions 
+SET deleted_at = created_at + INTERVAL '28 days'
+WHERE
+    submitted_at IS NULL
+    AND deleted_at IS NULL
+    AND locked_at IS NULL
+    AND created_at < TIMESTAMPTZ '2025-10-05 02:00:00+00:00';


### PR DESCRIPTION
Relates to [this ticket](https://trello.com/c/Uo7F9xxj).

This PR follows on from #5284, which ensures that all new sessions are 'soft' deleted after 28 days (or 28 days after invite to pay is activated, in that case). However, there are still 1000s of outstanding 'stray' sessions which were never deleted, submitted, or locked, and have therefore escaped sanitisation.

This Hasura migration therefore marks all sessions which are older than 1 month as deleted (i.e. sets the `deleted_at` timestamp equal to `created_at + 28 days`). These will then be sanitised in due course by the overnight cronjob.

We'll need to do this migration again in 1 month (with an adjusted `TIMESTAMPTZ` value). This is because some of the unexpired sessions that exist on this first pass, but which we don't yet know the fate of (because the user was still free to progress or submit them, etc.) and so should not delete yet, will not have one-off scheduled events to handle their deletion.

Once the migration has been applied we should be able to run the following query to check that it's been successful (it should return 0 records):

```sql
SELECT
    COUNT(*) AS unsanitised_sessions
FROM
    public.lowcal_sessions
WHERE
    submitted_at IS NULL
    AND deleted_at IS NULL
    AND locked_at IS NULL
    AND sanitised_at IS NULL
    AND created_at < TIMESTAMPTZ '2025-10-05 02:00:00+00:00'
```

See [this section of the Notion scoping doc](https://www.notion.so/opensystemslab/Data-sanitisation-23a35d469ad180758e3be8cd96357f22?source=copy_link#27235d469ad180a38af6db6d8fea2467) for additional detail and other useful SQL commands.