### PR TITLE
chore: change submission service landing page copy from 'application' to 'form' [skip pizza] 

### DIFF
--- a/apps/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
@@ -37,7 +37,7 @@ export const ConfirmEmail: React.FC<{
       <Card handleSubmit={formik.handleSubmit}>
         <CardHeader
           title="Enter your email address"
-          description="We will use this to save your application so you can come back to it later. We will also email you updates about your application."
+          description="We will use this to save your form so you can come back to it later. We will also use the address to email you updates about it."
         ></CardHeader>
         <InputRow>
           <InputLabel label={"Email address"} htmlFor={"email"}>


### PR DESCRIPTION
'Form' is more generally applicable than application. Same as https://github.com/theopensystemslab/planx-new/pull/5527

Will follow on with a more comprehensive review of 'application' references later.