### PR TITLE
refactor: Rename copy flow to make a copy

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
@@ -96,7 +96,7 @@ export const CopyDialog: React.FC<Props> = ({
           fullWidth
         >
           <DialogTitle variant="h3" component="h1" id="dialog-heading">
-            Copy "{sourceFlow.name}"
+            Make a copy of "{sourceFlow.name}"
           </DialogTitle>
           <Box>
             <Form>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/Menu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/Menu.tsx
@@ -100,7 +100,7 @@ const FlowCardMenu: React.FC<Props> = ({
             onClick: () => setOpenDialog("rename"),
           },
           {
-            label: "Copy",
+            label: "Make a copy",
             onClick: () => setOpenDialog("copy"),
             disabled: isAnyTemplate,
           },


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Renames "Copy" to "Make a copy" in the flow list menu
- Updates modal header to "Make a copy of"