### PR TITLE
chore: drop project types from `analytics_action_nodes` mv

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1762434981111_remove_project_type_from _analytics_action_nodes/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1762434981111_remove_project_type_from _analytics_action_nodes/down.sql
@@ -1,0 +1,24 @@
+DROP MATERIALIZED VIEW "public"."analytics_action_nodes";
+CREATE MATERIALIZED VIEW "public"."analytics_action_nodes" AS 
+ SELECT a.flow_id,
+    a.id AS analytics_id,
+    ((al.allow_list_answers -> 'drawBoundary.action'::text))::text AS draw_boundary_action,
+    ((al.allow_list_answers -> 'proposal.projectType'::text))::text AS proposal_project_type,
+    ((al.allow_list_answers -> 'rab.exitReason'::text))::text AS rab_exit_reason,
+    ((al.allow_list_answers -> 'usedFOIYNPP'::text))::text AS used_foiynpp,
+    al.node_type,
+    al.node_title,
+    al.input_errors,
+    al.has_clicked_save,
+    al.has_clicked_help
+   FROM (analytics a
+     LEFT JOIN analytics_logs al ON ((a.id = al.analytics_id)))
+  WHERE (((al.allow_list_answers -> 'drawBoundary.action'::text) IS NOT NULL) 
+    OR ((al.allow_list_answers -> 'proposal.projectType'::text) IS NOT NULL) 
+    OR ((al.allow_list_answers -> 'rab.exitReason'::text) IS NOT NULL) 
+    OR ((al.allow_list_answers -> 'usedFOIYNPP'::text) IS NOT NULL) 
+    OR (al.has_clicked_save = true) 
+    OR (al.has_clicked_help = true) 
+    OR (al.input_errors::text != '[]'));
+
+GRANT SELECT on public.analytics_action_nodes TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1762434981111_remove_project_type_from _analytics_action_nodes/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1762434981111_remove_project_type_from _analytics_action_nodes/up.sql
@@ -1,0 +1,17 @@
+DROP MATERIALIZED VIEW "public"."analytics_action_nodes";
+CREATE MATERIALIZED VIEW "public"."analytics_action_nodes" AS 
+ SELECT a.flow_id,
+    a.id AS analytics_id,
+    ((al.allow_list_answers -> 'drawBoundary.action'::text))::text AS draw_boundary_action,
+    ((al.allow_list_answers -> 'rab.exitReason'::text))::text AS rab_exit_reason,
+    ((al.allow_list_answers -> 'usedFOIYNPP'::text))::text AS used_foiynpp,
+    al.node_type,
+    al.node_title,
+    al.input_errors,
+    al.has_clicked_save,
+    al.has_clicked_help
+   FROM (analytics a
+     LEFT JOIN analytics_logs al ON ((a.id = al.analytics_id)))
+  WHERE (((al.allow_list_answers -> 'drawBoundary.action'::text) IS NOT NULL) OR ((al.allow_list_answers -> 'rab.exitReason'::text) IS NOT NULL) OR ((al.allow_list_answers -> 'usedFOIYNPP'::text) IS NOT NULL) OR (al.has_clicked_save = true) OR (al.has_clicked_help = true) OR ((al.input_errors)::text <> '[]'::text));
+
+GRANT SELECT on public.analytics_action_nodes TO metabase_read_only;


### PR DESCRIPTION
Drops `proposal_project_type` from `analytics_action_nodes` because it will have its own view (incoming). Separate PRs because of failing tests again!