### PR TITLE
[api] handle session data aberrations gracefully during sanitisation

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/mocks/queries.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/mocks/queries.ts
@@ -64,7 +64,7 @@ export const mockGetExpiredSessionIdsQuery = {
   name: "GetExpiredSessionIds",
   matchOnVariables: false,
   data: {
-    lowcal_sessions: [{ id: "id1" }, { id: "id2" }, { id: "id3" }],
+    lowcal_sessions: mockIds.map((id) => ({ id })),
   },
 };
 

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
@@ -101,12 +101,22 @@ export const getExpiredSessionIds = async (): Promise<string[]> => {
  */
 export const deleteApplicationFiles: Operation = async () => {
   const deletedFiles: string[] = [];
-
   const sessionIds = await getExpiredSessionIds();
   for (const sessionId of sessionIds) {
     const session = await $api.session.find(sessionId);
     if (!session) {
       throw Error(`Unable to find session matching id ${sessionId}`);
+    }
+    // check session data and passport exist (none of these cases should occur, but there may be aberrations)
+    if (
+      !session.data ||
+      !session.data.passport ||
+      !session.data.passport.data
+    ) {
+      console.debug(
+        `Session ${sessionId} has no passport data, so there are no associated files to delete`,
+      );
+      continue;
     }
     const files = new Passport(session.data.passport)?.files;
     if (files?.length) {


### PR DESCRIPTION
After merging #5605 and letting the `sanitise_application_data` cronjob run over night, we saw that the `deleteApplicationFiles` operation failed, reporting `Error: Cannot read properties of undefined (reading 'data')`.

Because the same records were sanitised of their `data` field directly afterwards (by `sanitiseLowcalSessions`), we cannot see the malformed session data that prompted this error, but with this PR we introduce a guard to ensure that such an aberration doesn't cause the whole operation to fail.