### PR TITLE
style(lps): Improve footer layout

### DIFF
--- a/apps/localplanning.services/src/components/Footer.astro
+++ b/apps/localplanning.services/src/components/Footer.astro
@@ -11,36 +11,39 @@ const legalPages = await getCollection("legal");
 <footer class="bg-bg-dark text-white pb-20">
   <Container paddingY>
     <div class="flex flex-col gap-8">
-      <div class="flex flex-col gap-1">
-        <p class="text-body-md">Supported by:</p>
-        <div class="flex flex-row items-center gap-8">
-          <Image
-            src={mhclgLogo}
-            alt="Ministry of Housing, Communities and Local Government logo"
-            class="clamp-[w,30,36]"
-          />
-          <Image
-            src={odpLogo}
-            alt="Open Digital Planning logo"
-            class="clamp-[w,30,36]"
-          />
+      <div class="flex flex-col lg:flex-row lg:justify-between items-start flex-wrap gap-8">
+        <div class="flex flex-col gap-1">
+          <p class="text-body-md">Supported by:</p>
+          <div class="flex flex-row items-center gap-8">
+            <Image
+              src={mhclgLogo}
+              alt="Ministry of Housing, Communities and Local Government logo"
+              class="clamp-[w,30,36]"
+            />
+            <Image
+              src={odpLogo}
+              alt="Open Digital Planning logo"
+              class="clamp-[w,30,36]"
+            />
+          </div>
+        </div>
+        <div class="flex gap-8">
+          <a class="paragraph-link text-body-md" href="/directory">
+            Directory of local planning authorities
+          </a>
+          {
+            legalPages.map((page) => (
+              <a
+                class="paragraph-link capitalize text-body-md"
+                href={`/${page.slug}`}
+              >
+                {page.slug}
+              </a>
+            ))
+          }
         </div>
       </div>
-      <div class="flex gap-8">
-        <a class="paragraph-link text-body-md" href="/directory">
-          Directory of local planning authorities
-        </a>
-        {
-          legalPages.map((page) => (
-            <a
-              class="paragraph-link capitalize text-body-md"
-              href={`/${page.slug}`}
-            >
-              {page.slug}
-            </a>
-          ))
-        }
-      </div>
+      
       <p class="text-body-md">
         All content is available under the <a
           class="paragraph-link paragraph-link--external"


### PR DESCRIPTION
## What does this PR do?

- Improves footer layout to give more visibility to footer navigation menu at desktop sizes, mirrors positioning of header navigation

<img width="1538" height="274" alt="image" src="https://github.com/user-attachments/assets/de51fa5d-1ed7-444c-94c0-0100fdddbac6" />
