### PR TITLE
feat: Allow the `RuleBuilder` to accept labels

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/RuleBuilder.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/RuleBuilder.stories.tsx
@@ -76,6 +76,24 @@ export const SubsetOfConditions = {
   },
 } satisfies Story;
 
+export const WithCustomLabels = {
+  name: "With custom labels",
+  render: (args) => <RuleBuilderWithState {...args} />,
+  args: {
+    labels: {
+      [Condition.AlwaysRequired]: "Always display",
+      [Condition.RequiredIf]: "Display if",
+    },
+    conditions: [Condition.AlwaysRequired, Condition.RequiredIf],
+    rule: {
+      fn: "someFn",
+      val: "someVal",
+      condition: Condition.RequiredIf,
+      operator: Operator.Equals,
+    },
+  },
+} satisfies Story;
+
 export const WithDataSchema = {
   name: "With data schema",
   render: (args) => <RuleBuilderWithState {...args} />,

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
@@ -26,6 +26,10 @@ export interface Props {
   onChange: (rule: Rule) => void;
   conditions?: Condition[];
   dataSchema?: string[];
+  /**
+   * Override the default condition titles with custom labels
+   */
+  labels?: Partial<Record<Condition, string>>
 }
 
 export const RuleBuilder: React.FC<Props> = ({
@@ -34,6 +38,7 @@ export const RuleBuilder: React.FC<Props> = ({
   disabled,
   onChange,
   dataSchema,
+  labels,
   conditions = Object.values(Condition),
 }) => {
   const isConditionalRule = checkIfConditionalRule(rule.condition);
@@ -59,7 +64,7 @@ export const RuleBuilder: React.FC<Props> = ({
         >
           {conditions.map((condition) => (
             <MenuItem key={condition} value={condition}>
-              {upperFirst(lowerCase(condition))}
+              {labels?.[condition] || upperFirst(lowerCase(condition))}
             </MenuItem>
           ))}
         </SelectInput>


### PR DESCRIPTION
This PR allows customisable labels to be added to the `RuleBuilder`, which will allow us to more closely align this for both the conditionally showing file types and options.