### PR TITLE
feat: Conditional display "value" field as `<Input/>` or `<DataFieldAutocomplete/>`

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveQuestion/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveQuestion/Editor.test.tsx
@@ -121,4 +121,4 @@ it("can construct a valid payload", async () => {
       })
     ])
   ));
-}, 10_000);
+}, 20_000);

--- a/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/RuleBuilder/index.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import { lowerCase, merge, upperFirst } from "lodash";
 import React from "react";
 import { ModalSubtitle } from "ui/editor/ModalSubtitle";
+import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
 
@@ -73,14 +74,26 @@ export const RuleBuilder: React.FC<Props> = ({
             disabled={disabled}
           />
           <Operator variant="body2">Equals</Operator>
-          <DataFieldAutocomplete
-            required
-            schema={dataSchema}
-            value={rule.val}
-            onChange={handleValChange}
-            placeholder="Value"
-            disabled={disabled}
-          />
+          {dataSchema ? (
+              <DataFieldAutocomplete
+                required
+                schema={dataSchema}
+                value={rule.val}
+                onChange={handleValChange}
+                placeholder="Value"
+                disabled={disabled}
+              />
+            ) : (
+              <Input
+                required
+                name="val"
+                value={rule.val}
+                onChange={(e) => handleValChange(e.target.value)}
+                placeholder="Value"
+                disabled={disabled}
+              />
+            )
+          }
         </InputRow>
       )}
     </>


### PR DESCRIPTION
## What does this PR do?
Only displays the "value" field within the `<RuleBuilder/>` as a `<DataFieldAutcomplete/>` when a `dataSchema` is provided.

## Why are we making this change?
The original request to style this as a data field, and to populate it as an enum came from a request from the content team for this functionality within the file upload context. This field is usually one of "required" or "recommended" and using `DataFieldAutcomplete` was a simple way of achieving this.

However - "values" are not data field, and can (and will) be anything. Using a conditional toggle on `dataSchema` allows to to present this in both variants.