### PR TITLE
fix: Make flow table action cell clickable

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -47,6 +47,20 @@ export const StyledTableRow = styled(TableRow, {
       textDecoration: "underline",
     },
   },
+  "& .actions-cell": {
+    cursor: "default",
+    position: "relative",
+    // Min-height to compensate for padding
+    height: "80px",
+    // Make the entire cell clickable area for the menu button
+    "& > div, & button": {
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: "100%",
+      height: "100%",
+    },
+  },
   "&:has(.actions-cell:hover) a": {
     textDecoration: "none",
   },


### PR DESCRIPTION
## What does this PR do?

Currently the new table for flows has an actions button that sits within the cell padding, and confusingly the cursor is set as `pointer` anywhere within the cell:

<img width="1466" height="229" alt="image" src="https://github.com/user-attachments/assets/0fc4bcd5-38f0-4fba-8e6c-45d9cecdd45c" />

Expanding the contents by use of `position: absolute` allows for the full cell to be clickable:

<img width="1466" height="229" alt="image" src="https://github.com/user-attachments/assets/135d6071-d67a-4cb3-a775-97e588158e66" />
