### PR TITLE
chore: update gitignore [skip pizza]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,19 +30,19 @@ __pycache__
 .ruff_cache/
 
 # Ignore certificate files
-**/*.chain
-**/*.cert
-**/*.cer
-**/*.csr
-**/*.crt
+*.chain
+*.cert
+*.cer
+*.csr
+*.crt
 *.key
-**/*.pfx
-**/*.pfx.txt
-**/*.pkcs12
-**/*.p12
-**/*.p7b
-**/*.pem
-**/*.zip
+*.pfx
+*.pfx.txt
+*.pkcs12
+*.p12
+*.p7b
+*.pem
+*.zip
 
 # Tooling
 .aider*


### PR DESCRIPTION
To ensure that any keys created in root are also ignored. 

I've tested by creating various files (`*.key`, `*.csr` etc.) in root and other directories too. 