### PR TITLE
fix: Handle load of 'To review' tab

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 
 import { ReviewCard } from "./ReviewCard";
 
@@ -15,6 +15,16 @@ const Reviews = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [flow],
   );
+
+  const [orderedFlow, setOrderedFlow] = useStore((state) => [
+    state.orderedFlow,
+    state.setOrderedFlow,
+  ]);
+
+  // ReviewCard relies on the data from indexed nodes
+  useEffect(() => {
+    if (!orderedFlow) setOrderedFlow();
+  }, [orderedFlow, setOrderedFlow]);
 
   return (
     <Box p={2} sx={{ backgroundColor: "background.paper", minHeight: "100%" }}>

--- a/apps/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
@@ -2,7 +2,6 @@ import Box from "@mui/material/Box";
 import ListItemButton from "@mui/material/ListItemButton";
 import { alpha, styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { ComponentType } from "@opensystemslab/planx-core/types";
 import { ICONS } from "@planx/components/shared/icons";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { PropsWithChildren } from "react";


### PR DESCRIPTION
## What's the problem?
Right now, `ReviewCard` component return as `null` on initial load as `orderdFlow` is not set. 

This means the editor sees a blank panel and not the "No nodes are currently tagged 'To review'." message - we have `sortedReviewNodeIds`, but aren't able to render cards for them.

Reported here (OSL Slack) - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1762853082367069

## What's the solution?
Like with `<Search />`, ensure we have an `ordered` flow once in the parent, which will allow all child cards to render.

## Context
These still aren't "live" as "To review" tags are added and removed - we don't regenerate `orderedFlow` each time the flow changes (or `sortedReviewNodeIds` changes). I think this is fine for now, and matches the current behaviour, but probably one to revisit. I think ideally we'd always keep a single `orderedFlow` reference in sync with the flow the more times we reach for it.