### PR TITLE
chore(lps): Add 'Check if...' to the guidance service allow list

### DIFF
--- a/apps/localplanning.services/src/lib/lpa-api/index.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/index.ts
@@ -53,6 +53,7 @@ const NOTIFY_SERVICE_SLUGS = [
 
 const GUIDANCE_SERVICE_SLUGS = [
   "general-enquiries",
+  "check-if-you-need-planning-permission",
   "find-out-if-you-need-planning-permission",
   "find-out-if-you-need-planning-permission-energy-efficiency"
 ];


### PR DESCRIPTION
This will allow https://editor.planx.dev/gloucester/check-if-you-need-planning-permission to be listed.

The allow list method is pretty tedious / brittle, I think we probably need to revisit this one!