### PR TITLE
feat: New 2 column layout for settings

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/FlowSettings/Visibility/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/FlowSettings/Visibility/index.tsx
@@ -31,7 +31,6 @@ const FlowVisibilitySettings: React.FC = () => {
       })}
       queryVariables={{ flowId }}
       getMutationVariables={(values) => ({ flowId, ...values })}
-      newSettingsLayout
     >
       {({ formik }) => (
         <>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/Contact/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/Contact/index.tsx
@@ -56,7 +56,6 @@ export const TeamContactSettings: React.FC = () => {
           sendSlackMessage(message);
         }
       }}
-      newSettingsLayout
     >
       {({ formik }) => (
         <>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/shared/SettingsForm.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/shared/SettingsForm.tsx
@@ -38,8 +38,6 @@ interface SettingsFormContainerProps<
     data: TData | undefined;
     loading: boolean;
   }) => React.ReactNode;
-  /** Enable 2-column layout with title/description on left and form fields on right */
-  newSettingsLayout?: boolean;
 }
 
 /**
@@ -65,7 +63,6 @@ const SettingsFormContainer = <
   successMessage = "Settings updated successfully",
   children,
   preview,
-  newSettingsLayout = false,
 }: SettingsFormContainerProps<TData, TVariables, TFormValues>) => {
   const toast = useToast();
 
@@ -122,78 +119,41 @@ const SettingsFormContainer = <
     );
   }
 
-  // New 2-column layout
-  // TODO: Migrate all settings forms and remove old layout
-  if (newSettingsLayout) {
-    return (
-      <SettingsSection>
-        <Box component="form" onSubmit={formik.handleSubmit}>
-          <Grid container spacing={4}>
-            <Grid item xs={12} md={4}>
-              <InputLegend gutterBottom>{legend}</InputLegend>
-              <SettingsDescription>{description}</SettingsDescription>
-            </Grid>
-
-            <Grid item xs={12} md={8}>
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                {children({ formik, data, loading })}
-              </Box>
-              {preview && <Box mt={2}>{preview(formik)}</Box>}
-              <Box mt={2}>
-                <Button
-                  type="submit"
-                  variant="contained"
-                  disabled={!formik.dirty || updating}
-                >
-                  Save
-                </Button>
-                <Button
-                  onClick={() => formik.resetForm()}
-                  type="reset"
-                  variant="contained"
-                  disabled={!formik.dirty}
-                  color="secondary"
-                  sx={{ ml: 1.5 }}
-                >
-                  Reset changes
-                </Button>
-              </Box>
-            </Grid>
-          </Grid>
-        </Box>
-      </SettingsSection>
-    );
-  }
-
-  // Render original single-column layout for backwards compatibility until migration is complete
   return (
-    <SettingsSection background>
+    <SettingsSection>
       <Box component="form" onSubmit={formik.handleSubmit}>
-        <InputGroup flowSpacing>
-          <InputLegend>{legend}</InputLegend>
-          <SettingsDescription>{description}</SettingsDescription>
-          {children({ formik, data, loading })}
-        </InputGroup>
-        {preview && <Box mt={2}>{preview(formik)}</Box>}
-        <Box mt={2}>
-          <Button
-            type="submit"
-            variant="contained"
-            disabled={!formik.dirty || updating}
-          >
-            Save
-          </Button>
-          <Button
-            onClick={() => formik.resetForm()}
-            type="reset"
-            variant="contained"
-            disabled={!formik.dirty}
-            color="secondary"
-            sx={{ ml: 1.5 }}
-          >
-            Reset changes
-          </Button>
-        </Box>
+        <Grid container spacing={4}>
+          <Grid item xs={12} md={4}>
+            <InputLegend gutterBottom>{legend}</InputLegend>
+            <SettingsDescription>{description}</SettingsDescription>
+          </Grid>
+
+          <Grid item xs={12} md={8}>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {children({ formik, data, loading })}
+            </Box>
+            {preview && <Box mt={2}>{preview(formik)}</Box>}
+            <Box mt={2}>
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={!formik.dirty || updating}
+              >
+                Save
+              </Button>
+              <Button
+                onClick={() => formik.resetForm()}
+                type="reset"
+                variant="contained"
+                disabled={!formik.dirty}
+                color="secondary"
+                sx={{ ml: 1.5 }}
+              >
+                Reset changes
+              </Button>
+            </Box>
+          </Grid>
+        </Grid>
       </Box>
     </SettingsSection>
   );


### PR DESCRIPTION
## What does this PR do?

- Introduces a new 2 column layout for each `<SettingsSection>`, making use of the wider container and reducing visual height for each block
- Maintains original single column layout for backwards compatibility while we migrate settings over

**Before:**
<img width="1105" height="781" alt="image" src="https://github.com/user-attachments/assets/59c3bb21-b0f3-4fb8-9d94-e15295d6e096" />

**After:**
<img width="1105" height="663" alt="image" src="https://github.com/user-attachments/assets/c7d87788-bc37-4590-929d-08ef974d14fc" />