### PR TITLE
[api] rotate Microsoft SSO client secret

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -68,7 +68,7 @@ config:
   application:microsoft-client-id:
     secure: AAABAGm0SUnS8I54uBHI+Y0F1hMk8WSSKO1n+b52MCaYU8aGlbtsEuccJiQ8WXf7IFwWWgoBIeVPdk0eIGENHUet0HA=
   application:microsoft-client-secret:
-    secure: AAABAPPYmoB9WG1IcquEsIzJ7n8YtN/FPLsBzrCuULUfU1JC5oW/YV1oUu3bSE5Kd1/EpAdUVZG2tpVs2/n4H7YTq0r28wFL
+    secure: AAABADAL9YkrUfJaDga7MaVRD/dZaElsnFnnC+7IvqqlgBFywXFwVKnSMbVZ1SMFoitG8C6bKHhl2BPwOHcuvkzMKblwYzvu
   application:ordnance-survey-api-key:
     secure: AAABANmVR/iyxoja6JGBOBjhlijbMiqdqpNRwqS2p+ZusuwiYdKBACIi5y/vi2HMg7+ydXWR0SPVqtQuK5O/tA==
   application:session-secret:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -65,7 +65,7 @@ config:
   application:microsoft-client-id:
     secure: AAABAN/jlejEkv8Rf+u6nzbXy2yTIUNwWK7cw1Rz1P1DQTvvOYsPwhMYqo4Jjt9UAAx+b2FWPoUvrIOUm1dT+xpnqbU=
   application:microsoft-client-secret:
-    secure: AAABAJLeBiZ77GkBfHod1t/0zh2e7azba5b/YZ0O3lKYex25VZCI7YzuzuOaGk+SRmfNz7GZbuGYWgfAE/XrIUBiggs+7pnW
+    secure: AAABAGYZX5lmaa/axrVQODrnHmVIaoWpHP+yN/KsBt0RHnTNcPx63LJhHD0MB5d3WAjVF/Q3RLD+81tuq2ZC1sAYF18YwiZp
   application:ordnance-survey-api-key:
     secure: AAABAMqkRWGvu4THnzddRYpNddFfIFFKCqEE3gm9DkYuVJRCjZBCWpKogsT+X4j3R2f9V8OyeZxHK53yIpl8rQ==
   application:session-secret:


### PR DESCRIPTION
The client secret for our PlanX application on our [Azure](https://portal.azure.com/) account (managed by `devops@...`)  needs rotating. This applocation enables single sign-on via any email registered with Microsoft (and which appears in our db, of course).

The new secret has a duration of 365 days, so I will set calendar events for the first week of November 2026.

Once this change is on prod (to ensure zero downtime), we should delete the old secret.

Also updated the `.env`.

No ticket but see [this Slack thread](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1758729715511299) for motivation.