### PR TITLE
[application] double metabase CPU on prod

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -65,6 +65,8 @@ config:
     secure: AAABAKQ6L5aOwZWpj9YOsaW8bOOukjt1mZuTgdKjM/3nSmF/0nM/f9c9W9DXygUFj2wtq5/iugo1UTS0+bhEn8Dr9k1Qzr2EmuGpQw==
   application:metabasePgPassword:
     secure: AAABACVXNwP6Fo0v2/PoiWklNGRECTSYLRX/Ypk6APtvt9e4iOdqPVt5+tZULOxwqnfO+1bL4B6AAJxjt8gAbQ==
+  application:metabase-cpu: "1024"
+  application:metabase-memory: "2048"
   application:microsoft-client-id:
     secure: AAABAGm0SUnS8I54uBHI+Y0F1hMk8WSSKO1n+b52MCaYU8aGlbtsEuccJiQ8WXf7IFwWWgoBIeVPdk0eIGENHUet0HA=
   application:microsoft-client-secret:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -62,6 +62,8 @@ config:
     secure: AAABAGmfVICD8sR+IE6mHC8BNUY1WQXGCbv5F3C1fSgA+1ADiRem3GNrwY0YRZociRYuPIo3MIRS0aIg44jt10SBCE0ik58wHamcKA==
   application:metabasePgPassword:
     secure: AAABADfCkSRtVTdU8wi1F+nwuHl8OeI3bm9ZzaNkIY4yOGB9dsOqS30tkD8W7GZlNoWDZT2ojoP3zOFPuTLWbQ==
+  application:metabase-cpu: "512"
+  application:metabase-memory: "2048"
   application:microsoft-client-id:
     secure: AAABAN/jlejEkv8Rf+u6nzbXy2yTIUNwWK7cw1Rz1P1DQTvvOYsPwhMYqo4Jjt9UAAx+b2FWPoUvrIOUm1dT+xpnqbU=
   application:microsoft-client-secret:

--- a/infrastructure/application/utils/helpers.ts
+++ b/infrastructure/application/utils/helpers.ts
@@ -13,3 +13,10 @@ export const getPostgresDbUrl = (
   // the `postgres://` prefix provides a means of locating the resource, so this is a URL, not just a URI 
   return `postgres://${roleName}:${rolePassword}@${awsDbUri}:${port}/${databaseName}`
 }
+
+export const getJavaOpts = (containerMemoryMb: number): string => {
+  // max heap size for JVM should be no more than half total container memory, and a multiple of 1024M
+  const halvedHeapSize = Math.floor(containerMemoryMb / 2);
+  const maxHeapSizeGb = Math.floor(halvedHeapSize / 1024) || 1;
+  return `-Xmx${maxHeapSizeGb}g`
+}


### PR DESCRIPTION
Relates to [this ticket](https://trello.com/c/fFcKTg1P).

Metabase can be pretty slow. For example, it takes a good 40s to render the more complicated graphs in the [PlanX aggregate dashboard](https://metabase.editor.planx.uk/dashboard/116-osl-planx-aggregate-dashboard).

For the last few months the maximum CPU utilisation of the container on AWS ECS has hovered around 30-45%, which is high. In this PR we make explicit the vCPU allocation (which has been defaulting to 0.5, or 512MB - see [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size)), and double it for production.

@zz-hh-aa has been working on the same problem from another angle by adding materialised views to the database. I will look at a few other possibilities as well (as per ticket), but this small CPU bump is a no-brainer to start.