### PR TITLE
chore: Route team settings to integrations

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/SubmissionEmail/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/SubmissionEmail/index.tsx
@@ -13,7 +13,7 @@ import {
   UpdateTeamSettingsVariables,
 } from "./types";
 
-export const TeamSubmissionEmailSettings: React.FC = () => {
+export const TeamIntegrationSettings: React.FC = () => {
   const [teamId, teamSlug] = useStore((state) => [
     state.teamId,
     state.teamSlug,

--- a/apps/editor.planx.uk/src/routes/team.tsx
+++ b/apps/editor.planx.uk/src/routes/team.tsx
@@ -12,7 +12,7 @@ import {
   withView,
 } from "navi";
 import { TeamContactSettings } from "pages/FlowEditor/components/NewSettings/TeamSettings/Contact";
-import { TeamSubmissionEmailSettings } from "pages/FlowEditor/components/NewSettings/TeamSettings/SubmissionEmail";
+import { TeamIntegrationSettings } from "pages/FlowEditor/components/NewSettings/TeamSettings/SubmissionEmail";
 import TeamAdvancedSettings from "pages/FlowEditor/components/NewSettings/TeamSettings/TeamAdvancedSettings";
 import TeamGisDataSettings from "pages/FlowEditor/components/NewSettings/TeamSettings/TeamGisDataSettings";
 import TeamSettingsLayout from "pages/FlowEditor/components/NewSettings/TeamSettings/TeamSettingsLayout";
@@ -184,7 +184,7 @@ const routes = compose(
           title: makeTitle(
             [req.params.team, "new-settings", "integrations"].join("/"),
           ),
-          view: <TeamSubmissionEmailSettings />,
+          view: <TeamIntegrationSettings />,
         })),
         "/gis-data": route((req) => ({
           title: makeTitle(


### PR DESCRIPTION
## What does this PR do?

- Renames route to new integration settings as `TeamIntegrationSettings`