### PR TITLE
feat: Migrate trial account to new settings

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/index.tsx
@@ -1,0 +1,71 @@
+import Box from "@mui/material/Box";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { Switch } from "ui/shared/Switch";
+
+import SettingsFormContainer from "../../../shared/SettingsForm";
+import { GET_TEAM_SETTINGS, UPDATE_TEAM_SETTINGS } from "./queries";
+import { validationSchema } from "./schema";
+import {
+  GetTeamSettingsData,
+  TrialAccountFormValues,
+  UpdateTeamSettingsVariables,
+} from "./types";
+
+export const TrailAccount: React.FC = () => {
+  const [teamId, teamSlug] = useStore((state) => [
+    state.teamId,
+    state.teamSlug,
+  ]);
+
+  return (
+    <SettingsFormContainer<
+      GetTeamSettingsData,
+      UpdateTeamSettingsVariables,
+      TrialAccountFormValues
+    >
+      query={GET_TEAM_SETTINGS}
+      queryVariables={{ slug: teamSlug }}
+      mutation={UPDATE_TEAM_SETTINGS}
+      getInitialValues={({ teams: [team] }) => team.settings}
+      getMutationVariables={(values) => ({
+        teamId,
+        settings: {
+          is_trial: values.isTrial,
+        },
+      })}
+      validationSchema={validationSchema}
+      legend="Trial account"
+      description={
+        <>
+          <p>Toggle this team between "trial account" and "full access".</p>
+          <p>
+            A trial account has limited access to PlanX features - they are not
+            able to turn services online.
+          </p>
+          <p>
+            Toggling this to a trial account will turn this team's flows
+            offline.
+          </p>
+        </>
+      }
+    >
+      {({ formik }) => (
+        <Box>
+          <Switch
+            label="Trial account"
+            name="isTrial"
+            variant="editorPage"
+            capitalize
+            checked={formik.values.isTrial}
+            onChange={() =>
+              formik.setFieldValue("isTrial", !formik.values.isTrial)
+            }
+          />
+        </Box>
+      )}
+    </SettingsFormContainer>
+  );
+};
+
+export default TrailAccount;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/queries.ts
@@ -1,0 +1,30 @@
+import { gql } from "@apollo/client";
+
+export const GET_TEAM_SETTINGS = gql`
+  query GetTeamSettings($slug: String!) {
+    teams(where: { slug: { _eq: $slug } }, limit: 1) {
+      id
+      settings: team_settings {
+        id
+        isTrial: is_trial
+      }
+    }
+  }
+`;
+
+export const UPDATE_TEAM_SETTINGS = gql`
+  mutation UpdateTeamSettings(
+    $teamId: Int!
+    $settings: team_settings_set_input!
+  ) {
+    update_team_settings(
+      where: { team_id: { _eq: $teamId } }
+      _set: $settings
+    ) {
+      returning {
+        id
+        isTrial: is_trial
+      }
+    }
+  }
+`;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/schema.ts
@@ -1,0 +1,5 @@
+import { boolean, object } from "yup";
+
+export const validationSchema = object().shape({
+  isTrial: boolean().required().default(false),
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/TrialAccount/types.ts
@@ -1,0 +1,19 @@
+export interface TrialAccountFormValues {
+  isTrial: boolean;
+}
+
+export interface GetTeamSettingsData {
+  teams: {
+    id: string;
+    settings: {
+      isTrial: boolean;
+    };
+  }[];
+}
+
+export interface UpdateTeamSettingsVariables {
+  teamId: number;
+  settings: {
+    is_trial: boolean;
+  };
+}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import TrialAccount from "./TrialAccount";
+
+const GISSettings: React.FC = () => <TrialAccount />;
+
+export default GISSettings;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/TeamSettingsLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/TeamSettingsLayout.tsx
@@ -4,13 +4,20 @@ import React, { PropsWithChildren } from "react";
 import SettingsLayout from "../SettingsLayout";
 
 const TeamSettingsLayout: React.FC<PropsWithChildren> = ({ children }) => {
-  const [teamSlug] = useStore((state) => [state.teamSlug]);
+  const [teamSlug, isPlatformAdmin] = useStore((state) => [
+    state.teamSlug,
+    state.user?.isPlatformAdmin,
+  ]);
 
-  const settingsLinks = [
+  const baseSettingsLinks = [
     { label: "Contact information", path: "/contact" },
     { label: "Integrations", path: "/integrations" },
     { label: "GIS data", path: "/gis-data" },
-    { label: "Advanced", path: "/advanced" },
+  ];
+
+  const settingsLinks = [
+    ...baseSettingsLinks,
+    ...(isPlatformAdmin ? [{ label: "Advanced", path: "/advanced" }] : []),
   ];
 
   return (

--- a/apps/editor.planx.uk/src/routes/team.tsx
+++ b/apps/editor.planx.uk/src/routes/team.tsx
@@ -11,10 +11,10 @@ import {
   withData,
   withView,
 } from "navi";
+import AdvancedSettings from "pages/FlowEditor/components/NewSettings/TeamSettings/AdvancedSettings";
 import { TeamContactSettings } from "pages/FlowEditor/components/NewSettings/TeamSettings/Contact";
 import GISSettings from "pages/FlowEditor/components/NewSettings/TeamSettings/GISSettings";
 import { TeamIntegrationSettings } from "pages/FlowEditor/components/NewSettings/TeamSettings/SubmissionEmail";
-import TeamAdvancedSettings from "pages/FlowEditor/components/NewSettings/TeamSettings/TeamAdvancedSettings";
 import TeamSettingsLayout from "pages/FlowEditor/components/NewSettings/TeamSettings/TeamSettingsLayout";
 import DesignSettings from "pages/FlowEditor/components/Settings/DesignSettings";
 import GeneralSettings from "pages/FlowEditor/components/Settings/GeneralSettings";
@@ -196,7 +196,7 @@ const routes = compose(
           title: makeTitle(
             [req.params.team, "new-settings", "advanced"].join("/"),
           ),
-          view: <TeamAdvancedSettings />,
+          view: <AdvancedSettings />,
         })),
       }),
     ),


### PR DESCRIPTION
## What does this PR do?

- Migrates team trial account into `Advanced` tab of new team settings
- Updates logic so that the tab is only shown for platform admins

**Preview:**
https://5688.planx.pizza/barnet/new-settings/advanced