### PR TITLE
chore(editor): Replace depreacted `act()` from `react-dom/test-utils`

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
@@ -1,8 +1,7 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 

--- a/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -1,10 +1,9 @@
 import { Breadcrumbs } from "@opensystemslab/planx-core/types";
 import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/utils.ts
@@ -1,8 +1,7 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 // eslint-disable-next-line no-restricted-imports
 import type { UserEvent } from "@testing-library/user-event";
 import { Feature, Point, Polygon } from "geojson";
-import { act } from "react-dom/test-utils";
 
 import { mockTreeData } from "./mocks/GenericValues";
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -1,10 +1,9 @@
 import { User } from "@opensystemslab/planx-core/types";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
 import { it, vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -1,10 +1,9 @@
 import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { logger } from "airbrake";
 import { FullStore, Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import * as ReactNavi from "react-navi";
 import { setup } from "testUtils";
 import { ApplicationPath, Breadcrumbs } from "types";

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public.test.tsx
@@ -1,7 +1,7 @@
+import { act } from "@testing-library/react";
 import ErrorFallback from "components/Error/ErrorFallback";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { ErrorBoundary } from "react-error-boundary";
 import swr from "swr";
 import useSWR from "swr";

--- a/apps/editor.planx.uk/src/components/Header/Header.test.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.test.tsx
@@ -1,8 +1,7 @@
 import { Team } from "@opensystemslab/planx-core/types";
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import * as ReactNavi from "react-navi";
 import { setup } from "testUtils";
 import { vi } from "vitest";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/ExternalPortalList.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/ExternalPortalList.test.tsx
@@ -1,7 +1,6 @@
-import { waitFor } from "@testing-library/react";
+import { act, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
@@ -1,8 +1,7 @@
 import * as planxCore from "@opensystemslab/planx-core";
-import { waitFor, within } from "@testing-library/react";
-import { FullStore, useStore } from "pages/FlowEditor/lib/store";
+import { act, waitFor, within } from "@testing-library/react";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -1,12 +1,11 @@
 import { User } from "@opensystemslab/planx-core/types";
 import ChecklistComponent from "@planx/components/Checklist/Editor";
-import { within } from "@testing-library/react";
+import { act, within } from "@testing-library/react";
 import { TAG_DISPLAY_VALUES } from "pages/FlowEditor/components/Flow/components/Tag";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { act } from "react-dom/test-utils";
 import { setup } from "testUtils";
 import { it } from "vitest";
 


### PR DESCRIPTION
<img width="839" height="283" alt="Screenshot 2025-11-17 at 10 08 36" src="https://github.com/user-attachments/assets/50761770-a5d1-48ff-8543-68ecd8899c57" />

Docs: https://react.dev/warnings/react-dom-test-utils