### PR TITLE
fix: Stop `/flatten-data` being refetched on navigation to `/pages/:page`

### DIFF
--- a/apps/editor.planx.uk/src/routes/views/draft.tsx
+++ b/apps/editor.planx.uk/src/routes/views/draft.tsx
@@ -31,7 +31,7 @@ export const draftView = async (req: NaviRequest) => {
   const flow = data.flows[0];
   if (!flow) throw new NotFoundError();
 
-  const flowData = await queryClient.fetchQuery({
+  const flowData = await queryClient.ensureQueryData({
     queryKey: ["flattenedFlowData", "preview", flow.id],
     queryFn: () => getFlattenedFlowData({ flowId: flow.id, isDraft: true }),
   });

--- a/apps/editor.planx.uk/src/routes/views/preview.tsx
+++ b/apps/editor.planx.uk/src/routes/views/preview.tsx
@@ -26,7 +26,7 @@ export const previewView = async (req: NaviRequest) => {
   if (!flow)
     throw new NotFoundError(`Flow ${flowSlug} not found for ${teamSlug}`);
 
-  const flowData = await queryClient.fetchQuery({
+  const flowData = await queryClient.ensureQueryData({
     queryKey: ["flattenedFlowData", "preview", flow.id],
     queryFn: () => getFlattenedFlowData({ flowId: flow.id }),
   });


### PR DESCRIPTION
## What's the problem?
I realised when working on https://github.com/theopensystemslab/planx-new/pull/5699 that the slow / expensive `/flatten-data` endpoint is needlessly re-fetched on each navigation to a page (such as privacy, contact us). This makes for a pretty slow and frustrating process! This is not the case on `/published` routes.

## What's the solution?
Call `ensureQueryData()` which forces a fetch from the local cache, not a network re-fetch.

Docs: https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientensurequerydata

On a side note, I'd love to revisit the setup of these pages once we've progressed out routing update. Having these as weird popovers is not great!

