### PR TITLE
chore: Add conditional option data values to search keys

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
@@ -192,6 +192,9 @@ const keyFormatters: KeyMap = {
   "data.freeformQuestion": {
     getDisplayKey: () => "Freeform question",
   },
+  "data.rule.fn": {
+    getDisplayKey: () => "Option (rule data)",
+  },
 };
 
 const componentFormatters: ComponentMap = {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -8,6 +8,8 @@ const generalData: SearchFacets = ["data.fn", "data.val"];
 
 const fileUploadAndLabelData: SearchFacets = ["data.fileTypes.fn"];
 
+const optionData: SearchFacets = ["data.rule.fn"];
+
 const calculateData: SearchFacets = [
   {
     name: "formula",
@@ -26,6 +28,7 @@ export const DATA_FACETS: SearchFacets = [
   ...fileUploadAndLabelData,
   ...calculateData,
   ...listData,
+  ...optionData,
 ];
 
 const stripHTMLTags = (html = "") =>


### PR DESCRIPTION
## What does this PR do?
- Adds the conditional rule fields to the data search

Test flow: https://5710.planx.pizza/testing/responsive-checklist-question-search

<img width="1438" height="779" alt="image" src="https://github.com/user-attachments/assets/8d2616a3-3c85-40b4-ae81-5c6f79e10077" />
