### PR TITLE
feat: show node_title in analytics_project_types

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1763570417555_add_node_title_to_analytics_project_types/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763570417555_add_node_title_to_analytics_project_types/down.sql
@@ -1,0 +1,21 @@
+CREATE MATERIALIZED VIEW "public"."analytics_project_types" AS
+-- Arrays
+SELECT 
+  analytics_id,
+  jsonb_array_elements_text(
+    (allow_list_answers ->> 'proposal.projectType')::jsonb
+  ) AS project_type_value
+FROM analytics_logs
+WHERE jsonb_typeof((allow_list_answers ->> 'proposal.projectType')::jsonb) = 'array'
+
+UNION ALL
+
+-- Objects
+SELECT 
+  analytics_id,
+  e.value AS project_type_value
+FROM analytics_logs,
+     LATERAL jsonb_each_text((allow_list_answers ->> 'proposal.projectType')::jsonb) AS e
+WHERE jsonb_typeof((allow_list_answers ->> 'proposal.projectType')::jsonb) = 'object';
+
+GRANT SELECT ON "public"."analytics_project_types" TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1763570417555_add_node_title_to_analytics_project_types/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763570417555_add_node_title_to_analytics_project_types/up.sql
@@ -1,0 +1,16 @@
+DROP MATERIALIZED VIEW "public"."analytics_project_types";
+CREATE MATERIALIZED VIEW "public"."analytics_project_types" AS 
+ SELECT analytics_logs.analytics_id,
+    analytics_logs.node_title,
+    jsonb_array_elements_text(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) AS project_type_value
+   FROM analytics_logs
+  WHERE (jsonb_typeof(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) = 'array'::text)
+UNION ALL
+ SELECT analytics_logs.analytics_id,
+    analytics_logs.node_title,
+    e.value AS project_type_value
+   FROM analytics_logs,
+    LATERAL jsonb_each_text(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) e(key, value)
+  WHERE (jsonb_typeof(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) = 'object'::text);
+
+GRANT SELECT ON "public"."analytics_project_types" TO metabase_read_only;


### PR DESCRIPTION
Part of optimising the '[Project types](https://metabase.editor.planx.uk/public/dashboard/e5e1d601-f769-4556-a583-3a2cd4d53ee1?analytics_id=&date=&minimum_number_of_projects=&service_slug=&tab=364-'list-the-changes'&team_slug=)' dashboard for the service team (still using large, unmaterialized views). 
