### PR TITLE
[application] rotate Slack webhook for ECS rollback alerts

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -78,7 +78,7 @@ config:
   application:skip-rate-limit-secret:
     secure: AAABADPv0Fp55IK8xL0Kxx/Kq2sFeRIgbKn0sgHBFhTsWh09kV3/OyG0d/wkE3zm+15zbud0GR4TSl4z//MV5XgxLWDhJgGJ
   application:slack-internal-errors-webhook:
-    secure: AAABAD03UlWhbs3DiYA1+dWxlmNKA1kvgNT1Z4NsKFUpfUUtgsB8nEV5xbVHE7ZfPaJHF/G/BknTO7FqTZdxP0FIWJeKBxAL587+Bo47hBJQO0ETy0VMy02D5YovAlJ+wd33ctyQRB/t5J2v30smkoV25slDfMwQ5A==
+    secure: AAABAIdznmeJ53lLUde2j8a7FeSlBO7UpdQNRWWxErp7djbuAk3YdAIH2zK1qmz5nfFT8fRLh/RenS/bFHAW4/KsCjziio1JlDIy7YsnxOBsL6ZE+pUlzM6/SlMcZth/S/4FKVfv7FxwmK9boG8pCSoAbJx0GCCpXQ==
   application:slack-webhook-url:
     secure: AAABANpjl5NnZcSFTUB3iHS4qsQuSgHGkki0yYn/LEB9Oq6kqg/RFSvwl6toXoLjgKRwhcguba8Qyp/gA+nCSMyFu7i36QVFiTRjPFsoQ9esTEo/zGqyNf2tCL/AFd+oE2/WLo1TSq7/Qt7hVm49
   application:ssl-barking-and-dagenham-cert:

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -75,7 +75,7 @@ config:
   application:skip-rate-limit-secret:
     secure: AAABANwjBmGN73bwF6nqQP5i8tKMe3mi0NMBdae4uaLasG2VfPvC1D4mk7QWIFqVnzsD5jCN20Eqos/r2B+EAo2rAws3JeD/
   application:slack-internal-errors-webhook:
-    secure: AAABAPkO1mBzTkXVWjpzAeP9ZbkifOiBwxj+rL5OONBu6DY87Pw1FualS6jSmQ5yeoGovZowNy3iMsArq4lxSX2BnBAur4O4a90Qou5zGUFACSTfLkZOgsyImvbdwRRnFPBBskfQ+bqwX9OZjO5AAXkEa9bqu3ViFQ==
+    secure: AAABAA/QUOR2t9DKWtIGok1cSEmbVB5b56Wa9vdDK8tW9C/mgMB3cxOnqRpbY0Db2BfALGBiZbnx8tX6TwouZjtbrDJJT0ch/e2Put1Kw4LtsWprjGZbW0emt3gq/YDUst6KMJ5C37pEMjicStLPKy0vmBVLD9Y9ng==
   application:slack-webhook-url:
     secure: AAABALzK5KLP5po8giGePS/+ZpcWQHf8LfvCcdlY/oSv6NvC3y6D44CeIAiUdDXTB7VeUX5JFeaceDyZ9C1N5CAWFOLPCCKvuLjuDtk7QZe/rczqd2QnMDLh+Q9wPlQSb4PIoK8jWNEmvQC3QMgq
   application:uniform-client-buckinghamshire:

--- a/infrastructure/application/utils/failureNotification.ts
+++ b/infrastructure/application/utils/failureNotification.ts
@@ -15,11 +15,11 @@ export const setupNotificationForDeploymentRollback = (
   const config = new pulumi.Config();
 
   const topic = new aws.sns.Topic(`${simpleServiceName}-rollback-alerts`, {
-    name: `${simpleServiceName}-rollback-alerts`,
+    name: `${simpleServiceName}-rollback-alerts-topic`,
   });
 
   new aws.sns.TopicSubscription(
-    `${simpleServiceName}-rollback-slack-alert`,
+    `${simpleServiceName}-rollback-alerts-subscription`,
     {
       topic: topic.arn,
       protocol: "https",
@@ -28,7 +28,7 @@ export const setupNotificationForDeploymentRollback = (
   );
 
   // allow SNS topic to receive events from EventBridge
-  new aws.sns.TopicPolicy(`${simpleServiceName}-rollback-topic-policy`, {
+  new aws.sns.TopicPolicy(`${simpleServiceName}-rollback-alerts-topic-policy`, {
     arn: topic.arn,
     policy: pulumi.jsonStringify({
       Version: "2012-10-17",
@@ -66,7 +66,7 @@ export const setupNotificationForDeploymentRollback = (
 
   // XXX: this template may not be ingested by SNS/Slack as expected and can then be simplified
   new aws.cloudwatch.EventTarget(
-    `${simpleServiceName}-rollback-target`,
+    `${simpleServiceName}-rollback-alerts-target`,
     {
       rule: rollbackRule.name,
       arn: topic.arn,


### PR DESCRIPTION
Very small PR to reflect use of new Slack workflow (which can be managed by myself, @DafyddLlyr or @jessicamcinchak) to alert on ECS rollbacks.

Workflow includes the `SubscribeURL` variable so that we can confirm the subscription when it's created on AWS.