### PR TITLE
feat: create `analytics_property_types` mv

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_property_types.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_property_types.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_property_types
+  schema: public

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -6,6 +6,7 @@
 - "!include public_analytics_journeys_aggregated.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_project_types.yaml"
+- "!include public_analytics_property_types.yaml"
 - "!include public_analytics_results.yaml"
 - "!include public_analytics_sessions.yaml"
 - "!include public_analytics_summary.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1763572477603_create_analytics_property_types_mv/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763572477603_create_analytics_property_types_mv/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW "public"."analytics_property_types";

--- a/apps/hasura.planx.uk/migrations/default/1763572477603_create_analytics_property_types_mv/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763572477603_create_analytics_property_types_mv/up.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE MATERIALIZED VIEW "public"."analytics_property_types" AS 
+SELECT 
+    a.id AS analytics_id,
+    ((al.allow_list_answers -> 'property.type'::text) ->> 0) AS property_type,
+    al.node_type,
+    ((al.allow_list_answers -> 'propertyInformation.action'::text))::text AS property_information_action,
+    al.node_id,
+    ((al.allow_list_answers -> 'property.type.userProvided'::text))::text AS property_type_user_provided
+FROM analytics a
+LEFT JOIN analytics_logs al ON (a.id = al.analytics_id)
+WHERE (
+    ((al.allow_list_answers -> 'property.type'::text) ->> 0) IS NOT NULL 
+    OR ((al.allow_list_answers -> 'property.type.userProvided'::text))::text IS NOT NULL
+    OR ((al.allow_list_answers -> 'propertyInformation.action'::text))::text IS NOT NULL
+)
+GROUP BY 
+    a.id,
+    al.node_type,
+    ((al.allow_list_answers -> 'property.type'::text) ->> 0),
+    ((al.allow_list_answers -> 'propertyInformation.action'::text))::text,
+    al.node_id,
+    ((al.allow_list_answers -> 'property.type.userProvided'::text))::text;
+
+GRANT SELECT ON VIEW "public"."analytics_property_types" TO "metabase_read_only";

--- a/apps/hasura.planx.uk/migrations/default/1763572954433_create_index_on_analytics_property_types/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763572954433_create_index_on_analytics_property_types/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF NOT EXISTS analytics_property_types_analytics_id_idx
+  ON analytics_property_types (analytics_id);

--- a/apps/hasura.planx.uk/migrations/default/1763572954433_create_index_on_analytics_property_types/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763572954433_create_index_on_analytics_property_types/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS analytics_property_types_analytics_id_idx
+  ON analytics_property_types (analytics_id);

--- a/apps/hasura.planx.uk/migrations/default/1763573019907_refresh_analytics_property_types_mv/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763573019907_refresh_analytics_property_types_mv/down.sql
@@ -1,0 +1,1 @@
+SELECT cron.unschedule('refresh_analytics_property_types');

--- a/apps/hasura.planx.uk/migrations/default/1763573019907_refresh_analytics_property_types_mv/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763573019907_refresh_analytics_property_types_mv/up.sql
@@ -1,0 +1,5 @@
+SELECT cron.schedule(
+  'refresh_analytics_property_types',
+  '30 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_property_types$$
+);


### PR DESCRIPTION
Creates a view, index + cron job for `analytics_property_types`, in order to create a [more performant property types dashboard](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1763570099677799?thread_ts=1763569693.972899&cid=C5Q59R3HB) for service team. 