### PR TITLE
chore: Remove deprecated `addTypename` prop

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/FindProperty.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/FindProperty.stories.tsx
@@ -25,7 +25,7 @@ export default {
 
 export const EmptyForm: StoryObj = {
   render: () => (
-    <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+    <MockedProvider mocks={findAddressReturnMock}>
       <FindProperty
         title="Find your property"
         description="For example, SE5 0HU"
@@ -37,7 +37,7 @@ export const EmptyForm: StoryObj = {
 
 export const AllowNewAddressesOnMap: StoryObj = {
   render: () => (
-    <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+    <MockedProvider mocks={findAddressReturnMock}>
       <FindProperty
         title="Find your property"
         description="For example, SE5 0HU"
@@ -52,7 +52,7 @@ export const WithEditor = () => {
     <Wrapper
       Editor={Editor}
       Public={() => (
-        <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+        <MockedProvider mocks={findAddressReturnMock}>
           <FindProperty
             title="Find your property"
             description="For example, SE5 0HU"

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -143,7 +143,7 @@ describe("render states", () => {
     const handleSubmit = vi.fn();
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -177,7 +177,7 @@ describe("render states", () => {
     const handleSubmit = vi.fn();
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -217,7 +217,7 @@ describe("render states", () => {
     const handleSubmit = vi.fn();
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -251,7 +251,7 @@ describe("render states", () => {
     const previousData = osAddressProps;
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -285,7 +285,7 @@ describe("render states", () => {
   it("should not have any accessibility violations", async () => {
     const handleSubmit = vi.fn();
     const { container, user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -311,7 +311,7 @@ describe("picking an OS address", () => {
     const handleSubmit = vi.fn();
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -326,7 +326,7 @@ describe("picking an OS address", () => {
 
   it("updates the address-autocomplete props when the postcode is changed", async () => {
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -364,7 +364,7 @@ describe("picking an OS address", () => {
     const previousData = osAddressProps;
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -392,7 +392,7 @@ describe("plotting a new address that does not have a uprn yet", () => {
     const handleSubmit = vi.fn();
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"
@@ -438,7 +438,7 @@ describe("plotting a new address that does not have a uprn yet", () => {
     const previousData = proposedAddressProps;
 
     const { user } = setup(
-      <MockedProvider mocks={findAddressReturnMock} addTypename={false}>
+      <MockedProvider mocks={findAddressReturnMock}>
         <FindProperty
           description="Find your property"
           title="Type your postal code"

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/findAddressReturnMock.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/findAddressReturnMock.ts
@@ -13,6 +13,7 @@ export default [
             code: "RH01",
             description: "HMO Parent",
             value: "residential.HMO.parent",
+            __typename: "blpu_codes"
           },
         ],
       },


### PR DESCRIPTION
Small issue I spotted when working on #5717 

<img width="772" height="280" alt="image" src="https://github.com/user-attachments/assets/65bead59-f05c-4486-8a44-52d40ebb4a3d" />
