### PR TITLE
feat: add 'LPS listing' flow filter

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -229,6 +229,7 @@ export interface FlowSummary {
   publishedFlows: PublishedFlowSummary[];
   templatedFrom: string | null;
   isTemplate: boolean;
+  isListedOnLPS: boolean;
   template: {
     team: {
       name: string;
@@ -518,6 +519,7 @@ export const editorStore: StateCreator<
             status
             summary
             updatedAt: updated_at
+            isListedOnLPS: is_listed_on_lps
             operations(limit: 1, order_by: { created_at: desc }) {
               createdAt: created_at
               actor {

--- a/apps/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
+++ b/apps/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
@@ -30,6 +30,15 @@ const checkFlowServiceType: FilterOptions<FlowSummary>["validationFn"] = (
   _value,
 ) => flow.publishedFlows[0]?.hasSendComponent;
 
+const checkFlowLPSListing: FilterOptions<FlowSummary>["validationFn"] = (
+  flow,
+  value,
+) => {
+  if (value === "listed") return flow.isListedOnLPS === true;
+  if (value === "not listed") return flow.isListedOnLPS === false;
+  return false;
+};
+
 const checkFlowTemplateType: FilterOptions<FlowSummary>["validationFn"] = (
   flow,
   value,
@@ -57,6 +66,12 @@ const baseFilterOptions: FilterOptions<FlowSummary>[] = [
     optionKey: "templatedFrom",
     optionValue: ["templated", "source template"],
     validationFn: checkFlowTemplateType,
+  },
+  {
+    displayName: "LPS listing",
+    optionKey: "isListedOnLPS",
+    optionValue: ["listed", "not listed"],
+    validationFn: checkFlowLPSListing,
   },
 ];
 


### PR DESCRIPTION
Adds an _LPS listing_ flow filter to filter by Listed/Not listed [as per council request](https://trello.com/c/0pP7jhsv/3492-add-listed-on-lps-as-filter-option).