### PR TITLE
chore(lps): Drop flow allow list, group by category

### DIFF
--- a/apps/localplanning.services/src/lib/lpa-api/index.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/index.ts
@@ -46,21 +46,6 @@ const TEAMS_ALLOW_LIST = [
   "west-berkshire",
 ] as const;
 
-const NOTIFY_SERVICE_SLUGS = [
-  "report-a-planning-breach",
-  "camden-report-a-planning-breach",
-];
-
-const GUIDANCE_SERVICE_SLUGS = [
-  "check-constraints-on-a-property",
-  "check-if-you-need-planning-permission",
-  "check-your-planning-constraints",
-  "find-out-if-you-need-planning-permission-energy-efficiency",
-  "find-out-if-you-need-planning-permission",
-  "general-enquiries",
-  "heritage-constraints",
-];
-
 export async function fetchAllLPAs(): Promise<LPA[]> {
   try {
     const response = await fetch(PUBLIC_PLANX_BUILD_TIME_GRAPHQL_API_URL, {
@@ -70,8 +55,6 @@ export async function fetchAllLPAs(): Promise<LPA[]> {
         query: print(GET_LPAS_QUERY),
         variables: {
           teamSlugs: TEAMS_ALLOW_LIST,
-          notifyServiceSlugs: NOTIFY_SERVICE_SLUGS,
-          guidanceServiceSlugs: GUIDANCE_SERVICE_SLUGS,
         },
       }),
     });

--- a/apps/localplanning.services/src/lib/lpa-api/query.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/query.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
 export const GET_LPAS_QUERY = gql`
-  query GetLPAs($teamSlugs: [String!], $notifyServiceSlugs: [String!], $guidanceServiceSlugs: [String!]) {
+  query GetLPAs($teamSlugs: [String!]) {
     lpas: teams(
       order_by: { name: asc }
       where: { slug: { _in: $teamSlugs } }
@@ -17,11 +17,7 @@ export const GET_LPAS_QUERY = gql`
         where: {
           status: { _eq: online }
           is_listed_on_lps: { _eq: true }
-          _and: [
-            { slug: { _nin: $notifyServiceSlugs } }
-            { slug: { _nin: $guidanceServiceSlugs } }
-          ]
-          published_flows: { has_send_component: { _eq: true } }
+          category: { _eq: "apply" }
         }
         order_by: { name: asc }
       ) {
@@ -31,10 +27,7 @@ export const GET_LPAS_QUERY = gql`
         where: {
           status: { _eq: online }
           is_listed_on_lps: { _eq: true }
-          _and: [
-            { slug: { _nin: $notifyServiceSlugs } }
-            { slug: { _in: $guidanceServiceSlugs } }
-          ]
+          category: { _eq: "guidance" }
         }
         order_by: { name: asc }
       ) {
@@ -44,11 +37,7 @@ export const GET_LPAS_QUERY = gql`
         where: {
           status: { _eq: online }
           is_listed_on_lps: { _eq: true }
-          _and: [
-            { slug: { _in: $notifyServiceSlugs } }
-            { slug: { _nin: $guidanceServiceSlugs } }
-          ]
-          published_flows: { has_send_component: { _eq: true } }
+          category: { _eq: "notify" }
         }
         order_by: { name: asc }
       ) {


### PR DESCRIPTION
## What does this PR do?
This PR drops the flows allow list, and manual grouping via GQL query, in favour of the `flows.category` value.

I've tested the prod build locally and it's listing the same teams and services as the current prod build, I've also diffed the results of the old and new queries on prod and I'm getting identical results ✅ 