### PR TITLE
chore: allow Upload & Label, Next Steps, and Task List options to be customised [skip pizza]

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -110,7 +110,6 @@ function FileUploadAndLabelComponent(props: Props) {
             Editor={FileTypeEditor}
             newValue={newFileType}
             disabled={props.disabled}
-            isTemplatedNode={props.node?.data?.isTemplatedNode}
             errors={formik.errors.fileTypes}
           />
         </ModalSectionContent>

--- a/apps/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -1,7 +1,10 @@
 import Box from "@mui/material/Box";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { NextSteps, Step } from "@planx/components/NextSteps/model";
-import { parseNextSteps, validationSchema } from "@planx/components/NextSteps/model";
+import {
+  parseNextSteps,
+  validationSchema,
+} from "@planx/components/NextSteps/model";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
 import React, { ChangeEvent } from "react";
@@ -134,7 +137,6 @@ const NextStepsComponent: React.FC<Props> = (props) => {
             Editor={TaskEditor}
             newValue={newStep}
             disabled={props.disabled}
-            isTemplatedNode={props.node?.data?.isTemplatedNode}
           />
         </ModalSectionContent>
       </ModalSection>

--- a/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -2,7 +2,10 @@ import Box from "@mui/material/Box";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import type { Task, TaskList } from "@planx/components/TaskList/model";
-import { parseTaskList, validationSchema } from "@planx/components/TaskList/model";
+import {
+  parseTaskList,
+  validationSchema,
+} from "@planx/components/TaskList/model";
 import { Form, Formik, getIn, useFormikContext } from "formik";
 import React, { ChangeEvent } from "react";
 import ListManager, {
@@ -118,7 +121,6 @@ const TaskListComponent: React.FC<Props> = (props) => (
               Editor={TaskEditor}
               newValue={newTask}
               disabled={props.disabled}
-              isTemplatedNode={props.node?.data?.isTemplatedNode}
             />
           </ModalSectionContent>
         </ModalSection>


### PR DESCRIPTION
Allows customisation of options in customisable Upload & Label, Next Steps, and Task List components in templated copies.