### PR TITLE
chore: rename email_id to id

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_integrations.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_integrations.yaml
@@ -9,7 +9,7 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          email_id: email_id
+          email_id: id
         insertion_order: null
         remote_table:
           name: submission_integrations

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_submission_integrations.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_submission_integrations.yaml
@@ -11,7 +11,7 @@ insert_permissions:
       check: {}
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
         - team_id
     comment: ""
@@ -20,7 +20,7 @@ insert_permissions:
       check: {}
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
         - team_id
     comment: ""
@@ -29,7 +29,7 @@ select_permissions:
     permission:
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
       filter: {}
     comment: ""
@@ -37,7 +37,7 @@ select_permissions:
     permission:
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
         - team_id
       filter: {}
@@ -51,7 +51,7 @@ select_permissions:
     permission:
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
         - team_id
       filter: {}
@@ -61,7 +61,7 @@ update_permissions:
     permission:
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
       filter: {}
       check: null
@@ -70,7 +70,7 @@ update_permissions:
     permission:
       columns:
         - default_email
-        - email_id
+        - id
         - submission_email
       filter: {}
       check: null

--- a/apps/hasura.planx.uk/migrations/default/1763745157071_alter_table_public_submission_integrations_alter_column_email_id/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745157071_alter_table_public_submission_integrations_alter_column_email_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."submission_integrations" rename column "id" to "email_id";

--- a/apps/hasura.planx.uk/migrations/default/1763745157071_alter_table_public_submission_integrations_alter_column_email_id/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745157071_alter_table_public_submission_integrations_alter_column_email_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."submission_integrations" rename column "email_id" to "id";


### PR DESCRIPTION
This is the fix for Daf's comment from #5726 :

>We should apply the default: gen_random_uuid() pattern here in Hasura, and probably rename the column to just id instead of email_id (sorry for missing both of these earlier). If we retain email_id we'll need to keep a configure a cache ID for it within the GraphQL client - it's simpler to just use id where possible.

`oz/multiple-email-team-settings` was having some weird Hasura issues so I opened a separate PR for those changes. `gen_random_uuid()` isn't set again here because it's already set (that's what's on `main` anyway)! Will cherry-pick the other commits onto a new branch / open a separate PR. 