### PR TITLE
[hasura] add bad migration to force a rollback

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/down.sql
@@ -1,0 +1,3 @@
+-- inverse of the up migration (which will fail)
+ALTER TABLE not_a_table 
+DROP COLUMN spoof;

--- a/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/up.sql
@@ -1,0 +1,3 @@
+-- destined to fail!
+ALTER TABLE not_a_table 
+ADD COLUMN spoof BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
Should test #5684 / #5715 by attempting to apply a migration which will fail, causing the Hasura deployment on ECS to fail and rollback. We expect to see a message in Slack. We can then revert this PR for a clean deploy.