### PR TITLE
test(editor): Allow vitest to flush pending requests

### DIFF
--- a/apps/editor.planx.uk/src/test/mockServer.ts
+++ b/apps/editor.planx.uk/src/test/mockServer.ts
@@ -6,6 +6,12 @@ beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 
 afterEach(() => server.resetHandlers());
 
-afterAll(() => server.close());
+afterAll(async () => {
+  server.close();
+  // Wait for the next tick to allow pending MSW promises to resolve
+  // (e.g. bypasses / unhandled requests) before the environment
+  // (window/URL) is destroyed
+  await new Promise((resolve) => setImmediate(resolve));
+});
 
 export default server;


### PR DESCRIPTION
Small follow up to https://github.com/theopensystemslab/planx-new/pull/5583 and https://github.com/theopensystemslab/planx-new/pull/5705

We're currently still seeing some flakey React tests in CI which I think is still related to the above issue - there's a race condition between msw and vitest/jsdom teardown. As there's a large number of unhandled requests, some of these are resolving after the test env has been torn down.

This fix should allow an extra tick for these to resolve - let's see if this makes a difference!