### PR TITLE
feat: Display placeholder value for optional field summaries

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -8,6 +8,7 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
+import { formatTitle } from "@planx/components/shared/Schema/InputFields";
 import { isMapFieldResponse } from "@planx/components/shared/Schema/model";
 import { SchemaFields } from "@planx/components/shared/Schema/SchemaFields";
 import { PublicProps } from "@planx/components/shared/types";
@@ -162,7 +163,7 @@ const InactiveListCard: React.FC<{
                         maxWidth: "160px",
                       }}
                     >
-                      {field.data.title}
+                      {formatTitle(field)}
                     </TableCell>
                     <TableCell>
                       {formatSchemaDisplayValue(

--- a/apps/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -31,6 +31,8 @@ export const formatSchemaDisplayValue = <T extends Field>(
   value: ResponseValue<T>,
   field: T,
 ) => {
+  if (!value && !field.required) return "Not provided";
+
   switch (field.type) {
     case "number":
       if (!isNumberFieldResponse(value)) return;

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -5,9 +5,9 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import {
+  ComponentType as TYPES,
   GISResponse,
   NodeId,
-  ComponentType as TYPES,
 } from "@opensystemslab/planx-core/types";
 import { PASSPORT_UPLOAD_KEY } from "@planx/components/DrawBoundary/model";
 import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLabel/model";
@@ -24,6 +24,7 @@ import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
+import { formatTitle } from "../Schema/InputFields";
 import { SchemaUserResponse } from "../Schema/model";
 
 export default SummaryListsBySections;
@@ -318,8 +319,10 @@ function SummaryList(props: SummaryListProps) {
                       {(node.type === TYPES.FindProperty && FIND_PROPERTY_DT) ||
                         (node.type === TYPES.DrawBoundary &&
                           DRAW_BOUNDARY_DT) ||
-                        (node.type === TYPES.PropertyInformation && PROPERTY_INFORMATION_DT) ||
-                        (node.type === TYPES.PlanningConstraints && PLANNING_CONSTRAINTS_DT) ||
+                        (node.type === TYPES.PropertyInformation &&
+                          PROPERTY_INFORMATION_DT) ||
+                        (node.type === TYPES.PlanningConstraints &&
+                          PLANNING_CONSTRAINTS_DT) ||
                         node.data?.title ||
                         node.data?.text ||
                         "this answer"}
@@ -363,7 +366,9 @@ function PropertyInformation(props: ComponentProps) {
     <>
       <Box component="dt">{PROPERTY_INFORMATION_DT}</Box>
       <Box component="dd">
-        {find(blpuCodes?.blpu_codes, { value: propertyTypeVal })?.description || propertyTypeVal || "Unknown"}
+        {find(blpuCodes?.blpu_codes, { value: propertyTypeVal })?.description ||
+          propertyTypeVal ||
+          "Unknown"}
       </Box>
     </>
   );
@@ -377,7 +382,8 @@ function PlanningConstraints(props: ComponentProps) {
     return undefined;
   }
 
-  const applicableConstraints = props.passport.data?.["property.constraints.planning"];
+  const applicableConstraints =
+    props.passport.data?.["property.constraints.planning"];
   if (!applicableConstraints?.length) {
     return (
       <>
@@ -391,8 +397,12 @@ function PlanningConstraints(props: ComponentProps) {
   (applicableConstraints as string[]).forEach((fn) => {
     fetchedConstraints.forEach((constraintSource: GISResponse) => {
       // `hasOwnProperty(fn)` will naturally omit/de-duplicate "granular" constraints to their parent
-      if (constraintSource["metadata"].hasOwnProperty(fn)) {
-        formattedApplicableConstraints.push(constraintSource.metadata[fn]["plural"]);
+      if (
+        Object.prototype.hasOwnProperty.call(constraintSource["metadata"], fn)
+      ) {
+        formattedApplicableConstraints.push(
+          constraintSource.metadata[fn]["plural"],
+        );
       }
     });
   });
@@ -578,8 +588,9 @@ function DrawBoundary(props: ComponentProps) {
               geojsonColor="#ff0000"
               geojsonFill
               geojsonBuffer={20}
-              osProxyEndpoint={`${import.meta.env.VITE_APP_API_URL
-                }/proxy/ordnance-survey`}
+              osProxyEndpoint={`${
+                import.meta.env.VITE_APP_API_URL
+              }/proxy/ordnance-survey`}
               hideResetControl
               staticMode
               style={{ width: "100%", height: "30vh" }}
@@ -601,8 +612,9 @@ function NumberInput(props: ComponentProps) {
   return (
     <>
       <Box component="dt">{props.node.data.title}</Box>
-      <Box component="dd">{`${getAnswersByNode(props)} ${props.node.data.units ?? ""
-        }`}</Box>
+      <Box component="dd">{`${getAnswersByNode(props)} ${
+        props.node.data.units ?? ""
+      }`}</Box>
     </>
   );
 }
@@ -675,8 +687,8 @@ function FileUploadAndLabel(props: ComponentProps) {
         <ul>
           {uniqueFilenames.length
             ? uniqueFilenames.map((filename, index) => (
-              <li key={index}>{filename}</li>
-            ))
+                <li key={index}>{filename}</li>
+              ))
             : "No files uploaded"}
         </ul>
       </Box>
@@ -704,7 +716,7 @@ function Page(props: ComponentProps) {
         {fieldsWithAnswers.map((field) => (
           <Box key={field.data.fn}>
             <Typography fontWeight={FONT_WEIGHT_SEMI_BOLD}>
-              {field.data.title}
+              {formatTitle(field)}
             </Typography>
             <Typography>
               {formatSchemaDisplayValue(answers[0][field.data.fn], field)}
@@ -733,7 +745,7 @@ function getAnswers(props: ComponentProps): string[] {
   try {
     const array = props!.userData!.answers!;
     if (Array.isArray(array)) return array;
-  } catch (err) { }
+  } catch (err) {}
   return [];
 }
 
@@ -746,6 +758,6 @@ function getAnswersByNode(props: ComponentProps): any {
   try {
     const variableName: string = props.node!.data!.fn!;
     return props.userData?.data![variableName || props.nodeId];
-  } catch (err) { }
+  } catch (err) {}
   return "";
 }

--- a/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/index.tsx
@@ -29,7 +29,7 @@ export type Props<T extends Field> = {
 export const formatTitle = ({
   required = true,
   data: { title },
-}: Props<Field>): string => (required ? title : (title += " (optional)"));
+}: Field): string => (required ? title : (title += " (optional)"));
 
 /**
  * Helper function to get shared props derived from `Field` and `props.formik`


### PR DESCRIPTION
## What does this PR do?
 - For schema-based components (List, Page, MapAndLabel) with optional fields, shows "Not provided" as a value instead of a blank
 - Applies this on inactive cards and the SummaryList component
 - Small issue I spotted in Greg's last Show & Tell

### Content
There's no specific GDS guidance I could find here, the Summary List component doesn't cover this scenario of optional questions (see "Showing missing information") - https://design-system.service.gov.uk/components/summary-list/

The Scottish Design System has this for their SummaryList however which I've taken - 

> _If a user did not answer a question, show the question with an 'empty' response, such as 'not applicable' or 'not answered'._

Source: https://designsystem.gov.scot/components/summary-list

| Before | After |
|--------|--------|
| <img width="630" height="767" alt="image" src="https://github.com/user-attachments/assets/bd7edb4a-6b35-4921-aec3-bcebfe99ff51" /> | <img width="599" height="742" alt="image" src="https://github.com/user-attachments/assets/78b8bb87-4835-40f6-8b39-a79735d04a31" /> | 