### PR TITLE
fix: Hide env select in standalone routes

### DIFF
--- a/apps/editor.planx.uk/src/components/Header/Header.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.tsx
@@ -212,7 +212,7 @@ const Breadcrumbs: React.FC = () => {
         >
           Plan✕
         </BreadcrumbsLink>
-        <EnvironmentSelect />
+        {!isStandalone && <EnvironmentSelect />}
         {team.slug && (
           <>
             {" / "}


### PR DESCRIPTION
## What's the problem?
Currently, if a team does not have a logo, the `<EnvironmentSelect/>` component always displays in the header in `/preview`, `/draft` and `/published` routes.

Regression introduced in https://github.com/theopensystemslab/planx-new/pull/5696

## What's the solution?
Add a guard for `isStandalone` which wraps the component.

| Before | After |
|--------|--------|
| <img width="852" height="602" alt="image" src="https://github.com/user-attachments/assets/e6f2fb16-0452-49f0-88e4-3400acd84984" /> | <img width="836" height="628" alt="image" src="https://github.com/user-attachments/assets/131f0a27-ffd4-45a1-8815-b6a8782d2e45" /> | 