### PR TITLE
feat: settings page for multiple submission emails v2

### DIFF
--- a/apps/editor.planx.uk/src/lib/featureFlags.ts
+++ b/apps/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,8 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["RESPONSIVE_QUESTIONS_CHECKLISTS"] as const;
+const AVAILABLE_FEATURE_FLAGS = [
+  "RESPONSIVE_QUESTIONS_CHECKLISTS",
+  "TEAM_SUBMISSION_INTEGRATIONS",
+] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
@@ -1,0 +1,76 @@
+import Typography from "@mui/material/Typography";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { ChangeEvent } from "react";
+import InputLabel from "ui/editor/InputLabel";
+import Input from "ui/shared/Input/Input";
+
+import SettingsFormContainer from "../../../shared/SettingsForm";
+import {
+  GET_TEAM_SUBMISSION_INTEGRATIONS,
+  UPDATE_TEAM_SUBMISSION_INTEGRATIONS,
+} from "./queries";
+import { defaultValues, validationSchema } from "./schema";
+import {
+  GetTeamSubmissionIntegrationsData,
+  SubmissionEmailFormValues,
+  UpdateTeamSubmissionIntegrationsVariables,
+} from "./types";
+
+// Parallel feature to SubmissionEmail (singular)
+export const SubmissionEmails: React.FC = () => {
+  const teamId = useStore((state) => state.teamId);
+  console.log(teamId, typeof teamId);
+  console.log("Query Variables:", { team_id: teamId });
+
+  return (
+    <SettingsFormContainer<
+      GetTeamSubmissionIntegrationsData,
+      SubmissionEmailFormValues,
+      UpdateTeamSubmissionIntegrationsVariables
+    >
+      query={GET_TEAM_SUBMISSION_INTEGRATIONS}
+      defaultValues={defaultValues}
+      queryVariables={{ team_id: teamId }}
+      mutation={UPDATE_TEAM_SUBMISSION_INTEGRATIONS}
+      getInitialValues={({ submissionIntegrations }) =>
+        submissionIntegrations?.[0] || defaultValues
+      }
+      getMutationVariables={(values) => ({
+        teamId,
+        submissionEmail: values.submissionEmail,
+        defaultEmail: values.defaultEmail,
+      })}
+      validationSchema={validationSchema}
+      legend="Submission information"
+      description={
+        <>
+          <Typography variant="body2">
+            Enter multiple email addresses to receive applications. You can
+            assign one email address per service. A default address must be
+            selected, which will be used as a fallback for all applications.
+          </Typography>
+        </>
+      }
+    >
+      {({ formik }) => (
+        <InputLabel label="Submission email" htmlFor="submissionEmail">
+          <Input
+            name="submissionEmail"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              formik.setFieldValue("submissionEmail", e.target.value)
+            }
+            value={formik.values.submissionEmail ?? ""}
+            errorMessage={
+              typeof formik.errors.submissionEmail === "string"
+                ? formik.errors.submissionEmail
+                : undefined
+            }
+            id="submissionEmail"
+          />
+        </InputLabel>
+      )}
+    </SettingsFormContainer>
+  );
+};
+
+export default SubmissionEmails;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
@@ -19,6 +19,7 @@ import {
 // Parallel feature to SubmissionEmail (singular)
 export const SubmissionEmails: React.FC = () => {
   const teamId = useStore((state) => state.teamId);
+  console.log({ teamId });
 
   return (
     <SettingsFormContainer<

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
@@ -1,4 +1,5 @@
 import Typography from "@mui/material/Typography";
+import { getIn } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { ChangeEvent } from "react";
 import InputLabel from "ui/editor/InputLabel";
@@ -29,7 +30,7 @@ export const SubmissionEmails: React.FC = () => {
     >
       query={GET_TEAM_SUBMISSION_INTEGRATIONS}
       defaultValues={defaultValues}
-      queryVariables={{ team_id: teamId }}
+      queryVariables={{ teamId }}
       mutation={UPDATE_TEAM_SUBMISSION_INTEGRATIONS}
       getInitialValues={({ submissionIntegrations }) =>
         submissionIntegrations?.[0] || defaultValues
@@ -58,12 +59,8 @@ export const SubmissionEmails: React.FC = () => {
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               formik.setFieldValue("submissionEmail", e.target.value)
             }
-            value={formik.values.submissionEmail ?? ""}
-            errorMessage={
-              typeof formik.errors.submissionEmail === "string"
-                ? formik.errors.submissionEmail
-                : undefined
-            }
+            value={formik.values.submissionEmail}
+            errorMessage={getIn(formik.errors, "submissionEmail")}
             id="submissionEmail"
           />
         </InputLabel>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/index.tsx
@@ -19,8 +19,6 @@ import {
 // Parallel feature to SubmissionEmail (singular)
 export const SubmissionEmails: React.FC = () => {
   const teamId = useStore((state) => state.teamId);
-  console.log(teamId, typeof teamId);
-  console.log("Query Variables:", { team_id: teamId });
 
   return (
     <SettingsFormContainer<

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/queries.ts
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
 
 export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
-  query GetTeamSubmissionIntegrations($team_id: Int!) {
+  query GetTeamSubmissionIntegrations($teamId: Int!) {
     submissionIntegrations: submission_integrations(
-      where: { team_id: { _eq: $team_id } }
+      where: { team_id: { _eq: $teamId } }
     ) {
       teamId: team_id
       submissionEmail: submission_email
@@ -18,7 +18,7 @@ export const CREATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
       objects: { submission_email: $submission_email, team_id: $team_id }
     ) {
       returning {
-        emailId: email_id
+        id
       }
     }
   }
@@ -26,7 +26,8 @@ export const CREATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
 
 export const UPDATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
   mutation UpdateSubmissionIntegration {
-    update_submission_integrations_by_pk(pk_columns: { email_id: $email_id }) {
+    update_submission_integrations_by_pk(pk_columns: { id: $id }) {
+      id
       submissionEmail: submission_email
       teamId: team_id
     }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/queries.ts
@@ -25,8 +25,15 @@ export const CREATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
 `;
 
 export const UPDATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
-  mutation UpdateSubmissionIntegration {
-    update_submission_integrations_by_pk(pk_columns: { id: $id }) {
+  mutation UpdateSubmissionIntegration(
+    $id: uuid!
+    $submissionEmail: String
+    $teamId: Int
+  ) {
+    update_submission_integrations_by_pk(
+      pk_columns: { id: $id }
+      _set: { submission_email: $submissionEmail, team_id: $teamId }
+    ) {
       id
       submissionEmail: submission_email
       teamId: team_id

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/queries.ts
@@ -1,0 +1,34 @@
+import { gql } from "@apollo/client";
+
+export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
+  query GetTeamSubmissionIntegrations($team_id: Int!) {
+    submissionIntegrations: submission_integrations(
+      where: { team_id: { _eq: $team_id } }
+    ) {
+      teamId: team_id
+      submissionEmail: submission_email
+      defaultEmail: default_email
+    }
+  }
+`;
+
+export const CREATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
+  mutation InsertSubmissionIntegration {
+    insert_submission_integrations(
+      objects: { submission_email: $submission_email, team_id: $team_id }
+    ) {
+      returning {
+        emailId: email_id
+      }
+    }
+  }
+`;
+
+export const UPDATE_TEAM_SUBMISSION_INTEGRATIONS = gql`
+  mutation UpdateSubmissionIntegration {
+    update_submission_integrations_by_pk(pk_columns: { email_id: $email_id }) {
+      submissionEmail: submission_email
+      teamId: team_id
+    }
+  }
+`;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/schema.ts
@@ -1,0 +1,16 @@
+import { boolean, number,object, string } from "yup";
+
+import { SubmissionEmailFormValues } from "./types";
+
+export const validationSchema = object().shape({
+  teamId: number().required(),
+  submissionEmail: string()
+    .email("Enter a valid email address")
+    .required("Submission email is required"),
+  defaultEmail: boolean().required(),
+});
+
+export const defaultValues: SubmissionEmailFormValues = {
+  submissionEmail: "",
+  defaultEmail: false,
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/schema.ts
@@ -1,9 +1,8 @@
-import { boolean, number,object, string } from "yup";
+import { boolean, object, string } from "yup";
 
 import { SubmissionEmailFormValues } from "./types";
 
 export const validationSchema = object().shape({
-  teamId: number().required(),
   submissionEmail: string()
     .email("Enter a valid email address")
     .required("Submission email is required"),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/SubmissionEmails/types.ts
@@ -1,0 +1,16 @@
+export interface SubmissionEmailFormValues {
+  submissionEmail: string;
+  defaultEmail: boolean;
+}
+
+export interface GetTeamSubmissionIntegrationsData {
+  submissionIntegrations: {
+    submissionEmail: string;
+    defaultEmail: boolean;
+  }[];
+}
+
+export interface UpdateTeamSubmissionIntegrationsVariables {
+  submissionEmail: string;
+  defaultEmail: boolean;
+}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/NewSettings/TeamSettings/IntegrationSettings/index.tsx
@@ -1,7 +1,14 @@
+import { hasFeatureFlag } from "lib/featureFlags";
 import React from "react";
 
 import SubmissionEmail from "./SubmissionEmail";
+import SubmissionEmails from "./SubmissionEmails";
 
-const IntegrationSettings: React.FC = () => <SubmissionEmail />;
+const IntegrationSettings: React.FC = () => (
+  <>
+    {hasFeatureFlag("TEAM_SUBMISSION_INTEGRATIONS") && <SubmissionEmails />}
+    <SubmissionEmail />
+  </>
+);
 
 export default IntegrationSettings;


### PR DESCRIPTION
A new version of #5726 because Hasura metadata was out of date there and causing some weird problems. 

The Hasura changes from 5726 were separated into #5736 and these are the code changes. 

>To test:
Go to `/{team}/new-settings/integrations`
Run `window.featureFlags.toggle("TEAM_SUBMISSION_INTEGRATIONS")` and refresh
Check console for team ID number
Go to Hasura and add a new record in Hasura `submission_integrations` table, using the same team ID 
Refresh the new settings page and the newly submission email should be read