### PR TITLE
feat: add node_id to analytics_project_types [skip pizza]

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1764017710560_add_node_id_to_analytics_project_types/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1764017710560_add_node_id_to_analytics_project_types/down.sql
@@ -1,0 +1,54 @@
+DROP MATERIALIZED VIEW "public"."analytics_project_types";
+CREATE MATERIALIZED VIEW "public"."analytics_project_types" AS
+SELECT
+  analytics_logs.analytics_id,
+  analytics_logs.node_title,
+  jsonb_array_elements_text(
+    (
+      (
+        analytics_logs.allow_list_answers ->> 'proposal.projectType' :: text
+      )
+    ) :: jsonb
+  ) AS project_type_value
+FROM
+  analytics_logs
+WHERE
+  (
+    jsonb_typeof(
+      (
+        (
+          analytics_logs.allow_list_answers ->> 'proposal.projectType' :: text
+        )
+      ) :: jsonb
+    ) = 'array' :: text
+  )
+UNION ALL
+SELECT
+  analytics_logs.analytics_id,
+  analytics_logs.node_title,
+  e.value AS project_type_value
+FROM
+  analytics_logs,
+  LATERAL jsonb_each_text(
+    (
+      (
+        analytics_logs.allow_list_answers ->> 'proposal.projectType' :: text
+      )
+    ) :: jsonb
+  ) e(key, value)
+WHERE
+  (
+    jsonb_typeof(
+      (
+        (
+          analytics_logs.allow_list_answers ->> 'proposal.projectType' :: text
+        )
+      ) :: jsonb
+    ) = 'object' :: text
+  );
+
+CREATE INDEX IF NOT EXISTS analytics_project_types_analytics_id_idx
+  ON analytics_project_types (analytics_id);
+
+
+GRANT SELECT ON "public"."analytics_project_types" TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1764017710560_add_node_id_to_analytics_project_types/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1764017710560_add_node_id_to_analytics_project_types/up.sql
@@ -1,0 +1,21 @@
+DROP MATERIALIZED VIEW "public"."analytics_project_types";
+CREATE MATERIALIZED VIEW "public"."analytics_project_types" AS 
+ SELECT analytics_logs.analytics_id,
+    analytics_logs.node_title,
+    analytics_logs.node_id,
+    jsonb_array_elements_text(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) AS project_type_value
+   FROM analytics_logs
+  WHERE (jsonb_typeof(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) = 'array'::text)
+UNION ALL
+ SELECT analytics_logs.analytics_id,
+    analytics_logs.node_title,
+    analytics_logs.node_id,
+    e.value AS project_type_value
+   FROM analytics_logs,
+    LATERAL jsonb_each_text(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) e(key, value)
+  WHERE (jsonb_typeof(((analytics_logs.allow_list_answers ->> 'proposal.projectType'::text))::jsonb) = 'object'::text);
+
+CREATE INDEX IF NOT EXISTS analytics_project_types_analytics_id_idx
+  ON analytics_project_types (analytics_id);
+
+GRANT SELECT ON "public"."analytics_project_types" TO metabase_read_only;


### PR DESCRIPTION
Migration to add `node_id` so we can compare project types across different parts of a service. Recreates the index too because the whole view is dropped to be created again.