### PR TITLE
chore(lps): Add additional service to allow list

### DIFF
--- a/apps/localplanning.services/src/lib/lpa-api/index.ts
+++ b/apps/localplanning.services/src/lib/lpa-api/index.ts
@@ -52,6 +52,7 @@ const NOTIFY_SERVICE_SLUGS = [
 ];
 
 const GUIDANCE_SERVICE_SLUGS = [
+  "check-constraints-on-a-property",
   "check-if-you-need-planning-permission",
   "check-your-planning-constraints",
   "find-out-if-you-need-planning-permission-energy-efficiency",


### PR DESCRIPTION
Adds https://editor.planx.uk/epsom-and-ewell/check-constraints-on-a-property to LPS.

I'll merge this and get it to prod next, there are two queued up PRs here which replace this allow list method - 
 - https://github.com/theopensystemslab/planx-new/pull/5731
 - https://github.com/theopensystemslab/planx-new/pull/5732