### PR TITLE
feat: Improve copy in settings pages, toggle flow category

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Help/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Help/index.tsx
@@ -24,7 +24,7 @@ const Help: React.FC = () => {
       mutation={UPDATE_FLOW_SETTINGS}
       validationSchema={textContentValidationSchema}
       legend="Help page"
-      description="A place to communicate FAQs, useful tips, or contact information"
+      description="A place to communicate FAQs, useful tips, or contact information."
       defaultValues={defaultValues}
       getInitialValues={({ flow: { settings } }) =>
         settings?.elements?.help || DEFAULT_TEXT_CONTENT

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/LegalDisclaimer/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/LegalDisclaimer/index.tsx
@@ -24,7 +24,7 @@ const LegalDisclaimer: React.FC = () => {
       mutation={UPDATE_FLOW_SETTINGS}
       validationSchema={textContentValidationSchema}
       legend="Legal disclaimer"
-      description="Displayed on the 'Result' pages of the service (if it contains any)"
+      description="Displayed on the 'Result' pages of the service (if it contains any)."
       defaultValues={defaultValues}
       getInitialValues={({ flow: { settings } }) =>
         settings?.elements?.legalDisclaimer || DEFAULT_TEXT_CONTENT

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
@@ -14,7 +14,8 @@ const CATEGORIES: { value: LPSCategory; label: string; description: string }[] =
     {
       value: "apply",
       label: "Application service",
-      description: "Submits a planning application to your back office system",
+      description:
+        "Submits a planning application to your selected 'Send' destinations",
     },
     {
       value: "guidance",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
@@ -6,6 +6,7 @@ import BasicRadio from "@planx/components/shared/Radio/BasicRadio/BasicRadio";
 import { useFormikContext } from "formik";
 import React from "react";
 import SettingsDescription from "ui/editor/SettingsDescription";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import type { LPSCategory, LPSListingFormValues } from "../types";
 
@@ -44,8 +45,11 @@ const CategoryLabel: React.FC<(typeof CATEGORIES)[number]> = ({
 );
 
 const CategorySelection: React.FC = () => {
-  const { values, handleChange, setFieldValue } =
+  const { values, handleChange, setFieldValue, errors } =
     useFormikContext<LPSListingFormValues>();
+
+  // Only show if LPS is toggled on
+  if (!values.isListedOnLPS) return null;
 
   const handleRadioChange = (event: React.SyntheticEvent<Element, Event>) => {
     const target = event.target as HTMLInputElement;
@@ -58,27 +62,29 @@ const CategorySelection: React.FC = () => {
       <SettingsDescription mt={0}>
         Which of the following categories best describes your service?
       </SettingsDescription>
-      <RadioGroup
-        name="category"
-        value={values.category}
-        onChange={handleChange}
-        sx={{ gap: 2 }}
-      >
-        <FormControl component="fieldset">
-          <RadioGroup value={values.category} sx={{ gap: 1 }}>
-            {CATEGORIES.map((option) => (
-              <BasicRadio
-                key={option.value}
-                id={option.value}
-                label={<CategoryLabel {...option} />}
-                variant="compact"
-                value={option.value}
-                onChange={handleRadioChange}
-              />
-            ))}
-          </RadioGroup>
-        </FormControl>
-      </RadioGroup>
+      <ErrorWrapper error={errors.category}>
+        <RadioGroup
+          name="category"
+          value={values.category}
+          onChange={handleChange}
+          sx={{ gap: 2 }}
+        >
+          <FormControl component="fieldset">
+            <RadioGroup value={values.category} sx={{ gap: 1 }}>
+              {CATEGORIES.map((option) => (
+                <BasicRadio
+                  key={option.value}
+                  id={option.value}
+                  label={<CategoryLabel {...option} />}
+                  variant="compact"
+                  value={option.value}
+                  onChange={handleRadioChange}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
+        </RadioGroup>
+      </ErrorWrapper>
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/index.tsx
@@ -30,12 +30,12 @@ const LPSListingSettings: React.FC = () => {
       legend={"Local planning services"}
       description={
         <>
-          Control if this flow will be listed as a service on{" "}
+          Control whether this flow is listed as a service on{" "}
           <Link href={url} target="_blank" rel="noopener noreferrer">
             localplanning.services (opens in a new tab)
           </Link>{" "}
-          . By listing your service you allow applicants and agents to browse
-          the services which you offer via Plan✕.
+          . Listing your service makes it discoverable to applicants and agents
+          browsing the services you offer through Plan✕.
         </>
       }
       defaultValues={defaultValues}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/schema.ts
@@ -17,7 +17,9 @@ export const validationSchema: SchemaOf<LPSListingFormValues> = object({
       },
     ),
   summary: string().nullable(),
-  category: mixed().oneOf(["guidance", "notify", "apply"]),
+  category: mixed()
+    .oneOf(["guidance", "notify", "apply"])
+    .required("Category is a required field"),
 });
 
 export const defaultValues: LPSListingFormValues = {


### PR DESCRIPTION
## What does this PR do?
 - Updates copy across a number of settings pages, based on feedback provided here - https://opensystemslab.slack.com/archives/C5Q59R3HB/p1764075332435089 (OSL Slack)
 - Toggle "category" selection based on `isListedOnLPS` boolean
 - Adds proper error handling to category selection

https://github.com/user-attachments/assets/eb4bf7f9-e499-433c-abb3-e28be149810a

