### PR TITLE
[hasura] add bad migration to force a rollback (#2)

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/down.sql
@@ -1,0 +1,3 @@
+-- inverse of the up migration (which will fail)
+ALTER TABLE not_a_table 
+DROP COLUMN spoof;

--- a/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/up.sql
@@ -1,0 +1,3 @@
+-- destined to fail!
+ALTER TABLE not_a_table 
+ADD COLUMN spoof BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
Re-applies #5737, this time with ECS event capture *on*, so we can troubleshoot why the deployment failure event is not matching on the event detail in our Pulumi code.