### PR TITLE
Revert "[hasura] add bad migration to force a rollback (#2)"

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/down.sql
@@ -1,3 +1,0 @@
--- inverse of the up migration (which will fail)
-ALTER TABLE not_a_table 
-DROP COLUMN spoof;

--- a/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1763745724000_alter_non_existent_table/up.sql
@@ -1,3 +1,0 @@
--- destined to fail!
-ALTER TABLE not_a_table 
-ADD COLUMN spoof BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#5762

Aiming to clear up `main` so that https://github.com/theopensystemslab/planx-new/pull/5763 and https://github.com/theopensystemslab/planx-new/pull/5732 can get to prod.