### PR TITLE
[application] fix filtering of service on event rule

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -284,7 +284,7 @@ export = async () => {
 
   const rootDbUrl = pulumi.all([dbHost, dbRootPassword]).apply(([dbHost, dbRootPassword]) => 
     getPostgresDbUrl(DB_ROOT_USERNAME, dbRootPassword, dbHost))
-  createHasuraService({
+  const hasuraService = await createHasuraService({
     vpc,
     cluster,
     repo,
@@ -801,6 +801,7 @@ export = async () => {
 
   return {
     customDomains,
+    hasuraServiceName: hasuraService.service.name,
   };
 };
 

--- a/infrastructure/application/services/hasura.ts
+++ b/infrastructure/application/services/hasura.ts
@@ -21,7 +21,7 @@ export const createHasuraService = async ({
   stacks: {
     networking, certificates, data,
   },
-}: CreateService) => {
+}: CreateService): Promise<awsx.ecs.FargateService> => {
 
   const config = new pulumi.Config();
   const DOMAIN: string = await certificates.requireOutputValue("domain");
@@ -241,4 +241,5 @@ export const createHasuraService = async ({
   });
 
   setupNotificationForDeploymentRollback("hasura", cluster, hasuraService);
+  return hasuraService;
 }

--- a/infrastructure/application/utils/failureNotification.ts
+++ b/infrastructure/application/utils/failureNotification.ts
@@ -54,9 +54,11 @@ export const setupNotificationForDeploymentRollback = (
       eventPattern: pulumi.jsonStringify({
         source: ["aws.ecs"],
         "detail-type": ["ECS Deployment State Change"],
+        // with awsx at 0.x, we can't get the service ARN directly, so we filter on service name
+        // see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-pattern-operators.html
+        resources: [{ "suffix": { "equals-ignore-case": service.service.name }}],
         detail: {
           clusterArn: [cluster.cluster.arn],
-          serviceName: [service.service.name],
           eventType: ["ERROR"],
           eventName: ["SERVICE_DEPLOYMENT_FAILED"],
         }


### PR DESCRIPTION
I'd introduced an error in #5684 because `serviceName` is not part of the event pattern for ECS service state changes. This should repair that by filtering on `resources` using the generated service name instead.

I ascertained this by manually turning on ECS event capture in the AWS console (can turn off later), and forcing a failed deployment of Hasura to ECS (#5762). This allowed me to observe the following general pattern to match on:

```json
{
    "version": "0",
    "id": "e8274f8f-70f9-d79a-0762-06f129da68cd",
    "detail-type": "ECS Deployment State Change",
    "source": "aws.ecs",
    "account": "XXX",
    "time": "2025-11-25T15:05:06Z",
    "region": "eu-west-2",
    "resources": [
        "arn:aws:ecs:eu-west-2:XXX:service/cluster-asdf123/hasura-wxyz456"
    ],
    "detail": {
        "eventType": "ERROR",
        "eventName": "SERVICE_DEPLOYMENT_FAILED",
        "clusterArn": "arn:aws:ecs:eu-west-2:XXX:cluster/cluster-asdf123",
        "deploymentId": "ecs-svc/2833912168557404295",
        "updatedAt": "2025-11-25T14:57:05.921Z",
        "reason": "ECS deployment circuit breaker: tasks failed to start."
    }
}
```

