### PR TITLE
fix: `platfromAdmins` should still be able to select-all when nesting flows

### DIFF
--- a/apps/editor.planx.uk/src/routes/flow.tsx
+++ b/apps/editor.planx.uk/src/routes/flow.tsx
@@ -29,7 +29,7 @@ const sortFlows = (a: { text: string }, b: { text: string }) =>
   sorter(a.text.replace(/\W|\s/g, ""), b.text.replace(/\W|\s/g, ""));
 
 /**
- * External portal (aka nested flow) selection should return:
+ * For non admins, external portal (aka nested flow) selection should return:
  *   - Flows in my team
  *   - Flows set to copiable by others
  *   - Not source templates
@@ -38,20 +38,13 @@ const sortFlows = (a: { text: string }, b: { text: string }) =>
 const getExternalPortals = async (currentTeam: string, currentFlow: string) => {
   const { data } = await client.query({
     query: gql`
-      query GetExternalPortals($teamSlug: String!) {
-        flows(
-          where: {
-            _or: [
-              { team: { slug: { _eq: $teamSlug } } }
-              { can_create_from_copy: { _eq: true } }
-            ]
-          }
-          order_by: { slug: asc }
-        ) {
+      query GetExternalPortals {
+        flows(order_by: { slug: asc }) {
           id
           slug
           name
           isTemplate: is_template
+          canCreateFromCopy: can_create_from_copy
           team {
             id
             slug
@@ -60,24 +53,31 @@ const getExternalPortals = async (currentTeam: string, currentFlow: string) => {
         }
       }
     `,
-    variables: {
-      teamSlug: currentTeam,
-    },
   });
 
-  const filteredFlows = data.flows
-    .filter(
+  // Always filter out the parent flow I am currently nesting within
+  let filteredFlows = data.flows.filter(
+    (flow: Flow) =>
+      flow.team &&
+      `${currentTeam}/${currentFlow}` !== `${flow.team.slug}/${flow.slug}`,
+  );
+
+  // For non admins, also filter out source templates, flows not copiable by others, and flows not in my team for a less-overwhelming selection
+  const isPlatformAdmin = useStore.getState().user?.isPlatformAdmin;
+  if (!isPlatformAdmin) {
+    filteredFlows = filteredFlows.filter(
       (flow: Flow) =>
-        flow.team &&
-        `${currentTeam}/${currentFlow}` !== `${flow.team.slug}/${flow.slug}` &&
-        !flow.isTemplate,
-    )
-    .map(({ id, team, slug, name }: Flow) => ({
-      id,
-      name,
-      slug,
-      team: team.name,
-    }));
+        !flow.isTemplate &&
+        (flow.canCreateFromCopy || flow.team.slug === currentTeam),
+    );
+  }
+
+  filteredFlows = filteredFlows.map(({ id, team, slug, name }: Flow) => ({
+    id,
+    name,
+    slug,
+    team: team.name,
+  }));
 
   const flowsSortedByTeam = sortBy(filteredFlows, [(flow: Flow) => flow.team]);
 

--- a/apps/editor.planx.uk/src/types.ts
+++ b/apps/editor.planx.uk/src/types.ts
@@ -25,6 +25,7 @@ export interface Flow {
   settings?: FlowSettings;
   status?: FlowStatus;
   isTemplate?: boolean;
+  canCreateFromCopy?: boolean;
 }
 export interface GlobalSettings {
   footerContent?: { [key: string]: TextContent };


### PR DESCRIPTION
Follow-up fix for #5755 based on feedback here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1764086415455729