### PR TITLE
fix: Clone marker for all nodes

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -217,7 +217,6 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 
   & a {
-    position: relative;
     display: flex;
     flex-direction: row;
     align-items: flex-start;


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Fixes clone marker for nodes with data, and source template nodes

**Before change (all branched nodes are clones):**
<img width="773" height="699" alt="image" src="https://github.com/user-attachments/assets/3e993b28-46f4-438a-a759-55d65c02df61" />

**After change:**
<img width="773" height="699" alt="image" src="https://github.com/user-attachments/assets/080a5522-b26a-43eb-8ed1-277c9f24ac46" />
