### PR TITLE
chore: Standardise input labels across settings forms

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/TextInput.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/TextInput.tsx
@@ -7,8 +7,6 @@ import InputLabel from "ui/editor/InputLabel";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import SettingsDescription from "ui/editor/SettingsDescription";
 import Input, { Props as InputProps } from "ui/shared/Input/Input";
-import InputRow from "ui/shared/InputRow";
-import InputRowItem from "ui/shared/InputRowItem";
 import { Switch } from "ui/shared/Switch";
 
 export const TextInput: React.FC<{


### PR DESCRIPTION
## What does this PR do?

- Updates `Legal disclaimer`, `Help page` and `Privacy page` settings pages to have labels on text inputs, in line with all other text inputs on settings pages