### PR TITLE
fix(lps): Reset session for magic link errors

### DIFF
--- a/apps/localplanning.services/src/components/applications/errors/ConsumedLink.tsx
+++ b/apps/localplanning.services/src/components/applications/errors/ConsumedLink.tsx
@@ -1,7 +1,13 @@
-export const ConsumedLink: React.FC = () => (
+import { useResetSession } from "../hooks/useResetSession";
+
+export const ConsumedLink: React.FC = () => {
+  const { resetAndNavigate } = useResetSession();
+
+  return (
   <section className="styled-content">
     <h2>Error: You've already used this magic link</h2>
     <p>The links we send you are single use, and this one has already been used.</p>
-    <p>Please <a href="/applications">try to log in again</a>.</p>
+    <p>Please <button onClick={() => resetAndNavigate()} className="button-link button-focus-style">try to log in again</button>.</p>
   </section>
-);
+  );
+};

--- a/apps/localplanning.services/src/components/applications/errors/ExpiredLink.tsx
+++ b/apps/localplanning.services/src/components/applications/errors/ExpiredLink.tsx
@@ -1,7 +1,14 @@
-export const ExpiredLink: React.FC = () => (
+import { useResetSession } from "../hooks/useResetSession";
+
+export const ExpiredLink: React.FC = () => {
+  const { resetAndNavigate } = useResetSession();
+
+  return (
   <section className="styled-content">
     <h2>Error: Expired magic link</h2>
     <p>Your magic link has expired.</p>
-    <p>Please <a href="/applications">click here to trigger an email with a new magic link</a>.</p>
+    <p>Please <button onClick={() => resetAndNavigate()} className="button-link button-focus-style">log in again</button>.</p>
   </section>
-);
+  );
+};
+

--- a/apps/localplanning.services/src/components/applications/errors/InvalidLink.tsx
+++ b/apps/localplanning.services/src/components/applications/errors/InvalidLink.tsx
@@ -1,6 +1,12 @@
-export const InvalidLink: React.FC = () => (
+import { useResetSession } from "../hooks/useResetSession";
+
+export const InvalidLink: React.FC = () => {
+  const { resetAndNavigate } = useResetSession();
+
+  return (
   <section className="styled-content">
     <h2>Error: Invalid magic link</h2>
-    <p>Please <a href="/applications">try to log in again</a>.</p>
+    <p>Please <button onClick={() => resetAndNavigate()} className="button-link button-focus-style">try to log in again</button>.</p>
   </section>
-);
+  );
+};

--- a/apps/localplanning.services/src/components/applications/errors/UnhandledError.tsx
+++ b/apps/localplanning.services/src/components/applications/errors/UnhandledError.tsx
@@ -1,6 +1,12 @@
-export const UnhandledError: React.FC = () => (
+import { useResetSession } from "../hooks/useResetSession";
+
+export const UnhandledError: React.FC = () => {
+  const { resetAndNavigate } = useResetSession();
+
+  return (
   <section className="styled-content">
     <h2>Error: Unhandled error</h2>
-    <p>Please <a href="/applications">try to log in again</a>.</p>
+    <p>Please <button onClick={() => resetAndNavigate()} className="button-link button-focus-style">try to log in again</button>.</p>
   </section>
-);
+  );
+};

--- a/apps/localplanning.services/src/components/applications/hooks/useResetSession.tsx
+++ b/apps/localplanning.services/src/components/applications/hooks/useResetSession.tsx
@@ -1,0 +1,14 @@
+import { $session } from "@stores/session";
+import { queryClient } from "@lib/queryClient";
+
+export const useResetSession = () => {
+  const resetAndNavigate = (path: string = "/applications") => {
+    $session.set({ token: null, email: null });
+    
+    queryClient.removeQueries({ queryKey: ["fetchApplications"] });
+    
+    window.location.href = path;
+  };
+
+  return { resetAndNavigate };
+};

--- a/apps/localplanning.services/src/styles/global.css
+++ b/apps/localplanning.services/src/styles/global.css
@@ -134,12 +134,16 @@
     @apply my-8
   }
   .styled-content a:not(.button),
-  .paragraph-link {
+  .paragraph-link,
+  .button-link {
     @apply underline underline-offset-6;
   }
   .styled-content a.external::after,
   .paragraph-link--external::after {
     content: " ↗";
+  }
+  .button-link {
+    cursor: pointer;
   }
 
   /*


### PR DESCRIPTION
## What does this PR do?

Addresses an issue in which `/applications` is used as a shared URL for magic link errors, making it hard to direct users back to the login form state.

Introducing a hook to reset the user state allows us to provide a clean state for logging in.


Error highlighted by @jonnyrc in Slack:

https://github.com/user-attachments/assets/59fd65cb-311f-4038-a5b2-4a16e841a838
