### PR TITLE
[application] simplify input template for ECS rollback SNS target

### DIFF
--- a/infrastructure/application/utils/failureNotification.ts
+++ b/infrastructure/application/utils/failureNotification.ts
@@ -66,7 +66,6 @@ export const setupNotificationForDeploymentRollback = (
     }
   );
 
-  // XXX: this template may not be ingested by SNS/Slack as expected and can then be simplified
   new aws.cloudwatch.EventTarget(
     `${simpleServiceName}-rollback-alerts-target`,
     {
@@ -81,50 +80,16 @@ export const setupNotificationForDeploymentRollback = (
           reason: "$.detail.reason",
         },
         inputTemplate: pulumi.jsonStringify({
-          "text": `Circuit Breaker Rollback: ${simpleServiceName}`,
-          "blocks": [
-            {
-              "type": "header",
-              "text": {
-                "type": "plain_text",
-                "text": `Circuit Breaker Rollback: ${simpleServiceName}`
-              }
-            },
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "The ECS deployment circuit breaker has triggered a rollback due to deployment failure."
-              }
-            },
-            {
-              "type": "section",
-              "fields": [
-                {
-                  "type": "mrkdwn",
-                  "text": "*Event type:* <eventType>"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Event name:* <eventName>"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Deployment ID:* <deploymentId>"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Updated at:* <updatedAt>"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Reason:* <reason>"
-                }
-              ]
-            }
-          ]
-        })
-      }
+          text: [
+            `-> Affected service: ${simpleServiceName}`,
+            "-> Event type: <eventType>",
+            "-> Event name: <eventName>",
+            "-> Deployment ID: <deploymentId>",
+            "-> Updated at: <updatedAt>",
+            "-> Reason: <reason>",
+          ].join("\n"),
+        }),
+      },
     }
   );
 };


### PR DESCRIPTION
Slack webhook and previous input template were not playing nicely together, so this PR fixes that. I detail here for posterity the Slack webhook setup as well.

See an exemplar alert sent to Slack [here](https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1764174796425259) (triggered manually via curl).

## Webhook setup

In the 'Starts with a webhook' config in Slack, we include both `SubscribeURL` and `Message` as 'data variables'. The former is used by the SNS topic to confirm the subscription on first setup, and the latter is the key for the payload in the json which SNS dispatches when an ECS rollback is detected for a service for which the EventBridge rule is set up (for now, just `hasura`).

<img width="486" height="178" alt="image" src="https://github.com/user-attachments/assets/c22f59a8-11dd-48ed-a6e5-b9b2bb74dfa9" />

The message that is then sent to the channel is as follows:

```
:x: An ECS deployment has failed, triggering a rollback
Workflow initiated: {Time when workflow started}

{Message}
{SubscribeURL}
```

We can leave the `SubscribeURL` var there in case we need to set up the webhook again in future. If the key isn't in the message body, it simply won't feature in the message, so this is a neat solution.

Figured this out thanks to [this YouTube vid](https://www.youtube.com/watch?v=CszzQcPAqNM), as linked by @DafyddLlyr in initial attempt at this alert, in #4245.

See also relevant [Slack docs](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/).