### PR TITLE
feat: Dedicated graph folder styling

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -8,8 +8,8 @@ $lockedNodeBackground: #eee;
 $lockedBorder: #888;
 $dataBackground: #f0f0f0;
 $lockedDataBackground: #e2e2e2;
-$folderBackground: #b8d9f4;
-$folderBorder: #2d598b;
+$folderBackground: #b5d1f7;
+$folderBorder: #2c4b88;
 
 $endpointWidth: 50px;
 $hangerWidth: 16px;
@@ -97,6 +97,8 @@ $fontMonospace: "Source Code Pro", monospace;
     a:active {
       outline: 4px solid $focus;
       outline-offset: 0;
+      // Make focussed link outline more visible
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

- Add a dedicated "pastel blue" colour to folders, to distinguish them from embedded flows

<img width="384" height="300" alt="image" src="https://github.com/user-attachments/assets/68025981-cfb2-4f44-86bb-19440b7d1cf6" />

<img width="499" height="168" alt="image" src="https://github.com/user-attachments/assets/bd53d2c4-e02f-43e5-b6f8-db508c037f58" />

<img width="499" height="168" alt="image" src="https://github.com/user-attachments/assets/04cfe863-2c01-4c19-9f57-5ac2a52e52d1" />

<img width="499" height="168" alt="image" src="https://github.com/user-attachments/assets/cc3d03d2-b8f3-41c6-b8d0-1460b9bf529c" />

<img width="1141" height="254" alt="image" src="https://github.com/user-attachments/assets/ccfd1f0e-4da3-4699-8074-9a6033b59622" />
