### PR TITLE
chore: Remove deprecated GovPay metadata format

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#364a0f6",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d685fe8",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.12.2",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.701.0
         version: 3.936.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#364a0f6
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@19.2.6)
+        specifier: git+https://github.com/theopensystemslab/planx-core#d685fe8
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@19.2.6)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1032,8 +1032,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8}
     version: 1.0.0
 
   '@paralleldrive/cuid2@2.3.1':
@@ -5242,7 +5242,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -18,7 +18,7 @@
     "@mui/x-charts": "8.9.0",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.6",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#364a0f6",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d685fe8",
     "@tanstack/react-query": "^5.90.6",
     "@tiptap/core": "3.0.7",
     "@tiptap/extension-emoji": "3.0.7",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#364a0f6
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@18.3.27)
+        specifier: git+https://github.com/theopensystemslab/planx-core#d685fe8
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@18.3.27)
       '@tanstack/react-query':
         specifier: ^5.90.6
         version: 5.90.10(react@18.3.1)
@@ -1885,8 +1885,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.6':
     resolution: {integrity: sha512-EBOgrgBRFNg8p+7nDFvh+K7N4NFQ7+epBXjE9w7h0u87q4M+nOpBwXNc67+UdDs+j8Mi+vQ2R+uJBIKF25NQ7g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -8280,7 +8280,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@18.3.27)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@18.3.27)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -95,6 +95,7 @@ describe("Pay component - Editor Modal", () => {
             {
               key: "myKey",
               value: "myValue",
+              type: "static",
             },
           ],
         },
@@ -152,10 +153,10 @@ describe("Pay component - Editor Modal", () => {
         data: {
           fn: "application.fee.payable",
           govPayMetadata: [
-            { key: "flow", value: "flowName" },
-            { key: "source", value: "PlanX" },
-            { key: "paidViaInviteToPay", value: "@paidViaInviteToPay" },
-            { key: "deleteMe", value: "abc123" },
+            { key: "flow", value: "flowName", type: "static" },
+            { key: "source", value: "PlanX", type: "static" },
+            { key: "paidViaInviteToPay", value: "paidViaInviteToPay", type: "data" },
+            { key: "deleteMe", value: "abc123", type: "static" },
           ],
         },
       };

--- a/apps/editor.planx.uk/src/@planx/components/Pay/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/model.test.ts
@@ -86,7 +86,7 @@ describe("GovPayMetadata Schema", () => {
       {
         key: "myPassportVariable",
         value:
-          "@thisIsAVeryLongPassportVariable.itsUnlikelyToHappenButWeDontNeedToRestrict.theDynamicValueThisReadsWillBeTruncatedAtTimeOfSubmission",
+          "thisIsAVeryLongPassportVariable.itsUnlikelyToHappenButWeDontNeedToRestrict.theDynamicValueThisReadsWillBeTruncatedAtTimeOfSubmission",
         type: "data",
       },
     ];
@@ -151,34 +151,7 @@ describe("parsePay() helper function", () => {
       expect(result.govPayMetadata[2]).toHaveProperty("type", "data");
     });
 
-    it("handles existing nodes with legacy content", () => {
-      const result = parsePay({
-        govPayMetadata: [
-          {
-            key: "flow",
-            value: "flow name here",
-          },
-          {
-            key: "source",
-            value: "PlanX",
-          },
-          {
-            key: "paidViaInviteToPay",
-            value: "@paidViaInviteToPay",
-          },
-        ],
-      });
-
-      expect(result.govPayMetadata).toHaveLength(3);
-      expect(result.govPayMetadata[0]).toHaveProperty("type", "static");
-      expect(result.govPayMetadata[1]).toHaveProperty("type", "static");
-
-      // "@" stripped from value
-      expect(result.govPayMetadata[2].value).toEqual("paidViaInviteToPay");
-      expect(result.govPayMetadata[2]).toHaveProperty("type", "data");
-    });
-
-    it("handles existing nodes with current content (`type` property)", () => {
+    it("handles existing nodes", () => {
       const result = parsePay({
         govPayMetadata: [
           {

--- a/apps/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -208,27 +208,7 @@ export const getDefaultContent = (): Pay => ({
 });
 
 export const parsePay = (data?: Record<string, any>): Pay => ({
-  ...parseBaseNodeData(data),
   ...getDefaultContent(),
+  ...parseBaseNodeData(data),
   ...data,
-  govPayMetadata: parseGovPayMetadata(data),
 });
-
-const parseGovPayMetadata = (data?: Record<string, any>): GovPayMetadata[] => {
-  // Handle new component creation
-  if (!data?.govPayMetadata) return getDefaultContent().govPayMetadata;
-
-  // Existing data with `type` property
-  const hasMetadataType = (data: GovPayMetadata) => Boolean(data?.type);
-  if (data.govPayMetadata.every(hasMetadataType)) return data.govPayMetadata;
-
-  // Legacy content (to be migrated) - append `type` property
-  const addTypeProperty = ({ key, value }: GovPayMetadata) => ({
-    key,
-    value: value.toString().startsWith("@")
-      ? value.toString().substring(1)
-      : value,
-    type: value.toString().startsWith("@") ? "data" : "static",
-  });
-  return data.govPayMetadata.map(addTypeProperty);
-};

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.10.0",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#364a0f6",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d685fe8",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.1.1
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#364a0f6
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@19.2.6)
+        specifier: git+https://github.com/theopensystemslab/planx-core#d685fe8
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@19.2.6)
       axios:
         specifier: ^1.12.2
         version: 1.13.2
@@ -383,8 +383,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2146,7 +2146,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#364a0f6",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d685fe8",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#364a0f6
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@19.2.6)
+        specifier: git+https://github.com/theopensystemslab/planx-core#d685fe8
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@19.2.6)
       axios:
         specifier: ^1.12.2
         version: 1.13.2
@@ -313,8 +313,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8}
     version: 1.0.0
 
   '@playwright/test@1.56.1':
@@ -1805,7 +1805,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/364a0f6(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d685fe8(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)


### PR DESCRIPTION
## What does this PR do?
Now that [the data migration](https://github.com/theopensystemslab/planx-data-migrations/pull/16) has been completed, we have remove the handling of legacy GovPay metadata formats.

This PR updates types, tests, and data parsing.

Relies on https://github.com/theopensystemslab/planx-core/pull/877