### PR TITLE
chore: increase DischargeCondition list schema condition description limit to 750 characters

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/List/schemas/DischargeConditions.ts
+++ b/apps/editor.planx.uk/src/@planx/components/List/schemas/DischargeConditions.ts
@@ -21,7 +21,7 @@ export const DischargeConditions: Schema = {
         description:
           "This is the exact wording of the condition as shown on the decision notice.",
         fn: "description",
-        type: TextInputType.Long,
+        type: TextInputType.ExtraLong,
       },
     },
     {


### PR DESCRIPTION
Request by Lambeth. An applicant wasn't able to use the service due to their condition exceeding the existing limit.