### PR TITLE
chore: Display 'first online' date in the Editor

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/index.tsx
@@ -5,6 +5,7 @@ import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { ConfirmationDialog } from "components/ConfirmationDialog";
+import { format } from "date-fns";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { useLocation } from "react-use";
@@ -231,6 +232,12 @@ const FlowStatus: React.FC = () => {
                 subdomain={subdomainLink}
                 publishedLink={publishedLink}
               />
+            )}
+            {data?.flow.firstOnlineAt && (
+              <Typography variant="body2">
+                Your service first went online:{" "}
+                {format(new Date(data.flow.firstOnlineAt), "HH:mm dd/MM/yy")}
+              </Typography>
             )}
           </>
         );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/queries.ts
@@ -15,6 +15,7 @@ export const GET_FLOW_STATUS = gql`
       publishedFlows: published_flows(limit: 1) {
         id
       }
+      firstOnlineAt: first_online_at
     }
   }
 `;
@@ -26,6 +27,7 @@ export const UPDATE_FLOW_STATUS = gql`
     ) {
       id
       status
+      first_online_at
     }
   }
 `;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/types.ts
@@ -14,6 +14,7 @@ export interface GetFlowStatus {
     publishedFlows: {
       id: string;
     }[];
+    firstOnlineAt: string | null;
   };
 }
 


### PR DESCRIPTION
Currently, this is only shown in the admin panel and Editors cannot view this information. Requested at planning call 27/11/25.

<img width="1440" height="779" alt="image" src="https://github.com/user-attachments/assets/31a6932b-6c90-4538-90e5-d2dd550d9d60" />