### PR TITLE
chore: Invalidate cached hasPrivacyPage value on flow settings update

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/shared/queries.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/shared/queries.tsx
@@ -17,6 +17,7 @@ export const UPDATE_FLOW_SETTINGS = gql`
     ) {
       id
       settings
+      hasPrivacyPage: settings(path: "elements.privacy.show")
     }
   }
 `;


### PR DESCRIPTION
## What's the problem?
Currently on production, when the privacy page is updated, this is not immediately reflected on the "visibility" page. A refetch of the data is needed to get this working as expected (page refresh). Reported by @augustlindemer 

## What's the cause?
When `flow.settings` is updated, Apollo is not invalidating the cache for `flow.hasPrivacyPage`. Despite sharing a path these two fields aren't linked.

## What's the solution?
Return an updated value for `hasPrivacyPage` when `flow.settings` is updated.


https://github.com/user-attachments/assets/afde0e83-81f5-4e5d-a5c0-a4a72147652a

