### PR TITLE
chore(db): Populate new `published_flows.has_send_component` column

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1764591132321_populate_has_pay_component_column/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1764591132321_populate_has_pay_component_column/down.sql
@@ -1,0 +1,2 @@
+UPDATE published_flows
+SET has_pay_component = NULL

--- a/apps/hasura.planx.uk/migrations/default/1764591132321_populate_has_pay_component_column/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1764591132321_populate_has_pay_component_column/up.sql
@@ -1,0 +1,8 @@
+UPDATE published_flows pf
+SET has_pay_component = jsonb_path_exists(data, '$.* ? (@.type == 400)')
+FROM (
+    SELECT DISTINCT ON (flow_id) id
+    FROM published_flows
+    ORDER BY flow_id, created_at DESC
+) AS latest
+WHERE pf.id = latest.id;


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/5733

This migration will ensure that the filters work as expected - the most recent published version of each flow (including archived flows) will have its `has_send_component` column populated.

**Questions**
 - Any issues with ignoring historic flows? I _think_ this is what we've done for sections and send components
 - Should this be a Hasura migration? I can also just run this directly on prod once reviewed and close this PR