### PR TITLE
chore(perf): Improve lookup of component types when publishing

### DIFF
--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -10,7 +10,7 @@ import { dataMerged, getMostRecentPublishedFlow } from "../../../helpers.js";
 import { createScheduledEvent } from "../../../lib/hasura/metadata/index.js";
 import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
 import { userContext } from "../../auth/middleware.js";
-import { hasComponentType } from "../validate/helpers.js";
+import { buildNodeTypeSet } from "../validate/helpers.js";
 
 interface PublishFlow {
   publishedFlow: {
@@ -40,9 +40,10 @@ export const publishFlow = async (
   // If no changes, then nothing to publish nor events to queue up
   if (!delta) return null;
 
-  const hasSendComponent = hasComponentType(flattenedFlow, ComponentType.Send);
-  const hasSections = hasComponentType(flattenedFlow, ComponentType.Section);
-  const hasPayComponent = hasComponentType(flattenedFlow, ComponentType.Pay);
+  const nodeTypeSet = buildNodeTypeSet(flattenedFlow);
+  const hasSendComponent = nodeTypeSet.has(ComponentType.Send);
+  const hasSections = nodeTypeSet.has(ComponentType.Section);
+  const hasPayComponent = nodeTypeSet.has(ComponentType.Pay);
 
   const { client: $client } = getClient();
   const response = await $client.request<PublishFlow>(

--- a/apps/api.planx.uk/modules/flows/validate/helpers.test.ts
+++ b/apps/api.planx.uk/modules/flows/validate/helpers.test.ts
@@ -1,7 +1,11 @@
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 
-import { hasComponentType, numberOfComponentType } from "./helpers.js";
+import {
+  buildNodeTypeSet,
+  hasComponentType,
+  numberOfComponentType,
+} from "./helpers.js";
 
 describe("hasComponentType", () => {
   test("it returns true for a component type that is present", () => {
@@ -28,6 +32,18 @@ describe("hasComponentType", () => {
     expect(hasComponentType(flow, TYPES.Question, "application.type")).toEqual(
       false,
     );
+  });
+});
+
+describe("buildNodeTypeSet", () => {
+  const nodeTypeSet = buildNodeTypeSet(flow);
+
+  test("it returns true for a component type that is present", () => {
+    expect(nodeTypeSet.has(TYPES.Question)).toEqual(true);
+  });
+
+  test("it returns false for a component type that is not present", () => {
+    expect(nodeTypeSet.has(TYPES.DrawBoundary)).toEqual(false);
   });
 });
 

--- a/apps/api.planx.uk/modules/flows/validate/helpers.ts
+++ b/apps/api.planx.uk/modules/flows/validate/helpers.ts
@@ -25,6 +25,16 @@ export const hasComponentType = (
   return Boolean(nodeIds.length);
 };
 
+export const buildNodeTypeSet = (flowGraph: FlowGraph): Set<ComponentType> => {
+  const types = new Set<ComponentType>();
+
+  Object.values(flowGraph).forEach((node: Node) => {
+    if (node?.type) types.add(node.type as ComponentType);
+  });
+
+  return types;
+};
+
 export const numberOfComponentType = (
   flowGraph: FlowGraph,
   type: ComponentType,


### PR DESCRIPTION
Small room for improvement spotted here - https://github.com/theopensystemslab/planx-new/pull/5733#discussion_r2576469938

Currently, we're iterating over the entire published flow multiple times in order to get component type metadata. By generating a set of unique component types once, as can use this as a source of truth to derive `hasSendComponent`, `hasPayComponent` and `hasSections`.

This should (marginally) improve the performance of the publish operation, as well as putting in a place a pattern next time we need to extract more metadata.