### PR TITLE
chore(lps): Setup sitemap

### DIFF
--- a/apps/localplanning.services/astro.config.mjs
+++ b/apps/localplanning.services/astro.config.mjs
@@ -4,6 +4,8 @@ import tailwindcss from "@tailwindcss/vite";
 import { loadEnv } from "vite";
 import icon from "astro-icon";
 
+import sitemap from "@astrojs/sitemap";
+
 // Check args to access Astro mode
 // Env var is not available in Astro config files
 const mode = process.argv.at(-1).replaceAll("-", "")
@@ -11,7 +13,7 @@ const isCloudfrontBuild = ["staging", "production"].includes(mode);
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react(), icon()],
+  integrations: [react(), icon(), sitemap()],
   env: {
     schema: {
       PUBLIC_PLANX_EDITOR_URL: envField.string({ context: "client", access: "public", optional: false }),

--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.5",
     "@astrojs/react": "^4.4.2",
+    "@astrojs/sitemap": "^3.6.0",
     "@nanostores/react": "^1.0.0",
     "@opensystemslab/map": "1.0.0-alpha.10",
     "@tailwindcss/vite": "^4.1.15",

--- a/apps/localplanning.services/pnpm-lock.yaml
+++ b/apps/localplanning.services/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.4.2
         version: 4.4.2(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2)(stylus@0.62.0)(yaml@2.8.1)
+      '@astrojs/sitemap':
+        specifier: ^3.6.0
+        version: 3.6.0
       '@nanostores/react':
         specifier: ^1.0.0
         version: 1.0.0(nanostores@1.0.1)(react@19.2.0)
@@ -132,6 +135,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/sitemap@3.6.0':
+    resolution: {integrity: sha512-4aHkvcOZBWJigRmMIAJwRQXBS+ayoP5z40OklTXYXhUDhwusz+DyDl+nSshY6y9DvkVEavwNcFO8FD81iGhXjg==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -1277,6 +1283,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
@@ -1305,6 +1314,9 @@ packages:
 
   '@types/react@19.2.4':
     resolution: {integrity: sha512-tBFxBp9Nfyy5rsmefN+WXc1JeW/j2BpBHFdLZbEVfs9wn3E3NRFxwV0pJg8M1qQAexFpvz73hJXFofV0ZAu92A==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
@@ -1391,6 +1403,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2877,6 +2892,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@8.0.2:
+    resolution: {integrity: sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    hasBin: true
+
   smol-toml@1.5.0:
     resolution: {integrity: sha512-Jjsa8LZ+DyLbZ7gVi9d18bS8oxq0PQrTlVDfvYXgh7gxLwbW9QWgvakHD+hBLUtr5NahfStd8LQLGSPchaEJ8Q==}
     engines: {node: '>= 18'}
@@ -2902,6 +2922,9 @@ packages:
   stackblur-canvas@2.7.0:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
     engines: {node: '>=0.1.14'}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3575,6 +3598,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/sitemap@3.6.0':
+    dependencies:
+      sitemap: 8.0.2
+      stream-replace-string: 2.0.0
+      zod: 3.25.76
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -4494,6 +4523,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@17.0.45': {}
+
   '@types/node@24.10.1':
     dependencies:
       undici-types: 7.16.0
@@ -4524,6 +4555,10 @@ snapshots:
   '@types/react@19.2.4':
     dependencies:
       csstype: 3.1.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 24.10.1
 
   '@types/tar@6.1.13':
     dependencies:
@@ -4632,6 +4667,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -6524,8 +6561,7 @@ snapshots:
   sax@1.3.0:
     optional: true
 
-  sax@1.4.1:
-    optional: true
+  sax@1.4.1: {}
 
   scheduler@0.27.0: {}
 
@@ -6580,6 +6616,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@8.0.2:
+    dependencies:
+      '@types/node': 17.0.45
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.4.1
+
   smol-toml@1.5.0: {}
 
   source-map-js@1.2.1: {}
@@ -6596,6 +6639,8 @@ snapshots:
 
   stackblur-canvas@2.7.0:
     optional: true
+
+  stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:

--- a/apps/localplanning.services/src/layouts/Layout.astro
+++ b/apps/localplanning.services/src/layouts/Layout.astro
@@ -14,9 +14,9 @@ interface Props {
 }
 
 const siteName = "Find local planning services";
-const { 
+const {
   title,
-  description = "Modern digital services to send planning applications, reports and notices directly to local planning authorities"
+  description = "Modern digital services to send planning applications, reports and notices directly to local planning authorities",
 } = Astro.props;
 
 const fullTitle = title ? `${title} | ${siteName}` : siteName;
@@ -31,11 +31,9 @@ const fullTitle = title ? `${title} | ${siteName}` : siteName;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <SEO
-      title={fullTitle}
-      description={description}
-    />
+    <SEO title={fullTitle} description={description} />
     <Analytics />
+    <link rel="sitemap" href="/sitemap-index.xml" />
     <script src="../scripts/registerWebcomponents.js"></script>
   </head>
   <body class="bg-black">
@@ -60,7 +58,7 @@ const fullTitle = title ? `${title} | ${siteName}` : siteName;
 
 <script>
   import { navigate } from "astro:transitions/client";
-  
+
   // Force ClientRouter navigation event on browser "back" event
   // When navigating from /applications/:lpa back to /applications, Astro doesn't always re-render
   window.addEventListener("popstate", () => navigate(window.location.pathname));


### PR DESCRIPTION
Nothing is currently listed here for the Google Search Console sitemap - 
<img width="1921" height="775" alt="image" src="https://github.com/user-attachments/assets/37715a69-e2f9-4a8c-b0c8-a993b926b3f4" />

Follows process laid out here - https://docs.astro.build/en/guides/integrations-guide/sitemap/

On build, I can now see sitemap XML docs added to the `/dist` folder.