### PR TITLE
fix(perf): Use linear stack for `dfs()`, not recursive call

### DIFF
--- a/apps/editor.planx.uk/src/@planx/graph/index.ts
+++ b/apps/editor.planx.uk/src/@planx/graph/index.ts
@@ -512,15 +512,29 @@ export const makeUnique =
  * XXX: Clones will only appear in first graph position
  */
 const dfs = (graph: Graph) => (startId: string) => {
-  const visited = new Set([startId]);
-  const crawlFrom = (id: string) => {
-    if (!graph[id]) return;
+  const visited = new Set<string>();
+  const stack = [startId];
+
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+
+    if (visited.has(id)) continue;
     visited.add(id);
-    graph[id].edges?.forEach((childId) => {
-      crawlFrom(childId);
-    });
-  };
-  crawlFrom(startId);
+
+    const node = graph[id];
+    if (!node?.edges) continue;
+
+    // Node edges are traversed left-to-right
+    // We process our stack in last-in, first-out order
+    // This means we need to iterate backwards over edges
+    for (let i = node.edges.length - 1; i >= 0; i--) {
+      const childId = node.edges[i];
+      if (!visited.has(childId)) {
+        stack.push(childId);
+      }
+    }
+  }
+
   return [...visited];
 };
 


### PR DESCRIPTION
## What's the problem?
A number of PlanX service are very slow to load. The main JS thread is blocked for ~25 seconds in some instances, such as https://editor.planx.dev/doncaster/report-a-planning-breach/published?analytics=false

## What's the cause?
Profiling ([docs](https://react.dev/reference/dev-tools/react-performance-tracks)) points to `crawlFrom()` which is the main helper function of our recursive depth-first search algorithm.

<img width="1290" height="670" alt="image" src="https://github.com/user-attachments/assets/eba37b4d-7149-4661-a2b4-4c00eef11c90" />

## What's the solution?
We've actually hit the exact same issue on graph navigation before - please see writeup here https://github.com/theopensystemslab/planx-new/pull/5142

I've used the same methodology as before - 
- switch to an iterative stack over recursion
- `for..of` over `forEach()`
- Use of a set for lookups, not repeating sections
- Memory management / garbage collection - don't instantiate new objects on each iteration

## Testing
You should see a noticeable difference between the current staging links and the pizza links here - 

| Staging | Pizza |
|--------|--------|
| https://editor.planx.dev/doncaster/report-a-planning-breach/published?analytics=false | https://5805.planx.pizza/doncaster/report-a-planning-breach/published?analytics=false |
| https://editor.planx.uk/doncaster/find-out-if-you-need-planning-permission/published | https://5805.planx.pizza/doncaster/find-out-if-you-need-planning-permission/published |
| https://editor.planx.uk/barnet/apply-for-a-lawful-development-certificate/published | https://5805.planx.pizza/barnet/apply-for-a-lawful-development-certificate/published | 

## Metrics
| Before | After |
|--------|--------|
| <img width="416" height="92" alt="image" src="https://github.com/user-attachments/assets/06c429b2-f700-496e-8587-fdb5b2add6a4" /> | <img width="396" height="101" alt="image" src="https://github.com/user-attachments/assets/e1802ac9-d55f-4a4f-b8d2-21a44fe66c6a" /> | 

## Prior art
I tried a number of things before landing on this solution - all of which should be merged and are worthwhile improvements, but don't fix the underlying problem here - 
 - https://github.com/theopensystemslab/planx-new/pull/5779
 -  https://github.com/theopensystemslab/planx-new/pull/5786

