### PR TITLE
fix: Add all new columns to temp `published_flows` table

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -53,7 +53,7 @@ done
 psql --quiet ${REMOTE_PG} --command="\\copy (SELECT id, team_id, staging_bops_submission_url, staging_bops_secret, has_planning_data, staging_govpay_secret, staging_file_api_key, staging_power_automate_api_key FROM team_integrations) TO '/tmp/team_integrations.csv' (FORMAT csv, DELIMITER ';');"
 echo team_integrations downloaded
 
-psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at, has_send_component FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
+psql --quiet ${REMOTE_PG} --command="\\copy (SELECT DISTINCT ON (flow_id) id, data, flow_id, summary, publisher_id, created_at, has_send_component, has_sections, has_pay_component FROM published_flows ORDER BY flow_id, created_at DESC) TO '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');"
 echo published_flows downloaded
 
 if [[ ${RESET} == "reset_flows" ]]; then

--- a/scripts/seed-database/write/published_flows.sql
+++ b/scripts/seed-database/write/published_flows.sql
@@ -6,10 +6,12 @@ CREATE TEMPORARY TABLE sync_published_flows (
   summary text,
   publisher_id int,
   created_at timestamptz,
-  has_send_component boolean
+  has_send_component boolean,
+  has_sections boolean,
+  has_pay_component boolean
   );
 /* Ensure columns here are kept in sync with container.sh */
-\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
+\copy sync_published_flows (id, data, flow_id, summary, publisher_id, created_at, has_send_component, has_sections, has_pay_component) FROM '/tmp/published_flows.csv' (FORMAT csv, DELIMITER ';');
 
 INSERT INTO published_flows (
   id,


### PR DESCRIPTION
Follow up and fix for #5795, which adds required columns in all correct locations of `published_flows.sql`.

`pnpm test-sync` passing locally ✅ 