### PR TITLE
infra: reschedule regression tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -3,10 +3,10 @@ name: Regression Tests
 permissions: read-all
 
 on:
-  workflow_dispatch:
   schedule:
-    # Runs every morning at 06:00 (https://crontab.guru/#0_6_*_*_*)
-    - cron: '0 6 * * *'
+    # Runs every morning at 06:06 (https://crontab.guru/#06_6_*_*_*)
+    - cron: '06 6 * * *'
+  workflow_dispatch:
 
 env:
   EDITOR_DIRECTORY: apps/editor.planx.uk

--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  EDITOR_DIRECTORY: editor.planx.uk
+  EDITOR_DIRECTORY: apps/editor.planx.uk
   API_DIRECTORY: apps/api.planx.uk
   HASURA_DIRECTORY: apps/hasura.planx.uk
 


### PR DESCRIPTION
Regression tests are passing on `main` when manually triggered but have failed to run on schedule since November 5! 

Looked back at merged PRs (especially dependabot ones for ga-action deps) but no obvious culprits.

Our other scheduled GH Action is the data sync which has been running fine - these files largely rely on the same secrets (like AWS secrets), so ruled that out too!

Not sure this will make a difference, but worth a shot!