### PR TITLE
feat: add a default entry page to non-submission services with flow name and summary

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -117,6 +117,8 @@ export interface PreviewStore extends Store.Store {
   autoAnswerableFlag: (filterId: NodeId) => NodeId | undefined;
   hasAcknowledgedWarning: boolean;
   setHasAcknowledgedWarning: () => void;
+  hasAcknowledgedSingleSessionEntry: boolean;
+  setHasAcknowledgedSingleSessionEntry: () => void;
 }
 
 export const previewStore: StateCreator<
@@ -859,6 +861,10 @@ export const previewStore: StateCreator<
 
   hasAcknowledgedWarning: false,
   setHasAcknowledgedWarning: () => set({ hasAcknowledgedWarning: true }),
+
+  hasAcknowledgedSingleSessionEntry: false,
+  setHasAcknowledgedSingleSessionEntry: () =>
+    set({ hasAcknowledgedSingleSessionEntry: true }),
 });
 
 interface RemoveOrphansFromBreadcrumbsProps {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -91,6 +91,7 @@ export const sharedStore: StateCreator<
       changedNode: undefined,
       saveToEmail: "",
       currentCard: null,
+      hasAcknowledgedSingleSessionEntry: false,
     });
 
     removeSessionIdSearchParam();

--- a/apps/editor.planx.uk/src/pages/Preview/SingleSession.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/SingleSession.tsx
@@ -1,0 +1,80 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Card from "@planx/components/shared/Preview/Card";
+import { CardHeader } from "@planx/components/shared/Preview/CardHeader/CardHeader";
+import { getLocalFlow } from "lib/local";
+import { getLocalFlowIdb } from "lib/local.idb";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { PropsWithChildren, useEffect, useState } from "react";
+import { useCurrentRoute } from "react-navi";
+import { Session } from "types";
+import Main from "ui/shared/Main";
+
+export const SingleSession = ({ children }: PropsWithChildren) => {
+  const [
+    flowId,
+    flowName,
+    flowSummary,
+    hasAcknowledgedSingleSessionEntry,
+    setHasAcknowledgedSingleSessionEntry,
+  ] = useStore((state) => [
+    state.id,
+    state.flowName,
+    state.flowSummary,
+    state.hasAcknowledgedSingleSessionEntry,
+    state.setHasAcknowledgedSingleSessionEntry,
+  ]);
+
+  const isContentPage = useCurrentRoute()?.data?.isContentPage;
+
+  const [storedSession, setStoredSession] = useState<Session | undefined>(
+    undefined,
+  );
+  const [loadingSession, setLoadingSession] = useState<boolean>(true);
+
+  useEffect(() => {
+    const loadSession = async () => {
+      try {
+        // First check IndexedDB (preferred storage)
+        //   If flow not in IndexedDB (or db connection fails), try localStorage
+        //   ** Keep in sync with ../src/pages/Preview/Questions `loadSession`
+        const storedSession = await getLocalFlowIdb(flowId);
+        if (!storedSession) getLocalFlow(flowId);
+        setStoredSession(storedSession);
+      } catch (err) {
+        console.log(`Error loading session for flow ${flowId}:`, err);
+      } finally {
+        setLoadingSession(false);
+      }
+    };
+
+    loadSession();
+  }, []);
+
+  return (
+    <>
+      {!loadingSession &&
+      (hasAcknowledgedSingleSessionEntry ||
+        storedSession?.sessionId ||
+        isContentPage) ? (
+        children
+      ) : (
+        <Main>
+          <Card handleSubmit={() => setHasAcknowledgedSingleSessionEntry()}>
+            <CardHeader title={flowName} description={flowSummary}></CardHeader>
+            <Box
+              mb={(theme) => theme.spacing(1)}
+              mt={(theme) => theme.spacing(0.75)}
+            >
+              <Typography variant="subtitle1" component="div">
+                {`You can leave and come back to this service anytime using the same link, device, and browser.`}
+              </Typography>
+            </Box>
+          </Card>
+        </Main>
+      )}
+    </>
+  );
+};
+
+export default SingleSession;

--- a/apps/editor.planx.uk/src/pages/layout/SaveAndReturnLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/layout/SaveAndReturnLayout.tsx
@@ -8,6 +8,7 @@ import { ApplicationPath as AppPath } from "../../types";
 import ResumePage from "../Preview/Resume";
 import SaveAndReturn from "../Preview/SaveAndReturn";
 import SavePage from "../Preview/SavePage";
+import SingleSession from "../Preview/SingleSession";
 
 const SaveAndReturnLayout = ({ children }: PropsWithChildren) => {
   const path = useStore((state) => state.path);
@@ -22,7 +23,7 @@ const SaveAndReturnLayout = ({ children }: PropsWithChildren) => {
     <>
       {
         {
-          [AppPath.SingleSession]: children,
+          [AppPath.SingleSession]: <SingleSession>{children}</SingleSession>,
           [AppPath.Save]: (
             <Main>
               <SavePage />


### PR DESCRIPTION
Follows on from #5754 

I still need to update / add tests here !

**Testing instructions:**
- Open the `/published` link of any online, non-submission service - it should now display a new default entry page with `flowName` and `flowSummary`
- Click "Continue" from the entry page and fill out a couple questions
- Confirm you can close your tab, re-open the URL, and you haven't lost your progress (eg should _not_ see the entry page again)
- Confirm you can "Restart" in the upper right to clear your session, and you start back over at the entry page