### PR TITLE
[hasura] apply `soft_delete_stray_sessions_2` migration

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1764767960998_soft_delete_stray_sessions_2/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1764767960998_soft_delete_stray_sessions_2/down.sql
@@ -1,0 +1,7 @@
+UPDATE public.lowcal_sessions
+SET deleted_at = NULL
+WHERE
+    submitted_at IS NULL
+    AND deleted_at = created_at + INTERVAL '28 days'
+    AND locked_at IS NULL
+    AND created_at < TIMESTAMPTZ '2025-11-05 02:00:00+00:00';

--- a/apps/hasura.planx.uk/migrations/default/1764767960998_soft_delete_stray_sessions_2/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1764767960998_soft_delete_stray_sessions_2/up.sql
@@ -1,0 +1,7 @@
+UPDATE public.lowcal_sessions 
+SET deleted_at = created_at + INTERVAL '28 days'
+WHERE
+    submitted_at IS NULL
+    AND deleted_at IS NULL
+    AND locked_at IS NULL
+    AND created_at < TIMESTAMPTZ '2025-11-05 02:00:00+00:00';


### PR DESCRIPTION
As per #5605, we are returning 1 month later to ensure that all sessions started after 2am on 5th Oct, but which are not subject to the scheduled deletions introduced on 4th Nov (in #5284), are also soft deleted (if not already deleted, submitted or locked).