### PR TITLE
feat: only show "Property type" on Review page when supported by `PropertyInformation` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -357,6 +357,14 @@ interface ComponentProps {
 function PropertyInformation(props: ComponentProps) {
   const { data, loading } = useBLPUCodes();
 
+  // If we didn't show the user `Property type` on the original component,
+  //   then don't show them on Review either
+  const propertyTypeSupported =
+    props.flow[props.nodeId]?.data?.showPropertyTypeOverride;
+  if (!propertyTypeSupported) {
+    return undefined;
+  }
+
   const propertyTypeVal = props.passport.data?.["property.type"]?.[0];
   const value =
     find(data?.blpuCodes, { value: propertyTypeVal })?.description ||


### PR DESCRIPTION
Quick follow-up for https://github.com/theopensystemslab/planx-new/pull/5782#issuecomment-3598683119 - cc @augustlindemer !