### PR TITLE
feat: Reinstate ESC-to-close on editor modal

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -11,7 +11,6 @@ import { styled } from "@mui/material/styles";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { parseFormValues } from "@planx/components/shared";
 import ErrorFallback from "components/Error/ErrorFallback";
-import { hasFeatureFlag } from "lib/featureFlags";
 import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
@@ -183,7 +182,16 @@ const FormModal: React.FC<{
     : !canUserEditNode(teamSlug);
 
   return (
-    <StyledDialog open fullWidth maxWidth="md" disableScrollLock>
+    <StyledDialog
+      open
+      fullWidth
+      disableScrollLock
+      onClose={(_event, reason) => {
+        if (reason === "escapeKeyDown") {
+          handleClose();
+        }
+      }}
+    >
       <DialogTitle
         sx={{
           py: 1,


### PR DESCRIPTION
## What does this PR do?

Reinstates ESC key to close the graph editor modal.

We previously removed the functionality where clicking outside the modal closes it, with the intention of preventing it closing unintentionally in user-error. However the ESC key is more of deliberate action, so I propose we reinstate this functionality.