### PR TITLE
feat: Add tooltips to team page view switch

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -8,6 +8,7 @@ import ToggleButton, { toggleButtonClasses } from "@mui/material/ToggleButton";
 import ToggleButtonGroup, {
   toggleButtonGroupClasses,
 } from "@mui/material/ToggleButtonGroup";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { isEmpty, orderBy } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
@@ -264,12 +265,16 @@ const Team: React.FC = () => {
                 onChange={handleViewChange}
                 size="small"
               >
-                <StyledToggleButton value="grid" disableRipple>
-                  <ViewModuleIcon />
-                </StyledToggleButton>
-                <StyledToggleButton value="row" disableRipple>
-                  <TableRowsIcon />
-                </StyledToggleButton>
+                <Tooltip title="Card view" placement="bottom">
+                  <StyledToggleButton value="grid" disableRipple>
+                    <ViewModuleIcon />
+                  </StyledToggleButton>
+                </Tooltip>
+                <Tooltip title="Table view" placement="bottom">
+                  <StyledToggleButton value="row" disableRipple>
+                    <TableRowsIcon />
+                  </StyledToggleButton>
+                </Tooltip>
               </ToggleButtonGroup>
             </Box>
             {sortedFlows && (


### PR DESCRIPTION
## What does this PR do?

- Adds tooltips to the view-switch button group on the team page. We've developed a pattern in the editor in which functional/button icons used without text are given tooltips, this brings the switch buttons to be aligned with this.

<img width="551" height="404" alt="image" src="https://github.com/user-attachments/assets/60d84862-b9ca-4bf2-a4e1-c425b69ac650" />
