### PR TITLE
fix: exempt Pay components set to hidePay from Fee carrying service filter

### DIFF
--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -43,10 +43,10 @@ export const publishFlow = async (
   const nodeTypeSet = buildNodeTypeSet(flattenedFlow);
   const hasSendComponent = nodeTypeSet.has(ComponentType.Send);
   const hasSections = nodeTypeSet.has(ComponentType.Section);
-  
+
   const flowTypeMap = createFlowTypeMap(flattenedFlow);
   const hasPayComponent = Array.from(
-    flowTypeMap.get(ComponentType.Pay) ?? new Set<string>()
+    flowTypeMap.get(ComponentType.Pay) ?? new Set<string>(),
   ).some((id) => !flattenedFlow[id]?.data?.hidePay);
 
   const { client: $client } = getClient();

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -37,7 +37,7 @@ export const publishFlow = async (
   const mostRecent = await getMostRecentPublishedFlow(flowId);
   const delta = jsondiffpatch.diff(mostRecent, flattenedFlow);
 
-  // If no changes, then nothing to publish nor events to queue up!
+  // If no changes, then nothing to publish nor events to queue up
   if (!delta) return null;
 
   const nodeTypeSet = buildNodeTypeSet(flattenedFlow);

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -37,7 +37,7 @@ export const publishFlow = async (
   const mostRecent = await getMostRecentPublishedFlow(flowId);
   const delta = jsondiffpatch.diff(mostRecent, flattenedFlow);
 
-  // If no changes, then nothing to publish nor events to queue up
+  // If no changes, then nothing to publish nor events to queue up!
   if (!delta) return null;
 
   const nodeTypeSet = buildNodeTypeSet(flattenedFlow);

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -45,9 +45,13 @@ export const publishFlow = async (
   const hasSections = nodeTypeSet.has(ComponentType.Section);
 
   const flowTypeMap = createFlowTypeMap(flattenedFlow);
-  const hasPayComponent = Array.from(
+  const payNodeIds = Array.from(
     flowTypeMap.get(ComponentType.Pay) ?? new Set<string>(),
-  ).some((id) => !flattenedFlow[id]?.data?.hidePay);
+  );
+
+  const hasVisiblePayComponent = payNodeIds.some(
+    (id) => !flattenedFlow[id]?.data?.hidePay,
+  );
 
   const { client: $client } = getClient();
   const response = await $client.request<PublishFlow>(
@@ -87,7 +91,7 @@ export const publishFlow = async (
       summary: summary,
       has_send_component: hasSendComponent,
       has_sections: hasSections,
-      has_pay_component: hasPayComponent,
+      has_pay_component: hasVisiblePayComponent,
     },
   );
 

--- a/apps/api.planx.uk/modules/flows/validate/helpers.ts
+++ b/apps/api.planx.uk/modules/flows/validate/helpers.ts
@@ -35,6 +35,25 @@ export const buildNodeTypeSet = (flowGraph: FlowGraph): Set<ComponentType> => {
   return types;
 };
 
+export const createFlowTypeMap = (
+  flowGraph: FlowGraph,
+): Map<ComponentType, Set<string>> => {
+  const map = new Map<ComponentType, Set<string>>();
+
+  Object.entries(flowGraph).forEach(([nodeId, node]: [string, Node | undefined]) => {
+    if (nodeId === "_root") return;
+    const type = node?.type as ComponentType | undefined;
+    if (!type) return;
+
+    if (!map.has(type)) {
+      map.set(type, new Set<string>());
+    }
+    map.get(type)!.add(nodeId);
+  });
+
+  return map;
+};
+
 export const numberOfComponentType = (
   flowGraph: FlowGraph,
   type: ComponentType,

--- a/apps/api.planx.uk/modules/flows/validate/helpers.ts
+++ b/apps/api.planx.uk/modules/flows/validate/helpers.ts
@@ -40,16 +40,18 @@ export const createFlowTypeMap = (
 ): Map<ComponentType, Set<string>> => {
   const map = new Map<ComponentType, Set<string>>();
 
-  Object.entries(flowGraph).forEach(([nodeId, node]: [string, Node | undefined]) => {
-    if (nodeId === "_root") return;
-    const type = node?.type as ComponentType | undefined;
-    if (!type) return;
+  Object.entries(flowGraph).forEach(
+    ([nodeId, node]: [string, Node | undefined]) => {
+      if (nodeId === "_root") return;
+      const type = node?.type as ComponentType | undefined;
+      if (!type) return;
 
-    if (!map.has(type)) {
-      map.set(type, new Set<string>());
-    }
-    map.get(type)!.add(nodeId);
-  });
+      if (!map.has(type)) {
+        map.set(type, new Set<string>());
+      }
+      map.get(type)!.add(nodeId);
+    },
+  );
 
   return map;
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -208,7 +208,7 @@ export const editorUIStore: StateCreator<
 export type PublishedFlowSummary = {
   publishedAt: string;
   hasSendComponent: boolean;
-  hasPayComponent: boolean;
+  hasVisiblePayComponent: boolean;
 };
 
 export type FlowSummaryOperations = {
@@ -542,7 +542,7 @@ export const editorStore: StateCreator<
             ) {
               publishedAt: created_at
               hasSendComponent: has_send_component
-              hasPayComponent: has_pay_component
+              hasVisiblePayComponent: has_pay_component
             }
           }
         }

--- a/apps/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
+++ b/apps/editor.planx.uk/src/pages/Team/helpers/sortAndFilterOptions.ts
@@ -30,7 +30,8 @@ const checkFlowServiceType: FilterOptions<FlowSummary>["validationFn"] = (
   value,
 ) => {
   if (value === "submission") return flow.publishedFlows[0]?.hasSendComponent;
-  if (value === "fee carrying") return flow.publishedFlows[0]?.hasPayComponent;
+  if (value === "fee carrying")
+    return flow.publishedFlows[0]?.hasVisiblePayComponent;
   return false;
 };
 


### PR DESCRIPTION
This PR fixes an oversight on https://github.com/theopensystemslab/planx-new/pull/5733, which included non-fee carrying services in the _Fee carrying_ filter if they use a Pay component for information only (toggled to `hidePay`). A flow can have any number of Pay components set to `hidePay`. Only if it has any pay component **not** set to `hidePay`, it is _Fee carrying_.

Adds a new `createFlowTypeMap` helper that groups node IDs by component type, making it easier to categorise flows based on conditions of all nodes of a particular type in a flow.