### PR TITLE
chore: Bump API CPU

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -375,8 +375,8 @@ export = async () => {
           context: "../../apps/api.planx.uk",
           target: "production",
         }),
-        cpu: 2048,
-        memory: 4096 /*MB*/,
+        cpu: 4096,
+        memory: 8192 /*MB*/,
         portMappings: [apiListenerHttp],
         environment: [
           { name: "NODE_ENV", value: env },


### PR DESCRIPTION
A (hopefully!) temp bump of CPU to help mitigate spikes which are bringing the API down when a `.zip` is generated for download.

You can see health and metrics below from attempts this morning - 

<img width="1033" height="422" alt="image" src="https://github.com/user-attachments/assets/0dba1678-e7ba-4182-bc39-8a0015c2b764" />

<img width="1161" height="550" alt="image" src="https://github.com/user-attachments/assets/f156ed89-d7f0-4529-8c34-1fc538d5089b" />

**Next steps...** 
- Identify bottleneck in process, try to fix and roll back this size bump
- (Longer term) Pre-generate files for download
