### PR TITLE
feat: Warn against losing editor modal changes

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -5,6 +5,7 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio/BasicRadio";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormik } from "formik";
+import isEqual from "lodash/isEqual";
 import React, { useEffect } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
@@ -19,7 +20,7 @@ import { ICONS } from "../shared/icons";
 import { editorValidationSchema, parseTextInput, TextInput } from "./model";
 
 export type Props = EditorProps<TYPES.TextInput, TextInput> & {
-  onFieldChange?: () => void;
+  onFieldChange?: (hasChanges: boolean) => void;
 };
 
 const TextInputComponent: React.FC<Props> = (props) => {
@@ -39,12 +40,11 @@ const TextInputComponent: React.FC<Props> = (props) => {
     validationSchema: editorValidationSchema,
   });
 
-  // Notify parent when form elements change
+  // Notify parent when form has changes against initial values
   useEffect(() => {
-    if (formik.dirty) {
-      onFieldChange?.();
-    }
-  }, [formik.dirty, onFieldChange]);
+    const hasActualChanges = !isEqual(formik.values, formik.initialValues);
+    onFieldChange?.(hasActualChanges);
+  }, [formik.values, formik.initialValues, onFieldChange]);
 
   const handleRadioChange = (event: React.SyntheticEvent<Element, Event>) => {
     const target = event.target as HTMLInputElement;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -234,7 +234,9 @@ const FormModal: React.FC<{
             {...extraProps}
             id={id}
             disabled={disabled}
-            onFieldChange={() => setHasUnsavedChanges(true)}
+            onFieldChange={(hasChanges: boolean) =>
+              setHasUnsavedChanges(hasChanges)
+            }
             handleSubmit={(
               data: { data?: Record<string, unknown> },
               children: Array<any> | undefined = undefined,


### PR DESCRIPTION
## What does this PR do?

As part of https://trello.com/c/2xsHU7tv/3448-optimise-editing-modal we have the following task:

> When trying to close without saving, editors will be prompted with a reminder.

This PR sets an approach out, using ~~Formik `dirty`~~ `lodash/isEqual` to detect changes to a form after first render.
Docs: https://lodash.com/docs/4.17.15#isEqual

As proof-of-concept I've applied the changes to the `Text input` component.

**Testing:**
https://5851.planx.pizza/testing/modal-close-warning