### PR TITLE
feat(api): Improve zip generation

### DIFF
--- a/apps/api.planx.uk/modules/send/utils/exportZip.test.ts
+++ b/apps/api.planx.uk/modules/send/utils/exportZip.test.ts
@@ -277,7 +277,7 @@ describe("buildSubmissionExportZip", () => {
           sessionId: "1234",
           includeDigitalPlanningJSON: true,
         }),
-      ).rejects.toThrow(/Failed to generate ODP Schema JSON/);
+      ).rejects.toThrow(/validation test error/);
     });
   });
 
@@ -312,7 +312,7 @@ describe("buildSubmissionExportZip", () => {
           sessionId: "1234",
           onlyDigitalPlanningJSON: true,
         }),
-      ).rejects.toThrow(/Failed to generate ODP Schema JSON/);
+      ).rejects.toThrow(/validation test error/);
     });
   });
 });

--- a/apps/api.planx.uk/modules/send/utils/exportZip.ts
+++ b/apps/api.planx.uk/modules/send/utils/exportZip.ts
@@ -67,7 +67,7 @@ export async function buildSubmissionExportZip({
       }
     } catch (error) {
       throw new Error(
-        `Failed to generate ODP Schema JSON for ${sessionId} zip. Error - ${error}`,
+        `Failed to add ODP Schema JSON to zip for ${sessionId} zip. Error - ${error}`,
       );
     }
   }


### PR DESCRIPTION
## What does this PR do?
Attempts to improve the zip generation process via the following two methods - 
- Parallelise requests for files by using `Promise.all()`
- Only run schema validation once

## Next steps...
 - Look at alternatives to `AdmZip` which can stream directly (should reduce CPU demands)
 - Improve logging to properly identify bottlenecks