### PR TITLE
style: Simplify ListManager collapse expand buttons

### DIFF
--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -316,7 +316,7 @@ const getThemeOptions = ({
               fontWeight: "initial",
               fontSize: "inherit",
               textDecoration: "underline",
-              textUnderlineOffset: "0.1em",
+              textUnderlineOffset: "0.15em",
               gap: "10px",
               minHeight: "48px",
               "&:hover": {
@@ -328,6 +328,9 @@ const getThemeOptions = ({
               "&:focus": {
                 borderColor: palette.text.primary,
                 borderStyle: "solid",
+              },
+              "&:disabled": {
+                textDecoration: "none",
               },
             },
           },

--- a/apps/editor.planx.uk/src/ui/editor/ListManager/ListManagerHeader.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ListManager/ListManagerHeader.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 const StyledListManagerHeader = styled(Box)(({ theme }) => ({
   display: "flex",
-  gap: theme.spacing(1),
+  gap: theme.spacing(2),
   marginBottom: theme.spacing(2),
   position: "sticky",
   top: 0,
@@ -34,17 +34,19 @@ export const ListManagerHeader: React.FC<ListManagerHeaderProps> = ({
     <StyledListManagerHeader>
       <Button
         size="small"
+        variant="link"
         onClick={onCollapseAll}
         disabled={disabled || !hasItems || allCollapsed}
-        sx={{ px: 1 }}
+        sx={{ p: 0 }}
       >
         Collapse all
       </Button>
       <Button
         size="small"
+        variant="link"
         onClick={onExpandAll}
         disabled={disabled || !hasItems || allExpanded}
-        sx={{ px: 1 }}
+        sx={{ p: 0 }}
       >
         Expand all
       </Button>


### PR DESCRIPTION
## What does this PR do?

- Simplifies ListManager collapse/expand controls to be simple links

<img width="859" height="499" alt="image" src="https://github.com/user-attachments/assets/26199a94-4b31-4364-acbc-4ea38b309650" />