### PR TITLE
feat: add custom text limit support to Schemas

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -193,14 +193,14 @@ it("should change the role of the ErrorText when an invalid input is given", asy
   expect(errorMessage).toHaveAttribute("role", "alert");
 });
 
-test("character limit counter should appear for long text inputs", async () => {
+test("character limit counter should appear when text limit is more than 120 characters", async () => {
   setup(<TextInput title="hello" type={TextInputType.Long} />);
 
   const characterCounter = await screen.findByTestId("screen-reader-count");
   expect(characterCounter).toBeInTheDocument();
 });
 
-test("character limit counter should not appear for short text inputs", async () => {
+test("character limit counter should not appear when text limit is 120 characters or less", async () => {
   setup(<TextInput title="hello" type={TextInputType.Short} />);
   const characterCounter = screen.queryByTestId("screen-reader-count");
 

--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -193,14 +193,14 @@ it("should change the role of the ErrorText when an invalid input is given", asy
   expect(errorMessage).toHaveAttribute("role", "alert");
 });
 
-test("character limit counter should appear when text limit is more than 120 characters", async () => {
+test("character limit counter should appear for long text inputs", async () => {
   setup(<TextInput title="hello" type={TextInputType.Long} />);
 
   const characterCounter = await screen.findByTestId("screen-reader-count");
   expect(characterCounter).toBeInTheDocument();
 });
 
-test("character limit counter should not appear when text limit is 120 characters or less", async () => {
+test("character limit counter should not appear for short text inputs", async () => {
   setup(<TextInput title="hello" type={TextInputType.Short} />);
   const characterCounter = screen.queryByTestId("screen-reader-count");
 

--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Public.tsx
@@ -34,7 +34,9 @@ const TextInputComponent: React.FC<Props> = (props) => {
 
   const characterCountLimit = getTextLimit(props.type, props.customLength);
   const displayCharacterCount =
-    characterCountLimit > 120 && props.type !== "email";
+    characterCountLimit > 120 &&
+    characterCountLimit <= 1500 &&
+    props.type !== "email";
 
   // Auto-answered TextInputs still set a breadcrumb even though they render null
   useEffect(() => {

--- a/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/TextFieldInput.tsx
@@ -14,10 +14,18 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
   const { data, formik } = props;
   const { id, errorMessage, required, title } = fieldProps;
 
-  const characterCountLimit = data.type && getTextLimit(data.type);
+  const characterCountLimit =
+    data.type &&
+    getTextLimit(
+      data.type,
+      "customLength" in data ? data.customLength : undefined,
+    );
 
   const displayCharacterCount = Boolean(
-    data.type !== TextInputType.Short && characterCountLimit,
+    characterCountLimit &&
+    characterCountLimit > 120 &&
+    characterCountLimit <= 1500 &&
+    data.type !== TextInputType.Email,
   );
 
   return (
@@ -33,10 +41,18 @@ export const TextFieldInput: React.FC<Props<TextField>> = (props) => {
           else if (type === "phone") return "tel";
           return "text";
         })(data.type)}
-        multiline={data.type && ["long", "extraLong"].includes(data.type)}
+        multiline={Boolean(
+          characterCountLimit &&
+          characterCountLimit > 120 &&
+          data.type !== TextInputType.Email,
+        )}
         bordered
         rows={
-          data.type && ["long", "extraLong"].includes(data.type) ? 5 : undefined
+          characterCountLimit &&
+          characterCountLimit > 120 &&
+          data.type !== TextInputType.Email
+            ? 5
+            : undefined
         }
         required={required}
         inputProps={{


### PR DESCRIPTION
This PR adds support for custom text input limits to Schemas (Page and List components), and removes the displayCharacterCount from text inputs with character limits >1500. This effectively allows for an 'unlimited' text input customisation for editors.

It also fixes some previously undetected misalignments between Schema text fields and the Text input component that I accidentally introduced when updating types and character limits for the latter.