### PR TITLE
chore: bump planx-core (improved `sortBreadcrumbs` performance only)

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -13,7 +13,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.696.0",
     "@aws-sdk/s3-request-presigner": "^3.701.0",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d8bbbbe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#59b0fbb",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.10",
     "axios": "^1.12.2",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.701.0
         version: 3.940.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#d8bbbbe
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@19.2.6)
+        specifier: git+https://github.com/theopensystemslab/planx-core#59b0fbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@19.2.6)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1184,8 +1184,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb}
     version: 1.0.0
 
   '@paralleldrive/cuid2@2.3.1':
@@ -5398,7 +5398,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -18,7 +18,7 @@
     "@mui/x-charts": "8.9.0",
     "@mui/x-data-grid": "^7.25.0",
     "@opensystemslab/map": "1.0.0-alpha.6",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d8bbbbe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#59b0fbb",
     "@tanstack/react-query": "^5.90.6",
     "@tiptap/core": "3.0.7",
     "@tiptap/extension-emoji": "3.0.7",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#d8bbbbe
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@18.3.27)
+        specifier: git+https://github.com/theopensystemslab/planx-core#59b0fbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@18.3.27)
       '@tanstack/react-query':
         specifier: ^5.90.6
         version: 5.90.11(react@18.3.1)
@@ -1885,8 +1885,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.6':
     resolution: {integrity: sha512-EBOgrgBRFNg8p+7nDFvh+K7N4NFQ7+epBXjE9w7h0u87q4M+nOpBwXNc67+UdDs+j8Mi+vQ2R+uJBIKF25NQ7g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -8293,7 +8293,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@18.3.27)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@18.3.27)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.10.0",
   "dependencies": {
     "@cucumber/cucumber": "^11.1.1",
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d8bbbbe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#59b0fbb",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.1.1
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#d8bbbbe
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@19.2.6)
+        specifier: git+https://github.com/theopensystemslab/planx-core#59b0fbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@19.2.6)
       axios:
         specifier: ^1.12.2
         version: 1.13.2
@@ -383,8 +383,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -1297,8 +1297,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.7.4:
+    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2146,7 +2146,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)
@@ -2163,7 +2163,7 @@ snapshots:
       json-schema-to-typescript: 15.0.4
       lodash-es: 4.17.21
       marked: 17.0.0
-      prettier: 3.6.2
+      prettier: 3.7.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.41.0
@@ -2847,7 +2847,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.17.21
       minimist: 1.2.8
-      prettier: 3.6.2
+      prettier: 3.7.4
       tinyglobby: 0.2.15
 
   json-schema-traverse@0.4.1: {}
@@ -3089,7 +3089,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.6.2: {}
+  prettier@3.7.4: {}
 
   process-nextick-args@2.0.1: {}
 

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#d8bbbbe",
+    "@opensystemslab/planx-core": "git+https://github.com/theopensystemslab/planx-core#59b0fbb",
     "axios": "^1.12.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: git+https://github.com/theopensystemslab/planx-core#d8bbbbe
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@19.2.6)
+        specifier: git+https://github.com/theopensystemslab/planx-core#59b0fbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@19.2.6)
       axios:
         specifier: ^1.12.2
         version: 1.13.2
@@ -313,8 +313,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb}
     version: 1.0.0
 
   '@playwright/test@1.56.1':
@@ -1182,8 +1182,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.7.4:
+    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1805,7 +1805,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/d8bbbbe(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/59b0fbb(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)
@@ -1822,7 +1822,7 @@ snapshots:
       json-schema-to-typescript: 15.0.4
       lodash-es: 4.17.21
       marked: 17.0.0
-      prettier: 3.6.2
+      prettier: 3.7.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       type-fest: 4.41.0
@@ -2487,7 +2487,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.17.21
       minimist: 1.2.8
-      prettier: 3.6.2
+      prettier: 3.7.4
       tinyglobby: 0.2.15
 
   json-schema-traverse@0.4.1: {}
@@ -2695,7 +2695,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.6.2: {}
+  prettier@3.7.4: {}
 
   process-nextick-args@2.0.1: {}
 


### PR DESCRIPTION
This fixes the primary issue impacting councils downloading submissions, _without_ refactoring wider `Session` types and requests like #5862 does (which impacts invite to pay).

Opening as a separate PR in case we want to cautiously merge separately ! 

Regression tests against this branch are passing :white_check_mark: https://github.com/theopensystemslab/planx-new/actions/runs/20011461204