### PR TITLE
Revert "chore: Bump API CPU"

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -375,8 +375,8 @@ export = async () => {
           context: "../../apps/api.planx.uk",
           target: "production",
         }),
-        cpu: 4096,
-        memory: 8192 /*MB*/,
+        cpu: 2048,
+        memory: 4096 /*MB*/,
         portMappings: [apiListenerHttp],
         environment: [
           { name: "NODE_ENV", value: env },


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#5850

The above PR was only intended as a temporary measure, and didn't really succeed in making a difference.

This now takes us back to where we were before in terms of size and cost. See below for metrics when I trigger many (~20?) zip downloads back to back on prod - barely a bump!

<img width="1157" height="651" alt="image" src="https://github.com/user-attachments/assets/dbeda7c1-c05e-4b55-8bf3-ef959dae5c4a" />
