### PR TITLE
fix: add unlimited condition description [skip pizza]

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/List/schemas/DischargeConditions.ts
+++ b/apps/editor.planx.uk/src/@planx/components/List/schemas/DischargeConditions.ts
@@ -21,7 +21,8 @@ export const DischargeConditions: Schema = {
         description:
           "This is the exact wording of the condition as shown on the decision notice.",
         fn: "description",
-        type: TextInputType.ExtraLong,
+        type: TextInputType.Custom,
+        customLength: 10000,
       },
     },
     {


### PR DESCRIPTION
Adds unlimited (10k character) descriptions to condition schema as requested by Lambeth.