### PR TITLE
fix: Visual regression of `ListManager` on global settings page

### DIFF
--- a/apps/editor.planx.uk/src/pages/GlobalSettings.tsx
+++ b/apps/editor.planx.uk/src/pages/GlobalSettings.tsx
@@ -82,7 +82,7 @@ function Component() {
                 content page.
               </p>
             </SettingsDescription>
-            <Box width="100%" mb={4} p={0}>
+            <Box width="100%" mb={4} p={4}>
               <ListManager
                 values={formik.values.footerContent}
                 onChange={(newOptions) => {


### PR DESCRIPTION
Small visual regression - `ListManager` icons (drag handle and delete) are outside the wrapper.

| Before | After |
|--------|--------|
| <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/8e0eb890-a395-4d9b-a0cf-7ebf2e91a1bd" /> | <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/8c326f6b-8006-4e66-943b-eda7d6ffb04c" /> | 