### PR TITLE
fix(editor): Allow RichTextAreas to have multiline rows

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/About/components/Summary.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/About/components/Summary.tsx
@@ -53,6 +53,7 @@ const Summary: React.FC = () => {
           <InputLabel label="Summary" htmlFor="summary">
             <Input
               multiline
+              rows={2}
               {...formik.getFieldProps("summary")}
               id="summary"
               placeholder="Summary"

--- a/apps/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -33,6 +33,8 @@ import { commonExtensions, passportClassName } from "./tiptapExtensions";
 import { Props } from "./types";
 import { fromHtml, initialUrlValue, toHtml, trimUrlValue } from "./utils";
 
+const LINE_HEIGHT_REM = 1.5;
+
 const RichTextInput: FC<Props> = (props) => {
   const stringValue = String(props.value || "");
   const variant = props.variant ?? "default";
@@ -50,6 +52,13 @@ const RichTextInput: FC<Props> = (props) => {
     contenteditable: "false",
     role: "textbox",
     translate: "no",
+    ...(props.multiline && props.rows && {
+      style: `
+        min-height: ${(props.rows as number) * LINE_HEIGHT_REM}rem; 
+        display: flex;
+        justify-content: flex-start;
+      `,
+    }),
   } as unknown as EditorOptions["editorProps"]["attributes"];
 
   const editor = useEditor({


### PR DESCRIPTION
Small issue that's been on my radar for a while. Currently, despite accepting both `multiline` and `rows` arguments, `<RichTextArea/>` components do not respect them and only grow when content is entered.

This fix allows us to make it visually obvious which inputs are rich text before they contain content.

| Before | After |
|--------|--------|
|<img width="1440" height="779" alt="image" src="https://github.com/user-attachments/assets/63a855dc-598a-49ff-ba85-4438bd0101d9" /> | <img width="1440" height="778" alt="image" src="https://github.com/user-attachments/assets/650f775c-faa9-4290-b116-08a5d4beec7b" /> | 