### PR TITLE
chore: Add missing tables to sync script

### DIFF
--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -27,6 +27,8 @@ tables=(
   team_themes
   team_settings
   templated_flow_edits
+  submission_integrations
+  flow_integrations
   # Optional tables
   # Please comment in if working on a feature and you require example data locally
   # You will need to manually grant select permissions to the github_actions on production, and update main.sql

--- a/scripts/seed-database/write/flow_integrations.sql
+++ b/scripts/seed-database/write/flow_integrations.sql
@@ -1,0 +1,21 @@
+-- insert flow_integrations overwriting conflicts
+CREATE TEMPORARY TABLE sync_flow_integrations (
+  flow_id uuid,
+  team_id integer,
+  email_id uuid
+);
+
+\COPY sync_flow_integrations FROM '/tmp/flow_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  flow_integrations (flow_id, team_id, email_id)
+SELECT
+  flow_id uuid,
+  team_id integer,
+  email_id uuid
+FROM
+  sync_flow_integrations ON CONFLICT (flow_id) DO
+UPDATE
+SET
+  team_id = EXCLUDED.team_id,
+  email_id = EXCLUDED.email_id;

--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -8,6 +8,8 @@
 \include write/team_integrations.sql
 \include write/team_themes.sql
 \include write/team_settings.sql
+\include write/submission_integrations.sql
+\include write/flow_integrations.sql
 
 -- Optional tables
 -- \include write/feedback.sql

--- a/scripts/seed-database/write/submission_integrations.sql
+++ b/scripts/seed-database/write/submission_integrations.sql
@@ -1,0 +1,24 @@
+-- insert submission_integrations overwriting conflicts
+CREATE TEMPORARY TABLE sync_submission_integrations (
+  team_id integer,
+  id uuid,
+  submission_email text,
+  default_email boolean
+);
+
+\COPY sync_submission_integrations FROM '/tmp/submission_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
+
+INSERT INTO
+  submission_integrations (team_id, id, submission_email, default_email)
+SELECT
+  team_id integer,
+  id uuid,
+  submission_email text,
+  default_email boolean
+FROM
+  sync_submission_integrations ON CONFLICT (id) DO
+UPDATE
+SET
+  team_id = EXCLUDED.team_id,
+  submission_email = EXCLUDED.submission_email,
+  default_email = EXCLUDED.default_email;


### PR DESCRIPTION
## What does this PR do?
 - Adds `flows_integrations` table to the sync script
 - Adds `submission_integrations` table to the sync script
 - `github_action` user has been `GRANT`ed relevant permissions on the prod DB

## Testing
- Tested locally with `pnpm test-sync` ✅ 
- Pizza DB populated as expected ✅ 

Long overdue sorry...! This was a forgotten step from https://github.com/theopensystemslab/planx-new/pull/5590