### PR TITLE
chore: differentiate Power Automate and FME Workbench end user destinations in S3 Slack notifications

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -87,10 +87,14 @@ const getMessageForEventType = (data: EventData, type: EventType) => {
     const { session_id, team_slug, webhook_request } = data as S3EventData;
 
     let endUserDestination = "Power Automate";
-    if (webhook_request.data.message.includes("without Power Automate notification")) {
-      endUserDestination = "FME Workbench"
+    if (
+      webhook_request.data.message.includes(
+        "without Power Automate notification",
+      )
+    ) {
+      endUserDestination = "FME Workbench";
     }
-    
+
     return `New S3 + ${endUserDestination} submission "${webhook_request.data.service}" *${session_id}* [${team_slug}]`;
   }
 };


### PR DESCRIPTION
Minor one but will be helpful for troubleshooting if Camden moves their FME testing to prod anytime soon