### PR TITLE
fix(wip): render analytics link (when available) in all flow settings views

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -35,6 +35,10 @@ function EditorNavMenu() {
       state.getTeam(),
     ],
   );
+
+  useStore.getState().getFlowInformation(flowSlug, teamSlug);
+  console.log("EditorNavMenu: ", flowAnalyticsLink);
+
   const referenceCode = team?.settings?.referenceCode;
   const { url: lpsBaseUrl } = useLPS();
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/settings.ts
@@ -121,7 +121,7 @@ export const settingsStore: StateCreator<
       : undefined;
 
     const analyticsLink =
-      environment === "production" && dashboardId
+      environment === "production" && dashboardId // change to "development" for local testing (we don't have analytics in staging)
         ? generateAnalyticsLink({
             flowId: id,
             dashboardId,

--- a/apps/editor.planx.uk/src/routes/views/flowEditor.tsx
+++ b/apps/editor.planx.uk/src/routes/views/flowEditor.tsx
@@ -127,9 +127,6 @@ export const flowEditorView = async (req: NaviRequest) => {
     template,
   } = await getFlowEditorData(flow, req.params.team);
 
-  // We need to call `getFlowInformation` here to ensure that the store updates and we have the correct analytics link showing
-  useStore.getState().getFlowInformation(flow, req.params.team);
-
   useStore.setState({
     id,
     flowStatus,


### PR DESCRIPTION
This bug only [shows analytics links](https://opendigitalplanning.slack.com/archives/C01AD3YPZ24/p1765267554903829) when the nav bar first loads, but when a user navigates to another tab, the link disappears. 
<img width="200" alt="image" src="https://github.com/user-attachments/assets/d162bb7f-f46e-4ad8-be99-4f7a49529a03" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/d686ca52-b0ca-470c-83dc-b1f2bffcb33f" />

I can achieve our desired functionality but only by creating an infinite loop! Switching to `useEffect` sidesteps the circular dependency and fixes the infinite loop, but not the functionality. 

Any tips? 
