### PR TITLE
fix: Restrict component types which can appear as sticky nodes in the graph

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -29,13 +29,12 @@ type Props = {
 };
 
 const Question: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, showHelpText, showTags, showNotes] = useStore(
+  const [isClone, childNodes, showHelpText, showTags] = useStore(
     (state) => [
       state.isClone,
       state.childNodesOf(props.id),
       state.showHelpText,
       state.showTags,
-      state.showNotes,
     ],
   );
 
@@ -67,12 +66,6 @@ const Question: React.FC<Props> = React.memo((props) => {
     },
   });
 
-  // Hide sticky notes when toggled off
-  const isStickyNote = childNodes.length === 0;
-  if (isStickyNote && !showNotes) {
-    return null;
-  }
-
   const Icon = props.type === "Error" ? ErrorIcon : ICONS[props.type];
   // If there is an error, the icon has a semantic meaning and needs a title
   const iconTitleAccess = props.type === "Error" ? "Error" : undefined;
@@ -91,7 +84,6 @@ const Question: React.FC<Props> = React.memo((props) => {
           {
             isDragging,
             isClone: isClone(props.id),
-            isNote: isStickyNote,
             wasVisited: props.wasVisited,
             hasFailed: props.hasFailed,
           },


### PR DESCRIPTION
## What's the problem?
Currently, any node without edges will disappear from the graph when the "Show notes" option is toggled.

## What's the cause?
We're checking the `isStickyNote` condition within the (badly named!) `<Question/>` component which is what appears on the graph. This component is used for most nodes which are not branching or portals, so we never need to check `isStickyNote` here.

## What's the solution?
We already have a type check in place within `Node.tsx` inside the big `switch/case` statement which controls the visual display of the graph - 

https://github.com/theopensystemslab/planx-new/blob/3947e179859bf4dded8793733e3716e332e59c4a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx#L151-L161

The components we wish to display as "sticky notes" are already grouped and use the (also badly named!) `<Checklist/>` component.

As these are the only nodes which can be "sticky notes", it's fine to leave this check in place.

Longer term the introduction of a more formalised method of adding notes to the graph should largely resolve this complexity.

## Testing
**Before**
_Any component without edges is toggled off (see `main`)_

https://github.com/user-attachments/assets/014a7f29-177a-4afc-854d-ce0e67f58888



**After**
_Only the four possible "sticky note" types can be toggled (see Pizza)_

https://github.com/user-attachments/assets/4c6b07e2-c405-4eeb-913a-7c7fb890f185

