### PR TITLE
feat(hasura): Add `flows.production_url` column

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -112,6 +112,11 @@ computed_fields:
       function:
         name: flow_first_online_at
         schema: public
+  - name: production_url
+    definition:
+      function:
+        name: flow_production_url
+        schema: public
 insert_permissions:
   - role: api
     permission:
@@ -277,6 +282,8 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - first_online_at
+        - production_url
       filter:
         deleted_at:
           _is_null: true
@@ -306,6 +313,7 @@ select_permissions:
       computed_fields:
         - data_merged
         - first_online_at
+        - production_url
       filter:
         _and:
           - _or:
@@ -351,6 +359,7 @@ select_permissions:
       computed_fields:
         - data_merged
         - first_online_at
+        - production_url
       filter:
         deleted_at:
           _is_null: true
@@ -379,6 +388,8 @@ select_permissions:
         - version
       computed_fields:
         - data_merged
+        - first_online_at
+        - production_url
       filter:
         deleted_at:
           _is_null: true
@@ -411,6 +422,7 @@ select_permissions:
       computed_fields:
         - data_merged
         - first_online_at
+        - production_url
       filter:
         deleted_at:
           _is_null: true

--- a/apps/hasura.planx.uk/migrations/default/1765367438460_add_flows_url_computed_field/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1765367438460_add_flows_url_computed_field/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.flow_production_url;

--- a/apps/hasura.planx.uk/migrations/default/1765367438460_add_flows_url_computed_field/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1765367438460_add_flows_url_computed_field/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION public.flow_production_url(flow_row flows)
+RETURNS TEXT AS $$
+  SELECT 
+    CASE 
+      WHEN t.domain IS NOT NULL AND t.domain != '' 
+      THEN 'https://' || t.domain || '/' || flow_row.slug
+      ELSE 'https://editor.planx.uk/' || t.slug || '/' || flow_row.slug || '/published'
+    END
+  FROM teams t
+  WHERE t.id = flow_row.team_id
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
## What does this PR do?
 - Adds `flows.production_url` computed field
 - Allows `public` role access to `flows.first_online_at`

## Context
Both have come up as requirements for MHCLG analytics - see thread here (OSL Slack) https://opensystemslab.slack.com/archives/C01E3AC0C03/p1765389251808299