### PR TITLE
refactor: Use button to view application

### DIFF
--- a/apps/editor.planx.uk/src/ui/public/ViewApplicationLink.tsx
+++ b/apps/editor.planx.uk/src/ui/public/ViewApplicationLink.tsx
@@ -1,19 +1,18 @@
-import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
-import React, {  } from "react";
+import Button from "@mui/material/Button";
+import React from "react";
 import { Link as ReactNaviLink } from "react-navi";
 
 const ViewApplicationLink: React.FC = () => (
-  <Link
-    sx={{ display: "block", mt: 1, textAlign: "right" }}
-    component={ReactNaviLink}
+  <ReactNaviLink
     href="view-application"
     prefetch={false}
+    onContextMenu={(e) => e.preventDefault()}
+    style={{ textDecoration: "none" }}
   >
-    <Typography variant="body2">
+    <Button variant="contained" color="secondary">
       View form
-    </Typography>
-  </Link>
-)
+    </Button>
+  </ReactNaviLink>
+);
 
 export default ViewApplicationLink;


### PR DESCRIPTION
## What does this PR do?

- Uses a button to view application from confirmation, preventing the option to open in a new tab (which would break data retention)

<img width="749" height="346" alt="image" src="https://github.com/user-attachments/assets/3bfdb94c-7df4-42a1-86d0-1552562827c7" />
