### PR TITLE
style: Update LPS icon to same scale as MUI icons

### DIFF
--- a/apps/editor.planx.uk/src/ui/icons/LocalPlanningServices.tsx
+++ b/apps/editor.planx.uk/src/ui/icons/LocalPlanningServices.tsx
@@ -3,31 +3,11 @@ import * as React from "react";
 
 export default function LocalPlanningServicesIcon(props: SvgIconProps) {
   return (
-    <SvgIcon
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 132 131.14"
-    >
-      <path
-        d="M127.74,9.2c-2.99-.9-28.2-8.53-30.43-9.2-3.26.99-27.56,8.33-31.3,9.46-3.83-1.16-27.96-8.45-31.3-9.46C28.59,1.85,6.11,8.64,0,10.49v120.66c5.81-1.76,28.5-8.62,34.7-10.49,3.83,1.16,27.96,8.45,31.3,9.46,3.26-.99,27.56-8.33,31.3-9.46,6.29,1.9,28.78,8.7,34.7,10.49V10.49l-4.26-1.29Z"
-        fill="#fff"
-      />
-      <polygon
-        points="6 123.06 32.09 115.18 32.09 7.06 6 14.94 6 123.06"
-        fill="currentColor"
-      />
-      <polygon
-        points="37.3 115.18 63.39 123.06 63.39 14.94 37.3 7.06 37.3 115.18"
-        fill="currentColor"
-      />
-      <polygon
-        points="68.61 123.06 94.7 115.18 94.7 7.06 68.61 14.94 68.61 123.06"
-        fill="currentColor"
-      />
-      <polygon
-        points="99.91 115.18 126 123.06 126 14.94 99.91 7.06 99.91 115.18"
-        fill="currentColor"
-      />
+    <SvgIcon {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <polygon points="2.06 17.67 5.51 16.63 5.51 2.33 2.06 3.37 2.06 17.67" />
+      <polygon points="6.2 16.63 9.65 17.67 9.65 3.37 6.2 2.33 6.2 16.63" />
+      <polygon points="10.35 17.67 13.8 16.63 13.8 2.33 10.35 3.37 10.35 17.67" />
+      <polygon points="14.49 16.63 17.94 17.67 17.94 3.37 14.49 2.33 14.49 16.63" />
     </SvgIcon>
   );
 }


### PR DESCRIPTION
## What does this PR do?

- Quick one: scales LPS icon in the editor to the same dimensions as MUI icons (also removes white border)

Before vs after, compared against an MUI icon (subtle difference):
<img width="128" height="202" alt="image" src="https://github.com/user-attachments/assets/132550ec-27b0-4eac-bb35-e47ed743e0a7" />
