### PR TITLE
feat: add a simple view of each team's Planning Data onboarding "health" that Metabase can access

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -133,7 +133,7 @@ function EditorNavMenu() {
         : `Planning Data unavailable`,
       Icon: LayersIcon,
       route: referenceCode
-        ? `https://submit.planning.data.gov.uk/organisations/local-authority:${referenceCode}`
+        ? `https://provide.planning.data.gov.uk/organisations/local-authority:${referenceCode}`
         : `#`,
       accessibleBy: "*",
       disabled: !referenceCode,

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_planning_data_health.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_planning_data_health.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_planning_data_health
+  schema: public

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -5,6 +5,7 @@
 - "!include public_analytics_exits.yaml"
 - "!include public_analytics_journeys_aggregated.yaml"
 - "!include public_analytics_logs.yaml"
+- "!include public_analytics_planning_data_health.yaml"
 - "!include public_analytics_project_types.yaml"
 - "!include public_analytics_rab.yaml"
 - "!include public_analytics_results.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1765484954679_create_view_analytics_planning_data_health/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1765484954679_create_view_analytics_planning_data_health/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_planning_data_health;

--- a/apps/hasura.planx.uk/migrations/default/1765484954679_create_view_analytics_planning_data_health/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1765484954679_create_view_analytics_planning_data_health/up.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW analytics_planning_data_health AS (
+SELECT
+    t.id AS team_id,
+    t.name AS team_name,
+    t.slug AS team_slug,
+    ti.has_planning_data AS planning_constraints_enabled_in_planx,
+    ts.reference_code AS planning_data_reference_code,
+    CASE 
+        WHEN ts.reference_code IS NOT NULL
+        THEN FORMAT('https://provide.planning.data.gov.uk/organisations/local-authority:%s', ts.reference_code)
+        ELSE NULL
+    END AS planning_data_link
+FROM teams t
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+);
+
+GRANT SELECT ON public.analytics_planning_data_health TO metabase_read_only;


### PR DESCRIPTION
Per this thread https://opensystemslab.slack.com/archives/C01E3AC0C03/p1765481375166119?thread_ts=1765389251.808299&cid=C01E3AC0C03

Very simple solution, but easy to expose in Metabase now (all public info): 
<img width="1434" height="264" alt="Screenshot from 2025-12-11 15-28-43" src="https://github.com/user-attachments/assets/77be8c45-282e-4bdc-9a66-4cf22b767161" />