### PR TITLE
fix(editor): Update type for `BaseQuestion`

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/model.ts
@@ -10,20 +10,20 @@ import { Child } from "../types";
  * Base fields shared between Question and ResponsiveQuestion components
  */
 export interface BaseQuestion extends BaseNodeData {
-  fn?: string;
+  fn?: string,
   text?: string;
   description?: string;
   img?: string;
 }
 
-export const baseQuestionValidationSchema: SchemaOf<BaseQuestion> =
+export const baseQuestionValidationSchema =
   baseNodeDataValidationSchema
     .concat(
       object({
         text: string().required(),
         description: richText(),
         img: string(),
-        fn: string(),
+        fn: string().nullable(),
         options: array(optionValidationSchema).required(),
       }),
     )


### PR DESCRIPTION
## What's the problem?
The editor displays an unintelligible Yup validation error when a data field is empty, and does not allow the form to be saved.

<img width="1544" height="862" alt="image" src="https://github.com/user-attachments/assets/665b24e2-3d8c-4ac2-a3d2-91a10f67838c" />

## What's the solution?
Update the `BaseQuestion` validation schema to allow the `<DataFieldAutocomplete/>` to set a `null` value here.