### PR TITLE
fix: Graph editor toggle position

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -31,9 +31,9 @@ const EditorContainer = styled(Box)(() => ({
 }));
 
 const EditorVisualControls = styled(ButtonGroup)(({ theme }) => ({
-  position: "fixed",
+  position: "absolute",
   bottom: theme.spacing(2.5),
-  left: theme.spacing(7.5),
+  left: theme.spacing(2.5),
   zIndex: theme.zIndex.appBar,
   border: `1px solid ${theme.palette.border.main}`,
   borderRadius: "3px",


### PR DESCRIPTION
## What does this PR do?

- Fixes position of graph toggle button group, making it positioned `absolute` to container rather than `fixed`


Example of non-`teamEditor` view for a graph editor (before vs after):

<img width="1750" height="1910" alt="image" src="https://github.com/user-attachments/assets/0a39e90d-3fdf-4c70-905c-87eb3928b69a" />
