### PR TITLE
fix(ci): Permissions in LPS deploy workflow

### DIFF
--- a/.github/workflows/deploy-lps.yml
+++ b/.github/workflows/deploy-lps.yml
@@ -1,7 +1,6 @@
 name: Deploy LPS (staging)
 
-permissions:
-  contents: read
+permissions: read-all
 
 # TODO: Add schedule (or webhook?)
 on:


### PR DESCRIPTION
Hitting a permissions error - it looks like this needs to match the permission level of `./.github/workflows/action-failure.yml` which is calls.

Failure here - https://github.com/theopensystemslab/planx-new/actions/runs/20174049673