### PR TITLE
[application] transform ECS rollback output direct to string

### DIFF
--- a/infrastructure/application/utils/failureNotification.ts
+++ b/infrastructure/application/utils/failureNotification.ts
@@ -80,8 +80,7 @@ export const setupNotificationForDeploymentRollback = (
           updatedAt: "$.detail.updatedAt",
           reason: "$.detail.reason",
         },
-        inputTemplate: pulumi.jsonStringify({
-          text: [
+        inputTemplate: pulumi.jsonStringify([
             `-> Environment: ${env}`,
             `-> Affected service: ${simpleServiceName}`,
             "-> Event type: <eventType>",
@@ -89,8 +88,7 @@ export const setupNotificationForDeploymentRollback = (
             "-> Deployment ID: <deploymentId>",
             "-> Updated at: <updatedAt>",
             "-> Reason: <reason>",
-          ].join("\n"),
-        }),
+          ].join("\n")),
       },
     }
   );


### PR DESCRIPTION
We had an in-the-wild trigger of the ECS rollback alert to Slack for Hasura today, but the message was formatted like:

```
{"text":"-> Environment: staging\n-> Affected service: hasura\n-> Event type: ERROR\n-> Event name: SERVICE_DEPLOYMENT_FAILED\n-> Deployment ID: ecs-svc/xxx\n-> Updated at: 2025-12-15T16:01:05.092Z\n-> Reason: ECS deployment circuit breaker: tasks failed to start."}
```

This is not very nice. As per [this article](https://slack.dev/flatten-json-for-workflow-builder/):

> ... Workflow Builder can only extract variables from top-level JSON keys in the payload

So we just need to remove the `text` key here and the text should be sent directly as the value of `Message`, which is the variable we're accessing in the Slack workflow builder (see #5780).

