### PR TITLE
fix(a11y): Bump contrast checker to AA ratio for small text

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/TextLinkColour/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/TextLinkColour/index.tsx
@@ -31,7 +31,7 @@ const TextLinkColour: React.FC = () => {
       validationSchema={validationSchema.pick(["linkColour"])}
       legend="Text link colour"
       preview={(formik) => [
-        <DesignPreview bgcolor="white">
+        <DesignPreview bgcolor="paper">
           <Link sx={{ color: formik.values.linkColour }}>
             Example text link
           </Link>
@@ -41,7 +41,7 @@ const TextLinkColour: React.FC = () => {
         <>
           <p>
             The text link colour should be a dark colour that contrasts with
-            white ("#ffffff").
+            paper / off-white background ("#f9f8f8").
           </p>
           <p>
             <Link

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/shared/validationSchema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/shared/validationSchema.ts
@@ -20,7 +20,7 @@ export const validationSchema = object({
       return this.createError({
         path: "linkColour",
         message:
-          "Colour does not meet accessibility contrast requirements (3:1)",
+          "Colour does not meet accessibility contrast requirements (4.5:1)",
       });
     },
   })
@@ -34,7 +34,7 @@ export const validationSchema = object({
       return this.createError({
         path: "primaryColour",
         message:
-          "Theme colour does not meet accessibility contrast requirements (3:1)",
+          "Theme colour does not meet accessibility contrast requirements (4.5:1)",
       });
     },
   });
@@ -48,4 +48,4 @@ export const defaultValues: TeamTheme = {
 };
 
 const isContrastThresholdMet = (color: string) =>
-  getContrastRatio("#FFF", color) > DEFAULT_CONTRAST_THRESHOLD;
+  getContrastRatio("#f9f8f8", color) > DEFAULT_CONTRAST_THRESHOLD;

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -27,7 +27,7 @@ import { getContrastTextColor } from "styleUtils";
 
 const DEFAULT_PRIMARY_COLOR = "#0010A4";
 const DEFAULT_TONAL_OFFSET = 0.1;
-export const DEFAULT_CONTRAST_THRESHOLD = 3;
+export const DEFAULT_CONTRAST_THRESHOLD = 4.5;
 
 // Type styles
 export const FONT_WEIGHT_SEMI_BOLD = "600";


### PR DESCRIPTION
## What does this PR do?

- Bumps ratio for validating text contrast from 3:1 to 4.5:1, in line with WCAG AA guidance around colour contrast
- Adjusts reference background to our paper (`#f9f8f8`) colour

In addition to this I'll bump up Horsham's text link colour to match that on their website (`#006eb8`), which satisfies a 4.5:1 contrast ratio: https://www.horsham.gov.uk/