### PR TITLE
style: Layout for description options

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -77,12 +77,12 @@ const ProjectDescription: React.FC<Props> = (props) => {
          <Card>
           <Typography variant="h4">Suggested description:</Typography>
           <Typography variant="body2">{data.enhanced}</Typography>
-          <Button variant="contained" color="secondary" sx={{ mt: "auto", backgroundColor: "common.white" }} onClick={() => setFieldValue("userInput", data.enhanced)}>Use suggested description</Button>
+          <Button variant="contained" color="secondary" sx={{ mt: "auto", backgroundColor: "common.white" }}>Use suggested description</Button>
         </Card>
         <Card>
           <Typography variant="h4">Your description:</Typography>
           <Typography variant="body2">{data.original}</Typography>
-          <Button variant="contained" color="secondary" sx={{ mt: "auto", backgroundColor: "common.white" }} onClick={() => setFieldValue("userInput", data.original)}>Revert to original description</Button>
+          <Button variant="contained" color="secondary" sx={{ mt: "auto", backgroundColor: "common.white" }}>Revert to original description</Button>
         </Card>
       </Box>
       <InputRow>


### PR DESCRIPTION
## What does this PR do?

- Sets out layout for suggested vs original project descriptions

Next task: wire up buttons to inject text into `textarea`


<img width="933" height="899" alt="image" src="https://github.com/user-attachments/assets/ec6c9ef6-eb6c-4889-ba4b-5f75f5394bc7" />


