### PR TITLE
feat: Basic error UI for ETI component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ErrorCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ErrorCard.tsx
@@ -1,0 +1,22 @@
+import Typography from "@mui/material/Typography";
+import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
+import React, { type PropsWithChildren } from "react";
+
+interface Props {
+  title: string;
+  description: string;
+}
+
+const ErrorCard: React.FC<PropsWithChildren<Props>> = ({ title, description, children }) => (
+  <ErrorSummaryContainer role="status">
+    <Typography variant="h4" component="h2" gutterBottom>
+      {title}
+    </Typography>
+    <Typography variant="body2">
+      {description}
+    </Typography>
+    { children && children }
+  </ErrorSummaryContainer>
+)
+
+export default ErrorCard;

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -22,6 +22,7 @@ import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHt
 
 import { HOW_DOES_THIS_WORK } from "../../content";
 import type { EnhancedTextInputForTask } from "../../types";
+import ErrorCard from "./ErrorCard";
 
 type Props = PublicProps<EnhancedTextInputForTask<"projectDescription">>
 
@@ -49,12 +50,18 @@ const ProjectDescription: React.FC<Props> = (props) => {
     switch (error.data.error) {
       case "INVALID_DESCRIPTION":
         return (
-          <p>invalid description</p>
+          <ErrorCard
+            title="Invalid description"
+            description="We weren't able to generate a description based on your input. The description doesn't appear to be related to a planning application."
+          />
         )
 
       case "SERVICE_UNAVAILABLE":
         return (
-          <p>service unavailable</p>
+          <ErrorCard
+            title="Service unavailable"
+            description="We weren't able to generate a description based on your input. We'll use your original project description."
+          />
         )
     }
   }


### PR DESCRIPTION
## What does this PR do?
- Adds basic UI for error states
- Matches how `PlanningConstraints` is handled - 

https://github.com/theopensystemslab/planx-new/blob/ac62662605059bee99b9654204a6dcc048edd22d/apps/editor.planx.uk/src/%40planx/components/PlanningConstraints/Public/Presentational.tsx#L130-L153

## Not in this PR...
Any sort of reset / retry logic - just focused on most basic UI here...!