### PR TITLE
fix: Prevent duplicate help button when submitting descriptions

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -20,15 +20,10 @@ const taskComponents: TaskComponentMap = {
 
 const EnhancedTextInputComponent = (props: Props) => {
   const [step, setStep] = useState<"input" | "task">("input");
-  const [hasSubmittedInput, setHasSubmittedInput] = useState(false);
   const isRunningTask = useIsFetching({ queryKey: [props.task] });
 
   const nextStep = () => {
-    if (step === "input") {
-      setStep("task");
-      setHasSubmittedInput(true);
-      return;
-    }
+    if (step === "input") return setStep("task")
     if (step === "task") props.handleSubmit?.(makeData(props, {}));
   }
 
@@ -56,7 +51,7 @@ const EnhancedTextInputComponent = (props: Props) => {
         <CardHeader
           title={props.title}
           description={props.description}
-          {...(!hasSubmittedInput && {
+          {...(step === "input" && {
             info: props.info,
             policyRef: props.policyRef,
             howMeasured: props.howMeasured,


### PR DESCRIPTION
## What does this PR do?

- Prevents redundant help button appearing when project descriptions have been entered

**Before:**
<img width="691" height="457" alt="image" src="https://github.com/user-attachments/assets/fa8ee4e0-e39b-42b3-bbf8-f285e344a9f8" />


**After:**
<img width="691" height="457" alt="image" src="https://github.com/user-attachments/assets/5776d100-c7fb-4d47-8241-f15c602a965e" />
