### PR TITLE
fix: Editor overflow width and toggle position

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -28,7 +28,7 @@ const EditorContainer = styled(Box)<{ hasNavMenu?: boolean }>(
     overflow: "hidden",
     flexGrow: 1,
     maxHeight: `calc(100vh - ${HEADER_HEIGHT_EDITOR}px)`,
-    minWidth: hasNavMenu ? `calc(100vw - ${MENU_WIDTH_COMPACT}px)` : "100vw",
+    maxWidth: hasNavMenu ? `calc(100vw - ${MENU_WIDTH_COMPACT}px)` : "100vw",
   }),
 );
 
@@ -99,13 +99,13 @@ const FlowEditor = () => {
           flexDirection: "column",
           width: "100%",
           overflowX: "auto",
+          position: "relative",
         }}
       >
         <Box
           id="editor"
           ref={scrollContainerRef}
           className={lockedFlow ? "flow-locked" : ""}
-          sx={{ position: "relative" }}
         >
           {" "}
           {isLoading ? (


### PR DESCRIPTION
## What does this PR do?

Fixes issue highlighted by @DafyddLlyr in Slack:
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1765904899672269

- Fixing the graph editor max-width for non `teamEditors` (nav menu not present) caused a regression for `teamEditors` (nav menu present

To test:
1. View an active (graph larger than viewport) flow, content should not overflow the viewport width
2. Do the same with a flow that you don't have editor permissions for