### PR TITLE
fix(ci): Typo in env var for LPS deploy (prod)

### DIFF
--- a/.github/workflows/deploy-lps-production.yml
+++ b/.github/workflows/deploy-lps-production.yml
@@ -15,7 +15,7 @@ env:
   BUCKET_NAME: localplanning.services
   BUILD_MODE: production
   SITE_URL: https://localplanning.services
-  DIST_ID: ${{ secrets.LPS_PRODUCTION_DIST_ID }}
+  DIST_ID: ${{ secrets.LPS_PROD_DIST_ID }}
 
 jobs:
   deploy:


### PR DESCRIPTION
Picking this task back up from https://github.com/theopensystemslab/planx-new/pull/5903

I've just manually ran the `Deploy LPS (Production)` action ([logs here](https://github.com/theopensystemslab/planx-new/actions/runs/20281197538)), which succeeded apart from the final "invalidate CDN" step - 

**Success - time matches GHA time**
<img width="475" height="219" alt="image" src="https://github.com/user-attachments/assets/328b7276-2339-4080-aeee-2c85782d57c6" />

This env var now correctly matches what I set up in Settings > Secrets & Variables > Actions

<img width="662" height="216" alt="image" src="https://github.com/user-attachments/assets/59764f77-47a8-43af-96af-8bdcef2e4dfc" />
