### PR TITLE
chore(ci): Schedule LPS deployments

### DIFF
--- a/.github/workflows/deploy-lps-production.yml
+++ b/.github/workflows/deploy-lps-production.yml
@@ -2,9 +2,14 @@ name: Deploy LPS (production)
 
 permissions: read-all
 
-# TODO: Add schedule (or webhook?)
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - production
+  schedule:
+    # Runs at 08:30, 12:30 and 16:30, Monday through Friday
+    - cron: 30 8,12,16 * * 1-5
 
 # Queue job so the site will always remain in a stable state
 concurrency:

--- a/.github/workflows/deploy-lps-staging.yml
+++ b/.github/workflows/deploy-lps-staging.yml
@@ -5,6 +5,9 @@ permissions: read-all
 # TODO: Add schedule (or webhook?)
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 # Queue job so the site will always remain in a stable state
 concurrency:


### PR DESCRIPTION
This will build and deploy LPS as follows -

 **Staging**
 - On each merge to `main` (required to pick up any new code changes)
 - On workflow dispatch (manual action)

 **Production**
 - 3 times a day (8.30, 12.30, 16.30 UTC)
 - On each merge to `production` (required to pick up any new code changes)
 - On workflow dispatch (manual action)
 
 I think this is simple enough for now? We could easily improve this in a number of ways in the future - 
  - Link to Hasura webhooks, only rebuild when a flow is toggled as listed/unlisted on LPS
  - Add a check before build to see if there are new services to list