### PR TITLE
fix(editor): Consistent alignment on filters

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -218,8 +218,8 @@ const Team: React.FC = () => {
                 clearFilters={shouldClearFilters}
               />
               {teamHasFlows && matchingFlows && (
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-                  <Typography variant="body2">
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Typography variant="body2" sx={{ width: "70px" }}>
                     <strong>Sort by</strong>
                   </Typography>
                   <SortControl<FlowSummary>

--- a/apps/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/Filter/Filter.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import { get, isEmpty, omit } from "lodash";
@@ -164,12 +165,13 @@ export const Filters = <T extends object>({
 
   return (
     <FiltersContent>
-      <form
+      <Box
+        component="form"
         name="filters"
         aria-label="Filter options"
-        style={{ display: "flex", alignItems: "center", gap: "10px" }}
+        sx={{ display: "flex", alignItems: "center", gap: 1 }}
       >
-        <Typography variant="body2" sx={{ flexShrink: 0 }}>
+        <Typography variant="body2" sx={{ width: "70px" }}>
           <strong>Filter by</strong>
         </Typography>
         {optionsToFilter.map((option) => (
@@ -197,7 +199,7 @@ export const Filters = <T extends object>({
             />
           </fieldset>
         ))}
-      </form>
+      </Box>
     </FiltersContent>
   );
 };


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1086" height="326" alt="image" src="https://github.com/user-attachments/assets/3c62443b-320a-4123-8a00-d5e4e2e947fc" /> | <img width="1175" height="332" alt="image" src="https://github.com/user-attachments/assets/32f3c848-5b44-4492-a546-0feab0ba99cc" /> | 