### PR TITLE
fix: Use allow list of events to filter `submission_services_log`, not block list

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1765990402810_allow_listed_events_for_submission_services_log/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1765990402810_allow_listed_events_for_submission_services_log/down.sql
@@ -1,0 +1,81 @@
+-- Previous iteration from apps/hasura.planx.uk/migrations/default/1765238556684_update_s3_upload_event_with_notification/up.sql
+
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id, 'govuk_pay_metadata', ps.gov_pay_metadata) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf) :: text ~~ '%?notify=false%' :: text) THEN 'Upload to AWS S3 (no notification)' :: text -- eg FME Workbench
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text -- eg Power Automate Webhook
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE (((se.webhook_conf)::text !~~ '%/send-email%'::text) AND ((se.webhook_conf)::text !~~ '%/delete-session%'::text) AND (seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id,
+    f.name AS flow_name
+   FROM ((all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1765990402810_allow_listed_events_for_submission_services_log/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1765990402810_allow_listed_events_for_submission_services_log/up.sql
@@ -1,0 +1,89 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id, 'govuk_pay_metadata', ps.gov_pay_metadata) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    -- Event display names
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf) :: text ~~ '%?notify=false%' :: text) THEN 'Upload to AWS S3 (no notification)' :: text -- eg FME Workbench
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text -- eg Power Automate Webhook
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone
+            AND (
+               -- Allow listed events
+              (se.webhook_conf)::text ~~ '%bops%'::text OR
+              (se.webhook_conf)::text ~~ '%uniform%'::text OR
+              (se.webhook_conf)::text ~~ '%email-submission%'::text OR
+              (se.webhook_conf)::text ~~ '%?notify=false%'::text OR
+              (se.webhook_conf)::text ~~ '%upload-submission%'::text OR
+              (se.webhook_conf)::text ~~ '%idox%'::text
+            )
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id,
+    f.name AS flow_name
+   FROM ((all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;

--- a/doc/how-to/how-to-add-a-send-destination.md
+++ b/doc/how-to/how-to-add-a-send-destination.md
@@ -76,4 +76,29 @@ Submission can also be driven by an invite to pay event (not triggered by an app
 
 1. **Update views**
    - Update `submission_services_log` view
+
+```sql
+-- Generate display name
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+   ...
+   CASE
+      -- Event display names
+      WHEN ((se.webhook_conf)::text ~~ '%my-new-destination%'::text) THEN 'Submit to My New Destination'::text
+      ...
+   END AS event_type,
+   ...
+```
+
+```sql
+-- Add to allow list of events
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+   ...
+   WHERE seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone
+   AND (
+      -- Allow listed events
+      (se.webhook_conf)::text ~~ '%my-new-destination%'::text OR
+      ...
+   )
+   ...
+```
    - Update `submission_services_summary` view

--- a/doc/how-to/how-to-add-a-send-destination.md
+++ b/doc/how-to/how-to-add-a-send-destination.md
@@ -78,27 +78,27 @@ Submission can also be driven by an invite to pay event (not triggered by an app
    - Update `submission_services_log` view
 
 ```sql
--- Generate display name
 CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+
    ...
+
+   -- Generate display name
    CASE
       -- Event display names
       WHEN ((se.webhook_conf)::text ~~ '%my-new-destination%'::text) THEN 'Submit to My New Destination'::text
       ...
    END AS event_type,
-   ...
-```
 
-```sql
--- Add to allow list of events
-CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
    ...
+
+   -- Add to allow list of events
    WHERE seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone
    AND (
       -- Allow listed events
       (se.webhook_conf)::text ~~ '%my-new-destination%'::text OR
       ...
    )
+
    ...
 ```
    - Update `submission_services_summary` view


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/5833 and https://github.com/theopensystemslab/planx-new/pull/5838

The above solution requires us to maintain a block list of events - a cleaner (and safer) pattern would be to just use an allow list. This then makes updating the view a normal part of adding a send destination (docs updated also) rather than a weird side effect to remember when modifying any Hasura events.

Trello ticket here - https://trello.com/c/uvAcdTpQ/3504-update-submissionserviceslog-to-only-include-the-relevant-send-and-pay-events

## Testing
Running the view here as just a `SELECT` statement with a `COUNT(*)` gives me the same results on staging and production as just `SELECT COUNT(*) from submission_services_log` ✅ 