### PR TITLE
chore(editor): Style conditional option rule builder as data field

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor/index.tsx
@@ -107,10 +107,11 @@ export const BaseOptionsEditor: React.FC<Props> = (props) => {
         />
         {showRuleBuilder && (
           <RuleBuilder
-            labels={{ 
-              [Condition.AlwaysRequired]: "Always show", 
-              [Condition.RequiredIf]: "Show if", 
+            labels={{
+              [Condition.AlwaysRequired]: "Always show",
+              [Condition.RequiredIf]: "Show if",
             }}
+            dataSchema={[]}
             conditions={[Condition.AlwaysRequired, Condition.RequiredIf]}
             disabled={props.disabled}
             rule={props.value.data.rule}


### PR DESCRIPTION
## What does this PR do?
Converts the "value" field for the `<RuleBuilder/>` within conditional options as a data field - it is currently a plain text field.

<img width="663" height="740" alt="image" src="https://github.com/user-attachments/assets/9c2ee520-5c87-4f05-9808-ddcf7ae63165" />
