### PR TITLE
feat(editor): Pre-fetch classified roads as soon as we have a USRN

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/hooks/useFindPropertyData.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/hooks/useFindPropertyData.ts
@@ -1,8 +1,10 @@
-import { SiteAddress } from "@opensystemslab/planx-core/types";
+import { usePrefetchClassifiedRoads } from "@planx/components/PlanningConstraints/Public/hooks/useClassifiedRoads";
 import { useQuery } from "@tanstack/react-query";
 import { Feature } from "geojson";
 import { getFindPropertyData } from "lib/planningData/requests";
 import { useMemo } from "react";
+
+import type { SiteAddress } from "../../model";
 
 interface FindPropertyData {
   localAuthorityDistricts?: string[];
@@ -73,9 +75,14 @@ export const useFindPropertyData = (address?: SiteAddress) => {
     };
   }, [data]);
 
+  // Side effect - As soon as we have a USR, pre-fetch classified roads data.
+  // This is a long-running request, so prefetching in the background allows
+  // us to reduce the overall wait time for the user
+  usePrefetchClassifiedRoads(address?.usrn);
+
   return {
     ...findPropertyData,
     isPending,
     error,
   };
-}
+};

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/hooks/useClassifiedRoads.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/hooks/useClassifiedRoads.tsx
@@ -1,7 +1,11 @@
+import { ComponentType } from "@opensystemslab/planx-core/types";
 import type { SiteAddress } from "@planx/components/FindProperty/model";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getClassifiedRoads } from "lib/api/gis/requests";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { useEffect } from "react";
+
+import type { PlanningConstraints } from "../../model";
 
 export const useClassifiedRoads = (dataValues: string[]) => {
   const [hasPlanningData, { usrn }] = useStore((state) => [
@@ -19,7 +23,44 @@ export const useClassifiedRoads = (dataValues: string[]) => {
     queryFn: () => getClassifiedRoads(usrn),
     enabled: shouldFetchRoads,
     refetchOnWindowFocus: false,
+    staleTime: Infinity,
   });
 
   return query;
+};
+
+/**
+ * Prefetch the expensive "classified roads" query in order to reduce the overall latency for the user
+ * Triggered as soon as the user selects an address with USRN in useFindPropertyData()
+ */
+export const usePrefetchClassifiedRoads = (usrn?: string) => {
+  const queryClient = useQueryClient();
+
+  const [hasPlanningData, flow] = useStore((state) => [
+    state.teamIntegrations?.hasPlanningData,
+    state.flow,
+  ]);
+
+  // Validation rules enforce that each graph can only contain a single PlanningConstraints node
+  const planningConstraintsNode = Object.values(flow).find(
+    ({ type }) => type === ComponentType.PlanningConstraints,
+  );
+
+  const dataValues = (planningConstraintsNode?.data as PlanningConstraints)
+    ?.dataValues;
+
+  useEffect(() => {
+    const shouldPrefetch =
+      hasPlanningData &&
+      Boolean(usrn) &&
+      dataValues.includes("road.classified");
+
+    if (shouldPrefetch) {
+      queryClient.prefetchQuery({
+        queryKey: ["classifiedRoads", usrn],
+        queryFn: () => getClassifiedRoads(usrn),
+        staleTime: Infinity,
+      });
+    }
+  }, [usrn, queryClient]);
 };


### PR DESCRIPTION
## What does this PR do?
Once an applicant has a USRN, prefetch the `/roads` request in the background. This will result in less overall wait time for an applicant, as the (often long-running) request is running quietly in the background whilst they navigate through `PropertyInformation` and `DrawBoundary`.

## Context
This is one of the very nice benefits of the switch to TanstackQuery! 

As this request can take ~25s (e.g. https://api.editor.planx.dev/roads?usrn=20499403), even if they only spend a few seconds each on the `PropertyInformation` and `DrawBoundary` components this is still less time spent waiting at a loading screen.

**Why not also do this for the Planning Data query?**
We certainly could, but the complexity to reward ratio here is a little off here in my opinion.

Most requests to planning data take ~400ms which is pretty quick - this is our max time saving possible. The point as which we can prefetch can also be much later as we need the `siteBoundary` for this. For all "happy paths" (where a user accepts a title boundary) we can prefetch at the same spot. The complexity here though is that unhappy paths will invalidate the prefetched query - if the user amend their geom, the request will re-fire anyway once they reach planning constraints.

Having said this though, it could be nice to have Planning Constraints be basically instant...! 🪄 

## To test...
-  Open a flow which makes a planning constraints request, e.g. https://5942.planx.pizza/buckinghamshire/apply-for-a-lawful-development-certificate/preview
- Open "Network" tab
- Reach `FindProperty`, search address
  - The following address will hit a classified road constraint - 419 Amersham Rd, Hazlemere, High Wycombe HP15 7JG
- Once the address is selected, the `/roads?...` query can be seen as started
  - Changing address triggers another request
- Wait for request to end (optional - this is non-blocking)
- Navigate forwards to `PlanningConstraints`
- `/roads?...` query is not retriggered, but information is still displayed from prior query ✅ 


https://github.com/user-attachments/assets/3102df9b-6ae0-4e7c-8505-d4c7257d4e75

