### PR TITLE
chore: Remove duplicate glob from Storybook config

### DIFF
--- a/apps/editor.planx.uk/.storybook/main.ts
+++ b/apps/editor.planx.uk/.storybook/main.ts
@@ -1,7 +1,6 @@
 module.exports = {
   stories: [
     "../src/**/*.stories.@(js|jsx|ts|tsx)",
-    "../src/@planx/**/*.stories.@(js|jsx|ts|tsx)"
   ],
   addons: [
     "@storybook/addon-links",


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/5936#discussion_r2632120894

This wasn't the issue at all it turns out...! It was simply incorrect config on Netlify. Please see https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1766156637258089 (OSL Slack)