### PR TITLE
chore: Bump react-error-boundary to v6

### DIFF
--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -68,7 +68,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
-    "react-error-boundary": "^3.1.4",
+    "react-error-boundary": "^6.0.2",
     "react-markdown": "^8.0.7",
     "react-navi": "^0.15.0",
     "react-navi-helmet-async": "^0.15.0",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: ^14.2.3
         version: 14.3.8(react@18.3.1)
       react-error-boundary:
-        specifier: ^3.1.4
-        version: 3.1.4(react@18.3.1)
+        specifier: ^6.0.2
+        version: 6.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-markdown:
         specifier: ^8.0.7
         version: 8.0.7(@types/react@18.3.27)(react@18.3.1)
@@ -5463,11 +5463,11 @@ packages:
     peerDependencies:
       react: '>= 16.8 || 18.0.0'
 
-  react-error-boundary@3.1.4:
-    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
-    engines: {node: '>=10', npm: '>=6'}
+  react-error-boundary@6.0.2:
+    resolution: {integrity: sha512-yvWErn55ag/ywZEFqYpXYX9rxIDPIabXIX25F184KY3F5Szk2x/cVieOflw5R47ltN3KzWOw82Lmlb4vNjyn9A==}
     peerDependencies:
-      react: '>=16.13.1'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-fast-compare@2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
@@ -12427,10 +12427,10 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
 
-  react-error-boundary@3.1.4(react@18.3.1):
+  react-error-boundary@6.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.4
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-fast-compare@2.0.4: {}
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -11,7 +11,6 @@ import { getPayment, initiatePayment } from "lib/api/pay/requests";
 import { saveSession } from "lib/local.new";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useReducer } from "react";
-import { useErrorHandler } from "react-error-boundary";
 
 import { makeData } from "../../shared/utils";
 import { createPayload, getDefaultContent, Pay } from "../model";
@@ -108,8 +107,6 @@ function Component(props: Props) {
     status: "indeterminate",
     displayText: "Loading...",
   });
-
-  const handleError = useErrorHandler();
 
   const isTeamSupported =
     state.status !== "unsupported_team" && teamSlug !== "demo";
@@ -272,7 +269,7 @@ function Component(props: Props) {
           dispatch(Action.StartNewPaymentError);
         } else {
           // Throw all other errors so they're caught by our ErrorBoundary
-          handleError(apiErrorMessage ? { message: apiErrorMessage } : error);
+          throw apiErrorMessage ? { message: apiErrorMessage } : error;
         }
       });
   };


### PR DESCRIPTION
Replaces https://github.com/theopensystemslab/planx-new/pull/5953