### PR TITLE
fix: update `email_events_log` view to correctly capture all emails

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1767804023822_drop_view_public_email_events_log/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1767804023822_drop_view_public_email_events_log/down.sql
@@ -1,0 +1,53 @@
+-- OLD SQL does not properly account for ITP (joins on payment request id, not session id) and confirmation emails (db triggered, not scheduled)
+CREATE OR REPLACE VIEW public.email_events_log AS 
+WITH retries AS (
+   SELECT hdb_scheduled_event_invocation_logs.id
+   FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+   WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( 
+      SELECT 
+         seil.event_id,
+         max(seil.created_at) AS max
+      FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+      LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+      WHERE (se.tries > 1)
+      GROUP BY seil.event_id))
+), emails AS (
+   SELECT 
+      ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+      se.id AS event_id,
+   CASE
+      WHEN ((webhook_conf)::text ~~ '%/send-email/expiry"'::text) THEN 'Session expiry'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/reminder"'::text) THEN 'Session reminder'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/confirmation"'::text) THEN 'Submission confirmation'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/invite-to-pay"'::text) THEN 'Invitation to pay'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/invite-to-pay-agent"'::text) THEN 'Invitation to pay - agent'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/payment-expiry"'::text) THEN 'Payment expiry'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/payment-expiry-agent"'::text) THEN 'Payment expiry - agent'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/payment-reminder"'::text) THEN 'Payment reminder'::text
+      WHEN ((webhook_conf)::text ~~ '%/send-email/payment-reminder-agent"'::text) THEN 'Payment reminder - agent'::text
+      ELSE (webhook_conf)::text
+   END AS event_type,
+   CASE
+      WHEN (seil.status = 200) THEN 'Success'::text
+      ELSE format('Failed (%s)'::text, seil.status)
+   END AS status,
+   (seil.response)::jsonb AS response,
+   seil.created_at,
+   (EXISTS (
+      SELECT 1 FROM retries r WHERE (r.id = seil.id))) AS retry
+      FROM (hdb_catalog.hdb_scheduled_events se
+         LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+      WHERE (((se.webhook_conf)::text ~~ '%/send-email/%'::text) AND (seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+)
+SELECT 
+   ls.flow_id,
+   e.session_id,
+   e.event_id,
+   e.event_type,
+   e.status,
+   e.response,
+   e.created_at,
+   e.retry
+FROM (emails e LEFT JOIN lowcal_sessions ls ON ((ls.id = e.session_id)))
+WHERE (ls.flow_id IS NOT NULL)
+ORDER BY e.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1767804023822_drop_view_public_email_events_log/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1767804023822_drop_view_public_email_events_log/up.sql
@@ -1,0 +1,59 @@
+DROP VIEW "public"."email_events_log";
+
+-- Fully recreate from scratch (do not replace)
+CREATE VIEW "public"."email_events_log" AS
+WITH scheduled_emails AS (
+    SELECT
+    	id as event_id,
+    	'Scheduled' as event_trigger,
+    	created_at,
+    	scheduled_time,
+    	(payload ->> 'sessionId')::uuid as session_id,
+    	(payload ->> 'paymentRequestId')::uuid as payment_request_id,
+    	CASE
+    	  WHEN ((webhook_conf)::text ~~ '%/save"'::text) THEN 'Session saved'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/expiry"'::text) THEN 'Session expiry'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/reminder"'::text) THEN 'Session reminder'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/invite-to-pay"'::text) THEN 'Invitation to pay'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/invite-to-pay-agent"'::text) THEN 'Invitation to pay - agent'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/payment-expiry"'::text) THEN 'Payment expiry'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/payment-expiry-agent"'::text) THEN 'Payment expiry - agent'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/payment-reminder"'::text) THEN 'Payment reminder'::text
+    	  WHEN ((webhook_conf)::text ~~ '%/payment-reminder-agent"'::text) THEN 'Payment reminder - agent'::text
+    	  ELSE (webhook_conf)::text
+       END AS event_type,
+       status
+    FROM hdb_catalog.hdb_scheduled_events
+    WHERE (webhook_conf)::text ~~ '%/send-email/%'
+), database_triggered_emails AS (
+    SELECT
+         id as event_id,
+         'Database' as event_trigger,
+          created_at,
+          created_at as scheduled_time,
+         (payload -> 'data' -> 'new' -> 'data' ->> 'sessionId')::uuid as session_id,
+         null::uuid as payment_request_id,
+         'Submission confirmation' as event_type,
+         case 
+         	WHEN delivered = true THEN 'Delivered'
+        	WHEN error = true THEN 'Errored'
+        	ELSE 'Unknown'
+         END as status
+    FROM hdb_catalog.event_log 
+    WHERE trigger_name = 'email_user_submission_confirmation'
+), emails AS (
+    SELECT * FROM scheduled_emails 
+        UNION ALL
+    SELECT * FROM database_triggered_emails
+)
+SELECT 
+	coalesce(e.session_id, ls.id, pr.session_id) as session_id,
+	e.event_id,
+	e.event_trigger,
+	e.event_type,
+	e.created_at,
+	e.scheduled_time,
+	e.status
+FROM emails e
+  LEFT JOIN lowcal_sessions ls on ls.id = e.session_id
+  LEFT JOIN payment_requests pr on pr.id = e.payment_request_id;


### PR DESCRIPTION
A few fixes following on from this help-issues report: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1767015199631409

Our prior view definition (used for internal auditing/trouble-shooting only) was failing to account for:
- Emails can be triggered via scheduled events (most email types) _and_ database triggers (submission confirmation emails). This requires querying distinct tables in the `hdb_catalog` schema
- Invite to pay emails do _not_ have a `sessionId` in the payload or comment, but rather a `paymentRequestId` which needs to be handled/joined differently 

Should now work correctly! Once on prod, we should see 3 rows returned for original session (`9ad0dcce-f4de-4693-99f4-2576a4b0b396`) reported by Nora (invitation to pay, invitation to pay agent, and submission confirmation - all "successful" on our side - rather than 0 rows returned by current prod view definition).