### PR TITLE
fix(editor): Account for flows which may not have a PlanningConstraints component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/hooks/useClassifiedRoads.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/hooks/useClassifiedRoads.tsx
@@ -48,18 +48,18 @@ export const usePrefetchClassifiedRoads = (usrn?: string) => {
 
   const dataValues = planningConstraintsNode?.dataValues;
 
-  useEffect(() => {
-    const shouldPrefetch =
-      hasPlanningData &&
-      Boolean(usrn) &&
-      dataValues?.includes("road.classified");
+  const shouldPrefetch =
+    hasPlanningData &&
+    Boolean(usrn) &&
+    dataValues?.includes("road.classified");
 
+  useEffect(() => {
     if (shouldPrefetch) {
       queryClient.prefetchQuery({
         queryKey: ["classifiedRoads", usrn],
-        queryFn: () => getClassifiedRoads(usrn),
+        queryFn: () => getClassifiedRoads(usrn!),
         staleTime: Infinity,
       });
     }
-  }, [usrn, queryClient, dataValues, planningConstraintsNode, hasPlanningData]);
+  }, [usrn, queryClient, shouldPrefetch]);
 };


### PR DESCRIPTION
## What's the problem?
E2E test were failing on the `FindProperty` component, specifically when triggering the USRN based pre-fetch introduced here - https://github.com/theopensystemslab/planx-new/pull/5942

## What's the solution?
The above PR assumes that all flows with a `FindProperty` will also contain _at least_ one `PlanningConstraints`. Whilst this is usually true for most planning-based services, it's not a requirement and out mock flows did not include this.

By correctly treating the `PlanningConstraints` component as optional, we can get E2E regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/20813585036