### PR TITLE
fix: Omit environment select from public interface

### DIFF
--- a/apps/editor.planx.uk/src/components/Header/Header.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.tsx
@@ -198,7 +198,9 @@ const TeamLogo: React.FC = () => {
   );
 };
 
-const Breadcrumbs: React.FC = () => {
+const Breadcrumbs: React.FC<{ showEnvironmentSelect?: boolean }> = ({
+  showEnvironmentSelect = false,
+}) => {
   const route = useCurrentRoute();
   const [team, isStandalone] = useStore((state) => [
     state.getTeam(),
@@ -219,7 +221,7 @@ const Breadcrumbs: React.FC = () => {
         >
           Plan✕
         </BreadcrumbsLink>
-        {!isStandalone && <EnvironmentSelect />}
+        {showEnvironmentSelect && <EnvironmentSelect />}
         {team.slug && (
           <>
             {" / "}
@@ -433,7 +435,7 @@ const EditorToolbar: React.FC<{
         <EditorHeaderContainer>
           <InnerContainer>
             <LeftBox>
-              <Breadcrumbs />
+              <Breadcrumbs showEnvironmentSelect />
             </LeftBox>
             <RightBox>
               {user && (


### PR DESCRIPTION
## What does this PR do?

Removes the environment selector from all public interface screens.

Previously this was addressed in https://github.com/theopensystemslab/planx-new/pull/5748, however the env selector appears when clicking past the initial screen.

Issue demonstrated (continue to second screen):
https://editor.planx.dev/testing/responsive-checklist-context/preview

Issue resolved:
https://5975.planx.pizza/testing/responsive-checklist-context/preview