### PR TITLE
chore(editor): Populate `SummaryList` for `EnhancedTextInput` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -110,8 +110,7 @@ const presentationalComponents: {
   [TYPES.Content]: undefined,
   [TYPES.DateInput]: DateInput,
   [TYPES.DrawBoundary]: DrawBoundary,
-  // TODO: This component will have an output
-  [TYPES.EnhancedTextInput]: undefined,
+  [TYPES.EnhancedTextInput]: TextInput,
   [TYPES.ExternalPortal]: undefined,
   [TYPES.Feedback]: undefined,
   [TYPES.FileUpload]: FileUpload,
@@ -318,7 +317,9 @@ function SummaryList(props: SummaryListProps) {
   return (
     <>
       <SummaryListTable showChangeButton={props.showChangeButton}>
-        {!props.summaryBreadcrumbs.length && <Typography variant="body2">No responses to display</Typography>}
+        {!props.summaryBreadcrumbs.length && (
+          <Typography variant="body2">No responses to display</Typography>
+        )}
         {props.summaryBreadcrumbs.map(
           ({ component: Component, nodeId, node, userData }, i) => (
             <React.Fragment key={i}>
@@ -605,8 +606,9 @@ function DrawBoundary(props: ComponentProps) {
               geojsonColor="#ff0000"
               geojsonFill
               geojsonBuffer={20}
-              osProxyEndpoint={`${import.meta.env.VITE_APP_API_URL
-                }/proxy/ordnance-survey`}
+              osProxyEndpoint={`${
+                import.meta.env.VITE_APP_API_URL
+              }/proxy/ordnance-survey`}
               hideResetControl
               staticMode
               style={{ width: "100%", height: "30vh" }}
@@ -628,8 +630,9 @@ function NumberInput(props: ComponentProps) {
   return (
     <>
       <Box component="dt">{props.node.data.title}</Box>
-      <Box component="dd">{`${getAnswersByNode(props)} ${props.node.data.units ?? ""
-        }`}</Box>
+      <Box component="dd">{`${getAnswersByNode(props)} ${
+        props.node.data.units ?? ""
+      }`}</Box>
     </>
   );
 }
@@ -702,8 +705,8 @@ function FileUploadAndLabel(props: ComponentProps) {
         <ul>
           {uniqueFilenames.length
             ? uniqueFilenames.map((filename, index) => (
-              <li key={index}>{filename}</li>
-            ))
+                <li key={index}>{filename}</li>
+              ))
             : "No files uploaded"}
         </ul>
       </Box>


### PR DESCRIPTION
Relies on #5980 

Uses the existing `TextInput` component to display the output of the `EnhancedTextInput` component on the Review page.