### PR TITLE
feat: add Planning Data check for `property.developmentCorporation` to FindProperty

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/hooks/useFindPropertyData.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/hooks/useFindPropertyData.ts
@@ -11,6 +11,7 @@ interface FindPropertyData {
   localPlanningAuthorities?: string[];
   regions?: string[];
   wards?: string[];
+  developmentCorporations?: string[];
   titleBoundary?: Feature;
 }
 
@@ -34,6 +35,7 @@ export const useFindPropertyData = (address?: SiteAddress) => {
         localPlanningAuthorities: undefined,
         regions: undefined,
         wards: undefined,
+        developmentCorporations: undefined,
         titleBoundary: undefined,
       };
     }
@@ -42,6 +44,7 @@ export const useFindPropertyData = (address?: SiteAddress) => {
     const localPlanningAuthorities = new Set<string>();
     const regions = new Set<string>();
     const wards = new Set<string>();
+    const developmentCorporations = new Set<string>();
     let titleBoundary: Feature | undefined;
 
     data.features.forEach((feature) => {
@@ -60,6 +63,9 @@ export const useFindPropertyData = (address?: SiteAddress) => {
         case "ward":
           wards.add(name);
           break;
+        case "development-corporation-boundary":
+          developmentCorporations.add(name);
+          break;
         case "title-boundary":
           titleBoundary = feature;
           break;
@@ -71,6 +77,7 @@ export const useFindPropertyData = (address?: SiteAddress) => {
       localPlanningAuthorities: Array.from(localPlanningAuthorities),
       regions: Array.from(regions),
       wards: Array.from(wards),
+      developmentCorporations: Array.from(developmentCorporations),
       titleBoundary,
     };
   }, [data]);

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -51,6 +51,7 @@ function Component(props: Props) {
     localPlanningAuthorities,
     regions,
     wards,
+    developmentCorporations,
     titleBoundary,
     isPending,
   } = useFindPropertyData(address);
@@ -91,6 +92,12 @@ function Component(props: Props) {
 
       if (wards) {
         newPassportData["property.ward"] = wards;
+      }
+
+      // Unlike above datasets, `development-corporation-boundary` is not yet available for all of England via planning.data
+      //  So, we want to avoid writing `[]` to passport
+      if (developmentCorporations?.length) {
+        newPassportData["property.developmentCorporation"] = developmentCorporations;
       }
 
       if (titleBoundary) {

--- a/apps/editor.planx.uk/src/lib/planningData/requests.ts
+++ b/apps/editor.planx.uk/src/lib/planningData/requests.ts
@@ -43,6 +43,7 @@ export const getFindPropertyData = async (
       "local-planning-authority",
       "region",
       "ward",
+      "development-corporation-boundary",
       "title-boundary",
     ],
   });


### PR DESCRIPTION
https://trello.com/c/PbO29ubM/3526-fetch-development-corporation-boundaries-from-planning-data-at-findproperty-step

Adds an additional check to FindProperty against Planning Data's `development-corporation-boundary` dataset, an upcoming requirement for Camden applications: https://www.planning.data.gov.uk/dataset/development-corporation-boundary