### PR TITLE
feat(editor): allow "Propose a new address" to be set as first page of FindProperty instead of postcode input

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -85,6 +85,20 @@ function FindPropertyComponent(props: Props) {
           {formik.values.allowNewAddresses ? (
             <>
               <InputRow>
+                <Switch
+                  checked={formik.values.newAddressFirstPage}
+                  onChange={() => 
+                    formik.setFieldValue(
+                      "newAddressFirstPage",
+                      !formik.values.newAddressFirstPage,
+                    )
+                  }
+                  label="Show the new address map as the primary journey, and existing postcode/address inputs page secondary"
+                  disabled={props.disabled}
+                />
+              </InputRow>
+              <br />
+              <InputRow>
                 <Input
                   format="large"
                   placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -219,6 +219,41 @@ describe("render states", () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
+  it("renders correctly when non-UPRN address map is set as first page", async () => {
+    const handleSubmit = vi.fn();
+
+    const { user } = setup(
+      <FindProperty
+        description="Find your property"
+        title="Type your postal code"
+        allowNewAddresses={true}
+        newAddressFirstPage={true}
+        newAddressTitle="Plot a new address"
+        handleSubmit={handleSubmit}
+      />,
+    );
+
+    // starts on propose new address page
+    expect(
+      await screen.findByText("Plot a new address"),
+    ).toBeInTheDocument();
+
+    const map = screen.getByTestId("map-web-component");
+    expect(map).toBeInTheDocument();
+
+    const descriptionInput = screen.getByTestId("new-address-input");
+    expect(descriptionInput).toBeInTheDocument();
+
+    expect(
+      await screen.findByText("I want to select an existing address"),
+    ).toBeInTheDocument();
+
+    // Continue button is always enabled, but validation prevents submit until we have complete address details
+    expect(screen.getByTestId("continue-button")).toBeEnabled();
+    await user.click(screen.getByTestId("continue-button"));
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
   it("opens the external planning site dialog by default if allowNewAddresses is toggled off", async () => {
     const handleSubmit = vi.fn();
 

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/index.tsx
@@ -30,10 +30,10 @@ type Props = PublicProps<FindProperty>;
 function Component(props: Props) {
   const previouslySubmittedData = props.previouslySubmittedData?.data;
   const previouslySubmittedAddressSource =
-    props.previouslySubmittedData?.data?._address?.source;
+    previouslySubmittedData?._address?.source;
 
   const startPage =
-    previouslySubmittedAddressSource === "proposed"
+    Boolean(props.newAddressFirstPage) || previouslySubmittedAddressSource === "proposed"
       ? "new-address"
       : "os-address";
   const [page, setPage] = useState<"os-address" | "new-address">(startPage);

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/model.ts
@@ -18,6 +18,7 @@ export interface FindProperty extends BaseNodeData {
   title: string;
   description: string;
   allowNewAddresses?: boolean;
+  newAddressFirstPage?: boolean;
   newAddressTitle?: string;
   newAddressDescription?: string;
   newAddressDescriptionLabel?: string;
@@ -29,6 +30,7 @@ export const parseFindProperty = (
   title: data?.title || DEFAULT_TITLE,
   description: data?.description || "",
   allowNewAddresses: data?.allowNewAddresses || false,
+  newAddressFirstPage: data?.newAddressFirstPage || false,
   newAddressTitle: data?.newAddressTitle || DEFAULT_NEW_ADDRESS_TITLE,
   newAddressDescription:
     data?.newAddressDescription || DEFAULT_NEW_ADDRESS_DESCRIPTION,
@@ -86,6 +88,7 @@ export const validationSchema: SchemaOf<FindProperty> =
       title: string().required(),
       description: richText(),
       allowNewAddresses: boolean(),
+      newAddressFirstPage: boolean(),
       newAddressTitle: string(),
       newAddressDescription: richText(),
       newAddressDescriptionLabel: string(),


### PR DESCRIPTION
See https://trello.com/c/ilwM3LE8/3516-add-a-toggle-in-the-editor-to-allow-users-to-go-down-the-my-site-does-not-have-an-address-as-default-route

By request of TPX/Call for sites prototype !

<img width="905" height="1053" alt="Screenshot from 2026-01-12 19-15-04" src="https://github.com/user-attachments/assets/c39fe00c-40f8-421e-9f0f-b3de479d8208" />
