### PR TITLE
fix(editor): Double merge is preseving old rule values

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -159,7 +159,7 @@ function FileTypeEditor(props: ListManagerEditorProps<FileType>) {
         <RuleBuilder
           rule={props.value.rule}
           disabled={props.disabled}
-          onChange={(rule) => props.onChange(merge(props.value, { rule }))}
+          onChange={(rule) => props.onChange({ ...props.value, rule })}
           dataSchema={["recommended", "required"]}
         />
         <ModalSubtitle title="Additional file information" />


### PR DESCRIPTION
## What's the problem?
When toggling a rule from conditional to non-conditional, the previous `fn` and `value` values are persisted within Formik's state. This means that the form is invalid and cannot be saved.

https://github.com/user-attachments/assets/17395778-5cef-4ac4-b1d5-4e5191142eaa

Reported here (OSL Slack) - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1768298387843629

## What's the cause?
The `RuleBuilder` already handles clearing these fields via the `formatRule()` helper - 

https://github.com/theopensystemslab/planx-new/blob/ee1ae3fab572b38cd7556a53c94f08db87baea61/apps/editor.planx.uk/src/%40planx/components/shared/RuleBuilder/utils.ts#L27-L33

However, as we're using lodash's `merge()` within the parent `onChange()` handler as well - this preserves the previous values as the rule has them removed.

## What's the solution?
Don't call `merge()` - it's not necessary as `formatRule()` is already handling this logic for us.

