### PR TITLE
fix: ensure `definitionImg` help text field is pulled through for `PropertyInformation` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -37,6 +37,7 @@ function Component(props: PublicProps<PropertyInformation>) {
       info={props.info}
       policyRef={props.policyRef}
       howMeasured={props.howMeasured}
+      definitionImg={props.definitionImg}
       showPropertyTypeOverride={props.showPropertyTypeOverride}
       address={passport.data?._address}
       propertyType={passport.data?.["property.type"]}
@@ -93,6 +94,7 @@ export function Presentational(props: PresentationalProps) {
     info,
     policyRef,
     howMeasured,
+    definitionImg,
     showPropertyTypeOverride,
     address,
     propertyType,
@@ -144,6 +146,7 @@ export function Presentational(props: PresentationalProps) {
         info={info}
         policyRef={policyRef}
         howMeasured={howMeasured}
+        definitionImg={definitionImg}
       />
       <MapContainer environment={environment}>
         <p style={visuallyHidden}>


### PR DESCRIPTION
Minor bug caught while looking into this thread https://opensystemslab.slack.com/archives/C5Q59R3HB/p1768397273229459