### PR TITLE
feat: new `analytics_service_overview` mv

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1768565608889_create_analytics_service_overview_mv/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1768565608889_create_analytics_service_overview_mv/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS "public"."analytics_service_overview";

--- a/apps/hasura.planx.uk/migrations/default/1768565608889_create_analytics_service_overview_mv/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1768565608889_create_analytics_service_overview_mv/up.sql
@@ -1,0 +1,22 @@
+CREATE MATERIALIZED VIEW "public"."analytics_service_overview" AS
+    SELECT 
+        teams.slug AS team,
+        flows.slug AS service,
+        flows.status AS status,
+        flows.created_at,
+        MIN(analytics.created_at) AS first_used,
+        flows.id AS flow_id
+    FROM 
+        flows
+    INNER JOIN 
+        teams ON flows.team_id = teams.id
+    LEFT JOIN 
+        analytics ON analytics.flow_id = flows.id
+    GROUP BY 
+        teams.slug,
+        flows.slug,
+        flows.status,
+        flows.created_at,
+        flows.id;
+
+GRANT SELECT ON "public"."analytics_service_overview" TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1768565873766_refresh_analytics_service_overview/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1768565873766_refresh_analytics_service_overview/down.sql
@@ -1,0 +1,1 @@
+SELECT cron.unschedule('refresh_analytics_service_overview');

--- a/apps/hasura.planx.uk/migrations/default/1768565873766_refresh_analytics_service_overview/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1768565873766_refresh_analytics_service_overview/up.sql
@@ -1,0 +1,5 @@
+SELECT cron.schedule(
+  'refresh_analytics_service_overview',
+  '35 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_service_overview$$
+);


### PR DESCRIPTION
Creates an overview pulling from `flows` and `analytics` table for the new ODP service overview dashboard. Sets up a cron job to refresh the mv too. 