### PR TITLE
feat: add team and first usage to analytics_planx_flows

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1768567874094_add_team_to_analytics_planx_flows/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1768567874094_add_team_to_analytics_planx_flows/down.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS public.analytics_planx_flows CASCADE;  
+
+CREATE OR REPLACE VIEW public.analytics_planx_flows AS (
+SELECT
+    f.id AS flow_id,
+    f.name AS flow_name,
+    f.slug AS flow_slug,
+    f.team_id,
+    public.flow_first_online_at(f) as first_online_at,
+    public.flow_production_url(f) as url,
+    f.status
+FROM flows f
+    JOIN teams t ON f.team_id = t.id
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+);
+
+GRANT SELECT ON public.analytics_planx_flows TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1768567874094_add_team_to_analytics_planx_flows/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1768567874094_add_team_to_analytics_planx_flows/up.sql
@@ -1,0 +1,32 @@
+DROP VIEW IF EXISTS public.analytics_planx_flows CASCADE;
+
+CREATE VIEW public.analytics_planx_flows AS (
+SELECT
+    f.id AS flow_id,
+    f.name AS flow_name,
+    f.slug AS flow_slug,
+    f.team_id,
+    t.slug AS team_slug,
+    t.name AS team_name,
+    f.created_at,
+    MIN(a.created_at) AS first_used,
+    public.flow_first_online_at(f) AS first_online_at,
+    public.flow_production_url(f) AS url
+FROM flows f
+    JOIN teams t ON f.team_id = t.id
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+    LEFT JOIN analytics a ON a.flow_id = f.id
+GROUP BY
+    f.id,
+    f.name,
+    f.slug,
+    f.team_id,
+    t.slug,
+    t.name,
+    f.created_at,
+    public.flow_first_online_at(f),
+    public.flow_production_url(f)
+);
+
+GRANT SELECT ON public.analytics_planx_flows TO metabase_read_only;


### PR DESCRIPTION
These changes are for the ODP service overview dashboard (for Dan P more specifically). 

I ended up dropping the view and recreating it because I was changing the column order. Adds team name & slug, as well as a date for first analytics session per-flow. 

Are there any dependencies (eg in Alki's work) that dropping the view and recreating it will affect? 