### PR TITLE
feat: ensure that the first email per-team is always default = true

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
@@ -32,11 +32,14 @@ export const EmailsUpsertModal = ({
 
   const [upsertEmail] = useMutation(UPSERT_TEAM_SUBMISSION_INTEGRATIONS);
 
+  const isFirstEmail =
+    !currentEmails || currentEmails.length === 0 ? true : false;
+
   return (
     <Formik
       initialValues={{
         submissionEmail: initialValues?.submissionEmail || "",
-        defaultEmail: initialValues?.defaultEmail || false,
+        defaultEmail: isFirstEmail || initialValues?.defaultEmail || false,
         teamId: teamId,
       }}
       validationSchema={upsertEmailSchema(
@@ -115,6 +118,7 @@ export const EmailsUpsertModal = ({
                     setFieldValue("defaultEmail", e.target.checked)
                   }
                   label={"Default email"}
+                  disabled={isFirstEmail}
                 />
               </Box>
             </DialogContent>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
@@ -32,8 +32,7 @@ export const EmailsUpsertModal = ({
 
   const [upsertEmail] = useMutation(UPSERT_TEAM_SUBMISSION_INTEGRATIONS);
 
-  const isFirstEmail =
-    !currentEmails || currentEmails.length === 0 ? true : false;
+  const isFirstEmail = !currentEmails || currentEmails.length === 0;
 
   return (
     <Formik


### PR DESCRIPTION
Tiny PR for the last outstanding task from #5969 (see [discussion on managing defaults](https://github.com/theopensystemslab/planx-new/pull/5969#discussion_r2694477555)). 

I did this in the frontend because the logic was simple & the UI seemed clear, but let me know if it would be more suited to another DB trigger? 