### PR TITLE
chore(editor): GHSA-73rr-hh4g-fpgx

### DIFF
--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -69,7 +69,7 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-error-boundary": "^6.0.2",
-    "react-markdown": "^9.1.0",
+    "react-markdown": "^10.1.0",
     "react-navi": "^0.15.0",
     "react-navi-helmet-async": "^0.15.0",
     "react-toastify": "^9.1.3",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-markdown:
-        specifier: ^9.1.0
-        version: 9.1.0(@types/react@18.3.27)(react@18.3.1)
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.27)(react@18.3.1)
       react-navi:
         specifier: ^0.15.0
         version: 0.15.0(navi@0.15.0)(react@18.3.1)
@@ -5645,8 +5645,8 @@ packages:
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
-  react-markdown@9.1.0:
-    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
@@ -9320,7 +9320,7 @@ snapshots:
 
   '@types/hast@3.0.4':
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 3.0.3
 
   '@types/history@4.7.11': {}
 
@@ -9364,7 +9364,7 @@ snapshots:
 
   '@types/mdast@4.0.4':
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 3.0.3
 
   '@types/mdurl@2.0.0': {}
 
@@ -12838,7 +12838,7 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
-  react-markdown@9.1.0(@types/react@18.3.27)(react@18.3.1):
+  react-markdown@10.1.0(@types/react@18.3.27)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4

--- a/apps/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml.tsx
@@ -37,7 +37,7 @@ const styles = (theme: Theme) => ({
 
 const HTMLRoot = styled(Box)(({ theme }) => styles(theme));
 
-const MarkdownRoot = styled(ReactMarkdown)(({ theme }) => styles(theme));
+const MarkdownRoot = styled(Box)(({ theme }) => styles(theme));
 
 // Increment H1 and H2 elements to meet a11y requirements in user submitted rich text
 export const incrementHeaderElements = (source: string): string => {
@@ -81,8 +81,8 @@ export default function ReactMarkdownOrHtml(props: {
     );
   }
   return (
-    <div id={props.id} color={props.textColor}>
-      <MarkdownRoot>{props.source}</MarkdownRoot>
-    </div>
+    <MarkdownRoot id={props.id} color={props.textColor}>
+      <ReactMarkdown>{props.source}</ReactMarkdown>
+    </MarkdownRoot>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/385 by bumping [react-markdown](https://github.com/remarkjs/react-markdown) to v10.1.0 (latest).