### PR TITLE
feat: one flow_integration per-flow

### DIFF
--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -68,12 +68,6 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
   return flow;
 };
 
-interface CreateFlowResponse {
-  flow: {
-    id: Flow["id"];
-  };
-}
-
 const getDefaultEmail = async (teamId: number): Promise<string | null> => {
   const { client: $client } = getClient();
 

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -119,16 +119,14 @@ const createFlow = async ({
         team_id: teamId,
       },
     );
-    console.log({submissionIntegrations})
 
     const emailId = submissionIntegrations.length
       ? submissionIntegrations[0].id
       : null;
-    console.log({emailId})
     
     const response = await $client.request<{
       insertFlowWithIntegration: {
-        flow: { id: Flow["id"] };
+        id: Flow["id"];
       };
     }>(
       gql`
@@ -185,7 +183,7 @@ const createFlow = async ({
       },
     );
 
-    const flowId = response.insertFlowWithIntegration.flow.id;
+    const flowId = response.insertFlowWithIntegration.id;
 
     await createAssociatedOperation(flowId);
     await publishFlow(flowId, "Created flow");

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -119,11 +119,13 @@ const createFlow = async ({
         team_id: teamId,
       },
     );
+    console.log({submissionIntegrations})
 
     const emailId = submissionIntegrations.length
       ? submissionIntegrations[0].id
       : null;
-
+    console.log({emailId})
+    
     const response = await $client.request<{
       insertFlowWithIntegration: {
         flow: { id: Flow["id"] };

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -152,12 +152,12 @@ const createFlow = async ({
     );
 
     // Fetch the default email id from submission_integrations table
-    const { submission_integrations } = await $client.request<{
-      submission_integrations: { id: string }[];
+    const { submissionIntegrations } = await $client.request<{
+      submissionIntegrations: { id: string }[];
     }>(
       gql`
         query GetDefaultEmail($team_id: Int!) {
-          submission_integrations(
+          submissionIntegrations: submission_integrations(
             where: { team_id: { _eq: $team_id }, default_email: { _eq: true } }
             limit: 1
           ) {
@@ -170,8 +170,8 @@ const createFlow = async ({
       },
     );
 
-    const emailId = submission_integrations.length
-      ? submission_integrations[0].id
+    const emailId = submissionIntegrations.length
+      ? submissionIntegrations[0].id
       : null;
 
     // Insert a new record into the flow_integrations table

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -127,7 +127,7 @@ const createFlow = async ({
 
   try {
     const emailId = await getDefaultEmail(teamId);
-    
+
     const response = await $client.request<{
       insertFlowWithIntegration: {
         id: Flow["id"];
@@ -161,10 +161,7 @@ const createFlow = async ({
               description: $description
               limitations: $limitations
               flow_integration: {
-                data: {
-                  team_id: $team_id
-                  email_id: $email_id
-                }
+                data: { team_id: $team_id, email_id: $email_id }
               }
             }
           ) {

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -60,6 +60,28 @@ beforeEach(() => {
       },
     },
   });
+
+  queryMock.mockQuery({
+    name: "GetDefaultEmail",
+    matchOnVariables: false,
+    data: {
+      submission_integrations: [
+        {
+          id: "default-email-id",
+        },
+      ],
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertFlowIntegration",
+    matchOnVariables: false,
+    data: {
+      insert_flow_integrations_one: {
+        flow_id: 2,
+      },
+    },
+  });
 });
 
 const auth = authHeader({ role: "teamEditor" });

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -18,10 +18,10 @@ beforeEach(() => {
   });
 
   queryMock.mockQuery({
-    name: "InsertFlow",
+    name: "InsertFlowWithIntegration",
     matchOnVariables: false,
     data: {
-      flow: {
+      insertFlowWithIntegration: {
         id: 2,
       },
     },
@@ -159,7 +159,7 @@ describe("authentication and error handling", () => {
     });
 
     queryMock.mockQuery({
-      name: "InsertFlow",
+      name: "InsertFlowWithIntegration",
       matchOnVariables: false,
       data: {
         flow: {

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
     name: "GetDefaultEmail",
     matchOnVariables: false,
     data: {
-      submission_integrations: [
+      submissionIntegrations: [
         {
           id: "default-email-id",
         },

--- a/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
@@ -149,7 +149,7 @@ describe("success", () => {
         team_id: 1,
       },
       data: {
-        submission_integrations: [
+        submissionIntegrations: [
           {
             id: "default-email-id",
             team_id: 1,

--- a/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
@@ -142,7 +142,7 @@ describe("success", () => {
         },
       },
     });
-    
+
     queryMock.mockQuery({
       name: "GetDefaultEmail",
       variables: {
@@ -157,7 +157,7 @@ describe("success", () => {
         ],
       },
     });
-  
+
     queryMock.mockQuery({
       name: "InsertFlowIntegration",
       matchOnVariables: false,

--- a/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
@@ -142,6 +142,31 @@ describe("success", () => {
         },
       },
     });
+    
+    queryMock.mockQuery({
+      name: "GetDefaultEmail",
+      variables: {
+        team_id: 1,
+      },
+      data: {
+        submission_integrations: [
+          {
+            id: "default-email-id",
+            team_id: 1,
+          },
+        ],
+      },
+    });
+  
+    queryMock.mockQuery({
+      name: "InsertFlowIntegration",
+      matchOnVariables: false,
+      data: {
+        insert_flow_integrations_one: {
+          flow_id: 2,
+        },
+      },
+    });
   });
 
   it("successfully creates a new flow", async () => {

--- a/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlow/createFlow.test.ts
@@ -26,19 +26,26 @@ const auth = authHeader({ role: "teamEditor" });
 describe("authentication and error handling", () => {
   beforeAll(() => {
     queryMock.mockQuery({
-      name: "InsertFlow",
+      name: "InsertFlowWithIntegration",
+      matchOnVariables: false,
+      data: {
+        insertFlowWithIntegration: {
+          id: "2",
+        },
+      },
       variables: {
         team_id: 1,
         slug: "my-new-flow",
         name: "My new flow",
         data: mockNewFlowData,
-      },
-      data: {},
-      graphqlErrors: [
-        {
-          message: "Something went wrong",
+        email_id: "default-email-id",
+        flow_integration: {
+          data: {
+            team_id: 1,
+            email_id: "default-email-id",
+          },
         },
-      ],
+      },
     });
   });
 
@@ -99,12 +106,19 @@ describe("success", () => {
     });
 
     queryMock.mockQuery({
-      name: "InsertFlow",
+      name: "InsertFlowWithIntegration",
       matchOnVariables: false,
       data: {
-        flow: {
+        insertFlowWithIntegration: {
           id: "2",
         },
+      },
+      variables: {
+        team_id: 1,
+        slug: "my-new-flow",
+        name: "My new flow",
+        data: mockNewFlowData,
+        email_id: "default-email-id",
       },
     });
 
@@ -155,16 +169,6 @@ describe("success", () => {
             team_id: 1,
           },
         ],
-      },
-    });
-
-    queryMock.mockQuery({
-      name: "InsertFlowIntegration",
-      matchOnVariables: false,
-      data: {
-        insert_flow_integrations_one: {
-          flow_id: 2,
-        },
       },
     });
   });

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
@@ -116,6 +116,28 @@ describe("success", () => {
         },
       },
     });
+
+    queryMock.mockQuery({
+        name: "GetDefaultEmail",
+        matchOnVariables: false,
+        data: {
+          submission_integrations: [
+            {
+              id: "default-email-id",
+            },
+          ],
+        },
+      });
+    
+      queryMock.mockQuery({
+        name: "InsertFlowIntegration",
+        matchOnVariables: false,
+        data: {
+          insert_flow_integrations_one: {
+            flow_id: 2,
+          },
+        },
+      });
   });
 
   it("successfully creates a new flow from a template", async () => {

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
@@ -121,7 +121,7 @@ describe("success", () => {
       name: "GetDefaultEmail",
       matchOnVariables: false,
       data: {
-        submission_integrations: [
+        submissionIntegrations: [
           {
             id: "default-email-id",
           },

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
@@ -118,26 +118,26 @@ describe("success", () => {
     });
 
     queryMock.mockQuery({
-        name: "GetDefaultEmail",
-        matchOnVariables: false,
-        data: {
-          submission_integrations: [
-            {
-              id: "default-email-id",
-            },
-          ],
-        },
-      });
-    
-      queryMock.mockQuery({
-        name: "InsertFlowIntegration",
-        matchOnVariables: false,
-        data: {
-          insert_flow_integrations_one: {
-            flow_id: 2,
+      name: "GetDefaultEmail",
+      matchOnVariables: false,
+      data: {
+        submission_integrations: [
+          {
+            id: "default-email-id",
           },
+        ],
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "InsertFlowIntegration",
+      matchOnVariables: false,
+      data: {
+        insert_flow_integrations_one: {
+          flow_id: 2,
         },
-      });
+      },
+    });
   });
 
   it("successfully creates a new flow from a template", async () => {

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
@@ -74,11 +74,24 @@ describe("success", () => {
     });
 
     queryMock.mockQuery({
-      name: "InsertFlow",
+      name: "InsertFlowWithIntegration",
       matchOnVariables: false,
       data: {
-        flow: {
+        insertFlowWithIntegration: {
           id: "2",
+        },
+      },
+      variables: {
+        team_id: 1,
+        slug: "my-new-flow",
+        name: "My New Flow",
+        data: mockSourceTemplateFlowData,
+        email_id: "default-email-id",
+        flow_integration: {
+          data: {
+            team_id: 1,
+            email_id: "default-email-id",
+          },
         },
       },
     });
@@ -119,23 +132,15 @@ describe("success", () => {
 
     queryMock.mockQuery({
       name: "GetDefaultEmail",
-      matchOnVariables: false,
+      variables: {
+        team_id: 1,
+      },
       data: {
         submissionIntegrations: [
           {
             id: "default-email-id",
           },
         ],
-      },
-    });
-
-    queryMock.mockQuery({
-      name: "InsertFlowIntegration",
-      matchOnVariables: false,
-      data: {
-        insert_flow_integrations_one: {
-          flow_id: 2,
-        },
       },
     });
   });

--- a/apps/api.planx.uk/modules/flows/publish/publish.test.ts
+++ b/apps/api.planx.uk/modules/flows/publish/publish.test.ts
@@ -102,6 +102,20 @@ describe("publish", () => {
       },
     });
 
+    queryMock.mockQuery({
+      name: "GetSubmissionEmail",
+      variables: {
+        flow_id: "1",
+      },
+      data: {
+        flowIntegrations: [
+          {
+            email_id: "mock-email-id",
+          },
+        ],
+      },
+    });
+
     await supertest(app).post(mockEndpoint).set(auth).expect(200);
   });
 
@@ -146,6 +160,20 @@ describe("publish", () => {
           },
           publishedFlows: [{ data: alteredFlow }],
         },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetSubmissionEmail",
+      variables: {
+        flow_id: "1",
+      },
+      data: {
+        flowIntegrations: [
+          {
+            email_id: "mock-email-id",
+          },
+        ],
       },
     });
 

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -61,6 +61,30 @@ export const publishFlow = async (
   );
 
   const { client: $client } = getClient();
+
+  // Fetch submissionEmailId from flow_integrations table
+  const { flowIntegrations } = await $client.request<{
+    flowIntegrations: { email_id: string }[];
+  }>(
+    gql`
+      query GetSubmissionEmail($flow_id: uuid!) {
+        flowIntegrations: flow_integrations(
+          where: { flow_id: { _eq: $flow_id } }
+          limit: 1
+        ) {
+          email_id
+        }
+      }
+    `,
+    {
+      flow_id: flowId,
+    },
+  );
+
+  const submissionEmailId = flowIntegrations.length
+    ? flowIntegrations[0].email_id
+    : null;
+
   const response = await $client.request<PublishFlow>(
     gql`
       mutation PublishFlow(
@@ -72,6 +96,7 @@ export const publishFlow = async (
         $has_sections: Boolean
         $has_pay_component: Boolean
         $service_charge_enabled: Boolean
+        $submission_email_id: uuid
       ) {
         publishedFlow: insert_published_flows_one(
           object: {
@@ -83,6 +108,7 @@ export const publishFlow = async (
             has_sections: $has_sections
             has_pay_component: $has_pay_component
             service_charge_enabled: $service_charge_enabled
+            submission_email_id: $submission_email_id
           }
         ) {
           id
@@ -102,6 +128,7 @@ export const publishFlow = async (
       has_sections: hasSections,
       has_pay_component: hasVisiblePayComponent,
       service_charge_enabled: hasEnabledServiceCharge,
+      submission_email_id: submissionEmailId,
     },
   );
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -23,7 +23,6 @@ export interface GetFlowInformation {
 }
 
 export const formatLastEditDate = (date: string): string => {
-  console.log({ date });
   return formatDistanceToNow(new Date(date), {
     includeSeconds: true,
     addSuffix: true,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -23,6 +23,7 @@ export interface GetFlowInformation {
 }
 
 export const formatLastEditDate = (date: string): string => {
+  console.log({ date });
   return formatDistanceToNow(new Date(date), {
     includeSeconds: true,
     addSuffix: true,

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -52,6 +52,13 @@ array_relationships:
         remote_table:
           name: feedback
           schema: public
+  - name: flow_integration
+    using:
+      foreign_key_constraint_on:
+        column: flow_id
+        table:
+          name: flow_integrations
+          schema: public
   - name: flow_status_histories
     using:
       foreign_key_constraint_on:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
@@ -13,16 +13,17 @@ insert_permissions:
     permission:
       check: {}
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
   - role: demoUser
     permission:
       check:
@@ -35,31 +36,33 @@ insert_permissions:
                 id:
                   _eq: 32
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
     comment: A demoUser can only insert a published flow for their own flows and for flows inside the Demo team [id = 32]
   - role: platformAdmin
     permission:
       check: {}
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
   - role: teamEditor
     permission:
       check:
@@ -72,60 +75,64 @@ insert_permissions:
                 - role:
                     _eq: teamEditor
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
 select_permissions:
   - role: api
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true
   - role: demoUser
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true
   - role: platformAdmin
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true
   - role: public
@@ -146,15 +153,16 @@ select_permissions:
   - role: teamEditor
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_submission_integrations.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_submission_integrations.yaml
@@ -31,6 +31,7 @@ select_permissions:
         - default_email
         - id
         - submission_email
+        - team_id
       filter: {}
     comment: ""
   - role: platformAdmin

--- a/apps/hasura.planx.uk/migrations/default/1769012547642_update_submission_integrations/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769012547642_update_submission_integrations/up.sql
@@ -1,0 +1,13 @@
+INSERT INTO submission_integrations (team_id, submission_email, default_email)
+SELECT 
+    ts.team_id,
+    ts.submission_email,
+    true AS default_email
+FROM team_settings ts
+WHERE ts.submission_email IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1 
+    FROM submission_integrations si 
+    WHERE si.team_id = ts.team_id 
+    AND si.submission_email = ts.submission_email
+);

--- a/apps/hasura.planx.uk/migrations/default/1769012855239_alter_table_public_flow_integrations_alter_column_team_id/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769012855239_alter_table_public_flow_integrations_alter_column_team_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."flow_integrations" alter column "team_id" drop not null;

--- a/apps/hasura.planx.uk/migrations/default/1769012855239_alter_table_public_flow_integrations_alter_column_team_id/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769012855239_alter_table_public_flow_integrations_alter_column_team_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."flow_integrations" alter column "team_id" set not null;

--- a/apps/hasura.planx.uk/migrations/default/1769013134021_create_flow_integration_per_flow/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769013134021_create_flow_integration_per_flow/up.sql
@@ -1,0 +1,14 @@
+INSERT INTO flow_integrations (flow_id, team_id, email_id)
+SELECT DISTINCT ON (f.id)
+    f.id AS flow_id,
+    f.team_id,
+    si.id AS email_id
+FROM flows f
+LEFT JOIN submission_integrations si 
+    ON si.team_id = f.team_id
+WHERE NOT EXISTS (
+    SELECT 1 
+    FROM flow_integrations fi 
+    WHERE fi.flow_id = f.id
+)
+ORDER BY f.id, si.default_email DESC NULLS LAST;

--- a/apps/hasura.planx.uk/migrations/default/1769078432825_cascade_delete_flows_to_flow_integrations/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769078432825_cascade_delete_flows_to_flow_integrations/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE flow_integrations
+DROP CONSTRAINT IF EXISTS fk_flow_integrations_flows;
+
+ALTER TABLE flow_integrations
+ADD CONSTRAINT fk_flow_integrations_flows
+FOREIGN KEY (flow_id)
+REFERENCES flows(id);

--- a/apps/hasura.planx.uk/migrations/default/1769078432825_cascade_delete_flows_to_flow_integrations/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769078432825_cascade_delete_flows_to_flow_integrations/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE flow_integrations
+DROP CONSTRAINT IF EXISTS fk_flow_integrations_flows,
+ADD CONSTRAINT fk_flow_integrations_flows
+FOREIGN KEY (flow_id)
+REFERENCES flows(id)
+ON DELETE CASCADE;

--- a/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."published_flows" drop column "submission_email_id";

--- a/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."published_flows" add column "submission_email_id" uuid
+ null;

--- a/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/down.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.diff_latest_published_flow(source_flow_id uuid, since timestamp with time zone)
+ RETURNS published_flows
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH current_published_flow as (
+  SELECT
+    id, data, created_at, flow_id, publisher_id, summary, has_send_component, has_sections, has_pay_component, service_charge_enabled
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+  ORDER BY
+    created_at desc
+  LIMIT
+    1
+),
+previous_published_flow as (
+  SELECT
+    flow_id, data
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+    AND
+    published_flows.created_at < since
+  ORDER BY
+    created_at desc -- the latest published version before "since"
+  LIMIT
+    1
+),
+data_diff as (
+  SELECT
+    flow_id,
+    ( SELECT
+        jsonb_object_agg(COALESCE(old.key, new.key), new.value)
+      FROM
+        jsonb_each(previous_published_flow.data) AS old
+      FULL OUTER JOIN 
+        jsonb_each(current_published_flow.data) AS new 
+      ON
+        new.key = old.key 
+      WHERE 
+        new.value IS DISTINCT FROM old.value
+    ) as data -- shallow diff where deleted keys have a 'null' value
+  FROM 
+    current_published_flow
+  JOIN
+    previous_published_flow USING (flow_id)
+)
+SELECT 
+    id, data_diff.data as data, created_at, flow_id, publisher_id, 'auto generated diff' as summary, has_send_component, has_sections, has_pay_component, service_charge_enabled
+FROM 
+    current_published_flow
+FULL OUTER JOIN
+    data_diff USING (flow_id);
+$function$;

--- a/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/up.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.diff_latest_published_flow(source_flow_id uuid, since timestamp with time zone)
+ RETURNS published_flows
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH current_published_flow as (
+  SELECT
+    id, data, created_at, flow_id, publisher_id, summary, has_send_component, has_sections, has_pay_component, service_charge_enabled, submission_email_id
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+  ORDER BY
+    created_at desc
+  LIMIT
+    1
+),
+previous_published_flow as (
+  SELECT
+    flow_id, data
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+    AND
+    published_flows.created_at < since
+  ORDER BY
+    created_at desc -- the latest published version before "since"
+  LIMIT
+    1
+),
+data_diff as (
+  SELECT
+    flow_id,
+    ( SELECT
+        jsonb_object_agg(COALESCE(old.key, new.key), new.value)
+      FROM
+        jsonb_each(previous_published_flow.data) AS old
+      FULL OUTER JOIN 
+        jsonb_each(current_published_flow.data) AS new 
+      ON
+        new.key = old.key 
+      WHERE 
+        new.value IS DISTINCT FROM old.value
+    ) as data -- shallow diff where deleted keys have a 'null' value
+  FROM 
+    current_published_flow
+  JOIN
+    previous_published_flow USING (flow_id)
+)
+SELECT 
+    id, data_diff.data as data, created_at, flow_id, publisher_id, 'auto generated diff' as summary, has_send_component, has_sections, has_pay_component, service_charge_enabled, submission_email_id
+FROM 
+    current_published_flow
+FULL OUTER JOIN
+    data_diff USING (flow_id);
+$function$;


### PR DESCRIPTION
This is part of the multiple submission email work, following on from #5977. 

# What does this PR do?
- Migration to update the `submission_integrations` table (eg for any teams that have updated their submission email since the last migration in early November). Since there will be max one per-team, they are all set as `default = true`. 
- Migration ensuring that `flow_integrations.team_id` is not nullable, since every flow should be associated with a team. 
- Migration to update the `flow_integrations` table, creating one entry per-flow. Where a team has a submission email, that `email_id` will show. Where a team does not, `email_id = null`. 
- Update `createFlow()` to ensure that `flow_integration` records are created with flows
- Create a relationship between `flows` and `flow_integrations` in Hasura
- Cascade flow deletions to `flow_integrations` too

# Why? 
Every flow [should have an entry](https://github.com/theopensystemslab/planx-new/pull/5977#discussion_r2686876725) in `flow_integrations` by default. This simplifies how we manage the `flow_integrations` table and follows other patterns (eg one `team` to `team_setting`). 

I did this in this order so that the `flow_integrations` table would be as up to date as possible, and so we won't need to do another migration to create records in `flow_integrations`. Updating the db to match this model also seemed like a prerequisite to finishing up the piece of work involving writing new emails from the send component.

We still need to work out deletion and add submission email records to `published_flows` so we can keep track of where a service's submissions are going at any given time. 