### PR TITLE
feat: add `submission_email_id` to `published_flows`

### DIFF
--- a/apps/api.planx.uk/modules/flows/publish/publish.test.ts
+++ b/apps/api.planx.uk/modules/flows/publish/publish.test.ts
@@ -102,6 +102,20 @@ describe("publish", () => {
       },
     });
 
+    queryMock.mockQuery({
+      name: "GetSubmissionEmail",
+      variables: {
+        flow_id: "1",
+      },
+      data: {
+        flowIntegrations: [
+          {
+            email_id: "mock-email-id",
+          },
+        ],
+      },
+    });
+
     await supertest(app).post(mockEndpoint).set(auth).expect(200);
   });
 
@@ -146,6 +160,20 @@ describe("publish", () => {
           },
           publishedFlows: [{ data: alteredFlow }],
         },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetSubmissionEmail",
+      variables: {
+        flow_id: "1",
+      },
+      data: {
+        flowIntegrations: [
+          {
+            email_id: "mock-email-id",
+          },
+        ],
       },
     });
 

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -63,12 +63,12 @@ export const publishFlow = async (
   const { client: $client } = getClient();
 
   // Fetch submissionEmailId from flow_integrations table
-  const { flow_integrations } = await $client.request<{
-    flow_integrations: { email_id: string }[];
+  const { flowIntegrations } = await $client.request<{
+    flowIntegrations: { email_id: string }[];
   }>(
     gql`
       query GetSubmissionEmail($flow_id: uuid!) {
-        flow_integrations(
+        flowIntegrations: flow_integrations(
           where: { flow_id: { _eq: $flow_id } }
           limit: 1
         ) {
@@ -81,8 +81,8 @@ export const publishFlow = async (
     },
   );
 
-  const submissionEmailId = flow_integrations.length
-    ? flow_integrations[0].email_id
+  const submissionEmailId = flowIntegrations.length
+    ? flowIntegrations[0].email_id
     : null;
 
   const response = await $client.request<PublishFlow>(
@@ -128,7 +128,7 @@ export const publishFlow = async (
       has_sections: hasSections,
       has_pay_component: hasVisiblePayComponent,
       service_charge_enabled: hasEnabledServiceCharge,
-      submission_email_id: submissionEmailId
+      submission_email_id: submissionEmailId,
     },
   );
 

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -61,6 +61,30 @@ export const publishFlow = async (
   );
 
   const { client: $client } = getClient();
+
+  // Fetch submissionEmailId from flow_integrations table
+  const { flow_integrations } = await $client.request<{
+    flow_integrations: { email_id: string }[];
+  }>(
+    gql`
+      query GetSubmissionEmail($flow_id: uuid!) {
+        flow_integrations(
+          where: { flow_id: { _eq: $flow_id } }
+          limit: 1
+        ) {
+          email_id
+        }
+      }
+    `,
+    {
+      flow_id: flowId,
+    },
+  );
+
+  const submissionEmailId = flow_integrations.length
+    ? flow_integrations[0].email_id
+    : null;
+
   const response = await $client.request<PublishFlow>(
     gql`
       mutation PublishFlow(
@@ -72,6 +96,7 @@ export const publishFlow = async (
         $has_sections: Boolean
         $has_pay_component: Boolean
         $service_charge_enabled: Boolean
+        $submission_email_id: uuid
       ) {
         publishedFlow: insert_published_flows_one(
           object: {
@@ -83,6 +108,7 @@ export const publishFlow = async (
             has_sections: $has_sections
             has_pay_component: $has_pay_component
             service_charge_enabled: $service_charge_enabled
+            submission_email_id: $submission_email_id
           }
         ) {
           id
@@ -102,6 +128,7 @@ export const publishFlow = async (
       has_sections: hasSections,
       has_pay_component: hasVisiblePayComponent,
       service_charge_enabled: hasEnabledServiceCharge,
+      submission_email_id: submissionEmailId
     },
   );
 

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
@@ -13,16 +13,17 @@ insert_permissions:
     permission:
       check: {}
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
   - role: demoUser
     permission:
       check:
@@ -35,31 +36,33 @@ insert_permissions:
                 id:
                   _eq: 32
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
     comment: A demoUser can only insert a published flow for their own flows and for flows inside the Demo team [id = 32]
   - role: platformAdmin
     permission:
       check: {}
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
   - role: teamEditor
     permission:
       check:
@@ -72,60 +75,64 @@ insert_permissions:
                 - role:
                     _eq: teamEditor
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
 select_permissions:
   - role: api
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true
   - role: demoUser
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true
   - role: platformAdmin
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true
   - role: public
@@ -146,15 +153,16 @@ select_permissions:
   - role: teamEditor
     permission:
       columns:
+        - created_at
+        - data
+        - flow_id
         - has_pay_component
         - has_sections
         - has_send_component
-        - service_charge_enabled
         - id
         - publisher_id
+        - service_charge_enabled
+        - submission_email_id
         - summary
-        - created_at
-        - flow_id
-        - data
       filter: {}
       allow_aggregations: true

--- a/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."published_flows" drop column "submission_email_id";

--- a/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093216500_alter_table_public_published_flows_add_column_submission_email_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."published_flows" add column "submission_email_id" uuid
+ null;

--- a/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/down.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.diff_latest_published_flow(source_flow_id uuid, since timestamp with time zone)
+ RETURNS published_flows
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH current_published_flow as (
+  SELECT
+    id, data, created_at, flow_id, publisher_id, summary, has_send_component, has_sections, has_pay_component, service_charge_enabled
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+  ORDER BY
+    created_at desc
+  LIMIT
+    1
+),
+previous_published_flow as (
+  SELECT
+    flow_id, data
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+    AND
+    published_flows.created_at < since
+  ORDER BY
+    created_at desc -- the latest published version before "since"
+  LIMIT
+    1
+),
+data_diff as (
+  SELECT
+    flow_id,
+    ( SELECT
+        jsonb_object_agg(COALESCE(old.key, new.key), new.value)
+      FROM
+        jsonb_each(previous_published_flow.data) AS old
+      FULL OUTER JOIN 
+        jsonb_each(current_published_flow.data) AS new 
+      ON
+        new.key = old.key 
+      WHERE 
+        new.value IS DISTINCT FROM old.value
+    ) as data -- shallow diff where deleted keys have a 'null' value
+  FROM 
+    current_published_flow
+  JOIN
+    previous_published_flow USING (flow_id)
+)
+SELECT 
+    id, data_diff.data as data, created_at, flow_id, publisher_id, 'auto generated diff' as summary, has_send_component, has_sections, has_pay_component, service_charge_enabled
+FROM 
+    current_published_flow
+FULL OUTER JOIN
+    data_diff USING (flow_id);
+$function$;

--- a/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769093285516_add_email_id_to_diff_latest_published_flow/up.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.diff_latest_published_flow(source_flow_id uuid, since timestamp with time zone)
+ RETURNS published_flows
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH current_published_flow as (
+  SELECT
+    id, data, created_at, flow_id, publisher_id, summary, has_send_component, has_sections, has_pay_component, service_charge_enabled, submission_email_id
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+  ORDER BY
+    created_at desc
+  LIMIT
+    1
+),
+previous_published_flow as (
+  SELECT
+    flow_id, data
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+    AND
+    published_flows.created_at < since
+  ORDER BY
+    created_at desc -- the latest published version before "since"
+  LIMIT
+    1
+),
+data_diff as (
+  SELECT
+    flow_id,
+    ( SELECT
+        jsonb_object_agg(COALESCE(old.key, new.key), new.value)
+      FROM
+        jsonb_each(previous_published_flow.data) AS old
+      FULL OUTER JOIN 
+        jsonb_each(current_published_flow.data) AS new 
+      ON
+        new.key = old.key 
+      WHERE 
+        new.value IS DISTINCT FROM old.value
+    ) as data -- shallow diff where deleted keys have a 'null' value
+  FROM 
+    current_published_flow
+  JOIN
+    previous_published_flow USING (flow_id)
+)
+SELECT 
+    id, data_diff.data as data, created_at, flow_id, publisher_id, 'auto generated diff' as summary, has_send_component, has_sections, has_pay_component, service_charge_enabled, submission_email_id
+FROM 
+    current_published_flow
+FULL OUTER JOIN
+    data_diff USING (flow_id);
+$function$;


### PR DESCRIPTION
# What does this PR do?
- Adds nullable UUID col `submission_email_id` to `published_flows`
- Updates `diff_latest_published_flows`
- Updates permissions so API and editor users can create and select
- `publishFlow()` gets the `submissionEmailId` from `flow_integrations` and writes it into `published_flows`

# Why? 
So we have a record for where a flow was sending submissions to over time. Brought up in [previous multiple submission email work](https://github.com/theopensystemslab/planx-new/pull/5977#discussion_r2708302675). 