### PR TITLE
fix(editor): Disable retries on the `SetItem` operation

### DIFF
--- a/apps/editor.planx.uk/src/lib/graphql/links.ts
+++ b/apps/editor.planx.uk/src/lib/graphql/links.ts
@@ -26,7 +26,13 @@ const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
 
 export const retryLink = new RetryLink({
   delay: { initial: 500, max: Infinity },
-  attempts: { max: Infinity },
+  attempts: {
+    retryIf: (_error, operation) => {
+      if (operation.getContext().skipRetry) return false;
+      return true;
+    },
+    max: Infinity,
+  },
 });
 
 export const publicHttpLink = createHttpLink({

--- a/apps/editor.planx.uk/src/lib/lowcalStorage.ts
+++ b/apps/editor.planx.uk/src/lib/lowcalStorage.ts
@@ -90,7 +90,12 @@ class LowcalStorage {
         email: useStore.getState().saveToEmail || "",
         flowId: useStore.getState().id,
       },
-      context: getSessionContext(id),
+      context: {
+        ...getSessionContext(id),
+        // Do not retry failed requests (e.g. due to network connectivity or timeouts)
+        // This prevents older, failed, updates from overwriting the most recent requests
+        skipRetry: true,
+      },
     });
   });
 }


### PR DESCRIPTION
## What's the problem?
When a `SetItem` call fails (i.e. updating `lowcal_sessions.data -> breadcrumbs`), retires with exponential back-offs are started.

This allows the following possibility - 
 - Network connectivity or other problem
 - `SetItem` 1 fails
 - User hits "Continue"
 - `SetItem` 2 fails
 - User hits "Continue"
 - `SetItem` 3 fails
 - Connectivity restored / problem resolved
 - Requests resolve in non-linear order, e.g. 3-2-1
 - The latest server-side copy of the data is `SetItem` 1
 - Local and server-side breadcrumbs out of sync, leading to issues like payload generation
 
 ## What's the solution?
In this PR I've simply stopped retires for this mission-critical operation in order to solve this quickly and pragmatically. This means that once connectivity is restored, the server- and client- data will be synchronised.

## Short term...
We should also - 
 - Disable "continue" if there's a network issue
 - Identify the issue with Medway RAB (connectivity seems unlikely?) x3

### Longer term...
This exposes a few issues - mainly around the fact that we're just cloning client-state to the DB (which allows the drift) as opposed to operating on a truly synched source of truth. The source of truth from the application's POV is the `breadcrumbs` in the Zustand store, and `lowcal_sessions.data -> breadcrumbs` is just a copy made as a side effect. I suspect the "best" / "correct" answer here would be to consider the server-side data as the source of truth, getting `breadcrumbs` from the Apollo cache. The challenge here of course is how to maintain client-side (non-Save&Return) functionality...!

## To test
- Open a service, and the network tab
- Step through a number of nodes, monitoring one `SetItem` per node (not one-per visual component) - maybe we should debounce / abort these?
- Toggle to "offline"
- Continue through a number of nodes
- One (failed) `SetItem` request per-node, no retries