### PR TITLE
chore: add flow status to analytics_planx_flows [skip pizza]

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1769502595885_add_status_to_analytics_planx_flows/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769502595885_add_status_to_analytics_planx_flows/down.sql
@@ -1,0 +1,32 @@
+DROP VIEW IF EXISTS public.analytics_planx_flows CASCADE;
+
+CREATE VIEW public.analytics_planx_flows AS (
+SELECT
+    f.id AS flow_id,
+    f.name AS flow_name,
+    f.slug AS flow_slug,
+    f.team_id,
+    t.slug AS team_slug,
+    t.name AS team_name,
+    f.created_at,
+    MIN(a.created_at) AS first_used,
+    public.flow_first_online_at(f) AS first_online_at,
+    public.flow_production_url(f) AS url
+FROM flows f
+    JOIN teams t ON f.team_id = t.id
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+    LEFT JOIN analytics a ON a.flow_id = f.id
+GROUP BY
+    f.id,
+    f.name,
+    f.slug,
+    f.team_id,
+    t.slug,
+    t.name,
+    f.created_at,
+    public.flow_first_online_at(f),
+    public.flow_production_url(f)
+);
+
+GRANT SELECT ON public.analytics_planx_flows TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1769502595885_add_status_to_analytics_planx_flows/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769502595885_add_status_to_analytics_planx_flows/up.sql
@@ -1,0 +1,34 @@
+DROP VIEW IF EXISTS public.analytics_planx_flows CASCADE;
+
+CREATE VIEW public.analytics_planx_flows AS (
+SELECT
+    f.id AS flow_id,
+    f.name AS flow_name,
+    f.slug AS flow_slug,
+    f.team_id,
+    t.slug AS team_slug,
+    t.name AS team_name,
+    f.created_at,
+    f.status,
+    MIN(a.created_at) AS first_used,
+    public.flow_first_online_at(f) AS first_online_at,
+    public.flow_production_url(f) AS url
+FROM flows f
+    JOIN teams t ON f.team_id = t.id
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+    LEFT JOIN analytics a ON a.flow_id = f.id
+GROUP BY
+    f.id,
+    f.name,
+    f.slug,
+    f.team_id,
+    t.slug,
+    t.name,
+    f.created_at,
+    f.status,
+    public.flow_first_online_at(f),
+    public.flow_production_url(f)
+);
+
+GRANT SELECT ON public.analytics_planx_flows TO metabase_read_only;


### PR DESCRIPTION
I missed off the `f.status` column from the [original view migration](https://github.com/theopensystemslab/planx-new/pull/5998/changes#diff-df8bc7cdb8eb96aa7cb8d80b41f0d626abf4a055e474747a231219c6e80aee6cR3-R12). 