### PR TITLE
chore(editor): Omit redundant `previouslySubmittedData` from `MapAndLabel` breadcrumb

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -11,7 +11,7 @@ import {
 import { FormikProps, useFormik } from "formik";
 import { Feature, FeatureCollection } from "geojson";
 import { GeoJSONChange, GeoJSONChangeEvent, useGeoJSONChange } from "lib/gis";
-import { get } from "lodash";
+import { get, omit } from "lodash";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, {
   createContext,
@@ -107,7 +107,10 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
 
       // This key will only be referenced at the individual breadcrumb level,
       //   it's okay if multiple MapAndLabels overwrite eachother when the passport is computed
-      extraPassportData["_mapAndLabelNodeData"] = props;
+      // Do not save redundant `previouslySubmittedData` key
+      extraPassportData["_mapAndLabelNodeData"] = omit(props, [
+        "previouslySubmittedData",
+      ]);
 
       handleSubmit?.({
         data: {


### PR DESCRIPTION
Each time `SetItem` is called (to update `lowcal_session.data`) there's a larger than required payload. This can lead to latency and drift between client- and server-state.

This has mostly been mitigated by simplifying the GeoJSON bounding box ([see here for more detail](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1769521951086159?thread_ts=1765893530.146079&cid=C088K9ZL8EA)).

This change is a small optimisation to exclude redundant data from the user's breadcrumbs and passport.

<img width="1882" height="411" alt="image" src="https://github.com/user-attachments/assets/3d4580f3-9596-4a8e-bd17-43ca36ab362e" />
