### PR TITLE
chore: optimise analytics_planx_flows view

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1769595120820_optimise_analytics_planx_flows/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769595120820_optimise_analytics_planx_flows/down.sql
@@ -1,0 +1,34 @@
+DROP VIEW IF EXISTS public.analytics_planx_flows CASCADE;
+
+CREATE VIEW public.analytics_planx_flows AS (
+SELECT
+    f.id AS flow_id,
+    f.name AS flow_name,
+    f.slug AS flow_slug,
+    f.team_id,
+    t.slug AS team_slug,
+    t.name AS team_name,
+    f.created_at,
+    f.status,
+    MIN(a.created_at) AS first_used,
+    public.flow_first_online_at(f) AS first_online_at, 
+    public.flow_production_url(f) AS url
+FROM flows f
+    JOIN teams t ON f.team_id = t.id
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+    LEFT JOIN analytics a ON a.flow_id = f.id
+GROUP BY
+    f.id,
+    f.name,
+    f.slug,
+    f.team_id,
+    t.slug,
+    t.name,
+    f.created_at,
+    f.status,
+    public.flow_first_online_at(f),
+    public.flow_production_url(f)
+);
+
+GRANT SELECT ON public.analytics_planx_flows TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1769595120820_optimise_analytics_planx_flows/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1769595120820_optimise_analytics_planx_flows/up.sql
@@ -1,0 +1,30 @@
+DROP VIEW IF EXISTS public.analytics_planx_flows CASCADE;
+
+CREATE VIEW public.analytics_planx_flows AS (
+SELECT
+    f.id AS flow_id,
+    f.name AS flow_name,
+    f.slug AS flow_slug,
+    f.team_id,
+    t.slug AS team_slug,
+    t.name AS team_name,
+    f.created_at,
+    f.status,
+    public.flow_first_online_at(f) AS first_online_at,
+    public.flow_production_url(f) AS url
+FROM flows f
+    JOIN teams t ON f.team_id = t.id
+    JOIN team_settings ts ON ts.team_id = t.id
+    JOIN team_integrations ti ON ti.team_id = t.id
+GROUP BY
+    f.id,
+    f.name,
+    f.slug,
+    f.team_id,
+    t.slug,
+    t.name,
+    f.created_at,
+    f.status
+);
+
+GRANT SELECT ON public.analytics_planx_flows TO metabase_read_only;


### PR DESCRIPTION
Here's another version of the `analytics_planx_flows` view, which was timing out recently (after #6029)--it seems there was an error in the way I was including functions in the `GROUP BY`. When I ran this new version in pgAdmin, this reduces the query time to between 29-40 seconds (previously ~65). 

Other things we can think about: 
- Creating an index eg `CREATE INDEX CONCURRENTLY idx_analytics_flow_created ON analytics(flow_id, created_at);` (`CONCURRENTLY` so that we don't lock the `analytics` table) 
- We could remove the `first_used` column altogether, but I feel like it's useful for getting a sense of how long it takes between a service being 'ready' and actually being used 
- Making this into a materialized view instead