### PR TITLE
feat: two-step submission email delete

### DIFF
--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -68,30 +68,6 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
   return flow;
 };
 
-const getDefaultEmail = async (teamId: number): Promise<string | null> => {
-  const { client: $client } = getClient();
-
-  const { submissionIntegrations } = await $client.request<{
-    submissionIntegrations: { id: string }[];
-  }>(
-    gql`
-      query GetDefaultEmail($team_id: Int!) {
-        submissionIntegrations: submission_integrations(
-          where: { team_id: { _eq: $team_id }, default_email: { _eq: true } }
-          limit: 1
-        ) {
-          id
-        }
-      }
-    `,
-    {
-      team_id: teamId,
-    },
-  );
-
-  return submissionIntegrations.length ? submissionIntegrations[0].id : null;
-};
-
 // Insert a new flow into the `flows` table
 const createFlow = async ({
   teamId,
@@ -120,8 +96,6 @@ const createFlow = async ({
   const userId = userContext.getStore()?.user?.sub;
 
   try {
-    const emailId = await getDefaultEmail(teamId);
-
     const response = await $client.request<{
       insertFlowWithIntegration: {
         id: Flow["id"];
@@ -174,7 +148,6 @@ const createFlow = async ({
         summary: summary,
         description: description,
         limitations: limitations,
-        email_id: emailId,
       },
     );
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -125,6 +125,7 @@ const EmailsTableContent = () => {
             setShowModal={setShowUpsertModal}
             initialValues={initialValues}
             actionType={actionType}
+            refetch={refetch}
           />
         )}
         {showDeleteModal && (
@@ -133,6 +134,7 @@ const EmailsTableContent = () => {
             setShowModal={setShowDeleteModal}
             initialValues={initialValues}
             actionType={actionType}
+            refetch={refetch}
           />
         )}
       </>
@@ -191,6 +193,7 @@ const EmailsTableContent = () => {
           currentEmails={data.submissionIntegrations.map(
             (email) => email.submissionEmail,
           )}
+          refetch={refetch}
         />
       )}
       {showDeleteModal && (
@@ -200,6 +203,7 @@ const EmailsTableContent = () => {
           initialValues={initialValues}
           actionType={actionType}
           teamId={teamId}
+          refetch={refetch}
         />
       )}
     </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -25,6 +25,7 @@ export const RemoveEmailModal = ({
   actionType,
   initialValues,
   teamId,
+  refetch
 }: EditorModalProps) => {
   const toast = useToast();
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
@@ -57,6 +58,7 @@ export const RemoveEmailModal = ({
       });
       setShowModal(false);
       toast.success("Email removed successfully");
+      refetch();
     } catch (error) {
       console.error("Error deleting email:", error);
       toast.error("Failed to remove email");
@@ -82,11 +84,15 @@ export const RemoveEmailModal = ({
               {initialValues?.submissionEmail}" from receiving submissions?
             </Typography>
           ) : (
+            <>
             <Typography mb={2} color="error">
-              This email address cannot be removed as it is currently in use by
-              one or more flows. Please update the flow settings to use a
+              This email address cannot be removed as it is currently used in: 
+            </Typography>
+            <Typography mb={2} color="error">
+            Please update the flow settings to use a
               different email before removing this one.
             </Typography>
+            </>
           )}
         </Box>
       </DialogContent>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -32,14 +32,13 @@ export const RemoveEmailModal = ({
   const toast = useToast();
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
   const emailId = initialValues?.id || null;
-  console.log({ emailId });
+  console.log({ emailId }); // TODO: eventually delete, keeping for local testing for now
   const { data, error } = useQuery<GetFlowsWithSubmissionIntegration>(
     GET_FLOWS_WITH_SUBMISSION_INTEGRATION,
     {
       variables: { emailId },
     }
   );
-  console.log({ data });
 
   // The GET query returns deleted flows, so filter for existing flows here
   const usedFlows = data?.flowIntegrations
@@ -48,9 +47,7 @@ export const RemoveEmailModal = ({
       slug: integration.flow?.slug,
       name: integration.flow?.name,
     })) || [];  
-  console.log({ usedFlows });
   const deletable = usedFlows.length === 0 ? true : false;
-  console.log({ deletable });
 
   const handleRemoveEmail = async (email: SubmissionEmailInput) => {
     if (!email?.id) {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -31,14 +31,21 @@ export const RemoveEmailModal = ({
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
   const emailId = initialValues?.id || null;
   console.log({ emailId });
-  const { data } = useQuery<GetFlowsWithSubmissionIntegration>(
+  const { data, error } = useQuery<GetFlowsWithSubmissionIntegration>(
     GET_FLOWS_WITH_SUBMISSION_INTEGRATION,
     {
       variables: { emailId },
-    },
+    }
   );
   console.log({ data });
-  const usedFlows = data?.flowIntegrations || [];
+
+  // The GET query returns deleted flows, so filter for existing flows here
+  const usedFlows = data?.flowIntegrations
+    .filter((integration) => integration.flow)
+    .map((integration) => ({
+      slug: integration.flow?.slug,
+      name: integration.flow?.name,
+    })) || [];  
   console.log({ usedFlows });
   const deletable = usedFlows.length === 0 ? true : false;
   console.log({ deletable });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -113,7 +113,7 @@ export const RemoveEmailModal = ({
               {usedFlows.map((flow) => (
                 <ListItem key={flow.name}>
                   <Link
-                    href="#" // TODO: update link after routing work merged; /{team}/{slug}
+                    href={`/app/${teamSlug}/${flow.slug}`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -1,0 +1,85 @@
+import { useMutation } from "@apollo/client";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Typography from "@mui/material/Typography";
+import { useToast } from "hooks/useToast";
+import React from "react";
+
+import { DELETE_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
+import { EditorModalProps, SubmissionEmailInput } from "./types";
+
+export const RemoveEmailModal = ({
+  setShowModal,
+  showModal,
+  actionType,
+  initialValues,
+  teamId,
+}: EditorModalProps) => {
+  const toast = useToast();
+  const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
+
+  const handleRemoveEmail = async (email: SubmissionEmailInput) => {
+    if (!email?.id) {
+      return;
+    }
+    try {
+      await deleteEmail({
+        variables: { submissionEmail: email.submissionEmail, teamId },
+        optimisticResponse: {
+          delete_submission_integrations: {
+            returning: [{ ...email }],
+          },
+        },
+      });
+      setShowModal(false);
+      toast.success("Email removed successfully");
+    } catch (error) {
+      console.error("Error deleting email:", error);
+      toast.error("Failed to remove email");
+    }
+  };
+
+  return (
+    <Dialog
+      aria-labelledby="dialog-heading"
+      data-testid={`modal-${actionType}-email`}
+      open={showModal || false}
+      onClose={() => setShowModal(false)}
+      fullWidth
+    >
+      <DialogTitle variant="h3" component="h1" id="dialog-heading">
+        Remove an email
+      </DialogTitle>
+      <DialogContent>
+        <Box mt={2}>
+          <Typography mb={2}>
+            Are you sure you want to remove the email address "
+            {initialValues?.submissionEmail}" from receiving submissions?
+          </Typography>
+          <Typography>
+            It will be removed from live services. Any services sending
+            applications to this destination will fall back to your default
+            email.
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={() => setShowModal(false)}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={() => initialValues && handleRemoveEmail(initialValues)}
+          data-testid="confirm-remove-email-button"
+        >
+          Remove Email
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -13,7 +13,7 @@ import Link from "@mui/material/Link";
 
 import {
   DELETE_TEAM_SUBMISSION_INTEGRATIONS,
-  GET_FLOWS_WITH_SUBMISSION_INTEGRATION,
+  GET_PUBLISHED_FLOWS_WITH_SUBMISSION_INTEGRATION,
 } from "./queries";
 import {
   EditorModalProps,
@@ -34,19 +34,19 @@ export const RemoveEmailModal = ({
   const emailId = initialValues?.id || null;
   console.log({ emailId }); // TODO: eventually delete, keeping for local testing for now
   const { data, error } = useQuery<GetFlowsWithSubmissionIntegration>(
-    GET_FLOWS_WITH_SUBMISSION_INTEGRATION,
+    GET_PUBLISHED_FLOWS_WITH_SUBMISSION_INTEGRATION,
     {
       variables: { emailId },
     }
   );
 
   // The GET query returns deleted flows, so filter for existing flows here
-  const usedFlows = data?.flowIntegrations
-    .filter((integration) => integration.flow)
-    .map((integration) => ({
-      slug: integration.flow?.slug,
-      name: integration.flow?.name,
-    })) || [];  
+  const usedFlows = data?.publishedFlows
+    .map((publishedFlow) => ({
+      slug: publishedFlow.flow?.slug,
+      name: publishedFlow.flow?.name,
+    })) || []; 
+  console.log({usedFlows}) 
   const deletable = usedFlows.length === 0 ? true : false;
 
   const handleRemoveEmail = async (email: SubmissionEmailInput) => {
@@ -105,7 +105,7 @@ export const RemoveEmailModal = ({
                 </ListItem>
               ))}
             <Typography mt={2}>
-            Please update the flow settings to use a
+            Please <strong>update and republish</strong> the flow settings to use a
               different email address before removing this one.
             </Typography>
             </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -8,6 +8,8 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Typography from "@mui/material/Typography";
 import { useToast } from "hooks/useToast";
 import React from "react";
+import ListItem from "@mui/material/ListItem";
+import Link from "@mui/material/Link";
 
 import {
   DELETE_TEAM_SUBMISSION_INTEGRATIONS,
@@ -80,7 +82,7 @@ export const RemoveEmailModal = ({
       onClose={() => setShowModal(false)}
       fullWidth
     >
-      <DialogTitle variant="h3" component="h1" id="dialog-heading">
+      <DialogTitle variant="h3" component="h1">
         Remove an email
       </DialogTitle>
       <DialogContent>
@@ -92,19 +94,33 @@ export const RemoveEmailModal = ({
             </Typography>
           ) : (
             <>
-            <Typography mb={2} color="error">
-              This email address cannot be removed as it is currently used in: 
+            <Typography mb={2}>
+              This email address cannot be removed as it is currently used in the following flows: 
             </Typography>
-            <Typography mb={2} color="error">
+              {usedFlows.map((flow) => (
+                <ListItem key={flow.name}>
+                  <Link
+                      href="#" // TODO: update link after routing work merged; /{team}/{slug}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >{flow.name}
+                  </Link>
+                </ListItem>
+              ))}
+            <Typography mt={2}>
             Please update the flow settings to use a
-              different email before removing this one.
+              different email address before removing this one.
             </Typography>
             </>
           )}
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button variant="outlined" onClick={() => setShowModal(false)}>
+        <Button 
+          color="secondary"
+          variant="contained" 
+          onClick={() => setShowModal(false)}
+          >
           Cancel
         </Button>
         <Button

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -14,6 +14,20 @@ export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
   }
 `;
 
+export const GET_FLOWS_WITH_SUBMISSION_INTEGRATION = gql`
+  query GetFlowsWithSubmissionIntegration($emailId: uuid!) {
+    flowIntegrations: flow_integrations(
+      where: { email_id: { _eq: $emailId } }
+    ) {
+      flowId: flow_id
+      submissionEmailId: email_id
+      flow {
+        name
+      }
+    }
+  }
+`;
+
 export const UPSERT_TEAM_SUBMISSION_INTEGRATIONS = gql`
   mutation UpsertSubmissionIntegrations(
     $emails: [submission_integrations_insert_input!]!

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -14,16 +14,29 @@ export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
   }
 `;
 
-export const GET_PUBLISHED_FLOWS_WITH_SUBMISSION_INTEGRATION = gql`
-  query GetFlowsWithSubmissionIntegration($emailId: uuid!) {
-    publishedFlows: published_flows(
+export const GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION = gql`
+  query GetFlowIdsBySubmissionIntegration($emailId: uuid!) {
+    flowIds: published_flows(
       where: { submission_email_id: { _eq: $emailId } }
       distinct_on: flow_id
+    ) {
+      flowId: flow_id
+    }
+  }
+`;
+
+export const GET_LATEST_PUBLISHED_FLOWS = gql`
+  query GetLatestPublishedFlows($emailId: uuid!, $flowIds: [uuid!]!) {
+    publishedFlows: published_flows(
+      where: {
+        submission_email_id: { _eq: $emailId }
+        flow_id: { _in: $flowIds }
+      }
       order_by: [{ flow_id: asc }, { created_at: desc }]
     ) {
       flowId: flow_id
       submissionEmailId: submission_email_id
-      flow(where: { deleted_at: { _is_null: true } }) {
+      flow {
         name
         slug
       }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -39,6 +39,7 @@ export const GET_LATEST_PUBLISHED_FLOWS = gql`
       flow {
         name
         slug
+        createdAt: created_at
       }
     }
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -14,17 +14,18 @@ export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
   }
 `;
 
-export const GET_FLOWS_WITH_SUBMISSION_INTEGRATION = gql`
+export const GET_PUBLISHED_FLOWS_WITH_SUBMISSION_INTEGRATION = gql`
   query GetFlowsWithSubmissionIntegration($emailId: uuid!) {
-    flowIntegrations: flow_integrations(
-      where: { email_id: { _eq: $emailId } }
+    publishedFlows: published_flows(
+      where: { submission_email_id: { _eq: $emailId } }
+      distinct_on: flow_id
+      order_by: [{ flow_id: asc }, { created_at: desc }]
     ) {
       flowId: flow_id
-      submissionEmailId: email_id
-      flow {
+      submissionEmailId: submission_email_id
+      flow(where: { deleted_at: { _is_null: true } }) {
         name
         slug
-        deleted_at
       }
     }
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -23,6 +23,8 @@ export const GET_FLOWS_WITH_SUBMISSION_INTEGRATION = gql`
       submissionEmailId: email_id
       flow {
         name
+        slug
+        deleted_at
       }
     }
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -32,4 +32,5 @@ export interface EditorModalProps {
   actionType?: ActionType;
   previousDefaultEmail?: SubmissionEmailInput;
   currentEmails?: string[];
+  teamId?: number;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -20,17 +20,24 @@ export interface SubmissionEmailValues {
   submissionIntegrations: SubmissionEmailInput[];
 }
 
-export type GetFlowsWithSubmissionIntegration = {
-  publishedFlows: {
-    flowId: number;
-    id: string;
-    submissionEmailId: string;
-    flow: {
-      name: string;
-      slug: string;
-    } | null;
-  }[];
-};
+export interface Flow {
+  name: string;
+  slug: string;
+}
+
+export interface PublishedFlow {
+  flowId: string;
+  submissionEmailId: string;
+  flow: Flow | null;
+}
+
+export interface GetFlowIdsBySubmissionIntegration {
+  flowIds: { flowId: string }[];
+}
+
+export interface GetLatestPublishedFlows {
+  publishedFlows: PublishedFlow[];
+}
 
 export interface UpdateTeamSubmissionIntegrationsVariables {
   emails: SubmissionEmailMutation[];
@@ -46,5 +53,7 @@ export interface EditorModalProps {
   previousDefaultEmail?: SubmissionEmailInput;
   currentEmails?: string[];
   teamId?: number;
-  refetch: (variables?: Partial<Record<string, any>>) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
+  refetch: (
+    variables?: Partial<Record<string, any>>,
+  ) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -27,7 +27,8 @@ export type GetFlowsWithSubmissionIntegration = {
     submissionEmailId: string;
     flow: {
       name: string;
-    };
+      slug: string;
+    } | null;
   }[];
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -1,3 +1,4 @@
+import { ApolloQueryResult } from "@apollo/client";
 import { SetStateAction } from "react";
 import type { SnakeCasedProperties } from "type-fest";
 
@@ -44,4 +45,5 @@ export interface EditorModalProps {
   previousDefaultEmail?: SubmissionEmailInput;
   currentEmails?: string[];
   teamId?: number;
+  refetch: (variables?: Partial<Record<string, any>>) => Promise<ApolloQueryResult<GetSubmissionEmails>>; // Update this line
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -21,7 +21,7 @@ export interface SubmissionEmailValues {
 }
 
 export type GetFlowsWithSubmissionIntegration = {
-  flowIntegrations: {
+  publishedFlows: {
     flowId: number;
     id: string;
     submissionEmailId: string;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -46,5 +46,5 @@ export interface EditorModalProps {
   previousDefaultEmail?: SubmissionEmailInput;
   currentEmails?: string[];
   teamId?: number;
-  refetch: (variables?: Partial<Record<string, any>>) => Promise<ApolloQueryResult<GetSubmissionEmails>>; // Update this line
+  refetch: (variables?: Partial<Record<string, any>>) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -19,6 +19,17 @@ export interface SubmissionEmailValues {
   submissionIntegrations: SubmissionEmailInput[];
 }
 
+export type GetFlowsWithSubmissionIntegration = {
+  flowIntegrations: {
+    flowId: number;
+    id: string;
+    submissionEmailId: string;
+    flow: {
+      name: string;
+    };
+  }[];
+};
+
 export interface UpdateTeamSubmissionIntegrationsVariables {
   emails: SubmissionEmailMutation[];
 }


### PR DESCRIPTION
# What does this PR do?
- Creates a modal when a user hits the 'Remove' button
- If the email address is being used, disable deletion and show a list of flows in which the email needs to be removed from first

# Why?
Ian pointed out that email deletion should probably be a two-step process. 

After discussing with Jess, it seemed to make more sense to prevent deletion if an email was being used anywhere, instead of setting up a complicated chain of events to delete from `submission_integrations` and cascade to `flow_integrations` etc. 

# Testing
1. Go to the Team Settings page, enable the `TEAM_SUBMISSION_INTEGRATIONS` feature flag
2. Create some emails in the `EmailsTable`
3. Delete an email with two steps
4. Go to Hasura and add the email ID (logged in console) to a flow in the same teamspace by editing its record in the `flow_integrations` table (you might want to double check that `deleted_at` is null).
5. Refresh the Settings page and try to delete the email; you should see the second type of modal and a list of the flows that the email is being used in
    - NB: The flow links are just placeholders for now, pending routing work merge

<img width="500" alt="Screenshot 2026-02-03 132240" src="https://github.com/user-attachments/assets/b43dfb48-48df-43ca-9161-6f970f5c40cb" />

<img width="500" alt="Screenshot 2026-02-03 132248" src="https://github.com/user-attachments/assets/d553d900-7da0-4688-a6e9-467fe0947943" />

# Questions
- Should we be getting the flow usage from `flow_integrations` or from most recent `published_flows.submission_email_id`? Does this have knockon effects for how we save the flow integration in the first place? (eg `flow_integrations` is updated when the Send component updates; it doesn't wait until Publish)