### PR TITLE
feat: add a 'limit to one file' switch to file upload

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -9,6 +9,7 @@ import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+import { Switch } from "ui/shared/Switch";
 
 import { DataFieldAutocomplete } from "../shared/DataFieldAutocomplete";
 import { ICONS } from "../shared/icons";
@@ -78,6 +79,19 @@ function Component(props: Props) {
             disabled={props.disabled}
             allowCustomValues={false}
           />
+          <InputRow>
+            <Switch
+              checked={Boolean(formik.values.maxFiles === 1)}
+              onChange={() =>
+                formik.setFieldValue(
+                  "maxFiles",
+                  formik.values.maxFiles === 1 ? 0 : 1,
+                )
+              }
+              label="Limit to one file"
+              disabled={props.disabled}
+            />
+          </InputRow>
         </ModalSectionContent>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -108,3 +108,21 @@ it("should not have any accessibility violations", async () => {
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 });
+
+test("shows singular 'Drop file here' text when maxFiles is 1", async () => {
+  const handleSubmit = vi.fn();
+  const componentId = uniqueId();
+
+  await setup(
+    <FileUpload
+      title="Upload single file"
+      fn="singleFile"
+      id={componentId}
+      handleSubmit={handleSubmit}
+      maxFiles={1}
+    />,
+  );
+
+  expect(screen.getByText(/Drop file here/)).toBeInTheDocument();
+  expect(screen.queryByText(/Drop files here/)).not.toBeInTheDocument();
+});

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -95,7 +95,11 @@ const FileUploadComponent: React.FC<Props> = (props) => {
         policyRef={props.policyRef}
       />
       <ErrorWrapper error={validationError} id={props.id}>
-        <PrivateFileUpload slots={slots} setSlots={setSlots} />
+        <PrivateFileUpload
+          slots={slots}
+          setSlots={setSlots}
+          maxFiles={props.maxFiles}
+        />
       </ErrorWrapper>
     </Card>
   );

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -5,12 +5,13 @@ import {
 } from "@planx/components/shared";
 import { richText } from "lib/yupExtensions";
 import { FileWithPath } from "react-dropzone";
-import { array, object, SchemaOf, string } from "yup";
+import { array, number, object, SchemaOf, string } from "yup";
 
 export interface FileUpload extends BaseNodeData {
   title: string;
   fn: string;
   description?: string;
+  maxFiles?: number;
 }
 
 export interface FileUploadSlot {
@@ -33,6 +34,7 @@ export const parseFileUpload = (
   notes: data?.notes || "",
   policyRef: data?.policyRef,
   title: data?.title || "",
+  maxFiles: data?.maxFiles,
   ...parseBaseNodeData(data),
 });
 
@@ -75,6 +77,7 @@ export const validationSchema: SchemaOf<FileUpload> =
       description: richText(),
       title: string().required(),
       fn: string().nullable().required(),
+      maxFiles: number().optional(),
     }),
   );
 

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -169,7 +169,10 @@ export const Dropzone: React.FC<Props> = ({
           ) : (
             <>
               Drop {maxFiles === 1 ? "file" : "files"} here or{" "}
-              <FauxLink component="span">choose files</FauxLink> to upload
+              <FauxLink component="span">
+                {maxFiles === 1 ? "choose a file" : "choose files"}
+              </FauxLink>{" "}
+              to upload
             </>
           )}
         </Typography>


### PR DESCRIPTION
This PR adds a switch to the File Upload component to allow editors to restrict the number of files to one. Default is kept to multiple files, so no content migration needed.