### PR TITLE
feat: encode restricted characters in uploaded filenames

### DIFF
--- a/apps/api.planx.uk/modules/file/controller.ts
+++ b/apps/api.planx.uk/modules/file/controller.ts
@@ -27,7 +27,8 @@ export const uploadFileSchema = z.object({
       .min(1)
       .refine(validateExtension, (input) => ({
         message: `Unsupported file type: ${path.extname(input).toLowerCase()}`,
-      })),
+      }))
+      .transform((filename) => encodeURIComponent(filename)),
   }),
 });
 


### PR DESCRIPTION
This PR adds encoding to uploaded filenames to remove restricted characters that may break back office integrations.

[See Trello card for more context](https://trello.com/c/XJORcR0C/3414-unable-to-upload-files-with-into-uniform-dms-or-open-on-windows-consider-adding-frontend-filename-validation-rules-to-ensure-the).