### PR TITLE
feat: get email send destination from published_flows

### DIFF
--- a/apps/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
+++ b/apps/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
@@ -32,26 +32,6 @@ export async function downloadApplicationFiles(
     const { id: teamId, teamSettings } =
       await getTeamEmailSettings(localAuthority);
 
-    // Get flow ID, in order to access flow submission email
-    const flowId = await getFlowId(sessionId);
-    console.log({ flowId });
-    if (!flowId) {
-      return next({
-        status: 400,
-        message: "Failed to find flow ID for this sessionId",
-      });
-    }
-
-    // MULTIPLE SUBMISSION TODO: Toggle this back on once record automatically created and all values populated
-    // Get the flow submission email, which will run parallel to getTeamEmailSettings for now
-    // const submissionEmail = await getSubmissionEmail(flowId, teamId);
-    // if (!submissionEmail) {
-    //   return next({
-    //     status: 400,
-    //     message: "Failed to retrieve submission email for this flow",
-    //   });
-    // }
-
     if (teamSettings.submissionEmail !== decodeURIComponent(email)) {
       // MULTIPLE SUBMISSION TODO: use submissionEmail
 
@@ -70,6 +50,25 @@ export async function downloadApplicationFiles(
         message: "Failed to find session data for this sessionId",
       });
     }
+
+    // Get flow ID, in order to access flow submission email
+    const flowId = await getFlowId(sessionId);
+    if (!flowId) {
+      return next({
+        status: 400,
+        message: "Failed to find flow ID for this sessionId",
+      });
+    }
+
+    // MULTIPLE SUBMISSION TODO: Toggle this back on once record automatically created and all values populated
+    // Get the flow submission email, which will run parallel to getTeamEmailSettings for now
+    // const submissionEmail = await getSubmissionEmail(flowId, teamId);
+    // if (!submissionEmail) {
+    //   return next({
+    //     status: 400,
+    //     message: "Failed to retrieve submission email for this flow",
+    //   });
+    // }
 
     // create the submission zip
     const zip = await logDuration(`zipTotal-${sessionId}`, () =>

--- a/apps/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
+++ b/apps/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
@@ -4,7 +4,7 @@ import {
   getFlowId,
   getSessionData,
   getTeamEmailSettings,
-  getSubmissionEmail,
+  // getSubmissionEmail,
 } from "../email/service.js";
 import { logDuration } from "../../../lib/performance.js";
 
@@ -31,7 +31,30 @@ export async function downloadApplicationFiles(
     // Confirm that the provided email matches the stored team settings for the provided localAuthority
     const { id: teamId, teamSettings } =
       await getTeamEmailSettings(localAuthority);
+
+    // Get flow ID, in order to access flow submission email
+    const flowId = await getFlowId(sessionId);
+    console.log({ flowId });
+    if (!flowId) {
+      return next({
+        status: 400,
+        message: "Failed to find flow ID for this sessionId",
+      });
+    }
+
+    // MULTIPLE SUBMISSION TODO: Toggle this back on once record automatically created and all values populated
+    // Get the flow submission email, which will run parallel to getTeamEmailSettings for now
+    // const submissionEmail = await getSubmissionEmail(flowId, teamId);
+    // if (!submissionEmail) {
+    //   return next({
+    //     status: 400,
+    //     message: "Failed to retrieve submission email for this flow",
+    //   });
+    // }
+
     if (teamSettings.submissionEmail !== decodeURIComponent(email)) {
+      // MULTIPLE SUBMISSION TODO: use submissionEmail
+
       return next({
         status: 403,
         message:
@@ -45,26 +68,6 @@ export async function downloadApplicationFiles(
       return next({
         status: 400,
         message: "Failed to find session data for this sessionId",
-      });
-    }
-
-    // Get flow ID, in order to access flow submission email
-    const flowId = await getFlowId(sessionId);
-    if (!flowId) {
-      return next({
-        status: 400,
-        message: "Failed to find flow ID for this sessionId",
-      });
-    }
-
-    // TODO: Toggle this back on once record automatically created and all values populated
-
-    // Get the flow submission email, which will run parallel to getTeamEmailSettings for now
-    const submissionEmail = await getSubmissionEmail(flowId, teamId);
-    if (!submissionEmail) {
-      return next({
-        status: 400,
-        message: "Failed to retrieve submission email for this flow",
       });
     }
 

--- a/apps/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
+++ b/apps/api.planx.uk/modules/send/downloadApplicationFiles/index.ts
@@ -4,7 +4,7 @@ import {
   getFlowId,
   getSessionData,
   getTeamEmailSettings,
-  getFlowSubmissionEmail,
+  getSubmissionEmail,
 } from "../email/service.js";
 import { logDuration } from "../../../lib/performance.js";
 
@@ -29,7 +29,8 @@ export async function downloadApplicationFiles(
 
   try {
     // Confirm that the provided email matches the stored team settings for the provided localAuthority
-    const { teamSettings } = await getTeamEmailSettings(localAuthority);
+    const { id: teamId, teamSettings } =
+      await getTeamEmailSettings(localAuthority);
     if (teamSettings.submissionEmail !== decodeURIComponent(email)) {
       return next({
         status: 403,
@@ -59,13 +60,13 @@ export async function downloadApplicationFiles(
     // TODO: Toggle this back on once record automatically created and all values populated
 
     // Get the flow submission email, which will run parallel to getTeamEmailSettings for now
-    // const submissionEmail = await getFlowSubmissionEmail(flowId);
-    // if (!submissionEmail) {
-    //   return next({
-    //     status: 400,
-    //     message: "Failed to retrieve submission email for this flow",
-    //   });
-    // }
+    const submissionEmail = await getSubmissionEmail(flowId, teamId);
+    if (!submissionEmail) {
+      return next({
+        status: 400,
+        message: "Failed to retrieve submission email for this flow",
+      });
+    }
 
     // create the submission zip
     const zip = await logDuration(`zipTotal-${sessionId}`, () =>

--- a/apps/api.planx.uk/modules/send/email/index.test.ts
+++ b/apps/api.planx.uk/modules/send/email/index.test.ts
@@ -273,12 +273,11 @@ describe(`downloading application data received by email`, () => {
     });
 
     queryMock.mockQuery({
-      name: "GetFlowSubmissionEmail",
+      name: "GetPublishedFlowIntegration",
       matchOnVariables: true,
       data: {
-        flowIntegrations: [
+        publishedFlows: [
           {
-            emailId: "727d48fa-cb8a-42f9-b8b2-55032f3bb451",
             submissionIntegration: {
               submissionEmail: "planning.office.example@council.gov.uk",
             },
@@ -288,6 +287,8 @@ describe(`downloading application data received by email`, () => {
       variables: { flowId: "91693304-fc37-4079-8ec3-e33a6164a27a" },
     });
   });
+
+  //  MULTIPLE SUBMISSION TODO: add test for fallback logic
 
   it("errors if required query params are missing", async () => {
     await supertest(app)
@@ -303,7 +304,7 @@ describe(`downloading application data received by email`, () => {
   it("errors if email query param does not match the stored database value for this team", async () => {
     await supertest(app)
       .get(
-        "/download-application-files/123?email=wrong@council.gov.uk&localAuthority=southwark",
+        "/download-application-files/33d373d4-fff2-4ef7-a5f2-2a36e39ccc49?email=wrong@council.gov.uk&localAuthority=southwark",
       )
       .expect(403)
       .then((res) => {
@@ -321,6 +322,15 @@ describe(`downloading application data received by email`, () => {
         session: { data: null },
       },
       variables: { id: "456" },
+    });
+
+    queryMock.mockQuery({
+      name: "GetFlowId",
+      matchOnVariables: false,
+      data: {
+        lowcalSessions: [],
+      },
+      variables: { session_id: "456" },
     });
 
     await supertest(app)
@@ -357,6 +367,7 @@ describe(`downloading application data received by email`, () => {
       });
   });
 
+  // MULTIPLE SUBMISSION TODO
   it.skip("errors if submissionEmail is missing in GetFlowSubmissionEmail query response", async () => {
     queryMock.mockQuery({
       name: "GetFlowSubmissionEmail",

--- a/apps/api.planx.uk/modules/send/email/index.ts
+++ b/apps/api.planx.uk/modules/send/email/index.ts
@@ -10,7 +10,9 @@ import type { SendIntegrationController } from "../types.js";
 import {
   checkEmailAuditTable,
   getSessionEmailDetailsById,
+  // getFlowId,
   getTeamEmailSettings,
+  // getSubmissionEmail,
   insertAuditEntry,
 } from "./service.js";
 import type {
@@ -32,13 +34,19 @@ export const sendToEmail: SendIntegrationController = async (
 
   try {
     // Confirm this local authority (aka team) has an email configured in teams.submission_email
-    const { teamSettings } = await getTeamEmailSettings(localAuthority);
+    // MULTIPLE SUBMISSION TODO change check
+    const { id: teamId, teamSettings } =
+      await getTeamEmailSettings(localAuthority);
     if (!teamSettings.submissionEmail) {
       return next({
         status: 400,
         message: `Send to email is not enabled for this local authority (${localAuthority})`,
       });
     }
+
+    // MULTIPLE SUBMISSION TODO (uncomment)
+    // const flowId = await getFlowId(sessionId);
+    // const submissionEmail = await getSubmissionEmail(flowId, teamId);
 
     // Confirm that this session has not already been successfully submitted before proceeding
     const lastSubmittedAppStatus = await checkEmailAuditTable(sessionId);
@@ -58,7 +66,7 @@ export const sendToEmail: SendIntegrationController = async (
     // Send the email
     const response = await sendEmail(
       "submit",
-      teamSettings.submissionEmail,
+      teamSettings.submissionEmail, // MULTIPLE SUBMISSION TODO use submissionEmail or
       config,
     );
 
@@ -69,14 +77,14 @@ export const sendToEmail: SendIntegrationController = async (
     insertAuditEntry(
       sessionId,
       localAuthority,
-      teamSettings.submissionEmail,
+      teamSettings.submissionEmail, // MULTIPLE SUBMISSION TODO use submissionEmail
       config,
       response,
     );
 
     return res.status(200).send({
       message: `Successfully sent to email`,
-      inbox: teamSettings.submissionEmail,
+      inbox: teamSettings.submissionEmail, // MULTIPLE SUBMISSION TODO use submissionEmail
       govuk_notify_template: "Submit",
     });
   } catch (error) {
@@ -104,7 +112,7 @@ const getSubmitEmailConfig = async ({
       await getSessionEmailDetailsById(sessionId);
 
     // Type narrowing
-    if (!teamSettings.submissionEmail) throw Error("Submission email missing!");
+    if (!teamSettings.submissionEmail) throw Error("Submission email missing!"); // MULTIPLE SUBMISSION TODO
 
     const projectTypes = passportData["proposal.projectType"] as
       | string[]

--- a/apps/api.planx.uk/modules/send/email/service.ts
+++ b/apps/api.planx.uk/modules/send/email/service.ts
@@ -70,7 +70,7 @@ interface GetPublishedFlowIntegration {
 async function getPublishedFlowIntegration(flowId: string) {
   const response = await $api.client.request<GetPublishedFlowIntegration>(
     gql`
-      query getPublishedFlowIntegration($flowId: uuid!) {
+      query GetPublishedFlowIntegration($flowId: uuid!) {
         publishedFlows: published_flows(
           where: { flow_id: { _eq: $flowId } }
           order_by: [{ flow_id: asc }, { created_at: desc }]

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
@@ -5,6 +5,15 @@ object_relationships:
   - name: flow
     using:
       foreign_key_constraint_on: flow_id
+  - name: submission_integration
+    using:
+      manual_configuration:
+        column_mapping:
+          submission_email_id: id
+        insertion_order: null
+        remote_table:
+          name: submission_integrations
+          schema: public
   - name: user
     using:
       foreign_key_constraint_on: publisher_id

--- a/apps/hasura.planx.uk/migrations/default/1770824593024_alter_table_public_submission_integrations_add_column_deleted_at/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1770824593024_alter_table_public_submission_integrations_add_column_deleted_at/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."submission_integrations" drop column "deleted_at";

--- a/apps/hasura.planx.uk/migrations/default/1770824593024_alter_table_public_submission_integrations_add_column_deleted_at/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1770824593024_alter_table_public_submission_integrations_add_column_deleted_at/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."submission_integrations" add column "deleted_at" timestamptz
+ null;


### PR DESCRIPTION
- Following changes to the data model, this PR updates `getPublishedFlowIntegration` function and interface, to be used in Send events + when downloading applications received via email. 
- Creates `getDefaultSubmissionIntegration` function for fallback logic (eg if a flow integration email ID was deleted _after_ the flow was last published)
- Creates `getSubmissionEmail` function that runs both of the above.
- In `apps/api.planx.uk/modules/send/email/index.ts` and `apps/api.planx.uk/modules/send/email/index.ts` I leave comments for where we'll swap existing `teamSettings.submissionEmail` for the `submissionEmail` gotten from the new data model 
    - ❓ Is there a better / neater way to do this, or some sort of API feature flag equivalent? Is it okay to leave the comments in and fix forward (hopefully very soon)? I've tested the new code and fallback logic and all works as expected.