### PR TITLE
fix(editor): Don't throw not found error for `/download-application`

### DIFF
--- a/apps/editor.planx.uk/src/hooks/usePublicRouteContext.ts
+++ b/apps/editor.planx.uk/src/hooks/usePublicRouteContext.ts
@@ -34,6 +34,7 @@ export const usePublicRouteContext = (): PublicRoutePattern => {
       if (routeId.includes("/draft")) return "/$team/$flow/draft";
       if (routeId.includes("/published")) return "/$team/$flow/published";
       if (routeId.includes("/pay")) return "/$team/$flow";
+      if (routeId.includes("/download-application")) return "/$team/$flow";
     }
 
     throw notFound();


### PR DESCRIPTION
Alternate method for #6108 