### PR TITLE
chore: tidy multiple submission email db changes

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_published_flows.yaml
@@ -5,15 +5,6 @@ object_relationships:
   - name: flow
     using:
       foreign_key_constraint_on: flow_id
-  - name: submission_integration
-    using:
-      manual_configuration:
-        column_mapping:
-          submission_email_id: id
-        insertion_order: null
-        remote_table:
-          name: submission_integrations
-          schema: public
   - name: user
     using:
       foreign_key_constraint_on: publisher_id
@@ -31,7 +22,6 @@ insert_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
   - role: demoUser
     permission:
@@ -54,7 +44,6 @@ insert_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
     comment: A demoUser can only insert a published flow for their own flows and for flows inside the Demo team [id = 32]
   - role: platformAdmin
@@ -70,7 +59,6 @@ insert_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
   - role: teamEditor
     permission:
@@ -93,7 +81,6 @@ insert_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
 select_permissions:
   - role: api
@@ -108,7 +95,6 @@ select_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
       filter: {}
       allow_aggregations: true
@@ -124,7 +110,6 @@ select_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
       filter: {}
       allow_aggregations: true
@@ -140,7 +125,6 @@ select_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
       filter: {}
       allow_aggregations: true
@@ -171,7 +155,6 @@ select_permissions:
         - id
         - publisher_id
         - service_charge_enabled
-        - submission_email_id
         - summary
       filter: {}
       allow_aggregations: true

--- a/apps/hasura.planx.uk/migrations/default/1771502286436_alter_table_public_submission_integrations_drop_column_deleted_at/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1771502286436_alter_table_public_submission_integrations_drop_column_deleted_at/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."submission_integrations" alter column "deleted_at" drop not null;
+alter table "public"."submission_integrations" add column "deleted_at" timestamptz;

--- a/apps/hasura.planx.uk/migrations/default/1771502286436_alter_table_public_submission_integrations_drop_column_deleted_at/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1771502286436_alter_table_public_submission_integrations_drop_column_deleted_at/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."submission_integrations" drop column "deleted_at" cascade;

--- a/apps/hasura.planx.uk/migrations/default/1771502550325_alter_table_public_published_flows_drop_column_submission_email_id/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1771502550325_alter_table_public_published_flows_drop_column_submission_email_id/down.sql
@@ -1,0 +1,3 @@
+comment on column "public"."published_flows"."submission_email_id" is E'Snapshots of flow content that are "live" to public users, links to `flows`. When adding or removing columns please ensure that the `diff_latest_published_flow` function is also updated';
+alter table "public"."published_flows" alter column "submission_email_id" drop not null;
+alter table "public"."published_flows" add column "submission_email_id" uuid;

--- a/apps/hasura.planx.uk/migrations/default/1771502550325_alter_table_public_published_flows_drop_column_submission_email_id/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1771502550325_alter_table_public_published_flows_drop_column_submission_email_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."published_flows" drop column "submission_email_id" cascade;

--- a/apps/hasura.planx.uk/migrations/default/1771502660139_update_diff_latest_published_flows/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1771502660139_update_diff_latest_published_flows/down.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.diff_latest_published_flow(source_flow_id uuid, since timestamp with time zone)
+ RETURNS published_flows
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH current_published_flow as (
+  SELECT
+    id, data, created_at, flow_id, publisher_id, summary, has_send_component, has_sections, has_pay_component, service_charge_enabled, submission_email_id
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+  ORDER BY
+    created_at desc
+  LIMIT
+    1
+),
+previous_published_flow as (
+  SELECT
+    flow_id, data
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+    AND
+    published_flows.created_at < since
+  ORDER BY
+    created_at desc -- the latest published version before "since"
+  LIMIT
+    1
+),
+data_diff as (
+  SELECT
+    flow_id,
+    ( SELECT
+        jsonb_object_agg(COALESCE(old.key, new.key), new.value)
+      FROM
+        jsonb_each(previous_published_flow.data) AS old
+      FULL OUTER JOIN 
+        jsonb_each(current_published_flow.data) AS new 
+      ON
+        new.key = old.key 
+      WHERE 
+        new.value IS DISTINCT FROM old.value
+    ) as data -- shallow diff where deleted keys have a 'null' value
+  FROM 
+    current_published_flow
+  JOIN
+    previous_published_flow USING (flow_id)
+)
+SELECT 
+    id, data_diff.data as data, created_at, flow_id, publisher_id, 'auto generated diff' as summary, has_send_component, has_sections, has_pay_component, service_charge_enabled, submission_email_id
+FROM 
+    current_published_flow
+FULL OUTER JOIN
+    data_diff USING (flow_id);
+$function$;

--- a/apps/hasura.planx.uk/migrations/default/1771502660139_update_diff_latest_published_flows/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1771502660139_update_diff_latest_published_flows/up.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.diff_latest_published_flow(source_flow_id uuid, since timestamp with time zone)
+ RETURNS published_flows
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH current_published_flow as (
+  SELECT
+    id, data, created_at, flow_id, publisher_id, summary, has_send_component, has_sections, has_pay_component, service_charge_enabled
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+  ORDER BY
+    created_at desc
+  LIMIT
+    1
+),
+previous_published_flow as (
+  SELECT
+    flow_id, data
+  FROM
+    published_flows
+  WHERE
+    published_flows.flow_id = source_flow_id
+    AND
+    published_flows.created_at < since
+  ORDER BY
+    created_at desc -- the latest published version before "since"
+  LIMIT
+    1
+),
+data_diff as (
+  SELECT
+    flow_id,
+    ( SELECT
+        jsonb_object_agg(COALESCE(old.key, new.key), new.value)
+      FROM
+        jsonb_each(previous_published_flow.data) AS old
+      FULL OUTER JOIN 
+        jsonb_each(current_published_flow.data) AS new 
+      ON
+        new.key = old.key 
+      WHERE 
+        new.value IS DISTINCT FROM old.value
+    ) as data -- shallow diff where deleted keys have a 'null' value
+  FROM 
+    current_published_flow
+  JOIN
+    previous_published_flow USING (flow_id)
+)
+SELECT 
+    id, data_diff.data as data, created_at, flow_id, publisher_id, 'auto generated diff' as summary, has_send_component, has_sections, has_pay_component, service_charge_enabled
+FROM 
+    current_published_flow
+FULL OUTER JOIN
+    data_diff USING (flow_id);
+$function$;

--- a/scripts/seed-database/write/submission_integrations.sql
+++ b/scripts/seed-database/write/submission_integrations.sql
@@ -3,25 +3,22 @@ CREATE TEMPORARY TABLE sync_submission_integrations (
   team_id integer,
   id uuid,
   submission_email text,
-  default_email boolean,
-  deleted_at timestamptz
+  default_email boolean
 );
 
 \COPY sync_submission_integrations FROM '/tmp/submission_integrations.csv' WITH (FORMAT csv, DELIMITER ';');
 
 INSERT INTO
-  submission_integrations (team_id, id, submission_email, default_email, deleted_at)
+  submission_integrations (team_id, id, submission_email, default_email)
 SELECT
   team_id integer,
   id uuid,
   submission_email text,
-  default_email boolean,
-  deleted_at timestamptz
+  default_email boolean
 FROM
   sync_submission_integrations ON CONFLICT (id) DO
 UPDATE
 SET
   team_id = EXCLUDED.team_id,
   submission_email = EXCLUDED.submission_email,
-  default_email = EXCLUDED.default_email,
-  deleted_at = EXCLUDED.deleted_at;
+  default_email = EXCLUDED.default_email


### PR DESCRIPTION
As part of the multiple submission email work, I made a series of changes to the db that will not end up being used in the first version of this feature. If they end up being used in future versions (eg when we write from the Send component or enable delete), we can make the changes again if need be. For now, they are cruft, so as discussed with Daf earlier, this PR deletes them! 

This PR:
- Removes col `deleted_at` from `submission_integrations` table (#6098)
- Updates permissions and removes the column `published_flows.submission_email_id` (and thus the relationship between `published_flows` and `submission_integrations`, #6023)
    - Updates `diff_latest_published_flow` accordingly
- Undoes the changes to the `submission_integrations` sync script too (#6115)