### PR TITLE
feat: Implement recent flows list using store

### DIFF
--- a/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
+++ b/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
@@ -60,6 +60,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
               }}
               {...(isStandalone && { target: "_blank" })}
               variant="body1"
+              preload={false}
             >
               {params.team}
             </BreadcrumbsLink>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlows.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlows.tsx
@@ -6,6 +6,7 @@ import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { useNavigate } from "@tanstack/react-router";
 import React, { useState } from "react";
 
 export interface RecentFlow {
@@ -99,18 +100,31 @@ const ExpandableContent = styled(Box)<{ isExpanded: boolean }>(
 
 const RecentFlows: React.FC<RecentFlowsProps> = ({ flows }) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const navigate = useNavigate();
 
   const handleToggle = () => setIsExpanded((prev) => !prev);
 
-  const reversedFlows = [...flows].reverse();
-  const firstFlow = isExpanded ? reversedFlows[0] : flows[0];
-  const additionalFlows = reversedFlows.slice(1);
+  const handleFlowClick = (e: React.MouseEvent, flow: RecentFlow) => {
+    e.preventDefault();
+    // Extract the root flow slug from the stored href (/app/$team/$flow)
+    const [, , team, flowSlug] = flow.href.split("/");
+    navigate({ to: "/app/$team/$flow", params: { team, flow: flowSlug } });
+  };
+
+  // Collapsed: show the directly previous (most recent) flow
+  // Expanded: show the original flow at top, then in oldest→newest order
+  const firstFlow = isExpanded ? flows[0] : flows[flows.length - 1];
+  const additionalFlows = flows.slice(1);
 
   return (
     <RecentFlowContainer>
       <RecentFlowList>
         <RecentFlowItem indent={0}>
-          <RecentFlowLink variant="body3" href={firstFlow.href}>
+          <RecentFlowLink
+            variant="body3"
+            href={firstFlow.href}
+            onClick={(e) => handleFlowClick(e, firstFlow)}
+          >
             <Box component="span" sx={{ mr: 0.25 }}>
               back to
             </Box>
@@ -127,7 +141,11 @@ const RecentFlows: React.FC<RecentFlowsProps> = ({ flows }) => {
                 key={`${flow.team}-${flow.flow}-${index}`}
                 indent={index + 1}
               >
-                <RecentFlowLink variant="body3" href={flow.href}>
+                <RecentFlowLink
+                  variant="body3"
+                  href={flow.href}
+                  onClick={(e) => handleFlowClick(e, flow)}
+                >
                   <TurnSharpLeftIcon sx={{ mr: 0.25 }} fontSize="small" />
                   <Box component="span" className="flow-name">
                     {flow.flow}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -15,6 +15,7 @@ import { ToggleHelpTextButton } from "./components/FlowEditor/ToggleHelpTextButt
 import { ToggleImagesButton } from "./components/FlowEditor/ToggleImagesButton";
 import { ToggleNotesButton } from "./components/FlowEditor/ToggleNotesButton";
 import { ToggleTagsButton } from "./components/FlowEditor/ToggleTagsButton";
+import RecentFlows from "./components/RecentFlows/RecentFlows";
 import Sidebar from "./components/Sidebar";
 import { useStore } from "./lib/store";
 import useScrollControlsAndRememberPosition from "./lib/useScrollControlsAndRememberPosition";
@@ -42,15 +43,30 @@ const EditorVisualControls = styled(ButtonGroup)(({ theme }) => ({
   overflow: "hidden",
 }));
 
+const RecentFlowsOverlay = styled(Box)(({ theme }) => ({
+  position: "absolute",
+  top: theme.spacing(1.5),
+  left: theme.spacing(1.5),
+  zIndex: theme.zIndex.appBar,
+  maxWidth: `calc(100% - ${theme.spacing(5)})`,
+}));
+
 const FlowEditor = () => {
-  const [flowObject, orderedFlow, isTemplatedFrom, teamSlug, isNavMenuVisible] =
-    useStore((state) => [
-      state.flow,
-      state.orderedFlow,
-      state.isTemplatedFrom,
-      state.getTeam().slug,
-      state.isNavMenuVisible,
-    ]);
+  const [
+    flowObject,
+    orderedFlow,
+    isTemplatedFrom,
+    teamSlug,
+    isNavMenuVisible,
+    recentFlows,
+  ] = useStore((state) => [
+    state.flow,
+    state.orderedFlow,
+    state.isTemplatedFrom,
+    state.getTeam().slug,
+    state.isNavMenuVisible,
+    state.recentFlows,
+  ]);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   useScrollControlsAndRememberPosition(scrollContainerRef);
@@ -90,6 +106,11 @@ const FlowEditor = () => {
             lockedFlow={lockedFlow}
             showTemplatedNodeStatus={showTemplatedNodeStatus}
           />
+          {recentFlows.length > 0 && (
+            <RecentFlowsOverlay>
+              <RecentFlows flows={recentFlows} />
+            </RecentFlowsOverlay>
+          )}
           <EditorVisualControls
             orientation="vertical"
             aria-label="Toggle node attributes"

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -13,6 +13,8 @@ import type { NavigationStore } from "./navigation";
 import { navigationStore } from "./navigation";
 import type { PreviewStore } from "./preview";
 import { previewStore } from "./preview";
+import type { RecentFlowsStore } from "./recentFlows";
+import { recentFlowsStore } from "./recentFlows";
 import type { SettingsStore } from "./settings";
 import { settingsStore } from "./settings";
 import type { SharedStore } from "./shared";
@@ -60,7 +62,11 @@ export type PublicStore = SharedStore &
   SettingsStore &
   TeamStore;
 
-export type FullStore = PublicStore & EditorStore & EditorUIStore & UserStore;
+export type FullStore = PublicStore &
+  EditorStore &
+  EditorUIStore &
+  UserStore &
+  RecentFlowsStore;
 
 /**
  * If accessing the public preview, don't load editor store files
@@ -85,6 +91,7 @@ const createFullStore = () => {
     ...navigationStore(...args),
     ...editorStore(...args),
     ...editorUIStore(...args),
+    ...recentFlowsStore(...args),
     ...settingsStore(...args),
     ...teamStore(...args),
     ...userStore(...args),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/recentFlows.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/recentFlows.ts
@@ -1,0 +1,168 @@
+import type { RegisteredRouter } from "@tanstack/react-router";
+import type { StateCreator } from "zustand";
+
+import type { SharedStore } from "./shared";
+
+export interface RecentFlowEntry {
+  team: string;
+  flow: string;
+  href: string;
+}
+
+export interface RecentFlowsStore {
+  recentFlows: RecentFlowEntry[];
+  initRecentFlowsTracking: (router: RegisteredRouter) => () => void;
+}
+
+const FLOW_URL_PATTERN = /^\/app\/([^/]+)\/([^/]+)/;
+const SESSION_KEY = "planx:recentFlows";
+
+/**
+ * The display name of the flow we're navigating FROM, captured in
+ * onBeforeNavigate before beforeLoad overwrites flowName in the shared store.
+ */
+let pendingFromFlowName: string | undefined = undefined;
+
+/**
+ * Deduplicates onResolved calls for the same navigation (e.g. from React
+ * StrictMode double-invoking effects which creates duplicate subscriptions).
+ * Keyed as "fromPathname→toPathname".
+ */
+let lastProcessedNavKey = "";
+
+function parseFlowPathname(pathname: string): {
+  teamSlug: string;
+  rootFlowSlug: string;
+  isFolder: boolean;
+} | null {
+  const match = pathname.match(FLOW_URL_PATTERN);
+  if (!match) return null;
+  const teamSlug = match[1];
+  const [rootFlowSlug, ...folderIds] = decodeURIComponent(match[2]).split(",");
+  return { teamSlug, rootFlowSlug, isFolder: folderIds.length > 0 };
+}
+
+function loadFromSession(currentPathname: string): RecentFlowEntry[] {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return [];
+    const { currentFlowHref, recentFlows } = JSON.parse(raw) as {
+      currentFlowHref: string;
+      recentFlows: RecentFlowEntry[];
+    };
+    const parsed = parseFlowPathname(currentPathname);
+    if (!parsed || parsed.isFolder) return [];
+    const flowHref = `/app/${parsed.teamSlug}/${parsed.rootFlowSlug}`;
+
+    // Same flow: restore as-is (e.g. page refresh while already on this flow)
+    if (flowHref === currentFlowHref) return recentFlows;
+
+    // Back navigation via page refresh: the current flow is already in the list,
+    // so restore only the entries that precede it
+    const backIndex = recentFlows.findIndex((e) => e.href === flowHref);
+    if (backIndex >= 0) return recentFlows.slice(0, backIndex);
+
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function saveToSession(
+  currentFlowHref: string,
+  recentFlows: RecentFlowEntry[],
+): void {
+  try {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ currentFlowHref, recentFlows }),
+    );
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export const recentFlowsStore: StateCreator<
+  SharedStore & RecentFlowsStore,
+  [],
+  [],
+  RecentFlowsStore
+> = (set, get) => ({
+  recentFlows: loadFromSession(window.location.pathname),
+
+  initRecentFlowsTracking: (router: RegisteredRouter) => {
+    /**
+     * Capture the display name of the flow we're leaving BEFORE beforeLoad
+     * runs and overwrites flowName in the shared store.
+     *
+     * The event's fromLocation is router.state.resolvedLocation — the previous
+     * successfully-resolved location — and is reliable for all navigation types
+     * including browser back/forward (popstate).
+     */
+    const unsubscribePreNav = router.subscribe("onBeforeNavigate", () => {
+      pendingFromFlowName = get().flowName || undefined;
+    });
+
+    const unsubscribeResolved = router.subscribe("onResolved", (event) => {
+      const toPathname = event.toLocation.pathname;
+      const fromPathname = event.fromLocation?.pathname;
+
+      // Deduplicate: same from→to pair already processed (double subscription)
+      const navKey = `${fromPathname ?? ""}→${toPathname}`;
+      if (navKey === lastProcessedNavKey) return;
+      lastProcessedNavKey = navKey;
+
+      const toParsed = parseFlowPathname(toPathname);
+      if (!toParsed) return;
+
+      // Folder (InternalPortal) navigation — skip entirely
+      if (toParsed.isFolder) return;
+
+      const newFlowHref = `/app/${toParsed.teamSlug}/${toParsed.rootFlowSlug}`;
+      const { recentFlows } = get();
+
+      // Back navigation: destination already in list → truncate to just before it
+      const backIndex = recentFlows.findIndex((e) => e.href === newFlowHref);
+      if (backIndex >= 0) {
+        const updated = recentFlows.slice(0, backIndex);
+        set({ recentFlows: updated });
+        saveToSession(newFlowHref, updated);
+        return;
+      }
+
+      const fromParsed = fromPathname ? parseFlowPathname(fromPathname) : null;
+
+      if (fromParsed) {
+        const fromRootHref = `/app/${fromParsed.teamSlug}/${fromParsed.rootFlowSlug}`;
+
+        // Folder → same root flow (navigating up from an InternalPortal): skip
+        if (fromRootHref === newFlowHref) return;
+
+        // Came from a root flow or a folder of a different flow → ExternalPortal
+        const entry: RecentFlowEntry = {
+          team: fromParsed.teamSlug,
+          flow: pendingFromFlowName || fromParsed.rootFlowSlug,
+          href: fromRootHref,
+        };
+        const updated = [...recentFlows, entry];
+        set({ recentFlows: updated });
+        saveToSession(newFlowHref, updated);
+        return;
+      }
+
+      // fromLocation is undefined: initial page load — keep existing state
+      // (already loaded from sessionStorage at store initialisation)
+      if (!fromPathname) return;
+
+      // Navigated from a non-flow URL (team page, etc.) → direct access, reset
+      const updated: RecentFlowEntry[] = [];
+      set({ recentFlows: updated });
+      saveToSession(newFlowHref, updated);
+    });
+
+    return () => {
+      unsubscribePreNav();
+      unsubscribeResolved();
+    };
+  },
+});

--- a/apps/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
@@ -43,10 +43,17 @@ const DashboardContainer = styled(Box)(({ theme }) => ({
 const Layout: React.FC<PropsWithChildren> = ({ children }) => {
   const router = useRouter();
   const initURLTracking = useStore((state) => state.initURLTracking);
+  const initRecentFlowsTracking = useStore(
+    (state) => state.initRecentFlowsTracking,
+  );
 
   useEffect(() => {
-    const cleanup = initURLTracking(router);
-    return cleanup;
+    const cleanupURLTracking = initURLTracking(router);
+    const cleanupRecentFlows = initRecentFlowsTracking(router);
+    return () => {
+      cleanupURLTracking();
+      cleanupRecentFlows();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty deps - run once on mount
 


### PR DESCRIPTION
## What does this PR do?

Implements `RecentFlows` component using a Zustand store to collect a list of flows traversed in a session.

- Recent flows list be hidden when directly accessing a flow from the team page or direct URL
- The list should populate a single flow when navigating into a nested flow
- The list should update the displayed "back to" link when navigating into subsequent nested flows
- When expanded the list should display a full trail back to the origin flow
- The list should respect native back/forward navigation in/out of nested flows

### Simplified flow for testing

https://6251.planx.pizza/app/testing/nested-flows

### Real world flow for testing

https://6251.planx.pizza/app/barnet/find-out-if-you-need-planning-permission
- Navigate into the flow `opensystemslab / permitteddevelopment`
- This flow contains several more nested flows, including `change-the-use-of-a-property-in-the-future` which has subsequent nested flows