### PR TITLE
chore(iac): Replace wildcard certificates with list on known subdomains

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -370,8 +370,12 @@ export = async () => {
       subjectAlternativeNames: [
         // Root
         `${DOMAIN}`,
-        // Wildcard / subdomains
-        `*.${DOMAIN}`,
+        // Subdomains
+        `api.${DOMAIN}`,
+        `hasura.${DOMAIN}`,
+        `sharedb.${DOMAIN}`,
+        `metabase.${DOMAIN}`,
+        ...(env === "staging" ? [`localplanning.${DOMAIN}`] : []),
       ],
     },
     {


### PR DESCRIPTION
Jumpsec have reported the following issue - 

> **Issue**
> Wildcard SSL Certificate Use on External Service
>
> **Description**
> Wildcard SSL certificates are used on external services, which means the same private key can be deployed across multiple servers and subdomains. This increases the impact of any single system compromise, as an attacker with access to that key could potentially impersonate other services or decrypt encrypted traffic.	
>
> **Recommendation**
> Wildcard certificates should be phased out on external services where practical and replace them with certificates that are specific to individual FQDNs, while strengthening controls around private key storage and access.

The PR implements their exact recommendation - replacing `*.editor.planx.(dev|uk)` with a list of known subdomains we'll be using.